### PR TITLE
tree: Document unhydrated issues

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -99,6 +99,20 @@ export enum TreeStatus {
 
 	/**
 	 * Is created but has not yet been inserted into the tree.
+	 * @remarks
+	 * See also {@link Unhydrated}.
+	 *
+	 * Nodes in the new state have some limitations:
+	 *
+	 * - Events are not currently triggered for changes. Fixes for this are planned.
+	 *
+	 * - Reading identifiers from nodes which were left unspecified (defaulted) when creating the tree will error.
+	 * This is because allocating unique identifiers in a compressible manner requires knowing which tree the nodes will be inserted into.
+	 *
+	 * - Transactions do not work: transactions apply to a single {@link TreeView}, and `New` nodes are not part of one.
+	 *
+	 * - `Tree.shortId` (when the identifier was explicitly specified and thus works at all) will just return the full identifier as a string,
+	 * but might return a compressed form as a number once hydrated.
 	 */
 	New = 3,
 }

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -203,6 +203,7 @@ export {
 	type FlexTreeSequenceField,
 	Skip,
 	type FlexTreeContext,
+	type FlexTreeHydratedContext,
 	type FlexTreeTypedField,
 	type FlexTreeEntity,
 	type FlexTreeField,

--- a/packages/dds/tree/src/shared-tree/treeApi.ts
+++ b/packages/dds/tree/src/shared-tree/treeApi.ts
@@ -4,8 +4,9 @@
  */
 
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import { Context, TreeStatus } from "../feature-libraries/index.js";
+import { TreeStatus } from "../feature-libraries/index.js";
 import {
 	type ImplicitFieldSchema,
 	type TreeNode,
@@ -436,8 +437,11 @@ export function runTransaction<
 		const node = treeOrNode as TNode;
 		const t = transaction as (node: TNode) => TResult | typeof rollback;
 		const context = getOrCreateInnerNode(node).context;
-		// TODO: AB#14628: this can fail for unhydrated nodes.
-		assert(context instanceof Context, 0x901 /* Unsupported context */);
+		if (context.isHydrated() === false) {
+			throw new UsageError(
+				"Transactions cannot be run on Unhydrated nodes. Transactions apply to a TreeView and Unhydrated nodes are not part of a TreeView.",
+			);
+		}
 		const treeView =
 			contextToTreeView.get(context) ?? fail("Expected view to be registered for context");
 

--- a/packages/dds/tree/src/shared-tree/treeView.ts
+++ b/packages/dds/tree/src/shared-tree/treeView.ts
@@ -10,6 +10,7 @@ import {
 	type FlexTreeSchema,
 	type NodeKeyManager,
 	getTreeContext,
+	type FlexTreeHydratedContext,
 } from "../feature-libraries/index.js";
 import { tryDisposeTreeNode } from "../simple-tree/index.js";
 import { type IDisposable, disposeSymbol } from "../util/index.js";
@@ -94,4 +95,4 @@ export class CheckoutFlexTreeView<out TCheckout extends ITreeCheckout = ITreeChe
  * Maps the context of every {@link CheckoutFlexTreeView} to the view.
  * In practice, this allows the view or checkout to be obtained from a flex node by first getting the context from the flex node and then using this map.
  */
-export const contextToTreeView = new WeakMap<Context, FlexTreeView>();
+export const contextToTreeView = new WeakMap<FlexTreeHydratedContext, FlexTreeView>();

--- a/packages/dds/tree/src/simple-tree/core/types.ts
+++ b/packages/dds/tree/src/simple-tree/core/types.ts
@@ -20,6 +20,11 @@ import { isFlexTreeNode, type FlexTreeNode } from "../../feature-libraries/index
  *
  * Since un-hydrated nodes become hydrated when inserted, strong typing can't be used to distinguish them.
  * This no-op wrapper is used instead.
+ * @remarks
+ * Nodes which are Unhydrated report {@link TreeStatus}.new from `Tree.status(node)`.
+ * @privateRemarks
+ * TODO: Linking tree status is failing in intellisense and linking directly to its .new item is failing in API extractor as well.
+ * WOuld be nice to have a working link here.
  * @public
  */
 export type Unhydrated<T> = T;

--- a/packages/dds/tree/src/test/simple-tree/api/treeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeApi.spec.ts
@@ -14,6 +14,7 @@ import {
 	cursorForJsonableTreeNode,
 	MockNodeKeyManager,
 	TreeStatus,
+	type StableNodeKey,
 } from "../../../feature-libraries/index.js";
 import {
 	type NodeFromSchema,
@@ -24,7 +25,7 @@ import {
 	type TreeNode,
 	TreeViewConfiguration,
 } from "../../../simple-tree/index.js";
-import { getView } from "../../utils.js";
+import { getView, validateUsageError } from "../../utils.js";
 import { getViewForForkedBranch, hydrate } from "../utils.js";
 import { brand, type areSafelyAssignable, type requireTrue } from "../../../util/index.js";
 
@@ -269,6 +270,41 @@ describe("treeNodeApi", () => {
 			const view = getView(config);
 			view.initialize([1, 2, 3]);
 			assert.equal(Tree.shortId(view.root), undefined);
+		});
+
+		describe("unhydrated", () => {
+			class HasIdentifier extends schema.object("HasIdentifier", {
+				identifier: schema.identifier,
+			}) {}
+			it("returns uncompressed string for unhydrated nodes", () => {
+				const node = new HasIdentifier({ identifier: "x" });
+				assert.equal(Tree.shortId(node), "x");
+			});
+			it("errors accessing defaulted", () => {
+				const node = new HasIdentifier({});
+				assert.throws(
+					() => {
+						Tree.shortId(node);
+					},
+					validateUsageError(/default/),
+				);
+			});
+
+			// TODO: this policy seems questionable, but its whats implemented, and is documented in TreeStatus.new
+			it("returns string when unhydrated then local id when hydrated", () => {
+				const nodeKeyManager = new MockNodeKeyManager();
+				const config = new TreeViewConfiguration({ schema: HasIdentifier });
+				const view = getView(config, nodeKeyManager);
+				view.initialize({});
+				const identifier = view.root.identifier;
+				const shortId = Tree.shortId(view.root);
+				assert.equal(shortId, nodeKeyManager.localizeNodeKey(identifier as StableNodeKey));
+
+				const node = new HasIdentifier({ identifier });
+				assert.equal(Tree.shortId(node), identifier);
+				view.root = node;
+				assert.equal(Tree.shortId(node), shortId);
+			});
 		});
 	});
 


### PR DESCRIPTION
## Description

Document some limitation of unhydrated nodes, and fix that transactions can assert on them (replace with usage error)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

