### PR TITLE
fix(ci): Add 'patches' folder to pipeline triggers that need them

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -89,6 +89,7 @@ trigger:
     - packages
     - PACKAGES.md
     - package.json
+    - patches/*
     - pnpm-lock.yaml
     - pnpm-workspace.yaml
     - prettier.config.cjs
@@ -149,6 +150,7 @@ pr:
     - packages
     - PACKAGES.md
     - package.json
+    - patches/*
     - pnpm-lock.yaml
     - pnpm-workspace.yaml
     - prettier.config.cjs

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -52,6 +52,9 @@ trigger:
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
+    # Common-utils references files from the patches folder at the root of the repo.
+    # Using the whole folder as dependency because when patch files are updated they might get new names.
+    - patches/*
 
 pr:
   branches:
@@ -74,6 +77,9 @@ pr:
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
+    # Common-utils references files from the patches folder at the root of the repo.
+    # Using the whole folder as dependency because when patch files are updated they might get new names.
+    - patches/*
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -39,6 +39,10 @@ trigger:
     - .prettierignore
     - common/build/build-common
     - common/lib/common-utils
+    # Common-utils references files from the patches folder at the root of the repo.
+    # Using the whole folder as dependency because when patch files are updated they might get new names.
+    - patches/*
+    - scripts/*
     - tools/pipelines/build-common-utils.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
@@ -51,10 +55,6 @@ trigger:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
-    - scripts/*
-    # Common-utils references files from the patches folder at the root of the repo.
-    # Using the whole folder as dependency because when patch files are updated they might get new names.
-    - patches/*
 
 pr:
   branches:
@@ -68,6 +68,10 @@ pr:
     - .prettierignore
     - common/build/build-common
     - common/lib/common-utils
+    # Common-utils references files from the patches folder at the root of the repo.
+    # Using the whole folder as dependency because when patch files are updated they might get new names.
+    - patches/*
+    - scripts/*
     - tools/pipelines/build-common-utils.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
@@ -76,10 +80,6 @@ pr:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
-    - scripts/*
-    # Common-utils references files from the patches folder at the root of the repo.
-    # Using the whole folder as dependency because when patch files are updated they might get new names.
-    - patches/*
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -40,6 +40,10 @@ trigger:
     - fluidBuild.config.cjs
     - common/build/build-common
     - common/lib/protocol-definitions
+    # Protocol-definitions references files from the patches folder at the root of the repo.
+    # Using the whole folder as dependency because when patch files are updated they might get new names.
+    - patches/*
+    - scripts/*
     - tools/pipelines/build-protocol-definitions.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
@@ -52,10 +56,6 @@ trigger:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
-    - scripts/*
-    # Protocol-definitions references files from the patches folder at the root of the repo.
-    # Using the whole folder as dependency because when patch files are updated they might get new names.
-    - patches/*
 
 pr:
   branches:
@@ -69,6 +69,10 @@ pr:
     - .prettierignore
     - common/build/build-common
     - common/lib/protocol-definitions
+    # Protocol-definitions references files from the patches folder at the root of the repo.
+    # Using the whole folder as dependency because when patch files are updated they might get new names.
+    - patches/*
+    - scripts/*
     - tools/pipelines/build-protocol-definitions.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
@@ -77,10 +81,6 @@ pr:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
-    - scripts/*
-    # Protocol-definitions references files from the patches folder at the root of the repo.
-    # Using the whole folder as dependency because when patch files are updated they might get new names.
-    - patches/*
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -53,6 +53,9 @@ trigger:
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
+    # Protocol-definitions references files from the patches folder at the root of the repo.
+    # Using the whole folder as dependency because when patch files are updated they might get new names.
+    - patches/*
 
 pr:
   branches:
@@ -75,6 +78,9 @@ pr:
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
+    # Protocol-definitions references files from the patches folder at the root of the repo.
+    # Using the whole folder as dependency because when patch files are updated they might get new names.
+    - patches/*
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self


### PR DESCRIPTION
## Description

Adds the `patches/` folder to pipeline triggers so changes to it cause relevant pipelines to run.

Also reorders the triggers in the common-utils and protocol-definitions pipeline to be in alphabetical order.

Related to https://github.com/microsoft/FluidFramework/pull/22484 and https://github.com/microsoft/FluidFramework/pull/22474.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
