### PR TITLE
Normalize @fluid-experimental/presence dep

### DIFF
--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -122,7 +122,7 @@
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/datastore": "workspace:~",
-		"@fluidframework/datastore-definitions": "workspace:^",
+		"@fluidframework/datastore-definitions": "workspace:~",
 		"@fluidframework/fluid-static": "workspace:~",
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11337,7 +11337,7 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/datastore
       '@fluidframework/datastore-definitions':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../../runtime/datastore-definitions
       '@fluidframework/fluid-static':
         specifier: workspace:~


### PR DESCRIPTION
## Description

We use ~ deps for workspace deps so changes to internal API don't break customers which otherwise could mismatch packages withing a release group from different minor releases.

This corrects the one dep not following this pattern.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
