### PR TITLE
tree: Add revision tag to changes from edit builder

### DIFF
--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -8,10 +8,13 @@ import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
 import type { ICodecFamily, IJsonCodec } from "../../codec/index.js";
 import type { SchemaAndPolicy } from "../../core/index.js";
 import type { JsonCompatibleReadOnly } from "../../util/index.js";
-import type { ChangeRebaser, RevisionTag } from "../rebase/index.js";
+import type { ChangeRebaser, RevisionTag, TaggedChange } from "../rebase/index.js";
 
 export interface ChangeFamily<TEditor extends ChangeFamilyEditor, TChange> {
-	buildEditor(changeReceiver: (change: TChange) => void): TEditor;
+	buildEditor(
+		mintRevisionTag: () => RevisionTag,
+		changeReceiver: (change: TaggedChange<TChange>) => void,
+	): TEditor;
 
 	readonly rebaser: ChangeRebaser<TChange>;
 	readonly codecs: ICodecFamily<TChange, ChangeEncodingContext>;

--- a/packages/dds/tree/src/core/change-family/editBuilder.ts
+++ b/packages/dds/tree/src/core/change-family/editBuilder.ts
@@ -3,12 +3,14 @@
  * Licensed under the MIT License.
  */
 
+import { tagChange, type RevisionTag, type TaggedChange } from "../rebase/index.js";
 import type { ChangeFamily, ChangeFamilyEditor } from "./changeFamily.js";
 
 export abstract class EditBuilder<TChange> implements ChangeFamilyEditor {
 	public constructor(
 		protected readonly changeFamily: ChangeFamily<ChangeFamilyEditor, TChange>,
-		private readonly changeReceiver: (change: TChange) => void,
+		private readonly mintRevisionTag: () => RevisionTag,
+		private readonly changeReceiver: (change: TaggedChange<TChange>) => void,
 	) {}
 
 	/**
@@ -17,7 +19,7 @@ export abstract class EditBuilder<TChange> implements ChangeFamilyEditor {
 	 * @sealed
 	 */
 	protected applyChange(change: TChange): void {
-		this.changeReceiver(change);
+		this.changeReceiver(tagChange(change, this.mintRevisionTag()));
 	}
 
 	public enterTransaction(): void {}

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -18,6 +18,7 @@ import {
 	type DeltaRoot,
 	type FieldUpPath,
 	type ITreeCursorSynchronous,
+	type RevisionTag,
 	type TaggedChange,
 	type UpPath,
 	compareFieldUpPaths,
@@ -67,8 +68,11 @@ export class DefaultChangeFamily
 		return this.modularFamily.codecs;
 	}
 
-	public buildEditor(changeReceiver: (change: DefaultChangeset) => void): DefaultEditBuilder {
-		return new DefaultEditBuilder(this, changeReceiver);
+	public buildEditor(
+		mintRevisionTag: () => RevisionTag,
+		changeReceiver: (change: TaggedChange<DefaultChangeset>) => void,
+	): DefaultEditBuilder {
+		return new DefaultEditBuilder(this, mintRevisionTag, changeReceiver);
 	}
 }
 
@@ -167,9 +171,15 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 
 	public constructor(
 		family: ChangeFamily<ChangeFamilyEditor, DefaultChangeset>,
-		changeReceiver: (change: DefaultChangeset) => void,
+		mintRevisionTag: () => RevisionTag,
+		changeReceiver: (change: TaggedChange<DefaultChangeset>) => void,
 	) {
-		this.modularBuilder = new ModularEditBuilder(family, fieldKinds, changeReceiver);
+		this.modularBuilder = new ModularEditBuilder(
+			family,
+			fieldKinds,
+			mintRevisionTag,
+			changeReceiver,
+		);
 	}
 
 	public enterTransaction(): void {

--- a/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
@@ -32,8 +32,11 @@ export function makeMitigatedChangeFamily<TEditor extends ChangeFamilyEditor, TC
 	onError: (error: unknown) => void,
 ): ChangeFamily<TEditor, TChange> {
 	return {
-		buildEditor: (changeReceiver: (change: TChange) => void): TEditor => {
-			return unmitigatedChangeFamily.buildEditor(changeReceiver);
+		buildEditor: (
+			mintRevisionTag: () => RevisionTag,
+			changeReceiver: (change: TaggedChange<TChange>) => void,
+		): TEditor => {
+			return unmitigatedChangeFamily.buildEditor(mintRevisionTag, changeReceiver);
 		},
 		rebaser: makeMitigatedRebaser(unmitigatedChangeFamily.rebaser, fallbackChange, onError),
 		codecs: unmitigatedChangeFamily.codecs,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -1575,8 +1575,11 @@ export class ModularChangeFamily
 		}
 	}
 
-	public buildEditor(changeReceiver: (change: ModularChangeset) => void): ModularEditBuilder {
-		return new ModularEditBuilder(this, this.fieldKinds, changeReceiver);
+	public buildEditor(
+		mintRevisionTag: () => RevisionTag,
+		changeReceiver: (change: TaggedChange<ModularChangeset>) => void,
+	): ModularEditBuilder {
+		return new ModularEditBuilder(this, this.fieldKinds, mintRevisionTag, changeReceiver);
 	}
 
 	private createEmptyFieldChange(fieldKind: FieldKindIdentifier): FieldChange {
@@ -2441,9 +2444,10 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 	public constructor(
 		family: ChangeFamily<ChangeFamilyEditor, ModularChangeset>,
 		private readonly fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor>,
-		changeReceiver: (change: ModularChangeset) => void,
+		mintRevisionTag: () => RevisionTag,
+		changeReceiver: (change: TaggedChange<ModularChangeset>) => void,
 	) {
-		super(family, changeReceiver);
+		super(family, mintRevisionTag, changeReceiver);
 		this.idAllocator = idAllocatorFromMaxId();
 	}
 

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -17,6 +17,7 @@ import {
 	mintCommit,
 	rebaseChange,
 	type RebaseStatsWithDuration,
+	tagChange,
 } from "../core/index.js";
 import { type Mutable, brand, fail, getOrCreate, mapIterable } from "../util/index.js";
 
@@ -642,7 +643,10 @@ export class EditManager<
 				...newChangeFullyRebased.telemetryProperties,
 			});
 
-			peerLocalBranch.apply(newCommit.change, newCommit.revision);
+			peerLocalBranch.apply(
+				tagChange(newCommit.change, newCommit.revision),
+				newCommit.revision,
+			);
 			this.pushCommitToTrunk(sequenceId, {
 				...newCommit,
 				change: newChangeFullyRebased.change,

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -446,7 +446,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		const {
 			commit: { revision, change },
 		} = this.messageCodec.decode(content, { idCompressor: this.idCompressor });
-		this.editManager.localBranch.apply(change, revision);
+		this.editManager.localBranch.apply({ change, revision }, revision);
 	}
 
 	public override getGCData(fullGC?: boolean): IGarbageCollectionData {

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -77,9 +77,14 @@ export class SharedTreeChangeFamily
 	}
 
 	public buildEditor(
-		changeReceiver: (change: SharedTreeChange) => void,
+		mintRevisionTag: () => RevisionTag,
+		changeReceiver: (change: TaggedChange<SharedTreeChange>) => void,
 	): SharedTreeEditBuilder {
-		return new SharedTreeEditBuilder(this.modularChangeFamily, changeReceiver);
+		return new SharedTreeEditBuilder(
+			this.modularChangeFamily,
+			mintRevisionTag,
+			changeReceiver,
+		);
 	}
 
 	public compose(changes: TaggedChange<SharedTreeChange>[]): SharedTreeChange {

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -720,9 +720,10 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			);
 		}
 
+		const revisionForApply = this.mintRevisionTag();
 		this.branch.apply(
-			change.change,
-			this.mintRevisionTag(),
+			{ change: change.change, revision: revisionForApply },
+			revisionForApply,
 			kind === CommitKind.Default || kind === CommitKind.Redo
 				? CommitKind.Undo
 				: CommitKind.Redo,

--- a/packages/dds/tree/src/test/editMinter.ts
+++ b/packages/dds/tree/src/test/editMinter.ts
@@ -10,6 +10,7 @@ import type {
 	DefaultChangeset,
 	DefaultEditBuilder,
 } from "../feature-libraries/index.js";
+import { mintRevisionTag } from "./utils.js";
 
 export type Editor = (builder: DefaultEditBuilder) => void;
 
@@ -18,9 +19,9 @@ export function makeEditMinter(
 	editor: Editor,
 ): () => DefaultChangeset {
 	let builtChangeset: DefaultChangeset | undefined;
-	const innerEditor = family.buildEditor((change) => {
+	const innerEditor = family.buildEditor(mintRevisionTag, (taggedChange) => {
 		assert(builtChangeset === undefined);
-		builtChangeset = change;
+		builtChangeset = taggedChange.change;
 	});
 	return (): DefaultChangeset => {
 		assert(builtChangeset === undefined);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -14,6 +14,7 @@ import {
 	mapCursorField,
 	RevisionTagCodec,
 	rootFieldKey,
+	type TaggedChange,
 	TreeStoredSchemaRepository,
 } from "../../../core/index.js";
 import { typeboxValidator } from "../../../external-utilities/index.js";
@@ -56,6 +57,7 @@ import {
 	checkoutWithContent,
 	cursorFromInsertableTreeField,
 	forestWithContent,
+	mintRevisionTag,
 	testIdCompressor,
 } from "../../utils.js";
 import { numberSchema, SchemaFactory, stringSchema } from "../../../simple-tree/index.js";
@@ -137,8 +139,8 @@ describe("End to end chunked encoding", () => {
 		assert(!chunk.isShared());
 		const changeLog: ModularChangeset[] = [];
 
-		const changeReceiver = (change: ModularChangeset) => {
-			changeLog.push(change);
+		const changeReceiver = (change: TaggedChange<ModularChangeset>) => {
+			changeLog.push(change.change);
 		};
 		const codec = makeModularChangeCodecFamily(
 			fieldKindConfigurations,
@@ -146,7 +148,11 @@ describe("End to end chunked encoding", () => {
 			fieldBatchCodec,
 			{ jsonValidator: typeboxValidator },
 		);
-		const dummyEditor = new DefaultEditBuilder(new DefaultChangeFamily(codec), changeReceiver);
+		const dummyEditor = new DefaultEditBuilder(
+			new DefaultChangeFamily(codec),
+			mintRevisionTag,
+			changeReceiver,
+		);
 		const checkout = new MockTreeCheckout(forest, dummyEditor as unknown as ISharedTreeEditor);
 		checkout.editor
 			.sequenceField({ field: rootFieldKey, parent: undefined })

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -121,7 +121,6 @@ function initializeEditableForest(data?: JsonableTree): {
 			testIdCompressor,
 		);
 	}
-	let currentRevision = mintRevisionTag();
 	const changes: TaggedChange<DefaultChangeset>[] = [];
 	const deltas: DeltaRoot[] = [];
 	const detachedFieldIndex = makeDetachedFieldIndex(
@@ -129,13 +128,11 @@ function initializeEditableForest(data?: JsonableTree): {
 		testRevisionTagCodec,
 		testIdCompressor,
 	);
-	const builder = new DefaultEditBuilder(family, (change) => {
-		const taggedChange = { revision: currentRevision, change };
+	const builder = new DefaultEditBuilder(family, mintRevisionTag, (taggedChange) => {
 		changes.push(taggedChange);
 		const delta = intoDelta(taggedChange);
 		deltas.push(delta);
-		applyDelta(delta, currentRevision, forest, detachedFieldIndex);
-		currentRevision = mintRevisionTag();
+		applyDelta(delta, taggedChange.revision, forest, detachedFieldIndex);
 	});
 	return {
 		forest,

--- a/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
@@ -13,6 +13,7 @@ import type {
 } from "../../core/index.js";
 import { makeMitigatedChangeFamily } from "../../feature-libraries/index.js";
 import type { ICodecFamily } from "../../codec/index.js";
+import { mintRevisionTag } from "../utils.js";
 
 const fallback = "Fallback";
 
@@ -88,8 +89,8 @@ const returningRebaser = returningFamily.rebaser;
 describe("makeMitigatedChangeFamily", () => {
 	it("does not interfere so long as nothing is thrown", () => {
 		assert.equal(
-			mitigatedReturningFamily.buildEditor(arg1),
-			returningFamily.buildEditor(arg1),
+			mitigatedReturningFamily.buildEditor(mintRevisionTag, arg1),
+			returningFamily.buildEditor(mintRevisionTag, arg1),
 		);
 		assert.equal(
 			mitigatedReturningRebaser.rebase(arg1, arg2, arg3),
@@ -120,7 +121,10 @@ describe("makeMitigatedChangeFamily", () => {
 	});
 	it("does not catch errors from buildEditor", () => {
 		errorLog.length = 0;
-		assert.throws(() => mitigatedThrowingFamily.buildEditor(arg1), new Error("buildEditor"));
+		assert.throws(
+			() => mitigatedThrowingFamily.buildEditor(mintRevisionTag, arg1),
+			new Error("buildEditor"),
+		);
 		assert.deepEqual(errorLog, []);
 	});
 	it("does affect codecs", () => {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -206,7 +206,7 @@ const pathA0A: FieldUpPath = { parent: pathA0, field: fieldA };
 const pathA0B: FieldUpPath = { parent: pathA0, field: fieldB };
 const pathB0A: FieldUpPath = { parent: pathB0, field: fieldA };
 
-const mainEditor = family.buildEditor(() => undefined);
+const mainEditor = family.buildEditor(mintRevisionTag, () => undefined);
 const rootChange1a = removeAliases(
 	mainEditor.buildChanges([
 		{
@@ -1378,7 +1378,7 @@ describe("ModularChangeFamily", () => {
 
 	it("build child change", () => {
 		const [changeReceiver, getChanges] = testChangeReceiver(family);
-		const editor = family.buildEditor(changeReceiver);
+		const editor = family.buildEditor(mintRevisionTag, changeReceiver);
 		const path: UpPath = {
 			parent: undefined,
 			parentField: fieldA,
@@ -1527,13 +1527,15 @@ function deepFreeze(object: object) {
 }
 
 function buildChangeset(edits: EditDescription[]): ModularChangeset {
-	const editor = family.buildEditor(() => undefined);
+	const editor = family.buildEditor(mintRevisionTag, () => undefined);
 	return editor.buildChanges(edits);
 }
 
 function buildExistsConstraint(path: UpPath): ModularChangeset {
 	const edits: ModularChangeset[] = [];
-	const editor = family.buildEditor((change) => edits.push(change));
+	const editor = family.buildEditor(mintRevisionTag, (taggedChange) =>
+		edits.push(taggedChange.change),
+	);
 	editor.addNodeExistsConstraint(path);
 	return edits[0];
 }

--- a/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -82,7 +82,7 @@ describe("ModularChangeFamily integration", () => {
 	describe("rebase", () => {
 		it("remove over cross-field move", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 
 			const rootPath = { parent: undefined, parentField: rootField, parentIndex: 0 };
 			editor.move(
@@ -136,7 +136,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("remove over cross-field move to edited field", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 
 			const rootPath = { parent: undefined, parentField: rootField, parentIndex: 0 };
 			editor.move(
@@ -191,7 +191,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("nested change over cross-field move", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 
 			editor.move(
 				{ parent: undefined, field: fieldA },
@@ -234,7 +234,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("cross-field move over remove", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			editor.sequenceField({ parent: undefined, field: fieldA }).remove(1, 1);
 			editor.move(
 				{ parent: undefined, field: fieldA },
@@ -263,7 +263,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("move over cross-field move", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			editor.move(
 				{ parent: undefined, field: fieldA },
 				0,
@@ -295,7 +295,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("Nested moves both requiring a second pass", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 
 			const fieldAPath = { parent: undefined, field: fieldA };
 
@@ -380,7 +380,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("over change which moves node upward", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			const nodeAPath: UpPath = { parent: undefined, parentField: fieldA, parentIndex: 0 };
 			const nodeBPath: UpPath = {
 				parent: nodeAPath,
@@ -426,7 +426,7 @@ describe("ModularChangeFamily integration", () => {
 		// This test demonstrates that a field may need three rebasing passes.
 		it("over change which moves into moved subtree", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			const nodePath1: UpPath = { parent: undefined, parentField: fieldA, parentIndex: 1 };
 
 			// The base changeset consists of the following two move edits.
@@ -485,7 +485,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("prunes its output", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			const nodeAPath: UpPath = { parent: undefined, parentField: fieldA, parentIndex: 0 };
 			const nodeBPath: UpPath = { parent: undefined, parentField: fieldB, parentIndex: 0 };
 
@@ -517,7 +517,7 @@ describe("ModularChangeFamily integration", () => {
 			 */
 
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			const nodeAPath: UpPath = { parent: undefined, parentField: fieldA, parentIndex: 0 };
 
 			// Moves A to an adjacent cell to its right
@@ -583,7 +583,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("cross-field move and nested changes", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			editor.move(
 				{ parent: undefined, field: fieldA },
 				0,
@@ -643,7 +643,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("cross-field move and inverse with nested changes", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			editor.move(
 				{ parent: undefined, field: fieldA },
 				0,
@@ -710,7 +710,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("two cross-field moves of same node", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			editor.move(
 				{ parent: undefined, field: fieldA },
 				0,
@@ -748,7 +748,7 @@ describe("ModularChangeFamily integration", () => {
 	describe("invert", () => {
 		it("Cross-field move of edited node", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 
 			editor.enterTransaction();
 
@@ -803,7 +803,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("Nested moves both requiring a second pass", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 
 			const fieldAPath = { parent: undefined, field: fieldA };
 			editor.enterTransaction();
@@ -1045,6 +1045,6 @@ function tagChangeInline(
 }
 
 function buildChangeset(edits: EditDescription[]): ModularChangeset {
-	const editor = family.buildEditor(() => undefined);
+	const editor = family.buildEditor(mintRevisionTag, () => undefined);
 	return editor.buildChanges(edits);
 }

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
@@ -276,7 +276,10 @@ describe("EditManager - Bench", () => {
 							const sequencedEdits: Commit<TestChange>[] = [];
 							for (let iChange = 0; iChange < count; iChange++) {
 								const revision = mintRevisionTag();
-								manager.localBranch.apply(TestChange.emptyChange, revision);
+								manager.localBranch.apply(
+									{ change: TestChange.emptyChange, revision },
+									revision,
+								);
 								sequencedEdits.push({
 									change: TestChange.emptyChange,
 									revision,

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
@@ -568,9 +568,20 @@ export function testCorrectness() {
 						rebaser: new NoOpChangeRebaser(),
 					});
 					const sequencedLocalChange = mintRevisionTag();
-					manager.localBranch.apply(TestChange.emptyChange, sequencedLocalChange);
-					manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
-					manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
+					manager.localBranch.apply(
+						{ change: TestChange.emptyChange, revision: sequencedLocalChange },
+						sequencedLocalChange,
+					);
+					const revision1 = mintRevisionTag();
+					manager.localBranch.apply(
+						{ change: TestChange.emptyChange, revision: revision1 },
+						revision1,
+					);
+					const revision2 = mintRevisionTag();
+					manager.localBranch.apply(
+						{ change: TestChange.emptyChange, revision: revision2 },
+						revision2,
+					);
 					manager.addSequencedChange(
 						{
 							change: TestChange.emptyChange,
@@ -596,8 +607,15 @@ export function testCorrectness() {
 						rebaser: new NoOpChangeRebaser(),
 					});
 					const sequencedLocalChange = mintRevisionTag();
-					manager.localBranch.apply(TestChange.emptyChange, sequencedLocalChange);
-					manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
+					manager.localBranch.apply(
+						{ change: TestChange.emptyChange, revision: sequencedLocalChange },
+						sequencedLocalChange,
+					);
+					const revision1 = mintRevisionTag();
+					manager.localBranch.apply(
+						{ change: TestChange.emptyChange, revision: revision1 },
+						revision1,
+					);
 					manager.addSequencedChange(
 						{
 							change: TestChange.emptyChange,
@@ -683,9 +701,10 @@ function applyLocalCommit(
 	inputContext: readonly number[] = [],
 	intention: number | number[] = [],
 ): Commit<TestChange> {
+	const revision = mintRevisionTag();
 	const [_, commit] = manager.localBranch.apply(
-		TestChange.mint(inputContext, intention),
-		mintRevisionTag(),
+		{ change: TestChange.mint(inputContext, intention), revision },
+		revision,
 	);
 	return {
 		change: commit.change,

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
@@ -269,7 +269,7 @@ export function runUnitTestScenario(
 					localCommits.push(commit);
 					knownToLocal.push(seq);
 					// Local changes should always lead to a delta that is equivalent to the local change.
-					manager.localBranch.apply(changeset, revision);
+					manager.localBranch.apply({ change: changeset, revision }, revision);
 					assert.deepEqual(
 						asDelta(manager.localBranch.getHead().change.intentions),
 						asDelta([seq]),

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
@@ -123,7 +123,8 @@ export function rebaseLocalEditsOverTrunkEdits<TChange>(
 	// Subscribe to the local branch to emulate the behavior of SharedTree
 	manager.localBranch.on("afterChange", ({ change }) => {});
 	for (let iChange = 0; iChange < localEditCount; iChange++) {
-		manager.localBranch.apply(mintChange(undefined), mintRevisionTag());
+		const revision = mintRevisionTag();
+		manager.localBranch.apply({ change: mintChange(undefined), revision }, revision);
 	}
 	const trunkEdits = makeArray(trunkEditCount, () => {
 		const revision = mintRevisionTag();

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
@@ -47,6 +47,7 @@ import { Change } from "../feature-libraries/optional-field/optionalFieldUtils.j
 import {
 	failCodecFamily,
 	jsonTreeFromForest,
+	mintRevisionTag,
 	testIdCompressor,
 	testRevisionTagCodec,
 } from "../utils.js";
@@ -56,12 +57,13 @@ const content: JsonCompatible = { x: 42 };
 const modularFamily = new ModularChangeFamily(fieldKinds, failCodecFamily);
 
 const dataChanges: ModularChangeset[] = [];
-const defaultEditor = new DefaultEditBuilder(modularFamily, (change) =>
-	dataChanges.push(change),
+const defaultEditor = new DefaultEditBuilder(modularFamily, mintRevisionTag, (change) =>
+	dataChanges.push(change.change),
 );
 const modularBuilder = new ModularEditBuilder(
 	modularFamily,
 	modularFamily.fieldKinds,
+	mintRevisionTag,
 	() => {},
 );
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
@@ -35,7 +35,7 @@ import type {
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../shared-tree/sharedTreeChangeTypes.js";
 import { ajvValidator } from "../codec/index.js";
-import { failCodecFamily, testRevisionTagCodec } from "../utils.js";
+import { failCodecFamily, mintRevisionTag, testRevisionTagCodec } from "../utils.js";
 import { singleJsonCursor } from "../json/index.js";
 
 const dataChanges: ModularChangeset[] = [];
@@ -46,8 +46,8 @@ const fieldBatchCodec = {
 };
 
 const modularFamily = new ModularChangeFamily(fieldKinds, failCodecFamily);
-const defaultEditor = new DefaultEditBuilder(modularFamily, (change) =>
-	dataChanges.push(change),
+const defaultEditor = new DefaultEditBuilder(modularFamily, mintRevisionTag, (taggedChange) =>
+	dataChanges.push(taggedChange.change),
 );
 
 // Side effects results in `dataChanges` being populated

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -942,11 +942,12 @@ export function makeEncodingTestSuite<TDecoded, TEncoded, TContext>(
 export function testChangeReceiver<TChange>(
 	_changeFamily?: ChangeFamily<ChangeFamilyEditor, TChange>,
 ): [
-	changeReceiver: Parameters<ChangeFamily<ChangeFamilyEditor, TChange>["buildEditor"]>[0],
+	changeReceiver: Parameters<ChangeFamily<ChangeFamilyEditor, TChange>["buildEditor"]>[1],
 	getChanges: () => readonly TChange[],
 ] {
 	const changes: TChange[] = [];
-	const changeReceiver = (change: TChange): number => changes.push(change);
+	const changeReceiver = (taggedChange: TaggedChange<TChange>): number =>
+		changes.push(taggedChange.change);
 	return [changeReceiver, () => [...changes]];
 }
 


### PR DESCRIPTION
## Description
When the Edit builder generates a change, it does not have a revision tag associated with it. The revision tag is added later by calling `ChangeRebaser.changeRevision`. We would prefer to instead ensure that edit builder generates changes that have this RevisionTag baked in from the start.
This PR updates the edit builder to generate a tagged change.

## Reviewer guidance
`SharedTreeBranch::apply` still accepts a `revision` parameter because the `revision` in `TaggedChange` may be undefined. One way to remove this for now would be to call `mintRevisionTag` in the `apply` function if tag is missing. Later the revision can be made required once all the code paths and usages have been updated.

[AB#13508](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/13508)