### PR TITLE
docs: link to tree quick start guide

### DIFF
--- a/docs/content/docs/data-structures/tree.md
+++ b/docs/content/docs/data-structures/tree.md
@@ -7,6 +7,8 @@ menuPosition: 6
 
 The `SharedTree` distributed data structure (DDS), available in Fluid Framework 2 and later, is used to store most or all of your application's shared data in a hierarchical structure.
 
+To get started working with `SharedTree` in your application, read this [quick start guide](../start/tree-start.md).
+
 A `SharedTree` has the following characteristics:
 
 -   It is accessed through a `TreeView` object that exposes all the functionality for reading and editing data within a `SharedTree`.

--- a/packages/dds/tree/README.md
+++ b/packages/dds/tree/README.md
@@ -2,6 +2,8 @@
 
 A [tree](<https://en.wikipedia.org/wiki/Tree_(data_structure)>) data structure for the [Fluid Framework](https://fluidframework.com/).
 
+To get started working with `SharedTree` in your application, read this [quick start guide](https://fluidframework.com/docs/start/tree-start/).
+
 The contents of this package are also reported as part of the [`fluid-framework` package](https://www.npmjs.com/package/fluid-framework) which provides an alternative way to consume the functionality from this package.
 
 [SharedTree Philosophy](./docs/SharedTree%20Philosophy.md) covers the goals of the SharedTree project,


### PR DESCRIPTION
adds links to the new quick start guide to the tree dds page and the tree package readme