### PR TITLE
fix(client-presence): clientValues impl+

### DIFF
--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -43,10 +43,10 @@ export interface ISessionClient<SpecificSessionClientId extends ClientSessionId 
 }
 
 // @alpha
-export function Latest<T extends object, Key extends string>(initialValue: JsonSerializable<T> & JsonDeserialized<T> & object, controls?: LatestValueControls): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestValueManager<T>>;
+export function Latest<T extends object, Key extends string = string>(initialValue: JsonSerializable<T> & JsonDeserialized<T> & object, controls?: LatestValueControls): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestValueManager<T>>;
 
 // @alpha
-export function LatestMap<T extends object, RegistrationKey extends string, Keys extends string | number = string | number>(initialValues?: {
+export function LatestMap<T extends object, Keys extends string | number = string | number, RegistrationKey extends string = string>(initialValues?: {
     [K in Keys]: JsonSerializable<T> & JsonDeserialized<T>;
 }, controls?: LatestValueControls): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T>, LatestMapValueManager<T, Keys>>;
 
@@ -76,7 +76,7 @@ export interface LatestMapValueClientData<T, Keys extends string | number, Speci
 // @alpha @sealed
 export interface LatestMapValueManager<T, Keys extends string | number = string | number> {
     clients(): ISessionClient[];
-    clientValue<SpecificSessionClientId extends ClientSessionId>(client: ISessionClient<SpecificSessionClientId>): LatestMapValueClientData<T, Keys, SpecificSessionClientId>;
+    clientValue(client: ISessionClient): ReadonlyMap<Keys, LatestValueData<T>>;
     clientValues(): IterableIterator<LatestMapValueClientData<T, Keys>>;
     readonly controls: LatestValueControls;
     readonly events: ISubscribable<LatestMapValueManagerEvents<T, Keys>>;
@@ -143,7 +143,7 @@ export interface NotificationEmitter<E extends InternalUtilityTypes.Notification
 }
 
 // @alpha
-export function Notifications<T extends InternalUtilityTypes.NotificationEvents<T>, Key extends string>(initialSubscriptions: NotificationSubscriptions<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<InternalTypes.NotificationType>, NotificationsManager<T>>;
+export function Notifications<T extends InternalUtilityTypes.NotificationEvents<T>, Key extends string = string>(initialSubscriptions: NotificationSubscriptions<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<InternalTypes.NotificationType>, NotificationsManager<T>>;
 
 // @alpha @sealed
 export interface NotificationsManager<T extends InternalUtilityTypes.NotificationEvents<T>> {

--- a/packages/framework/presence/src/internalTypes.ts
+++ b/packages/framework/presence/src/internalTypes.ts
@@ -19,6 +19,15 @@ export interface ClientRecord<
 }
 
 /**
+ * Object.entries retyped to support branded string-based keys.
+ *
+ * @internal
+ */
+export const brandedObjectEntries = Object.entries as <K extends string, T>(
+	o: Record<K, T>,
+) => [K, T][];
+
+/**
  * @internal
  */
 export interface ValueManager<

--- a/packages/framework/presence/src/latestMapValueManager.ts
+++ b/packages/framework/presence/src/latestMapValueManager.ts
@@ -306,9 +306,7 @@ export interface LatestMapValueManager<T, Keys extends string | number = string 
 	/**
 	 * Access to a specific client's map of values.
 	 */
-	clientValue<SpecificSessionClientId extends ClientSessionId>(
-		client: ISessionClient<SpecificSessionClientId>,
-	): LatestMapValueClientData<T, Keys, SpecificSessionClientId>;
+	clientValue(client: ISessionClient): ReadonlyMap<Keys, LatestValueData<T>>;
 }
 
 class LatestMapValueManagerImpl<
@@ -343,8 +341,15 @@ class LatestMapValueManagerImpl<
 
 	public readonly local: ValueMap<Keys, T>;
 
-	public clientValues(): IterableIterator<LatestMapValueClientData<T, Keys>> {
-		throw new Error("Method not implemented.");
+	public *clientValues(): IterableIterator<LatestMapValueClientData<T, Keys>> {
+		const allKnownStates = this.datastore.knownValues(this.key);
+		for (const clientSessionId of Object.keys(allKnownStates.states)) {
+			if (clientSessionId !== allKnownStates.self) {
+				const client = this.datastore.lookupClient(clientSessionId);
+				const items = this.clientValue(client);
+				yield { client, items };
+			}
+		}
 	}
 
 	public clients(): ISessionClient[] {
@@ -354,11 +359,9 @@ class LatestMapValueManagerImpl<
 			.map((clientSessionId) => this.datastore.lookupClient(clientSessionId));
 	}
 
-	public clientValue<SpecificSessionClientId extends ClientSessionId>(
-		client: SpecificSessionClient<SpecificSessionClientId>,
-	): LatestMapValueClientData<T, Keys, SpecificSessionClientId> {
+	public clientValue(client: ISessionClient): ReadonlyMap<Keys, LatestValueData<T>> {
 		const allKnownStates = this.datastore.knownValues(this.key);
-		const clientSessionId: SpecificSessionClientId = client.sessionId;
+		const clientSessionId = client.sessionId;
 		if (!(clientSessionId in allKnownStates.states)) {
 			throw new Error("No entry for client");
 		}
@@ -373,7 +376,7 @@ class LatestMapValueManagerImpl<
 				});
 			}
 		}
-		return { client, items };
+		return items;
 	}
 
 	public update<SpecificSessionClientId extends ClientSessionId>(
@@ -441,8 +444,8 @@ class LatestMapValueManagerImpl<
  */
 export function LatestMap<
 	T extends object,
-	RegistrationKey extends string,
 	Keys extends string | number = string | number,
+	RegistrationKey extends string = string,
 >(
 	initialValues?: {
 		[K in Keys]: JsonSerializable<T> & JsonDeserialized<T>;

--- a/packages/framework/presence/src/notificationsManager.ts
+++ b/packages/framework/presence/src/notificationsManager.ts
@@ -167,7 +167,7 @@ class NotificationsManagerImpl<
 			Key,
 			InternalTypes.ValueRequiredState<InternalTypes.NotificationType>
 		>,
-		_initialSubscriptions: NotificationSubscriptions<T>,
+		_initialSubscriptions: Partial<NotificationSubscriptions<T>>,
 	) {}
 
 	public update(
@@ -182,11 +182,15 @@ class NotificationsManagerImpl<
 /**
  * Factory for creating a {@link NotificationsManager}.
  *
+ * @remarks
+ * Typescript inference for `Notifications` is not working correctly yet.
+ * Explicitly specify generics to make result types usable.
+ *
  * @alpha
  */
 export function Notifications<
 	T extends InternalUtilityTypes.NotificationEvents<T>,
-	Key extends string,
+	Key extends string = string,
 >(
 	initialSubscriptions: NotificationSubscriptions<T>,
 ): InternalTypes.ManagerFactory<

--- a/packages/framework/presence/src/presenceStates.ts
+++ b/packages/framework/presence/src/presenceStates.ts
@@ -8,6 +8,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import type { ClientConnectionId } from "./baseTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { ClientRecord } from "./internalTypes.js";
+import { brandedObjectEntries } from "./internalTypes.js";
 import type { ClientSessionId, ISessionClient } from "./presence.js";
 import { handleFromDatastore, type StateDatastore } from "./stateDatastore.js";
 import type { PresenceStates, PresenceStatesMethods, PresenceStatesSchema } from "./types.js";
@@ -191,13 +192,6 @@ export function mergeUntrackedDatastore(
 		}
 	}
 }
-
-/**
- * Object.entries retyped to support branded string-based keys.
- */
-const brandedObjectEntries = Object.entries as <K extends string, T>(
-	o: Record<K, T>,
-) => [K, T][];
 
 class PresenceStatesImpl<TSchema extends PresenceStatesSchema>
 	implements

--- a/packages/framework/presence/src/stateDatastore.ts
+++ b/packages/framework/presence/src/stateDatastore.ts
@@ -12,16 +12,16 @@ import type { ClientSessionId, ISessionClient } from "./presence.js";
 // 	TValue extends InternalTypes.ValueDirectoryOrState<any> = InternalTypes.ValueDirectoryOrState<unknown>,
 // > = TValue extends InternalTypes.ValueDirectoryOrState<infer T> ? InternalTypes.ValueDirectoryOrState<T> : never;
 
-/**
- * @internal
- */
-export interface StateDatastoreSchema {
-	// This type is not precise. It may
-	// need to be replaced with PresenceStates schema pattern
-	// similar to what is commented out.
-	[key: string]: InternalTypes.ValueDirectoryOrState<unknown>;
-	// [key: string]: StateDatastoreSchemaNode;
-}
+// /**
+//  * @internal
+//  */
+// export interface StateDatastoreSchema {
+// 	// This type is not precise. It may
+// 	// need to be replaced with PresenceStates schema pattern
+// 	// similar to what is commented out.
+// 	[key: string]: InternalTypes.ValueDirectoryOrState<unknown>;
+// 	// [key: string]: StateDatastoreSchemaNode;
+// }
 
 /**
  * @internal

--- a/packages/framework/presence/src/test/latestMapValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestMapValueManager.spec.ts
@@ -53,7 +53,7 @@ export function checkCompiles(): void {
 		tilt?: number;
 	}
 
-	map.add("pointers", LatestMap<PointerData, "pointers">({}));
+	map.add("pointers", LatestMap<PointerData>({}));
 
 	const pointers = map.pointers;
 	const localPointers = pointers.local;
@@ -75,8 +75,8 @@ export function checkCompiles(): void {
 	pointerItemUpdatedOff();
 
 	for (const client of pointers.clients()) {
-		const clientData = pointers.clientValue(client);
-		for (const [key, { value }] of clientData.items.entries()) {
+		const items = pointers.clientValue(client);
+		for (const [key, { value }] of items.entries()) {
 			logClientValue({ client, key, value });
 		}
 	}

--- a/packages/framework/presence/src/test/notificationsManager.spec.ts
+++ b/packages/framework/presence/src/test/notificationsManager.spec.ts
@@ -23,12 +23,9 @@ export function checkCompiles(): void {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 	const presence = {} as IPresence;
 	const notificationsWorkspace = presence.getNotifications("name:testNotificationWorkspace", {
-		chat: Notifications<
-			{
-				msg: (message: string) => void;
-			},
-			string
-		>({
+		chat: Notifications<{
+			msg: (message: string) => void;
+		}>({
 			msg: (client: ISessionClient, message: string) => {
 				console.log(`${client.sessionId} says, "${message}"`);
 			},


### PR DESCRIPTION
- add implementation for Latest*.clientValues
   - relocate brandedObjectEntries helper
- API changes:
   - correct LatestMapValueManager.clientValue to just return the value map (caller already has the client)
   - push manager factory `Key` generics to last and give default of `string`

- Additionally, comment out speculative, unused StateDatastoreSchema