### PR TITLE
MergeTree: Conflict Farm Support Apply Ops During Generations

### DIFF
--- a/packages/dds/merge-tree/src/test/testClientLogger.ts
+++ b/packages/dds/merge-tree/src/test/testClientLogger.ts
@@ -42,9 +42,8 @@ function getOpString(msg: ISequencedDocumentMessage | undefined): string {
 			: // eslint-disable-next-line @typescript-eslint/dot-notation
 				`@${op["pos1"]}${op["pos2"] === undefined ? "" : `,${op["pos2"]}`}`;
 
-	const seq =
-		msg.sequenceNumber < 0 ? "L" : (msg.sequenceNumber - msg.minimumSequenceNumber).toString();
-	const ref = (msg.referenceSequenceNumber - msg.minimumSequenceNumber).toString();
+	const seq = msg.sequenceNumber < 0 ? "L" : msg.sequenceNumber.toString();
+	const ref = msg.referenceSequenceNumber.toString();
 	const client = msg.clientId;
 	return `${seq}:${ref}:${client}${opType}${opPos}`;
 }
@@ -316,7 +315,7 @@ export class TestClientLogger {
 				`${this.clients[0].getCollabWindow().minSeq}: msn/offset\n` +
 				`Op format <seq>:<ref>:<client><type>@<pos1>,<pos2>\n` +
 				`sequence number represented as offset from msn. L means local.\n` +
-				`op types: 0) insert 1) remove 2) annotate\n`;
+				`op types: 0) insert 1) remove 2) annotate 4) obliterate\n`;
 
 			if (this.title) {
 				str += `${this.title}\n`;


### PR DESCRIPTION
I had thought we already had support for this as I know I prototyped it in the past but looks like it was never committed. Regardless, this change enables applying ops while we generate ops, which creates more variety in the refSeqs of subsequent ops, therefore tests more cases. 

However, though adding this i found some errors when run with obliterate enable, these apply to both the current implementation, and the new implementation in #22462. To account for this i've split the test in two such that we expand coverage without obliterate, and keep converge for obliterate