### PR TITLE
Fix build pipelines which don't run coverage

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -406,6 +406,7 @@ extends:
                         inputs:
                           sourceFolder: '${{ parameters.buildDirectory }}/nyc/report'
                           targetFolder: $(Build.ArtifactStagingDirectory)/codeCoverageAnalysis
+                        condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
 
                   # Process test result, include publishing and logging
                   - template: /tools/pipelines/templates/include-process-test-results.yml@self


### PR DESCRIPTION
## Description

Fixes a regression introduced in #22346: coverage artifacts should only be copied when the report files exists. This uses the same condition as above steps.