### PR TITLE
ci(client): explicitly add root files to client trigger

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -60,18 +60,42 @@ trigger:
     - release/*
   paths:
     include:
+    - .dockerignore
+    - .gitattributes
+    - .gitignore
+    - .gitmodules
+    - .git-blame-ignore-revs
+    - .markdownlint.json
+    - .npmrc
+    - .nvmrc
     - .prettierignore
+    - .releaseGroup
+    - azure
     - biome.json
     - biome.jsonc
-    - packages
-    - azure
+    - BREAKING.md
+    - common/build/build-common
+    - ClientRequirements.md
+    - CODE_OF_CONDUCT.md
+    - CONTRIBUTING.md
+    - CredScanSuppressions.json
     - examples
     - experimental
-    - common/build/build-common
+    - fluidBuild.config.cjs
+    - layerInfo.json
     - lerna.json
+    - LICENSE
+    - NOTICE.md
+    - packages
+    - PACKAGES.md
     - package.json
     - pnpm-lock.yaml
     - pnpm-workspace.yaml
+    - prettier.config.cjs
+    - README.md
+    - scripts/*
+    - SECURITY.md
+    - syncpack.config.cjs
     # markdown-magic is part of the client release group
     - tools/markdown-magic/*
     - tools/pipelines/build-client.yml
@@ -86,7 +110,6 @@ trigger:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
-    - scripts/*
 
 pr:
   branches:
@@ -97,17 +120,42 @@ pr:
     - release/*
   paths:
     include:
+    - .dockerignore
+    - .gitattributes
+    - .gitignore
+    - .gitmodules
+    - .git-blame-ignore-revs
+    - .markdownlint.json
+    - .npmrc
+    - .nvmrc
     - .prettierignore
-    - packages
+    - .releaseGroup
     - azure
+    - biome.json
+    - biome.jsonc
+    - BREAKING.md
+    - common/build/build-common
+    - ClientRequirements.md
+    - CODE_OF_CONDUCT.md
+    - CONTRIBUTING.md
+    - CredScanSuppressions.json
     - examples
     - experimental
-    - common/build/build-common
+    - fluidBuild.config.cjs
+    - layerInfo.json
     - lerna.json
+    - LICENSE
+    - NOTICE.md
+    - packages
+    - PACKAGES.md
     - package.json
     - pnpm-lock.yaml
     - pnpm-workspace.yaml
-    - fluidBuild.config.cjs
+    - prettier.config.cjs
+    - README.md
+    - scripts/*
+    - SECURITY.md
+    - syncpack.config.cjs
     # markdown-magic is part of the client release group
     - tools/markdown-magic/*
     - tools/pipelines/build-client.yml
@@ -119,7 +167,6 @@ pr:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
-    - scripts/*
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self


### PR DESCRIPTION
The change in #22203 didn't work as expected. Instead of matching root entries with wildcards, adding explicit file entries to trigger changes to root files. Also ordered entries alphabetically.