### PR TITLE
build: exclude alpha APIs from review requirement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,6 +59,7 @@
 # TODO: if we ever add `.internal` API reports, we will want to omit them here
 /**/api-report/*.api.md                        @microsoft/fluid-cr-api
 /build-tools/**/api-report/*.api.md            # Do not require API review for build-tools packages
+/packages/framework/presence/**/api-report/*.api.md # Do not require API review for experimental presence package
 /server/**/api-report/*.api.md                 # Do not require API review for server packages
 /tools/**/api-report/*.api.md                  # Do not require API review for tools packages
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,11 +56,9 @@
 /packages/tools/devtools/**/src                @microsoft/fluid-cr-devtools
 
 # API report changes
-# TODO: if we ever add `.internal` API reports, we will want to omit them here
-/**/api-report/*.api.md                        @microsoft/fluid-cr-api
-/build-tools/**/api-report/*.api.md            # Do not require API review for build-tools packages
-/packages/framework/presence/**/api-report/*.api.md # Do not require API review for experimental presence package
-/server/**/api-report/*.api.md                 # Do not require API review for server packages
+/**/api-report/*.public.api.md                 @microsoft/fluid-cr-api
+/**/api-report/*.beta.api.md                   @microsoft/fluid-cr-api
+/**/api-report/*.legacy.*.api.md               @microsoft/fluid-cr-api
 /tools/**/api-report/*.api.md                  # Do not require API review for tools packages
 
 # Changesets and release notes


### PR DESCRIPTION
Whitelist `public`, `beta`, and `legacy.*` as requiring review.

`build-tools` and `server` exclusions can be removed as not broken into those categories.