### PR TITLE
ci(client): trigger build client on changes to root directory

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -60,6 +60,7 @@ trigger:
     - release/*
   paths:
     include:
+    - '*'
     - packages/**
     - azure/**
     - examples/**
@@ -91,6 +92,7 @@ pr:
     - release/*
   paths:
     include:
+    - '*'
     - packages/**
     - azure/**
     - examples/**

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -60,18 +60,11 @@ trigger:
     - release/*
   paths:
     include:
-    - .prettierignore
-    - biome.json
-    - biome.jsonc
-    - packages
-    - azure
-    - examples
-    - experimental
-    - common/build/build-common
-    - lerna.json
-    - package.json
-    - pnpm-lock.yaml
-    - pnpm-workspace.yaml
+    - packages/**
+    - azure/**
+    - examples/**
+    - experimental/**
+    - common/build/build-common/**
     # markdown-magic is part of the client release group
     - tools/markdown-magic/*
     - tools/pipelines/build-client.yml
@@ -87,7 +80,8 @@ trigger:
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
-
+    exclude:
+      - '*/**'
 pr:
   branches:
     include:
@@ -97,17 +91,11 @@ pr:
     - release/*
   paths:
     include:
-    - .prettierignore
-    - packages
-    - azure
-    - examples
-    - experimental
-    - common/build/build-common
-    - lerna.json
-    - package.json
-    - pnpm-lock.yaml
-    - pnpm-workspace.yaml
-    - fluidBuild.config.cjs
+    - packages/**
+    - azure/**
+    - examples/**
+    - experimental/**
+    - common/build/build-common/**
     # markdown-magic is part of the client release group
     - tools/markdown-magic/*
     - tools/pipelines/build-client.yml
@@ -120,6 +108,8 @@ pr:
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
+    exclude:
+     - '*/**'
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -60,6 +60,7 @@ trigger:
     - release/*
   paths:
     include:
+    # Using * along with */** exclusion to capture changes to files in the root directory
     - '*'
     - packages/**
     - azure/**
@@ -82,7 +83,9 @@ trigger:
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
     exclude:
-      - '*/**'
+    # Since the * wildcard includes all changes in root and subdirectories
+    # we need to exclude the subdirectories to avoid triggering the pipeline on all changes
+    - '*/**'
 pr:
   branches:
     include:
@@ -92,6 +95,7 @@ pr:
     - release/*
   paths:
     include:
+    # Using * along with */** exclusion to capture changes to files in the root directory
     - '*'
     - packages/**
     - azure/**
@@ -111,7 +115,9 @@ pr:
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
     exclude:
-     - '*/**'
+    # Since the * wildcard includes all changes in root and subdirectories
+    # we need to exclude the subdirectories to avoid triggering the pipeline on all changes
+    - '*/**'
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self


### PR DESCRIPTION
Follow up to #22397:
- using the `'*/**'` exclusion patter to prevent `*` from including every sub directory

from the docs: "If you exclude a path, you cannot also include it unless you qualify it to a deeper folder. For example if you exclude /tools then you could include /tools/trigger-runs-on-these"

- since  `'*/**'` is such a broad pattern, adding `**` to current subdirectories to prevent conflict