### PR TITLE
fix(odsp-client): Fail earlier when OdspTestTokenProvider cannot auth

### DIFF
--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspTokenFactory.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspTokenFactory.ts
@@ -70,6 +70,9 @@ export class OdspTestTokenProvider implements IOdspTokenProvider {
 			getFetchTokenUrl(server),
 			new URLSearchParams(body),
 		);
+		if (!response.ok) {
+			throw new Error(`Failed to obtain tokens: ${await response.text()}`);
+		}
 
 		const parsedResponse = await response.json();
 		const accessToken = parsedResponse.access_token;


### PR DESCRIPTION
## Description

Makes OdspTestTokenProvider throw when it's unable to fetch a token. This propagates the immediate error from auth servers to the test, rather than give a generic 401 (previous implementation would result in returning an undefined access token)
