### PR TITLE
fix(build-tools): restore support for older git versions

### DIFF
--- a/build-tools/packages/build-cli/src/library/git.ts
+++ b/build-tools/packages/build-cli/src/library/git.ts
@@ -211,6 +211,41 @@ export class Repository {
 	}
 
 	/**
+	 * Returns git output of all non-ignored files including deleted files that are not staged.
+	 * A given path may be included multiple timed in the array if git version does not support
+	 * `--deduplicate` option (introduced in v2.31.0).
+	 * Note that this function excludes files that are deleted locally AND staged.
+	 *
+	 * @param directory - A directory to filter the results by. Only files under this directory will be returned. To
+	 * return all files in the repo use the value `"."`.
+	 */
+	private async getAllGitFilesOutput(directory: string): Promise<string> {
+		const args = [
+			"ls-files",
+			directory,
+			// Includes cached (staged) files.
+			"--cached",
+			// Includes other (untracked) files that are not ignored.
+			"--others",
+			// Excludes files that are ignored by standard ignore rules.
+			"--exclude-standard",
+			// Shows the full path of the files relative to the repository root.
+			"--full-name",
+		];
+		const version = await this.gitClient.version();
+		if (version.major < 2 || version.minor < 31) {
+			this.log?.warning(
+				`git version (${version.major}.${version.minor}.${version.patch}) is stale. Recommend updating.`,
+			);
+		} else {
+			// Removes duplicate entries from the output.
+			args.push("--deduplicate");
+		}
+
+		return this.gitClient.raw(args);
+	}
+
+	/**
 	 * Returns an array containing repo repo-relative paths to all the files in the provided directory.
 	 * A given path will only be included once in the array; that is, there will be no duplicate paths.
 	 * Note that this function excludes files that are deleted locally whether the deletion is staged or not.
@@ -219,21 +254,7 @@ export class Repository {
 	 * return all files in the repo use the value `"."`.
 	 */
 	public async getFiles(directory: string): Promise<string[]> {
-		const results = await this.gitClient.raw(
-			"ls-files",
-			// Includes cached (staged) files.
-			"--cached",
-			// Includes other (untracked) files that are not ignored.
-			"--others",
-			// Excludes files that are ignored by standard ignore rules.
-			"--exclude-standard",
-			// Removes duplicate entries from the output.
-			"--deduplicate",
-			// Shows the full path of the files relative to the repository root.
-			"--full-name",
-			"--",
-			directory,
-		);
+		const results = await this.getAllGitFilesOutput(directory);
 
 		// This includes paths to deleted, unstaged files, so we get the list of deleted files from git status and remove
 		// those from the full list.

--- a/build-tools/packages/build-tools/src/common/gitRepo.ts
+++ b/build-tools/packages/build-tools/src/common/gitRepo.ts
@@ -226,41 +226,6 @@ export class GitRepo {
 	}
 
 	/**
-	 * Returns git output of all non-ignored files including deleted files that are not staged.
-	 * A given path may be included multiple timed in the array if git version does not support
-	 * `--deduplicate` option (introduced in v2.31.0).
-	 * Note that this function excludes files that are deleted locally AND staged.
-	 *
-	 * @param directory - A directory to filter the results by. Only files under this directory will be returned. To
-	 * return all files in the repo use the value `"."`.
-	 */
-	private async getAllGitFilesOutput(
-		directory: string,
-		preferredOptions: "--deduplicate"[] = ["--deduplicate"],
-	): Promise<string> {
-		/**
-		 * What these git ls-files flags do:
-		 *
-		 * ```
-		 * --cached: Includes cached (staged) files.
-		 * --others: Includes other (untracked) files that are not ignored.
-		 * --exclude-standard: Excludes files that are ignored by standard ignore rules.
-		 * --deduplicate: [If used] removes duplicate entries from the output.
-		 * --full-name: Shows the full path of the files relative to the repository root.
-		 * ```
-		 */
-		const command = `ls-files --cached --others --exclude-standard ${preferredOptions.join(" ")} --full-name ${directory}`;
-		try {
-			return await this.exec(command, `get files`);
-		} catch (error) {
-			if (preferredOptions.length === 0) {
-				throw error;
-			}
-			return this.getAllGitFilesOutput(directory, preferredOptions.slice(1));
-		}
-	}
-
-	/**
 	 * Returns an array containing repo repo-relative paths to all the files in the provided directory.
 	 * A given path will only be included once in the array; that is, there will be no duplicate paths.
 	 * Note that this function excludes files that are deleted locally whether the deletion is staged or not.
@@ -269,15 +234,27 @@ export class GitRepo {
 	 * return all files in the repo use the value `"."`.
 	 */
 	public async getFiles(directory: string): Promise<string[]> {
+		/**
+		 * What these git ls-files flags do:
+		 *
+		 * ```
+		 * --cached: Includes cached (staged) files.
+		 * --others: Includes other (untracked) files that are not ignored.
+		 * --exclude-standard: Excludes files that are ignored by standard ignore rules.
+		 * --full-name: Shows the full path of the files relative to the repository root.
+		 * ```
+		 *
+		 * Note that `--deduplicate` is not used here because it is not available until git version 2.31.0.
+		 */
+		const command = `ls-files --cached --others --exclude-standard --full-name ${directory}`;
 		const [fileResults, deletedFiles] = await Promise.all([
-			this.getAllGitFilesOutput(directory),
+			this.exec(command, `get files`),
 			this.getDeletedFiles(),
 		]);
 
+		// Deduplicate the list of files by building a Set.
 		// This includes paths to deleted, unstaged files, so we get the list of deleted files from git status and remove
 		// those from the full list.
-		// Note: an alternative mechanism to exclude deleted files is to use
-		// --debug and filter out files with zeroed stats.
 		const allFiles = new Set(
 			fileResults
 				.split("\n")
@@ -317,23 +294,20 @@ export class GitRepo {
 	/**
 	 * Execute git command
 	 *
-	 * @param command - the git command
-	 * @param error - description of command line to print when error happens
-	 * @param pipeStdIn - optinal string to pipe to stdin
-	 * @returns the output of the command
+	 * @param command the git command
+	 * @param error description of command line to print when error happens
 	 */
-	private async exec(command: string, error: string, pipeStdIn?: string): Promise<string> {
+	private async exec(command: string, error: string, pipeStdIn?: string) {
 		return exec(`git ${command}`, this.resolvedRoot, error, pipeStdIn);
 	}
 
 	/**
 	 * Execute git command
 	 *
-	 * @param command - the git command
-	 * @param pipeStdIn - optinal string to pipe to stdin
-	 * @returns the output of the command or undefined if there was an error
+	 * @param command the git command
+	 * @param error description of command line to print when error happens
 	 */
-	private async execNoError(command: string, pipeStdIn?: string): Promise<string | undefined> {
+	private async execNoError(command: string, pipeStdIn?: string) {
 		return execNoError(`git ${command}`, this.resolvedRoot, pipeStdIn);
 	}
 }

--- a/build-tools/packages/build-tools/src/common/utils.ts
+++ b/build-tools/packages/build-tools/src/common/utils.ts
@@ -180,11 +180,12 @@ export function isSameFileOrDir(f1: string, f2: string) {
 }
 
 /**
- * Execute a command. If there is an error, print error message and exit process
+ * Execute a command. If there is an error, throw.
  *
- * @param cmd Command line to execute
- * @param dir dir the directory to execute on
- * @param error description of command line to print when error happens
+ * @param cmd - Command line to execute
+ * @param dir - dir the directory to execute on
+ * @param error - description of command line to print when error happens
+ * @param pipeStdIn - optinal string to pipe to stdin
  */
 export async function exec(cmd: string, dir: string, error: string, pipeStdIn?: string) {
 	const result = await execAsync(cmd, { cwd: dir }, pipeStdIn);
@@ -197,13 +198,17 @@ export async function exec(cmd: string, dir: string, error: string, pipeStdIn?: 
 }
 
 /**
- * Execute a command. If there is an error, print error message and exit process
+ * Execute a command. If there is an error, undefined is returned.
  *
- * @param cmd Command line to execute
- * @param dir dir the directory to execute on
- * @param error description of command line to print when error happens
+ * @param cmd - Command line to execute
+ * @param dir - dir the directory to execute on
+ * @param pipeStdIn - optinal string to pipe to stdin
  */
-export async function execNoError(cmd: string, dir: string, pipeStdIn?: string) {
+export async function execNoError(
+	cmd: string,
+	dir: string,
+	pipeStdIn?: string,
+): Promise<string | undefined> {
 	const result = await execAsync(cmd, { cwd: dir }, pipeStdIn);
 	if (result.error) {
 		return undefined;

--- a/build-tools/packages/build-tools/src/common/utils.ts
+++ b/build-tools/packages/build-tools/src/common/utils.ts
@@ -185,7 +185,7 @@ export function isSameFileOrDir(f1: string, f2: string) {
  * @param cmd - Command line to execute
  * @param dir - dir the directory to execute on
  * @param error - description of command line to print when error happens
- * @param pipeStdIn - optinal string to pipe to stdin
+ * @param pipeStdIn - optional string to pipe to stdin
  */
 export async function exec(cmd: string, dir: string, error: string, pipeStdIn?: string) {
 	const result = await execAsync(cmd, { cwd: dir }, pipeStdIn);
@@ -202,7 +202,7 @@ export async function exec(cmd: string, dir: string, error: string, pipeStdIn?: 
  *
  * @param cmd - Command line to execute
  * @param dir - dir the directory to execute on
- * @param pipeStdIn - optinal string to pipe to stdin
+ * @param pipeStdIn - optional string to pipe to stdin
  */
 export async function execNoError(
 	cmd: string,


### PR DESCRIPTION
`--deduplicate` option was added to git in version 2.31.0 and is used as an optimization within build-tools. There is no policy or checking for a minimum git version; so, don't require a version with that support. Existing code already uses a Set; so, no additional deduplication logic is needed after removing the option.

Additionally, update comments in build-tool utils.

[AB#14894](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/14894)