### PR TITLE
refactor(fluid-build): Mark symlink and depcheck-related APIs deprecated

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
@@ -99,6 +99,9 @@ export class FluidRepoBuild extends FluidRepo {
 		return true;
 	}
 
+	/**
+	 * @deprecated depcheck-related functionality will be removed in an upcoming release.
+	 */
 	public async depcheck(fix: boolean) {
 		for (const pkg of this.packages.packages) {
 			// Fluid specific
@@ -122,6 +125,9 @@ export class FluidRepoBuild extends FluidRepo {
 		}
 	}
 
+	/**
+	 * @deprecated symlink-related functionality will be removed in an upcoming release.
+	 */
 	public async symlink(options: ISymlinkOptions) {
 		// Only do parallel if we are checking only
 		const result = await this.packages.forEachAsync(

--- a/build-tools/packages/build-tools/src/fluidBuild/npmDepChecker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/npmDepChecker.ts
@@ -9,10 +9,10 @@ import { readFileAsync } from "../common/utils";
 import registerDebug from "debug";
 const traceDepCheck = registerDebug("fluid-build:depCheck");
 
-	/**
-	 * @deprecated depcheck-related functionality will be removed in an upcoming release.
-	 */
-	interface DepCheckRecord {
+/**
+ * @deprecated depcheck-related functionality will be removed in an upcoming release.
+ */
+interface DepCheckRecord {
 	name: string;
 	import: RegExp;
 	declare: RegExp;
@@ -21,10 +21,10 @@ const traceDepCheck = registerDebug("fluid-build:depCheck");
 	found: boolean;
 }
 
-	/**
-	 * @deprecated depcheck-related functionality will be removed in an upcoming release.
-	 */
-	export class NpmDepChecker {
+/**
+ * @deprecated depcheck-related functionality will be removed in an upcoming release.
+ */
+export class NpmDepChecker {
 	private readonly foundTypes: string[] = [
 		"@types/node",
 		"@types/expect-puppeteer",

--- a/build-tools/packages/build-tools/src/fluidBuild/npmDepChecker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/npmDepChecker.ts
@@ -9,7 +9,10 @@ import { readFileAsync } from "../common/utils";
 import registerDebug from "debug";
 const traceDepCheck = registerDebug("fluid-build:depCheck");
 
-interface DepCheckRecord {
+	/**
+	 * @deprecated depcheck-related functionality will be removed in an upcoming release.
+	 */
+	interface DepCheckRecord {
 	name: string;
 	import: RegExp;
 	declare: RegExp;
@@ -18,7 +21,10 @@ interface DepCheckRecord {
 	found: boolean;
 }
 
-export class NpmDepChecker {
+	/**
+	 * @deprecated depcheck-related functionality will be removed in an upcoming release.
+	 */
+	export class NpmDepChecker {
 	private readonly foundTypes: string[] = [
 		"@types/node",
 		"@types/expect-puppeteer",

--- a/build-tools/packages/build-tools/src/fluidBuild/options.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/options.ts
@@ -24,8 +24,20 @@ interface FastBuildOptions extends IPackageMatchedOptions, ISymlinkOptions {
 	buildTaskNames: string[];
 	build?: boolean;
 	vscode: boolean;
+
+	/**
+	 * @deprecated symlink-related functionality will be removed in an upcoming release.
+	 */
 	symlink: boolean;
+
+	/**
+	 * @deprecated symlink-related functionality will be removed in an upcoming release.
+	 */
 	fullSymlink: boolean | undefined;
+
+	/**
+	 * @deprecated depcheck-related functionality will be removed in an upcoming release.
+	 */
 	depcheck: boolean;
 	force: boolean;
 	install: boolean;
@@ -212,16 +224,25 @@ export function parseOptions(argv: string[]) {
 		}
 
 		if (arg === "--symlink") {
+			console.warn(
+				"The --symlink flag is deprecated and will be removed in an upcoming release.",
+			);
 			setSymlink(false);
 			continue;
 		}
 
 		if (arg === "--symlink:full") {
+			console.warn(
+				"The --symlink:full flag is deprecated and will be removed in an upcoming release.",
+			);
 			setSymlink(true);
 			continue;
 		}
 
 		if (arg === "--depcheck") {
+			console.warn(
+				"The --depcheck flag is deprecated and will be removed in an upcoming release.",
+			);
 			options.depcheck = true;
 			setBuild(false);
 			continue;

--- a/build-tools/packages/build-tools/src/fluidBuild/symlinkUtils.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/symlinkUtils.ts
@@ -27,6 +27,9 @@ const traceSymLink = registerDebug("fluid-build:symlink");
 
 const { warning } = defaultLogger;
 
+/**
+ * @deprecated symlink-related functionality will be removed in an upcoming release.
+ */
 async function writeAndReplace(outFile: string, bakFile: string, content: string) {
 	traceSymLink(`Writing ${outFile}`);
 	if (existsSync(`${outFile}`)) {
@@ -35,6 +38,9 @@ async function writeAndReplace(outFile: string, bakFile: string, content: string
 	return writeFileAsync(`${outFile}`, content);
 }
 
+/**
+ * @deprecated symlink-related functionality will be removed in an upcoming release.
+ */
 async function writeBin(dir: string, binName: string, pkgName: string, binPath: string) {
 	const outFile = path.normalize(`${dir}/node_modules/.bin/${binName}`);
 	const bakFile = path.normalize(`${dir}/node_modules/.bin/_${binName}`);
@@ -72,6 +78,9 @@ exit $ret`;
 	await writeAndReplace(`${outFile}`, `${bakFile}`, sh);
 }
 
+/**
+ * @deprecated symlink-related functionality will be removed in an upcoming release.
+ */
 async function revertBin(dir: string, binName: string) {
 	const outFile = path.normalize(`${dir}/node_modules/.bin/${binName}`);
 	const bakFile = path.normalize(`${dir}/node_modules/.bin/_${binName}`);
@@ -86,6 +95,9 @@ async function revertBin(dir: string, binName: string) {
 	}
 }
 
+/**
+ * @deprecated symlink-related functionality will be removed in an upcoming release.
+ */
 async function fixSymlink(
 	stat: fs.Stats | undefined,
 	symlinkPath: string,
@@ -138,11 +150,17 @@ async function revertSymlink(symlinkPath: string, pkg: Package, depBuildPackage:
 	}
 }
 
+/**
+ * @deprecated symlink-related functionality will be removed in an upcoming release.
+ */
 export interface ISymlinkOptions {
 	symlink: boolean;
 	fullSymlink: boolean | undefined;
 }
 
+/**
+ * @deprecated symlink-related functionality will be removed in an upcoming release.
+ */
 export async function symlinkPackage(
 	repo: FluidRepoBuild,
 	pkg: Package,


### PR DESCRIPTION
The symlink and depcheck-related functionality in fluid-build is not maintained and we are moving to rely on the workspace management features of the package manager instead of doing our own symlink management. Since these features are not well-maintained, documented, or used, they are marked as deprecated in this change. We can remove them in a future change, possibly in 0.46.