### PR TITLE
tree: Remove FlexTreeField.isExactly

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -301,9 +301,6 @@ const unparentedLocation: LocationInField = {
 		is<TKind2 extends FlexFieldKind>(kind: TKind2) {
 			return this.schema.kind === kind.identifier;
 		},
-		isExactly(schema: FlexFieldSchema) {
-			return schema === FlexFieldSchema.empty;
-		},
 		boxedIterator(): IterableIterator<FlexTreeNode> {
 			return [].values();
 		},
@@ -360,10 +357,6 @@ class EagerMapTreeField implements MapTreeField {
 
 	public is<TKind2 extends FlexFieldKind>(kind: TKind2): this is FlexTreeTypedField<TKind2> {
 		return this.schema.kind === kind.identifier;
-	}
-
-	public isExactly(schema: FlexFieldSchema): boolean {
-		return this.flexSchema.equals(schema);
 	}
 
 	public boxedIterator(): IterableIterator<FlexTreeNode> {

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -20,7 +20,7 @@ import type {
 	OptionalFieldEditBuilder,
 } from "../default-schema/index.js";
 import type { FlexFieldKind } from "../modular-schema/index.js";
-import type { FlexFieldSchema, FlexTreeNodeSchema } from "../typed-schema/index.js";
+import type { FlexTreeNodeSchema } from "../typed-schema/index.js";
 
 import type { FlexTreeContext } from "./context.js";
 
@@ -230,11 +230,6 @@ export interface FlexTreeField extends FlexTreeEntity {
 	 * Type guard for narrowing / down-casting to a specific schema.
 	 */
 	is<TKind extends FlexFieldKind>(kind: TKind): this is FlexTreeTypedField<TKind>;
-
-	/**
-	 * Type guard for narrowing / down-casting to a specific schema.
-	 */
-	isExactly(schema: FlexFieldSchema): boolean;
 
 	boxedIterator(): IterableIterator<FlexTreeNode>;
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -174,15 +174,6 @@ export abstract class LazyField<out TKind extends FlexFieldKind>
 		return this.flexSchema.kind === (kind as unknown);
 	}
 
-	public isExactly<TSchema extends FlexFieldSchema>(schema: TSchema): boolean {
-		assert(
-			this.context.flexSchema.policy.fieldKinds.get(schema.kind.identifier) === schema.kind,
-			0x77c /* Narrowing must be done to a kind that exists in this context */,
-		);
-
-		return this.flexSchema.equals(schema);
-	}
-
 	public get parent(): FlexTreeNode | undefined {
 		if (this[anchorSymbol].parent === undefined) {
 			return undefined;

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -120,24 +120,9 @@ describe("LazyField", () => {
 			detachedFieldAnchor,
 		);
 
-		assert(
-			booleanOptionalField.isExactly(
-				FlexFieldSchema.create(FieldKinds.optional, [getFlexSchema(booleanSchema)]),
-			),
-		);
-
-		// Different types
-		assert(
-			!booleanOptionalField.isExactly(
-				FlexFieldSchema.create(FieldKinds.optional, [getFlexSchema(nullSchema)]),
-			),
-		);
+		assert(booleanOptionalField.is(FieldKinds.optional));
 		// Different kinds
-		assert(
-			!booleanOptionalField.isExactly(
-				FlexFieldSchema.create(FieldKinds.required, [getFlexSchema(booleanSchema)]),
-			),
-		);
+		assert(!booleanOptionalField.is(FieldKinds.required));
 		// #endregion
 	});
 

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -43,7 +43,6 @@ import {
 import {
 	booleanSchema,
 	cursorFromInsertable,
-	nullSchema,
 	numberSchema,
 	SchemaFactory,
 	stringSchema,


### PR DESCRIPTION
## Description

FlexTreeField.isExactly uses flex tree schema which are being removed, and is unneeded, so remove it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

