### PR TITLE
fix(client): make DataStore Runtime events intersectable

### DIFF
--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.legacy.alpha.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.legacy.alpha.api.md
@@ -107,7 +107,13 @@ export interface IFluidDataStoreRuntime extends IEventProvider<IFluidDataStoreRu
 // @alpha
 export interface IFluidDataStoreRuntimeEvents extends IEvent {
     // (undocumented)
-    (event: "disconnected" | "dispose" | "attaching" | "attached", listener: () => void): any;
+    (event: "disconnected", listener: () => void): any;
+    // (undocumented)
+    (event: "dispose", listener: () => void): any;
+    // (undocumented)
+    (event: "attaching", listener: () => void): any;
+    // (undocumented)
+    (event: "attached", listener: () => void): any;
     // (undocumented)
     (event: "op", listener: (message: ISequencedDocumentMessage) => void): any;
     // (undocumented)

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -27,7 +27,10 @@ import type { IChannel } from "./channel.js";
  * @alpha
  */
 export interface IFluidDataStoreRuntimeEvents extends IEvent {
-	(event: "disconnected" | "dispose" | "attaching" | "attached", listener: () => void);
+	(event: "disconnected", listener: () => void);
+	(event: "dispose", listener: () => void);
+	(event: "attaching", listener: () => void);
+	(event: "attached", listener: () => void);
 	(event: "op", listener: (message: ISequencedDocumentMessage) => void);
 	(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void);
 	(event: "connected", listener: (clientId: string) => void);


### PR DESCRIPTION
Keep events distinct such that interfaces with similar capabilities may be intersected.

No runtime change