### PR TITLE
fix(client): send Presence initial values (when added)

### DIFF
--- a/packages/framework/presence/src/exposedInternalTypes.ts
+++ b/packages/framework/presence/src/exposedInternalTypes.ts
@@ -112,7 +112,7 @@ export namespace InternalTypes {
 		key: TKey,
 		datastoreHandle: StateDatastoreHandle<TKey, TValue>,
 	) => {
-		value: TValue;
+		value?: TValue;
 		manager: StateValue<TManager>;
 	};
 

--- a/packages/framework/presence/src/internalTypes.ts
+++ b/packages/framework/presence/src/internalTypes.ts
@@ -9,11 +9,13 @@ import type { ClientSessionId, ISessionClient } from "./presence.js";
 /**
  * @internal
  */
-export interface ClientRecord<TValue extends InternalTypes.ValueDirectoryOrState<unknown>> {
+export interface ClientRecord<
+	TValue extends InternalTypes.ValueDirectoryOrState<unknown> | undefined,
+> {
 	// Caution: any particular item may or may not exist
 	// Typescript does not support absent keys without forcing type to also be undefined.
 	// See https://github.com/microsoft/TypeScript/issues/42810.
-	[ClientSessionId: ClientSessionId]: TValue;
+	[ClientSessionId: ClientSessionId]: Exclude<TValue, undefined>;
 }
 
 /**
@@ -24,6 +26,7 @@ export interface ValueManager<
 	TValueState extends
 		InternalTypes.ValueDirectoryOrState<TValue> = InternalTypes.ValueDirectoryOrState<TValue>,
 > {
-	get value(): TValueState;
+	// Most value managers should provide value - implement Required<ValueManager<...>>
+	readonly value?: TValueState;
 	update(client: ISessionClient, received: number, value: TValueState): void;
 }

--- a/packages/framework/presence/src/latestMapValueManager.ts
+++ b/packages/framework/presence/src/latestMapValueManager.ts
@@ -315,7 +315,9 @@ class LatestMapValueManagerImpl<
 	T,
 	RegistrationKey extends string,
 	Keys extends string | number = string | number,
-> implements LatestMapValueManager<T, Keys>, ValueManager<T, InternalTypes.MapValueState<T>>
+> implements
+		LatestMapValueManager<T, Keys>,
+		Required<ValueManager<T, InternalTypes.MapValueState<T>>>
 {
 	public readonly events = createEmitter<LatestMapValueManagerEvents<T, Keys>>();
 	public readonly controls: LatestValueControl;

--- a/packages/framework/presence/src/latestValueManager.ts
+++ b/packages/framework/presence/src/latestValueManager.ts
@@ -78,7 +78,9 @@ export interface LatestValueManager<T> {
 }
 
 class LatestValueManagerImpl<T, Key extends string>
-	implements LatestValueManager<T>, ValueManager<T, InternalTypes.ValueRequiredState<T>>
+	implements
+		LatestValueManager<T>,
+		Required<ValueManager<T, InternalTypes.ValueRequiredState<T>>>
 {
 	public readonly events = createEmitter<LatestValueManagerEvents<T>>();
 	public readonly controls: LatestValueControl;

--- a/packages/framework/presence/src/notificationsManager.ts
+++ b/packages/framework/presence/src/notificationsManager.ts
@@ -168,7 +168,6 @@ class NotificationsManagerImpl<
 			InternalTypes.ValueRequiredState<InternalTypes.NotificationType>
 		>,
 		_initialSubscriptions: NotificationSubscriptions<T>,
-		public readonly value: InternalTypes.ValueRequiredState<InternalTypes.NotificationType>,
 	) {}
 
 	public update(
@@ -195,11 +194,6 @@ export function Notifications<
 	InternalTypes.ValueRequiredState<InternalTypes.NotificationType>,
 	NotificationsManager<T>
 > {
-	const value: InternalTypes.ValueRequiredState<InternalTypes.NotificationType> = {
-		rev: 0,
-		timestamp: Date.now(),
-		value: { name: "", args: [] },
-	};
 	return (
 		key: Key,
 		datastoreHandle: InternalTypes.StateDatastoreHandle<
@@ -207,7 +201,6 @@ export function Notifications<
 			InternalTypes.ValueRequiredState<InternalTypes.NotificationType>
 		>,
 	) => ({
-		value,
 		manager: brandIVM<
 			NotificationsManagerImpl<T, Key>,
 			InternalTypes.NotificationType,
@@ -217,7 +210,6 @@ export function Notifications<
 				key,
 				datastoreFromHandle(datastoreHandle),
 				initialSubscriptions,
-				value,
 			),
 		),
 	});

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -174,8 +174,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 		}
 
 		const localUpdate = (
-			stateKey: string,
-			value: ClientUpdateEntry,
+			states: { [key: string]: ClientUpdateEntry },
 			forceBroadcast: boolean,
 		): void => {
 			// Check for connectivity before sending updates.
@@ -183,11 +182,13 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 				return;
 			}
 
+			const updates: GeneralDatastoreMessageContent[string] = {};
+			for (const [key, value] of Object.entries(states)) {
+				updates[key] = { [this.clientSessionId]: value };
+			}
 			this.localUpdate(
 				{
-					[internalWorkspaceAddress]: {
-						[stateKey]: { [this.clientSessionId]: value },
-					},
+					[internalWorkspaceAddress]: updates,
 				},
 				forceBroadcast,
 			);

--- a/packages/framework/presence/src/stateDatastore.ts
+++ b/packages/framework/presence/src/stateDatastore.ts
@@ -28,7 +28,7 @@ export interface StateDatastoreSchema {
  */
 export interface StateDatastore<
 	TKey extends string,
-	TValue extends InternalTypes.ValueDirectoryOrState<any>,
+	TValue extends InternalTypes.ValueDirectoryOrState<any> | undefined,
 > {
 	localUpdate(
 		key: TKey,
@@ -55,9 +55,14 @@ export function handleFromDatastore<
 	// TSchema as `unknown` still provides some type safety.
 	// TSchema extends StateDatastoreSchema,
 	TKey extends string /* & keyof TSchema */,
-	TValue extends InternalTypes.ValueDirectoryOrState<unknown>,
->(datastore: StateDatastore<TKey, TValue>): InternalTypes.StateDatastoreHandle<TKey, TValue> {
-	return datastore as unknown as InternalTypes.StateDatastoreHandle<TKey, TValue>;
+	TValue extends InternalTypes.ValueDirectoryOrState<unknown> | undefined,
+>(
+	datastore: StateDatastore<TKey, TValue>,
+): InternalTypes.StateDatastoreHandle<TKey, Exclude<TValue, undefined>> {
+	return datastore as unknown as InternalTypes.StateDatastoreHandle<
+		TKey,
+		Exclude<TValue, undefined>
+	>;
 }
 
 /**


### PR DESCRIPTION
Values were only being sent after an update or when broadcast refresh was request (like another client joining).

Now initial values are sent when they are added to the system. A block when using requestedContent (original schema) or individually when `add` is called later.

In support of that `value` are no longer strictly required by the value managers (`NotificationsManager` was always providing dummy values and we never wanted to send those.)