### PR TITLE
Use the net Library for IP Type

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { isIPv4, isIPv6 } from "net";
 import {
 	IDeltaService,
 	IDocumentStorage,
@@ -105,17 +106,9 @@ export function create(
 						additionalProperties.hashedClientIPAddress = hashedClientIP;
 
 						const clientIPAddress = req.ip ? req.ip : "";
-						const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}$/;
-						const ipv6Regex = /^([\da-f]{1,4}:){7}[\da-f]{1,4}$/i;
-						if (
-							ipv4Regex.test(clientIPAddress) &&
-							clientIPAddress.split(".").every((part) => Number(part) <= 255)
-						) {
+						if (isIPv4(clientIPAddress)) {
 							additionalProperties.clientIPType = "IPv4";
-						} else if (
-							ipv6Regex.test(clientIPAddress) &&
-							clientIPAddress.split(":").every((part) => part.length <= 4)
-						) {
+						} else if (isIPv6(clientIPAddress)) {
 							additionalProperties.clientIPType = "IPv6";
 						} else {
 							additionalProperties.clientIPType = "";


### PR DESCRIPTION
Use the net library for IP type detection instead of your custom method. Some IP addresses may not be recognized or printed correctly if you use your own regular expression method.