### PR TITLE
ci: Use custom scoped token in release approval workflow

### DIFF
--- a/.github/workflows/release-approval.yml
+++ b/.github/workflows/release-approval.yml
@@ -156,7 +156,9 @@ jobs:
       - name: Check PR approval
         id: check-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The standard token doesn't have org:read permissions, and that scope can't be added using permissions in
+          # the workflow.
+          GITHUB_TOKEN: ${{ secrets.ORGANIZATION_READ_PAT }}
         continue-on-error: true
         run: |
           # This command will fail with an error if the PR is not approved, which


### PR DESCRIPTION
The standard token doesn't have `org:read` permissions, and that scope can't be added using permissions in the workflow. So instead use a custom token that has only those permissions.