### PR TITLE
Add Biome extension for VSCode by default to our codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,7 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
+				"biomejs.biome",
 				"dbaeumer.vscode-eslint",
 				"esbenp.prettier-vscode",
 				"ms-azure-devops.azure-pipelines",


### PR DESCRIPTION
## Description

Add the Biome extension for VSCode to our codespaces instances as part of the default things that come with them. Just noticed that I was being asked to install it when I created a new codespaces instance.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
