### PR TITLE
improvement(client): experimental presence use Session Id

### DIFF
--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -11,7 +11,9 @@ export function acquirePresence(fluidContainer: IFluidContainer): IPresence;
 export function acquirePresenceViaDataObject(fluidLoadable: ExperimentalPresenceDO): IPresence;
 
 // @alpha
-export type ClientSessionId = string;
+export type ClientSessionId = SessionId & {
+    readonly ClientSessionId: "ClientSessionId";
+};
 
 // @alpha
 export type ConnectedClientId = string;

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -11,6 +11,9 @@ export function acquirePresence(fluidContainer: IFluidContainer): IPresence;
 export function acquirePresenceViaDataObject(fluidLoadable: ExperimentalPresenceDO): Promise<IPresence>;
 
 // @alpha
+export type ClientSessionId = string;
+
+// @alpha
 export type ConnectedClientId = string;
 
 // @alpha @sealed
@@ -31,8 +34,10 @@ export interface IPresence {
 }
 
 // @alpha @sealed
-export interface ISessionClient<SpecificClientId extends ConnectedClientId = ConnectedClientId> {
-    currentClientId(): SpecificClientId;
+export interface ISessionClient<SpecificSessionClientId extends ClientSessionId = ClientSessionId> {
+    currentClientId(): ConnectedClientId;
+    // (undocumented)
+    readonly sessionId: SpecificSessionClientId;
 }
 
 // @alpha
@@ -60,8 +65,8 @@ export interface LatestMapItemValueClientData<T, K extends string | number> exte
 }
 
 // @alpha @sealed
-export interface LatestMapValueClientData<T, Keys extends string | number, SpecificClientId extends ConnectedClientId = ConnectedClientId> {
-    client: ISessionClient<SpecificClientId>;
+export interface LatestMapValueClientData<T, Keys extends string | number, SpecificSessionClientId extends ClientSessionId = ClientSessionId> {
+    client: ISessionClient<SpecificSessionClientId>;
     // (undocumented)
     items: ReadonlyMap<Keys, LatestValueData<T>>;
 }
@@ -69,7 +74,7 @@ export interface LatestMapValueClientData<T, Keys extends string | number, Speci
 // @alpha @sealed
 export interface LatestMapValueManager<T, Keys extends string | number = string | number> {
     clients(): ISessionClient[];
-    clientValue<SpecificClientId extends ConnectedClientId>(client: ISessionClient<SpecificClientId>): LatestMapValueClientData<T, Keys, SpecificClientId>;
+    clientValue<SpecificSessionClientId extends ClientSessionId>(client: ISessionClient<SpecificSessionClientId>): LatestMapValueClientData<T, Keys, SpecificSessionClientId>;
     clientValues(): IterableIterator<LatestMapValueClientData<T, Keys>>;
     readonly controls: LatestValueControls;
     readonly events: ISubscribable<LatestMapValueManagerEvents<T, Keys>>;

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -28,7 +28,7 @@ export const ExperimentalPresenceManager: SharedObjectKind<IFluidLoadable & Expe
 // @alpha @sealed
 export interface IPresence {
     readonly events: ISubscribable<PresenceEvents>;
-    getAttendee(clientId: ClientConnectionId): ISessionClient;
+    getAttendee(clientId: ClientConnectionId | ClientSessionId): ISessionClient;
     getAttendees(): ReadonlySet<ISessionClient>;
     getMyself(): ISessionClient;
     getNotifications<NotificationsSchema extends PresenceNotificationsSchema>(notificationsId: PresenceWorkspaceAddress, requestedContent: NotificationsSchema): PresenceNotifications<NotificationsSchema>;

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -8,7 +8,7 @@
 export function acquirePresence(fluidContainer: IFluidContainer): IPresence;
 
 // @alpha
-export function acquirePresenceViaDataObject(fluidLoadable: ExperimentalPresenceDO): Promise<IPresence>;
+export function acquirePresenceViaDataObject(fluidLoadable: ExperimentalPresenceDO): IPresence;
 
 // @alpha
 export type ClientSessionId = string;

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -11,12 +11,12 @@ export function acquirePresence(fluidContainer: IFluidContainer): IPresence;
 export function acquirePresenceViaDataObject(fluidLoadable: ExperimentalPresenceDO): IPresence;
 
 // @alpha
+export type ClientConnectionId = string;
+
+// @alpha
 export type ClientSessionId = SessionId & {
     readonly ClientSessionId: "ClientSessionId";
 };
-
-// @alpha
-export type ConnectedClientId = string;
 
 // @alpha @sealed
 export class ExperimentalPresenceDO {
@@ -28,7 +28,7 @@ export const ExperimentalPresenceManager: SharedObjectKind<IFluidLoadable & Expe
 // @alpha @sealed
 export interface IPresence {
     readonly events: ISubscribable<PresenceEvents>;
-    getAttendee(clientId: ConnectedClientId): ISessionClient;
+    getAttendee(clientId: ClientConnectionId): ISessionClient;
     getAttendees(): ReadonlySet<ISessionClient>;
     getMyself(): ISessionClient;
     getNotifications<NotificationsSchema extends PresenceNotificationsSchema>(notificationsId: PresenceWorkspaceAddress, requestedContent: NotificationsSchema): PresenceNotifications<NotificationsSchema>;
@@ -37,7 +37,7 @@ export interface IPresence {
 
 // @alpha @sealed
 export interface ISessionClient<SpecificSessionClientId extends ClientSessionId = ClientSessionId> {
-    currentClientId(): ConnectedClientId;
+    currentConnectionId(): ClientConnectionId;
     // (undocumented)
     readonly sessionId: SpecificSessionClientId;
 }

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -124,6 +124,7 @@
 		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/datastore-definitions": "workspace:~",
 		"@fluidframework/fluid-static": "workspace:~",
+		"@fluidframework/id-compressor": "workspace:~",
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/shared-object-base": "workspace:~"

--- a/packages/framework/presence/src/baseTypes.ts
+++ b/packages/framework/presence/src/baseTypes.ts
@@ -10,7 +10,7 @@
  * Each client connection is given a unique identifier for the duration of the
  * connection. If a client disconnects and reconnects, it will be given a new
  * identifier. Prefer use of {@link ISessionClient} as a way to identify clients
- * in a session. {@link ISessionClient.currentClientId} will provide the current
+ * in a session. {@link ISessionClient.currentConnectionId} will provide the current
  * connection identifier for a logical session client.
  *
  * @privateRemarks
@@ -21,4 +21,4 @@
  *
  * @alpha
  */
-export type ConnectedClientId = string;
+export type ClientConnectionId = string;

--- a/packages/framework/presence/src/datastorePresenceManagerFactory.ts
+++ b/packages/framework/presence/src/datastorePresenceManagerFactory.ts
@@ -90,9 +90,9 @@ export const ExperimentalPresenceManager =
  *
  * @alpha
  */
-export async function acquirePresenceViaDataObject(
+export function acquirePresenceViaDataObject(
 	fluidLoadable: ExperimentalPresenceDO,
-): Promise<IPresence> {
+): IPresence {
 	if (fluidLoadable instanceof PresenceManagerDataObject) {
 		return fluidLoadable.presenceManager();
 	}

--- a/packages/framework/presence/src/index.ts
+++ b/packages/framework/presence/src/index.ts
@@ -35,7 +35,12 @@ export type {
 	PresenceWorkspaceAddress,
 } from "./types.js";
 
-export type { IPresence, ISessionClient, PresenceEvents } from "./presence.js";
+export type {
+	ClientSessionId,
+	IPresence,
+	ISessionClient,
+	PresenceEvents,
+} from "./presence.js";
 
 export { acquirePresence } from "./experimentalAccess.js";
 

--- a/packages/framework/presence/src/index.ts
+++ b/packages/framework/presence/src/index.ts
@@ -22,7 +22,7 @@
 // 	ISubscribable,
 // } from "@fluid-experimental/presence/internal/events";
 
-export type { ConnectedClientId } from "./baseTypes.js";
+export type { ClientConnectionId } from "./baseTypes.js";
 
 export type {
 	PresenceNotifications,

--- a/packages/framework/presence/src/internalTypes.ts
+++ b/packages/framework/presence/src/internalTypes.ts
@@ -3,9 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import type { ConnectedClientId } from "./baseTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
-import type { ISessionClient } from "./presence.js";
+import type { ClientSessionId, ISessionClient } from "./presence.js";
 
 /**
  * @internal
@@ -14,7 +13,7 @@ export interface ClientRecord<TValue extends InternalTypes.ValueDirectoryOrState
 	// Caution: any particular item may or may not exist
 	// Typescript does not support absent keys without forcing type to also be undefined.
 	// See https://github.com/microsoft/TypeScript/issues/42810.
-	[ClientId: ConnectedClientId]: TValue;
+	[ClientSessionId: ClientSessionId]: TValue;
 }
 
 /**

--- a/packages/framework/presence/src/latestValueManager.ts
+++ b/packages/framework/presence/src/latestValueManager.ts
@@ -110,15 +110,15 @@ class LatestValueManagerImpl<T, Key extends string>
 	public clients(): ISessionClient[] {
 		const allKnownStates = this.datastore.knownValues(this.key);
 		return Object.keys(allKnownStates.states)
-			.filter((clientId) => clientId !== allKnownStates.self)
-			.map((clientId) => this.datastore.lookupClient(clientId));
+			.filter((clientSessionId) => clientSessionId !== allKnownStates.self)
+			.map((clientSessionId) => this.datastore.lookupClient(clientSessionId));
 	}
 
 	public clientValue(client: ISessionClient): LatestValueData<T> {
 		const allKnownStates = this.datastore.knownValues(this.key);
-		const clientId = client.currentClientId();
-		if (clientId in allKnownStates.states) {
-			const { value, rev: revision } = allKnownStates.states[clientId];
+		const clientSessionId = client.sessionId;
+		if (clientSessionId in allKnownStates.states) {
+			const { value, rev: revision } = allKnownStates.states[clientSessionId];
 			return { value, metadata: { revision, timestamp: Date.now() } };
 		}
 		throw new Error("No entry for clientId");
@@ -130,14 +130,14 @@ class LatestValueManagerImpl<T, Key extends string>
 		value: InternalTypes.ValueRequiredState<T>,
 	): void {
 		const allKnownStates = this.datastore.knownValues(this.key);
-		const clientId = client.currentClientId();
-		if (clientId in allKnownStates.states) {
-			const currentState = allKnownStates.states[clientId];
+		const clientSessionId = client.sessionId;
+		if (clientSessionId in allKnownStates.states) {
+			const currentState = allKnownStates.states[clientSessionId];
 			if (currentState.rev >= value.rev) {
 				return;
 			}
 		}
-		this.datastore.update(this.key, clientId, value);
+		this.datastore.update(this.key, clientSessionId, value);
 		this.events.emit("updated", {
 			client,
 			value: value.value,

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import type { SessionId } from "@fluidframework/id-compressor";
+
 import type { ConnectedClientId } from "./baseTypes.js";
 import type {
 	PresenceNotifications,
@@ -26,7 +28,7 @@ import type { ISubscribable } from "@fluid-experimental/presence/internal/events
  *
  * @alpha
  */
-export type ClientSessionId = string;
+export type ClientSessionId = SessionId & { readonly ClientSessionId: "ClientSessionId" };
 
 /**
  * A client within a Fluid session (period of container connectivity to service).

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -5,7 +5,7 @@
 
 import type { SessionId } from "@fluidframework/id-compressor";
 
-import type { ConnectedClientId } from "./baseTypes.js";
+import type { ClientConnectionId } from "./baseTypes.js";
 import type {
 	PresenceNotifications,
 	PresenceNotificationsSchema,
@@ -38,7 +38,7 @@ export type ClientSessionId = SessionId & { readonly ClientSessionId: "ClientSes
  *
  * `ISessionClient` should be used as key to distinguish between different
  * clients as they join, rejoin, and disconnect from a session. While a
- * client's {@link ConnectedClientId} may change over time `ISessionClient`
+ * client's {@link ClientConnectionId} may change over time `ISessionClient`
  * will be fixed.
  *
  * @privateRemarks
@@ -59,9 +59,9 @@ export interface ISessionClient<
 	 * @returns Current client connection id.
 	 *
 	 * @remarks
-	 * Connection id will change on reconnection.
+	 * Connection id will change on reconnect.
 	 */
-	currentClientId(): ConnectedClientId;
+	currentConnectionId(): ClientConnectionId;
 }
 
 /**
@@ -136,7 +136,7 @@ export interface IPresence {
 	 *
 	 * @param clientId - Client connection id
 	 */
-	getAttendee(clientId: ConnectedClientId): ISessionClient;
+	getAttendee(clientId: ClientConnectionId): ISessionClient;
 
 	/**
 	 * Get this client's session client.

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -15,10 +15,24 @@ import type {
 import type { ISubscribable } from "@fluid-experimental/presence/internal/events";
 
 /**
+ * A Fluid client session identifier.
+ *
+ * @remarks
+ * Each client once connected to a session is given a unique identifier for the
+ * duration of the session. If a client disconnects and reconnects, it will
+ * retain its identifier. Prefer use of {@link ISessionClient} as a way to
+ * identify clients in a session. {@link ISessionClient.sessionId} will provide
+ * the session id.
+ *
+ * @alpha
+ */
+export type ClientSessionId = string;
+
+/**
  * A client within a Fluid session (period of container connectivity to service).
  *
  * @remarks
- * Note: This is very preliminary session client represenation.
+ * Note: This is very preliminary session client representation.
  *
  * `ISessionClient` should be used as key to distinguish between different
  * clients as they join, rejoin, and disconnect from a session. While a
@@ -33,8 +47,10 @@ import type { ISubscribable } from "@fluid-experimental/presence/internal/events
  * @alpha
  */
 export interface ISessionClient<
-	SpecificClientId extends ConnectedClientId = ConnectedClientId,
+	SpecificSessionClientId extends ClientSessionId = ClientSessionId,
 > {
+	readonly sessionId: SpecificSessionClientId;
+
 	/**
 	 * Get current client connection id.
 	 *
@@ -43,17 +59,17 @@ export interface ISessionClient<
 	 * @remarks
 	 * Connection id will change on reconnection.
 	 */
-	currentClientId(): SpecificClientId;
+	currentClientId(): ConnectedClientId;
 }
 
 /**
  * Utility type limiting to a specific session client. (A session client with
- * a specific connection id - not just any connection id.)
+ * a specific session id - not just any session id.)
  *
  * @internal
  */
-export type SpecificSessionClient<SpecificClientId extends ConnectedClientId> =
-	string extends SpecificClientId ? never : ISessionClient<SpecificClientId>;
+export type SpecificSessionClient<SpecificSessionClientId extends ClientSessionId> =
+	string extends SpecificSessionClientId ? never : ISessionClient<SpecificSessionClientId>;
 
 /**
  * @sealed

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -134,9 +134,9 @@ export interface IPresence {
 	/**
 	 * Lookup a specific attendee in the session.
 	 *
-	 * @param clientId - Client connection id
+	 * @param clientId - Client connection or session id
 	 */
-	getAttendee(clientId: ClientConnectionId): ISessionClient;
+	getAttendee(clientId: ClientConnectionId | ClientSessionId): ISessionClient;
 
 	/**
 	 * Get this client's session client.

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -10,7 +10,7 @@ import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions/
 
 import type { ConnectedClientId } from "./baseTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
-import type { IPresence } from "./presence.js";
+import type { ClientSessionId, IPresence } from "./presence.js";
 import type {
 	ClientUpdateEntry,
 	PresenceStatesInternal,
@@ -28,13 +28,14 @@ interface PresenceStatesEntry<TSchema extends PresenceStatesSchema> {
 
 interface SystemDatastore {
 	"system:presence": {
-		priorClientIds: {
-			[ClientId: ConnectedClientId]: InternalTypes.ValueRequiredState<ConnectedClientId[]>;
+		clientToSessionId: {
+			[
+				ConnectedClientId: ConnectedClientId
+			]: InternalTypes.ValueRequiredState<ClientSessionId>;
 		};
 	};
 }
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type PresenceDatastore = {
 	[WorkspaceAddress: string]: ValueElementMap<PresenceStatesSchema>;
 } & SystemDatastore;
@@ -42,7 +43,7 @@ type PresenceDatastore = {
 interface GeneralDatastoreMessageContent {
 	[WorkspaceAddress: string]: {
 		[StateValueManagerKey: string]: {
-			[ClientId: ConnectedClientId]: ClientUpdateEntry;
+			[ClientSessionId: ClientSessionId]: ClientUpdateEntry;
 		};
 	};
 }
@@ -87,7 +88,7 @@ function isPresenceMessage(
  */
 export type IEphemeralRuntime = Pick<
 	(IContainerRuntime & IRuntimeInternal) | IFluidDataStoreRuntime,
-	"clientId" | "getAudience" | "off" | "on" | "submitSignal"
+	"clientId" | "getQuorum" | "off" | "on" | "submitSignal"
 >;
 
 /**
@@ -106,7 +107,7 @@ export interface PresenceDatastoreManager {
  */
 export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 	private readonly datastore: PresenceDatastore = {
-		"system:presence": { priorClientIds: {} },
+		"system:presence": { clientToSessionId: {} },
 	};
 	private averageLatency = 0;
 	private returnedMessages = 0;
@@ -115,54 +116,47 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 	private readonly workspaces = new Map<string, PresenceStatesEntry<PresenceStatesSchema>>();
 
 	public constructor(
+		private readonly clientSessionId: ClientSessionId,
 		private readonly runtime: IEphemeralRuntime,
 		private readonly presence: IPresence,
 	) {
-		runtime.on("disconnected", () => {
-			const { clientId } = this.runtime;
-			assert(clientId !== undefined, "Disconnected without local clientId");
-			for (const [_address, allKnownWorkspaceState] of Object.entries(this.datastore)) {
-				for (const [_key, allKnownState] of Object.entries(allKnownWorkspaceState)) {
-					// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-					delete allKnownState[clientId];
-				}
-			}
-			// TODO: Consider caching prior (current) clientId to broadcast when reconnecting so others may remap state.
-		});
-		runtime.on("connected", () => {
-			const { clientId } = this.runtime;
-			assert(clientId !== undefined, "Connected without local clientId");
-			for (const [address, _allKnownWorkspaceState] of Object.entries(this.datastore)) {
-				const workspace = this.workspaces.get(address);
-				if (workspace) {
-					workspace.internal.onConnect(clientId);
-				} else {
-					// A client may not send state without creating a workspace.
-					// Once a workspace is created, it is never removed. So there
-					// should never be an unmanaged workspace with this client's
-					// clientId in it.
-					// TODO: Consider asserting there is no representation of this
-					// client in held state -- search for past client ids.
-				}
-			}
-
-			// Broadcast join message to all clients
-			const updateProviders = [...this.runtime.getAudience().getMembers().keys()].filter(
-				(audienceClientId) => audienceClientId !== clientId,
-			);
-			// Limit to three providers to prevent flooding the network.
-			// If none respond, others present will (should) after a delay.
-			if (updateProviders.length > 3) {
-				updateProviders.length = 3;
-			}
-			this.runtime.submitSignal(joinMessageType, {
-				sendTimestamp: Date.now(),
-				avgLatency: this.averageLatency,
-				data: this.datastore,
-				updateProviders,
-			} satisfies ClientJoinMessage["content"]);
-		});
+		runtime.on("connected", this.onConnect.bind(this));
 		runtime.on("signal", this.processSignal.bind(this));
+
+		// Check if already connected at the time of construction.
+		// If constructed during data store load, the runtime may already be connected
+		// and the "connected" event will be raised during completion. With construction
+		// delayed we expect that "connected" event has passed.
+		// Note: In some manual testing, this does not appear to be enough to
+		// always trigger an initial connect.
+		const clientId = runtime.clientId;
+		if (clientId !== undefined) {
+			this.onConnect(clientId);
+		}
+	}
+
+	private onConnect(clientId: ConnectedClientId): void {
+		this.datastore["system:presence"].clientToSessionId[clientId] = {
+			rev: 0,
+			timestamp: Date.now(),
+			value: this.clientSessionId,
+		};
+
+		// Broadcast join message to all clients
+		const updateProviders = [...this.runtime.getQuorum().getMembers().keys()].filter(
+			(quorumClientId) => quorumClientId !== clientId,
+		);
+		// Limit to three providers to prevent flooding the network.
+		// If none respond, others present will (should) after a delay.
+		if (updateProviders.length > 3) {
+			updateProviders.length = 3;
+		}
+		this.runtime.submitSignal(joinMessageType, {
+			sendTimestamp: Date.now(),
+			avgLatency: this.averageLatency,
+			data: this.datastore,
+			updateProviders,
+		} satisfies ClientJoinMessage["content"]);
 	}
 
 	public getWorkspace<TSchema extends PresenceStatesSchema>(
@@ -184,15 +178,15 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 			value: ClientUpdateEntry,
 			forceBroadcast: boolean,
 		): void => {
-			const clientId = this.runtime.clientId;
-			if (clientId === undefined) {
+			// Check for connectivity before sending updates.
+			if (this.runtime.clientId === undefined) {
 				return;
 			}
 
 			this.localUpdate(
 				{
 					[internalWorkspaceAddress]: {
-						[stateKey]: { [clientId]: value },
+						[stateKey]: { [this.clientSessionId]: value },
 					},
 				},
 				forceBroadcast,
@@ -201,7 +195,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 
 		const entry = createPresenceStates(
 			{
-				clientId: () => this.runtime.clientId,
+				clientSessionId: this.clientSessionId,
 				lookupClient: this.presence.getAttendee.bind(this.presence),
 				localUpdate,
 			},
@@ -266,27 +260,30 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 			const updateProviders = message.content.updateProviders;
 			this.refreshBroadcastRequested = true;
 			// We must be connected to receive this message, so clientId should be defined.
-			// If it isn't then, not really a problem; just won't be in provider list.
+			// If it isn't then, not really a problem; just won't be in provider or quorum list.
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			if (updateProviders.includes(this.runtime.clientId!)) {
+			const clientId = this.runtime.clientId!;
+			if (updateProviders.includes(clientId)) {
 				// Send all current state to the new client
 				this.broadcastAllKnownState();
 			} else {
 				// Schedule a broadcast to the new client after a delay only to send if
 				// another broadcast hasn't been seen in the meantime. The delay is based
-				// on the position in the audience list. It doesn't have to be a stable
+				// on the position in the quorum list. It doesn't have to be a stable
 				// list across all clients. We need something to provide suggested order
 				// to prevent a flood of broadcasts.
-				let indexOfSelf = 0;
-				for (const clientId of this.runtime.getAudience().getMembers().keys()) {
-					if (clientId === this.runtime.clientId) {
-						break;
-					}
-					indexOfSelf += 1;
-				}
-				const waitTime = indexOfSelf * 20 + 200;
+				const quorumMembers = this.runtime.getQuorum().getMembers();
+				const indexOfSelf =
+					quorumMembers.get(clientId)?.sequenceNumber ??
+					// Index past quorum members + arbitrary additional offset up to 10
+					quorumMembers.size + Math.random() * 10;
+				// These numbers have been chosen arbitrarily to start with.
+				// 20 is minimum wait time, 20 is the additional wait time per provider
+				// given an chance before us with named providers given more time.
+				const waitTime = 20 + 20 * (3 * updateProviders.length + indexOfSelf);
 				setTimeout(() => {
 					if (this.refreshBroadcastRequested) {
+						// TODO: Add telemetry for this attempt to satisfy join
 						this.broadcastAllKnownState();
 					}
 				}, waitTime);
@@ -309,7 +306,9 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 				let workspaceDatastore = this.datastore[workspaceAddress];
 				if (workspaceDatastore === undefined) {
 					workspaceDatastore = this.datastore[workspaceAddress] = {};
-					// TODO: Emit workspaceActivated event for PresenceEvents
+					if (!workspaceAddress.startsWith("system:")) {
+						// TODO: Emit workspaceActivated event for PresenceEvents
+					}
 				}
 				for (const [key, remoteAllKnownState] of Object.entries(remoteDatastore)) {
 					mergeUntrackedDatastore(key, remoteAllKnownState, workspaceDatastore, timeModifier);

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -8,7 +8,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 
-import type { ConnectedClientId } from "./baseTypes.js";
+import type { ClientConnectionId } from "./baseTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { ClientSessionId, IPresence } from "./presence.js";
 import type {
@@ -30,7 +30,7 @@ interface SystemDatastore {
 	"system:presence": {
 		clientToSessionId: {
 			[
-				ConnectedClientId: ConnectedClientId
+				ClientConnectionId: ClientConnectionId
 			]: InternalTypes.ValueRequiredState<ClientSessionId>;
 		};
 	};
@@ -65,7 +65,7 @@ const joinMessageType = "Pres:ClientJoin";
 interface ClientJoinMessage extends IInboundSignalMessage {
 	type: typeof joinMessageType;
 	content: {
-		updateProviders: ConnectedClientId[];
+		updateProviders: ClientConnectionId[];
 		sendTimestamp: number;
 		avgLatency: number;
 		data: DatastoreMessageContent;
@@ -135,7 +135,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 		}
 	}
 
-	private onConnect(clientId: ConnectedClientId): void {
+	private onConnect(clientId: ClientConnectionId): void {
 		this.datastore["system:presence"].clientToSessionId[clientId] = {
 			rev: 0,
 			timestamp: Date.now(),

--- a/packages/framework/presence/src/presenceManager.ts
+++ b/packages/framework/presence/src/presenceManager.ts
@@ -42,7 +42,7 @@ export interface IPresenceManager
 class PresenceManager implements IPresenceManager {
 	private readonly datastoreManager: PresenceDatastoreManager;
 	private readonly selfAttendee: ISessionClient = {
-		sessionId: createSessionId(),
+		sessionId: createSessionId() as ClientSessionId,
 		currentClientId: () => {
 			throw new Error("Client has never been connected");
 		},
@@ -83,7 +83,7 @@ class PresenceManager implements IPresenceManager {
 		return new Set(this.attendees.values());
 	}
 
-	public getAttendee(clientId: ConnectedClientId): ISessionClient {
+	public getAttendee(clientId: ConnectedClientId | ClientSessionId): ISessionClient {
 		const attendee = this.attendees.get(clientId);
 		if (attendee) {
 			return attendee;
@@ -91,9 +91,9 @@ class PresenceManager implements IPresenceManager {
 		// This is a major hack to enable basic operation.
 		// Missing attendees should be rejected.
 		const newAttendee = {
-			sessionId: clientId,
+			sessionId: clientId as ClientSessionId,
 			currentClientId: () => clientId,
-		};
+		} satisfies ISessionClient;
 		this.attendees.set(clientId, newAttendee);
 		return newAttendee;
 	}

--- a/packages/framework/presence/src/presenceManager.ts
+++ b/packages/framework/presence/src/presenceManager.ts
@@ -3,10 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { createSessionId } from "@fluidframework/id-compressor/internal";
 
 import type { ConnectedClientId } from "./baseTypes.js";
-import type { IPresence, ISessionClient, PresenceEvents } from "./presence.js";
+import type {
+	ClientSessionId,
+	IPresence,
+	ISessionClient,
+	PresenceEvents,
+} from "./presence.js";
 import type {
 	IEphemeralRuntime,
 	PresenceDatastoreManager,
@@ -32,16 +37,19 @@ export interface IPresenceManager
 		Pick<Required<IContainerExtension<[]>>, "processSignal"> {}
 
 /**
- * Common Presence manager
+ * The Presence manager
  */
 class PresenceManager implements IPresenceManager {
 	private readonly datastoreManager: PresenceDatastoreManager;
-	private readonly attendees = new Map<ConnectedClientId, ISessionClient>();
 	private readonly selfAttendee: ISessionClient = {
+		sessionId: createSessionId(),
 		currentClientId: () => {
 			throw new Error("Client has never been connected");
 		},
 	};
+	private readonly attendees = new Map<ConnectedClientId | ClientSessionId, ISessionClient>([
+		[this.selfAttendee.sessionId, this.selfAttendee],
+	]);
 
 	public constructor(runtime: IEphemeralRuntime) {
 		// If already connected, populate self and attendees.
@@ -57,14 +65,16 @@ class PresenceManager implements IPresenceManager {
 		// might possibly try to use it. (Datastore manager is expected to
 		// use connected clientId more directly and no order dependence should
 		// be relied upon, but helps with debugging consistency.)
-		runtime.on("connected", () => {
-			const clientId = runtime.clientId;
-			assert(clientId !== undefined, "Connected without local clientId");
+		runtime.on("connected", (clientId: ConnectedClientId) => {
 			this.selfAttendee.currentClientId = () => clientId;
 			this.attendees.set(clientId, this.selfAttendee);
 		});
 
-		this.datastoreManager = new PresenceDatastoreManagerImpl(runtime, this);
+		this.datastoreManager = new PresenceDatastoreManagerImpl(
+			this.selfAttendee.sessionId,
+			runtime,
+			this,
+		);
 	}
 
 	public readonly events = createEmitter<PresenceEvents>();
@@ -72,17 +82,22 @@ class PresenceManager implements IPresenceManager {
 	public getAttendees(): ReadonlySet<ISessionClient> {
 		return new Set(this.attendees.values());
 	}
+
 	public getAttendee(clientId: ConnectedClientId): ISessionClient {
 		const attendee = this.attendees.get(clientId);
 		if (attendee) {
 			return attendee;
 		}
+		// This is a major hack to enable basic operation.
+		// Missing attendees should be rejected.
 		const newAttendee = {
+			sessionId: clientId,
 			currentClientId: () => clientId,
 		};
 		this.attendees.set(clientId, newAttendee);
 		return newAttendee;
 	}
+
 	public getMyself(): ISessionClient {
 		return this.selfAttendee;
 	}

--- a/packages/framework/presence/src/presenceStates.ts
+++ b/packages/framework/presence/src/presenceStates.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/core-utils/internal";
 
-import type { ConnectedClientId } from "./baseTypes.js";
+import type { ClientConnectionId } from "./baseTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { ClientRecord } from "./internalTypes.js";
 import type { ClientSessionId, ISessionClient } from "./presence.js";
@@ -27,7 +27,7 @@ export type MapSchemaElement<
  */
 export interface PresenceRuntime {
 	readonly clientSessionId: ClientSessionId;
-	lookupClient(clientId: ConnectedClientId): ISessionClient;
+	lookupClient(clientId: ClientConnectionId): ISessionClient;
 	localUpdate(stateKey: string, value: ClientUpdateEntry, forceBroadcast: boolean): void;
 }
 
@@ -265,7 +265,7 @@ class PresenceStatesImpl<TSchema extends PresenceStatesSchema>
 		allKnownState[clientId] = mergeValueDirectory(allKnownState[clientId], value, 0);
 	}
 
-	public lookupClient(clientId: ConnectedClientId): ISessionClient {
+	public lookupClient(clientId: ClientConnectionId): ISessionClient {
 		return this.runtime.lookupClient(clientId);
 	}
 

--- a/packages/framework/presence/src/stateDatastore.ts
+++ b/packages/framework/presence/src/stateDatastore.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { ConnectedClientId } from "./baseTypes.js";
+import type { ClientConnectionId } from "./baseTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { ClientRecord } from "./internalTypes.js";
 import type { ClientSessionId, ISessionClient } from "./presence.js";
@@ -42,7 +42,7 @@ export interface StateDatastore<
 		self: ClientSessionId | undefined;
 		states: ClientRecord<TValue>;
 	};
-	lookupClient(clientId: ConnectedClientId): ISessionClient;
+	lookupClient(clientId: ClientConnectionId): ISessionClient;
 }
 
 /**

--- a/packages/framework/presence/src/stateDatastore.ts
+++ b/packages/framework/presence/src/stateDatastore.ts
@@ -6,7 +6,7 @@
 import type { ConnectedClientId } from "./baseTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { ClientRecord } from "./internalTypes.js";
-import type { ISessionClient } from "./presence.js";
+import type { ClientSessionId, ISessionClient } from "./presence.js";
 
 // type StateDatastoreSchemaNode<
 // 	TValue extends InternalTypes.ValueDirectoryOrState<any> = InternalTypes.ValueDirectoryOrState<unknown>,
@@ -37,9 +37,9 @@ export interface StateDatastore<
 		},
 		forceBroadcast: boolean,
 	): void;
-	update(key: TKey, clientId: ConnectedClientId, value: TValue): void;
+	update(key: TKey, clientSessionId: ClientSessionId, value: TValue): void;
 	knownValues(key: TKey): {
-		self: ConnectedClientId | undefined;
+		self: ClientSessionId | undefined;
 		states: ClientRecord<TValue>;
 	};
 	lookupClient(clientId: ConnectedClientId): ISessionClient;

--- a/packages/framework/presence/src/test/latestMapValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestMapValueManager.spec.ts
@@ -66,7 +66,7 @@ export function checkCompiles(): void {
 		LatestMapItemValueClientData<T, string | number>,
 		"client" | "key" | "value"
 	>): void {
-		console.log(client.currentClientId(), key, value);
+		console.log(client.sessionId, key, value);
 	}
 
 	localPointers.set("pen", { x: 1, y: 2 });

--- a/packages/framework/presence/src/test/latestValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestValueManager.spec.ts
@@ -40,7 +40,7 @@ export function checkCompiles(): void {
 	function logClientValue<
 		T /* following extends should not be required: */ extends Record<string, unknown>,
 	>({ client, value }: Pick<LatestValueClientData<T>, "client" | "value">): void {
-		console.log(client.currentClientId(), value);
+		console.log(client.sessionId, value);
 	}
 
 	// Create new cursor state
@@ -51,9 +51,7 @@ export function checkCompiles(): void {
 
 	// Listen to others cursor updates
 	const cursorUpdatedOff = cursor.events.on("updated", ({ client, value }) =>
-		console.log(
-			`client ${client.currentClientId()}'s cursor is now at (${value.x},${value.y})`,
-		),
+		console.log(`client ${client.sessionId}'s cursor is now at (${value.x},${value.y})`),
 	);
 	cursorUpdatedOff();
 

--- a/packages/framework/presence/src/test/notificationsManager.spec.ts
+++ b/packages/framework/presence/src/test/notificationsManager.spec.ts
@@ -30,7 +30,7 @@ export function checkCompiles(): void {
 			string
 		>({
 			msg: (client: ISessionClient, message: string) => {
-				console.log(`${client.currentClientId()} says, "${message}"`);
+				console.log(`${client.sessionId} says, "${message}"`);
 			},
 		}),
 	});
@@ -42,7 +42,7 @@ export function checkCompiles(): void {
 	// produced after `add`.
 	const NF = Notifications({
 		newId: (client: ISessionClient, id: number): void => {
-			console.log(`${client.currentClientId()} has a new id: ${id}`);
+			console.log(`${client.sessionId} has a new id: ${id}`);
 		},
 	});
 
@@ -55,7 +55,7 @@ export function checkCompiles(): void {
 	// 		"events"
 	// 	>({
 	// 		newId: (client: ISessionClient, id: number) => {
-	// 			console.log(`${client.currentClientId()} has a new id: ${id}`);
+	// 			console.log(`${client.sessionId} has a new id: ${id}`);
 	// 		},
 	// 	}),
 	// );
@@ -65,7 +65,7 @@ export function checkCompiles(): void {
 
 	function logUnattended(name: string, client: ISessionClient, ...content: unknown[]): void {
 		console.log(
-			`${client.currentClientId()} sent unattended notification '${name}' with content`,
+			`${client.sessionId} sent unattended notification '${name}' with content`,
 			...content,
 		);
 	}
@@ -78,7 +78,7 @@ export function checkCompiles(): void {
 	const chatClients = new Set<ISessionClient>();
 	const chatMsgOff = chat.notifications.on("msg", (client, _message) => {
 		if (!chatClients.has(client)) {
-			console.log(`client ${client.currentClientId()} has started chatting`);
+			console.log(`client ${client.sessionId} has started chatting`);
 			chatClients.add(client);
 		}
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11342,6 +11342,9 @@ importers:
       '@fluidframework/fluid-static':
         specifier: workspace:~
         version: link:../fluid-static
+      '@fluidframework/id-compressor':
+        specifier: workspace:~
+        version: link:../../runtime/id-compressor
       '@fluidframework/runtime-definitions':
         specifier: workspace:~
         version: link:../../runtime/runtime-definitions


### PR DESCRIPTION
API changes:
1. create `ClientSessionId` that is stable for client's presence lifetime and use that as identity throughout 
2. rename `ConnectedClientId` to `ClientConnectionId`
3. remove async Promise from synchronous `acquirePresenceViaDataObject`

Implementation changes:
- Through out states workspace datastores use session id instead of connection id.
  - Self States are no longer cleared and restrore in datastore while reconnecting as id is stable.
- In system presence workspace datastore change value name to clientToSessionId and explicitly continue using ClientConnectionIds for keys.
- Use quorom on join to determine update providers and scheduling self to broadcast