### PR TITLE
MergeTree: Fix Text Client Logger for Obliterate

### DIFF
--- a/packages/dds/merge-tree/src/test/testClientLogger.ts
+++ b/packages/dds/merge-tree/src/test/testClientLogger.ts
@@ -16,7 +16,13 @@ import {
 	type IMergeTreeMaintenanceCallbackArgs,
 } from "../mergeTreeDeltaCallback.js";
 import { depthFirstNodeWalk } from "../mergeTreeNodeWalk.js";
-import { Marker, seqLTE, toRemovalInfo } from "../mergeTreeNodes.js";
+import {
+	Marker,
+	seqLTE,
+	toMoveInfo,
+	toRemovalInfo,
+	type ISegment,
+} from "../mergeTreeNodes.js";
 import { IMergeTreeOp } from "../ops.js";
 import { PropertySet, matchProperties } from "../properties.js";
 import { TextSegment } from "../textSegment.js";
@@ -350,7 +356,7 @@ export class TestClientLogger {
 					}
 					const text = TextSegment.is(node) ? node.text : Marker.is(node) ? "¶" : undefined;
 					if (text !== undefined) {
-						const removedNode = toRemovalInfo(node);
+						const removedNode = toMoveOrRemove(node);
 						if (removedNode === undefined) {
 							if (node.seq === UnassignedSequenceNumber) {
 								acked += "_".repeat(text.length);
@@ -360,17 +366,14 @@ export class TestClientLogger {
 								local += " ".repeat(text.length);
 							}
 						} else {
-							if (removedNode.removedSeq === UnassignedSequenceNumber) {
+							if (removedNode.seq === UnassignedSequenceNumber) {
 								acked += "_".repeat(text.length);
 								local +=
 									node.seq === UnassignedSequenceNumber
 										? "*".repeat(text.length)
 										: "-".repeat(text.length);
 							} else {
-								const removedSymbol = seqLTE(
-									removedNode.removedSeq,
-									client.getCollabWindow().minSeq,
-								)
+								const removedSymbol = seqLTE(removedNode.seq, client.getCollabWindow().minSeq)
 									? "~"
 									: "-";
 								acked += removedSymbol.repeat(text.length);
@@ -384,5 +387,16 @@ export class TestClientLogger {
 			}
 		}
 		return { acked, local };
+	}
+}
+
+function toMoveOrRemove(segment: ISegment): { seq: number } | undefined {
+	const mi = toMoveInfo(segment);
+	const ri = toRemovalInfo(segment);
+	if (mi !== undefined || ri !== undefined) {
+		return {
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
+			seq: mi?.movedSeq ?? ri?.removedSeq!,
+		};
 	}
 }


### PR DESCRIPTION
Adds support of obliterated segment to the test client logger output