### PR TITLE
docs(build-cli): Update type test documentation for 0.45

### DIFF
--- a/build-tools/packages/build-cli/docs/typetestDetails.md
+++ b/build-tools/packages/build-cli/docs/typetestDetails.md
@@ -1,13 +1,15 @@
 # Further information about `generate typetests`
 
-The `generate typetests` command generates type compatibility tests based on the individual package settings in
-package.json.
+_This documentation is accurate as of build-tools 0.45.0._
+
+The `typetests` `generate:typetests` commands are used to generate and manage type compatibility tests based on the
+individual package settings in package.json.
 
 ## What are type compatibility tests?
 
-Type compatibility tests are automatically generated test cases that check for type incompatibilities across package
-versions. They work by comparing types in the current version to the types in a previous version. The generated tests
-use the previous type in place of the new type, and vice-versa.
+Type compatibility tests, often referred to as "type tests," are automatically generated test cases that check for type
+incompatibilities across package versions. They work by comparing types in the current version to the types in a
+previous version. The generated tests use the previous type in place of the new type, and vice-versa.
 
 See the [API Type Validation][] page in the Fluid Framework wiki for more information about type compatibility tests,
 including how to annotate expected type incompatibilities to fix failing tests.
@@ -20,154 +22,73 @@ Type test generation is primarily configured in the package.json file of the pac
 ```json
 "typeValidation": {
   "disabled": false,
-  "version": "1.1.0",
   "broken": {
     "InterfaceDeclaration_AzureClientProps": {
       "forwardCompat": false
     }
-  }
+  },
+  "entrypoint": "legacy"
 }
 ```
 
-The `broken` section is used to indicate known breaking changes. Type tests can be completely disabled for a package
-using the `disabled` property. See [API Type Validation][] for more information.
+The `broken` section is used to indicate known breaking changes. See [API Type Validation][] for more information about
+disabling failing tests. The contents of this section can be removed using the `--reset` flag in `flub typetests`.
 
-Generating type tests has two parts: _preparing package.json_ and _generating test modules_. By default, both steps are
-run for each package. You can run only one part at a time using the `--prepare` and `--generate` flags.
+Type tests can be completely disabled for a package using the `disabled` property. This value can also be set using the
+`--disable` flag in `flub typetests`.
+
+Generating type tests has two parts: the prepare phase and the generate phase. The prepare phase is done using
+`flub typetests`, while `flub generate:typetests` handles the generate phase.
+
+See the [`flub typetests`](./typetests.md) and [`flub generate:typetests`](./generate.md#flub-generate-typetests)
+reference documentation for details about the flags and options they provide.
 
 [api type validation]: https://github.com/microsoft/FluidFramework/wiki/API-Type-Validation
 
-## Preparing package.json
+## The prepare phase: resetting tests and updating the previous version
 
-_Preparing package.json_ determines the baseline previous version to use, then sets that version in package.json. If the
-previous version changes after running preparation, then `npm install` must be run before the generate step will run
-correctly.
+The prepare phase determines the baseline previous version to use, updates the previous version devDependency in
+package.json, resets any typetest overrides (the entries in `typeValidation.broken`), and normalizes `typeValidation`
+settings.
 
-Optionally, any type tests that are marked "broken" in package.json can be reset using the `--reset` flag during
-preparation. This is useful when resetting the type tests to a clean state, such as after a major release.
+The prepare phase is typically used when resetting the type tests to a clean state, such as after a release.
 
-## Generating tests
+### Running typetests:prepare
 
-Generating test modules takes the type test information from package.json, most notably any known broken type tests, and
-generates test files that should be committed. By default, the generated files will contain `.generated` in their name,
-but this can be suppressed with the `--no-generateInName` flag.
+While you can run `flub typetests` directly, the prepare phase is typically done by running `pnpm typetests:prepare`,
+which invokes `flub typetests` with the following flags: `--reset --previous --normalize`
 
-## Branch configuration
+> [!TIP]
+> The `broken` and `entrypoint` properties in package.json are always present, even when typetests are disabled
+> (`"disabled"=true`). If removed, they will be added back during the prepare phase.
 
-Type tests can be configured to use different baseline versions on a given branch depending on the type of release that
-the branch is designated for. For example, for the client release group, the _next_ branch is the _major version series
-branch_ and _main_ is the _minor version series branch_. This can be declared in the root package.json for the release
-group, in the `fluidBuild.branchReleaseTypes` section. For example, the following configuration designates the _main_ and
-_lts_ branches as minor version series branches, while the _next_ branch is designated for major releases.
+If the version changes after running preparation, then `pnpm install --no-frozen-lockfile` must be run
+before the generate phase will run correctly.
 
-```json
-"fluidBuild": {
-  "branchReleaseTypes": {
-    "main": "minor",
-    "lts": "minor",
-    "release/**": "patch",
-    "next": "major"
-  }
-}
-```
+## The generate phase
 
-The branch names can be globs. They are matched using [minimatch](https://www.npmjs.com/package/minimatch).
+### Inputs to the generation process
 
-The type test generator takes this information into account when calculating the baseline version to use when it's run
-on a particular branch. Baseline versions are set as follows based on the branch release designation:
+The generation process has three inputs:
 
-| Branch release designation | Baseline version | Example: version 2.3.4 |
-| -------------------------- | ---------------- | ---------------------- |
-| `patch`                    | `previousPatch`  | **2.3.3**              |
-| `minor`                    | `~previousMinor` | **~2.2.0**             |
-| `major`                    | `^previousMajor` | **^1.0.0**             |
+1. The previous version of the package, which is a devDependency of the package being tested.
+2. The `typeValidation` settings in package.json, most notably the `broken` and `entrypoint` settings.
+3. The `--entrypoint` flag in `flub generate:typetests`. If provided, this overrides the `version.entrypoint` setting in
+   package.json.
 
-### Configuring a branch for a specific baseline
+The generation process reads the configuration from package.json, most notably any known broken type tests, and
+generates test files that should be committed. Notably, the type tests only read the previous version of the package,
+and use it to generate the tests. When types are removed, the tests can be disabled using the "broken" entries as usual.
 
-It may be useful to configure a branch for a specific baseline instead of the default based on the branch release
-designation. To do this, you can use any of the following strings instead of major/minor/patch.
+### Running typetests:gen
 
--   `baseMajor`
--   `baseMinor`
--   `~baseMinor`
--   `previousPatch`
--   `previousMinor`
--   `previousMajor`
--   `^previousMajor`
--   `^previousMinor`
--   `~previousMajor`
--   `~previousMinor`
+While you can run `flub generate:typetests` directly, the generate phase is typically done by running `pnpm typetests:gen`,
+which invokes each package's `typetests:gen` script.
 
-The "base" versions are calculated by zeroing out all version segments lower than the base. That is, for a version _v_,
-the baseMajor version is `${v.major}.0.0` and the baseMinor version is `${v.major}.${v.minor}.0`.
+See the [`flub generate:typetests`](./generate.md#flub-generate-typetests) reference documentation for
+details about the flags and options available.
 
-The "previous" versions work similarly, but the major/minor/patch segment is reduced by 1. That is, for a version _v_,
-the previousMajor version is `${min(v.major - 1, 1)}.0.0`, the previousMinor version is
-`${v.major}.${min(v.minor - 1, 0)}.0`, and the previousPatch is `${v.major}.${v.minor}.${min(v.patch - 1, 0)}`.
-
-The "previous" versions never roll back below 1 for the major version and 0 for minor and patch. That is, the
-previousMajor, previousMinor, and previousPatch versions for `1.0.0` are all `1.0.0`.
-
-**Warning**: `^previousMinor` allows the baseline (the "previous" version) to jump into the same range as the current version, so use with caution.
-In most cases, you probably want to use `~previousMinor`.
-
-#### Examples
-
-Given the version 3.4.5:
-
-| Previous version style | Baseline version for **3.4.5** |
-| ---------------------- | ------------------------------ |
-| `baseMajor`            | 3.0.0                          |
-| `baseMinor`            | 3.4.0                          |
-| `~baseMinor`           | ~3.4.0                         |
-| `previousPatch`        | 3.4.4                          |
-| `previousMajor`        | 2.0.0                          |
-| `previousMinor`        | 3.3.0                          |
-| `^previousMajor`       | ^2.0.0                         |
-| `^previousMinor`       | ^3.3.0                         |
-| `~previousMajor`       | ~2.0.0                         |
-| `~previousMinor`       | ~3.3.0                         |
-
-Given the version 2.0.0-internal.2.3.5:
-
-| Previous version style | Baseline version for **2.0.0-internal.2.3.5** |
-| ---------------------- | --------------------------------------------- |
-| `baseMajor`            | 2.0.0-internal.2.0.0                          |
-| `baseMinor`            | 2.0.0-internal.2.3.0                          |
-| `~baseMinor`           | >=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0  |
-| `previousPatch`        | 2.0.0-internal.2.3.4                          |
-| `previousMajor`        | 2.0.0-internal.1.0.0                          |
-| `previousMinor`        | 2.0.0-internal.2.2.0                          |
-| `^previousMajor`       | >=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0  |
-| `^previousMinor`       | >=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0  |
-| `~previousMajor`       | >=2.0.0-internal.1.0.0 <2.0.0-internal.1.1.0  |
-| `~previousMinor`       | >=2.0.0-internal.2.2.0 <2.0.0-internal.2.3.0  |
-
-Given the version 2.0.0-internal.2.0.0:
-
-| Previous version style | Baseline version for **2.0.0-internal.2.0.0** |
-| ---------------------- | --------------------------------------------- |
-| `baseMajor`            | 2.0.0-internal.2.0.0                          |
-| `baseMinor`            | 2.0.0-internal.2.0.0                          |
-| `~baseMinor`           | >=2.0.0-internal.2.0.0 <2.0.0-internal.2.1.0  |
-| `previousPatch`        | 2.0.0-internal.2.0.0                          |
-| `previousMajor`        | 2.0.0-internal.1.0.0                          |
-| `previousMinor`        | 2.0.0-internal.2.0.0                          |
-| `^previousMajor`       | >=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0  |
-| `^previousMinor`       | >=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0  |
-| `~previousMajor`       | >=2.0.0-internal.1.0.0 <2.0.0-internal.1.1.0  |
-| `~previousMinor`       | >=2.0.0-internal.2.0.0 <2.0.0-internal.2.1.0  |
-
-## Pinning to a specific version
-
-This is useful when you want to regularly update the baseline version when releases happen, but only when explicitly
-updated, such as part of a release process. You can do this with a combination of a baseline range such as
-`^previousMajor` and the `--pin` flag.
-
-The `--pin` flag searches the release git tags in the repo and selects the baseline version as the maximum released
-version that matches the range. This effectively pins the version to a specific version while allowing it to be updated
-manually as needed by running type test preparation again.
-
-This is functionally similar to what a lockfile does, but this provides us with an extra level of control so we don't
-rely on lockfiles for type test package versions, because we have found bugs in lockfile handling related to npm
-aliases, which the type test infrastructure relies on.
+> [!NOTE]
+> The `generate:typetests` command is designed to produce a single output file - the type tests - per invocation, and to
+> generate tests for a single entrypoint. If you want to generate tests for both the alpha entrypoint and the legacy
+> entrypoint, for example, you will need to use `generate:typetests` twice, once for each entrypoint.

--- a/build-tools/packages/build-cli/docs/typetestDetails.md
+++ b/build-tools/packages/build-cli/docs/typetestDetails.md
@@ -2,7 +2,7 @@
 
 _This documentation is accurate as of build-tools 0.45.0._
 
-The `typetests` `generate:typetests` commands are used to generate and manage type compatibility tests based on the
+The `typetests` and `generate:typetests` commands are used to generate and manage type compatibility tests based on the
 individual package settings in package.json.
 
 ## What are type compatibility tests?


### PR DESCRIPTION
There's been some confusion about how typetest generation and management works, so I've updated the type test docs in the repo to reflect the behavior and intended design as of 0.45.0.

I am very open to changing the design in the future, but I want to make sure the current behavior is documented so everyone can be on the same page when we discuss possible improvements.