### PR TITLE
Disable some gc/summarizer tests for standalone R11s

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
@@ -61,6 +61,14 @@ describeCompat("GC incremental summaries", "NoCompat", (getTestObjectProvider) =
 		return summaryResult.summaryVersion;
 	}
 
+	beforeEach("skip-r11s", async function () {
+		// Skip these tests for standalone r11s.  Summaries can take upwards of 20 seconds which times out the test.
+		// These tests are covering client logic and the coverage from other drivers/endpoints is sufficient.
+		if (provider.driver.type === "r11s" && provider.driver.endpointName !== "frs") {
+			this.skip();
+		}
+	});
+
 	beforeEach("setup", async () => {
 		provider = getTestObjectProvider({ syncSummarizer: true });
 		mainContainer = await provider.makeTestContainer(defaultGCConfig);
@@ -260,12 +268,12 @@ describeCompat("GC incremental summaries", "NoCompat", (getTestObjectProvider) =
 			await provider.ensureSynchronized();
 
 			// The next summary should fail - Override the "uploadSummaryWithContext" function so that that step fails.
-			const containerRuntime = (summarizer1 as any).runtime as ContainerRuntime;
-			const uploadSummaryWithContextFunc = containerRuntime.storage.uploadSummaryWithContext;
+			const containerRuntime1 = (summarizer1 as any).runtime as ContainerRuntime;
+			const uploadSummaryWithContextFunc = containerRuntime1.storage.uploadSummaryWithContext;
 			const uploadSummaryWithContextOverride = async () => {
 				throw new Error("Upload summary failed in test");
 			};
-			containerRuntime.storage.uploadSummaryWithContext = uploadSummaryWithContextOverride;
+			containerRuntime1.storage.uploadSummaryWithContext = uploadSummaryWithContextOverride;
 
 			// Summarize and validate that it fails.
 			const errorFn = (error: Error): boolean => {
@@ -281,7 +289,7 @@ describeCompat("GC incremental summaries", "NoCompat", (getTestObjectProvider) =
 			mockLogger.assertMatchNone([{ eventName: "IncrementalSummaryViolation" }]);
 
 			// Revert the "uploadSummaryWithContext" function so that summary will now succeed.
-			containerRuntime.storage.uploadSummaryWithContext = uploadSummaryWithContextFunc;
+			containerRuntime1.storage.uploadSummaryWithContext = uploadSummaryWithContextFunc;
 
 			// Summarize and validate that it succeeds.
 			await assert.doesNotReject(summarizeNow(summarizer1), "Summarize should have passed");

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
@@ -205,7 +205,7 @@ describeCompat("GC incremental summaries", "NoCompat", (getTestObjectProvider) =
 
 		// Summarize the new client and validate that both dataStoreA and dataStoreB are trees. dataStoreA because it
 		// has a new op and dataStoreB because its reference state changed from unreferenced -> referenced.
-		summaryVersion = await validateIncrementalSummary(summarizer2, dataStoreSummaryTypesMap); //* times out here
+		summaryVersion = await validateIncrementalSummary(summarizer2, dataStoreSummaryTypesMap);
 
 		// Close existing summarizer and load a new summarizer from the summary generated above.
 		summarizer2.close();
@@ -227,7 +227,7 @@ describeCompat("GC incremental summaries", "NoCompat", (getTestObjectProvider) =
 	 * test validates that when there are GC state updated data stores in a summary and that summary fails,
 	 * incrementalSummaryViolation is not logged in the next successful summary.
 	 */
-	itExpects.only(
+	itExpects(
 		"does not log incrementalSummaryViolation when summary fails with gc state updated data stores",
 		[
 			{
@@ -292,7 +292,7 @@ describeCompat("GC incremental summaries", "NoCompat", (getTestObjectProvider) =
 			containerRuntime1.storage.uploadSummaryWithContext = uploadSummaryWithContextFunc;
 
 			// Summarize and validate that it succeeds.
-			await assert.doesNotReject(summarizeNow(summarizer1), "Summarize should have passed"); //* Times out here
+			await assert.doesNotReject(summarizeNow(summarizer1), "Summarize should have passed");
 			// There should not be any IncrementalSummaryViolation errors.
 			mockLogger.assertMatchNone([{ eventName: "IncrementalSummaryViolation" }]);
 		},

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
@@ -61,19 +61,19 @@ describeCompat("GC incremental summaries", "NoCompat", (getTestObjectProvider) =
 		return summaryResult.summaryVersion;
 	}
 
+	beforeEach("setup", async () => {
+		provider = getTestObjectProvider({ syncSummarizer: true });
+		mainContainer = await provider.makeTestContainer(defaultGCConfig);
+		dataStoreA = (await mainContainer.getEntryPoint()) as ITestDataObject;
+		await waitForContainerConnection(mainContainer);
+	});
+
 	beforeEach("skip-r11s", async function () {
 		// Skip these tests for standalone r11s.  Summaries can take upwards of 20 seconds which times out the test.
 		// These tests are covering client logic and the coverage from other drivers/endpoints is sufficient.
 		if (provider.driver.type === "r11s" && provider.driver.endpointName !== "frs") {
 			this.skip();
 		}
-	});
-
-	beforeEach("setup", async () => {
-		provider = getTestObjectProvider({ syncSummarizer: true });
-		mainContainer = await provider.makeTestContainer(defaultGCConfig);
-		dataStoreA = (await mainContainer.getEntryPoint()) as ITestDataObject;
-		await waitForContainerConnection(mainContainer);
 	});
 
 	async function createNewDataStore() {
@@ -205,7 +205,7 @@ describeCompat("GC incremental summaries", "NoCompat", (getTestObjectProvider) =
 
 		// Summarize the new client and validate that both dataStoreA and dataStoreB are trees. dataStoreA because it
 		// has a new op and dataStoreB because its reference state changed from unreferenced -> referenced.
-		summaryVersion = await validateIncrementalSummary(summarizer2, dataStoreSummaryTypesMap);
+		summaryVersion = await validateIncrementalSummary(summarizer2, dataStoreSummaryTypesMap); //* times out here
 
 		// Close existing summarizer and load a new summarizer from the summary generated above.
 		summarizer2.close();
@@ -227,7 +227,7 @@ describeCompat("GC incremental summaries", "NoCompat", (getTestObjectProvider) =
 	 * test validates that when there are GC state updated data stores in a summary and that summary fails,
 	 * incrementalSummaryViolation is not logged in the next successful summary.
 	 */
-	itExpects(
+	itExpects.only(
 		"does not log incrementalSummaryViolation when summary fails with gc state updated data stores",
 		[
 			{
@@ -292,7 +292,7 @@ describeCompat("GC incremental summaries", "NoCompat", (getTestObjectProvider) =
 			containerRuntime1.storage.uploadSummaryWithContext = uploadSummaryWithContextFunc;
 
 			// Summarize and validate that it succeeds.
-			await assert.doesNotReject(summarizeNow(summarizer1), "Summarize should have passed");
+			await assert.doesNotReject(summarizeNow(summarizer1), "Summarize should have passed"); //* Times out here
 			// There should not be any IncrementalSummaryViolation errors.
 			mockLogger.assertMatchNone([{ eventName: "IncrementalSummaryViolation" }]);
 		},

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -187,7 +187,9 @@ export async function summarizeNow(
 		typeof inputs === "string" ? { reason: inputs } : inputs;
 	const result = summarizer.summarizeOnDemand(options);
 
-	const submitResult = await timeoutAwait(result.summarySubmitted);
+	const submitResult = await timeoutAwait(result.summarySubmitted, {
+		errorMsg: "Promise timed out: summarySubmitted",
+	});
 	if (!submitResult.success) {
 		throw submitResult.error;
 	}
@@ -197,12 +199,16 @@ export async function summarizeNow(
 	);
 	assert(submitResult.data.summaryTree !== undefined, "summary tree should exist");
 
-	const broadcastResult = await timeoutAwait(result.summaryOpBroadcasted);
+	const broadcastResult = await timeoutAwait(result.summaryOpBroadcasted, {
+		errorMsg: "Promise timed out: summaryOpBroadcasted",
+	});
 	if (!broadcastResult.success) {
 		throw broadcastResult.error;
 	}
 
-	const ackNackResult = await timeoutAwait(result.receivedSummaryAckOrNack);
+	const ackNackResult = await timeoutAwait(result.receivedSummaryAckOrNack, {
+		errorMsg: "Promise timed out: receivedSummaryAckOrNack",
+	});
 	if (!ackNackResult.success) {
 		throw ackNackResult.error;
 	}


### PR DESCRIPTION
## Description

Similar to #22409 -- These tests are timing out intermittently due to slow summarization on standalone R11s.  The test coverage we get from the other drivers/endpoints is sufficient, so just skip these tests there.

Fixes [AB#10954](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/10954)
Fixes [AB#11088](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/11088)
