### PR TITLE
tree: Organize simple tree code

### DIFF
--- a/packages/dds/tree/src/simple-tree/api/getJsonSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/getJsonSchema.ts
@@ -4,11 +4,11 @@
  */
 
 import type { JsonTreeSchema } from "./jsonSchema.js";
-import type { ImplicitAllowedTypes } from "./schemaTypes.js";
+import type { ImplicitAllowedTypes } from "../schemaTypes.js";
 import { toJsonSchema } from "./simpleSchemaToJsonSchema.js";
 import { getSimpleSchema } from "./getSimpleSchema.js";
-import { getOrCreate } from "../util/index.js";
-import type { TreeNodeSchema } from "./core/index.js";
+import { getOrCreate } from "../../util/index.js";
+import type { TreeNodeSchema } from "../core/index.js";
 
 /**
  * Cache in which the results of {@link getJsonSchema} are saved.

--- a/packages/dds/tree/src/simple-tree/api/getSimpleSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/getSimpleSchema.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { getOrCreate } from "../util/index.js";
-import type { TreeNodeSchema } from "./core/index.js";
-import type { ImplicitAllowedTypes } from "./schemaTypes.js";
+import { getOrCreate } from "../../util/index.js";
+import type { TreeNodeSchema } from "../core/index.js";
+import type { ImplicitAllowedTypes } from "../schemaTypes.js";
 import type { SimpleTreeSchema } from "./simpleSchema.js";
 import { toSimpleTreeSchema } from "./viewSchemaToSimpleSchema.js";
 

--- a/packages/dds/tree/src/simple-tree/api/index.ts
+++ b/packages/dds/tree/src/simple-tree/api/index.ts
@@ -26,6 +26,25 @@ export {
 } from "./schemaCreationUtilities.js";
 export { treeNodeApi, type TreeNodeApi } from "./treeNodeApi.js";
 export { createFromInsertable, cursorFromInsertable } from "./create.js";
+export type { SimpleTreeSchema } from "./simpleSchema.js";
+export {
+	type JsonSchemaId,
+	type JsonSchemaType,
+	type JsonObjectNodeSchema,
+	type JsonArrayNodeSchema,
+	type JsonMapNodeSchema,
+	type JsonLeafNodeSchema,
+	type JsonSchemaRef,
+	type JsonRefPath,
+	type JsonNodeSchema,
+	type JsonNodeSchemaBase,
+	type JsonTreeSchema,
+	type JsonFieldSchema,
+	type JsonLeafSchemaType,
+} from "./jsonSchema.js";
+export { getJsonSchema } from "./getJsonSchema.js";
+export { getSimpleSchema } from "./getSimpleSchema.js";
+
 export { TreeBeta, type NodeChangedData, type TreeChangeEventsBeta } from "./treeApiBeta.js";
 
 // Exporting the schema (RecursiveObject) to test that recursive types are working correctly.

--- a/packages/dds/tree/src/simple-tree/api/jsonSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/jsonSchema.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { NodeKind } from "./core/index.js";
+import type { NodeKind } from "../core/index.js";
 
 /**
  * The fully-qualified {@link TreeNodeSchemaCore.identifier}.

--- a/packages/dds/tree/src/simple-tree/api/simpleSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleSchema.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import type { ValueSchema } from "../core/index.js";
-import type { NodeKind } from "./core/index.js";
-import type { FieldKind } from "./schemaTypes.js";
+import type { ValueSchema } from "../../core/index.js";
+import type { NodeKind } from "../core/index.js";
+import type { FieldKind } from "../schemaTypes.js";
 
 /**
  * Base interface for all {@link SimpleNodeSchema} implementations.

--- a/packages/dds/tree/src/simple-tree/api/simpleSchemaToJsonSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleSchemaToJsonSchema.ts
@@ -5,8 +5,8 @@
 
 import { unreachableCase } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
-import { ValueSchema } from "../core/index.js";
-import { getOrCreate } from "../util/index.js";
+import { ValueSchema } from "../../core/index.js";
+import { getOrCreate } from "../../util/index.js";
 import type {
 	JsonArrayNodeSchema,
 	JsonFieldSchema,
@@ -19,7 +19,7 @@ import type {
 	JsonTreeSchema,
 	JsonLeafSchemaType,
 } from "./jsonSchema.js";
-import { FieldKind } from "./schemaTypes.js";
+import { FieldKind } from "../schemaTypes.js";
 import type {
 	SimpleArrayNodeSchema,
 	SimpleLeafNodeSchema,
@@ -28,7 +28,7 @@ import type {
 	SimpleObjectNodeSchema,
 	SimpleTreeSchema,
 } from "./simpleSchema.js";
-import { NodeKind } from "./core/index.js";
+import { NodeKind } from "../core/index.js";
 
 /**
  * Generates a JSON Schema representation from a simple tree schema.

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -10,13 +10,10 @@ import type { CommitMetadata, RevertibleFactory } from "../../core/index.js";
 import type { Listenable } from "../../events/index.js";
 
 import {
-	type ImplicitAllowedTypes,
-	normalizeFieldSchema,
 	type ImplicitFieldSchema,
 	type InsertableTreeFieldFromImplicitField,
 	type TreeFieldFromImplicitField,
 	FieldKind,
-	normalizeAllowedTypes,
 } from "../schemaTypes.js";
 import { NodeKind, type TreeNodeSchema } from "../core/index.js";
 import { toFlexSchema } from "../toFlexSchema.js";
@@ -26,6 +23,7 @@ import { isObjectNodeSchema, type ObjectNodeSchema } from "../objectNodeTypes.js
 import { markSchemaMostDerived } from "./schemaFactory.js";
 import { fail, getOrCreate } from "../../util/index.js";
 import type { MakeNominal } from "../../util/index.js";
+import { walkFieldSchema } from "../walkSchema.js";
 /**
  * Channel for a Fluid Tree DDS.
  * @remarks
@@ -340,72 +338,6 @@ export function checkUnion(union: Iterable<TreeNodeSchema>, errors: string[]): v
 			);
 		}
 	}
-}
-
-export function walkNodeSchema(
-	schema: TreeNodeSchema,
-	visitor: SchemaVisitor,
-	visitedSet: Set<TreeNodeSchema>,
-): void {
-	if (visitedSet.has(schema)) {
-		return;
-	}
-	visitedSet.add(schema);
-	if (schema instanceof LeafNodeSchema) {
-		// nothing to do
-	} else if (isObjectNodeSchema(schema)) {
-		for (const field of schema.fields.values()) {
-			walkFieldSchema(field, visitor, visitedSet);
-		}
-	} else {
-		assert(
-			schema.kind === NodeKind.Array || schema.kind === NodeKind.Map,
-			0x9b3 /* invalid schema */,
-		);
-		const childTypes = schema.info as ImplicitAllowedTypes;
-		walkAllowedTypes(normalizeAllowedTypes(childTypes), visitor, visitedSet);
-	}
-	// This visit is done at the end so the traversal order is most inner types first.
-	// This was picked since when fixing errors,
-	// working from the inner types out to the types that use them will probably go better than the reverse.
-	// This does not however ensure all types referenced by a type are visited before it, since in recursive cases thats impossible.
-	visitor.node?.(schema);
-}
-
-export function walkFieldSchema(
-	schema: ImplicitFieldSchema,
-	visitor: SchemaVisitor,
-	visitedSet: Set<TreeNodeSchema> = new Set(),
-): void {
-	walkAllowedTypes(normalizeFieldSchema(schema).allowedTypeSet, visitor, visitedSet);
-}
-
-export function walkAllowedTypes(
-	allowedTypes: Iterable<TreeNodeSchema>,
-	visitor: SchemaVisitor,
-	visitedSet: Set<TreeNodeSchema>,
-): void {
-	for (const childType of allowedTypes) {
-		walkNodeSchema(childType, visitor, visitedSet);
-	}
-	visitor.allowedTypes?.(allowedTypes);
-}
-
-/**
- * Callbacks for use in {@link walkFieldSchema} / {@link walkAllowedTypes} / {@link walkNodeSchema}.
- */
-export interface SchemaVisitor {
-	/**
-	 * Called once for each node schema.
-	 */
-	node?: (schema: TreeNodeSchema) => void;
-	/**
-	 * Called once for each set of allowed types.
-	 * Includes implicit allowed types (when a single type was used instead of an array).
-	 *
-	 * This includes every field, but also the allowed types array for maps and arrays and the root if starting at {@link walkAllowedTypes}.
-	 */
-	allowedTypes?: (allowedTypes: Iterable<TreeNodeSchema>) => void;
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/api/verboseTree.ts
+++ b/packages/dds/tree/src/simple-tree/api/verboseTree.ts
@@ -41,7 +41,7 @@ import {
 } from "../leafNodeSchema.js";
 import { toFlexSchema } from "../toFlexSchema.js";
 import { isObjectNodeSchema } from "../objectNodeTypes.js";
-import { walkFieldSchema } from "./tree.js";
+import { walkFieldSchema } from "../walkSchema.js";
 
 /**
  * Verbose encoding of a {@link TreeNode} or {@link TreeValue}.

--- a/packages/dds/tree/src/simple-tree/api/viewSchemaToSimpleSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/viewSchemaToSimpleSchema.ts
@@ -8,7 +8,7 @@ import {
 	normalizeFieldSchema,
 	type FieldSchema,
 	type ImplicitAllowedTypes,
-} from "./schemaTypes.js";
+} from "../schemaTypes.js";
 import type {
 	SimpleArrayNodeSchema,
 	SimpleFieldSchema,
@@ -18,10 +18,10 @@ import type {
 	SimpleObjectNodeSchema,
 	SimpleTreeSchema,
 } from "./simpleSchema.js";
-import type { ValueSchema } from "../core/index.js";
-import { getOrCreate } from "../util/index.js";
-import { isObjectNodeSchema, type ObjectNodeSchema } from "./objectNodeTypes.js";
-import { NodeKind, type TreeNodeSchema } from "./core/index.js";
+import type { ValueSchema } from "../../core/index.js";
+import { getOrCreate } from "../../util/index.js";
+import { isObjectNodeSchema, type ObjectNodeSchema } from "../objectNodeTypes.js";
+import { NodeKind, type TreeNodeSchema } from "../core/index.js";
 
 /**
  * Converts a "view" schema to a "simple" schema representation.

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -48,6 +48,22 @@ export {
 	type NodeChangedData,
 	TreeBeta,
 	type TreeChangeEventsBeta,
+	type SimpleTreeSchema,
+	type JsonSchemaId,
+	type JsonSchemaType,
+	type JsonObjectNodeSchema,
+	type JsonArrayNodeSchema,
+	type JsonMapNodeSchema,
+	type JsonLeafNodeSchema,
+	type JsonSchemaRef,
+	type JsonRefPath,
+	type JsonNodeSchema,
+	type JsonNodeSchemaBase,
+	type JsonTreeSchema,
+	type JsonFieldSchema,
+	type JsonLeafSchemaType,
+	getJsonSchema,
+	getSimpleSchema,
 } from "./api/index.js";
 export {
 	type NodeFromSchema,
@@ -107,24 +123,6 @@ export {
 } from "./objectNode.js";
 export type { TreeMapNode, MapNodeInsertableData } from "./mapNode.js";
 export { mapTreeFromNodeData, type InsertableContent } from "./toMapTree.js";
-export type { SimpleTreeSchema } from "./simpleSchema.js";
-export {
-	type JsonSchemaId,
-	type JsonSchemaType,
-	type JsonObjectNodeSchema,
-	type JsonArrayNodeSchema,
-	type JsonMapNodeSchema,
-	type JsonLeafNodeSchema,
-	type JsonSchemaRef,
-	type JsonRefPath,
-	type JsonNodeSchema,
-	type JsonNodeSchemaBase,
-	type JsonTreeSchema,
-	type JsonFieldSchema,
-	type JsonLeafSchemaType,
-} from "./jsonSchema.js";
-export { getJsonSchema } from "./getJsonSchema.js";
-export { getSimpleSchema } from "./getSimpleSchema.js";
 export { toStoredSchema, getStoredSchema, getFlexSchema } from "./toFlexSchema.js";
 export {
 	numberSchema,

--- a/packages/dds/tree/src/simple-tree/walkSchema.ts
+++ b/packages/dds/tree/src/simple-tree/walkSchema.ts
@@ -1,0 +1,81 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert } from "@fluidframework/core-utils/internal";
+import { type TreeNodeSchema, NodeKind } from "./core/index.js";
+import { LeafNodeSchema } from "./leafNodeSchema.js";
+import { isObjectNodeSchema } from "./objectNodeTypes.js";
+import {
+	type ImplicitAllowedTypes,
+	normalizeAllowedTypes,
+	type ImplicitFieldSchema,
+	normalizeFieldSchema,
+} from "./schemaTypes.js";
+
+export function walkNodeSchema(
+	schema: TreeNodeSchema,
+	visitor: SchemaVisitor,
+	visitedSet: Set<TreeNodeSchema>,
+): void {
+	if (visitedSet.has(schema)) {
+		return;
+	}
+	visitedSet.add(schema);
+	if (schema instanceof LeafNodeSchema) {
+		// nothing to do
+	} else if (isObjectNodeSchema(schema)) {
+		for (const field of schema.fields.values()) {
+			walkFieldSchema(field, visitor, visitedSet);
+		}
+	} else {
+		assert(
+			schema.kind === NodeKind.Array || schema.kind === NodeKind.Map,
+			0x9b3 /* invalid schema */,
+		);
+		const childTypes = schema.info as ImplicitAllowedTypes;
+		walkAllowedTypes(normalizeAllowedTypes(childTypes), visitor, visitedSet);
+	}
+	// This visit is done at the end so the traversal order is most inner types first.
+	// This was picked since when fixing errors,
+	// working from the inner types out to the types that use them will probably go better than the reverse.
+	// This does not however ensure all types referenced by a type are visited before it, since in recursive cases thats impossible.
+	visitor.node?.(schema);
+}
+
+export function walkFieldSchema(
+	schema: ImplicitFieldSchema,
+	visitor: SchemaVisitor,
+	visitedSet: Set<TreeNodeSchema> = new Set(),
+): void {
+	walkAllowedTypes(normalizeFieldSchema(schema).allowedTypeSet, visitor, visitedSet);
+}
+
+export function walkAllowedTypes(
+	allowedTypes: Iterable<TreeNodeSchema>,
+	visitor: SchemaVisitor,
+	visitedSet: Set<TreeNodeSchema>,
+): void {
+	for (const childType of allowedTypes) {
+		walkNodeSchema(childType, visitor, visitedSet);
+	}
+	visitor.allowedTypes?.(allowedTypes);
+}
+/**
+ * Callbacks for use in {@link walkFieldSchema} / {@link walkAllowedTypes} / {@link walkNodeSchema}.
+ */
+
+export interface SchemaVisitor {
+	/**
+	 * Called once for each node schema.
+	 */
+	node?: (schema: TreeNodeSchema) => void;
+	/**
+	 * Called once for each set of allowed types.
+	 * Includes implicit allowed types (when a single type was used instead of an array).
+	 *
+	 * This includes every field, but also the allowed types array for maps and arrays and the root if starting at {@link walkAllowedTypes}.
+	 */
+	allowedTypes?: (allowedTypes: Iterable<TreeNodeSchema>) => void;
+}

--- a/packages/dds/tree/src/test/simple-tree/api/simpleSchemaToJsonSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/simpleSchemaToJsonSchema.spec.ts
@@ -4,13 +4,16 @@
  */
 
 import { strict as assert } from "node:assert";
-import { FieldKind, NodeKind, type JsonTreeSchema } from "../../simple-tree/index.js";
-import { getJsonValidator } from "./jsonSchemaUtilities.js";
+import { FieldKind, NodeKind, type JsonTreeSchema } from "../../../simple-tree/index.js";
+import { getJsonValidator } from "../jsonSchemaUtilities.js";
+import type {
+	SimpleNodeSchema,
+	SimpleTreeSchema,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../../simple-tree/api/simpleSchema.js";
 // eslint-disable-next-line import/no-internal-modules
-import type { SimpleNodeSchema, SimpleTreeSchema } from "../../simple-tree/simpleSchema.js";
-// eslint-disable-next-line import/no-internal-modules
-import { toJsonSchema } from "../../simple-tree/simpleSchemaToJsonSchema.js";
-import { ValueSchema } from "../../core/index.js";
+import { toJsonSchema } from "../../../simple-tree/api/simpleSchemaToJsonSchema.js";
+import { ValueSchema } from "../../../core/index.js";
 
 describe("simpleSchemaToJsonSchema", () => {
 	it("Leaf schema", async () => {


### PR DESCRIPTION
## Description

move walkSchema out of /api so implementation code can use it.

Move simple-tree SimpleTreeSchema (the double simple ones, not the single simple ones) and the json schema stuff to /api since they are not used in the implementation of the tree.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

