### PR TITLE
fix(ci): Only try to do code-coverage report steps if the report exists

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -381,28 +381,29 @@ extends:
                   - ${{ if parameters.testCoverage }}:
                       - task: Bash@3
                         displayName: Check for nyc/report directory
+                        condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
                         inputs:
                           targetType: 'inline'
                           workingDirectory: '${{ parameters.buildDirectory }}'
                           script: |
                             test -d nyc/report && echo '##vso[task.setvariable variable=ReportDirExists;]true' || echo 'No nyc/report directory'
-                        condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
                       - task: Bash@3
                         displayName: Patch Coverage Results
+                        condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
                         inputs:
                           targetType: 'inline'
                           workingDirectory: '${{ parameters.buildDirectory }}/nyc/report'
                           script: |
                             sed -e 's/\(filename=\".*[\\/]external .*\)"\(.*\)""/\1\&quot;\2\&quot;"/' cobertura-coverage.xml > cobertura-coverage-patched.xml
-                        condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
                       - task: PublishCodeCoverageResults@2
                         displayName: Publish Code Coverage
+                        condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
                         inputs:
                           summaryFileLocation: ${{ parameters.buildDirectory }}/nyc/report/cobertura-coverage-patched.xml
                           failIfCoverageEmpty: true
-                        condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
                       - task: CopyFiles@2
                         displayName: Copy code coverage report to artifact staging directory
+                        condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
                         inputs:
                           sourceFolder: '${{ parameters.buildDirectory }}/nyc/report'
                           targetFolder: $(Build.ArtifactStagingDirectory)/codeCoverageAnalysis
@@ -578,7 +579,7 @@ extends:
                 - ${{ if eq(parameters.testCoverage, true) }}:
                   - output: pipelineArtifact
                     displayName: Publish Artifacts - code-coverage
-                    condition: and( succeeded(), ne(variables['Build.Reason'], 'PullRequest') )
+                    condition: and( succeededOrFailed(), eq(variables['ReportDirExists'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
                     targetPath: $(Build.ArtifactStagingDirectory)/codeCoverageAnalysis
                     artifactName: codeCoverageAnalysis
                     sbomEnabled: false


### PR DESCRIPTION
## Description

https://github.com/microsoft/FluidFramework/pull/22346 added steps to publish the code coverage report in pipeline runs, but we failed to consider that the builds for some packages never produce code coverage reports, and those are failing now because we unconditionally try to find it to publish it. This PR adds a condition to the step that was failing (a condition several of its "sibling steps" already used, which guarantees the code coverage report exists) so it only runs when it should. The condition to publish the artifact was also updated in the same way.

I also moved the existing `condition` in some steps to before the `inputs`, where it is more readable (avoids having to "scan back" from the indented contents of `inputs`, which we usually have as the last bit for a `task`).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[Sample successful run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=291427&view=results) (msft internal) vs a [sample failing run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=291303&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=39d6a9ef-e0b1-5dca-74ed-08b7e0ea3619) (also msft internal).