### PR TITLE
test(client): example experimental presence use

### DIFF
--- a/examples/service-clients/azure-client/external-controller/README.md
+++ b/examples/service-clients/azure-client/external-controller/README.md
@@ -10,6 +10,8 @@ This implementation demonstrates plugging that Container into a standalone appli
 [Tinylicious](/server/routerlicious/packages/tinylicious), so there are a few extra steps to get started. We bring our own view that we will
 bind to the data in the container.
 
+It also demonstrates use of Presence features to share each clients' local activity.
+
 <!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->

--- a/examples/service-clients/azure-client/external-controller/package.json
+++ b/examples/service-clients/azure-client/external-controller/package.json
@@ -42,6 +42,7 @@
 		"webpack:dev": "webpack --env development"
 	},
 	"dependencies": {
+		"@fluid-experimental/presence": "workspace:~",
 		"@fluidframework/azure-client": "workspace:~",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/routerlicious-driver": "workspace:~",
@@ -82,6 +83,7 @@
 		"process": "^0.11.10",
 		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
+		"source-map-loader": "^5.0.0",
 		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^5.0.0",
 		"ts-jest": "^29.1.1",

--- a/examples/service-clients/azure-client/external-controller/src/app.ts
+++ b/examples/service-clients/azure-client/external-controller/src/app.ts
@@ -4,6 +4,10 @@
  */
 
 import {
+	acquirePresenceViaDataObject,
+	ExperimentalPresenceManager,
+} from "@fluid-experimental/presence";
+import {
 	AzureClient,
 	AzureContainerServices,
 	AzureLocalConnectionConfig,
@@ -18,7 +22,12 @@ import { IFluidContainer } from "fluid-framework";
 import { v4 as uuid } from "uuid";
 
 import { AzureFunctionTokenProvider } from "./AzureFunctionTokenProvider.js";
-import { DiceRollerController, DiceRollerControllerProps } from "./controller.js";
+import {
+	DiceRollerController,
+	DiceRollerControllerProps,
+	type DieValue,
+} from "./controller.js";
+import { buildDicePresence } from "./presence.js";
 import { makeAppView } from "./view.js";
 
 export interface ICustomUserDetails {
@@ -66,6 +75,7 @@ const containerSchema = {
 		/* [id]: DataObject */
 		map1: SharedMap,
 		map2: SharedMap,
+		presence: ExperimentalPresenceManager,
 	},
 } satisfies ContainerSchema;
 type DiceRollerContainerSchema = typeof containerSchema;
@@ -167,6 +177,12 @@ async function start(): Promise<void> {
 
 	document.title = id;
 
+	// Biome insist on no semicolon - https://dev.azure.com/fluidframework/internal/_workitems/edit/9083
+	// eslint-disable-next-line @typescript-eslint/member-delimiter-style
+	const lastRoll: { die1?: DieValue; die2?: DieValue } = {};
+	const presence = acquirePresenceViaDataObject(container.initialObjects.presence);
+	const states = buildDicePresence(presence);
+
 	// Initialize Devtools
 	initializeDevtools({
 		logger: devtoolsLogger,
@@ -179,12 +195,38 @@ async function start(): Promise<void> {
 	});
 
 	// Here we are guaranteed that the maps have already been initialized for use with a DiceRollerController
-	const diceRollerController1 = new DiceRollerController(diceRollerController1Props);
-	const diceRollerController2 = new DiceRollerController(diceRollerController2Props);
+	const diceRollerController1 = new DiceRollerController(
+		diceRollerController1Props,
+		(value) => {
+			lastRoll.die1 = value;
+			states.lastRoll.local = lastRoll;
+			states.lastDiceRolls.local.set("die1", { value });
+		},
+	);
+	const diceRollerController2 = new DiceRollerController(
+		diceRollerController2Props,
+		(value) => {
+			lastRoll.die2 = value;
+			states.lastRoll.local = lastRoll;
+			states.lastDiceRolls.local.set("die2", { value });
+		},
+	);
+
+	// lastDiceRolls is here just to demonstrate an example of LatestMap
+	// Its updates are only logged to the console.
+	states.lastDiceRolls.events.on("itemUpdated", (update) => {
+		console.log(
+			`Client ${update.client.sessionId.slice(0, 8)}'s ${update.key} rolled to ${update.value.value}`,
+		);
+	});
 
 	const contentDiv = document.querySelector("#content") as HTMLDivElement;
 	contentDiv.append(
-		makeAppView([diceRollerController1, diceRollerController2], services.audience),
+		makeAppView(
+			[diceRollerController1, diceRollerController2],
+			{ presence, lastRoll: states.lastRoll },
+			services.audience,
+		),
 	);
 }
 

--- a/examples/service-clients/azure-client/external-controller/src/app.ts
+++ b/examples/service-clients/azure-client/external-controller/src/app.ts
@@ -75,6 +75,8 @@ const containerSchema = {
 		/* [id]: DataObject */
 		map1: SharedMap,
 		map2: SharedMap,
+		// A Presence Manager object temporarily needs to be placed within container schema
+		// https://github.com/microsoft/FluidFramework/blob/main/packages/framework/presence/README.md#onboarding
 		presence: ExperimentalPresenceManager,
 	},
 } satisfies ContainerSchema;

--- a/examples/service-clients/azure-client/external-controller/src/controller.ts
+++ b/examples/service-clients/azure-client/external-controller/src/controller.ts
@@ -88,6 +88,8 @@ export class DiceRollerController
 	public readonly roll = (): void => {
 		const rollValue = (Math.floor(Math.random() * 6) + 1) as DieValue;
 		this.props.set(diceValueKey, rollValue);
+
+		// Also notify the caller of the local roll (local value setting).
 		this.onSet(rollValue);
 	};
 }

--- a/examples/service-clients/azure-client/external-controller/src/controller.ts
+++ b/examples/service-clients/azure-client/external-controller/src/controller.ts
@@ -6,6 +6,8 @@
 import { IValueChanged } from "@fluidframework/map/internal";
 import events_pkg from "events_pkg";
 
+export type DieValue = 1 | 2 | 3 | 4 | 5 | 6;
+
 /**
  * IDiceRoller describes the public API surface for our dice roller data object.
  */
@@ -13,7 +15,7 @@ export interface IDiceRollerController extends events_pkg.EventEmitter {
 	/**
 	 * Get the dice value as a number.
 	 */
-	readonly value: number;
+	readonly value: DieValue;
 
 	/**
 	 * Roll the dice.  Will cause a "diceRolled" event to be emitted.
@@ -51,7 +53,10 @@ export class DiceRollerController
 		props.set(diceValueKey, 1);
 	}
 
-	constructor(private readonly props: DiceRollerControllerProps) {
+	constructor(
+		private readonly props: DiceRollerControllerProps,
+		private readonly onSet: (value: DieValue) => void,
+	) {
 		super();
 		const value = this.props.get(diceValueKey);
 		if (typeof value !== "number") {
@@ -67,18 +72,22 @@ export class DiceRollerController
 		});
 	}
 
-	public get value(): number {
+	public get value(): DieValue {
 		const value = this.props.get(diceValueKey);
 		if (typeof value !== "number") {
 			throw new TypeError(
 				"Model is incorrect - did you call DiceRollerController.initializeModel() to set it up?",
 			);
 		}
-		return value;
+		if (value < 1 || value > 6) {
+			throw new RangeError("Model is incorrect - value is out of range");
+		}
+		return value as DieValue;
 	}
 
 	public readonly roll = (): void => {
-		const rollValue = Math.floor(Math.random() * 6) + 1;
+		const rollValue = (Math.floor(Math.random() * 6) + 1) as DieValue;
 		this.props.set(diceValueKey, rollValue);
+		this.onSet(rollValue);
 	};
 }

--- a/examples/service-clients/azure-client/external-controller/src/presence.ts
+++ b/examples/service-clients/azure-client/external-controller/src/presence.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	IPresence,
+	Latest,
+	LatestMap,
+	type PresenceStates,
+	type PresenceStatesSchema,
+} from "@fluid-experimental/presence";
+
+import type { DieValue } from "./controller.js";
+
+export interface DiceValues {
+	die1?: DieValue;
+	die2?: DieValue;
+}
+
+const statesSchema = {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+	lastRoll: Latest({} as DiceValues),
+	// Both lastRoll and lastDiceRolls are not required. lastDiceRolls is here
+	// to demonstrate and example of LatestMap.
+	// eslint-disable-next-line @typescript-eslint/member-delimiter-style
+	lastDiceRolls: LatestMap<{ value: DieValue }, `die${number}`>(),
+} satisfies PresenceStatesSchema;
+
+export type DicePresence = PresenceStates<typeof statesSchema>;
+
+export function buildDicePresence(presence: IPresence): DicePresence {
+	const states = presence.getStates("name:app-client-states", statesSchema);
+	return states;
+}

--- a/examples/service-clients/azure-client/external-controller/src/presence.ts
+++ b/examples/service-clients/azure-client/external-controller/src/presence.ts
@@ -18,11 +18,28 @@ export interface DiceValues {
 	die2?: DieValue;
 }
 
+/**
+ * This example schema shows two ways to share a simple state (in this case
+ * the values of two dice as last rolled by clients). No practical application
+ * would need both of these states.
+ *
+ * The first state, lastRoll, is using the simpler {@link @fluid-experimental/presence#Latest | Latest}
+ * pattern (-\> {@link @fluid-experimental/presence#LatestValueManager | LatestValueManager}) where
+ * all dice values are updated as a whole ({@link DiceValues} structure which has optional values).
+ * If any part of the data is updated, then the entire data structure is shared. This means
+ * keeping a local copy of the data structure or recomposing it each time making an update.
+ *
+ * The second state, lastDiceRolls, is using the {@link @fluid-experimental/presence#LatestMap | LatestMap}
+ * pattern (-\> {@link @fluid-experimental/presence#LatestMapManager | LatestMapManager}) where
+ * each die is updated independently. This allows for more granular updates, but also requires
+ * more verbose setting/reading logic and use of boxed values (e.g. `{ value: DieValue}`). This
+ * pattern more directly lends itself to handling arbitrary numbers of dice.
+ *
+ * Throughout the code, the `lastRoll` state is focus of use.
+ */
 const statesSchema = {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 	lastRoll: Latest({} as DiceValues),
-	// Both lastRoll and lastDiceRolls are not required. lastDiceRolls is here
-	// to demonstrate and example of LatestMap.
 	// eslint-disable-next-line @typescript-eslint/member-delimiter-style
 	lastDiceRolls: LatestMap<{ value: DieValue }, `die${number}`>(),
 } satisfies PresenceStatesSchema;

--- a/examples/service-clients/azure-client/external-controller/src/view.ts
+++ b/examples/service-clients/azure-client/external-controller/src/view.ts
@@ -3,10 +3,12 @@
  * Licensed under the MIT License.
  */
 
+import type { IPresence, LatestValueManager } from "@fluid-experimental/presence";
 import { AzureMember, IAzureAudience } from "@fluidframework/azure-client";
 
 import { ICustomUserDetails } from "./app.js";
 import { IDiceRollerController } from "./controller.js";
+import type { DiceValues } from "./presence.js";
 
 function makeDiceRollerView(diceRoller: IDiceRollerController): HTMLDivElement {
 	const wrapperDiv = document.createElement("div");
@@ -84,16 +86,125 @@ function makeAudienceView(audience?: IAzureAudience): HTMLDivElement {
 	return wrapperDiv;
 }
 
+function makeTextDivs(texts: string[]): HTMLDivElement[] {
+	return texts.map((text) => {
+		const valueElement = document.createElement("div");
+		valueElement.textContent = text;
+		return valueElement;
+	});
+}
+
+function makeDiceHeaderElement(): HTMLDivElement[] {
+	return makeTextDivs(["id", "Die 1", "Die 2"]);
+}
+
+function makeDiceValueElement(id: string, value: DiceValues): HTMLDivElement[] {
+	return makeTextDivs([
+		id.slice(0, 8),
+		`${value.die1 ?? "not rolled"}`,
+		`${value.die2 ?? "not rolled"}`,
+	]);
+}
+
+export function makeDiceValuesView(
+	target: HTMLDivElement,
+	lastRoll: LatestValueManager<DiceValues>,
+): void {
+	const children = makeDiceHeaderElement();
+	for (const clientValue of lastRoll.clientValues()) {
+		children.push(...makeDiceValueElement(clientValue.client.sessionId, clientValue.value));
+	}
+	target.replaceChildren(...children);
+}
+
+function addLogEntry(logDiv: HTMLDivElement, entry: string): void {
+	const entryDiv = document.createElement("div");
+	entryDiv.textContent = entry;
+	logDiv.prepend(entryDiv);
+}
+
+function makePresenceView(
+	// Biome insist on no semicolon - https://dev.azure.com/fluidframework/internal/_workitems/edit/9083
+	// eslint-disable-next-line @typescript-eslint/member-delimiter-style
+	presenceConfig?: { presence: IPresence; lastRoll: LatestValueManager<DiceValues> },
+	audience?: IAzureAudience,
+): HTMLDivElement {
+	const presenceDiv = document.createElement("div");
+	// Accommodating the test which doesn't provide a presence
+	if (presenceConfig === undefined) {
+		presenceDiv.textContent = "No presence provided";
+		return presenceDiv;
+	}
+
+	presenceDiv.style.display = "flex";
+	presenceDiv.style.justifyContent = "center";
+
+	const statesDiv = document.createElement("div");
+	statesDiv.style.width = "30%";
+	statesDiv.style.marginRight = "10px";
+	statesDiv.style.border = "1px solid black";
+	const statesHeaderDiv = document.createElement("div");
+	statesHeaderDiv.textContent = "Last Rolls";
+	statesHeaderDiv.style.border = "1px solid black";
+	const statesContentDiv = document.createElement("div");
+	statesContentDiv.style.height = "120px";
+	statesContentDiv.style.overflowY = "scroll";
+	statesContentDiv.style.border = "1px solid black";
+	statesContentDiv.style.display = "grid";
+	statesContentDiv.style.gridTemplateColumns = "1fr 1fr 1fr";
+	statesContentDiv.style.alignContent = "start";
+	statesDiv.append(statesHeaderDiv, statesContentDiv);
+
+	const logDiv = document.createElement("div");
+	logDiv.style.width = "70%";
+	logDiv.style.border = "1px solid black";
+	const logHeaderDiv = document.createElement("div");
+	logHeaderDiv.textContent = "Remote Activity Log";
+	logHeaderDiv.style.border = "1px solid black";
+	const logContentDiv = document.createElement("div");
+	logContentDiv.style.height = "120px";
+	logContentDiv.style.overflowY = "scroll";
+	logContentDiv.style.border = "1px solid black";
+	if (audience !== undefined) {
+		presenceConfig.presence.events.on("attendeeJoined", (attendee) => {
+			const name = audience.getMembers().get(attendee.currentConnectionId())?.name;
+			const update = `client ${name === undefined ? "(unnamed)" : `named ${name}`} with id ${attendee.sessionId} joined`;
+			addLogEntry(logContentDiv, update);
+		});
+	}
+	logDiv.append(logHeaderDiv, logContentDiv);
+
+	presenceConfig.lastRoll.events.on("updated", (update) => {
+		const updateText = `updated ${update.client.sessionId.slice(0, 8)}'s last rolls to ${JSON.stringify(update.value)}`;
+		addLogEntry(logContentDiv, updateText);
+
+		makeDiceValuesView(statesContentDiv, presenceConfig.lastRoll);
+	});
+
+	presenceDiv.append(statesDiv, logDiv);
+	return presenceDiv;
+}
+
 export function makeAppView(
 	diceRollerControllers: IDiceRollerController[],
+	// Biome insist on no semicolon - https://dev.azure.com/fluidframework/internal/_workitems/edit/9083
+	// eslint-disable-next-line @typescript-eslint/member-delimiter-style
+	presenceConfig?: { presence: IPresence; lastRoll: LatestValueManager<DiceValues> },
 	audience?: IAzureAudience,
 ): HTMLDivElement {
 	const diceRollerViews = diceRollerControllers.map((controller) =>
 		makeDiceRollerView(controller),
 	);
+	const diceView = document.createElement("div");
+	diceView.style.display = "flex";
+	diceView.style.justifyContent = "center";
+	diceView.append(...diceRollerViews);
+
 	const audienceView = makeAudienceView(audience);
 
+	const presenceView = makePresenceView(presenceConfig, audience);
+
 	const wrapperDiv = document.createElement("div");
-	wrapperDiv.append(...diceRollerViews, audienceView);
+	wrapperDiv.append(diceView, audienceView, presenceView);
 	return wrapperDiv;
 }

--- a/examples/service-clients/azure-client/external-controller/tests/index.ts
+++ b/examples/service-clients/azure-client/external-controller/tests/index.ts
@@ -137,8 +137,8 @@ async function createContainerAndRenderInElement(
 
 	const sharedMap1 = fluidContainer.initialObjects.map1;
 	const sharedMap2 = fluidContainer.initialObjects.map2;
-	const diceRollerController = new DiceRollerController(sharedMap1);
-	const diceRollerController2 = new DiceRollerController(sharedMap2);
+	const diceRollerController = new DiceRollerController(sharedMap1, () => {});
+	const diceRollerController2 = new DiceRollerController(sharedMap2, () => {});
 
 	element.append(makeAppView([diceRollerController, diceRollerController2]));
 }

--- a/examples/service-clients/azure-client/external-controller/webpack.config.cjs
+++ b/examples/service-clients/azure-client/external-controller/webpack.config.cjs
@@ -32,6 +32,10 @@ module.exports = (env) => {
 						test: /\.tsx?$/,
 						loader: "ts-loader",
 					},
+					{
+						test: /\.m?js$/,
+						use: ["source-map-loader"],
+					},
 				],
 			},
 			output: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4105,6 +4105,9 @@ importers:
 
   examples/service-clients/azure-client/external-controller:
     dependencies:
+      '@fluid-experimental/presence':
+        specifier: workspace:~
+        version: link:../../../../packages/framework/presence
       '@fluidframework/azure-client':
         specifier: workspace:~
         version: link:../../../../packages/service-clients/azure-client
@@ -4220,6 +4223,9 @@ importers:
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
+      source-map-loader:
+        specifier: ^5.0.0
+        version: 5.0.0(webpack@5.94.0)
       start-server-and-test:
         specifier: ^2.0.3
         version: 2.0.3


### PR DESCRIPTION
Every client shares their last dice rolls using presence.

Presence activities as shown in a log and other client's last rolls are shown in a table.

To make space, two dice are laid horizontally now.

Additionally, add source map support to example.