### PR TITLE
tree: Mark internal types as system types

### DIFF
--- a/packages/dds/tree/src/feature-libraries/typed-schema/flexList.ts
+++ b/packages/dds/tree/src/feature-libraries/typed-schema/flexList.ts
@@ -45,7 +45,7 @@ export function markEager<T>(t: T): T {
  * To force a `"function"` item to be treated as an eager item, call `markEager` before putting it in the list.
  * This is necessary e.g. when the eager list items are function types and the lazy items are functions that _return_ function types.
  * `FlexList`s are processed by `normalizeFlexList` and `normalizeFlexListEager`.
- * @public
+ * @system @public
  */
 export type FlexList<Item = unknown> = readonly LazyItem<Item>[];
 
@@ -94,7 +94,7 @@ export type NormalizedLazyFlexList<Item> = (() => Item)[];
 
 /**
  * Get the `Item` type from a `LazyItem<Item>`.
- * @public
+ * @system @public
  */
 export type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result
 	? Result
@@ -120,7 +120,7 @@ export type FlexListToNonLazyArray<List extends FlexList> =
 
 /**
  * Normalize FlexList type to a union.
- * @public
+ * @system @public
  */
 export type FlexListToUnion<TList extends FlexList> = ExtractItemType<TList[number]>;
 

--- a/packages/dds/tree/src/shared-tree/treeApi.ts
+++ b/packages/dds/tree/src/shared-tree/treeApi.ts
@@ -324,9 +324,7 @@ export interface RunTransaction {
  * Provides various functions for interacting with {@link TreeNode}s.
  * @remarks
  * This type should only be used via the public `Tree` export.
- * @privateRemarks
- * Due to limitations of API-Extractor link resolution, this type can't be moved into internalTypes but should be considered just an implementation detail of the `Tree` export.
- * @sealed @public
+ * @system @sealed @public
  */
 export interface TreeApi extends TreeNodeApi {
 	/**

--- a/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
@@ -100,7 +100,7 @@ export function schemaFromValue(value: TreeValue): TreeNodeSchema {
 /**
  * The name of a schema produced by {@link SchemaFactory}, including its optional scope prefix.
  *
- * @public
+ * @system @public
  */
 export type ScopedSchemaName<
 	TScope extends string | undefined,

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -52,7 +52,7 @@ import { TreeNodeValid, type MostDerivedData } from "./treeNodeValid.js";
  * @privateRemarks
  * Inlining this into TreeArrayNode causes recursive array use to stop compiling.
  *
- * @sealed @public
+ * @system @sealed @public
  */
 export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
 	extends ReadonlyArray<T>,

--- a/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
@@ -33,7 +33,7 @@ export type TreeNodeSchema<
  * This is used for schema which cannot have their instances constructed using constructors, like leaf schema.
  * @privateRemarks
  * Non-class based schema can have issues with recursive types due to https://github.com/microsoft/TypeScript/issues/55832.
- * @sealed @public
+ * @system @sealed @public
  */
 export interface TreeNodeSchemaNonClass<
 	out Name extends string = string,

--- a/packages/dds/tree/src/simple-tree/core/withType.ts
+++ b/packages/dds/tree/src/simple-tree/core/withType.ts
@@ -17,7 +17,7 @@ import type { NodeKind, TreeNodeSchemaClass } from "./treeNodeSchema.js";
  * @privateRemarks
  * This prevents non-nodes from being accidentally used as nodes, as well as allows the type checker to distinguish different node types.
  * @deprecated External code should use `Tree.schema(theNode)` for schema related runtime data access. For type narrowing, use `WithType` instead of the symbols directly.
- * @system @public
+ * @system @system @public
  */
 export const typeNameSymbol: unique symbol = Symbol("TreeNode Type");
 

--- a/packages/dds/tree/src/simple-tree/core/withType.ts
+++ b/packages/dds/tree/src/simple-tree/core/withType.ts
@@ -17,7 +17,7 @@ import type { NodeKind, TreeNodeSchemaClass } from "./treeNodeSchema.js";
  * @privateRemarks
  * This prevents non-nodes from being accidentally used as nodes, as well as allows the type checker to distinguish different node types.
  * @deprecated External code should use `Tree.schema(theNode)` for schema related runtime data access. For type narrowing, use `WithType` instead of the symbols directly.
- * @system @system @public
+ * @system @public
  */
 export const typeNameSymbol: unique symbol = Symbol("TreeNode Type");
 

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -51,7 +51,7 @@ import { TreeNodeValid, type MostDerivedData } from "./treeNodeValid.js";
 
 /**
  * Helper used to produce types for object nodes.
- * @public
+ * @system @public
  */
 export type ObjectFromSchemaRecord<
 	T extends RestrictiveReadonlyRecord<string, ImplicitFieldSchema>,
@@ -82,7 +82,7 @@ export type TreeObjectNode<
  * TODO: Account for field schemas with default value providers.
  * For now, this only captures field kinds that we know always have defaults - optional fields and identifier fields.
  *
- * @public
+ * @system @public
  */
 export type FieldHasDefault<T extends ImplicitFieldSchema> = T extends FieldSchema<
 	FieldKind.Optional | FieldKind.Identifier
@@ -103,7 +103,7 @@ export type FieldHasDefault<T extends ImplicitFieldSchema> = T extends FieldSche
  *
  * @privateRemarks TODO: consider separating these cases into different types.
  *
- * @public
+ * @system @public
  */
 export type InsertableObjectFromSchemaRecord<
 	T extends RestrictiveReadonlyRecord<string, ImplicitFieldSchema>,

--- a/packages/dds/tree/src/simple-tree/schemaTypes.ts
+++ b/packages/dds/tree/src/simple-tree/schemaTypes.ts
@@ -187,7 +187,7 @@ export function isConstant(
  * Provides a default value for a field.
  * @remarks
  * If present in a `FieldSchema`, when constructing new tree content that field can be omitted, and a default will be provided.
- * @sealed @public
+ * @system @sealed @public
  */
 export interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {}
 
@@ -360,7 +360,7 @@ export type InsertableTreeFieldFromImplicitField<
 /**
  * Suitable for output.
  * For input must error on side of excluding undefined instead.
- * @public
+ * @system @public
  */
 export type ApplyKind<T, Kind extends FieldKind, DefaultsAreOptional extends boolean> = {
 	[FieldKind.Required]: T;
@@ -420,7 +420,7 @@ export type InsertableTypedNode<T extends TreeNodeSchema> =
  * This could be changed if needed.
  *
  * These factory functions can also take a FlexTreeNode, but this is not exposed in the public facing types.
- * @public
+ * @system @public
  */
 export type NodeBuilderData<T extends TreeNodeSchema> = T extends TreeNodeSchema<
 	string,

--- a/packages/dds/tree/src/simple-tree/typesUnsafe.ts
+++ b/packages/dds/tree/src/simple-tree/typesUnsafe.ts
@@ -41,7 +41,7 @@ import type { TreeArrayNodeBase, TreeArrayNode } from "./arrayNode.js";
  * {@link Unenforced} version of `ObjectFromSchemaRecord`.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @system @public
  */
 export type ObjectFromSchemaRecordUnsafe<
 	T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>,
@@ -53,7 +53,7 @@ export type ObjectFromSchemaRecordUnsafe<
  * {@link Unenforced} version of {@link TreeObjectNode}.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @system @public
  */
 export type TreeObjectNodeUnsafe<
 	T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>,
@@ -64,7 +64,7 @@ export type TreeObjectNodeUnsafe<
  * {@link Unenforced} version of {@link TreeFieldFromImplicitField}.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @system @public
  */
 export type TreeFieldFromImplicitFieldUnsafe<TSchema extends Unenforced<ImplicitFieldSchema>> =
 	TSchema extends FieldSchemaUnsafe<infer Kind, infer Types>
@@ -77,7 +77,7 @@ export type TreeFieldFromImplicitFieldUnsafe<TSchema extends Unenforced<Implicit
  * {@link Unenforced} version of {@link TreeNodeFromImplicitAllowedTypes}.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @system @public
  */
 export type TreeNodeFromImplicitAllowedTypesUnsafe<
 	TSchema extends Unenforced<ImplicitAllowedTypes>,
@@ -93,7 +93,7 @@ export type TreeNodeFromImplicitAllowedTypesUnsafe<
  * {@link Unenforced} version of {@link InsertableTreeNodeFromImplicitAllowedTypes}.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @system @public
  */
 export type InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
 	TSchema extends Unenforced<ImplicitAllowedTypes>,
@@ -105,7 +105,7 @@ export type InsertableTreeNodeFromImplicitAllowedTypesUnsafe<
  * {@link Unenforced} version of {@link InsertableTypedNode}.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @system @public
  */
 export type InsertableTypedNodeUnsafe<T extends Unenforced<TreeNodeSchema>> = [
 	| Unhydrated<NodeFromSchemaUnsafe<T>>
@@ -116,7 +116,7 @@ export type InsertableTypedNodeUnsafe<T extends Unenforced<TreeNodeSchema>> = [
  * {@link Unenforced} version of {@link NodeFromSchema}.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @system @public
  */
 export type NodeFromSchemaUnsafe<T extends Unenforced<TreeNodeSchema>> =
 	T extends TreeNodeSchema<string, NodeKind, infer TNode> ? TNode : never;
@@ -125,7 +125,7 @@ export type NodeFromSchemaUnsafe<T extends Unenforced<TreeNodeSchema>> =
  * {@link Unenforced} version of {@link InsertableTreeNodeFromImplicitAllowedTypes}.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @system @public
  */
 export type NodeBuilderDataUnsafe<T extends Unenforced<TreeNodeSchema>> =
 	T extends TreeNodeSchema<string, NodeKind, unknown, infer TBuild> ? TBuild : never;
@@ -134,7 +134,7 @@ export type NodeBuilderDataUnsafe<T extends Unenforced<TreeNodeSchema>> =
  * {@link Unenforced} version of {@link (TreeArrayNode:interface)}.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @sealed @public
+ * @system @sealed @public
  */
 export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAllowedTypes>>
 	extends TreeArrayNodeBase<
@@ -147,7 +147,7 @@ export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAl
  * {@link Unenforced} version of {@link TreeMapNode}.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @sealed @public
+ * @system @sealed @public
  */
 export interface TreeMapNodeUnsafe<T extends Unenforced<ImplicitAllowedTypes>>
 	extends ReadonlyMapInlined<string, T>,
@@ -213,7 +213,7 @@ export interface ReadonlyMapInlined<K, T extends Unenforced<ImplicitAllowedTypes
  * {@link Unenforced} version of `FieldHasDefault`.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @sealed @public
+ * @system @sealed @public
  */
 export type FieldHasDefaultUnsafe<T extends Unenforced<ImplicitFieldSchema>> =
 	T extends FieldSchemaUnsafe<
@@ -227,7 +227,7 @@ export type FieldHasDefaultUnsafe<T extends Unenforced<ImplicitFieldSchema>> =
  * {@link Unenforced} version of `InsertableObjectFromSchemaRecord`.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @system @public
  */
 export type InsertableObjectFromSchemaRecordUnsafe<
 	T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>,
@@ -248,7 +248,7 @@ export type InsertableObjectFromSchemaRecordUnsafe<
  * {@link Unenforced} version of {@link InsertableTreeFieldFromImplicitField}.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @system @public
  */
 export type InsertableTreeFieldFromImplicitFieldUnsafe<
 	TSchema extends Unenforced<ImplicitFieldSchema>,

--- a/packages/dds/tree/src/util/typeUtils.ts
+++ b/packages/dds/tree/src/util/typeUtils.ts
@@ -10,7 +10,7 @@
 /**
  * Return a type thats equivalent to the input, but with different IntelliSense.
  * This tends to convert unions and intersections into objects.
- * @public
+ * @system @public
  */
 export type FlattenKeys<T> = [{ [Property in keyof T]: T[Property] }][_InlineTrick];
 
@@ -81,7 +81,7 @@ export type AllowOptional<T> = [
  *
  * This constant is defined to provide a way to find this documentation from types which use this pattern,
  * and to locate types which use this pattern in case they need updating for compiler changes.
- * @public
+ * @system @public
  */
 export type _InlineTrick = 0;
 


### PR DESCRIPTION
## Description

Tree has several types that meet the requirements to be `@system` (grouped under InternalTypes) but predate the system tag. Now that system has public facing docs, they should be tagged accordingly.

In the future we may want to remove the InternalTypes grouping/pattern used on these types as it causes some issues with TypeScript reexports in customer code, as well as breaks API-Extractor in some cases. Regardless of if we make a such a change, making them as system better communicates their status.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
