### PR TITLE
Instrument whether Summary includes partial batch chunks

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2372,9 +2372,10 @@ export class ContainerRuntime
 			addBlobToSummary(summaryTree, idCompressorBlobName, idCompressorState);
 		}
 
-		if (this.remoteMessageProcessor.partialMessages.size > 0) {
-			const content = JSON.stringify([...this.remoteMessageProcessor.partialMessages]);
-			addBlobToSummary(summaryTree, chunksBlobName, content);
+		const partialMessages =
+			this.remoteMessageProcessor.getPartialMessageInfoForSummary(telemetryContext);
+		if (partialMessages !== undefined) {
+			addBlobToSummary(summaryTree, chunksBlobName, JSON.stringify(partialMessages));
 		}
 
 		const dataStoreAliases = this.channelCollection.aliases;

--- a/packages/runtime/container-runtime/src/opLifecycle/remoteMessageProcessor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/remoteMessageProcessor.ts
@@ -8,6 +8,7 @@ import {
 	MessageType,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
+import type { ITelemetryContext } from "@fluidframework/runtime-definitions/internal";
 
 import {
 	ContainerMessageType,
@@ -75,7 +76,19 @@ export class RemoteMessageProcessor {
 		private readonly opGroupingManager: OpGroupingManager,
 	) {}
 
-	public get partialMessages(): ReadonlyMap<string, string[]> {
+	public getPartialMessageInfoForSummary(
+		telemetryContext?: ITelemetryContext,
+	): ReadonlyMap<string, string[]> | undefined {
+		if (this.opSplitter.chunks.size === 0) {
+			return undefined;
+		}
+
+		telemetryContext?.set(
+			"fluid_RemoteMessageProcessor",
+			"partialMessageCount",
+			this.opSplitter.chunks.size,
+		);
+
 		return this.opSplitter.chunks;
 	}
 


### PR DESCRIPTION
## Description

~Based on the fact that inbound batches are always processed synchronously, we don't believe the RemoteMessageProcessor will ever have a partial batch in-flight when Summary happens.  But maybe there are cases I'm not thinking of.~

^ That was wrong - the leading chunks are sent not as part of the batch, but individually (i.e. a bunch of single-message "batches").  So this codepath is certainly hit at scale. And worth instrumenting IMO.

This change adds a stat to Summarizer's telemetryContext indicating how many chunks were added - or remains undefined if none.

After 2.4 ships we can look for this in the logs to find out if this ever happens at scale.
