### PR TITLE
Move changeset "Make SharedTree usable with legacy APIs" into "section": "tree"

### DIFF
--- a/.changeset/whole-carpets-sell.md
+++ b/.changeset/whole-carpets-sell.md
@@ -2,7 +2,7 @@
 "@fluidframework/tree": minor
 ---
 ---
-"section": "fix"
+"section": "tree"
 ---
 Make SharedTree usable with legacy APIs
 


### PR DESCRIPTION
## Description

Move changeset  "Make SharedTree usable with legacy APIs" into "section": "tree"

It is more of a feature than a bug fix (the fact this feature was missing was more accidental than planned, but still seems more tree than bug)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


