### PR TITLE
Pass down id compressor for in-memory identifier encoding

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -248,6 +248,10 @@ export function tryShapeFromSchema(
 	return getOrCreate(shapes, type, () => {
 		const treeSchema = schema.nodeSchema.get(type) ?? fail("missing schema");
 		if (treeSchema instanceof LeafNodeStoredSchema) {
+			// Allow all string values (but only string values) to be compressed by the id compressor.
+			// This allows compressing all compressible identifiers without requiring additional context to know which values could be identifiers.
+			// Attempting to compress other string shouldn't have significant overhead,
+			// and if any of them do end up compressing, that's a benefit not a bug.
 			return treeSchema.leafValue === ValueSchema.String
 				? new TreeShape(type, true, [], true)
 				: new TreeShape(type, true, [], false);
@@ -349,6 +353,9 @@ export interface ChunkCompressor {
 	readonly policy: ChunkPolicy;
 	/**
 	 * If the idCompressor is provided, {@link UniformChunk}s with identifiers will be encoded for its in-memory representation.
+	 * @remarks
+	 * This compression applies to {@link UniformChunk}s when {@link TreeShape.maybeDecompressedStringAsNumber} is set.
+	 * If the `policy` does not use UniformChunks or does not set `maybeDecompressedStringAsNumber`, then no compression will be applied even when providing `idCompressor`.
 	 */
 	readonly idCompressor: IIdCompressor | undefined;
 }

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -160,7 +160,11 @@ export class Chunker implements IChunker {
  *
  * @param cursor - cursor in nodes mode
  */
-export function chunkTree(cursor: ITreeCursorSynchronous, policy: ChunkPolicy, idCompressor?: IIdCompressor): TreeChunk {
+export function chunkTree(
+	cursor: ITreeCursorSynchronous,
+	policy: ChunkPolicy,
+	idCompressor?: IIdCompressor,
+): TreeChunk {
 	return chunkRange(cursor, policy, 1, true, idCompressor)[0] ?? oob();
 }
 
@@ -168,7 +172,11 @@ export function chunkTree(cursor: ITreeCursorSynchronous, policy: ChunkPolicy, i
  * Get a TreeChunk[] for the current field (and its children) of cursor.
  * This will copy if needed, but add refs to existing chunks which hold the data.
  */
-export function chunkField(cursor: ITreeCursorSynchronous, policy: ChunkPolicy, idCompressor?: IIdCompressor): TreeChunk[] {
+export function chunkField(
+	cursor: ITreeCursorSynchronous,
+	policy: ChunkPolicy,
+	idCompressor?: IIdCompressor,
+): TreeChunk[] {
 	const length = cursor.getFieldLength();
 	const started = cursor.firstNode();
 	assert(started, 0x57c /* field to chunk should have at least one node */);
@@ -182,7 +190,7 @@ export function chunkField(cursor: ITreeCursorSynchronous, policy: ChunkPolicy, 
 export function chunkFieldSingle(
 	cursor: ITreeCursorSynchronous,
 	policy: ChunkPolicy,
-	idCompressor?: IIdCompressor
+	idCompressor?: IIdCompressor,
 ): TreeChunk {
 	const chunks = chunkField(cursor, policy, idCompressor);
 	if (chunks.length === 1) {
@@ -246,7 +254,9 @@ export function tryShapeFromSchema(
 	return getOrCreate(shapes, type, () => {
 		const treeSchema = schema.nodeSchema.get(type) ?? fail("missing schema");
 		if (treeSchema instanceof LeafNodeStoredSchema) {
-			return treeSchema.leafValue === ValueSchema.String ?  new TreeShape(type, true, [], true) :  new TreeShape(type, true, [], false);
+			return treeSchema.leafValue === ValueSchema.String
+				? new TreeShape(type, true, [], true)
+				: new TreeShape(type, true, [], false);
 		}
 		if (treeSchema instanceof ObjectNodeStoredSchema) {
 			const fieldsArray: FieldShape[] = [];
@@ -360,7 +370,7 @@ export function chunkRange(
 	policy: ChunkPolicy,
 	length: number,
 	skipLastNavigation: boolean,
-	idCompressor?: IIdCompressor
+	idCompressor?: IIdCompressor,
 ): TreeChunk[] {
 	assert(cursor.mode === CursorLocationType.Nodes, 0x57e /* should be in nodes */);
 	let output: TreeChunk[] = [];
@@ -416,7 +426,7 @@ export function chunkRange(
 					shape,
 					maxLength,
 					maxLength === remaining && skipLastNavigation,
-					idCompressor
+					idCompressor,
 				);
 				remaining -= newChunk.topLevelLength;
 				output.push(newChunk);

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -347,6 +347,9 @@ export interface ChunkPolicy {
 
 export interface ChunkCompressor {
 	readonly policy: ChunkPolicy;
+	/**
+	 * If the idCompressor is provided, {@link UniformChunk}s with identifiers will be encoded for its in-memory representation.
+	 */
 	readonly idCompressor: IIdCompressor | undefined;
 }
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -346,8 +346,8 @@ export interface ChunkPolicy {
 }
 
 export interface ChunkCompressor {
-	policy: ChunkPolicy;
-	idCompressor?: IIdCompressor;
+	readonly policy: ChunkPolicy;
+	readonly idCompressor: IIdCompressor | undefined;
 }
 
 function newBasicChunkTree(

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -66,7 +66,7 @@ export class ChunkedForest implements IEditableForest {
 		public readonly schema: TreeStoredSchemaSubscription,
 		public readonly chunker: IChunker,
 		public readonly anchors: AnchorSet = new AnchorSet(),
-		public readonly idCompressor?: IIdCompressor
+		public readonly idCompressor?: IIdCompressor,
 	) {}
 
 	public get isEmpty(): boolean {
@@ -124,7 +124,9 @@ export class ChunkedForest implements IEditableForest {
 			},
 			create(content: ProtoNodes, destination: FieldKey): void {
 				this.forest.events.emit("beforeChange");
-				const chunks: TreeChunk[] = content.map((c) => chunkTree(c, this.forest.chunker, this.forest.idCompressor));
+				const chunks: TreeChunk[] = content.map((c) =>
+					chunkTree(c, this.forest.chunker, this.forest.idCompressor),
+				);
 				this.forest.roots.fields.set(destination, chunks);
 				this.forest.events.emit("afterRootFieldCreated", destination);
 			},
@@ -447,6 +449,10 @@ class Cursor extends BasicChunkCursor implements ITreeSubscriptionCursor {
 /**
  * @returns an implementation of {@link IEditableForest} with no data or schema.
  */
-export function buildChunkedForest(chunker: IChunker, anchors?: AnchorSet, idCompressor?: IIdCompressor): ChunkedForest {
+export function buildChunkedForest(
+	chunker: IChunker,
+	anchors?: AnchorSet,
+	idCompressor?: IIdCompressor,
+): ChunkedForest {
 	return new ChunkedForest(makeRoot(), chunker.schema, chunker, anchors, idCompressor);
 }

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -228,7 +228,10 @@ export class ChunkedForest implements IEditableForest {
 					//
 					// Maybe build path when visitor navigates then lazily sync to chunk tree when editing?
 					const newChunks = mapCursorField(found.cursor(), (cursor) =>
-						basicChunkTree(cursor, { policy: this.forest.chunker }),
+						basicChunkTree(cursor, {
+							policy: this.forest.chunker,
+							idCompressor: this.forest.idCompressor,
+						}),
 					);
 					// TODO: this could fail for really long chunks being split (due to argument count limits).
 					// Current implementations of chunks shouldn't ever be that long, but it could be an issue if they get bigger.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -34,6 +34,7 @@ import { assertValidRange, brand, fail, getOrAddEmptyToMap } from "../../util/in
 import { BasicChunk, BasicChunkCursor, type SiblingsOrKey } from "./basicChunk.js";
 import type { ChunkedCursor, TreeChunk } from "./chunk.js";
 import { type IChunker, basicChunkTree, chunkTree } from "./chunkTree.js";
+import type { IIdCompressor } from "@fluidframework/id-compressor";
 
 function makeRoot(): BasicChunk {
 	return new BasicChunk(aboveRootPlaceholder, new Map());
@@ -65,6 +66,7 @@ export class ChunkedForest implements IEditableForest {
 		public readonly schema: TreeStoredSchemaSubscription,
 		public readonly chunker: IChunker,
 		public readonly anchors: AnchorSet = new AnchorSet(),
+		public readonly idCompressor?: IIdCompressor
 	) {}
 
 	public get isEmpty(): boolean {
@@ -122,7 +124,7 @@ export class ChunkedForest implements IEditableForest {
 			},
 			create(content: ProtoNodes, destination: FieldKey): void {
 				this.forest.events.emit("beforeChange");
-				const chunks: TreeChunk[] = content.map((c) => chunkTree(c, this.forest.chunker));
+				const chunks: TreeChunk[] = content.map((c) => chunkTree(c, this.forest.chunker, this.forest.idCompressor));
 				this.forest.roots.fields.set(destination, chunks);
 				this.forest.events.emit("afterRootFieldCreated", destination);
 			},
@@ -445,6 +447,6 @@ class Cursor extends BasicChunkCursor implements ITreeSubscriptionCursor {
 /**
  * @returns an implementation of {@link IEditableForest} with no data or schema.
  */
-export function buildChunkedForest(chunker: IChunker, anchors?: AnchorSet): ChunkedForest {
-	return new ChunkedForest(makeRoot(), chunker.schema, chunker, anchors);
+export function buildChunkedForest(chunker: IChunker, anchors?: AnchorSet, idCompressor?: IIdCompressor): ChunkedForest {
+	return new ChunkedForest(makeRoot(), chunker.schema, chunker, anchors, idCompressor);
 }

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -125,7 +125,10 @@ export class ChunkedForest implements IEditableForest {
 			create(content: ProtoNodes, destination: FieldKey): void {
 				this.forest.events.emit("beforeChange");
 				const chunks: TreeChunk[] = content.map((c) =>
-					chunkTree(c, this.forest.chunker, this.forest.idCompressor),
+					chunkTree(c, {
+						policy: this.forest.chunker,
+						idCompressor: this.forest.idCompressor,
+					}),
 				);
 				this.forest.roots.fields.set(destination, chunks);
 				this.forest.events.emit("afterRootFieldCreated", destination);
@@ -225,7 +228,7 @@ export class ChunkedForest implements IEditableForest {
 					//
 					// Maybe build path when visitor navigates then lazily sync to chunk tree when editing?
 					const newChunks = mapCursorField(found.cursor(), (cursor) =>
-						basicChunkTree(cursor, this.forest.chunker),
+						basicChunkTree(cursor, { policy: this.forest.chunker }),
 					);
 					// TODO: this could fail for really long chunks being split (due to argument count limits).
 					// Current implementations of chunks shouldn't ever be that long, but it could be an issue if they get bigger.

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -169,7 +169,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 	public constructor(
 		family: ChangeFamily<ChangeFamilyEditor, DefaultChangeset>,
 		changeReceiver: (change: DefaultChangeset) => void,
-		private readonly idCompressor?: IIdCompressor
+		private readonly idCompressor?: IIdCompressor,
 	) {
 		this.modularBuilder = new ModularEditBuilder(family, fieldKinds, changeReceiver);
 	}

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -42,6 +42,7 @@ import {
 	sequence,
 	required as valueFieldKind,
 } from "./defaultFieldKinds.js";
+import type { IIdCompressor } from "@fluidframework/id-compressor";
 
 export type DefaultChangeset = ModularChangeset;
 
@@ -168,6 +169,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 	public constructor(
 		family: ChangeFamily<ChangeFamilyEditor, DefaultChangeset>,
 		changeReceiver: (change: DefaultChangeset) => void,
+		private readonly idCompressor?: IIdCompressor
 	) {
 		this.modularBuilder = new ModularEditBuilder(family, fieldKinds, changeReceiver);
 	}
@@ -188,7 +190,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 			set: (newContent: ITreeCursorSynchronous): void => {
 				const fillId = this.modularBuilder.generateId();
 
-				const build = this.modularBuilder.buildTrees(fillId, newContent);
+				const build = this.modularBuilder.buildTrees(fillId, newContent, this.idCompressor);
 				const change: FieldChangeset = brand(
 					valueFieldKind.changeHandler.editor.set({
 						fill: fillId,
@@ -216,7 +218,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 				let optionalChange: OptionalChangeset;
 				if (newContent !== undefined) {
 					fillId = this.modularBuilder.generateId();
-					const build = this.modularBuilder.buildTrees(fillId, newContent);
+					const build = this.modularBuilder.buildTrees(fillId, newContent, this.idCompressor);
 					edits.push(build);
 
 					optionalChange = optional.changeHandler.editor.set(wasEmpty, {
@@ -339,7 +341,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 				}
 
 				const firstId = this.modularBuilder.generateId(length);
-				const build = this.modularBuilder.buildTrees(firstId, content);
+				const build = this.modularBuilder.buildTrees(firstId, content, this.idCompressor);
 				const change: FieldChangeset = brand(
 					sequence.changeHandler.editor.insert(index, length, firstId),
 				);

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -138,7 +138,7 @@ export class ForestSummarizer implements Summarizable {
 			const fieldChanges: [FieldKey, DeltaFieldChanges][] = [];
 			const build: DeltaDetachedNodeBuild[] = [];
 			for (const [fieldKey, field] of fields) {
-				const chunked = chunkField(field, defaultChunkPolicy);
+				const chunked = chunkField(field, defaultChunkPolicy, this.idCompressor);
 				const nodeCursors = chunked.flatMap((chunk) =>
 					mapCursorField(chunk.cursor(), (cursor) => cursor.fork()),
 				);

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -138,7 +138,10 @@ export class ForestSummarizer implements Summarizable {
 			const fieldChanges: [FieldKey, DeltaFieldChanges][] = [];
 			const build: DeltaDetachedNodeBuild[] = [];
 			for (const [fieldKey, field] of fields) {
-				const chunked = chunkField(field, defaultChunkPolicy, this.idCompressor);
+				const chunked = chunkField(field, {
+					policy: defaultChunkPolicy,
+					idCompressor: this.idCompressor,
+				});
 				const nodeCursors = chunked.flatMap((chunk) =>
 					mapCursorField(chunk.cursor(), (cursor) => cursor.fork()),
 				);

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -382,7 +382,7 @@ function makeModularChangeCodec(
 		});
 		const getChunk = (index: number): TreeChunk => {
 			assert(index < chunks.length, 0x898 /* out of bounds index for build chunk */);
-			return chunkFieldSingle(chunks[index] ?? oob(), defaultChunkPolicy);
+			return chunkFieldSingle(chunks[index] ?? oob(), { policy: defaultChunkPolicy });
 		};
 
 		const map: ModularChangeset["builds"] = newTupleBTree();

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -382,7 +382,10 @@ function makeModularChangeCodec(
 		});
 		const getChunk = (index: number): TreeChunk => {
 			assert(index < chunks.length, 0x898 /* out of bounds index for build chunk */);
-			return chunkFieldSingle(chunks[index] ?? oob(), { policy: defaultChunkPolicy });
+			return chunkFieldSingle(chunks[index] ?? oob(), {
+				policy: defaultChunkPolicy,
+				idCompressor: context.idCompressor,
+			});
 		};
 
 		const map: ModularChangeset["builds"] = newTupleBTree();

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -2477,10 +2477,14 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 			return { type: "global" };
 		}
 		const builds: ChangeAtomIdBTree<TreeChunk> = newTupleBTree();
+		const chunkCompressor = {
+			policy: defaultChunkPolicy,
+			idCompressor,
+		};
 		const chunk =
 			content.mode === CursorLocationType.Fields
-				? chunkFieldSingle(content, { policy: defaultChunkPolicy })
-				: chunkTree(content, { policy: defaultChunkPolicy, idCompressor });
+				? chunkFieldSingle(content, chunkCompressor)
+				: chunkTree(content, chunkCompressor);
 		builds.set([undefined, firstId], chunk);
 
 		return {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -87,6 +87,7 @@ import type {
 	NodeId,
 	TupleBTree,
 } from "./modularChangeTypes.js";
+import type { IIdCompressor } from "@fluidframework/id-compressor";
 
 /**
  * Implementation of ChangeFamily which delegates work in a given field to the appropriate FieldKind
@@ -2470,6 +2471,7 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 	public buildTrees(
 		firstId: ChangesetLocalId,
 		content: ITreeCursorSynchronous,
+		idCompressor?: IIdCompressor
 	): GlobalEditDescription {
 		if (content.mode === CursorLocationType.Fields && content.getFieldLength() === 0) {
 			return { type: "global" };
@@ -2478,7 +2480,7 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 		const chunk =
 			content.mode === CursorLocationType.Fields
 				? chunkFieldSingle(content, defaultChunkPolicy)
-				: chunkTree(content, defaultChunkPolicy);
+				: chunkTree(content, defaultChunkPolicy, idCompressor);
 		builds.set([undefined, firstId], chunk);
 
 		return {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -2479,8 +2479,8 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 		const builds: ChangeAtomIdBTree<TreeChunk> = newTupleBTree();
 		const chunk =
 			content.mode === CursorLocationType.Fields
-				? chunkFieldSingle(content, defaultChunkPolicy)
-				: chunkTree(content, defaultChunkPolicy, idCompressor);
+				? chunkFieldSingle(content, { policy: defaultChunkPolicy })
+				: chunkTree(content, { policy: defaultChunkPolicy, idCompressor });
 		builds.set([undefined, firstId], chunk);
 
 		return {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -2471,7 +2471,7 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 	public buildTrees(
 		firstId: ChangesetLocalId,
 		content: ITreeCursorSynchronous,
-		idCompressor?: IIdCompressor
+		idCompressor?: IIdCompressor,
 	): GlobalEditDescription {
 		if (content.mode === CursorLocationType.Fields && content.getFieldLength() === 0) {
 			return { type: "global" };

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -178,7 +178,7 @@ export class SharedTree
 		const schema = new TreeStoredSchemaRepository();
 		const forest =
 			options.forest === ForestType.Optimized
-				? buildChunkedForest(makeTreeChunker(schema, defaultSchemaPolicy))
+				? buildChunkedForest(makeTreeChunker(schema, defaultSchemaPolicy), undefined, runtime.idCompressor)
 				: options.forest === ForestType.Reference
 					? buildForest()
 					: buildForest(undefined, true);
@@ -217,6 +217,7 @@ export class SharedTree
 			fieldBatchCodec,
 			options,
 			options.treeEncodeType,
+			runtime.idCompressor
 		);
 		const changeFamily = makeMitigatedChangeFamily(
 			innerChangeFamily,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -178,7 +178,11 @@ export class SharedTree
 		const schema = new TreeStoredSchemaRepository();
 		const forest =
 			options.forest === ForestType.Optimized
-				? buildChunkedForest(makeTreeChunker(schema, defaultSchemaPolicy), undefined, runtime.idCompressor)
+				? buildChunkedForest(
+						makeTreeChunker(schema, defaultSchemaPolicy),
+						undefined,
+						runtime.idCompressor,
+					)
 				: options.forest === ForestType.Reference
 					? buildForest()
 					: buildForest(undefined, true);
@@ -217,7 +221,7 @@ export class SharedTree
 			fieldBatchCodec,
 			options,
 			options.treeEncodeType,
-			runtime.idCompressor
+			runtime.idCompressor,
 		);
 		const changeFamily = makeMitigatedChangeFamily(
 			innerChangeFamily,

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeEnricher.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeEnricher.ts
@@ -29,6 +29,7 @@ import type {
 	ChangeEnricherMutableCheckout,
 	ChangeEnricherReadonlyCheckout,
 } from "../shared-tree-core/index.js";
+import type { IIdCompressor } from "@fluidframework/id-compressor";
 
 export class SharedTreeReadonlyChangeEnricher
 	implements ChangeEnricherReadonlyCheckout<SharedTreeChange>
@@ -44,6 +45,7 @@ export class SharedTreeReadonlyChangeEnricher
 		protected readonly forest: IEditableForest,
 		private readonly schema: TreeStoredSchemaRepository,
 		protected readonly removedRoots: DetachedFieldIndex,
+		private readonly idCompressor?: IIdCompressor,
 	) {}
 
 	public fork(): ChangeEnricherMutableCheckout<SharedTreeChange> {
@@ -70,7 +72,10 @@ export class SharedTreeReadonlyChangeEnricher
 			const parentField = this.removedRoots.toFieldKey(root);
 			cursor.enterField(parentField);
 			cursor.enterNode(0);
-			return chunkTree(cursor, defaultChunkPolicy);
+			return chunkTree(cursor, {
+				policy: defaultChunkPolicy,
+				idCompressor: this.idCompressor,
+			});
 		}
 		return undefined;
 	};

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -62,7 +62,7 @@ export class SharedTreeChangeFamily
 		fieldBatchCodec: FieldBatchCodec,
 		codecOptions: ICodecOptions,
 		chunkCompressionStrategy?: TreeCompressionStrategy,
-		private readonly idCompressor?: IIdCompressor
+		private readonly idCompressor?: IIdCompressor,
 	) {
 		const modularChangeCodec = makeModularChangeCodecFamily(
 			fieldKindConfigurations,
@@ -81,7 +81,11 @@ export class SharedTreeChangeFamily
 	public buildEditor(
 		changeReceiver: (change: SharedTreeChange) => void,
 	): SharedTreeEditBuilder {
-		return new SharedTreeEditBuilder(this.modularChangeFamily, changeReceiver, this.idCompressor);
+		return new SharedTreeEditBuilder(
+			this.modularChangeFamily,
+			changeReceiver,
+			this.idCompressor,
+		);
 	}
 
 	public compose(changes: TaggedChange<SharedTreeChange>[]): SharedTreeChange {

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -38,6 +38,7 @@ import {
 import { makeSharedTreeChangeCodecFamily } from "./sharedTreeChangeCodecs.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
+import type { IIdCompressor } from "@fluidframework/id-compressor";
 
 /**
  * Implementation of {@link ChangeFamily} that combines edits to fields and schema changes.
@@ -61,6 +62,7 @@ export class SharedTreeChangeFamily
 		fieldBatchCodec: FieldBatchCodec,
 		codecOptions: ICodecOptions,
 		chunkCompressionStrategy?: TreeCompressionStrategy,
+		private readonly idCompressor?: IIdCompressor
 	) {
 		const modularChangeCodec = makeModularChangeCodecFamily(
 			fieldKindConfigurations,
@@ -79,7 +81,7 @@ export class SharedTreeChangeFamily
 	public buildEditor(
 		changeReceiver: (change: SharedTreeChange) => void,
 	): SharedTreeEditBuilder {
-		return new SharedTreeEditBuilder(this.modularChangeFamily, changeReceiver);
+		return new SharedTreeEditBuilder(this.modularChangeFamily, changeReceiver, this.idCompressor);
 	}
 
 	public compose(changes: TaggedChange<SharedTreeChange>[]): SharedTreeChange {

--- a/packages/dds/tree/src/shared-tree/sharedTreeEditBuilder.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeEditBuilder.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type { ChangeFamilyEditor, TreeStoredSchema } from "../core/index.js";
 import {
 	DefaultEditBuilder,
@@ -48,11 +49,13 @@ export class SharedTreeEditBuilder
 	public constructor(
 		modularChangeFamily: ModularChangeFamily,
 		private readonly changeReceiver: (change: SharedTreeChange) => void,
+		idCompressor?: IIdCompressor
 	) {
 		super(modularChangeFamily, (change) =>
 			changeReceiver({
 				changes: [{ type: "data", innerChange: change }],
 			}),
+			idCompressor
 		);
 
 		this.schema = {

--- a/packages/dds/tree/src/shared-tree/sharedTreeEditBuilder.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeEditBuilder.ts
@@ -49,13 +49,15 @@ export class SharedTreeEditBuilder
 	public constructor(
 		modularChangeFamily: ModularChangeFamily,
 		private readonly changeReceiver: (change: SharedTreeChange) => void,
-		idCompressor?: IIdCompressor
+		idCompressor?: IIdCompressor,
 	) {
-		super(modularChangeFamily, (change) =>
-			changeReceiver({
-				changes: [{ type: "data", innerChange: change }],
-			}),
-			idCompressor
+		super(
+			modularChangeFamily,
+			(change) =>
+				changeReceiver({
+					changes: [{ type: "data", innerChange: change }],
+				}),
+			idCompressor,
 		);
 
 		this.schema = {

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -238,6 +238,7 @@ export function createTreeCheckout(
 				makeFieldBatchCodec(defaultCodecOptions, defaultFieldBatchVersion),
 			{ jsonValidator: noopValidator },
 			args?.chunkCompressionStrategy,
+			idCompressor
 		);
 	const branch =
 		args?.branch ??

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -238,7 +238,7 @@ export function createTreeCheckout(
 				makeFieldBatchCodec(defaultCodecOptions, defaultFieldBatchVersion),
 			{ jsonValidator: noopValidator },
 			args?.chunkCompressionStrategy,
-			idCompressor
+			idCompressor,
 		);
 	const branch =
 		args?.branch ??

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -111,7 +111,7 @@ function bench(
 					"BasicChunkCursor",
 					() => {
 						const input = cursorForJsonableTreeNode(encodedTree);
-						const chunk = basicChunkTree(input, defaultChunkPolicy);
+						const chunk = basicChunkTree(input, { policy: defaultChunkPolicy });
 						const cursor = chunk.cursor();
 						cursor.enterNode(0);
 						return cursor;

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -111,7 +111,10 @@ function bench(
 					"BasicChunkCursor",
 					() => {
 						const input = cursorForJsonableTreeNode(encodedTree);
-						const chunk = basicChunkTree(input, { policy: defaultChunkPolicy });
+						const chunk = basicChunkTree(input, {
+							policy: defaultChunkPolicy,
+							idCompressor: undefined,
+						});
 						const cursor = chunk.cursor();
 						cursor.enterNode(0);
 						return cursor;

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
@@ -21,6 +21,7 @@ import {
 	basicChunkTree,
 	basicOnlyChunkPolicy,
 	chunkField,
+	type ChunkCompressor,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/chunkTree.js";
 // eslint-disable-next-line import/no-internal-modules
@@ -44,16 +45,21 @@ import { emptyShape, testData } from "./uniformChunkTestData.js";
 import { JsonObject } from "../../json/index.js";
 import { numberSchema } from "../../../simple-tree/index.js";
 
+const basicOnlyChunkCompressor: ChunkCompressor = {
+	policy: basicOnlyChunkPolicy,
+	idCompressor: undefined,
+};
+
 describe("basic chunk", () => {
 	it("calling chunkTree on existing chunk adds a reference", () => {
 		const data: JsonableTree = { type: brand("Foo"), value: "test" };
 		const inputCursor = cursorForJsonableTreeNode(data);
-		const chunk = chunkTree(inputCursor, { policy: basicOnlyChunkPolicy });
+		const chunk = chunkTree(inputCursor, basicOnlyChunkCompressor);
 		assert(!chunk.isShared(), "newly created chunk should not have more than one reference");
 
 		const chunkCursor = chunk.cursor();
 		chunkCursor.firstNode();
-		const newChunk = chunkTree(chunkCursor, { policy: basicOnlyChunkPolicy });
+		const newChunk = chunkTree(chunkCursor, basicOnlyChunkCompressor);
 		assert(
 			newChunk.isShared() && chunk.isShared(),
 			"chunk created off of existing chunk should be shared",
@@ -63,11 +69,11 @@ describe("basic chunk", () => {
 	it("calling chunkField on existing chunk adds a reference", () => {
 		const data: JsonableTree = { type: brand("Foo"), value: "test" };
 		const inputCursor = cursorForJsonableTreeNode(data);
-		const chunk = chunkTree(inputCursor, { policy: basicOnlyChunkPolicy });
+		const chunk = chunkTree(inputCursor, basicOnlyChunkCompressor);
 		assert(!chunk.isShared(), "newly created chunk should not have more than one reference");
 
 		const chunkCursor = chunk.cursor();
-		const newChunk = chunkField(chunkCursor, { policy: basicOnlyChunkPolicy });
+		const newChunk = chunkField(chunkCursor, basicOnlyChunkCompressor);
 		assert(
 			newChunk[0].isShared() && chunk.isShared(),
 			"chunk created off of existing chunk should be shared",
@@ -78,7 +84,7 @@ describe("basic chunk", () => {
 		"basic chunk",
 		(data): ITreeCursor => {
 			const inputCursor = cursorForJsonableTreeNode(data);
-			const chunk = basicChunkTree(inputCursor, { policy: basicOnlyChunkPolicy });
+			const chunk = basicChunkTree(inputCursor, basicOnlyChunkCompressor);
 			const cursor: ITreeCursor = chunk.cursor();
 			cursor.enterNode(0);
 			return cursor;

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
@@ -48,12 +48,12 @@ describe("basic chunk", () => {
 	it("calling chunkTree on existing chunk adds a reference", () => {
 		const data: JsonableTree = { type: brand("Foo"), value: "test" };
 		const inputCursor = cursorForJsonableTreeNode(data);
-		const chunk = chunkTree(inputCursor, basicOnlyChunkPolicy);
+		const chunk = chunkTree(inputCursor, { policy: basicOnlyChunkPolicy });
 		assert(!chunk.isShared(), "newly created chunk should not have more than one reference");
 
 		const chunkCursor = chunk.cursor();
 		chunkCursor.firstNode();
-		const newChunk = chunkTree(chunkCursor, basicOnlyChunkPolicy);
+		const newChunk = chunkTree(chunkCursor, { policy: basicOnlyChunkPolicy });
 		assert(
 			newChunk.isShared() && chunk.isShared(),
 			"chunk created off of existing chunk should be shared",
@@ -63,11 +63,11 @@ describe("basic chunk", () => {
 	it("calling chunkField on existing chunk adds a reference", () => {
 		const data: JsonableTree = { type: brand("Foo"), value: "test" };
 		const inputCursor = cursorForJsonableTreeNode(data);
-		const chunk = chunkTree(inputCursor, basicOnlyChunkPolicy);
+		const chunk = chunkTree(inputCursor, { policy: basicOnlyChunkPolicy });
 		assert(!chunk.isShared(), "newly created chunk should not have more than one reference");
 
 		const chunkCursor = chunk.cursor();
-		const newChunk = chunkField(chunkCursor, basicOnlyChunkPolicy);
+		const newChunk = chunkField(chunkCursor, { policy: basicOnlyChunkPolicy });
 		assert(
 			newChunk[0].isShared() && chunk.isShared(),
 			"chunk created off of existing chunk should be shared",
@@ -78,7 +78,7 @@ describe("basic chunk", () => {
 		"basic chunk",
 		(data): ITreeCursor => {
 			const inputCursor = cursorForJsonableTreeNode(data);
-			const chunk = basicChunkTree(inputCursor, basicOnlyChunkPolicy);
+			const chunk = basicChunkTree(inputCursor, { policy: basicOnlyChunkPolicy });
 			const cursor: ITreeCursor = chunk.cursor();
 			cursor.enterNode(0);
 			return cursor;

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -54,15 +54,18 @@ import {
 } from "../../../shared-tree/index.js";
 import {
 	MockTreeCheckout,
-	SummarizeType,
-	TestTreeProvider,
 	TestTreeProviderLite,
 	checkoutWithContent,
 	cursorFromInsertableTreeField,
 	forestWithContent,
 	testIdCompressor,
 } from "../../utils.js";
-import { numberSchema, SchemaFactory, stringSchema, TreeViewConfiguration } from "../../../simple-tree/index.js";
+import {
+	numberSchema,
+	SchemaFactory,
+	stringSchema,
+	TreeViewConfiguration,
+} from "../../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { toStoredSchema } from "../../../simple-tree/toFlexSchema.js";
 import { SummaryType } from "@fluidframework/driver-definitions";
@@ -383,45 +386,50 @@ describe("End to end chunked encoding", () => {
 		});
 
 		it("Initializing tree creates uniform chunks with encoded identifiers", async () => {
-			const factory = new SharedTreeFactory({ jsonValidator: typeboxValidator, forest: ForestType.Optimized })
+			const factory = new SharedTreeFactory({
+				jsonValidator: typeboxValidator,
+				forest: ForestType.Optimized,
+			});
 			const provider = new TestTreeProviderLite(1, factory, true);
 
 			// Workaround for getting the same id values from the TestTreeProviderLite's deterministic id compressor
-			const random = makeRandom(0xdeadbeef)
-			const deterministicIdCompressor = createIdCompressor(random.uuid4() as SessionId)
-			const stableId = deterministicIdCompressor.decompress(deterministicIdCompressor.generateCompressedId())
+			const random = makeRandom(0xdeadbeef);
+			const deterministicIdCompressor = createIdCompressor(random.uuid4() as SessionId);
+			const stableId = deterministicIdCompressor.decompress(
+				deterministicIdCompressor.generateCompressedId(),
+			);
 
 			class TreeWithIdentifier extends schemaFactory.object("treeWithIdentifier", {
-				identifier: schemaFactory.identifier
-			}){}
+				identifier: schemaFactory.identifier,
+			}) {}
 			const view = provider.trees[0].viewWith(
 				new TreeViewConfiguration({
 					schema: TreeWithIdentifier,
 				}),
 			);
 			view.initialize({});
-			const forest = view.checkout.forest
-			assert(forest instanceof ChunkedForest)
-			const uniformChunk = forest.roots.fields.get(rootFieldKey)?.at(0)
-			assert(uniformChunk instanceof UniformChunk)
-			const chunkValues = uniformChunk.values
-			assert.deepEqual(chunkValues, [deterministicIdCompressor.recompress(stableId)])
+			const forest = view.checkout.forest;
+			assert(forest instanceof ChunkedForest);
+			const uniformChunk = forest.roots.fields.get(rootFieldKey)?.at(0);
+			assert(uniformChunk instanceof UniformChunk);
+			const chunkValues = uniformChunk.values;
+			assert.deepEqual(chunkValues, [deterministicIdCompressor.recompress(stableId)]);
 
 			// When getting the value from the cursor, check that the value is unencoded string
 			const jsonableTree = mapCursorField(uniformChunk.cursor(), jsonableTreeFromCursor);
 			assert.deepEqual(jsonableTree, [
-				   {
-				     fields: {
-				       identifier: [
-				         {
-				           type: 'com.fluidframework.leaf.string',
-				           value: stableId
-				         }
-				       ]
-				     },
-				     type: 'com.example.treeWithIdentifier'
-				   }
-				 ])
+				{
+					fields: {
+						identifier: [
+							{
+								type: "com.fluidframework.leaf.string",
+								value: stableId,
+							},
+						],
+					},
+					type: "com.example.treeWithIdentifier",
+				},
+			]);
 		});
 	});
 });

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
@@ -32,11 +32,9 @@ import {
 } from "../../../feature-libraries/chunked-forest/chunkTree.js";
 // eslint-disable-next-line import/no-internal-modules
 import { SequenceChunk } from "../../../feature-libraries/chunked-forest/sequenceChunk.js";
-// eslint-disable-next-line import/no-internal-modules
 import {
 	TreeShape,
-	UniformChunk,
-// eslint-disable-next-line import/no-internal-modules
+	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/uniformChunk.js";
 import {
 	type TreeChunk,

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
@@ -8,6 +8,8 @@ import { strict as assert } from "assert";
 import {
 	CursorLocationType,
 	EmptyKey,
+	type FieldKey,
+	type JsonableTree,
 	type Value,
 	mapCursorField,
 } from "../../../core/index.js";
@@ -31,7 +33,11 @@ import {
 // eslint-disable-next-line import/no-internal-modules
 import { SequenceChunk } from "../../../feature-libraries/chunked-forest/sequenceChunk.js";
 // eslint-disable-next-line import/no-internal-modules
-import { TreeShape } from "../../../feature-libraries/chunked-forest/uniformChunk.js";
+import {
+	TreeShape,
+	UniformChunk,
+// eslint-disable-next-line import/no-internal-modules
+} from "../../../feature-libraries/chunked-forest/uniformChunk.js";
 import {
 	type TreeChunk,
 	cursorForJsonableTreeField,
@@ -51,9 +57,11 @@ import {
 	nullSchema,
 	numberSchema,
 	SchemaFactory,
+	stringSchema,
 	toStoredSchema,
 } from "../../../simple-tree/index.js";
-import { fieldJsonCursor } from "../../json/index.js";
+import { fieldJsonCursor, JsonObject } from "../../json/index.js";
+import { testIdCompressor } from "../../utils.js";
 
 const builder = new SchemaFactory("chunkTree");
 const empty = builder.object("empty", {});
@@ -136,12 +144,45 @@ describe("chunkTree", () => {
 				assert.equal(cursor.fieldIndex, 2);
 			}
 		});
+
+		it("encodes identifiers for in-memory representation", () => {
+			const identifierField: FieldKey = brand("identifierField");
+			const stringShape = new TreeShape(brand(stringSchema.identifier), true, [], true);
+			const identifierShape = new TreeShape(brand(JsonObject.identifier), false, [
+				[identifierField, stringShape, 1],
+			]);
+
+			const compressedId = testIdCompressor.generateCompressedId();
+			const stableId = testIdCompressor.decompress(compressedId);
+
+			const initialTree = {
+				type: brand(JsonObject.identifier),
+				fields: {
+					identifierField: [
+						{ type: brand("com.fluidframework.leaf.string"), value: stableId },
+					],
+				},
+			} satisfies JsonableTree;
+			const chunk = uniformChunkFromCursor(
+				cursorForJsonableTreeNode(initialTree),
+				identifierShape,
+				1,
+				true,
+				testIdCompressor,
+			);
+			assert.deepEqual(chunk.values, [compressedId]);
+		});
 	});
 
 	describe("chunkRange", () => {
 		it("single basic chunk", () => {
 			const cursor = cursorForJsonableTreeNode({ type: brand(nullSchema.identifier) });
-			const chunks = chunkRange(cursor, { policy: basicOnlyChunkPolicy }, 1, true);
+			const chunks = chunkRange(
+				cursor,
+				{ policy: basicOnlyChunkPolicy, idCompressor: undefined },
+				1,
+				true,
+			);
 			assert.equal(chunks.length, 1);
 			assert.equal(chunks[0].topLevelLength, 1);
 			assert.equal(cursor.fieldIndex, 0);
@@ -156,7 +197,12 @@ describe("chunkTree", () => {
 		it("full field basic chunk without skipLastNavigation", () => {
 			const cursor = cursorForJsonableTreeField([{ type: brand(nullSchema.identifier) }]);
 			cursor.firstNode();
-			const chunks = chunkRange(cursor, { policy: basicOnlyChunkPolicy }, 1, false);
+			const chunks = chunkRange(
+				cursor,
+				{ policy: basicOnlyChunkPolicy, idCompressor: undefined },
+				1,
+				false,
+			);
 			assert.equal(chunks.length, 1);
 			assert.equal(chunks[0].topLevelLength, 1);
 			// Should have existed the nodes and now be at fields level.
@@ -170,7 +216,12 @@ describe("chunkTree", () => {
 				{ type: brand(nullSchema.identifier) },
 			]);
 			cursor.firstNode();
-			const chunks = chunkRange(cursor, { policy: basicOnlyChunkPolicy }, 2, false);
+			const chunks = chunkRange(
+				cursor,
+				{ policy: basicOnlyChunkPolicy, idCompressor: undefined },
+				2,
+				false,
+			);
 			assert.equal(chunks.length, 2);
 			assert.equal(cursor.fieldIndex, 2);
 			assert.deepEqual(jsonableTreesFromFieldCursor(new SequenceChunk(chunks).cursor()), [
@@ -189,7 +240,7 @@ describe("chunkTree", () => {
 
 			const cursor = cursorForJsonableTreeField(numberSequenceField(4));
 			cursor.firstNode();
-			const chunks = chunkRange(cursor, { policy }, 3, false);
+			const chunks = chunkRange(cursor, { policy, idCompressor: undefined }, 3, false);
 			assert.equal(chunks.length, 2);
 			assert(chunks[0] instanceof SequenceChunk);
 			assert.equal(chunks[0].subChunks.length, 2);
@@ -238,7 +289,12 @@ describe("chunkTree", () => {
 					const field = numberSequenceField(fieldLength);
 					const cursor = cursorForJsonableTreeField(field);
 					cursor.firstNode();
-					const chunks = chunkRange(cursor, { policy }, fieldLength, true);
+					const chunks = chunkRange(
+						cursor,
+						{ policy, idCompressor: undefined },
+						fieldLength,
+						true,
+					);
 					assert.equal(cursor.fieldIndex, fieldLength - 1);
 
 					function checkChunks(
@@ -272,7 +328,12 @@ describe("chunkTree", () => {
 			cursor.firstNode();
 			assert.equal(tryGetChunk(cursor), chunk);
 			assert(!chunk.isShared());
-			const chunks = chunkRange(cursor, { policy: defaultChunkPolicy }, 1, false);
+			const chunks = chunkRange(
+				cursor,
+				{ policy: defaultChunkPolicy, idCompressor: undefined },
+				1,
+				false,
+			);
 			assert(chunk.isShared());
 			assert.equal(chunks[0], chunk);
 		});

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
@@ -9,7 +9,6 @@ import {
 	CursorLocationType,
 	EmptyKey,
 	type FieldKey,
-	type JsonableTree,
 	type Value,
 	mapCursorField,
 } from "../../../core/index.js";
@@ -58,7 +57,7 @@ import {
 	stringSchema,
 	toStoredSchema,
 } from "../../../simple-tree/index.js";
-import { fieldJsonCursor, JsonObject } from "../../json/index.js";
+import { fieldJsonCursor, JsonObject, singleJsonCursor } from "../../json/index.js";
 import { testIdCompressor } from "../../utils.js";
 
 const builder = new SchemaFactory("chunkTree");
@@ -153,16 +152,8 @@ describe("chunkTree", () => {
 			const compressedId = testIdCompressor.generateCompressedId();
 			const stableId = testIdCompressor.decompress(compressedId);
 
-			const initialTree = {
-				type: brand(JsonObject.identifier),
-				fields: {
-					identifierField: [
-						{ type: brand("com.fluidframework.leaf.string"), value: stableId },
-					],
-				},
-			} satisfies JsonableTree;
 			const chunk = uniformChunkFromCursor(
-				cursorForJsonableTreeNode(initialTree),
+				singleJsonCursor({ identifierField: stableId }),
 				identifierShape,
 				1,
 				true,

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
@@ -141,7 +141,7 @@ describe("chunkTree", () => {
 	describe("chunkRange", () => {
 		it("single basic chunk", () => {
 			const cursor = cursorForJsonableTreeNode({ type: brand(nullSchema.identifier) });
-			const chunks = chunkRange(cursor, basicOnlyChunkPolicy, 1, true);
+			const chunks = chunkRange(cursor, { policy: basicOnlyChunkPolicy }, 1, true);
 			assert.equal(chunks.length, 1);
 			assert.equal(chunks[0].topLevelLength, 1);
 			assert.equal(cursor.fieldIndex, 0);
@@ -156,7 +156,7 @@ describe("chunkTree", () => {
 		it("full field basic chunk without skipLastNavigation", () => {
 			const cursor = cursorForJsonableTreeField([{ type: brand(nullSchema.identifier) }]);
 			cursor.firstNode();
-			const chunks = chunkRange(cursor, basicOnlyChunkPolicy, 1, false);
+			const chunks = chunkRange(cursor, { policy: basicOnlyChunkPolicy }, 1, false);
 			assert.equal(chunks.length, 1);
 			assert.equal(chunks[0].topLevelLength, 1);
 			// Should have existed the nodes and now be at fields level.
@@ -170,7 +170,7 @@ describe("chunkTree", () => {
 				{ type: brand(nullSchema.identifier) },
 			]);
 			cursor.firstNode();
-			const chunks = chunkRange(cursor, basicOnlyChunkPolicy, 2, false);
+			const chunks = chunkRange(cursor, { policy: basicOnlyChunkPolicy }, 2, false);
 			assert.equal(chunks.length, 2);
 			assert.equal(cursor.fieldIndex, 2);
 			assert.deepEqual(jsonableTreesFromFieldCursor(new SequenceChunk(chunks).cursor()), [
@@ -189,7 +189,7 @@ describe("chunkTree", () => {
 
 			const cursor = cursorForJsonableTreeField(numberSequenceField(4));
 			cursor.firstNode();
-			const chunks = chunkRange(cursor, policy, 3, false);
+			const chunks = chunkRange(cursor, { policy }, 3, false);
 			assert.equal(chunks.length, 2);
 			assert(chunks[0] instanceof SequenceChunk);
 			assert.equal(chunks[0].subChunks.length, 2);
@@ -238,7 +238,7 @@ describe("chunkTree", () => {
 					const field = numberSequenceField(fieldLength);
 					const cursor = cursorForJsonableTreeField(field);
 					cursor.firstNode();
-					const chunks = chunkRange(cursor, policy, fieldLength, true);
+					const chunks = chunkRange(cursor, { policy }, fieldLength, true);
 					assert.equal(cursor.fieldIndex, fieldLength - 1);
 
 					function checkChunks(
@@ -272,7 +272,7 @@ describe("chunkTree", () => {
 			cursor.firstNode();
 			assert.equal(tryGetChunk(cursor), chunk);
 			assert(!chunk.isShared());
-			const chunks = chunkRange(cursor, defaultChunkPolicy, 1, false);
+			const chunks = chunkRange(cursor, { policy: defaultChunkPolicy }, 1, false);
 			assert(chunk.isShared());
 			assert.equal(chunks[0], chunk);
 		});

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
@@ -45,7 +45,7 @@ const codec = makeForestSummarizerCodec(codecOptions, fieldBatchCodec);
 
 const testFieldChunks: TreeChunk[] = chunkField(
 	cursorForJsonableTreeField([{ type: brand(EmptyObject.identifier) }]),
-	{ policy: defaultChunkPolicy },
+	{ policy: defaultChunkPolicy, idCompressor: testIdCompressor },
 );
 assert(testFieldChunks.length === 1);
 const testFieldChunk: TreeChunk = testFieldChunks[0];

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizerCodec.spec.ts
@@ -45,7 +45,7 @@ const codec = makeForestSummarizerCodec(codecOptions, fieldBatchCodec);
 
 const testFieldChunks: TreeChunk[] = chunkField(
 	cursorForJsonableTreeField([{ type: brand(EmptyObject.identifier) }]),
-	defaultChunkPolicy,
+	{ policy: defaultChunkPolicy },
 );
 assert(testFieldChunks.length === 1);
 const testFieldChunk: TreeChunk = testFieldChunks[0];

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -422,7 +422,7 @@ const rootChangeWithoutNodeFieldChanges: ModularChangeset = family.compose([
 const node1 = singleJsonCursor(1);
 const objectNode = singleJsonCursor({});
 const node1Chunk = treeChunkFromCursor(node1);
-const nodesChunk = chunkFieldSingle(fieldJsonCursor([{}, {}]), defaultChunkPolicy);
+const nodesChunk = chunkFieldSingle(fieldJsonCursor([{}, {}]), { policy: defaultChunkPolicy });
 
 describe("ModularChangeFamily", () => {
 	describe("compose", () => {
@@ -1407,13 +1407,13 @@ describe("ModularChangeFamily", () => {
 });
 
 function treeChunkFromCursor(cursor: ITreeCursorSynchronous): TreeChunk {
-	return chunkTree(cursor, defaultChunkPolicy);
+	return chunkTree(cursor, { policy: defaultChunkPolicy });
 }
 
 function deepCloneChunkedTree(chunk: TreeChunk): TreeChunk {
 	const jsonable = jsonableTreeFromFieldCursor(chunk.cursor());
 	const cursor = cursorForJsonableTreeField(jsonable);
-	const clone = chunkFieldSingle(cursor, defaultChunkPolicy);
+	const clone = chunkFieldSingle(cursor, { policy: defaultChunkPolicy });
 	return clone;
 }
 

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -422,7 +422,10 @@ const rootChangeWithoutNodeFieldChanges: ModularChangeset = family.compose([
 const node1 = singleJsonCursor(1);
 const objectNode = singleJsonCursor({});
 const node1Chunk = treeChunkFromCursor(node1);
-const nodesChunk = chunkFieldSingle(fieldJsonCursor([{}, {}]), { policy: defaultChunkPolicy });
+const nodesChunk = chunkFieldSingle(fieldJsonCursor([{}, {}]), {
+	policy: defaultChunkPolicy,
+	idCompressor: testIdCompressor,
+});
 
 describe("ModularChangeFamily", () => {
 	describe("compose", () => {
@@ -1407,13 +1410,16 @@ describe("ModularChangeFamily", () => {
 });
 
 function treeChunkFromCursor(cursor: ITreeCursorSynchronous): TreeChunk {
-	return chunkTree(cursor, { policy: defaultChunkPolicy });
+	return chunkTree(cursor, { policy: defaultChunkPolicy, idCompressor: testIdCompressor });
 }
 
 function deepCloneChunkedTree(chunk: TreeChunk): TreeChunk {
 	const jsonable = jsonableTreeFromFieldCursor(chunk.cursor());
 	const cursor = cursorForJsonableTreeField(jsonable);
-	const clone = chunkFieldSingle(cursor, { policy: defaultChunkPolicy });
+	const clone = chunkFieldSingle(cursor, {
+		policy: defaultChunkPolicy,
+		idCompressor: testIdCompressor,
+	});
 	return clone;
 }
 


### PR DESCRIPTION
 ## Description
Pass down the `idCompressor` to `uniformChunkFromCursor` to enable in-memory identifier encoding from [this PR](https://github.com/microsoft/FluidFramework/pull/22327)