### PR TITLE
Restore patch for API-Extractor

### DIFF
--- a/patches/@microsoft__api-extractor@7.45.1.patch
+++ b/patches/@microsoft__api-extractor@7.45.1.patch
@@ -1,0 +1,49 @@
+diff --git a/lib/enhancers/ValidationEnhancer.js b/lib/enhancers/ValidationEnhancer.js
+index cdb0b22ed2e06592ea1c5f9dd3d18ae2c51b2484..a16f260579c3a696ea0692f4db8d74b19aa120fb 100644
+--- a/lib/enhancers/ValidationEnhancer.js
++++ b/lib/enhancers/ValidationEnhancer.js
+@@ -187,15 +187,14 @@ class ValidationEnhancer {
+             else {
+                 continue;
+             }
+-            if (collectorEntity && collectorEntity.consumable) {
+-                if (api_extractor_model_1.ReleaseTag.compare(declarationReleaseTag, referencedReleaseTag) > 0) {
+-                    collector.messageRouter.addAnalyzerIssue(ExtractorMessageId_1.ExtractorMessageId.IncompatibleReleaseTags, `The symbol "${astDeclaration.astSymbol.localName}"` +
+-                        ` is marked as ${api_extractor_model_1.ReleaseTag.getTagName(declarationReleaseTag)},` +
+-                        ` but its signature references "${localName}"` +
+-                        ` which is marked as ${api_extractor_model_1.ReleaseTag.getTagName(referencedReleaseTag)}`, astDeclaration);
+-                }
+-            }
+-            else {
++            // BUG MITIGATION: Always check release tag compatibility.
++            if (api_extractor_model_1.ReleaseTag.compare(declarationReleaseTag, referencedReleaseTag) > 0) {
++                collector.messageRouter.addAnalyzerIssue(ExtractorMessageId_1.ExtractorMessageId.IncompatibleReleaseTags, `The symbol "${astDeclaration.astSymbol.localName}"` +
++                    ` is marked as ${api_extractor_model_1.ReleaseTag.getTagName(declarationReleaseTag)},` +
++                    ` but its signature references "${localName}"` +
++                    ` which is marked as ${api_extractor_model_1.ReleaseTag.getTagName(referencedReleaseTag)}`, astDeclaration);
++            }
++            if (!(collectorEntity === null || collectorEntity === void 0 ? void 0 : collectorEntity.consumable)) {
+                 const entryPointFilename = path.basename(collector.workingPackage.entryPointSourceFile.fileName);
+                 if (!alreadyWarnedEntities.has(referencedEntity)) {
+                     alreadyWarnedEntities.add(referencedEntity);
+diff --git a/lib/generators/ApiReportGenerator.js b/lib/generators/ApiReportGenerator.js
+index c12b2665102901f971a4e2b5067dbe556a74c04f..bb63a18bc37b657fb3dd779df14b83df2853d5cb 100644
+--- a/lib/generators/ApiReportGenerator.js
++++ b/lib/generators/ApiReportGenerator.js
+@@ -85,13 +85,9 @@ class ApiReportGenerator {
+             writer.writeLine(`/// <reference lib="${libDirectiveReference}" />`);
+         }
+         writer.ensureSkippedLine();
+-        // Emit the imports
+-        for (const entity of collector.entities) {
+-            if (entity.astEntity instanceof AstImport_1.AstImport) {
+-                DtsEmitHelpers_1.DtsEmitHelpers.emitImport(writer, entity, entity.astEntity);
+-            }
+-        }
+-        writer.ensureSkippedLine();
++
++        // PATCH: Don't emit imports
++
+         // Emit the regular declarations
+         for (const entity of collector.entities) {
+             const astEntity = entity.astEntity;


### PR DESCRIPTION
## Description

https://github.com/microsoft/FluidFramework/pull/22474 Updated API-Extractor including its patch. Some packages (like common-utils) referenced that patch, while others (like server/routerlicious) duplicated it.

This change failed to trigger CI builds for common-utils, thus allowing a break for its install step to slip into main.

This restores the patch, fixing the install step and thus build.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

