### PR TITLE
Update experimental incremental summary context to readonly properties

### DIFF
--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -120,9 +120,9 @@ export interface IEnvelope {
 
 // @alpha
 export interface IExperimentalIncrementalSummaryContext {
-    latestSummarySequenceNumber: number;
-    summaryPath: string;
-    summarySequenceNumber: number;
+    readonly latestSummarySequenceNumber: number;
+    readonly summaryPath: string;
+    readonly summarySequenceNumber: number;
 }
 
 // @alpha

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -97,11 +97,11 @@ export interface IExperimentalIncrementalSummaryContext {
 	/**
 	 * The sequence number of the summary generated that will be sent to the server.
 	 */
-	summarySequenceNumber: number;
+	readonly summarySequenceNumber: number;
 	/**
 	 * The sequence number of the most recent summary that was acknowledged by the server.
 	 */
-	latestSummarySequenceNumber: number;
+	readonly latestSummarySequenceNumber: number;
 	/**
 	 * The path to the runtime/datastore/dds that is used to generate summary handles
 	 * Note: Summary handles are nodes of the summary tree that point to previous parts of the last successful summary
@@ -113,7 +113,7 @@ export interface IExperimentalIncrementalSummaryContext {
 	 * more dependencies.
 	 */
 	// TODO: remove summaryPath
-	summaryPath: string;
+	readonly summaryPath: string;
 }
 
 /**


### PR DESCRIPTION
Make the properties on `IExperimentalIncrementalSummaryContext` `readonly` as it does not makes sense for those values to be mutable.