### PR TITLE
Add deleted packages to changeset

### DIFF
--- a/.changeset/hand-picked-string.md
+++ b/.changeset/hand-picked-string.md
@@ -1,4 +1,9 @@
 ---
+# This metadata needs to be removed before running generate:changelog
+"@fluid-experimental/property-shared-tree-interop": "minor"
+"@fluid-experimental/property-binder": "minor"
+"@fluid-experimental/property-proxy": "minor"
+"@fluid-experimental/property-inspector-table": "minor"
 ---
 ---
 "section": "other"


### PR DESCRIPTION
This is a workaround for a bug in the release notes generator - it excludes changesets that apply to no packages.

The extra metadata will need to be deleted before generating changelogs. If this is not done, generate changelog will fail with an error like:

```
Error: Command failed with exit code 1: pnpm exec changeset version
    🦋  error TypeError: Cannot destructure property 'packageJson' of 'undefined' as it is undefined.
    🦋  error     at Object.shouldSkipPackage 
    (/home/tylerbu/code/FluidFramework/node_modules/.pnpm/@changesets+should-skip-package@0.1.1/node_modules/@changesets/should-skip-package/dist/changesets-should-skip-package.cjs.js:6:3)
    🦋  error     at getRelevantChangesets 
    (/home/tylerbu/code/FluidFramework/node_modules/.pnpm/@changesets+assemble-release-plan@6.0.4/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:608:29)
    🦋  error     at Object.assembleReleasePlan [as default] 
    (/home/tylerbu/code/FluidFramework/node_modules/.pnpm/@changesets+assemble-release-plan@6.0.4/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:536:30)
    🦋  error     at version (/home/tylerbu/code/FluidFramework/node_modules/.pnpm/@changesets+cli@2.27.8/node_modules/@changesets/cli/dist/changesets-cli.cjs.js:1281:60)
    🦋  error     at async run (/home/tylerbu/code/FluidFramework/node_modules/.pnpm/@changesets+cli@2.27.8/node_modules/@changesets/cli/dist/changesets-cli.cjs.js:1463:11)
```