### PR TITLE
tree: Cleanup toMapTree typing

### DIFF
--- a/packages/dds/tree/src/simple-tree/api/create.ts
+++ b/packages/dds/tree/src/simple-tree/api/create.ts
@@ -26,10 +26,10 @@ import {
 	UnhydratedContext,
 	type NodeKeyManager,
 } from "../../feature-libraries/index.js";
-import { getOrCreateNodeFromFlexTreeNode, type InsertableContent } from "../proxies.js";
+import { getOrCreateNodeFromFlexTreeNode } from "../proxies.js";
 import { getOrCreateMapTreeNode, isFieldInSchema } from "../../feature-libraries/index.js";
 import { toFlexSchema } from "../toFlexSchema.js";
-import { inSchemaOrThrow, mapTreeFromNodeData } from "../toMapTree.js";
+import { inSchemaOrThrow, mapTreeFromNodeData, type InsertableContent } from "../toMapTree.js";
 import {
 	applySchemaToParserOptions,
 	cursorFromVerbose,

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -4,6 +4,8 @@
  */
 
 import { oob } from "@fluidframework/core-utils/internal";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
+
 import { EmptyKey, type ExclusiveMapTree } from "../core/index.js";
 import {
 	type FlexTreeNodeSchema,
@@ -16,11 +18,7 @@ import {
 	isMapTreeSequenceField,
 	UnhydratedContext,
 } from "../feature-libraries/index.js";
-import {
-	type InsertableContent,
-	getOrCreateNodeFromFlexTreeNode,
-	prepareContentForHydration,
-} from "./proxies.js";
+import { getOrCreateNodeFromFlexTreeNode, prepareContentForHydration } from "./proxies.js";
 import { getOrCreateInnerNode } from "./proxyBinding.js";
 // This import seems to trigger a false positive `Type import "TreeNodeFromImplicitAllowedTypes" is used by decorator metadata` lint error.
 // Other ways to import (ex: import the module with the items as type imports) give different more real errors, and auto fix to this format,
@@ -42,10 +40,9 @@ import {
 	type TreeNodeSchema,
 	typeSchemaSymbol,
 } from "./core/index.js";
-import { mapTreeFromNodeData } from "./toMapTree.js";
+import { type InsertableContent, mapTreeFromNodeData } from "./toMapTree.js";
 import { fail } from "../util/index.js";
 import { getFlexSchema, toFlexSchema } from "./toFlexSchema.js";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { getKernel } from "./core/index.js";
 import { TreeNodeValid, type MostDerivedData } from "./treeNodeValid.js";
 

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -90,7 +90,6 @@ export type {
 } from "./typesUnsafe.js";
 export {
 	getTreeNodeForField,
-	type InsertableContent,
 	prepareContentForHydration,
 } from "./proxies.js";
 
@@ -107,7 +106,7 @@ export {
 	setField,
 } from "./objectNode.js";
 export type { TreeMapNode, MapNodeInsertableData } from "./mapNode.js";
-export { mapTreeFromNodeData } from "./toMapTree.js";
+export { mapTreeFromNodeData, type InsertableContent } from "./toMapTree.js";
 export type { SimpleTreeSchema } from "./simpleSchema.js";
 export {
 	type JsonSchemaId,

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -13,12 +13,7 @@ import {
 	getOrCreateMapTreeNode,
 	getSchemaAndPolicy,
 } from "../feature-libraries/index.js";
-import {
-	type FactoryContent,
-	type InsertableContent,
-	getTreeNodeForField,
-	prepareContentForHydration,
-} from "./proxies.js";
+import { getTreeNodeForField, prepareContentForHydration } from "./proxies.js";
 import { getOrCreateInnerNode } from "./proxyBinding.js";
 import {
 	createFieldSchema,
@@ -39,7 +34,11 @@ import {
 	type TreeNode,
 	typeSchemaSymbol,
 } from "./core/index.js";
-import { mapTreeFromNodeData } from "./toMapTree.js";
+import {
+	mapTreeFromNodeData,
+	type FactoryContent,
+	type InsertableContent,
+} from "./toMapTree.js";
 import { getFlexSchema, toFlexSchema } from "./toFlexSchema.js";
 import { brand, count, type RestrictiveReadonlyRecord } from "../util/index.js";
 import { TreeNodeValid, type MostDerivedData } from "./treeNodeValid.js";

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -20,11 +20,7 @@ import {
 	type MapTreeNode,
 	UnhydratedContext,
 } from "../feature-libraries/index.js";
-import {
-	type InsertableContent,
-	getTreeNodeForField,
-	prepareContentForHydration,
-} from "./proxies.js";
+import { getTreeNodeForField, prepareContentForHydration } from "./proxies.js";
 import { getOrCreateInnerNode } from "./proxyBinding.js";
 import {
 	type ImplicitFieldSchema,
@@ -47,7 +43,7 @@ import {
 	type InternalTreeNode,
 	type TreeNode,
 } from "./core/index.js";
-import { mapTreeFromNodeData } from "./toMapTree.js";
+import { mapTreeFromNodeData, type InsertableContent } from "./toMapTree.js";
 import { type RestrictiveReadonlyRecord, fail, type FlattenKeys } from "../util/index.js";
 import { getFlexSchema, toFlexSchema } from "./toFlexSchema.js";
 import type { ObjectNodeSchema, ObjectNodeSchemaInternalData } from "./objectNodeTypes.js";

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
@@ -28,7 +27,6 @@ import {
 	getKernel,
 	tryGetCachedTreeNode,
 	type TreeNode,
-	type Unhydrated,
 	getSimpleNodeSchemaFromNode,
 	type InternalTreeNode,
 } from "./core/index.js";
@@ -209,26 +207,3 @@ function bindProxies(proxies: RootedProxyPaths[], forest: IForestSubscription): 
 }
 
 // #endregion Content insertion and proxy binding
-
-/**
- * Content which can be used to build a node.
- * @remarks
- * Can contain unhydrated nodes, but can not be an unhydrated node at the root.
- */
-export type FactoryContent =
-	| IFluidHandle
-	| string
-	| number
-	| boolean
-	// eslint-disable-next-line @rushstack/no-new-null
-	| null
-	| Iterable<readonly [string, InsertableContent]>
-	| readonly InsertableContent[]
-	| {
-			readonly [P in string]?: InsertableContent;
-	  };
-
-/**
- * Content which can be inserted into a tree.
- */
-export type InsertableContent = Unhydrated<TreeNode> | FactoryContent;

--- a/packages/dds/tree/src/simple-tree/schemaTypes.ts
+++ b/packages/dds/tree/src/simple-tree/schemaTypes.ts
@@ -21,7 +21,7 @@ import type {
 	TreeNodeSchemaClass,
 } from "./core/index.js";
 import type { FieldKey } from "../core/index.js";
-import type { InsertableContent } from "./proxies.js";
+import type { InsertableContent } from "./toMapTree.js";
 
 /**
  * Returns true if the given schema is a {@link TreeNodeSchemaClass}, or otherwise false if it is a {@link TreeNodeSchemaNonClass}.

--- a/packages/dds/tree/src/simple-tree/toMapTree.ts
+++ b/packages/dds/tree/src/simple-tree/toMapTree.ts
@@ -715,7 +715,7 @@ export type FactoryContent =
 	| FactoryContentObject;
 
 /**
- * Record like object which can be used to build some kinds of nodes.
+ * Record-like object which can be used to build some kinds of nodes.
  * @remarks
  * Can contain unhydrated nodes, but can not be an unhydrated node at the root.
  *

--- a/packages/dds/tree/src/simple-tree/toMapTree.ts
+++ b/packages/dds/tree/src/simple-tree/toMapTree.ts
@@ -588,7 +588,7 @@ function shallowCompatibilityTest(
 	// If the schema has a required key which is not present in the input object, reject it.
 	for (const [fieldKey, fieldSchema] of schema.fields) {
 		if (data[fieldKey] === undefined && fieldSchema.requiresValue) {
-				return CompatibilityLevel.None;
+			return CompatibilityLevel.None;
 		}
 	}
 

--- a/packages/dds/tree/src/simple-tree/toMapTree.ts
+++ b/packages/dds/tree/src/simple-tree/toMapTree.ts
@@ -177,7 +177,7 @@ function nodeDataToMapTree(
 		}
 	}
 
-	assert(!isTreeNode(data), "data is known not to be a node after the above check.");
+	assert(!isTreeNode(data), "data without an inner node cannot be TreeNode");
 
 	const schema = getType(data, allowedTypes);
 

--- a/packages/dds/tree/src/simple-tree/toMapTree.ts
+++ b/packages/dds/tree/src/simple-tree/toMapTree.ts
@@ -25,7 +25,6 @@ import {
 import { brand, fail, isReadonlyArray, find } from "../util/index.js";
 
 import { nullSchema } from "./leafNodeSchema.js";
-import type { InsertableContent } from "./proxies.js";
 import {
 	type FieldSchema,
 	type ImplicitAllowedTypes,
@@ -44,10 +43,13 @@ import {
 	isTreeNode,
 	NodeKind,
 	type InnerNode,
+	type TreeNode,
 	type TreeNodeSchema,
+	type Unhydrated,
 } from "./core/index.js";
 import { SchemaValidationErrors, isNodeInSchema } from "../feature-libraries/index.js";
 import { isObjectNodeSchema } from "./objectNodeTypes.js";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 /**
  * Module notes:
@@ -157,10 +159,10 @@ function nodeDataToMapTree(
 ): ExclusiveMapTree {
 	// A special cache path for processing unhydrated nodes.
 	// They already have the mapTree, so there is no need to recompute it.
-	const flexNode = tryGetInnerNode(data);
-	if (flexNode !== undefined) {
-		if (isMapTreeNode(flexNode)) {
-			if (!allowedTypes.has(getSimpleNodeSchemaFromNode(flexNode))) {
+	const innerNode = tryGetInnerNode(data);
+	if (innerNode !== undefined) {
+		if (isMapTreeNode(innerNode)) {
+			if (!allowedTypes.has(getSimpleNodeSchemaFromNode(innerNode))) {
 				throw new UsageError("Invalid schema for this context.");
 			}
 			// TODO: mapTreeFromNodeData modifies the trees it gets to add defaults.
@@ -168,12 +170,14 @@ function nodeDataToMapTree(
 			// This is unnecessary and inefficient, but should be a no-op if all calls provide the same context (which they might not).
 			// A cleaner design (avoiding this cast) might be to apply defaults eagerly if they don't need a context, and lazily (when hydrating) if they do.
 			// This could avoid having to mutate the map tree to apply defaults, removing the need for this cast.
-			return flexNode.mapTree as ExclusiveMapTree;
+			return innerNode.mapTree as ExclusiveMapTree;
 		} else {
 			// The node is already hydrated, meaning that it already got inserted into the tree previously
 			throw new UsageError("A node may not be inserted into the tree more than once");
 		}
 	}
+
+	assert(!isTreeNode(data), "data is known not to be a node after the above check.");
 
 	const schema = getType(data, allowedTypes);
 
@@ -215,7 +219,7 @@ export function inSchemaOrThrow(maybeError: SchemaValidationErrors): void {
  * Used to determine which fallback values may be appropriate.
  */
 function leafToMapTree(
-	data: InsertableContent,
+	data: FactoryContent,
 	schema: TreeNodeSchema,
 	allowedTypes: ReadonlySet<TreeNodeSchema>,
 ): ExclusiveMapTree {
@@ -317,7 +321,7 @@ function arrayChildToMapTree(
  * validation should happen. If it does, the input tree will be validated against this schema + policy, and an error will
  * be thrown if the tree does not conform to the schema. If undefined, no validation against the stored schema is done.
  */
-function arrayToMapTree(data: InsertableContent, schema: TreeNodeSchema): ExclusiveMapTree {
+function arrayToMapTree(data: FactoryContent, schema: TreeNodeSchema): ExclusiveMapTree {
 	assert(schema.kind === NodeKind.Array, 0x922 /* Expected an array schema. */);
 	if (!(typeof data === "object" && data !== null && Symbol.iterator in data)) {
 		throw new UsageError(`Input data is incompatible with Array schema: ${data}`);
@@ -346,7 +350,7 @@ function arrayToMapTree(data: InsertableContent, schema: TreeNodeSchema): Exclus
  * validation should happen. If it does, the input tree will be validated against this schema + policy, and an error will
  * be thrown if the tree does not conform to the schema. If undefined, no validation against the stored schema is done.
  */
-function mapToMapTree(data: InsertableContent, schema: TreeNodeSchema): ExclusiveMapTree {
+function mapToMapTree(data: FactoryContent, schema: TreeNodeSchema): ExclusiveMapTree {
 	assert(schema.kind === NodeKind.Map, 0x923 /* Expected a Map schema. */);
 	if (!(typeof data === "object" && data !== null)) {
 		throw new UsageError(`Input data is incompatible with Map schema: ${data}`);
@@ -388,9 +392,14 @@ function mapToMapTree(data: InsertableContent, schema: TreeNodeSchema): Exclusiv
  * @param data - The tree data to be transformed. Must be a Record-like object.
  * @param schema - The schema associated with the value.
  */
-function objectToMapTree(data: InsertableContent, schema: TreeNodeSchema): ExclusiveMapTree {
+function objectToMapTree(data: FactoryContent, schema: TreeNodeSchema): ExclusiveMapTree {
 	assert(isObjectNodeSchema(schema), 0x924 /* Expected an Object schema. */);
-	if (typeof data !== "object" || data === null) {
+	if (
+		typeof data !== "object" ||
+		data === null ||
+		Symbol.iterator in data ||
+		isFluidHandle(data)
+	) {
 		throw new UsageError(`Input data is incompatible with Object schema: ${data}`);
 	}
 
@@ -426,10 +435,10 @@ function setFieldValue(
 }
 
 function getType(
-	data: InsertableContent,
+	data: FactoryContent,
 	allowedTypes: ReadonlySet<TreeNodeSchema>,
 ): TreeNodeSchema {
-	const possibleTypes = getPossibleTypes(allowedTypes, data as ContextuallyTypedNodeData);
+	const possibleTypes = getPossibleTypes(allowedTypes, data);
 	if (possibleTypes.length === 0) {
 		throw new UsageError(
 			`The provided data is incompatible with all of the types allowed by the schema. The set of allowed types is: ${JSON.stringify(
@@ -459,7 +468,7 @@ For class-based schema, this can be done by replacing an expression like "{foo: 
  */
 export function getPossibleTypes(
 	allowedTypes: ReadonlySet<TreeNodeSchema>,
-	data: ContextuallyTypedNodeData,
+	data: FactoryContent,
 ): TreeNodeSchema[] {
 	let best = CompatibilityLevel.None;
 	const possibleTypes: TreeNodeSchema[] = [];
@@ -507,12 +516,9 @@ enum CompatibilityLevel {
  */
 function shallowCompatibilityTest(
 	schema: TreeNodeSchema,
-	data: ContextuallyTypedNodeData,
+	data: FactoryContent,
 ): CompatibilityLevel {
-	assert(
-		data !== undefined,
-		0x889 /* undefined cannot be used as contextually typed data. Use ContextuallyTypedFieldData. */,
-	);
+	assert(data !== undefined, 0x889 /* undefined cannot be used as FactoryContent. */);
 
 	if (isTreeValue(data)) {
 		return allowsValue(schema, data) ? CompatibilityLevel.Normal : CompatibilityLevel.None;
@@ -582,7 +588,7 @@ function shallowCompatibilityTest(
 	// If the schema has a required key which is not present in the input object, reject it.
 	for (const [fieldKey, fieldSchema] of schema.fields) {
 		if (data[fieldKey] === undefined && fieldSchema.requiresValue) {
-			return CompatibilityLevel.None;
+				return CompatibilityLevel.None;
 		}
 	}
 
@@ -594,54 +600,6 @@ function allowsValue(schema: TreeNodeSchema, value: TreeValue): boolean {
 		return valueSchemaAllows(schema.info as ValueSchema, value);
 	}
 	return false;
-}
-
-/**
- * Content of a tree which needs external schema information to interpret.
- *
- * This format is intended for concise authoring of tree literals when the schema is statically known.
- *
- * Once schema aware APIs are implemented, they can be used to provide schema specific subsets of this type.
- */
-export type ContextuallyTypedNodeData =
-	| ContextuallyTypedNodeDataObject
-	| number
-	| string
-	| boolean
-	// eslint-disable-next-line @rushstack/no-new-null
-	| null
-	| readonly ContextuallyTypedNodeData[]
-	| ReadonlyMap<string, ContextuallyTypedNodeData>
-	| Iterable<ContextuallyTypedNodeData>
-	| Iterable<[string, ContextuallyTypedNodeData]>;
-
-/**
- * Content of a field which needs external schema information to interpret.
- *
- * This format is intended for concise authoring of tree literals when the schema is statically known.
- *
- * Once schema aware APIs are implemented, they can be used to provide schema specific subsets of this type.
- */
-export type ContextuallyTypedFieldData = ContextuallyTypedNodeData | undefined;
-
-/**
- * Object case of {@link ContextuallyTypedNodeData}.
- */
-export interface ContextuallyTypedNodeDataObject {
-	/**
-	 * Fields of this node, indexed by their field keys.
-	 *
-	 * Allow explicit undefined for compatibility with FlexTree, and type-safety on read.
-	 */
-	// TODO: make sure explicit undefined is actually handled correctly.
-	[key: FieldKey]: ContextuallyTypedFieldData;
-
-	/**
-	 * Fields of this node, indexed by their field keys as strings.
-	 *
-	 * Allow unbranded field keys as a convenience for literals.
-	 */
-	[key: string]: ContextuallyTypedFieldData;
 }
 
 /**
@@ -721,7 +679,7 @@ function provideDefault(
 		if (isConstant(fieldProvider)) {
 			return fieldProvider();
 		} else {
-			// Leaving field empty despite it needing a default value since a context was required and non was provided.
+			// Leaving field empty despite it needing a default value since a context was required and none was provided.
 			// Caller better handle this case by providing the default at some other point in time when the context becomes known.
 		}
 	}
@@ -739,3 +697,35 @@ function tryGetInnerNode(target: unknown): InnerNode | undefined {
 		return getKernel(target).tryGetInnerNode();
 	}
 }
+
+/**
+ * Content which can be used to build a node.
+ * @remarks
+ * Can contain unhydrated nodes, but can not be an unhydrated node at the root.
+ */
+export type FactoryContent =
+	| IFluidHandle
+	| string
+	| number
+	| boolean
+	// eslint-disable-next-line @rushstack/no-new-null
+	| null
+	| Iterable<readonly [string, InsertableContent]>
+	| readonly InsertableContent[]
+	| FactoryContentObject;
+
+/**
+ * Record like object which can be used to build some kinds of nodes.
+ * @remarks
+ * Can contain unhydrated nodes, but can not be an unhydrated node at the root.
+ *
+ * Supports object and map nodes.
+ */
+type FactoryContentObject = {
+	readonly [P in string]?: InsertableContent;
+};
+
+/**
+ * Content which can be inserted into a tree.
+ */
+export type InsertableContent = Unhydrated<TreeNode> | FactoryContent;

--- a/packages/dds/tree/src/test/simple-tree/mapTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/mapTree.spec.ts
@@ -36,8 +36,6 @@ import {
 	stringSchema,
 	type TreeNodeSchema,
 } from "../../simple-tree/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import type { InsertableContent } from "../../simple-tree/proxies.js";
 import {
 	type ContextualFieldProvider,
 	type ConstantFieldProvider,
@@ -52,6 +50,7 @@ import {
 	addDefaultsToMapTree,
 	getPossibleTypes,
 	mapTreeFromNodeData,
+	type InsertableContent,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../simple-tree/toMapTree.js";
 import { brand } from "../../util/index.js";

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -16,6 +16,7 @@ import {
 	isTreeNodeSchemaClass,
 	mapTreeFromNodeData,
 	type ImplicitFieldSchema,
+	type InsertableContent,
 	type InsertableTreeFieldFromImplicitField,
 	type NodeKind,
 	type TreeFieldFromImplicitField,
@@ -24,7 +25,6 @@ import {
 import {
 	getTreeNodeForField,
 	prepareContentForHydration,
-	type InsertableContent,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../simple-tree/proxies.js";
 // eslint-disable-next-line import/no-internal-modules


### PR DESCRIPTION
## Description

Deduplicate types used for input, removing the out of data (in both actual types allowed and names) contextually typed versions,
as well as making the typing more strict and reducing casts.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
