### PR TITLE
Revert back PR #21785. Process ops by batches in remoteMessageProcessor and pendingStateManager

### DIFF
--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -16,7 +16,7 @@ import {
 import Deque from "double-ended-queue";
 import { v4 as uuid } from "uuid";
 
-import { type InboundSequencedContainerRuntimeMessage } from "./messageTypes.js";
+import { InboundSequencedContainerRuntimeMessage } from "./messageTypes.js";
 import { asBatchMetadata, IBatchMetadata } from "./metadata.js";
 import { BatchId, BatchMessage, generateBatchId } from "./opLifecycle/index.js";
 import { pkgVersion } from "./packageVersion.js";
@@ -294,32 +294,13 @@ export class PendingStateManager implements IDisposable {
 	}
 
 	/**
-	 * Processes the incoming batch from the server. It verifies that messages are received in the right order and
-	 * that the batch information is correct.
-	 * @param batch - The batch that is being processed.
-	 * @param batchStartCsn - The clientSequenceNumber of the start of this message's batch
-	 */
-	public processPendingLocalBatch(
-		batch: InboundSequencedContainerRuntimeMessage[],
-		batchStartCsn: number,
-	): {
-		message: InboundSequencedContainerRuntimeMessage;
-		localOpMetadata: unknown;
-	}[] {
-		return batch.map((message) => ({
-			message,
-			localOpMetadata: this.processPendingLocalMessage(message, batchStartCsn),
-		}));
-	}
-
-	/**
 	 * Processes a local message once its ack'd by the server. It verifies that there was no data corruption and that
 	 * the batch information was preserved for batch messages.
 	 * @param message - The message that got ack'd and needs to be processed.
 	 * @param batchStartCsn - The clientSequenceNumber of the start of this message's batch (assigned during submit)
 	 * (not to be confused with message.clientSequenceNumber - the overwritten value in case of grouped batching)
 	 */
-	private processPendingLocalMessage(
+	public processPendingLocalMessage(
 		message: InboundSequencedContainerRuntimeMessage,
 		batchStartCsn: number,
 	): unknown {

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -743,11 +743,8 @@ describe("Runtime", () => {
 					processMessage: (_message: ISequencedDocumentMessage, _local: boolean) => {
 						return { localAck: false, localOpMetadata: undefined };
 					},
-					processPendingLocalBatch: (_messages: ISequencedDocumentMessage[]) => {
-						return _messages.map((message) => ({
-							message,
-							localOpMetadata: undefined,
-						}));
+					processPendingLocalMessage: (_message: ISequencedDocumentMessage) => {
+						return undefined;
 					},
 					get pendingMessagesCount() {
 						return pendingMessages;
@@ -924,7 +921,6 @@ describe("Runtime", () => {
 								contents: {
 									address: "address",
 								},
-								clientSequenceNumber: 0,
 							} as any as ISequencedDocumentMessage,
 							true /* local */,
 						);

--- a/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
@@ -289,9 +289,7 @@ describe("RemoteMessageProcessor", () => {
 			},
 		};
 		const messageProcessor = getMessageProcessor();
-		const result = messageProcessor.process(
-			groupedBatch as ISequencedDocumentMessage,
-		);
+		const result = messageProcessor.process(groupedBatch as ISequencedDocumentMessage);
 
 		const expected = [
 			{

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -161,10 +161,12 @@ describe("Pending State Manager", () => {
 		};
 
 		const process = (messages: Partial<ISequencedDocumentMessage>[], batchStartCsn: number) =>
-			pendingStateManager.processPendingLocalBatch(
-				messages as InboundSequencedContainerRuntimeMessage[],
-				batchStartCsn,
-			);
+			messages.forEach((message) => {
+				pendingStateManager.processPendingLocalMessage(
+					message as InboundSequencedContainerRuntimeMessage,
+					batchStartCsn,
+				);
+			});
 
 		it("proper batch is processed correctly", () => {
 			const messages: Partial<ISequencedDocumentMessage>[] = [
@@ -420,8 +422,8 @@ describe("Pending State Manager", () => {
 					],
 					1,
 				);
-				pendingStateManager.processPendingLocalBatch(
-					[futureRuntimeMessage as ISequencedDocumentMessage & UnknownContainerRuntimeMessage],
+				pendingStateManager.processPendingLocalMessage(
+					futureRuntimeMessage as ISequencedDocumentMessage & UnknownContainerRuntimeMessage,
 					1 /* batchStartCsn */,
 				);
 			});


### PR DESCRIPTION
Reverting back https://github.com/microsoft/FluidFramework/pull/21785 given discoveries described here [AB#15212](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/15212)