### PR TITLE
(tree): Add explicit revision tag to all changes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -386,7 +386,7 @@
 				// "fluid__test__odspEndpointName": "odsp-df", //values: odsp, odsp-df
 				// "fluid__test__r11sEndpointName": "docker", //values: frs, docker
 				// "fluid__test__backCompat": "FULL", //values: FULL This tests loader-driver compatibility for describeCompat tests
-				// "FLUID_TEST_VERBOSE": "1",
+				"FLUID_TEST_VERBOSE": "1",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
 			"windows": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -386,7 +386,7 @@
 				// "fluid__test__odspEndpointName": "odsp-df", //values: odsp, odsp-df
 				// "fluid__test__r11sEndpointName": "docker", //values: frs, docker
 				// "fluid__test__backCompat": "FULL", //values: FULL This tests loader-driver compatibility for describeCompat tests
-				"FLUID_TEST_VERBOSE": "1",
+				// "FLUID_TEST_VERBOSE": "1",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
 			"windows": {

--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -8,12 +8,12 @@ import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
 import type { ICodecFamily, IJsonCodec } from "../../codec/index.js";
 import type { SchemaAndPolicy } from "../../core/index.js";
 import type { JsonCompatibleReadOnly } from "../../util/index.js";
-import type { ChangeRebaser, RevisionTag } from "../rebase/index.js";
+import type { ChangeRebaser, RevisionTag, TaggedChange } from "../rebase/index.js";
 
 export interface ChangeFamily<TEditor extends ChangeFamilyEditor, TChange> {
 	buildEditor(
 		mintRevisionTag: () => RevisionTag,
-		changeReceiver: (change: TChange) => void,
+		changeReceiver: (change: TaggedChange<TChange>) => void,
 	): TEditor;
 
 	readonly rebaser: ChangeRebaser<TChange>;

--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -11,7 +11,10 @@ import type { JsonCompatibleReadOnly } from "../../util/index.js";
 import type { ChangeRebaser, RevisionTag } from "../rebase/index.js";
 
 export interface ChangeFamily<TEditor extends ChangeFamilyEditor, TChange> {
-	buildEditor(changeReceiver: (change: TChange) => void): TEditor;
+	buildEditor(
+		mintRevisionTag: () => RevisionTag,
+		changeReceiver: (change: TChange) => void,
+	): TEditor;
 
 	readonly rebaser: ChangeRebaser<TChange>;
 	readonly codecs: ICodecFamily<TChange, ChangeEncodingContext>;

--- a/packages/dds/tree/src/core/change-family/editBuilder.ts
+++ b/packages/dds/tree/src/core/change-family/editBuilder.ts
@@ -3,12 +3,13 @@
  * Licensed under the MIT License.
  */
 
+import type { TaggedChange } from "../rebase/index.js";
 import type { ChangeFamily, ChangeFamilyEditor } from "./changeFamily.js";
 
 export abstract class EditBuilder<TChange> implements ChangeFamilyEditor {
 	public constructor(
 		protected readonly changeFamily: ChangeFamily<ChangeFamilyEditor, TChange>,
-		private readonly changeReceiver: (change: TChange) => void,
+		private readonly changeReceiver: (change: TaggedChange<TChange>) => void,
 	) {}
 
 	/**
@@ -16,7 +17,7 @@ export abstract class EditBuilder<TChange> implements ChangeFamilyEditor {
 	 *
 	 * @sealed
 	 */
-	protected applyChange(change: TChange): void {
+	protected applyChange(change: TaggedChange<TChange>): void {
 		this.changeReceiver(change);
 	}
 

--- a/packages/dds/tree/src/core/rebase/changeRebaser.ts
+++ b/packages/dds/tree/src/core/rebase/changeRebaser.ts
@@ -51,6 +51,7 @@ export interface ChangeRebaser<TChangeset> {
 	 * @param changes - The changes to invert.
 	 * @param isRollback - Whether the inverted change is meant to rollback a change on a branch as is the case when
 	 * performing a sandwich rebase.
+	 * @param revision - The revision for the invert changeset.
 	 * This flag is relevant to merge semantics that are dependent on edit sequencing order:
 	 * - In the context of an undo, this function inverts a change that is sequenced and applied before the produced inverse.
 	 * - In the context of a rollback, this function inverts a change that is sequenced after but applied before the produced inverse.
@@ -62,7 +63,7 @@ export interface ChangeRebaser<TChangeset> {
 	invert(
 		changes: TaggedChange<TChangeset>,
 		isRollback: boolean,
-		revisionForApply: RevisionTag,
+		revision: RevisionTag,
 	): TChangeset;
 
 	/**

--- a/packages/dds/tree/src/core/rebase/changeRebaser.ts
+++ b/packages/dds/tree/src/core/rebase/changeRebaser.ts
@@ -59,7 +59,11 @@ export interface ChangeRebaser<TChangeset> {
 	 * `compose([changes, inverse(changes)])` be equal to `compose([])`:
 	 * See {@link ChangeRebaser} for details.
 	 */
-	invert(changes: TaggedChange<TChangeset>, isRollback: boolean): TChangeset;
+	invert(
+		changes: TaggedChange<TChangeset>,
+		isRollback: boolean,
+		revisionForApply: RevisionTag,
+	): TChangeset;
 
 	/**
 	 * Rebase `change` over `over`.

--- a/packages/dds/tree/src/core/rebase/utils.ts
+++ b/packages/dds/tree/src/core/rebase/utils.ts
@@ -444,8 +444,8 @@ function rollbackFromCommit<TChange>(
 	if (commit.rollback !== undefined) {
 		return commit.rollback;
 	}
-	const untagged = changeRebaser.invert(commit, true);
 	const tag = mintRevisionTag();
+	const untagged = changeRebaser.invert(commit, true, tag);
 	const deeplyTaggedRollback = changeRebaser.changeRevision(untagged, tag, commit.revision);
 	const fullyTaggedRollback = tagRollbackInverse(deeplyTaggedRollback, tag, commit.revision);
 

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -71,7 +71,7 @@ export class DefaultChangeFamily
 
 	public buildEditor(
 		mintRevisionTag: () => RevisionTag,
-		changeReceiver: (change: DefaultChangeset) => void,
+		changeReceiver: (change: TaggedChange<DefaultChangeset>) => void,
 	): DefaultEditBuilder {
 		return new DefaultEditBuilder(this, mintRevisionTag, changeReceiver);
 	}
@@ -173,7 +173,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 	public constructor(
 		family: ChangeFamily<ChangeFamilyEditor, DefaultChangeset>,
 		private readonly mintRevisionTag: () => RevisionTag,
-		changeReceiver: (change: DefaultChangeset) => void,
+		changeReceiver: (change: TaggedChange<DefaultChangeset>) => void,
 		private readonly idCompressor?: IIdCompressor,
 	) {
 		this.modularBuilder = new ModularEditBuilder(
@@ -224,7 +224,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 					change,
 					revision,
 				};
-				this.modularBuilder.submitChanges([build, edit]);
+				this.modularBuilder.submitChanges([build, edit], revision);
 			},
 		};
 	}
@@ -269,7 +269,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 				};
 				edits.push(edit);
 
-				this.modularBuilder.submitChanges(edits);
+				this.modularBuilder.submitChanges(edits, revision);
 			},
 		};
 	}
@@ -358,22 +358,25 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 				attachId,
 				revision,
 			);
-			this.modularBuilder.submitChanges([
-				{
-					type: "field",
-					field: sourceField,
-					fieldKind: sequence.identifier,
-					change: brand(moveOut),
-					revision,
-				},
-				{
-					type: "field",
-					field: adjustedAttachField,
-					fieldKind: sequence.identifier,
-					change: brand(moveIn),
-					revision,
-				},
-			]);
+			this.modularBuilder.submitChanges(
+				[
+					{
+						type: "field",
+						field: sourceField,
+						fieldKind: sequence.identifier,
+						change: brand(moveOut),
+						revision,
+					},
+					{
+						type: "field",
+						field: adjustedAttachField,
+						fieldKind: sequence.identifier,
+						change: brand(moveIn),
+						revision,
+					},
+				],
+				revision,
+			);
 		}
 	}
 
@@ -405,7 +408,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 				};
 				// The changes have to be submitted together, otherwise they will be assigned different revisions,
 				// which will prevent the build ID and the insert ID from matching.
-				this.modularBuilder.submitChanges([build, attach]);
+				this.modularBuilder.submitChanges([build, attach], revision);
 			},
 			remove: (index: number, count: number): void => {
 				if (count === 0) {

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -54,8 +54,7 @@ export const noChangeHandler: FieldChangeHandler<0> = {
 export interface ValueFieldEditor extends FieldEditor<OptionalChangeset> {
 	/**
 	 * Creates a change which replaces the current value of the field with `newValue`.
-	 * @param newContent - the new content for the field
-	 * @param changeId - the ID associated with the replacement of the current content.
+	 * @param ids - The ids for the fill and detach fields.
 	 */
 	set(ids: { fill: ChangeAtomId; detach: ChangeAtomId }): OptionalChangeset;
 }

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -10,6 +10,7 @@ import {
 	type FieldKindIdentifier,
 	forbiddenFieldKindIdentifier,
 	Multiplicity,
+	type RevisionTag,
 } from "../../core/index.js";
 import { fail } from "../../util/index.js";
 import {
@@ -58,7 +59,10 @@ export interface ValueFieldEditor extends FieldEditor<OptionalChangeset> {
 	 * @param changeId - the ID associated with the replacement of the current content.
 	 * @param buildId - the ID associated with the creation of the `newContent`.
 	 */
-	set(ids: { fill: ChangesetLocalId; detach: ChangesetLocalId }): OptionalChangeset;
+	set(
+		ids: { fill: ChangesetLocalId; detach: ChangesetLocalId },
+		revision: RevisionTag,
+	): OptionalChangeset;
 }
 
 const optionalIdentifier = "Optional";
@@ -77,8 +81,13 @@ export const optional = new FieldKindWithEditor(
 
 export const valueFieldEditor: ValueFieldEditor = {
 	...optionalFieldEditor,
-	set: (ids: { fill: ChangesetLocalId; detach: ChangesetLocalId }): OptionalChangeset =>
-		optionalFieldEditor.set(false, ids),
+	set: (
+		ids: {
+			fill: ChangesetLocalId;
+			detach: ChangesetLocalId;
+		},
+		revision: RevisionTag,
+	): OptionalChangeset => optionalFieldEditor.set(false, ids, revision),
 };
 
 export const valueChangeHandler: FieldChangeHandler<OptionalChangeset, ValueFieldEditor> = {

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -4,13 +4,12 @@
  */
 
 import {
-	type ChangesetLocalId,
+	type ChangeAtomId,
 	type DeltaDetachedNodeId,
 	type DeltaFieldChanges,
 	type FieldKindIdentifier,
 	forbiddenFieldKindIdentifier,
 	Multiplicity,
-	type RevisionTag,
 } from "../../core/index.js";
 import { fail } from "../../util/index.js";
 import {
@@ -57,12 +56,8 @@ export interface ValueFieldEditor extends FieldEditor<OptionalChangeset> {
 	 * Creates a change which replaces the current value of the field with `newValue`.
 	 * @param newContent - the new content for the field
 	 * @param changeId - the ID associated with the replacement of the current content.
-	 * @param buildId - the ID associated with the creation of the `newContent`.
 	 */
-	set(
-		ids: { fill: ChangesetLocalId; detach: ChangesetLocalId },
-		revision: RevisionTag,
-	): OptionalChangeset;
+	set(ids: { fill: ChangeAtomId; detach: ChangeAtomId }): OptionalChangeset;
 }
 
 const optionalIdentifier = "Optional";
@@ -81,13 +76,10 @@ export const optional = new FieldKindWithEditor(
 
 export const valueFieldEditor: ValueFieldEditor = {
 	...optionalFieldEditor,
-	set: (
-		ids: {
-			fill: ChangesetLocalId;
-			detach: ChangesetLocalId;
-		},
-		revision: RevisionTag,
-	): OptionalChangeset => optionalFieldEditor.set(false, ids, revision),
+	set: (ids: {
+		fill: ChangeAtomId;
+		detach: ChangeAtomId;
+	}): OptionalChangeset => optionalFieldEditor.set(false, ids),
 };
 
 export const valueChangeHandler: FieldChangeHandler<OptionalChangeset, ValueFieldEditor> = {

--- a/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
@@ -61,8 +61,14 @@ export function makeMitigatedRebaser<TChange>(
 		compose: (changes: TaggedChange<TChange>[]): TChange => {
 			return withFallback(() => unmitigatedRebaser.compose(changes));
 		},
-		invert: (changes: TaggedChange<TChange>, isRollback: boolean): TChange => {
-			return withFallback(() => unmitigatedRebaser.invert(changes, isRollback));
+		invert: (
+			changes: TaggedChange<TChange>,
+			isRollback: boolean,
+			revisionForApply: RevisionTag,
+		): TChange => {
+			return withFallback(() =>
+				unmitigatedRebaser.invert(changes, isRollback, revisionForApply),
+			);
 		},
 		rebase: (
 			change: TaggedChange<TChange>,

--- a/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
@@ -32,8 +32,11 @@ export function makeMitigatedChangeFamily<TEditor extends ChangeFamilyEditor, TC
 	onError: (error: unknown) => void,
 ): ChangeFamily<TEditor, TChange> {
 	return {
-		buildEditor: (changeReceiver: (change: TChange) => void): TEditor => {
-			return unmitigatedChangeFamily.buildEditor(changeReceiver);
+		buildEditor: (
+			mintRevisionTag: () => RevisionTag,
+			changeReceiver: (change: TChange) => void,
+		): TEditor => {
+			return unmitigatedChangeFamily.buildEditor(mintRevisionTag, changeReceiver);
 		},
 		rebaser: makeMitigatedRebaser(unmitigatedChangeFamily.rebaser, fallbackChange, onError),
 		codecs: unmitigatedChangeFamily.codecs,

--- a/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
@@ -34,7 +34,7 @@ export function makeMitigatedChangeFamily<TEditor extends ChangeFamilyEditor, TC
 	return {
 		buildEditor: (
 			mintRevisionTag: () => RevisionTag,
-			changeReceiver: (change: TChange) => void,
+			changeReceiver: (change: TaggedChange<TChange>) => void,
 		): TEditor => {
 			return unmitigatedChangeFamily.buildEditor(mintRevisionTag, changeReceiver);
 		},

--- a/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
@@ -64,11 +64,9 @@ export function makeMitigatedRebaser<TChange>(
 		invert: (
 			changes: TaggedChange<TChange>,
 			isRollback: boolean,
-			revisionForApply: RevisionTag,
+			revision: RevisionTag,
 		): TChange => {
-			return withFallback(() =>
-				unmitigatedRebaser.invert(changes, isRollback, revisionForApply),
-			);
+			return withFallback(() => unmitigatedRebaser.invert(changes, isRollback, revision));
 		},
 		rebase: (
 			change: TaggedChange<TChange>,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -118,6 +118,7 @@ export interface FieldChangeRebaser<TChangeset> {
 		isRollback: boolean,
 		genId: IdAllocator,
 		crossFieldManager: CrossFieldManager,
+		revision: RevisionTag,
 		revisionMetadata: RevisionMetadataSource,
 	): TChangeset;
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -117,8 +117,8 @@ export interface FieldChangeRebaser<TChangeset> {
 		change: TChangeset,
 		isRollback: boolean,
 		genId: IdAllocator,
-		crossFieldManager: CrossFieldManager,
 		revision: RevisionTag | undefined,
+		crossFieldManager: CrossFieldManager,
 		revisionMetadata: RevisionMetadataSource,
 	): TChangeset;
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -118,7 +118,7 @@ export interface FieldChangeRebaser<TChangeset> {
 		isRollback: boolean,
 		genId: IdAllocator,
 		crossFieldManager: CrossFieldManager,
-		revision: RevisionTag,
+		revision: RevisionTag | undefined,
 		revisionMetadata: RevisionMetadataSource,
 	): TChangeset;
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -677,6 +677,7 @@ export class ModularChangeFamily
 	/**
 	 * @param change - The change to invert.
 	 * @param isRollback - Whether the inverted change is meant to rollback a change on a branch as is the case when
+	 * @param revisionForInvert - The revision for the invert changeset.
 	 * performing a sandwich rebase.
 	 */
 	public invert(
@@ -2567,6 +2568,7 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 	/**
 	 * @param firstId - The ID to associate with the first node
 	 * @param content - The node(s) to build. Can be in either Field or Node mode.
+	 * @param revision - The revision to use for the build.
 	 * @returns A description of the edit that can be passed to `submitChanges`.
 	 */
 	public buildTrees(
@@ -2601,6 +2603,7 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 	 * @param field - the field which is being edited
 	 * @param fieldKind - the kind of the field
 	 * @param change - the change to the field
+	 * @param revision - the revision of the change
 	 */
 	public submitChange(
 		field: FieldUpPath,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -202,8 +202,6 @@ export class ModularChangeFamily
 
 	public compose(changes: TaggedChange<ModularChangeset>[]): ModularChangeset {
 		const { revInfos, maxId } = getRevInfoFromTaggedChanges(changes);
-		const revInfoSet: Set<RevisionInfo> = new Set(revInfos);
-		console.log(revInfoSet);
 		const idState: IdAllocationState = { maxId };
 
 		if (changes.length === 0) {
@@ -768,8 +766,8 @@ export class ModularChangeFamily
 					originalFieldChange,
 					isRollback,
 					genId,
-					new InvertManager(crossFieldTable, fieldChange, fieldId),
 					revisionForInvert,
+					new InvertManager(crossFieldTable, fieldChange, fieldId),
 					revisionMetadata,
 				);
 				invertedField.change = brand(amendedChange);
@@ -813,8 +811,8 @@ export class ModularChangeFamily
 				fieldChange.change,
 				isRollback,
 				genId,
-				manager,
 				revisionForInvert,
+				manager,
 				revisionMetadata,
 			);
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -2635,8 +2635,8 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 	}
 
 	public buildChanges(changes: EditDescription[]): ModularChangeset {
-		const changeMaps = changes.map((change) => {
-			return makeAnonChange(
+		const changeMaps = changes.map((change) =>
+			makeAnonChange(
 				change.type === "global"
 					? makeModularChangeset(
 							undefined /* fieldChanges */,
@@ -2665,8 +2665,8 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 							undefined /* childId */,
 							change.revision,
 						),
-			);
-		});
+			),
+		);
 		const composedChange: Mutable<ModularChangeset> =
 			this.changeFamily.rebaser.compose(changeMaps);
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -1597,7 +1597,7 @@ export class ModularChangeFamily
 
 	public buildEditor(
 		mintRevisionTag: () => RevisionTag,
-		changeReceiver: (change: ModularChangeset) => void,
+		changeReceiver: (change: TaggedChange<ModularChangeset>) => void,
 	): ModularEditBuilder {
 		return new ModularEditBuilder(this, this.fieldKinds, mintRevisionTag, changeReceiver);
 	}
@@ -2529,7 +2529,7 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 		family: ChangeFamily<ChangeFamilyEditor, ModularChangeset>,
 		private readonly fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor>,
 		private readonly mintRevisionTag: () => RevisionTag,
-		changeReceiver: (change: ModularChangeset) => void,
+		changeReceiver: (change: TaggedChange<ModularChangeset>) => void,
 	) {
 		super(family, changeReceiver);
 		this.idAllocator = idAllocatorFromMaxId();
@@ -2609,12 +2609,12 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 			undefined /* childId */,
 			revision,
 		);
-		this.applyChange(modularChange);
+		this.applyChange(tagChange(modularChange, revision));
 	}
 
-	public submitChanges(changes: EditDescription[]): void {
+	public submitChanges(changes: EditDescription[], revision: RevisionTag): void {
 		const modularChange = this.buildChanges(changes);
-		this.applyChange(modularChange);
+		this.applyChange(tagChange(modularChange, revision));
 	}
 
 	public buildChanges(changes: EditDescription[]): ModularChangeset {
@@ -2670,15 +2670,19 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 			nodeExistsConstraint: { violated: false },
 		};
 
+		const revision = this.mintRevisionTag();
 		this.applyChange(
-			buildModularChangesetFromNode(
-				path,
-				nodeChange,
-				newTupleBTree(),
-				newTupleBTree(),
-				newCrossFieldKeyTable(),
-				this.idAllocator,
-				this.mintRevisionTag(),
+			tagChange(
+				buildModularChangesetFromNode(
+					path,
+					nodeChange,
+					newTupleBTree(),
+					newTupleBTree(),
+					newCrossFieldKeyTable(),
+					this.idAllocator,
+					revision,
+				),
+				revision,
 			),
 		);
 	}

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -1612,10 +1612,9 @@ export class ModularChangeFamily
 	}
 
 	public buildEditor(
-		mintRevisionTag: () => RevisionTag,
 		changeReceiver: (change: TaggedChange<ModularChangeset>) => void,
 	): ModularEditBuilder {
-		return new ModularEditBuilder(this, this.fieldKinds, mintRevisionTag, changeReceiver);
+		return new ModularEditBuilder(this, this.fieldKinds, changeReceiver);
 	}
 
 	private createEmptyFieldChange(fieldKind: FieldKindIdentifier): FieldChange {
@@ -2544,7 +2543,6 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 	public constructor(
 		family: ChangeFamily<ChangeFamilyEditor, ModularChangeset>,
 		private readonly fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor>,
-		private readonly mintRevisionTag: () => RevisionTag,
 		changeReceiver: (change: TaggedChange<ModularChangeset>) => void,
 	) {
 		super(family, changeReceiver);
@@ -2680,12 +2678,11 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 		return brand(this.idAllocator.allocate(count));
 	}
 
-	public addNodeExistsConstraint(path: UpPath): void {
+	public addNodeExistsConstraint(path: UpPath, revision: RevisionTag): void {
 		const nodeChange: NodeChangeset = {
 			nodeExistsConstraint: { violated: false },
 		};
 
-		const revision = this.mintRevisionTag();
 		this.applyChange(
 			tagChange(
 				buildModularChangesetFromNode(

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -694,7 +694,9 @@ export class ModularChangeFamily
 			0x89a /* Unexpected destroys in change to invert */,
 		);
 
-		const revInfos: RevisionInfo[] = [{ revision: revisionForInvert }];
+		const revInfos: RevisionInfo[] = isRollback
+			? [{ revision: revisionForInvert, rollbackOf: change.revision }]
+			: [{ revision: revisionForInvert }];
 
 		if (hasConflicts(change.change)) {
 			return makeModularChangeset(

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -584,7 +584,10 @@ export function taggedRegister(id: RegisterId, revision: RevisionTag | undefined
 
 export interface OptionalFieldEditor extends FieldEditor<OptionalChangeset> {
 	/**
-	 * Creates a change which would replace "detach" field with "fill" field.
+	 * Creates a change which will replace the content already in the field (if any at the time the change applies)
+	 * with new content.
+	 * The content in the field will be moved to the `ids.detach` register.
+	 * The content in the `ids.detach` register will be moved to into the field.
 	 * @param wasEmpty - whether the field is empty when creating this change
 	 * @param ids - the "fill" and "detach" ids associated with the change.
 	 */
@@ -599,9 +602,9 @@ export interface OptionalFieldEditor extends FieldEditor<OptionalChangeset> {
 	/**
 	 * Creates a change which clears the field's contents (if any).
 	 * @param wasEmpty - whether the field is empty when creating this change
-	 * @param id - the ID associated with the change.
+	 * @param detachId - the ID of the register that existing field content (if any) will be moved to.
 	 */
-	clear(wasEmpty: boolean, id: ChangeAtomId): OptionalChangeset;
+	clear(wasEmpty: boolean, detachId: ChangeAtomId): OptionalChangeset;
 }
 
 export const optionalFieldEditor: OptionalFieldEditor = {

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -590,10 +590,9 @@ export interface OptionalFieldEditor extends FieldEditor<OptionalChangeset> {
 	set(
 		wasEmpty: boolean,
 		ids: {
-			fill: ChangesetLocalId;
-			detach: ChangesetLocalId;
+			fill: ChangeAtomId;
+			detach: ChangeAtomId;
 		},
-		revision: RevisionTag,
 	): OptionalChangeset;
 
 	/**
@@ -601,38 +600,33 @@ export interface OptionalFieldEditor extends FieldEditor<OptionalChangeset> {
 	 * @param wasEmpty - whether the field is empty when creating this change
 	 * @param changeId - the ID associated with the detach.
 	 */
-	clear(wasEmpty: boolean, id: ChangesetLocalId, revision: RevisionTag): OptionalChangeset;
+	clear(wasEmpty: boolean, id: ChangeAtomId): OptionalChangeset;
 }
 
 export const optionalFieldEditor: OptionalFieldEditor = {
 	set: (
 		wasEmpty: boolean,
 		ids: {
-			fill: ChangesetLocalId;
+			fill: ChangeAtomId;
 			// Should be interpreted as a set of an empty field if undefined.
-			detach: ChangesetLocalId;
+			detach: ChangeAtomId;
 		},
-		revision: RevisionTag,
 	): OptionalChangeset => ({
 		moves: [],
 		childChanges: [],
 		valueReplace: {
 			isEmpty: wasEmpty,
-			src: { localId: ids.fill, revision },
-			dst: { localId: ids.detach, revision },
+			src: ids.fill,
+			dst: ids.detach,
 		},
 	}),
 
-	clear: (
-		wasEmpty: boolean,
-		detachId: ChangesetLocalId,
-		revision: RevisionTag,
-	): OptionalChangeset => ({
+	clear: (wasEmpty: boolean, detachId: ChangeAtomId): OptionalChangeset => ({
 		moves: [],
 		childChanges: [],
 		valueReplace: {
 			isEmpty: wasEmpty,
-			dst: { localId: detachId, revision },
+			dst: detachId,
 		},
 	}),
 

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -593,6 +593,7 @@ export interface OptionalFieldEditor extends FieldEditor<OptionalChangeset> {
 			fill: ChangesetLocalId;
 			detach: ChangesetLocalId;
 		},
+		revision: RevisionTag,
 	): OptionalChangeset;
 
 	/**
@@ -600,7 +601,7 @@ export interface OptionalFieldEditor extends FieldEditor<OptionalChangeset> {
 	 * @param wasEmpty - whether the field is empty when creating this change
 	 * @param changeId - the ID associated with the detach.
 	 */
-	clear(wasEmpty: boolean, id: ChangesetLocalId): OptionalChangeset;
+	clear(wasEmpty: boolean, id: ChangesetLocalId, revision: RevisionTag): OptionalChangeset;
 }
 
 export const optionalFieldEditor: OptionalFieldEditor = {
@@ -611,22 +612,27 @@ export const optionalFieldEditor: OptionalFieldEditor = {
 			// Should be interpreted as a set of an empty field if undefined.
 			detach: ChangesetLocalId;
 		},
+		revision: RevisionTag,
 	): OptionalChangeset => ({
 		moves: [],
 		childChanges: [],
 		valueReplace: {
 			isEmpty: wasEmpty,
-			src: { localId: ids.fill },
-			dst: { localId: ids.detach },
+			src: { localId: ids.fill, revision },
+			dst: { localId: ids.detach, revision },
 		},
 	}),
 
-	clear: (wasEmpty: boolean, detachId: ChangesetLocalId): OptionalChangeset => ({
+	clear: (
+		wasEmpty: boolean,
+		detachId: ChangesetLocalId,
+		revision: RevisionTag,
+	): OptionalChangeset => ({
 		moves: [],
 		childChanges: [],
 		valueReplace: {
 			isEmpty: wasEmpty,
-			dst: { localId: detachId },
+			dst: { localId: detachId, revision },
 		},
 	}),
 

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -266,6 +266,7 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 		change: OptionalChangeset,
 		isRollback: boolean,
 		genId: IdAllocator<ChangesetLocalId>,
+		revision: RevisionTag | undefined,
 	): OptionalChangeset => {
 		const { moves, childChanges } = change;
 
@@ -298,11 +299,13 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 					change.valueReplace.src === undefined
 						? {
 								isEmpty: true,
-								dst: makeChangeAtomId(genId.allocate()),
+								dst: makeChangeAtomId(genId.allocate(), revision),
 							}
 						: {
 								isEmpty: false,
-								dst: isRollback ? change.valueReplace.src : makeChangeAtomId(genId.allocate()),
+								dst: isRollback
+									? change.valueReplace.src
+									: makeChangeAtomId(genId.allocate(), revision),
 							};
 				if (change.valueReplace.isEmpty === false) {
 					replace.src = change.valueReplace.dst;
@@ -312,7 +315,7 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 				inverted.valueReplace = {
 					isEmpty: false,
 					src: "self",
-					dst: makeChangeAtomId(genId.allocate()),
+					dst: makeChangeAtomId(genId.allocate(), revision),
 				};
 			}
 		}

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -581,11 +581,9 @@ export function taggedRegister(id: RegisterId, revision: RevisionTag | undefined
 
 export interface OptionalFieldEditor extends FieldEditor<OptionalChangeset> {
 	/**
-	 * Creates a change which replaces the field with `newContent`
-	 * @param newContent - the new content for the field
+	 * Creates a change which would replace "detach" field with "fill" field.
 	 * @param wasEmpty - whether the field is empty when creating this change
-	 * @param changeId - the ID associated with the replacement of the current content.
-	 * @param buildId - the ID associated with the creation of the `newContent`.
+	 * @param ids - the "fill" and "detach" ids associated with the change.
 	 */
 	set(
 		wasEmpty: boolean,
@@ -598,7 +596,7 @@ export interface OptionalFieldEditor extends FieldEditor<OptionalChangeset> {
 	/**
 	 * Creates a change which clears the field's contents (if any).
 	 * @param wasEmpty - whether the field is empty when creating this change
-	 * @param changeId - the ID associated with the detach.
+	 * @param id - the ID associated with the change.
 	 */
 	clear(wasEmpty: boolean, id: ChangeAtomId): OptionalChangeset;
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -60,7 +60,7 @@ export function invert(
 	isRollback: boolean,
 	genId: IdAllocator,
 	crossFieldManager: CrossFieldManager,
-	revision: RevisionTag,
+	revision: RevisionTag | undefined,
 ): Changeset {
 	return invertMarkList(
 		change,
@@ -74,7 +74,7 @@ function invertMarkList(
 	markList: MarkList,
 	isRollback: boolean,
 	crossFieldManager: CrossFieldManager<NodeId>,
-	revision: RevisionTag,
+	revision: RevisionTag | undefined,
 ): MarkList {
 	const inverseMarkList = new MarkListFactory();
 
@@ -90,7 +90,7 @@ function invertMark(
 	mark: Mark,
 	isRollback: boolean,
 	crossFieldManager: CrossFieldManager<NodeId>,
-	revision: RevisionTag,
+	revision: RevisionTag | undefined,
 ): Mark[] {
 	if (!isImpactful(mark)) {
 		const inputId = getInputCellId(mark);

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -59,8 +59,8 @@ export function invert(
 	change: Changeset,
 	isRollback: boolean,
 	genId: IdAllocator,
-	crossFieldManager: CrossFieldManager,
 	revision: RevisionTag | undefined,
+	crossFieldManager: CrossFieldManager,
 ): Changeset {
 	return invertMarkList(
 		change,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -56,19 +56,26 @@ export function invert(
 	isRollback: boolean,
 	genId: IdAllocator,
 	crossFieldManager: CrossFieldManager,
+	revision: RevisionTag,
 ): Changeset {
-	return invertMarkList(change, isRollback, crossFieldManager as CrossFieldManager<NodeId>);
+	return invertMarkList(
+		change,
+		isRollback,
+		crossFieldManager as CrossFieldManager<NodeId>,
+		revision,
+	);
 }
 
 function invertMarkList(
 	markList: MarkList,
 	isRollback: boolean,
 	crossFieldManager: CrossFieldManager<NodeId>,
+	revision: RevisionTag,
 ): MarkList {
 	const inverseMarkList = new MarkListFactory();
 
 	for (const mark of markList) {
-		const inverseMarks = invertMark(mark, isRollback, crossFieldManager);
+		const inverseMarks = invertMark(mark, isRollback, crossFieldManager, revision);
 		inverseMarkList.push(...inverseMarks);
 	}
 
@@ -79,6 +86,7 @@ function invertMark(
 	mark: Mark,
 	isRollback: boolean,
 	crossFieldManager: CrossFieldManager<NodeId>,
+	revision: RevisionTag,
 ): Mark[] {
 	if (!isImpactful(mark)) {
 		const inputId = getInputCellId(mark);
@@ -115,7 +123,7 @@ function invertMark(
 					id: mark.id,
 					cellId: outputId,
 					count: mark.count,
-					revision: mark.revision,
+					revision,
 				};
 			} else {
 				inverse = {
@@ -123,7 +131,7 @@ function invertMark(
 					id: mark.id,
 					cellId: outputId,
 					count: mark.count,
-					revision: mark.revision,
+					revision,
 				};
 				if (isRollback) {
 					inverse.idOverride = inputId;
@@ -138,7 +146,7 @@ function invertMark(
 				type: "Remove",
 				count: mark.count,
 				id: inputId.localId,
-				revision: mark.revision,
+				revision,
 			};
 
 			if (isRollback) {
@@ -171,7 +179,7 @@ function invertMark(
 			const moveIn: MoveIn = {
 				type: "MoveIn",
 				id: mark.id,
-				revision: mark.revision,
+				revision,
 			};
 
 			if (mark.finalEndpoint !== undefined) {
@@ -186,7 +194,7 @@ function invertMark(
 				const detach: Mutable<Detach> = {
 					type: "Remove",
 					id: mark.id,
-					revision: mark.revision,
+					revision,
 				};
 				if (isRollback) {
 					detach.idOverride = inputId;
@@ -206,7 +214,7 @@ function invertMark(
 				type: "MoveOut",
 				id: mark.id,
 				count: mark.count,
-				revision: mark.revision,
+				revision,
 			};
 
 			if (isRollback) {
@@ -237,8 +245,8 @@ function invertMark(
 				changes: mark.changes,
 				...mark.detach,
 			};
-			const attachInverses = invertMark(attach, isRollback, crossFieldManager);
-			const detachInverses = invertMark(detach, isRollback, crossFieldManager);
+			const attachInverses = invertMark(attach, isRollback, crossFieldManager, revision);
+			const detachInverses = invertMark(detach, isRollback, crossFieldManager, revision);
 
 			if (detachInverses.length === 0) {
 				return attachInverses;

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -115,6 +115,7 @@ function invertMark(
 					id: mark.id,
 					cellId: outputId,
 					count: mark.count,
+					revision: mark.revision,
 				};
 			} else {
 				inverse = {
@@ -122,6 +123,7 @@ function invertMark(
 					id: mark.id,
 					cellId: outputId,
 					count: mark.count,
+					revision: mark.revision,
 				};
 				if (isRollback) {
 					inverse.idOverride = inputId;
@@ -136,6 +138,7 @@ function invertMark(
 				type: "Remove",
 				count: mark.count,
 				id: inputId.localId,
+				revision: mark.revision,
 			};
 
 			if (isRollback) {
@@ -168,10 +171,14 @@ function invertMark(
 			const moveIn: MoveIn = {
 				type: "MoveIn",
 				id: mark.id,
+				revision: mark.revision,
 			};
 
 			if (mark.finalEndpoint !== undefined) {
-				moveIn.finalEndpoint = { localId: mark.finalEndpoint.localId };
+				moveIn.finalEndpoint = {
+					localId: mark.finalEndpoint.localId,
+					revision: mark.revision,
+				};
 			}
 			let effect: MarkEffect = moveIn;
 			const inputId = getInputCellId(mark);
@@ -179,6 +186,7 @@ function invertMark(
 				const detach: Mutable<Detach> = {
 					type: "Remove",
 					id: mark.id,
+					revision: mark.revision,
 				};
 				if (isRollback) {
 					detach.idOverride = inputId;
@@ -198,6 +206,7 @@ function invertMark(
 				type: "MoveOut",
 				id: mark.id,
 				count: mark.count,
+				revision: mark.revision,
 			};
 
 			if (isRollback) {
@@ -205,7 +214,10 @@ function invertMark(
 			}
 
 			if (mark.finalEndpoint) {
-				invertedMark.finalEndpoint = { localId: mark.finalEndpoint.localId };
+				invertedMark.finalEndpoint = {
+					localId: mark.finalEndpoint.localId,
+					revision: mark.revision,
+				};
 			}
 			return applyMovedChanges(invertedMark, mark.revision, crossFieldManager);
 		}

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -48,8 +48,8 @@ import {
  * @param change - The changeset to produce the inverse of.
  * @param isRollback - Whether the inverse is being produced for a rollback.
  * @param genId - The ID allocator to use for generating new IDs.
- * @param crossFieldManager - The cross-field manager to use for tracking cross-field changes.
  * @param revision - The revision to use for the inverse changeset.
+ * @param crossFieldManager - The cross-field manager to use for tracking cross-field changes.
  * @returns The inverse of the given `change` such that the inverse can be applied after `change`.
  *
  * WARNING! This implementation is incomplete:

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -46,6 +46,10 @@ import {
 /**
  * Inverts a given changeset.
  * @param change - The changeset to produce the inverse of.
+ * @param isRollback - Whether the inverse is being produced for a rollback.
+ * @param genId - The ID allocator to use for generating new IDs.
+ * @param crossFieldManager - The cross-field manager to use for tracking cross-field changes.
+ * @param revision - The revision to use for the inverse changeset.
  * @returns The inverse of the given `change` such that the inverse can be applied after `change`.
  *
  * WARNING! This implementation is incomplete:

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -115,7 +115,7 @@ export const sequenceFieldEditor = {
 			type: "Insert",
 			id: detachEvent.localId,
 			count,
-			cellId: { ...detachEvent, revision },
+			cellId: detachEvent,
 			revision,
 		};
 		return count === 0 ? [] : markAtIndex(index, mark);
@@ -188,7 +188,7 @@ export const sequenceFieldEditor = {
 		const moveOut: CellMark<MoveOut> = {
 			type: "MoveOut",
 			id: attachCellId.localId,
-			idOverride: { ...detachCellId, revision },
+			idOverride: detachCellId,
 			count,
 			revision,
 		};
@@ -197,7 +197,7 @@ export const sequenceFieldEditor = {
 			type: "MoveIn",
 			id: attachCellId.localId,
 			count,
-			cellId: { ...attachCellId, revision },
+			cellId: attachCellId,
 			revision,
 		};
 

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -38,7 +38,8 @@ export interface SequenceFieldEditor extends FieldEditor<Changeset> {
 	 * @param count - The number of nodes to move
 	 * @param destIndex - The index the nodes should be moved to, interpreted before detaching the moved nodes
 	 * @param detachCellId - The local ID to assign to the first cell being emptied by the move
-	 * @param attachCellId - The local ID to assign to the first cell being filled by the move
+	 * @param attachCellId - The ID to assign to the first cell being filled by the move
+	 * @param revision - The revision to assign to the move marks
 	 */
 	move(
 		sourceIndex: number,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -22,12 +22,7 @@ import type {
 import { splitMark } from "./utils.js";
 
 export interface SequenceFieldEditor extends FieldEditor<Changeset> {
-	insert(
-		index: number,
-		count: number,
-		firstId: ChangesetLocalId,
-		revision: RevisionTag,
-	): Changeset;
+	insert(index: number, count: number, firstId: CellId, revision: RevisionTag): Changeset;
 	remove(index: number, count: number, id: ChangesetLocalId, revision: RevisionTag): Changeset;
 	revive(
 		index: number,
@@ -50,7 +45,7 @@ export interface SequenceFieldEditor extends FieldEditor<Changeset> {
 		count: number,
 		destIndex: number,
 		detachCellId: ChangesetLocalId,
-		attachCellId: ChangesetLocalId,
+		attachCellId: CellId,
 		revision: RevisionTag,
 	): Changeset;
 
@@ -64,7 +59,7 @@ export interface SequenceFieldEditor extends FieldEditor<Changeset> {
 		destIndex: number,
 		count: number,
 		moveId: ChangesetLocalId,
-		attachCellId: ChangesetLocalId,
+		attachCellId: CellId,
 		revision: RevisionTag,
 	): Changeset;
 
@@ -84,14 +79,14 @@ export const sequenceFieldEditor = {
 	insert: (
 		index: number,
 		count: number,
-		firstId: ChangesetLocalId,
+		firstId: CellId,
 		revision: RevisionTag,
 	): Changeset => {
 		const mark: CellMark<Insert> = {
 			type: "Insert",
-			id: firstId,
+			id: firstId.localId,
 			count,
-			cellId: { localId: firstId, revision },
+			cellId: firstId,
 			revision,
 		};
 		return markAtIndex(index, mark);
@@ -126,14 +121,14 @@ export const sequenceFieldEditor = {
 		count: number,
 		destIndex: number,
 		detachCellId: ChangesetLocalId,
-		attachCellId: ChangesetLocalId,
+		attachCellId: CellId,
 		revision: RevisionTag,
 	): Changeset {
 		const moveIn: Mark = {
 			type: "MoveIn",
 			id: detachCellId,
 			count,
-			cellId: { localId: attachCellId, revision },
+			cellId: attachCellId,
 			revision,
 		};
 		const moveOut: Mark = {
@@ -164,14 +159,14 @@ export const sequenceFieldEditor = {
 		destIndex: number,
 		count: number,
 		moveId: ChangesetLocalId,
-		attachCellId: ChangesetLocalId,
+		attachCellId: CellId,
 		revision: RevisionTag,
 	): Changeset {
 		const moveIn: Mark = {
 			type: "MoveIn",
 			id: moveId,
 			count,
-			cellId: { localId: attachCellId, revision },
+			cellId: attachCellId,
 			revision,
 		};
 		return markAtIndex(destIndex, moveIn);

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -81,7 +81,7 @@ export const sequenceFieldEditor = {
 		index: number,
 		count: number,
 		firstId: CellId,
-		revision: RevisionTag,
+		revision: RevisionTag | undefined,
 	): Changeset => {
 		const mark: CellMark<Insert> = {
 			type: "Insert",
@@ -96,7 +96,7 @@ export const sequenceFieldEditor = {
 		index: number,
 		count: number,
 		id: ChangesetLocalId,
-		revision: RevisionTag,
+		revision: RevisionTag | undefined,
 	): Changeset =>
 		count === 0 ? [] : markAtIndex(index, { type: "Remove", count, id, revision }),
 
@@ -104,7 +104,7 @@ export const sequenceFieldEditor = {
 		index: number,
 		count: number,
 		detachEvent: CellId,
-		revision: RevisionTag,
+		revision: RevisionTag | undefined,
 	): Changeset => {
 		assert(detachEvent.revision !== undefined, 0x724 /* Detach event must have a revision */);
 		const mark: CellMark<Insert> = {
@@ -123,7 +123,7 @@ export const sequenceFieldEditor = {
 		destIndex: number,
 		detachCellId: ChangesetLocalId,
 		attachCellId: CellId,
-		revision: RevisionTag,
+		revision: RevisionTag | undefined,
 	): Changeset {
 		const moveIn: Mark = {
 			type: "MoveIn",
@@ -179,7 +179,7 @@ export const sequenceFieldEditor = {
 		destIndex: number,
 		detachCellId: CellId,
 		attachCellId: CellId,
-		revision: RevisionTag,
+		revision: RevisionTag | undefined,
 	): Changeset {
 		const moveOut: CellMark<MoveOut> = {
 			type: "MoveOut",

--- a/packages/dds/tree/src/shared-tree-core/branch.ts
+++ b/packages/dds/tree/src/shared-tree-core/branch.ts
@@ -257,15 +257,6 @@ export class SharedTreeBranch<
 		const revisionTag = taggedChange.revision;
 		assert(revisionTag !== undefined, "Revision tag must be provided");
 
-		// TODO: This should not be necessary when receiving changes from other clients.
-		const changeWithRevision = this.changeFamily.rebaser.changeRevision(
-			taggedChange.change,
-			revisionTag,
-		);
-
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		console.log((globalThis as any).merge(taggedChange.change, changeWithRevision));
-
 		const newHead = mintCommit(this.head, {
 			revision: revisionTag,
 			change: taggedChange.change,

--- a/packages/dds/tree/src/shared-tree-core/branch.ts
+++ b/packages/dds/tree/src/shared-tree-core/branch.ts
@@ -18,9 +18,9 @@ import {
 	makeAnonChange,
 	mintCommit,
 	rebaseBranch,
-	tagChange,
 	tagRollbackInverse,
 	type RebaseStatsWithDuration,
+	tagChange,
 } from "../core/index.js";
 import { EventEmitter, type Listenable } from "../events/index.js";
 
@@ -224,7 +224,7 @@ export class SharedTreeBranch<
 		>,
 	) {
 		super();
-		this.editor = this.changeFamily.buildEditor((change) =>
+		this.editor = this.changeFamily.buildEditor(mintRevisionTag, (change) =>
 			this.apply(change, mintRevisionTag()),
 		);
 		this.unsubscribeBranchTrimmer = branchTrimmer?.on("ancestryTrimmed", (commit) => {
@@ -255,8 +255,14 @@ export class SharedTreeBranch<
 	): [change: TChange, newCommit: GraphCommit<TChange>] {
 		this.assertNotDisposed();
 
+		const revision2 =
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(change as any).changes?.[0]?.innerChange?.revisions?.[0]?.revision ?? revision;
 		// TODO: This should not be necessary when receiving changes from other clients.
-		const changeWithRevision = this.changeFamily.rebaser.changeRevision(change, revision);
+		const changeWithRevision = this.changeFamily.rebaser.changeRevision(change, revision2);
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		console.log((globalThis as any).merge(change, changeWithRevision));
 
 		const newHead = mintCommit(this.head, {
 			revision,

--- a/packages/dds/tree/src/shared-tree-core/branch.ts
+++ b/packages/dds/tree/src/shared-tree-core/branch.ts
@@ -224,7 +224,7 @@ export class SharedTreeBranch<
 	) {
 		super();
 		this.editor = this.changeFamily.buildEditor(mintRevisionTag, (change) =>
-			this.apply(change, mintRevisionTag()),
+			this.apply(change),
 		);
 		this.unsubscribeBranchTrimmer = branchTrimmer?.on("ancestryTrimmed", (commit) => {
 			this.emit("ancestryTrimmed", commit);
@@ -243,13 +243,11 @@ export class SharedTreeBranch<
 	/**
 	 * Apply a change to this branch.
 	 * @param taggedChange - the change to apply
-	 * @param revision - the revision of the new head commit of the branch that contains `change`
 	 * @param kind - the kind of change to apply
 	 * @returns the change that was applied and the new head commit of the branch
 	 */
 	public apply(
 		taggedChange: TaggedChange<TChange>,
-		revision: RevisionTag, // This can be removed once we make revision required on taggedChange?
 		kind: CommitKind = CommitKind.Default,
 	): [change: TChange, newCommit: GraphCommit<TChange>] {
 		this.assertNotDisposed();
@@ -370,7 +368,7 @@ export class SharedTreeBranch<
 			const commit =
 				commits[i] ?? fail("This wont run because we are iterating through commits");
 			const inverse = this.changeFamily.rebaser.changeRevision(
-				this.changeFamily.rebaser.invert(commit, true),
+				this.changeFamily.rebaser.invert(commit, true, revision),
 				revision,
 				commit.revision,
 			);

--- a/packages/dds/tree/src/shared-tree-core/defaultResubmitMachine.ts
+++ b/packages/dds/tree/src/shared-tree-core/defaultResubmitMachine.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert, oob } from "@fluidframework/core-utils/internal";
-import type { ChangeRebaser, GraphCommit, RevisionTag } from "../core/index.js";
+import type { GraphCommit, TaggedChange } from "../core/index.js";
 import { disposeSymbol } from "../util/index.js";
 import type { ChangeEnricherReadonlyCheckout, ResubmitMachine } from "./index.js";
 
@@ -36,9 +36,9 @@ export class DefaultResubmitMachine<TChange> implements ResubmitMachine<TChange>
 
 	public constructor(
 		/**
-		 * A function that can invert a change.
+		 * A function that can create a rollback for a given change.
 		 */
-		private readonly inverter: ChangeRebaser<TChange>["invert"],
+		private readonly makeRollback: (change: TaggedChange<TChange>) => TChange,
 		/**
 		 * Change enricher that represent the tip of the top-level local branch (i.e., the branch on which in-flight
 		 * commits are applied and automatically rebased).
@@ -57,10 +57,7 @@ export class DefaultResubmitMachine<TChange> implements ResubmitMachine<TChange>
 		this.inFlightQueue.push(commit);
 	}
 
-	public prepareForResubmit(
-		toResubmit: readonly GraphCommit<TChange>[],
-		revision: RevisionTag,
-	): void {
+	public prepareForResubmit(toResubmit: readonly GraphCommit<TChange>[]): void {
 		assert(
 			!this.isInResubmitPhase,
 			0x957 /* Invalid resubmit phase start during incomplete resubmit phase */,
@@ -78,7 +75,7 @@ export class DefaultResubmitMachine<TChange> implements ResubmitMachine<TChange>
 			// Roll back the checkout to the state before the oldest commit
 			for (let iCommit = toResubmit.length - 1; iCommit >= 0; iCommit -= 1) {
 				const commit = toResubmit[iCommit] ?? oob();
-				const rollback = this.inverter(commit, true, revision);
+				const rollback = this.makeRollback(commit);
 				// WARNING: it's not currently possible to roll back past a schema change (see AB#7265).
 				// Either we have to make it possible to do so, or this logic will have to change to work
 				// forwards from an earlier fork instead of backwards.

--- a/packages/dds/tree/src/shared-tree-core/defaultResubmitMachine.ts
+++ b/packages/dds/tree/src/shared-tree-core/defaultResubmitMachine.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert, oob } from "@fluidframework/core-utils/internal";
-import type { ChangeRebaser, GraphCommit } from "../core/index.js";
+import type { ChangeRebaser, GraphCommit, RevisionTag } from "../core/index.js";
 import { disposeSymbol } from "../util/index.js";
 import type { ChangeEnricherReadonlyCheckout, ResubmitMachine } from "./index.js";
 
@@ -57,7 +57,10 @@ export class DefaultResubmitMachine<TChange> implements ResubmitMachine<TChange>
 		this.inFlightQueue.push(commit);
 	}
 
-	public prepareForResubmit(toResubmit: readonly GraphCommit<TChange>[]): void {
+	public prepareForResubmit(
+		toResubmit: readonly GraphCommit<TChange>[],
+		revision: RevisionTag,
+	): void {
 		assert(
 			!this.isInResubmitPhase,
 			0x957 /* Invalid resubmit phase start during incomplete resubmit phase */,
@@ -75,7 +78,7 @@ export class DefaultResubmitMachine<TChange> implements ResubmitMachine<TChange>
 			// Roll back the checkout to the state before the oldest commit
 			for (let iCommit = toResubmit.length - 1; iCommit >= 0; iCommit -= 1) {
 				const commit = toResubmit[iCommit] ?? oob();
-				const rollback = this.inverter(commit, true);
+				const rollback = this.inverter(commit, true, revision);
 				// WARNING: it's not currently possible to roll back past a schema change (see AB#7265).
 				// Either we have to make it possible to do so, or this logic will have to change to work
 				// forwards from an earlier fork instead of backwards.

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -643,10 +643,7 @@ export class EditManager<
 				...newChangeFullyRebased.telemetryProperties,
 			});
 
-			peerLocalBranch.apply(
-				tagChange(newCommit.change, newCommit.revision),
-				newCommit.revision,
-			);
+			peerLocalBranch.apply(tagChange(newCommit.change, newCommit.revision));
 			this.pushCommitToTrunk(sequenceId, {
 				...newCommit,
 				change: newChangeFullyRebased.change,

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -17,6 +17,7 @@ import {
 	mintCommit,
 	rebaseChange,
 	type RebaseStatsWithDuration,
+	tagChange,
 } from "../core/index.js";
 import { type Mutable, brand, fail, getOrCreate, mapIterable } from "../util/index.js";
 
@@ -642,7 +643,10 @@ export class EditManager<
 				...newChangeFullyRebased.telemetryProperties,
 			});
 
-			peerLocalBranch.apply(newCommit.change, newCommit.revision);
+			peerLocalBranch.apply(
+				tagChange(newCommit.change, newCommit.revision),
+				newCommit.revision,
+			);
 			this.pushCommitToTrunk(sequenceId, {
 				...newCommit,
 				change: newChangeFullyRebased.change,

--- a/packages/dds/tree/src/shared-tree-core/resubmitMachine.ts
+++ b/packages/dds/tree/src/shared-tree-core/resubmitMachine.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { GraphCommit, RevisionTag } from "../core/index.js";
+import type { GraphCommit } from "../core/index.js";
 
 /**
  * Encapsulates a state machine that can be used by a {@link SharedTreeCore} manage resubmit phases,
@@ -13,12 +13,11 @@ export interface ResubmitMachine<TChange> {
 	/**
 	 * Must be called before calling `enrichCommit` as part of a resubmit phase.
 	 * @param toResubmit - the commits that will be resubmitted (from oldest to newest).
-	 * @param revision - the revision tag to be used to resubmit the change.
 	 * This must be the most rebased version of these commits (i.e., rebased over all known concurrent edits)
 	 * as opposed to the version which was last submitted.
 	 * `toResubmit` can be safely mutated by the caller after this call returns.
 	 */
-	prepareForResubmit(toResubmit: readonly GraphCommit<TChange>[], revision: RevisionTag): void;
+	prepareForResubmit(toResubmit: readonly GraphCommit<TChange>[]): void;
 
 	/**
 	 * @returns the next commit that should be resubmitted.

--- a/packages/dds/tree/src/shared-tree-core/resubmitMachine.ts
+++ b/packages/dds/tree/src/shared-tree-core/resubmitMachine.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { GraphCommit } from "../core/index.js";
+import type { GraphCommit, RevisionTag } from "../core/index.js";
 
 /**
  * Encapsulates a state machine that can be used by a {@link SharedTreeCore} manage resubmit phases,
@@ -17,7 +17,7 @@ export interface ResubmitMachine<TChange> {
 	 * as opposed to the version which was last submitted.
 	 * `toResubmit` can be safely mutated by the caller after this call returns.
 	 */
-	prepareForResubmit(toResubmit: readonly GraphCommit<TChange>[]): void;
+	prepareForResubmit(toResubmit: readonly GraphCommit<TChange>[], revision: RevisionTag): void;
 
 	/**
 	 * @returns the next commit that should be resubmitted.

--- a/packages/dds/tree/src/shared-tree-core/resubmitMachine.ts
+++ b/packages/dds/tree/src/shared-tree-core/resubmitMachine.ts
@@ -13,6 +13,7 @@ export interface ResubmitMachine<TChange> {
 	/**
 	 * Must be called before calling `enrichCommit` as part of a resubmit phase.
 	 * @param toResubmit - the commits that will be resubmitted (from oldest to newest).
+	 * @param revision - the revision tag to be used to resubmit the change.
 	 * This must be the most rebased version of these commits (i.e., rebased over all known concurrent edits)
 	 * as opposed to the version which was last submitted.
 	 * `toResubmit` can be safely mutated by the caller after this call returns.

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -446,7 +446,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		const {
 			commit: { revision, change },
 		} = this.messageCodec.decode(content, { idCompressor: this.idCompressor });
-		this.editManager.localBranch.apply(change, revision);
+		this.editManager.localBranch.apply({ change, revision }, revision);
 	}
 
 	public override getGCData(fullGC?: boolean): IGarbageCollectionData {

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -272,8 +272,8 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		this.resubmitMachine =
 			resubmitMachine ??
 			new DefaultResubmitMachine(
-				(changes: TaggedChange<TChange>, isRollback: boolean) =>
-					changeFamily.rebaser.invert(changes, isRollback, this.mintRevisionTag()),
+				(change: TaggedChange<TChange>) =>
+					changeFamily.rebaser.invert(change, true, this.mintRevisionTag()),
 				changeEnricher,
 			);
 		this.commitEnricher = new BranchCommitEnricher(changeFamily.rebaser, changeEnricher);
@@ -425,7 +425,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 				commit === toResubmit[0],
 				0x95d /* Resubmit phase should start with the oldest local commit */,
 			);
-			this.resubmitMachine.prepareForResubmit(toResubmit, this.mintRevisionTag());
+			this.resubmitMachine.prepareForResubmit(toResubmit);
 		}
 		assert(
 			isClonableSchemaPolicy(localOpMetadata),

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -18,6 +18,7 @@ import { type ICodecOptions, noopValidator } from "../codec/index.js";
 import {
 	type JsonableTree,
 	RevisionTagCodec,
+	type TaggedChange,
 	type TreeStoredSchema,
 	TreeStoredSchemaRepository,
 	makeDetachedFieldIndex,
@@ -263,7 +264,8 @@ export class SharedTree
 			schema,
 			defaultSchemaPolicy,
 			new DefaultResubmitMachine(
-				changeFamily.rebaser.invert.bind(changeFamily.rebaser),
+				(changes: TaggedChange<SharedTreeChange>, isRollback: boolean) =>
+					changeFamily.rebaser.invert(changes, isRollback, this.mintRevisionTag()),
 				changeEnricher,
 			),
 			changeEnricher,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -264,8 +264,8 @@ export class SharedTree
 			schema,
 			defaultSchemaPolicy,
 			new DefaultResubmitMachine(
-				(changes: TaggedChange<SharedTreeChange>, isRollback: boolean) =>
-					changeFamily.rebaser.invert(changes, isRollback, this.mintRevisionTag()),
+				(change: TaggedChange<SharedTreeChange>) =>
+					changeFamily.rebaser.invert(change, true, this.mintRevisionTag()),
 				changeEnricher,
 			),
 			changeEnricher,

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -122,6 +122,7 @@ export class SharedTreeChangeFamily
 	public invert(
 		change: TaggedChange<SharedTreeChange>,
 		isRollback: boolean,
+		revision: RevisionTag,
 	): SharedTreeChange {
 		const invertInnerChange: (
 			innerChange: SharedTreeChange["changes"][number],
@@ -133,6 +134,7 @@ export class SharedTreeChangeFamily
 						innerChange: this.modularChangeFamily.invert(
 							mapTaggedChange(change, innerChange.innerChange),
 							isRollback,
+							revision,
 						),
 					};
 				case "schema": {

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -79,10 +79,12 @@ export class SharedTreeChangeFamily
 	}
 
 	public buildEditor(
+		mintRevisionTag: () => RevisionTag,
 		changeReceiver: (change: SharedTreeChange) => void,
 	): SharedTreeEditBuilder {
 		return new SharedTreeEditBuilder(
 			this.modularChangeFamily,
+			mintRevisionTag,
 			changeReceiver,
 			this.idCompressor,
 		);

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -80,7 +80,7 @@ export class SharedTreeChangeFamily
 
 	public buildEditor(
 		mintRevisionTag: () => RevisionTag,
-		changeReceiver: (change: SharedTreeChange) => void,
+		changeReceiver: (change: TaggedChange<SharedTreeChange>) => void,
 	): SharedTreeEditBuilder {
 		return new SharedTreeEditBuilder(
 			this.modularChangeFamily,

--- a/packages/dds/tree/src/shared-tree/sharedTreeEditBuilder.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeEditBuilder.ts
@@ -4,7 +4,7 @@
  */
 
 import type { IIdCompressor } from "@fluidframework/id-compressor";
-import type { ChangeFamilyEditor, TreeStoredSchema } from "../core/index.js";
+import type { ChangeFamilyEditor, RevisionTag, TreeStoredSchema } from "../core/index.js";
 import {
 	DefaultEditBuilder,
 	type IDefaultEditBuilder,
@@ -48,11 +48,13 @@ export class SharedTreeEditBuilder
 
 	public constructor(
 		modularChangeFamily: ModularChangeFamily,
+		mintRevisionTag: () => RevisionTag,
 		private readonly changeReceiver: (change: SharedTreeChange) => void,
 		idCompressor?: IIdCompressor,
 	) {
 		super(
 			modularChangeFamily,
+			mintRevisionTag,
 			(change) =>
 				changeReceiver({
 					changes: [{ type: "data", innerChange: change }],

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -787,11 +787,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		const revisionForInvert = this.mintRevisionTag();
 
 		let change = tagChange(
-			this.changeFamily.rebaser.invert(
-				tagChange(commitToRevert.change, revision),
-				false,
-				revisionForInvert,
-			),
+			this.changeFamily.rebaser.invert(commitToRevert, false, revisionForInvert),
 			revisionForInvert,
 		);
 

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -32,7 +32,6 @@ import {
 	TreeStoredSchemaRepository,
 	type TreeStoredSchemaSubscription,
 	combineVisitors,
-	makeAnonChange,
 	makeDetachedFieldIndex,
 	rebaseChange,
 	rootFieldKey,
@@ -785,15 +784,21 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		const revertibleBranch = this.revertibleCommitBranches.get(revision);
 		assert(revertibleBranch !== undefined, 0x7cc /* expected to find a revertible commit */);
 		const commitToRevert = revertibleBranch.getHead();
+		const revisionForInvert = this.mintRevisionTag();
 
-		let change = makeAnonChange(
-			this.changeFamily.rebaser.invert(tagChange(commitToRevert.change, revision), false),
+		let change = tagChange(
+			this.changeFamily.rebaser.invert(
+				tagChange(commitToRevert.change, revision),
+				false,
+				revisionForInvert,
+			),
+			revisionForInvert,
 		);
 
 		const headCommit = this._branch.getHead();
 		// Rebase the inverted change onto any commits that occurred after the undoable commits.
 		if (commitToRevert !== headCommit) {
-			change = makeAnonChange(
+			change = tagChange(
 				rebaseChange(
 					this.changeFamily.rebaser,
 					change,
@@ -801,13 +806,12 @@ export class TreeCheckout implements ITreeCheckoutFork {
 					headCommit,
 					this.mintRevisionTag,
 				).change,
+				revisionForInvert,
 			);
 		}
 
-		const revisionForApply = this.mintRevisionTag();
 		this._branch.apply(
-			{ change: change.change, revision: revisionForApply },
-			revisionForApply,
+			change,
 			kind === CommitKind.Default || kind === CommitKind.Redo
 				? CommitKind.Undo
 				: CommitKind.Redo,

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -804,9 +804,10 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			);
 		}
 
+		const revisionForApply = this.mintRevisionTag();
 		this._branch.apply(
-			change.change,
-			this.mintRevisionTag(),
+			{ change: change.change, revision: revisionForApply },
+			revisionForApply,
 			kind === CommitKind.Default || kind === CommitKind.Redo
 				? CommitKind.Undo
 				: CommitKind.Redo,

--- a/packages/dds/tree/src/test/changesetWrapper.ts
+++ b/packages/dds/tree/src/test/changesetWrapper.ts
@@ -146,16 +146,22 @@ function compose<T>(
 
 function invert<T>(
 	change: TaggedChange<ChangesetWrapper<T>>,
-	invertField: (field: TaggedChange<T>, isRollback: boolean) => T,
+	invertField: (
+		field: TaggedChange<T>,
+		revision: RevisionTag | undefined,
+		isRollback: boolean,
+	) => T,
+	revision: RevisionTag | undefined,
 	isRollback: boolean = false,
 ): ChangesetWrapper<T> {
 	const invertedField = invertField(
 		tagChange(change.change.fieldChange, change.revision),
+		revision,
 		isRollback,
 	);
 	const invertedNodes: ChangeAtomIdMap<TestChange> = new Map();
-	forEachInNestedMap(change.change.nodes, (testChange, revision, localId) => {
-		setInNestedMap(invertedNodes, revision, localId, TestChange.invert(testChange));
+	forEachInNestedMap(change.change.nodes, (testChange, revision2, localId) => {
+		setInNestedMap(invertedNodes, revision2, localId, TestChange.invert(testChange));
 	});
 
 	return { fieldChange: invertedField, nodes: invertedNodes };

--- a/packages/dds/tree/src/test/editMinter.ts
+++ b/packages/dds/tree/src/test/editMinter.ts
@@ -19,9 +19,9 @@ export function makeEditMinter(
 	editor: Editor,
 ): () => DefaultChangeset {
 	let builtChangeset: DefaultChangeset | undefined;
-	const innerEditor = family.buildEditor(mintRevisionTag, (change) => {
+	const innerEditor = family.buildEditor(mintRevisionTag, (taggedChange) => {
 		assert(builtChangeset === undefined);
-		builtChangeset = change;
+		builtChangeset = taggedChange.change;
 	});
 	return (): DefaultChangeset => {
 		assert(builtChangeset === undefined);

--- a/packages/dds/tree/src/test/editMinter.ts
+++ b/packages/dds/tree/src/test/editMinter.ts
@@ -10,6 +10,7 @@ import type {
 	DefaultChangeset,
 	DefaultEditBuilder,
 } from "../feature-libraries/index.js";
+import { mintRevisionTag } from "./utils.js";
 
 export type Editor = (builder: DefaultEditBuilder) => void;
 
@@ -18,7 +19,7 @@ export function makeEditMinter(
 	editor: Editor,
 ): () => DefaultChangeset {
 	let builtChangeset: DefaultChangeset | undefined;
-	const innerEditor = family.buildEditor((change) => {
+	const innerEditor = family.buildEditor(mintRevisionTag, (change) => {
 		assert(builtChangeset === undefined);
 		builtChangeset = change;
 	});

--- a/packages/dds/tree/src/test/exhaustiveRebaserUtils.ts
+++ b/packages/dds/tree/src/test/exhaustiveRebaserUtils.ts
@@ -44,7 +44,11 @@ export function getSequentialStates<TContent, TChangeset>(
  * - revision metadata source
  */
 export interface BoundFieldChangeRebaser<TChangeset> {
-	invert(change: TaggedChange<TChangeset>, isRollback: boolean): TChangeset;
+	invert(
+		change: TaggedChange<TChangeset>,
+		revision: RevisionTag | undefined,
+		isRollback: boolean,
+	): TChangeset;
 	rebase(
 		change: TaggedChange<TChangeset>,
 		base: TaggedChange<TChangeset>,

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -12,6 +12,7 @@ import {
 	type FieldKey,
 	type JsonableTree,
 	mapCursorField,
+	type RevisionTag,
 	RevisionTagCodec,
 	rootFieldKey,
 	type TaggedChange,
@@ -171,7 +172,7 @@ describe("End to end chunked encoding", () => {
 		// Check that inserted change contains chunk which is reference equal to the original chunk.
 		const insertedChange = changeLog[0];
 		assert(insertedChange.builds !== undefined);
-		const insertedChunk = insertedChange.builds.get([undefined, 0 as ChangesetLocalId]);
+		const insertedChunk = insertedChange.builds.get([0 as RevisionTag, 0 as ChangesetLocalId]);
 		assert.equal(insertedChunk, chunk);
 		assert(chunk.isShared());
 	});

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -58,6 +58,7 @@ import {
 	checkoutWithContent,
 	cursorFromInsertableTreeField,
 	forestWithContent,
+	mintRevisionTag,
 	testIdCompressor,
 	type SharedTreeWithConnectionStateSetter,
 } from "../../utils.js";
@@ -157,10 +158,12 @@ describe("End to end chunked encoding", () => {
 			fieldBatchCodec,
 			{ jsonValidator: typeboxValidator },
 		);
-		const dummyEditor = new DefaultEditBuilder(new DefaultChangeFamily(codec), changeReceiver);
-		const checkout = new MockTreeCheckout(forest, {
-			editor: dummyEditor as unknown as ISharedTreeEditor,
-		});
+		const dummyEditor = new DefaultEditBuilder(
+			new DefaultChangeFamily(codec),
+			mintRevisionTag,
+			changeReceiver,
+		);
+		const checkout = new MockTreeCheckout(forest, dummyEditor as unknown as ISharedTreeEditor);
 		checkout.editor
 			.sequenceField({ field: rootFieldKey, parent: undefined })
 			.insert(0, chunk.cursor());

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -12,7 +12,6 @@ import {
 	type FieldKey,
 	type JsonableTree,
 	mapCursorField,
-	type RevisionTag,
 	RevisionTagCodec,
 	rootFieldKey,
 	type TaggedChange,
@@ -149,10 +148,10 @@ describe("End to end chunked encoding", () => {
 		const numberShape = new TreeShape(brand(numberSchema.identifier), true, []);
 		const chunk = new UniformChunk(numberShape.withTopLevelLength(4), [1, 2, 3, 4]);
 		assert(!chunk.isShared());
-		const changeLog: ModularChangeset[] = [];
+		const changeLog: TaggedChange<ModularChangeset>[] = [];
 
 		const changeReceiver = (taggedChange: TaggedChange<ModularChangeset>) => {
-			changeLog.push(taggedChange.change);
+			changeLog.push(taggedChange);
 		};
 		const codec = makeModularChangeCodecFamily(
 			fieldKindConfigurations,
@@ -170,9 +169,9 @@ describe("End to end chunked encoding", () => {
 			.sequenceField({ field: rootFieldKey, parent: undefined })
 			.insert(0, chunk.cursor());
 		// Check that inserted change contains chunk which is reference equal to the original chunk.
-		const insertedChange = changeLog[0];
+		const { change: insertedChange, revision } = changeLog[0];
 		assert(insertedChange.builds !== undefined);
-		const insertedChunk = insertedChange.builds.get([0 as RevisionTag, 0 as ChangesetLocalId]);
+		const insertedChunk = insertedChange.builds.get([revision, 0 as ChangesetLocalId]);
 		assert.equal(insertedChunk, chunk);
 		assert(chunk.isShared());
 	});

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -14,6 +14,7 @@ import {
 	mapCursorField,
 	RevisionTagCodec,
 	rootFieldKey,
+	type TaggedChange,
 	TreeStoredSchemaRepository,
 } from "../../../core/index.js";
 import { typeboxValidator } from "../../../external-utilities/index.js";
@@ -149,8 +150,8 @@ describe("End to end chunked encoding", () => {
 		assert(!chunk.isShared());
 		const changeLog: ModularChangeset[] = [];
 
-		const changeReceiver = (change: ModularChangeset) => {
-			changeLog.push(change);
+		const changeReceiver = (taggedChange: TaggedChange<ModularChangeset>) => {
+			changeLog.push(taggedChange.change);
 		};
 		const codec = makeModularChangeCodecFamily(
 			fieldKindConfigurations,

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -164,7 +164,9 @@ describe("End to end chunked encoding", () => {
 			mintRevisionTag,
 			changeReceiver,
 		);
-		const checkout = new MockTreeCheckout(forest, dummyEditor as unknown as ISharedTreeEditor);
+		const checkout = new MockTreeCheckout(forest, {
+			editor: dummyEditor as unknown as ISharedTreeEditor,
+		});
 		checkout.editor
 			.sequenceField({ field: rootFieldKey, parent: undefined })
 			.insert(0, chunk.cursor());

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -121,7 +121,6 @@ function initializeEditableForest(data?: JsonableTree): {
 			testIdCompressor,
 		);
 	}
-	let currentRevision = mintRevisionTag();
 	const changes: TaggedChange<DefaultChangeset>[] = [];
 	const deltas: DeltaRoot[] = [];
 	const detachedFieldIndex = makeDetachedFieldIndex(
@@ -129,13 +128,11 @@ function initializeEditableForest(data?: JsonableTree): {
 		testRevisionTagCodec,
 		testIdCompressor,
 	);
-	const builder = new DefaultEditBuilder(family, mintRevisionTag, (change) => {
-		const taggedChange = { revision: currentRevision, change };
+	const builder = new DefaultEditBuilder(family, mintRevisionTag, (taggedChange) => {
 		changes.push(taggedChange);
 		const delta = intoDelta(taggedChange);
 		deltas.push(delta);
-		applyDelta(delta, currentRevision, forest, detachedFieldIndex);
-		currentRevision = mintRevisionTag();
+		applyDelta(delta, taggedChange.revision, forest, detachedFieldIndex);
 	});
 	return {
 		forest,

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -129,7 +129,7 @@ function initializeEditableForest(data?: JsonableTree): {
 		testRevisionTagCodec,
 		testIdCompressor,
 	);
-	const builder = new DefaultEditBuilder(family, (change) => {
+	const builder = new DefaultEditBuilder(family, mintRevisionTag, (change) => {
 		const taggedChange = { revision: currentRevision, change };
 		changes.push(taggedChange);
 		const delta = intoDelta(taggedChange);

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
@@ -68,14 +68,12 @@ describe("defaultFieldKinds", () => {
 				Change.clear("self", brand(1)),
 				Change.move(brand(41), "self"),
 			);
+			const revision = mintRevisionTag();
 			assertEqual(
-				valueFieldEditor.set(
-					{
-						detach: brand(1),
-						fill: brand(41),
-					},
-					mintRevisionTag(),
-				),
+				valueFieldEditor.set({
+					detach: { localId: brand(1), revision },
+					fill: { localId: brand(41), revision },
+				}),
 				expected,
 			);
 		});
@@ -92,13 +90,21 @@ describe("defaultFieldKinds", () => {
 		const childChange2 = Change.child(nodeChange2);
 		const childChange3 = Change.child(arbitraryChildChange);
 
+		const revision1 = mintRevisionTag();
 		const change1 = tagChangeInline(
-			fieldHandler.editor.set({ detach: brand(1), fill: brand(41) }, mintRevisionTag()),
-			mintRevisionTag(),
+			fieldHandler.editor.set({
+				detach: { localId: brand(1), revision: revision1 },
+				fill: { localId: brand(41), revision: revision1 },
+			}),
+			revision1,
 		);
+		const revision2 = mintRevisionTag();
 		const change2 = tagChangeInline(
-			fieldHandler.editor.set({ detach: brand(2), fill: brand(42) }, mintRevisionTag()),
-			mintRevisionTag(),
+			fieldHandler.editor.set({
+				detach: { localId: brand(2), revision: revision2 },
+				fill: { localId: brand(42), revision: revision2 },
+			}),
+			revision2,
 		);
 
 		const change1WithChildChange = Change.atOnce(

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
@@ -200,6 +200,7 @@ describe("defaultFieldKinds", () => {
 				true,
 				idAllocatorFromMaxId(),
 				failCrossFieldManager,
+				mintRevisionTag(),
 				defaultRevisionMetadataFromChanges([taggedChange]),
 			);
 

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
@@ -205,8 +205,8 @@ describe("defaultFieldKinds", () => {
 				taggedChange.change,
 				true,
 				idAllocatorFromMaxId(),
-				failCrossFieldManager,
 				mintRevisionTag(),
+				failCrossFieldManager,
 				defaultRevisionMetadataFromChanges([taggedChange]),
 			);
 

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
@@ -69,10 +69,13 @@ describe("defaultFieldKinds", () => {
 				Change.move(brand(41), "self"),
 			);
 			assertEqual(
-				valueFieldEditor.set({
-					detach: brand(1),
-					fill: brand(41),
-				}),
+				valueFieldEditor.set(
+					{
+						detach: brand(1),
+						fill: brand(41),
+					},
+					mintRevisionTag(),
+				),
 				expected,
 			);
 		});
@@ -90,11 +93,11 @@ describe("defaultFieldKinds", () => {
 		const childChange3 = Change.child(arbitraryChildChange);
 
 		const change1 = tagChangeInline(
-			fieldHandler.editor.set({ detach: brand(1), fill: brand(41) }),
+			fieldHandler.editor.set({ detach: brand(1), fill: brand(41) }, mintRevisionTag()),
 			mintRevisionTag(),
 		);
 		const change2 = tagChangeInline(
-			fieldHandler.editor.set({ detach: brand(2), fill: brand(42) }),
+			fieldHandler.editor.set({ detach: brand(2), fill: brand(42) }, mintRevisionTag()),
 			mintRevisionTag(),
 		);
 

--- a/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
@@ -13,6 +13,7 @@ import type {
 } from "../../core/index.js";
 import { makeMitigatedChangeFamily } from "../../feature-libraries/index.js";
 import type { ICodecFamily } from "../../codec/index.js";
+import { mintRevisionTag } from "../utils.js";
 
 const fallback = "Fallback";
 
@@ -88,8 +89,8 @@ const returningRebaser = returningFamily.rebaser;
 describe("makeMitigatedChangeFamily", () => {
 	it("does not interfere so long as nothing is thrown", () => {
 		assert.equal(
-			mitigatedReturningFamily.buildEditor(arg1),
-			returningFamily.buildEditor(arg1),
+			mitigatedReturningFamily.buildEditor(mintRevisionTag, arg1),
+			returningFamily.buildEditor(mintRevisionTag, arg1),
 		);
 		assert.equal(
 			mitigatedReturningRebaser.rebase(arg1, arg2, arg3),
@@ -120,7 +121,10 @@ describe("makeMitigatedChangeFamily", () => {
 	});
 	it("does not catch errors from buildEditor", () => {
 		errorLog.length = 0;
-		assert.throws(() => mitigatedThrowingFamily.buildEditor(arg1), new Error("buildEditor"));
+		assert.throws(
+			() => mitigatedThrowingFamily.buildEditor(mintRevisionTag, arg1),
+			new Error("buildEditor"),
+		);
 		assert.deepEqual(errorLog, []);
 	});
 	it("does affect codecs", () => {

--- a/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
@@ -10,6 +10,7 @@ import type {
 	ChangeFamilyEditor,
 	TaggedChange,
 	ChangeEncodingContext,
+	RevisionTag,
 } from "../../core/index.js";
 import { makeMitigatedChangeFamily } from "../../feature-libraries/index.js";
 import type { ICodecFamily } from "../../codec/index.js";
@@ -25,7 +26,10 @@ const arg3: any = "arg3";
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 const throwingFamily: ChangeFamily<ChangeFamilyEditor, string> = {
-	buildEditor: (changeReceiver: (change: string) => void): ChangeFamilyEditor => {
+	buildEditor: (
+		mintRevisionTagThrow: () => RevisionTag,
+		changeReceiver: (change: TaggedChange<string>) => void,
+	): ChangeFamilyEditor => {
 		assert.equal(changeReceiver, arg1);
 		throw new Error("buildEditor");
 	},
@@ -51,7 +55,10 @@ const throwingFamily: ChangeFamily<ChangeFamilyEditor, string> = {
 	codecs: {} as unknown as ICodecFamily<string, ChangeEncodingContext>,
 };
 const returningFamily: ChangeFamily<ChangeFamilyEditor, string> = {
-	buildEditor: (changeReceiver: (change: string) => void): ChangeFamilyEditor => {
+	buildEditor: (
+		mintRevisionTagRet: () => RevisionTag,
+		changeReceiver: (change: TaggedChange<string>) => void,
+	): ChangeFamilyEditor => {
 		assert.equal(changeReceiver, arg1);
 		return "buildEditor" as unknown as ChangeFamilyEditor;
 	},

--- a/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
@@ -96,9 +96,10 @@ describe("makeMitigatedChangeFamily", () => {
 			mitigatedReturningRebaser.rebase(arg1, arg2, arg3),
 			returningRebaser.rebase(arg1, arg2, arg3),
 		);
+		const revision = mintRevisionTag();
 		assert.equal(
-			mitigatedReturningRebaser.invert(arg1, arg2),
-			returningRebaser.invert(arg1, arg2),
+			mitigatedReturningRebaser.invert(arg1, arg2, revision),
+			returningRebaser.invert(arg1, arg2, revision),
 		);
 		assert.equal(mitigatedReturningRebaser.compose(arg1), returningRebaser.compose(arg1));
 	});
@@ -110,7 +111,7 @@ describe("makeMitigatedChangeFamily", () => {
 		});
 		it("invert", () => {
 			errorLog.length = 0;
-			assert.equal(mitigatedThrowingRebaser.invert(arg1, arg2), fallback);
+			assert.equal(mitigatedThrowingRebaser.invert(arg1, arg2, mintRevisionTag()), fallback);
 			assert.deepEqual(errorLog, ["invert"]);
 		});
 		it("compose", () => {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -17,6 +17,7 @@ import {
 	type EncodingTestData,
 	defaultRevisionMetadataFromChanges,
 	makeEncodingTestSuite,
+	mintRevisionTag,
 	testIdCompressor,
 	testRevisionTagCodec,
 } from "../../utils.js";
@@ -174,6 +175,7 @@ describe("GenericField", () => {
 			true,
 			idAllocatorFromMaxId(),
 			crossFieldManager,
+			mintRevisionTag(),
 			defaultRevisionMetadataFromChanges([]),
 		);
 		assert.deepEqual(actual, expected);

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -174,8 +174,8 @@ describe("GenericField", () => {
 			forward,
 			true,
 			idAllocatorFromMaxId(),
-			crossFieldManager,
 			mintRevisionTag(),
+			crossFieldManager,
 			defaultRevisionMetadataFromChanges([]),
 		);
 		assert.deepEqual(actual, expected);

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -50,6 +50,7 @@ import {
 	Multiplicity,
 	replaceAtomRevisions,
 	type FieldUpPath,
+	type RevisionInfo,
 } from "../../../core/index.js";
 import {
 	type Mutable,
@@ -187,6 +188,7 @@ const family = new ModularChangeFamily(fieldKinds, codec);
 const tag1: RevisionTag = mintRevisionTag();
 const tag2: RevisionTag = mintRevisionTag();
 const tag3: RevisionTag = mintRevisionTag();
+const tag4: RevisionTag = mintRevisionTag();
 
 const fieldA: FieldKey = brand("a");
 const fieldB: FieldKey = brand("b");
@@ -355,21 +357,21 @@ const rootChange2: ModularChangeset = removeAliases(
 			field: pathA,
 			fieldKind: singleNodeField.identifier,
 			change: brand(undefined),
-			revision: tag1,
+			revision: tag2,
 		},
 		{
 			type: "field",
 			field: pathA0A,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange2),
-			revision: tag1,
+			revision: tag2,
 		},
 		{
 			type: "field",
 			field: pathA0B,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange1a),
-			revision: tag1,
+			revision: tag2,
 		},
 	]),
 );
@@ -381,14 +383,14 @@ const rootChange2Generic: ModularChangeset = removeAliases(
 			field: pathA0A,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange2),
-			revision: tag1,
+			revision: tag2,
 		},
 		{
 			type: "field",
 			field: pathA0B,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange1a),
-			revision: tag1,
+			revision: tag2,
 		},
 	]),
 );
@@ -400,21 +402,21 @@ const rootChange3: ModularChangeset = removeAliases(
 			field: pathA,
 			fieldKind: singleNodeField.identifier,
 			change: brand(undefined),
-			revision: tag1,
+			revision: tag3,
 		},
 		{
 			type: "field",
 			field: pathA0A,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange1a),
-			revision: tag1,
+			revision: tag3,
 		},
 	]),
 );
 
 const rootChange4: ModularChangeset = removeAliases(
 	family.compose([
-		tagChangeInline(rootChange3, tag1),
+		tagChangeInline(rootChange3, tag4),
 		makeAnonChange(buildExistsConstraint(pathA0)),
 	]),
 );
@@ -489,103 +491,119 @@ describe("ModularChangeFamily", () => {
 		});
 
 		it("compose specific ○ specific", () => {
-			const expectedCompose = tagChangeInline(
-				Change.build(
-					{ family, maxId: rootChange2.maxId },
-					Change.field(
-						fieldA,
-						singleNodeField.identifier,
-						singleNodeField.changeHandler.createEmpty(),
-						Change.node(
-							0,
-							Change.field(fieldA, valueField.identifier, composedValues),
-							Change.field(fieldB, valueField.identifier, valueChange1a),
+			const expectedRevision: RevisionInfo[] = [{ revision: tag1 }, { revision: tag2 }];
+			const expectedCompose = {
+				...tagChangeInline(
+					Change.build(
+						{ family, maxId: rootChange2.maxId },
+						Change.field(
+							fieldA,
+							singleNodeField.identifier,
+							singleNodeField.changeHandler.createEmpty(),
+							Change.node(
+								0,
+								Change.field(fieldA, valueField.identifier, composedValues),
+								Change.field(fieldB, valueField.identifier, valueChange1a),
+							),
 						),
+						Change.field(fieldB, valueField.identifier, valueChange2),
 					),
-					Change.field(fieldB, valueField.identifier, valueChange2),
-				),
-				tag1,
-			);
+					tag1,
+				).change,
+				revisions: expectedRevision,
+			};
 
 			const composed = removeAliases(
 				family.compose([makeAnonChange(rootChange1a), makeAnonChange(rootChange2)]),
 			);
 
-			assertEqual(composed, expectedCompose.change);
+			assertEqual(composed, expectedCompose);
 		});
 
 		it("compose specific ○ generic", () => {
-			const expectedCompose = tagChangeInline(
-				Change.build(
-					{ family, maxId: rootChange2Generic.maxId },
-					Change.field(
-						fieldA,
-						singleNodeField.identifier,
-						singleNodeField.changeHandler.createEmpty(),
-						Change.node(
-							0,
-							Change.field(fieldA, valueField.identifier, composedValues),
-							Change.field(fieldB, valueField.identifier, valueChange1a),
+			const expectedRevision: RevisionInfo[] = [{ revision: tag1 }, { revision: tag2 }];
+			const expectedCompose = {
+				...tagChangeInline(
+					Change.build(
+						{ family, maxId: rootChange2Generic.maxId },
+						Change.field(
+							fieldA,
+							singleNodeField.identifier,
+							singleNodeField.changeHandler.createEmpty(),
+							Change.node(
+								0,
+								Change.field(fieldA, valueField.identifier, composedValues),
+								Change.field(fieldB, valueField.identifier, valueChange1a),
+							),
 						),
+						Change.field(fieldB, valueField.identifier, valueChange2),
 					),
-					Change.field(fieldB, valueField.identifier, valueChange2),
-				),
-				tag1,
-			);
+					tag1,
+				).change,
+				revisions: expectedRevision,
+			};
 
 			const composed = removeAliases(
 				family.compose([makeAnonChange(rootChange1a), makeAnonChange(rootChange2Generic)]),
 			);
 
-			assertEqual(composed, expectedCompose.change);
+			assertEqual(composed, expectedCompose);
 		});
 
 		it("compose generic ○ specific", () => {
-			const expectedCompose = tagChangeInline(
-				Change.build(
-					{ family, maxId: rootChange2.maxId },
-					Change.field(
-						fieldA,
-						singleNodeField.identifier,
-						singleNodeField.changeHandler.createEmpty(),
-						Change.nodeWithId(
-							0,
-							{ localId: brand(1) },
-							Change.field(fieldA, valueField.identifier, composedValues),
-							Change.field(fieldB, valueField.identifier, valueChange1a),
+			const expectedRevision: RevisionInfo[] = [{ revision: tag1 }, { revision: tag2 }];
+			const expectedCompose = {
+				...tagChangeInline(
+					Change.build(
+						{ family, maxId: rootChange2.maxId },
+						Change.field(
+							fieldA,
+							singleNodeField.identifier,
+							singleNodeField.changeHandler.createEmpty(),
+							Change.nodeWithId(
+								0,
+								{ localId: brand(1) },
+								Change.field(fieldA, valueField.identifier, composedValues),
+								Change.field(fieldB, valueField.identifier, valueChange1a),
+							),
 						),
+						Change.field(fieldB, valueField.identifier, valueChange2),
 					),
-					Change.field(fieldB, valueField.identifier, valueChange2),
-				),
-				tag1,
-			);
+					tag1,
+				).change,
+				revisions: expectedRevision,
+			};
 
 			const composed = removeAliases(
 				family.compose([makeAnonChange(rootChange1aGeneric), makeAnonChange(rootChange2)]),
 			);
 
-			assertEqual(composed, expectedCompose.change);
+			assertEqual(composed, expectedCompose);
 		});
 
 		it("compose generic ○ generic", () => {
-			const expectedCompose = tagChangeInline(
-				Change.build(
-					{ family, maxId: rootChange2Generic.maxId },
-					Change.field(
-						fieldA,
-						genericFieldKind.identifier,
-						genericFieldKind.changeHandler.createEmpty(),
-						Change.nodeWithId(
-							0,
-							{ localId: brand(1) },
-							Change.field(fieldA, valueField.identifier, composedValues),
-							Change.field(fieldB, valueField.identifier, valueChange1a),
+			const expectedRevision: RevisionInfo[] = [{ revision: tag1 }, { revision: tag2 }];
+			const expectedCompose = {
+				...tagChangeInline(
+					Change.build(
+						{ family, maxId: rootChange2Generic.maxId },
+						Change.field(
+							fieldA,
+							genericFieldKind.identifier,
+							genericFieldKind.changeHandler.createEmpty(),
+							Change.nodeWithId(
+								0,
+								{ localId: brand(1) },
+								Change.field(fieldA, valueField.identifier, composedValues),
+								Change.field(fieldB, valueField.identifier, valueChange1a),
+							),
 						),
+						Change.field(fieldB, valueField.identifier, valueChange2),
 					),
-					Change.field(fieldB, valueField.identifier, valueChange2),
-				),
-				tag1,
-			);
+					tag1,
+				).change,
+				revisions: expectedRevision,
+			};
 
 			const composed = removeAliases(
 				family.compose([
@@ -594,7 +612,7 @@ describe("ModularChangeFamily", () => {
 				]),
 			);
 
-			assertEqual(composed, expectedCompose.change);
+			assertEqual(composed, expectedCompose);
 		});
 
 		it("compose tagged changes", () => {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -423,15 +423,18 @@ const dummyRevisionTag = mintRevisionTag();
 
 const rootChangeWithoutNodeFieldChanges: ModularChangeset = family.compose([
 	tagChangeInline(
-		buildChangeset([
-			{
-				type: "field",
-				field: pathA,
-				fieldKind: singleNodeField.identifier,
-				change: brand(undefined),
-				revision: tag1,
-			},
-		]),
+		buildChangeset(
+			[
+				{
+					type: "field",
+					field: pathA,
+					fieldKind: singleNodeField.identifier,
+					change: brand(undefined),
+					revision: dummyRevisionTag,
+				},
+			],
+			dummyRevisionTag,
+		),
 		dummyRevisionTag,
 	),
 	makeAnonChange(buildExistsConstraint(pathA0)),
@@ -489,90 +492,102 @@ describe("ModularChangeFamily", () => {
 		});
 
 		it("compose specific ○ specific", () => {
-			const expectedCompose = Change.build(
-				{ family, maxId: rootChange2.maxId },
-				Change.field(
-					fieldA,
-					singleNodeField.identifier,
-					singleNodeField.changeHandler.createEmpty(),
-					Change.node(
-						0,
-						Change.field(fieldA, valueField.identifier, composedValues),
-						Change.field(fieldB, valueField.identifier, valueChange1a),
+			const expectedCompose = tagChangeInline(
+				Change.build(
+					{ family, maxId: rootChange2.maxId },
+					Change.field(
+						fieldA,
+						singleNodeField.identifier,
+						singleNodeField.changeHandler.createEmpty(),
+						Change.node(
+							0,
+							Change.field(fieldA, valueField.identifier, composedValues),
+							Change.field(fieldB, valueField.identifier, valueChange1a),
+						),
 					),
+					Change.field(fieldB, valueField.identifier, valueChange2),
 				),
-				Change.field(fieldB, valueField.identifier, valueChange2),
+				tag1,
 			);
 
 			const composed = removeAliases(
 				family.compose([makeAnonChange(rootChange1a), makeAnonChange(rootChange2)]),
 			);
 
-			assertEqual(composed, expectedCompose);
+			assertEqual(composed, expectedCompose.change);
 		});
 
 		it("compose specific ○ generic", () => {
-			const expectedCompose = Change.build(
-				{ family, maxId: rootChange2Generic.maxId },
-				Change.field(
-					fieldA,
-					singleNodeField.identifier,
-					singleNodeField.changeHandler.createEmpty(),
-					Change.node(
-						0,
-						Change.field(fieldA, valueField.identifier, composedValues),
-						Change.field(fieldB, valueField.identifier, valueChange1a),
+			const expectedCompose = tagChangeInline(
+				Change.build(
+					{ family, maxId: rootChange2Generic.maxId },
+					Change.field(
+						fieldA,
+						singleNodeField.identifier,
+						singleNodeField.changeHandler.createEmpty(),
+						Change.node(
+							0,
+							Change.field(fieldA, valueField.identifier, composedValues),
+							Change.field(fieldB, valueField.identifier, valueChange1a),
+						),
 					),
+					Change.field(fieldB, valueField.identifier, valueChange2),
 				),
-				Change.field(fieldB, valueField.identifier, valueChange2),
+				tag1,
 			);
 
 			const composed = removeAliases(
 				family.compose([makeAnonChange(rootChange1a), makeAnonChange(rootChange2Generic)]),
 			);
 
-			assertEqual(composed, expectedCompose);
+			assertEqual(composed, expectedCompose.change);
 		});
 
 		it("compose generic ○ specific", () => {
-			const expectedCompose = Change.build(
-				{ family, maxId: rootChange2.maxId },
-				Change.field(
-					fieldA,
-					singleNodeField.identifier,
-					singleNodeField.changeHandler.createEmpty(),
-					Change.nodeWithId(
-						0,
-						{ localId: brand(1) },
-						Change.field(fieldA, valueField.identifier, composedValues),
-						Change.field(fieldB, valueField.identifier, valueChange1a),
+			const expectedCompose = tagChangeInline(
+				Change.build(
+					{ family, maxId: rootChange2.maxId },
+					Change.field(
+						fieldA,
+						singleNodeField.identifier,
+						singleNodeField.changeHandler.createEmpty(),
+						Change.nodeWithId(
+							0,
+							{ localId: brand(1) },
+							Change.field(fieldA, valueField.identifier, composedValues),
+							Change.field(fieldB, valueField.identifier, valueChange1a),
+						),
 					),
+					Change.field(fieldB, valueField.identifier, valueChange2),
 				),
-				Change.field(fieldB, valueField.identifier, valueChange2),
+				tag1,
 			);
 
 			const composed = removeAliases(
 				family.compose([makeAnonChange(rootChange1aGeneric), makeAnonChange(rootChange2)]),
 			);
 
-			assertEqual(composed, expectedCompose);
+			assertEqual(composed, expectedCompose.change);
 		});
 
 		it("compose generic ○ generic", () => {
-			const expectedCompose = Change.build(
-				{ family, maxId: rootChange2Generic.maxId },
-				Change.field(
-					fieldA,
-					genericFieldKind.identifier,
-					genericFieldKind.changeHandler.createEmpty(),
-					Change.nodeWithId(
-						0,
-						{ localId: brand(1) },
-						Change.field(fieldA, valueField.identifier, composedValues),
-						Change.field(fieldB, valueField.identifier, valueChange1a),
+			const expectedCompose = tagChangeInline(
+				Change.build(
+					{ family, maxId: rootChange2Generic.maxId },
+					Change.field(
+						fieldA,
+						genericFieldKind.identifier,
+						genericFieldKind.changeHandler.createEmpty(),
+						Change.nodeWithId(
+							0,
+							{ localId: brand(1) },
+							Change.field(fieldA, valueField.identifier, composedValues),
+							Change.field(fieldB, valueField.identifier, valueChange1a),
+						),
 					),
+					Change.field(fieldB, valueField.identifier, valueChange2),
 				),
-				Change.field(fieldB, valueField.identifier, valueChange2),
+				tag1,
 			);
 
 			const composed = removeAliases(
@@ -582,40 +597,46 @@ describe("ModularChangeFamily", () => {
 				]),
 			);
 
-			assertEqual(composed, expectedCompose);
+			assertEqual(composed, expectedCompose.change);
 		});
 
 		it("compose tagged changes", () => {
 			const change1 = tagChangeInline(
-				buildChangeset([
-					{
-						type: "field",
-						field: pathA,
-						fieldKind: valueField.identifier,
-						change: brand(valueChange1a),
-						revision: tag1,
-					},
-				]),
+				buildChangeset(
+					[
+						{
+							type: "field",
+							field: pathA,
+							fieldKind: valueField.identifier,
+							change: brand(valueChange1a),
+							revision: tag1,
+						},
+					],
+					tag1,
+				),
 				tag1,
 			);
 
 			const change2 = tagChangeInline(
-				buildChangeset([
-					{
-						type: "field",
-						field: pathB,
-						fieldKind: singleNodeField.identifier,
-						change: brand(undefined),
-						revision: tag1,
-					},
-					{
-						type: "field",
-						field: pathB0A,
-						fieldKind: valueField.identifier,
-						change: brand(valueChange2),
-						revision: tag1,
-					},
-				]),
+				buildChangeset(
+					[
+						{
+							type: "field",
+							field: pathB,
+							fieldKind: singleNodeField.identifier,
+							change: brand(undefined),
+							revision: tag2,
+						},
+						{
+							type: "field",
+							field: pathB0A,
+							fieldKind: valueField.identifier,
+							change: brand(valueChange2),
+							revision: tag2,
+						},
+					],
+					tag2,
+				),
 				tag2,
 			);
 
@@ -861,29 +882,32 @@ describe("ModularChangeFamily", () => {
 		const valueInverse2: ValueChangeset = { old: 2, new: 1 };
 
 		it("specific", () => {
-			const expectedInverse = buildChangeset([
-				{
-					type: "field",
-					field: pathA,
-					fieldKind: singleNodeField.identifier,
-					change: brand(undefined),
-					revision: tag1,
-				},
-				{
-					type: "field",
-					field: pathA0A,
-					fieldKind: valueField.identifier,
-					change: brand(valueInverse1),
-					revision: tag1,
-				},
-				{
-					type: "field",
-					field: pathB,
-					fieldKind: valueField.identifier,
-					change: brand(valueInverse2),
-					revision: tag1,
-				},
-			]);
+			const expectedInverse = buildChangeset(
+				[
+					{
+						type: "field",
+						field: pathA,
+						fieldKind: singleNodeField.identifier,
+						change: brand(undefined),
+						revision: tag1,
+					},
+					{
+						type: "field",
+						field: pathA0A,
+						fieldKind: valueField.identifier,
+						change: brand(valueInverse1),
+						revision: tag1,
+					},
+					{
+						type: "field",
+						field: pathB,
+						fieldKind: valueField.identifier,
+						change: brand(valueInverse2),
+						revision: tag1,
+					},
+				],
+				tag1,
+			);
 
 			assertEqual(
 				family.invert(makeAnonChange(rootChange1a), false, mintRevisionTag()),
@@ -1366,14 +1390,14 @@ describe("ModularChangeFamily", () => {
 				["with constraint", inlineRevision(rootChange3, tag1), context],
 				[
 					"with violated constraint",
-					inlineRevision({ ...buildChangeset([]), constraintViolationCount: 42 }, tag1),
+					inlineRevision({ ...buildChangeset([], tag1), constraintViolationCount: 42 }, tag1),
 					context,
 				],
 				[
 					"with builds",
 					inlineRevision(
 						{
-							...buildChangeset([]),
+							...buildChangeset([], tag1),
 							builds: newTupleBTree([
 								[[undefined, brand(1)], node1Chunk],
 								[[tag2, brand(2)], nodesChunk],
@@ -1387,7 +1411,7 @@ describe("ModularChangeFamily", () => {
 					"with refreshers",
 					inlineRevision(
 						{
-							...buildChangeset([]),
+							...buildChangeset([], tag1),
 							refreshers: newTupleBTree([
 								[[undefined, brand(1)], node1Chunk],
 								[[tag2, brand(2)], nodesChunk],
@@ -1426,17 +1450,20 @@ describe("ModularChangeFamily", () => {
 		);
 		const changes = getChanges();
 
-		const expectedChange: ModularChangeset = Change.build(
-			{ family, maxId: 0 },
-			Change.field(
-				fieldA,
-				genericFieldKind.identifier,
-				genericFieldKind.changeHandler.createEmpty(),
-				Change.node(0, Change.field(fieldB, valueField.identifier, valueChange1a)),
+		const expectedChange = tagChangeInline(
+			Change.build(
+				{ family, maxId: 0 },
+				Change.field(
+					fieldA,
+					genericFieldKind.identifier,
+					genericFieldKind.changeHandler.createEmpty(),
+					Change.node(0, Change.field(fieldB, valueField.identifier, valueChange1a)),
+				),
 			),
+			tag1,
 		);
 
-		assertEqual(changes, [expectedChange]);
+		assertEqual(changes, [expectedChange.change]);
 	});
 });
 
@@ -1563,7 +1590,7 @@ function deepFreeze(object: object) {
 	});
 }
 
-function buildChangeset(edits: EditDescription[]): ModularChangeset {
+function buildChangeset(edits: EditDescription[], revision: RevisionTag): ModularChangeset {
 	const editor = family.buildEditor(() => undefined);
 	return editor.buildChanges(edits);
 }

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -206,7 +206,7 @@ const pathA0A: FieldUpPath = { parent: pathA0, field: fieldA };
 const pathA0B: FieldUpPath = { parent: pathA0, field: fieldB };
 const pathB0A: FieldUpPath = { parent: pathB0, field: fieldA };
 
-const mainEditor = family.buildEditor(mintRevisionTag, () => undefined);
+const mainEditor = family.buildEditor(() => undefined);
 const rootChange1a = removeAliases(
 	mainEditor.buildChanges([
 		{
@@ -1411,7 +1411,7 @@ describe("ModularChangeFamily", () => {
 
 	it("build child change", () => {
 		const [changeReceiver, getChanges] = testChangeReceiver(family);
-		const editor = family.buildEditor(mintRevisionTag, changeReceiver);
+		const editor = family.buildEditor(changeReceiver);
 		const path: UpPath = {
 			parent: undefined,
 			parentField: fieldA,
@@ -1564,15 +1564,13 @@ function deepFreeze(object: object) {
 }
 
 function buildChangeset(edits: EditDescription[]): ModularChangeset {
-	const editor = family.buildEditor(mintRevisionTag, () => undefined);
+	const editor = family.buildEditor(() => undefined);
 	return editor.buildChanges(edits);
 }
 
 function buildExistsConstraint(path: UpPath): ModularChangeset {
 	const edits: ModularChangeset[] = [];
-	const editor = family.buildEditor(mintRevisionTag, (taggedChange) =>
-		edits.push(taggedChange.change),
-	);
-	editor.addNodeExistsConstraint(path);
+	const editor = family.buildEditor((taggedChange) => edits.push(taggedChange.change));
+	editor.addNodeExistsConstraint(path, mintRevisionTag());
 	return edits[0];
 }

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -206,7 +206,7 @@ const pathA0A: FieldUpPath = { parent: pathA0, field: fieldA };
 const pathA0B: FieldUpPath = { parent: pathA0, field: fieldB };
 const pathB0A: FieldUpPath = { parent: pathB0, field: fieldA };
 
-const mainEditor = family.buildEditor(() => undefined);
+const mainEditor = family.buildEditor(mintRevisionTag, () => undefined);
 const rootChange1a = removeAliases(
 	mainEditor.buildChanges([
 		{
@@ -214,18 +214,21 @@ const rootChange1a = removeAliases(
 			field: pathA,
 			fieldKind: singleNodeField.identifier,
 			change: brand(undefined),
+			revision: tag1,
 		},
 		{
 			type: "field",
 			field: pathA0A,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange1a),
+			revision: tag1,
 		},
 		{
 			type: "field",
 			field: pathB,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange2),
+			revision: tag1,
 		},
 	]),
 );
@@ -237,12 +240,14 @@ const rootChange1aGeneric: ModularChangeset = removeAliases(
 			field: pathA0A,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange1a),
+			revision: tag1,
 		},
 		{
 			type: "field",
 			field: pathB,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange2),
+			revision: tag1,
 		},
 	]),
 );
@@ -254,18 +259,21 @@ const rootChange1b: ModularChangeset = removeAliases(
 			field: pathA,
 			fieldKind: singleNodeField.identifier,
 			change: brand(undefined),
+			revision: tag1,
 		},
 		{
 			type: "field",
 			field: pathA0A,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange1b),
+			revision: tag1,
 		},
 		{
 			type: "field",
 			field: pathA0B,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange1a),
+			revision: tag1,
 		},
 	]),
 );
@@ -277,12 +285,14 @@ const rootChange1bGeneric: ModularChangeset = removeAliases(
 			field: pathA0A,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange1b),
+			revision: tag1,
 		},
 		{
 			type: "field",
 			field: pathA0B,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange1a),
+			revision: tag1,
 		},
 	]),
 );
@@ -345,18 +355,21 @@ const rootChange2: ModularChangeset = removeAliases(
 			field: pathA,
 			fieldKind: singleNodeField.identifier,
 			change: brand(undefined),
+			revision: tag1,
 		},
 		{
 			type: "field",
 			field: pathA0A,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange2),
+			revision: tag1,
 		},
 		{
 			type: "field",
 			field: pathA0B,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange1a),
+			revision: tag1,
 		},
 	]),
 );
@@ -368,12 +381,14 @@ const rootChange2Generic: ModularChangeset = removeAliases(
 			field: pathA0A,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange2),
+			revision: tag1,
 		},
 		{
 			type: "field",
 			field: pathA0B,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange1a),
+			revision: tag1,
 		},
 	]),
 );
@@ -385,12 +400,14 @@ const rootChange3: ModularChangeset = removeAliases(
 			field: pathA,
 			fieldKind: singleNodeField.identifier,
 			change: brand(undefined),
+			revision: tag1,
 		},
 		{
 			type: "field",
 			field: pathA0A,
 			fieldKind: valueField.identifier,
 			change: brand(valueChange1a),
+			revision: tag1,
 		},
 	]),
 );
@@ -412,6 +429,7 @@ const rootChangeWithoutNodeFieldChanges: ModularChangeset = family.compose([
 				field: pathA,
 				fieldKind: singleNodeField.identifier,
 				change: brand(undefined),
+				revision: tag1,
 			},
 		]),
 		dummyRevisionTag,
@@ -575,6 +593,7 @@ describe("ModularChangeFamily", () => {
 						field: pathA,
 						fieldKind: valueField.identifier,
 						change: brand(valueChange1a),
+						revision: tag1,
 					},
 				]),
 				tag1,
@@ -587,12 +606,14 @@ describe("ModularChangeFamily", () => {
 						field: pathB,
 						fieldKind: singleNodeField.identifier,
 						change: brand(undefined),
+						revision: tag1,
 					},
 					{
 						type: "field",
 						field: pathB0A,
 						fieldKind: valueField.identifier,
 						change: brand(valueChange2),
+						revision: tag1,
 					},
 				]),
 				tag2,
@@ -846,18 +867,21 @@ describe("ModularChangeFamily", () => {
 					field: pathA,
 					fieldKind: singleNodeField.identifier,
 					change: brand(undefined),
+					revision: tag1,
 				},
 				{
 					type: "field",
 					field: pathA0A,
 					fieldKind: valueField.identifier,
 					change: brand(valueInverse1),
+					revision: tag1,
 				},
 				{
 					type: "field",
 					field: pathB,
 					fieldKind: valueField.identifier,
 					change: brand(valueInverse2),
+					revision: tag1,
 				},
 			]);
 
@@ -1381,7 +1405,7 @@ describe("ModularChangeFamily", () => {
 
 	it("build child change", () => {
 		const [changeReceiver, getChanges] = testChangeReceiver(family);
-		const editor = family.buildEditor(changeReceiver);
+		const editor = family.buildEditor(mintRevisionTag, changeReceiver);
 		const path: UpPath = {
 			parent: undefined,
 			parentField: fieldA,
@@ -1392,6 +1416,7 @@ describe("ModularChangeFamily", () => {
 			{ parent: path, field: fieldB },
 			valueField.identifier,
 			brand(valueChange1a),
+			tag1,
 		);
 		const changes = getChanges();
 
@@ -1533,13 +1558,13 @@ function deepFreeze(object: object) {
 }
 
 function buildChangeset(edits: EditDescription[]): ModularChangeset {
-	const editor = family.buildEditor(() => undefined);
+	const editor = family.buildEditor(mintRevisionTag, () => undefined);
 	return editor.buildChanges(edits);
 }
 
 function buildExistsConstraint(path: UpPath): ModularChangeset {
 	const edits: ModularChangeset[] = [];
-	const editor = family.buildEditor((change) => edits.push(change));
+	const editor = family.buildEditor(mintRevisionTag, (change) => edits.push(change));
 	editor.addNodeExistsConstraint(path);
 	return edits[0];
 }

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -1564,7 +1564,9 @@ function buildChangeset(edits: EditDescription[]): ModularChangeset {
 
 function buildExistsConstraint(path: UpPath): ModularChangeset {
 	const edits: ModularChangeset[] = [];
-	const editor = family.buildEditor(mintRevisionTag, (change) => edits.push(change));
+	const editor = family.buildEditor(mintRevisionTag, (taggedChange) =>
+		edits.push(taggedChange.change),
+	);
 	editor.addNodeExistsConstraint(path);
 	return edits[0];
 }

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -909,31 +909,31 @@ describe("ModularChangeFamily", () => {
 				tag1,
 			);
 
-			assertEqual(
-				family.invert(makeAnonChange(rootChange1a), false, mintRevisionTag()),
-				expectedInverse,
-			);
+			assertEqual(family.invert(makeAnonChange(rootChange1a), false, tag1), expectedInverse);
 		});
 
 		it("generic", () => {
-			const expectedInverse = Change.build(
-				{ family, maxId: rootChange1aGeneric.maxId },
-				Change.field(
-					fieldA,
-					genericFieldKind.identifier,
-					genericFieldKind.changeHandler.createEmpty(),
-					Change.nodeWithId(
-						0,
-						{ localId: brand(1) },
-						Change.field(fieldA, valueField.identifier, valueInverse1),
+			const expectedInverse = tagChangeInline(
+				Change.build(
+					{ family, maxId: rootChange1aGeneric.maxId },
+					Change.field(
+						fieldA,
+						genericFieldKind.identifier,
+						genericFieldKind.changeHandler.createEmpty(),
+						Change.nodeWithId(
+							0,
+							{ localId: brand(1) },
+							Change.field(fieldA, valueField.identifier, valueInverse1),
+						),
 					),
+					Change.field(fieldB, valueField.identifier, valueInverse2),
 				),
-				Change.field(fieldB, valueField.identifier, valueInverse2),
+				tag1,
 			);
 
 			assertEqual(
-				family.invert(makeAnonChange(rootChange1aGeneric), false, mintRevisionTag()),
-				expectedInverse,
+				family.invert(makeAnonChange(rootChange1aGeneric), false, tag1),
+				expectedInverse.change,
 			);
 		});
 
@@ -955,12 +955,13 @@ describe("ModularChangeFamily", () => {
 					[[tag1 as RevisionTag | undefined, brand(0)], 1],
 					[[tag2, brand(1)], 1],
 				]),
+				revisions: [{ revision: tag1 }],
 			};
-			const expectedUndo: ModularChangeset = Change.empty();
+			const expectedUndo: ModularChangeset = tagChangeInline(Change.empty(), tag1).change;
 
 			deepFreeze(change1);
-			const actualRollback = family.invert(change1, true, mintRevisionTag());
-			const actualUndo = family.invert(change1, false, mintRevisionTag());
+			const actualRollback = family.invert(change1, true, tag1);
+			const actualUndo = family.invert(change1, false, tag1);
 
 			actualRollback.crossFieldKeys.unfreeze();
 			actualUndo.crossFieldKeys.unfreeze();
@@ -976,7 +977,11 @@ describe("ModularChangeFamily", () => {
 				makeAnonChange(rootChange1a),
 				revisionMetadataSourceFromInfo([]),
 			);
-			assertEqual(rebased, rebasedChange);
+			const tagForCompare = mintRevisionTag();
+			assertEqual(
+				tagChangeInline(rebased, tagForCompare),
+				tagChangeInline(rebasedChange, tagForCompare),
+			);
 		});
 
 		it("rebase specific ↷ generic", () => {
@@ -985,7 +990,11 @@ describe("ModularChangeFamily", () => {
 				makeAnonChange(rootChange1aGeneric),
 				revisionMetadataSourceFromInfo([]),
 			);
-			assertEqual(rebased, rebasedChange);
+			const tagForCompare = mintRevisionTag();
+			assertEqual(
+				tagChangeInline(rebased, tagForCompare),
+				tagChangeInline(rebasedChange, tagForCompare),
+			);
 		});
 
 		it("rebase generic ↷ specific", () => {
@@ -994,7 +1003,11 @@ describe("ModularChangeFamily", () => {
 				makeAnonChange(rootChange1a),
 				revisionMetadataSourceFromInfo([]),
 			);
-			assertEqual(rebased, genericChangeRebasedOverSpecific);
+			const tagForCompare = mintRevisionTag();
+			assertEqual(
+				tagChangeInline(rebased, tagForCompare),
+				tagChangeInline(genericChangeRebasedOverSpecific, tagForCompare),
+			);
 		});
 
 		it("rebase generic ↷ generic", () => {
@@ -1003,7 +1016,11 @@ describe("ModularChangeFamily", () => {
 				makeAnonChange(rootChange1aGeneric),
 				revisionMetadataSourceFromInfo([]),
 			);
-			assertEqual(rebased, rebasedChangeGeneric);
+			const tagForCompare = mintRevisionTag();
+			assertEqual(
+				tagChangeInline(rebased, tagForCompare),
+				tagChangeInline(rebasedChangeGeneric, tagForCompare),
+			);
 		});
 	});
 

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -885,7 +885,10 @@ describe("ModularChangeFamily", () => {
 				},
 			]);
 
-			assertEqual(family.invert(makeAnonChange(rootChange1a), false), expectedInverse);
+			assertEqual(
+				family.invert(makeAnonChange(rootChange1a), false, mintRevisionTag()),
+				expectedInverse,
+			);
 		});
 
 		it("generic", () => {
@@ -904,7 +907,10 @@ describe("ModularChangeFamily", () => {
 				Change.field(fieldB, valueField.identifier, valueInverse2),
 			);
 
-			assertEqual(family.invert(makeAnonChange(rootChange1aGeneric), false), expectedInverse);
+			assertEqual(
+				family.invert(makeAnonChange(rootChange1aGeneric), false, mintRevisionTag()),
+				expectedInverse,
+			);
 		});
 
 		it("build => destroy but only for rollback", () => {
@@ -929,8 +935,8 @@ describe("ModularChangeFamily", () => {
 			const expectedUndo: ModularChangeset = Change.empty();
 
 			deepFreeze(change1);
-			const actualRollback = family.invert(change1, true);
-			const actualUndo = family.invert(change1, false);
+			const actualRollback = family.invert(change1, true, mintRevisionTag());
+			const actualUndo = family.invert(change1, false, mintRevisionTag());
 
 			actualRollback.crossFieldKeys.unfreeze();
 			actualUndo.crossFieldKeys.unfreeze();

--- a/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -82,7 +82,7 @@ describe("ModularChangeFamily integration", () => {
 	describe("rebase", () => {
 		it("remove over cross-field move", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 
 			const rootPath = { parent: undefined, parentField: rootField, parentIndex: 0 };
 			editor.move(
@@ -136,7 +136,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("remove over cross-field move to edited field", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 
 			const rootPath = { parent: undefined, parentField: rootField, parentIndex: 0 };
 			editor.move(
@@ -191,7 +191,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("nested change over cross-field move", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 
 			editor.move(
 				{ parent: undefined, field: fieldA },
@@ -234,7 +234,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("cross-field move over remove", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			editor.sequenceField({ parent: undefined, field: fieldA }).remove(1, 1);
 			editor.move(
 				{ parent: undefined, field: fieldA },
@@ -263,7 +263,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("move over cross-field move", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			editor.move(
 				{ parent: undefined, field: fieldA },
 				0,
@@ -295,7 +295,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("Nested moves both requiring a second pass", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 
 			const fieldAPath = { parent: undefined, field: fieldA };
 
@@ -380,7 +380,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("over change which moves node upward", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			const nodeAPath: UpPath = { parent: undefined, parentField: fieldA, parentIndex: 0 };
 			const nodeBPath: UpPath = {
 				parent: nodeAPath,
@@ -426,7 +426,7 @@ describe("ModularChangeFamily integration", () => {
 		// This test demonstrates that a field may need three rebasing passes.
 		it("over change which moves into moved subtree", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			const nodePath1: UpPath = { parent: undefined, parentField: fieldA, parentIndex: 1 };
 
 			// The base changeset consists of the following two move edits.
@@ -485,7 +485,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("prunes its output", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			const nodeAPath: UpPath = { parent: undefined, parentField: fieldA, parentIndex: 0 };
 			const nodeBPath: UpPath = { parent: undefined, parentField: fieldB, parentIndex: 0 };
 
@@ -517,7 +517,7 @@ describe("ModularChangeFamily integration", () => {
 			 */
 
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			const nodeAPath: UpPath = { parent: undefined, parentField: fieldA, parentIndex: 0 };
 
 			// Moves A to an adjacent cell to its right
@@ -584,7 +584,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("cross-field move and nested changes", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			editor.move(
 				{ parent: undefined, field: fieldA },
 				0,
@@ -645,7 +645,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("cross-field move and inverse with nested changes", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			editor.move(
 				{ parent: undefined, field: fieldA },
 				0,
@@ -714,7 +714,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("two cross-field moves of same node", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 			editor.move(
 				{ parent: undefined, field: fieldA },
 				0,
@@ -753,7 +753,7 @@ describe("ModularChangeFamily integration", () => {
 	describe("invert", () => {
 		it("Cross-field move of edited node", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 
 			editor.enterTransaction();
 
@@ -808,7 +808,7 @@ describe("ModularChangeFamily integration", () => {
 
 		it("Nested moves both requiring a second pass", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
-			const editor = new DefaultEditBuilder(family, changeReceiver);
+			const editor = new DefaultEditBuilder(family, mintRevisionTag, changeReceiver);
 
 			const fieldAPath = { parent: undefined, field: fieldA };
 			editor.enterTransaction();
@@ -908,6 +908,7 @@ describe("ModularChangeFamily integration", () => {
 						MarkMaker.moveOut(1, { revision: tag1, localId: brand(0) }),
 						MarkMaker.moveIn(1, { revision: tag1, localId: brand(0) }),
 					]),
+					revision: tag1,
 				},
 				{
 					type: "field",
@@ -920,6 +921,7 @@ describe("ModularChangeFamily integration", () => {
 						MarkMaker.moveOut(2, { revision: tag2, localId: brand(0) }),
 						MarkMaker.moveIn(2, { revision: tag2, localId: brand(0) }),
 					]),
+					revision: tag1,
 				},
 			]);
 
@@ -1050,6 +1052,6 @@ function tagChangeInline(
 }
 
 function buildChangeset(edits: EditDescription[]): ModularChangeset {
-	const editor = family.buildEditor(() => undefined);
+	const editor = family.buildEditor(mintRevisionTag, () => undefined);
 	return editor.buildChanges(edits);
 }

--- a/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -131,7 +131,10 @@ describe("ModularChangeFamily integration", () => {
 				),
 			);
 
-			assertEqual(rebased, expected);
+			// Tag changes before comparing them because default edit builder will assign tags to changes and
+			// the expected tag needs to be the same.
+			const tag = mintRevisionTag();
+			assertEqual(tagChangeInline(rebased, tag), tagChangeInline(expected, tag));
 		});
 
 		it("remove over cross-field move to edited field", () => {
@@ -186,7 +189,8 @@ describe("ModularChangeFamily integration", () => {
 				),
 			);
 
-			assertEqual(rebased, expected);
+			const tag = mintRevisionTag();
+			assertEqual(tagChangeInline(rebased, tag), tagChangeInline(expected, tag));
 		});
 
 		it("nested change over cross-field move", () => {
@@ -229,7 +233,8 @@ describe("ModularChangeFamily integration", () => {
 				),
 			);
 
-			assertEqual(rebased, expected);
+			const tag = mintRevisionTag();
+			assertEqual(tagChangeInline(rebased, tag), tagChangeInline(expected, tag));
 		});
 
 		it("cross-field move over remove", () => {
@@ -294,7 +299,8 @@ describe("ModularChangeFamily integration", () => {
 				Change.field(fieldB, sequence.identifier, [MarkMaker.moveOut(1, brand(2))]),
 			);
 
-			assertEqual(rebased, expected);
+			const tag = mintRevisionTag();
+			assertEqual(tagChangeInline(rebased, tag), tagChangeInline(expected, tag));
 		});
 
 		it("Nested moves both requiring a second pass", () => {
@@ -379,7 +385,8 @@ describe("ModularChangeFamily integration", () => {
 				),
 			);
 
-			assertEqual(rebased, expected);
+			const tag = mintRevisionTag();
+			assertEqual(tagChangeInline(rebased, tag), tagChangeInline(expected, tag));
 		});
 
 		it("over change which moves node upward", () => {
@@ -418,10 +425,10 @@ describe("ModularChangeFamily integration", () => {
 			);
 
 			const rebasedDelta = normalizeDelta(
-				intoDelta(makeAnonChange(rebased), family.fieldKinds),
+				intoDelta(tagChangeInline(rebased, baseTag), family.fieldKinds),
 			);
 			const expectedDelta = normalizeDelta(
-				intoDelta(makeAnonChange(expected), family.fieldKinds),
+				intoDelta(tagChangeInline(expected, baseTag), family.fieldKinds),
 			);
 
 			assertDeltaEqual(rebasedDelta, expectedDelta);
@@ -484,7 +491,8 @@ describe("ModularChangeFamily integration", () => {
 				),
 			);
 
-			assertEqual(rebased, expected);
+			const tag = mintRevisionTag();
+			assertEqual(tagChangeInline(rebased, tag), tagChangeInline(expected, tag));
 		});
 
 		it("prunes its output", () => {

--- a/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -551,39 +551,45 @@ describe("ModularChangeFamily integration", () => {
 
 			const [moveA, moveB, moveC, removeD] = getChanges();
 
+			const tagForCompare = mintRevisionTag();
+
 			const moves = makeAnonChange(
-				family.compose([makeAnonChange(moveA), makeAnonChange(moveB), makeAnonChange(moveC)]),
+				family.compose([
+					tagChangeInline(moveA, tagForCompare),
+					tagChangeInline(moveB, tagForCompare),
+					tagChangeInline(moveC, tagForCompare),
+				]),
 			);
 
-			const remove = makeAnonChange(removeD);
+			const remove = tagChangeInline(removeD, tagForCompare);
 
 			const composed = family.compose([moves, remove]);
 			family.validateChangeset(composed);
 			const composedDelta = normalizeDelta(intoDelta(makeAnonChange(composed), fieldKinds));
 
 			const nodeAChanges: DeltaFieldMap = new Map([
-				[fieldB, { local: [{ count: 1, attach: { minor: 1 } }] }],
+				[fieldB, { local: [{ count: 1, attach: { minor: 1, major: tagForCompare } }] }],
 			]);
 
 			const nodeBChanges: DeltaFieldMap = new Map([
 				[
 					fieldC,
 					{
-						local: [{ count: 1, attach: { minor: 2 } }],
+						local: [{ count: 1, attach: { minor: 2, major: tagForCompare } }],
 					},
 				],
 			]);
 
 			const nodeCChanges: DeltaFieldMap = new Map([
-				[fieldC, { local: [{ count: 1, detach: { minor: 3 } }] }],
+				[fieldC, { local: [{ count: 1, detach: { minor: 3, major: tagForCompare } }] }],
 			]);
 
 			const fieldAChanges: DeltaFieldChanges = {
 				local: [
-					{ count: 1, detach: { minor: 0 }, fields: nodeAChanges },
-					{ count: 1, attach: { minor: 0 } },
-					{ count: 1, detach: { minor: 1 }, fields: nodeBChanges },
-					{ count: 1, detach: { minor: 2 }, fields: nodeCChanges },
+					{ count: 1, detach: { minor: 0, major: tagForCompare }, fields: nodeAChanges },
+					{ count: 1, attach: { minor: 0, major: tagForCompare } },
+					{ count: 1, detach: { minor: 1, major: tagForCompare }, fields: nodeBChanges },
+					{ count: 1, detach: { minor: 2, major: tagForCompare }, fields: nodeCChanges },
 				],
 			};
 
@@ -618,9 +624,13 @@ describe("ModularChangeFamily integration", () => {
 				.insert(0, newNode);
 
 			const [move, insert] = getChanges();
-			const composed = family.compose([makeAnonChange(move), makeAnonChange(insert)]);
+			const tagForCompare = mintRevisionTag();
+			const composed = family.compose([
+				tagChangeInline(move, tagForCompare),
+				tagChangeInline(insert, tagForCompare),
+			]);
 			const expected: DeltaRoot = {
-				build: [{ id: { minor: 2 }, trees: [newNode] }],
+				build: [{ id: { minor: 2, major: tagForCompare }, trees: [newNode] }],
 				fields: new Map([
 					[
 						fieldA,
@@ -628,12 +638,12 @@ describe("ModularChangeFamily integration", () => {
 							local: [
 								{
 									count: 1,
-									detach: { minor: 0 },
+									detach: { minor: 0, major: tagForCompare },
 									fields: new Map([
 										[
 											fieldC,
 											{
-												local: [{ count: 1, attach: { minor: 2 } }],
+												local: [{ count: 1, attach: { minor: 2, major: tagForCompare } }],
 											},
 										],
 									]),
@@ -644,7 +654,7 @@ describe("ModularChangeFamily integration", () => {
 					[
 						fieldB,
 						{
-							local: [{ count: 1, attach: { minor: 0 } }],
+							local: [{ count: 1, attach: { minor: 0, major: tagForCompare } }],
 						},
 					],
 				]),
@@ -754,13 +764,17 @@ describe("ModularChangeFamily integration", () => {
 			);
 
 			const [move1, move2, expected] = getChanges();
-			const composed = family.compose([makeAnonChange(move1), makeAnonChange(move2)]);
+			const tagForCompare = mintRevisionTag();
+			const composed = family.compose([
+				tagChangeInline(move1, tagForCompare),
+				tagChangeInline(move2, tagForCompare),
+			]);
 			family.validateChangeset(composed);
 			const actualDelta = normalizeDelta(
-				intoDelta(makeAnonChange(composed), family.fieldKinds),
+				intoDelta(tagChangeInline(composed, tagForCompare), family.fieldKinds),
 			);
 			const expectedDelta = normalizeDelta(
-				intoDelta(makeAnonChange(expected), family.fieldKinds),
+				intoDelta(tagChangeInline(expected, tagForCompare), family.fieldKinds),
 			);
 			assertEqual(actualDelta, expectedDelta);
 		});
@@ -792,11 +806,13 @@ describe("ModularChangeFamily integration", () => {
 			editor.exitTransaction();
 
 			const [remove, move] = getChanges();
-			const edit = family.compose([makeAnonChange(remove), makeAnonChange(move)]);
+			const tagForCompare = mintRevisionTag();
+			const edit = family.compose([
+				tagChangeInline(remove, tagForCompare),
+				tagChangeInline(move, tagForCompare),
+			]);
 
-			const inverse = removeAliases(
-				family.invert(tagChangeInline(edit, tag1), false, mintRevisionTag()),
-			);
+			const inverse = removeAliases(family.invert(tagChangeInline(edit, tag1), false, tag1));
 
 			const fieldAExpected = [
 				MarkMaker.returnTo(1, brand(2), { revision: tag1, localId: brand(2) }),
@@ -806,20 +822,23 @@ describe("ModularChangeFamily integration", () => {
 			];
 			const fieldCExpected = [MarkMaker.revive(1, { revision: tag1, localId: brand(0) })];
 
-			const expected = Change.build(
-				{ family, maxId: 3 },
-				Change.field(fieldA, sequence.identifier, fieldAExpected),
-				Change.field(
-					fieldB,
-					sequence.identifier,
-					fieldBExpected,
-					Change.nodeWithId(
-						0,
-						{ revision: tag1, localId: brand(1) },
-						Change.field(fieldC, sequence.identifier, fieldCExpected),
+			const expected = tagChangeInline(
+				Change.build(
+					{ family, maxId: 3 },
+					Change.field(fieldA, sequence.identifier, fieldAExpected),
+					Change.field(
+						fieldB,
+						sequence.identifier,
+						fieldBExpected,
+						Change.nodeWithId(
+							0,
+							{ revision: tag1, localId: brand(1) },
+							Change.field(fieldC, sequence.identifier, fieldCExpected),
+						),
 					),
 				),
-			);
+				tag1,
+			).change;
 
 			assertEqual(inverse, expected);
 		});
@@ -859,16 +878,15 @@ describe("ModularChangeFamily integration", () => {
 
 			editor.exitTransaction();
 			const [move1, move2, modify] = getChanges();
+			const tagForCompare = mintRevisionTag();
 
 			const moves = family.compose([
-				makeAnonChange(move1),
-				makeAnonChange(move2),
-				makeAnonChange(modify),
+				tagChangeInline(move1, tagForCompare),
+				tagChangeInline(move2, tagForCompare),
+				tagChangeInline(modify, tagForCompare),
 			]);
 
-			const inverse = removeAliases(
-				family.invert(tagChangeInline(moves, tag1), false, mintRevisionTag()),
-			);
+			const inverse = removeAliases(family.invert(tagChangeInline(moves, tag1), false, tag1));
 
 			const fieldAExpected: SF.Changeset = [
 				MarkMaker.moveOut(1, brand(0)),
@@ -887,28 +905,31 @@ describe("ModularChangeFamily integration", () => {
 			const nodeId1: NodeId = { revision: tag1, localId: brand(4) };
 			const nodeId2: NodeId = { revision: tag1, localId: brand(6) };
 
-			const expected: ModularChangeset = Change.build(
-				{ family, maxId: 7 },
-				Change.field(
-					fieldA,
-					sequence.identifier,
-					fieldAExpected,
-					Change.nodeWithId(
-						0,
-						nodeId1,
-						Change.field(
-							fieldB,
-							sequence.identifier,
-							fieldBExpected,
-							Change.nodeWithId(
-								0,
-								nodeId2,
-								Change.field(fieldC, sequence.identifier, fieldCExpected),
+			const expected: ModularChangeset = tagChangeInline(
+				Change.build(
+					{ family, maxId: 7 },
+					Change.field(
+						fieldA,
+						sequence.identifier,
+						fieldAExpected,
+						Change.nodeWithId(
+							0,
+							nodeId1,
+							Change.field(
+								fieldB,
+								sequence.identifier,
+								fieldBExpected,
+								Change.nodeWithId(
+									0,
+									nodeId2,
+									Change.field(fieldC, sequence.identifier, fieldCExpected),
+								),
 							),
 						),
 					),
 				),
-			);
+				tag1,
+			).change;
 
 			assertEqual(inverse, expected);
 		});
@@ -1056,12 +1077,9 @@ function normalizeDeltaDetachedNodeId(
 	genId: IdAllocator,
 	idMap: Map<number, number>,
 ): DeltaDetachedNodeId {
-	if (delta.major !== undefined) {
-		return delta;
-	}
 	const minor = idMap.get(delta.minor) ?? genId.allocate();
 	idMap.set(delta.minor, minor);
-	return { minor };
+	return { minor, major: delta.major };
 }
 
 function tagChangeInline(

--- a/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -1064,6 +1064,6 @@ function tagChangeInline(
 }
 
 function buildChangeset(edits: EditDescription[]): ModularChangeset {
-	const editor = family.buildEditor(mintRevisionTag, () => undefined);
+	const editor = family.buildEditor(() => undefined);
 	return editor.buildChanges(edits);
 }

--- a/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -245,7 +245,11 @@ describe("ModularChangeFamily integration", () => {
 			);
 			const [remove, move] = getChanges();
 			const baseTag = mintRevisionTag();
-			const restore = family.invert(tagChangeInline(remove, baseTag), false);
+			const restore = family.invert(
+				tagChangeInline(remove, baseTag),
+				false,
+				mintRevisionTag(),
+			);
 			const expected = family.compose([makeAnonChange(restore), makeAnonChange(move)]);
 			const rebased = family.rebase(
 				makeAnonChange(move),
@@ -669,7 +673,11 @@ describe("ModularChangeFamily integration", () => {
 			const [move, insert] = getChanges();
 			const moveTagged = tagChangeInline(move, tag1);
 			const returnTagged = tagRollbackInverse(
-				family.changeRevision(family.invert(moveTagged, true), tag3, moveTagged.revision),
+				family.changeRevision(
+					family.invert(moveTagged, true, mintRevisionTag()),
+					tag3,
+					moveTagged.revision,
+				),
 				tag3,
 				moveTagged.revision,
 			);
@@ -778,7 +786,9 @@ describe("ModularChangeFamily integration", () => {
 			const [remove, move] = getChanges();
 			const edit = family.compose([makeAnonChange(remove), makeAnonChange(move)]);
 
-			const inverse = removeAliases(family.invert(tagChangeInline(edit, tag1), false));
+			const inverse = removeAliases(
+				family.invert(tagChangeInline(edit, tag1), false, mintRevisionTag()),
+			);
 
 			const fieldAExpected = [
 				MarkMaker.returnTo(1, brand(2), { revision: tag1, localId: brand(2) }),
@@ -848,7 +858,9 @@ describe("ModularChangeFamily integration", () => {
 				makeAnonChange(modify),
 			]);
 
-			const inverse = removeAliases(family.invert(tagChangeInline(moves, tag1), false));
+			const inverse = removeAliases(
+				family.invert(tagChangeInline(moves, tag1), false, mintRevisionTag()),
+			);
 
 			const fieldAExpected: SF.Changeset = [
 				MarkMaker.moveOut(1, brand(0)),

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
@@ -160,8 +160,8 @@ function invert(
 		change.change,
 		isRollback,
 		idAllocatorFromMaxId(),
-		failCrossFieldManager,
 		revision,
+		failCrossFieldManager,
 		defaultRevisionMetadataFromChanges([change]),
 	);
 	verifyContextChain(change, makeAnonChange(inverted));

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
@@ -89,8 +89,8 @@ const OptionalChange = {
 		return optionalFieldEditor.set(wasEmpty, ids);
 	},
 
-	clear(wasEmpty: boolean, id: ChangeAtomId) {
-		return optionalFieldEditor.clear(wasEmpty, id);
+	clear(wasEmpty: boolean, detachId: ChangeAtomId) {
+		return optionalFieldEditor.clear(wasEmpty, detachId);
 	},
 
 	buildChildChange(childChange: NodeId) {
@@ -427,7 +427,7 @@ const generateChildStates: ChildStateGenerator<string | undefined, WrappedChange
 						state.mostRecentEdit.changeset.change.fieldChange,
 						state.mostRecentEdit.changeset.revision,
 					),
-					tag1,
+					tagFromIntention(undoIntention),
 					false,
 				),
 				nodes: invertedNodeChanges,

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
@@ -159,6 +159,7 @@ function invert(
 		isRollback,
 		idAllocatorFromMaxId(),
 		failCrossFieldManager,
+		mintRevisionTag(),
 		defaultRevisionMetadataFromChanges([change]),
 	);
 	verifyContextChain(change, makeAnonChange(inverted));

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
@@ -85,11 +85,11 @@ const OptionalChange = {
 			detach: ChangesetLocalId;
 		},
 	) {
-		return optionalFieldEditor.set(wasEmpty, ids);
+		return optionalFieldEditor.set(wasEmpty, ids, tag1);
 	},
 
 	clear(wasEmpty: boolean, id: ChangesetLocalId) {
-		return optionalFieldEditor.clear(wasEmpty, id);
+		return optionalFieldEditor.clear(wasEmpty, id, tag1);
 	},
 
 	buildChildChange(childChange: NodeId) {

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
@@ -8,6 +8,7 @@ import { strict as assert } from "assert";
 import { describeStress } from "@fluid-private/stochastic-test-utils";
 import type { CrossFieldManager } from "../../../feature-libraries/index.js";
 import {
+	type ChangeAtomId,
 	type ChangeAtomIdMap,
 	type ChangesetLocalId,
 	type DeltaFieldChanges,
@@ -81,15 +82,15 @@ const OptionalChange = {
 		value: string,
 		wasEmpty: boolean,
 		ids: {
-			fill: ChangesetLocalId;
-			detach: ChangesetLocalId;
+			fill: ChangeAtomId;
+			detach: ChangeAtomId;
 		},
 	) {
-		return optionalFieldEditor.set(wasEmpty, ids, tag1);
+		return optionalFieldEditor.set(wasEmpty, ids);
 	},
 
-	clear(wasEmpty: boolean, id: ChangesetLocalId) {
-		return optionalFieldEditor.clear(wasEmpty, id, tag1);
+	clear(wasEmpty: boolean, id: ChangeAtomId) {
+		return optionalFieldEditor.clear(wasEmpty, id);
 	},
 
 	buildChildChange(childChange: NodeId) {
@@ -314,7 +315,11 @@ const generateChildStates: ChildStateGenerator<string | undefined, WrappedChange
 		tagFromIntention: (intention: number) => RevisionTag,
 		mintIntention: () => number,
 	): Iterable<OptionalFieldTestState> {
-		const mintId = mintIntention as () => ChangesetLocalId;
+		const mintId: () => ChangeAtomId = () => {
+			return {
+				localId: mintIntention() as ChangesetLocalId,
+			};
+		};
 		const edits = getSequentialEdits(state);
 		if (state.content !== undefined) {
 			const changeChildIntention = mintIntention();

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -76,30 +76,26 @@ const change1 = tagChangeInline(
 );
 
 const change2Tag = mintRevisionTag();
-const change2: TaggedChange<OptionalChangeset> = tagChange(
+const change2: TaggedChange<OptionalChangeset> = tagChangeInline(
 	optionalFieldEditor.set(false, {
-		fill: { localId: brand(42), revision: change2Tag },
-		detach: { localId: brand(2), revision: change2Tag },
+		fill: { localId: brand(42) },
+		detach: { localId: brand(2) },
 	}),
 	change2Tag,
 );
 
-const revertChange2Tag = mintRevisionTag();
-const revertChange2: TaggedChange<OptionalChangeset> = tagChange(
-	Change.atOnce(
-		Change.clear("self", { localId: brand(42), revision: revertChange2Tag }),
-		Change.move({ localId: brand(2), revision: revertChange2Tag }, "self"),
-	),
-	revertChange2Tag,
+const revertChange2: TaggedChange<OptionalChangeset> = tagChangeInline(
+	Change.atOnce(Change.clear("self", brand(42)), Change.move(brand(2), "self")),
+	mintRevisionTag(),
 );
 
 /**
  * Represents what change2 would have been had it been concurrent with change1.
  */
-const change2PreChange1: TaggedChange<OptionalChangeset> = tagChange(
+const change2PreChange1: TaggedChange<OptionalChangeset> = tagChangeInline(
 	optionalFieldEditor.set(true, {
-		fill: { localId: brand(42), revision: change2Tag },
-		detach: { localId: brand(2), revision: change2Tag },
+		fill: { localId: brand(42) },
+		detach: { localId: brand(2) },
 	}),
 	change2Tag,
 );
@@ -732,9 +728,10 @@ describe("optionalField", () => {
 			optionalFieldEditor.clear(false, { localId: brand(1), revision: tag2 }),
 			tag2,
 		);
+		const childChangeTag = mintRevisionTag();
 		const hasChildChanges = tagChange(
-			optionalFieldEditor.buildChildChange(0, nodeId1),
-			mintRevisionTag(),
+			optionalFieldEditor.buildChildChange(0, { ...nodeId1, revision: childChangeTag }),
+			childChangeTag,
 		);
 		const relevantNestedTree = { minor: 4242 };
 		const noTreesDelegate: RelevantRemovedRootsFromChild = () => [];

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -328,8 +328,8 @@ describe("optionalField", () => {
 					change.change,
 					false,
 					idAllocatorFromMaxId(),
-					failCrossFieldManager,
 					mintRevisionTag(),
+					failCrossFieldManager,
 					defaultRevisionMetadataFromChanges([change]),
 				);
 			}
@@ -338,8 +338,8 @@ describe("optionalField", () => {
 					change.change,
 					true,
 					idAllocatorFromMaxId(),
-					failCrossFieldManager,
 					mintRevisionTag(),
+					failCrossFieldManager,
 					defaultRevisionMetadataFromChanges([change]),
 				);
 			}
@@ -519,8 +519,8 @@ describe("optionalField", () => {
 						deletion.change,
 						false,
 						idAllocatorFromMaxId(),
-						failCrossFieldManager,
 						tag2,
+						failCrossFieldManager,
 						defaultRevisionMetadataFromChanges([deletion]),
 					),
 					tag2,
@@ -786,8 +786,8 @@ describe("optionalField", () => {
 					clear.change,
 					false,
 					idAllocatorFromMaxId(),
-					failCrossFieldManager,
 					mintRevisionTag(),
+					failCrossFieldManager,
 					defaultRevisionMetadataFromChanges([clear]),
 				);
 				const actual = Array.from(
@@ -852,8 +852,8 @@ describe("optionalField", () => {
 						clear.change,
 						false,
 						idAllocatorFromMaxId(),
-						failCrossFieldManager,
 						mintRevisionTag(),
+						failCrossFieldManager,
 						defaultRevisionMetadataFromChanges([clear]),
 					),
 					mintRevisionTag(),

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -326,6 +326,7 @@ describe("optionalField", () => {
 					false,
 					idAllocatorFromMaxId(),
 					failCrossFieldManager,
+					mintRevisionTag(),
 					defaultRevisionMetadataFromChanges([change]),
 				);
 			}
@@ -335,6 +336,7 @@ describe("optionalField", () => {
 					true,
 					idAllocatorFromMaxId(),
 					failCrossFieldManager,
+					mintRevisionTag(),
 					defaultRevisionMetadataFromChanges([change]),
 				);
 			}
@@ -515,6 +517,7 @@ describe("optionalField", () => {
 						false,
 						idAllocatorFromMaxId(),
 						failCrossFieldManager,
+						mintRevisionTag(),
 						defaultRevisionMetadataFromChanges([deletion]),
 					),
 					tag2,
@@ -773,6 +776,7 @@ describe("optionalField", () => {
 					false,
 					idAllocatorFromMaxId(),
 					failCrossFieldManager,
+					mintRevisionTag(),
 					defaultRevisionMetadataFromChanges([clear]),
 				);
 				const actual = Array.from(
@@ -838,6 +842,7 @@ describe("optionalField", () => {
 						false,
 						idAllocatorFromMaxId(),
 						failCrossFieldManager,
+						mintRevisionTag(),
 						defaultRevisionMetadataFromChanges([clear]),
 					),
 					mintRevisionTag(),

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -76,7 +76,7 @@ const change1 = tagChangeInline(
 
 const change2Tag = mintRevisionTag();
 const change2: TaggedChange<OptionalChangeset> = tagChangeInline(
-	optionalFieldEditor.set(false, { fill: brand(42), detach: brand(2) }),
+	optionalFieldEditor.set(false, { fill: brand(42), detach: brand(2) }, tag),
 	change2Tag,
 );
 
@@ -89,7 +89,7 @@ const revertChange2: TaggedChange<OptionalChangeset> = tagChangeInline(
  * Represents what change2 would have been had it been concurrent with change1.
  */
 const change2PreChange1: TaggedChange<OptionalChangeset> = tagChangeInline(
-	optionalFieldEditor.set(true, { fill: brand(42), detach: brand(2) }),
+	optionalFieldEditor.set(true, { fill: brand(42), detach: brand(2) }, tag),
 	change2Tag,
 );
 
@@ -108,10 +108,14 @@ describe("optionalField", () => {
 	// TODO: more editor tests
 	describe("editor", () => {
 		it("can be created", () => {
-			const actual: OptionalChangeset = optionalFieldEditor.set(true, {
-				fill: brand(42),
-				detach: brand(43),
-			});
+			const actual: OptionalChangeset = optionalFieldEditor.set(
+				true,
+				{
+					fill: brand(42),
+					detach: brand(43),
+				},
+				tag,
+			);
 			const expected = Change.atOnce(
 				Change.reserve("self", brand(43)),
 				Change.move(brand(42), "self"),
@@ -501,7 +505,10 @@ describe("optionalField", () => {
 				const tag1 = mintRevisionTag();
 				const tag2 = mintRevisionTag();
 				const changeToRebase = optionalFieldEditor.buildChildChange(0, nodeId1);
-				const deletion = tagChangeInline(optionalFieldEditor.clear(false, brand(1)), tag1);
+				const deletion = tagChangeInline(
+					optionalFieldEditor.clear(false, brand(1), tag1),
+					tag1,
+				);
 				const revive = tagChangeInline(
 					optionalChangeRebaser.invert(
 						deletion.change,
@@ -551,7 +558,7 @@ describe("optionalField", () => {
 			it("can rebase a child change over a reserved detach on empty field", () => {
 				const changeToRebase = optionalFieldEditor.buildChildChange(0, nodeId1);
 				deepFreeze(changeToRebase);
-				const clear = tagChangeInline(optionalFieldEditor.clear(true, brand(42)), tag);
+				const clear = tagChangeInline(optionalFieldEditor.clear(true, brand(42), tag), tag);
 
 				const childRebaser = (
 					nodeChange: NodeId | undefined,
@@ -701,11 +708,11 @@ describe("optionalField", () => {
 
 	describe("relevantRemovedRoots", () => {
 		const fill = tagChangeInline(
-			optionalFieldEditor.set(true, { detach: brand(1), fill: brand(2) }),
+			optionalFieldEditor.set(true, { detach: brand(1), fill: brand(2) }, tag),
 			mintRevisionTag(),
 		);
 		const clear = tagChangeInline(
-			optionalFieldEditor.clear(false, brand(1)),
+			optionalFieldEditor.clear(false, brand(1), tag),
 			mintRevisionTag(),
 		);
 		const hasChildChanges = tagChangeInline(

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
@@ -36,10 +36,14 @@ const change1 = inlineRevision(
 );
 
 const change2: OptionalChangeset = inlineRevision(
-	optionalFieldEditor.set(false, {
-		fill: brand(42),
-		detach: brand(2),
-	}),
+	optionalFieldEditor.set(
+		false,
+		{
+			fill: brand(42),
+			detach: brand(2),
+		},
+		tag1,
+	),
 	tag1,
 );
 

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
@@ -36,14 +36,10 @@ const change1 = inlineRevision(
 );
 
 const change2: OptionalChangeset = inlineRevision(
-	optionalFieldEditor.set(
-		false,
-		{
-			fill: brand(42),
-			detach: brand(2),
-		},
-		tag1,
-	),
+	optionalFieldEditor.set(false, {
+		fill: { localId: brand(42), revision: tag1 },
+		detach: { localId: brand(2), revision: tag1 },
+	}),
 	tag1,
 );
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.test.ts
@@ -98,9 +98,9 @@ export function testCompose() {
 		});
 
 		it("remove ○ revive => Noop", () => {
-			const deletion = tagChangeInline(Change.remove(0, 1), tag1);
+			const deletion = tagChangeInline(Change.remove(0, 1, tag1), tag1);
 			const insertion = tagChangeInline(
-				Change.revive(0, 1, { revision: tag1, localId: brand(0) }),
+				Change.revive(0, 1, { revision: tag1, localId: brand(0) }, tag1),
 				tag2,
 				tag1,
 			);
@@ -109,16 +109,18 @@ export function testCompose() {
 		});
 
 		it("insert ○ modify", () => {
-			const insert = Change.insert(0, 2);
+			const cellId: ChangeAtomId = { revision: tag1, localId: brand(0) };
+			const insert = Change.insert(0, 2, tag1, cellId);
 			const modify = Change.modify(
 				0,
 				TestNodeId.create({ localId: brand(0) }, TestChange.mint([], 42)),
 			);
 			const expected = [
-				Mark.insert(1, brand(0), {
+				Mark.insert(1, cellId, {
 					changes: TestNodeId.create({ localId: brand(0) }, TestChange.mint([], 42)),
+					revision: tag1,
 				}),
-				Mark.insert(1, brand(1)),
+				Mark.insert(1, { localId: brand(1), revision: tag1 }, { revision: tag1 }),
 			];
 			const actual = compose([makeAnonChange(insert), makeAnonChange(modify)]);
 			assertChangesetsEqual(actual, expected);
@@ -225,23 +227,26 @@ export function testCompose() {
 		});
 
 		it("remove ○ modify", () => {
-			const deletion = Change.remove(0, 3);
+			const deletion = Change.remove(0, 3, tag1);
 			const childChange = TestNodeId.create({ localId: brand(1) }, TestChange.mint([0, 1], 2));
 
 			const modify = Change.modify(0, childChange);
-			const expected = [Mark.remove(3, brand(0)), Mark.modify(childChange)];
+			const expected = [
+				Mark.remove(3, { localId: brand(0), revision: tag1 }),
+				Mark.modify(childChange),
+			];
 			const actual = shallowCompose([makeAnonChange(deletion), makeAnonChange(modify)]);
 			assertChangesetsEqual(actual, expected);
 		});
 
 		it("revive ○ modify", () => {
-			const revive = Change.revive(0, 3, { revision: tag1, localId: brand(0) });
+			const revive = Change.revive(0, 3, { revision: tag1, localId: brand(0) }, tag1);
 			const changes = TestNodeId.create({ localId: brand(1) }, TestChange.mint([0, 1], 2));
 
 			const modify = Change.modify(0, changes);
 			const expected = [
-				Mark.revive(1, { revision: tag1, localId: brand(0) }, { changes }),
-				Mark.revive(2, { revision: tag1, localId: brand(1) }),
+				Mark.revive(1, { revision: tag1, localId: brand(0) }, { changes, revision: tag1 }),
+				Mark.revive(2, { revision: tag1, localId: brand(1) }, { revision: tag1 }),
 			];
 			const actual = shallowCompose([makeAnonChange(revive), makeAnonChange(modify)]);
 			assertChangesetsEqual(actual, expected);
@@ -317,11 +322,14 @@ export function testCompose() {
 		});
 
 		it("insert ○ remove (within insert)", () => {
-			const insert = tagChangeInline(Change.insert(0, 3, brand(1)), tag1);
-			const deletion = tagChangeInline(Change.remove(1, 1), tag2);
+			const insert = tagChangeInline(
+				Change.insert(0, 3, tag1, { localId: brand(1), revision: tag1 }),
+				tag1,
+			);
+			const deletion = tagChangeInline(Change.remove(1, 1, tag2), tag2);
 			const actual = shallowCompose([insert, deletion]);
 			const expected = [
-				Mark.insert(1, { localId: brand(1), revision: tag1 }),
+				Mark.insert(1, { localId: brand(1), revision: tag1 }, { revision: tag1 }),
 				Mark.remove(1, brand(0), {
 					revision: tag2,
 					cellId: { localId: brand(2), revision: tag1 },
@@ -332,14 +340,17 @@ export function testCompose() {
 		});
 
 		it("insert ○ move (within insert)", () => {
-			const insert = Change.insert(0, 3, brand(1));
-			const move = Change.move(1, 1, 0);
+			const insert = Change.insert(0, 3, tag1, { localId: brand(1), revision: tag1 });
+			const move = Change.move(1, 1, 0, tag2);
 			const actual = shallowCompose([makeAnonChange(insert), makeAnonChange(move)]);
 			const expected = [
-				Mark.moveIn(1, brand(0)),
-				Mark.insert(1, { localId: brand(1) }),
-				Mark.moveOut(1, brand(0), { cellId: { localId: brand(2) } }),
-				Mark.insert(1, { localId: brand(3) }),
+				Mark.moveIn(1, { localId: brand(0), revision: tag2 }, { revision: tag2 }),
+				Mark.insert(1, { localId: brand(1), revision: tag1 }, { revision: tag1 }),
+				Mark.moveOut(1, brand(0), {
+					cellId: { localId: brand(2), revision: tag1 },
+					revision: tag2,
+				}),
+				Mark.insert(1, { localId: brand(3), revision: tag1 }, { revision: tag1 }),
 			];
 			assertChangesetsEqual(actual, expected);
 		});
@@ -350,7 +361,7 @@ export function testCompose() {
 				Mark.insert(2, { localId: brand(3), revision: tag2 }),
 				Mark.insert(2, { localId: brand(5), revision: tag1 }),
 			];
-			const deletion = tagChangeInline(Change.remove(1, 4), tag2);
+			const deletion = tagChangeInline(Change.remove(1, 4, tag2), tag2);
 			const actual = shallowCompose([makeAnonChange(insert), deletion], revInfos);
 			const expected = [
 				Mark.insert(1, { localId: brand(1), revision: tag1 }),
@@ -377,16 +388,25 @@ export function testCompose() {
 				Mark.insert(2, { localId: brand(3), revision: tag2 }),
 				Mark.insert(2, { localId: brand(5), revision: tag1 }),
 			];
-			const move = Change.move(1, 4, 0);
+			const move = Change.move(1, 4, 0, tag3);
 			const actual = shallowCompose([makeAnonChange(insert), makeAnonChange(move)], revInfos);
 
 			const expected = [
-				Mark.moveIn(4, brand(0)),
+				Mark.moveIn(4, { localId: brand(0), revision: tag3 }, { revision: tag3 }),
 				Mark.insert(1, { localId: brand(1), revision: tag1 }),
-				Mark.moveOut(1, brand(0), { cellId: { localId: brand(2), revision: tag1 } }),
-				Mark.moveOut(2, brand(1), { cellId: { localId: brand(3), revision: tag2 } }),
-				Mark.moveOut(1, brand(3), { cellId: { localId: brand(5), revision: tag1 } }),
-				Mark.insert(1, { localId: brand(6), revision: tag1 }),
+				Mark.moveOut(1, brand(0), {
+					cellId: { localId: brand(2), revision: tag1 },
+					revision: tag3,
+				}),
+				Mark.moveOut(2, brand(1), {
+					cellId: { localId: brand(3), revision: tag2 },
+					revision: tag3,
+				}),
+				Mark.moveOut(1, brand(3), {
+					cellId: { localId: brand(5), revision: tag1 },
+					revision: tag3,
+				}),
+				Mark.insert(1, { localId: brand(6), revision: tag1 }, { revision: tag1 }),
 			];
 			assertChangesetsEqual(actual, expected);
 		});
@@ -395,9 +415,9 @@ export function testCompose() {
 			const changes = TestNodeId.create({ localId: brand(1) }, TestChange.mint([0, 1], 2));
 
 			const modify = Change.modify(0, changes);
-			const deletion = Change.remove(0, 1);
+			const deletion = Change.remove(0, 1, tag1);
 			const actual = shallowCompose([makeAnonChange(modify), makeAnonChange(deletion)]);
-			const expected = [Mark.remove(1, brand(0), { changes })];
+			const expected = [Mark.remove(1, brand(0), { changes, revision: tag1 })];
 			assertChangesetsEqual(actual, expected);
 		});
 
@@ -424,7 +444,7 @@ export function testCompose() {
 
 		it("revive ○ remove", () => {
 			// Revive ABCDE
-			const revive = Change.revive(0, 5, { revision: tag1, localId: brand(0) });
+			const revive = Change.revive(0, 5, { revision: tag1, localId: brand(0) }, tag1);
 			// Remove _B_DEF
 			const deletion = [
 				{ count: 1 },
@@ -434,17 +454,17 @@ export function testCompose() {
 			];
 			const actual = shallowCompose([makeAnonChange(revive), tagChangeInline(deletion, tag2)]);
 			const expected = [
-				Mark.revive(1, { revision: tag1, localId: brand(0) }),
+				Mark.revive(1, { revision: tag1, localId: brand(0) }, { revision: tag1 }),
 				Mark.remove(
 					1,
 					{ revision: tag2, localId: brand(0) },
-					{ cellId: { revision: tag1, localId: brand(1) } },
+					{ cellId: { revision: tag1, localId: brand(1) }, revision: tag2 },
 				),
-				Mark.revive(1, { revision: tag1, localId: brand(2) }),
+				Mark.revive(1, { revision: tag1, localId: brand(2) }, { revision: tag1 }),
 				Mark.remove(
 					2,
 					{ revision: tag2, localId: brand(1) },
-					{ cellId: { revision: tag1, localId: brand(3) } },
+					{ cellId: { revision: tag1, localId: brand(3) }, revision: tag2 },
 				),
 				Mark.remove(1, brand(3), { revision: tag2 }),
 			];
@@ -478,18 +498,21 @@ export function testCompose() {
 			const childChange = TestNodeId.create({ localId: brand(3) }, TestChange.mint([0, 1], 2));
 
 			const modify = Change.modify(0, childChange);
-			const insert = Change.insert(0, 1, brand(2));
-			const expected = [Mark.insert(1, brand(2)), Mark.modify(childChange)];
+			const insert = Change.insert(0, 1, tag1, { localId: brand(2), revision: tag1 });
+			const expected = [
+				Mark.insert(1, { localId: brand(2), revision: tag1 }, { revision: tag1 }),
+				Mark.modify(childChange),
+			];
 			const actual = shallowCompose([makeAnonChange(modify), makeAnonChange(insert)]);
 			assertChangesetsEqual(actual, expected);
 		});
 
 		it("remove ○ insert", () => {
-			const deletion = Change.remove(0, 3);
-			const insert = Change.insert(0, 1, brand(2));
+			const deletion = Change.remove(0, 3, tag1);
+			const insert = Change.insert(0, 1, tag2, { localId: brand(2), revision: tag2 });
 			// TODO: test with merge-right policy as well
 			const expected = [
-				Mark.insert(1, { localId: brand(2), revision: tag2 }),
+				Mark.insert(1, { localId: brand(2), revision: tag2 }, { revision: tag2 }),
 				Mark.remove(3, brand(0), { revision: tag1 }),
 			];
 			const actual = shallowCompose([
@@ -500,12 +523,12 @@ export function testCompose() {
 		});
 
 		it("revive ○ insert", () => {
-			const revive = Change.revive(0, 5, { revision: tag1, localId: brand(0) });
-			const insert = Change.insert(0, 1, brand(2));
+			const revive = Change.revive(0, 5, { revision: tag1, localId: brand(0) }, tag1);
+			const insert = Change.insert(0, 1, tag2, { localId: brand(2), revision: tag2 });
 			// TODO: test with merge-right policy as well
 			const expected = [
-				Mark.insert(1, brand(2)),
-				Mark.revive(5, { revision: tag1, localId: brand(0) }),
+				Mark.insert(1, { localId: brand(2), revision: tag2 }, { revision: tag2 }),
+				Mark.revive(5, { revision: tag1, localId: brand(0) }, { revision: tag1 }),
 			];
 			const actual = shallowCompose([makeAnonChange(revive), makeAnonChange(insert)]);
 			assertChangesetsEqual(actual, expected);
@@ -542,9 +565,9 @@ export function testCompose() {
 			const childChange = TestNodeId.create({ localId: brand(1) }, TestChange.mint([0, 1], 2));
 
 			const modify = Change.modify(0, childChange);
-			const revive = Change.revive(0, 2, { revision: tag1, localId: brand(0) });
+			const revive = Change.revive(0, 2, { revision: tag1, localId: brand(0) }, tag1);
 			const expected = [
-				Mark.revive(2, { revision: tag1, localId: brand(0) }),
+				Mark.revive(2, { revision: tag1, localId: brand(0) }, { revision: tag1 }),
 				Mark.modify(childChange),
 			];
 			const actual = shallowCompose([makeAnonChange(modify), makeAnonChange(revive)]);
@@ -552,7 +575,7 @@ export function testCompose() {
 		});
 
 		it("remove ○ revive (different earlier nodes)", () => {
-			const deletion = tagChangeInline(Change.remove(0, 2), tag1);
+			const deletion = tagChangeInline(Change.remove(0, 2, tag1), tag1);
 			const revive = makeAnonChange([
 				Mark.revive(2, { revision: tag2, localId: brand(0) }),
 				Mark.tomb(tag1, brand(0), 2),
@@ -566,7 +589,7 @@ export function testCompose() {
 		});
 
 		it("remove ○ revive (different in-between nodes)", () => {
-			const deletion = tagChangeInline(Change.remove(0, 2), tag1);
+			const deletion = tagChangeInline(Change.remove(0, 2, tag1), tag1);
 			const revive = makeAnonChange([
 				Mark.tomb(tag1),
 				Mark.revive(2, { revision: tag2, localId: brand(0) }),
@@ -582,7 +605,7 @@ export function testCompose() {
 		});
 
 		it("remove ○ revive (different later nodes)", () => {
-			const deletion = tagChangeInline(Change.remove(0, 2), tag1);
+			const deletion = tagChangeInline(Change.remove(0, 2, tag1), tag1);
 			const revive = makeAnonChange([
 				Mark.tomb(tag1, brand(0), 2),
 				Mark.revive(2, { revision: tag2, localId: brand(0) }),
@@ -596,8 +619,8 @@ export function testCompose() {
 		});
 
 		it("remove1 ○ remove2 ○ revive (remove1)", () => {
-			const remove1 = Change.remove(1, 3);
-			const remove2 = Change.remove(0, 2);
+			const remove1 = Change.remove(1, 3, tag1);
+			const remove2 = Change.remove(0, 2, tag2);
 			const revive = [
 				Mark.tomb(tag2),
 				Mark.tomb(tag1),
@@ -621,8 +644,8 @@ export function testCompose() {
 		});
 
 		it("remove1 ○ remove2 ○ revive (remove2)", () => {
-			const remove1 = Change.remove(1, 3);
-			const remove2 = Change.remove(0, 2);
+			const remove1 = Change.remove(1, 3, tag1);
+			const remove2 = Change.remove(0, 2, tag2);
 			const revive = [Mark.revive(2, { revision: tag2, localId: brand(0) })];
 			const expected = [{ count: 1 }, Mark.remove(3, brand(0), { revision: tag1 })];
 			const actual = shallowCompose([
@@ -636,12 +659,12 @@ export function testCompose() {
 		it("reviveAA ○ reviveB => BAA", () => {
 			const reviveAA = [
 				Mark.tomb(tag2),
-				Mark.revive(2, { revision: tag1, localId: brand(1) }),
+				Mark.revive(2, { revision: tag1, localId: brand(1) }, { revision: tag2 }),
 			];
-			const reviveB = Change.revive(0, 1, { revision: tag2, localId: brand(0) });
+			const reviveB = Change.revive(0, 1, { revision: tag2, localId: brand(0) }, tag2);
 			const expected = [
-				Mark.revive(1, { revision: tag2, localId: brand(0) }),
-				Mark.revive(2, { revision: tag1, localId: brand(1) }),
+				Mark.revive(1, { revision: tag2, localId: brand(0) }, { revision: tag2 }),
+				Mark.revive(2, { revision: tag1, localId: brand(1) }, { revision: tag2 }),
 			];
 			const actual = shallowCompose([makeAnonChange(reviveAA), makeAnonChange(reviveB)]);
 			assertChangesetsEqual(actual, expected);
@@ -650,15 +673,15 @@ export function testCompose() {
 		it("reviveA ○ reviveBB => BAB", () => {
 			const reviveA = [
 				Mark.tomb(tag2),
-				Mark.revive(1, { revision: tag1, localId: brand(1) }),
+				Mark.revive(1, { revision: tag1, localId: brand(1) }, { revision: tag2 }),
 				Mark.tomb(tag2, brand(1)),
 			];
-			const reviveB1 = Change.revive(0, 1, { revision: tag2, localId: brand(0) });
-			const reviveB2 = Change.revive(2, 1, { revision: tag2, localId: brand(1) });
+			const reviveB1 = Change.revive(0, 1, { revision: tag2, localId: brand(0) }, tag2);
+			const reviveB2 = Change.revive(2, 1, { revision: tag2, localId: brand(1) }, tag2);
 			const expected = [
-				Mark.revive(1, { revision: tag2, localId: brand(0) }),
-				Mark.revive(1, { revision: tag1, localId: brand(1) }),
-				Mark.revive(1, { revision: tag2, localId: brand(1) }),
+				Mark.revive(1, { revision: tag2, localId: brand(0) }, { revision: tag2 }),
+				Mark.revive(1, { revision: tag1, localId: brand(1) }, { revision: tag2 }),
+				Mark.revive(1, { revision: tag2, localId: brand(1) }, { revision: tag2 }),
 			];
 			const actual = shallowCompose([
 				makeAnonChange(reviveA),
@@ -669,34 +692,37 @@ export function testCompose() {
 		});
 
 		it("reviveAA ○ reviveB => AAB", () => {
-			const reviveA = [Mark.revive(2, { revision: tag1, localId: brand(0) }), Mark.tomb(tag2)];
-			const reviveB = Change.revive(2, 1, { revision: tag2, localId: brand(0) });
+			const reviveA = [
+				Mark.revive(2, { revision: tag1, localId: brand(0) }, { revision: tag1 }),
+				Mark.tomb(tag2),
+			];
+			const reviveB = Change.revive(2, 1, { revision: tag2, localId: brand(0) }, tag2);
 			const expected = [
-				Mark.revive(2, { revision: tag1, localId: brand(0) }),
-				Mark.revive(1, { revision: tag2, localId: brand(0) }),
+				Mark.revive(2, { revision: tag1, localId: brand(0) }, { revision: tag1 }),
+				Mark.revive(1, { revision: tag2, localId: brand(0) }, { revision: tag2 }),
 			];
 			const actual = shallowCompose([makeAnonChange(reviveA), makeAnonChange(reviveB)]);
 			assertChangesetsEqual(actual, expected);
 		});
 
 		it("revive ○ redundant revive", () => {
-			const reviveA = Change.revive(0, 2, { revision: tag1, localId: brand(0) });
-			const reviveB = Change.pin(0, 2, { revision: tag1, localId: brand(0) });
+			const reviveA = Change.revive(0, 2, { revision: tag1, localId: brand(0) }, tag1);
+			const reviveB = Change.pin(0, 2, { revision: tag1, localId: brand(0) }, tag1);
 			const expected = [
-				Mark.revive(2, { revision: tag1, localId: brand(0) }, { revision: tag2 }),
+				Mark.revive(2, { revision: tag1, localId: brand(0) }, { revision: tag1 }),
 			];
 			const actual = shallowCompose([tagChangeInline(reviveA, tag2), makeAnonChange(reviveB)]);
 			assertChangesetsEqual(actual, expected);
 		});
 
 		it("move ○ modify", () => {
-			const move = Change.move(0, 1, 2);
+			const move = Change.move(0, 1, 2, tag1);
 			const changes = TestNodeId.create({ localId: brand(1) }, TestChange.mint([], 42));
 			const modify = Change.modify(1, changes);
 			const expected = [
-				Mark.moveOut(1, brand(0), { changes }),
+				Mark.moveOut(1, { localId: brand(0), revision: tag1 }, { changes, revision: tag1 }),
 				{ count: 1 },
-				Mark.moveIn(1, brand(0)),
+				Mark.moveIn(1, { localId: brand(0), revision: tag1 }, { revision: tag1 }),
 			];
 			const actual = shallowCompose([makeAnonChange(move), makeAnonChange(modify)]);
 			assertChangesetsEqual(actual, expected);
@@ -725,13 +751,16 @@ export function testCompose() {
 		});
 
 		it("move ○ remove", () => {
-			const move = Change.move(1, 1, 4, brand(0));
-			const deletion = Change.remove(3, 1, brand(2));
+			const move = Change.move(1, 1, 4, tag1, brand(0));
+			const deletion = Change.remove(3, 1, tag2, brand(2));
 			const expected = [
 				{ count: 1 },
-				Mark.moveOut(1, brand(0)),
+				Mark.moveOut(1, brand(0), { revision: tag1 }),
 				{ count: 2 },
-				Mark.attachAndDetach(Mark.moveIn(1, brand(0)), Mark.remove(1, brand(2))),
+				Mark.attachAndDetach(
+					Mark.moveIn(1, { localId: brand(0), revision: tag1 }, { revision: tag1 }),
+					Mark.remove(1, brand(2), { revision: tag2 }),
+				),
 			];
 			const actual = shallowCompose([makeAnonChange(move), makeAnonChange(deletion)]);
 			assertChangesetsEqual(actual, expected);
@@ -741,9 +770,9 @@ export function testCompose() {
 			const cellIdA: ChangeAtomId = { revision: tag2, localId: brand(0) };
 			const cellIdB: ChangeAtomId = { revision: tag2, localId: brand(1) };
 			// Return from B back to A
-			const return1 = tagChangeInline(Change.return(0, 1, 4, cellIdB, cellIdA), tag3);
+			const return1 = tagChangeInline(Change.return(0, 1, 4, cellIdB, cellIdA, tag3), tag3);
 			// Return from A back to B
-			const return2 = tagChangeInline(Change.return(3, 1, 0, cellIdA, cellIdB), tag4);
+			const return2 = tagChangeInline(Change.return(3, 1, 0, cellIdA, cellIdB, tag4), tag4);
 			const actual = shallowCompose([return1, return2]);
 
 			const expected = [{ count: 4 }, Mark.tomb(tag2, brand(0))];
@@ -754,7 +783,7 @@ export function testCompose() {
 			const cellIdA: ChangeAtomId = { revision: tag2, localId: brand(0) };
 			const cellIdB: ChangeAtomId = { revision: tag2, localId: brand(1) };
 			// Return from B back to A
-			const return1 = tagChangeInline(Change.return(0, 1, 4, cellIdB, cellIdA), tag3);
+			const return1 = tagChangeInline(Change.return(0, 1, 4, cellIdB, cellIdA, tag3), tag3);
 			// Return from A back to B
 			const return2 = tagChangeInline(
 				[Mark.returnTo(1, brand(0), cellIdB), { count: 3 }, Mark.moveOut(1, brand(0))],
@@ -781,6 +810,7 @@ export function testCompose() {
 					0,
 					{ revision: tag1, localId: brand(2) },
 					{ revision: tag1, localId: brand(0) },
+					tag4,
 				),
 				tag4,
 			);
@@ -853,44 +883,68 @@ export function testCompose() {
 		});
 
 		it("move ○ move (forward)", () => {
-			const move1 = Change.move(0, 1, 2, brand(0));
-			const move2 = Change.move(1, 1, 3, brand(2));
+			const move1 = Change.move(0, 1, 2, tag1, brand(0));
+			const move2 = Change.move(1, 1, 3, tag2, brand(2));
 			const actual = shallowCompose([makeAnonChange(move1), makeAnonChange(move2)]);
 			const expected = [
-				Mark.moveOut(1, brand(0), {
-					finalEndpoint: { revision: undefined, localId: brand(2) },
-				}),
+				Mark.moveOut(
+					1,
+					{ localId: brand(0), revision: tag1 },
+					{
+						finalEndpoint: { revision: tag2, localId: brand(2) },
+					},
+				),
 				{ count: 1 },
-				Mark.rename(1, { localId: brand(1) }, { localId: brand(2) }),
+				Mark.rename(
+					1,
+					{ localId: brand(1), revision: tag1 },
+					{ localId: brand(2), revision: tag2 },
+				),
 				{ count: 1 },
-				Mark.moveIn(1, brand(2), {
-					finalEndpoint: { revision: undefined, localId: brand(0) },
-				}),
+				Mark.moveIn(
+					1,
+					{ localId: brand(2), revision: tag2 },
+					{
+						finalEndpoint: { revision: tag1, localId: brand(0) },
+					},
+				),
 			];
 			assertChangesetsEqual(actual, expected);
 		});
 
 		it("move ○ move (back)", () => {
-			const move1 = Change.move(2, 1, 1, brand(0));
-			const move2 = Change.move(1, 1, 0, brand(2));
+			const move1 = Change.move(2, 1, 1, tag1, brand(0));
+			const move2 = Change.move(1, 1, 0, tag2, brand(2));
 			const actual = shallowCompose([makeAnonChange(move1), makeAnonChange(move2)]);
 			const expected = [
-				Mark.moveIn(1, brand(2), {
-					finalEndpoint: { revision: undefined, localId: brand(0) },
-				}),
+				Mark.moveIn(
+					1,
+					{ localId: brand(2), revision: tag2 },
+					{
+						finalEndpoint: { revision: tag1, localId: brand(0) },
+					},
+				),
 				{ count: 1 },
-				Mark.rename(1, { localId: brand(1) }, { localId: brand(2) }),
+				Mark.rename(
+					1,
+					{ localId: brand(1), revision: tag1 },
+					{ localId: brand(2), revision: tag2 },
+				),
 				{ count: 1 },
-				Mark.moveOut(1, brand(0), {
-					finalEndpoint: { revision: undefined, localId: brand(2) },
-				}),
+				Mark.moveOut(
+					1,
+					{ localId: brand(0), revision: tag1 },
+					{
+						finalEndpoint: { revision: tag2, localId: brand(2) },
+					},
+				),
 			];
 			assertChangesetsEqual(actual, expected);
 		});
 
 		it("move ○ move adjacent to starting position (back and forward)", () => {
-			const move1 = Change.move(1, 1, 0);
-			const move2 = Change.move(0, 1, 2);
+			const move1 = Change.move(1, 1, 0, tag1);
+			const move2 = Change.move(0, 1, 2, tag2);
 			const actual = shallowCompose([
 				tagChangeInline(move1, tag1),
 				tagChangeInline(move2, tag2),
@@ -921,8 +975,8 @@ export function testCompose() {
 		});
 
 		it("move ○ move adjacent to starting position (forward and back)", () => {
-			const move1 = Change.move(0, 1, 2);
-			const move2 = Change.move(1, 1, 0);
+			const move1 = Change.move(0, 1, 2, tag1);
+			const move2 = Change.move(1, 1, 0, tag2);
 			const actual = shallowCompose([
 				tagChangeInline(move1, tag1),
 				tagChangeInline(move2, tag2),
@@ -1046,10 +1100,10 @@ export function testCompose() {
 		});
 
 		it("move, remove, revive", () => {
-			const move = tagChangeInline(Change.move(1, 1, 0), tag1);
-			const del = tagChangeInline(Change.remove(0, 1), tag2);
+			const move = tagChangeInline(Change.move(1, 1, 0, tag1), tag1);
+			const del = tagChangeInline(Change.remove(0, 1, tag2), tag2);
 			const revive = tagChangeInline(
-				Change.revive(0, 1, { revision: tag2, localId: brand(0) }),
+				Change.revive(0, 1, { revision: tag2, localId: brand(0) }, tag3),
 				tag3,
 			);
 			const actual = shallowCompose([move, del, revive]);
@@ -1088,8 +1142,8 @@ export function testCompose() {
 				[0, 1, 2],
 				[2, 1, 0],
 			]) {
-				const move1 = tagChangeInline(Change.move(a, 1, b > a ? b + 1 : b), tag1);
-				const move2 = tagChangeInline(Change.move(b, 1, c > b ? c + 1 : c), tag2);
+				const move1 = tagChangeInline(Change.move(a, 1, b > a ? b + 1 : b, tag1), tag1);
+				const move2 = tagChangeInline(Change.move(b, 1, c > b ? c + 1 : c, tag2), tag2);
 				const return2 = tagChangeInline(
 					Change.return(
 						c,
@@ -1097,6 +1151,7 @@ export function testCompose() {
 						b > c ? b + 1 : b,
 						{ revision: tag2, localId: brand(1) },
 						{ revision: tag2, localId: brand(0) },
+						tag3,
 					),
 					tag3,
 					tag2,
@@ -1159,13 +1214,20 @@ export function testCompose() {
 				[0, 1, 2],
 				[2, 1, 0],
 			]) {
-				const move1 = tagChangeInline(Change.move(a, 1, b > a ? b + 1 : b), tag1);
+				const move1 = tagChangeInline(Change.move(a, 1, b > a ? b + 1 : b, tag1), tag1);
 				const return1 = tagChangeInline(
-					Change.return(b, 1, a > b ? a + 1 : a, { ...leg1Id, localId: brand(1) }, leg1Id),
+					Change.return(
+						b,
+						1,
+						a > b ? a + 1 : a,
+						{ ...leg1Id, localId: brand(1) },
+						leg1Id,
+						tag1,
+					),
 					tag2,
 					tag1,
 				);
-				const move2 = tagChangeInline(Change.move(a, 1, c > a ? c + 1 : c), tag3);
+				const move2 = tagChangeInline(Change.move(a, 1, c > a ? c + 1 : c, tag3), tag3);
 				const part2 = shallowCompose([return1, move2]);
 				const composed = shallowCompose(
 					[move1, makeAnonChange(part2)],
@@ -1198,7 +1260,7 @@ export function testCompose() {
 		});
 
 		it("move1 ○ [return1, move2, move3]", () => {
-			const move1 = tagChangeInline(Change.move(3, 1, 2), tag1);
+			const move1 = tagChangeInline(Change.move(3, 1, 2, tag1), tag1);
 			const return1 = tagChangeInline(
 				[
 					Mark.skip(2),
@@ -1211,8 +1273,8 @@ export function testCompose() {
 				tag2,
 				tag1,
 			);
-			const move2 = tagChangeInline(Change.move(3, 1, 1), tag3);
-			const move3 = tagChangeInline(Change.move(1, 1, 0), tag4);
+			const move2 = tagChangeInline(Change.move(3, 1, 1, tag3), tag3);
+			const move3 = tagChangeInline(Change.move(1, 1, 0, tag4), tag4);
 			const part2 = shallowCompose([return1, move2, move3]);
 
 			const composed = shallowCompose(
@@ -1250,8 +1312,8 @@ export function testCompose() {
 				[0, 1, 2, 3],
 				[3, 2, 1, 0],
 			]) {
-				const move1 = tagChangeInline(Change.move(a, 1, b > a ? b + 1 : b), tag1);
-				const move2 = tagChangeInline(Change.move(b, 1, c > b ? c + 1 : c), tag2);
+				const move1 = tagChangeInline(Change.move(a, 1, b > a ? b + 1 : b, tag1), tag1);
+				const move2 = tagChangeInline(Change.move(b, 1, c > b ? c + 1 : c, tag2), tag2);
 				const part1 = shallowCompose([move1, move2]);
 				const return2 = tagChangeInline(
 					Change.return(
@@ -1263,11 +1325,12 @@ export function testCompose() {
 							revision: tag2,
 							localId: brand(0),
 						},
+						tag3,
 					),
 					tag3,
 					tag2,
 				);
-				const move3 = tagChangeInline(Change.move(b, 1, d > b ? d + 1 : d), tag4);
+				const move3 = tagChangeInline(Change.move(b, 1, d > b ? d + 1 : d, tag4), tag4);
 				const part2 = shallowCompose([return2, move3]);
 				const composed = shallowCompose(
 					[makeAnonChange(part1), makeAnonChange(part2)],
@@ -1310,8 +1373,8 @@ export function testCompose() {
 		});
 
 		it("[move1, move2] ○ return1", () => {
-			const move1 = tagChangeInline(Change.move(0, 1, 2), tag1);
-			const move2 = tagChangeInline(Change.move(1, 1, 3), tag2);
+			const move1 = tagChangeInline(Change.move(0, 1, 2, tag1), tag1);
+			const move2 = tagChangeInline(Change.move(1, 1, 3, tag2), tag2);
 			const return1 = tagChangeInline(
 				Change.return(
 					2,
@@ -1319,6 +1382,7 @@ export function testCompose() {
 					0,
 					{ revision: tag2, localId: brand(1) },
 					{ revision: tag1, localId: brand(0) },
+					tag3,
 				),
 				tag3,
 			);
@@ -1339,7 +1403,7 @@ export function testCompose() {
 		});
 
 		it("move1 (back) ○ [return1, move2 (forward)]", () => {
-			const move1 = tagChangeInline(Change.move(2, 1, 0), tag1);
+			const move1 = tagChangeInline(Change.move(2, 1, 0, tag1), tag1);
 			const return1 = tagChangeInline(
 				[
 					Mark.moveOut(1, brand(0), {
@@ -1351,7 +1415,7 @@ export function testCompose() {
 				tag2,
 			);
 
-			const move2 = tagChangeInline(Change.move(2, 1, 1), tag3);
+			const move2 = tagChangeInline(Change.move(2, 1, 1, tag3), tag3);
 
 			const returnAndMove = makeAnonChange(shallowCompose([return1, move2]));
 			const composed = shallowCompose([move1, returnAndMove]);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.test.ts
@@ -20,7 +20,7 @@ import { invert as invertChange, assertChangesetsEqual, tagChangeInline } from "
 import { ChangeMaker as Change, MarkMaker as Mark } from "./testEdits.js";
 
 function invert(change: SF.Changeset, tag: RevisionTag = tag1): SF.Changeset {
-	return invertChange(tagChangeInline(change, tag));
+	return invertChange(tagChangeInline(change, tag), tag);
 }
 
 const tag1: RevisionTag = mintRevisionTag();
@@ -69,10 +69,10 @@ export function testInvert() {
 		});
 
 		it("insert => remove", () => {
-			const idOverride: SF.CellId = { revision: tag1, localId: brand(0) };
-			const input = Change.insert(0, 2);
-			const expected = [Mark.remove(2, brand(0), { idOverride })];
-			const actual = invert(input);
+			const cellId: SF.CellId = { revision: tag1, localId: brand(0) };
+			const input = Change.insert(0, 2, tag1, cellId);
+			const actual = invert(input, tag2);
+			const expected = [Mark.remove(2, brand(0), { idOverride: cellId, revision: tag2 })];
 			assertChangesetsEqual(actual, expected);
 		});
 
@@ -114,7 +114,7 @@ export function testInvert() {
 				tag3, // This ID should be ignored
 			);
 			const expected = [Mark.revive(2, detachId)];
-			const actual = invertChange(input);
+			const actual = invertChange(input, tag3);
 			assertChangesetsEqual(actual, expected);
 		});
 
@@ -128,9 +128,9 @@ export function testInvert() {
 
 		it("active revive => remove", () => {
 			const cellId: CellId = { revision: tag1, localId: brand(0) };
-			const input = Change.revive(0, 2, cellId);
+			const input = Change.revive(0, 2, cellId, tag1);
 			const expected: SF.Changeset = [Mark.remove(2, brand(0), { idOverride: cellId })];
-			const actual = invert(input, tag2);
+			const actual = invert(input, tag1);
 			assertChangesetsEqual(actual, expected);
 		});
 
@@ -394,7 +394,7 @@ export function testInvert() {
 					),
 				];
 
-				const actual = invertChange(tagChangeInline(input, tag2, tag3 /* <= ignored */));
+				const actual = invertChange(tagChangeInline(input, tag2, tag3 /* <= ignored */), tag3);
 				const expected = Change.modifyDetached(0, { ...childChange1, revision: tag2 }, cellId);
 				assertChangesetsEqual(actual, expected);
 			});
@@ -437,3 +437,5 @@ export function testInvert() {
 		});
 	});
 }
+
+testInvert();

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
@@ -154,7 +154,13 @@ const testChanges: [
 				[nodeId3, TestChange.mint([], 2)],
 			),
 	],
-	["Insert", (i) => ChangesetWrapper.create(Change.insert(i, 2, brand(42)))],
+	[
+		"Insert",
+		(i) =>
+			ChangesetWrapper.create(
+				Change.insert(i, 2, undefined /* revision */, { localId: brand(42) }),
+			),
+	],
 	["NoOp", (i) => ChangesetWrapper.create([])],
 	[
 		"TransientInsert",
@@ -164,7 +170,7 @@ const testChanges: [
 				Mark.remove(1, brand(0), { cellId: { localId: brand(0) } }),
 			]),
 	],
-	["Remove", (i) => ChangesetWrapper.create(Change.remove(i, 2))],
+	["Remove", (i) => ChangesetWrapper.create(Change.remove(i, 2, undefined /* revision */))],
 	[
 		"Revive",
 		(i, max) =>
@@ -192,10 +198,13 @@ const testChanges: [
 	],
 	[
 		"Pin",
-		(i) => ChangesetWrapper.create(Change.pin(2, 2, { revision: tag2, localId: brand(i) })),
+		(i) =>
+			ChangesetWrapper.create(
+				Change.pin(2, 2, { revision: tag2, localId: brand(i) }, undefined /* revision */),
+			),
 	],
-	["MoveOut", (i) => ChangesetWrapper.create(Change.move(i, 2, 1))],
-	["MoveIn", (i) => ChangesetWrapper.create(Change.move(1, 2, i))],
+	["MoveOut", (i) => ChangesetWrapper.create(Change.move(i, 2, 1, undefined /* revision */))],
+	["MoveIn", (i) => ChangesetWrapper.create(Change.move(1, 2, i, undefined /* revision */))],
 	[
 		"ReturnFrom",
 		(i, max) =>
@@ -207,6 +216,7 @@ const testChanges: [
 						1,
 						{ revision: tag3, localId: brand(i + 2) },
 						{ revision: tag3, localId: brand(i) },
+						undefined /* revision */,
 					),
 					"MoveIn",
 					max,
@@ -224,6 +234,7 @@ const testChanges: [
 						i,
 						{ revision: tag3, localId: brand(i + 2) },
 						{ revision: tag3, localId: brand(i) },
+						undefined /* revision */,
 					),
 					"MoveIn",
 					max,
@@ -266,7 +277,11 @@ export function testRebaserAxioms() {
 								if (!areRebasable(change1.change.fieldChange, change2.change.fieldChange)) {
 									continue;
 								}
-								const inv = tagWrappedChangeInline(invertDeep(change2), tag6, tag5);
+								const inv = tagWrappedChangeInline(
+									invertDeep(change2, undefined /* revision */),
+									tag6,
+									tag5,
+								);
 								const r1 = rebaseDeepTagged(change1, change2);
 								const r2 = rebaseDeepTagged(r1, inv);
 
@@ -284,11 +299,15 @@ export function testRebaserAxioms() {
 		// Hand-crafted version of the above tests to add coverage for returns
 		it("Return ↷ [Return, Return⁻¹] === Return", () => {
 			const move: SF.Changeset = Mark.move(1, { revision: tag0, localId: brand(0) });
-			const r: SF.Changeset = invert(tagChange(move, tag0), false);
+			const r: SF.Changeset = invert(tagChange(move, tag0), undefined /* revision */, false);
 			const base1 = tagChange(r, tag1);
-			const base2 = tagChange(invert(base1, true), tag2);
-			const actual = rebaseOverChanges(tagChange(r, tag3), [base1, base2]);
-			assertChangesetsEqual(withoutTombstones(actual.change), r);
+			const base2 = tagChange(invert(base1, undefined /* revision */, true), tag2);
+			const actual = tagChangeInline(
+				rebaseOverChanges(tagChange(r, tag3), [base1, base2]).change,
+				tag3,
+			);
+			const expected = tagChangeInline(r, tag3);
+			assertChangesetsEqual(actual.change, expected.change);
 		});
 
 		/**
@@ -327,7 +346,10 @@ export function testRebaserAxioms() {
 								if (!areRebasable(change1.change.fieldChange, change2.change.fieldChange)) {
 									continue;
 								}
-								const inv = tagWrappedChangeInline(invertDeep(change2), tag6);
+								const inv = tagWrappedChangeInline(
+									invertDeep(change2, undefined /* revision */),
+									tag6,
+								);
 								const r1 = rebaseDeepTagged(change1, change2);
 								const r2 = rebaseDeepTagged(r1, inv);
 								assertWrappedChangesetsEqual(
@@ -378,7 +400,7 @@ export function testRebaserAxioms() {
 									continue;
 								}
 								const inverse2 = tagWrappedChangeInline(
-									invertDeep(change2),
+									invertDeep(change2, undefined /* revision */),
 									tag6,
 									change2.revision,
 								);
@@ -401,7 +423,7 @@ export function testRebaserAxioms() {
 				it(`${name} ○ ${name}⁻¹ === ε`, () => {
 					const change = makeChange(0, 0);
 					const taggedChange = tagWrappedChangeInline(change, tag5);
-					const inv = invertDeep(taggedChange);
+					const inv = invertDeep(taggedChange, undefined /* revision */);
 					const changes = [
 						taggedChange,
 						tagWrappedChangeInline(inv, tag6, taggedChange.revision),
@@ -419,7 +441,7 @@ export function testRebaserAxioms() {
 					const change = makeChange(0, 0);
 					const taggedChange = tagWrappedChangeInline(change, tag5);
 					const inv = tagWrappedChangeInline(
-						invertDeep(taggedChange),
+						invertDeep(taggedChange, undefined /* revision */),
 						tag6,
 						taggedChange.revision,
 					);
@@ -539,7 +561,7 @@ const generateChildStates: ChildStateGenerator<TestState, WrappedChange> = funct
 	if (state.mostRecentEdit !== undefined) {
 		assert(state.parent?.content !== undefined, "Must have parent state to undo");
 		const undoIntention = mintIntention();
-		const invertedEdit = invertDeep(state.mostRecentEdit.changeset);
+		const invertedEdit = invertDeep(state.mostRecentEdit.changeset, undefined /* revision */);
 		yield {
 			content: state.parent.content,
 			mostRecentEdit: {
@@ -570,7 +592,7 @@ const generateChildStates: ChildStateGenerator<TestState, WrappedChange> = funct
 					},
 					mostRecentEdit: {
 						changeset: tagWrappedChangeInline(
-							ChangesetWrapper.create(Change.insert(i, nodeCount)),
+							ChangesetWrapper.create(Change.insert(i, nodeCount, undefined /* revision */)),
 							tagFromIntention(insertIntention),
 						),
 						intention: insertIntention,
@@ -596,7 +618,7 @@ const generateChildStates: ChildStateGenerator<TestState, WrappedChange> = funct
 				},
 				mostRecentEdit: {
 					changeset: tagWrappedChangeInline(
-						ChangesetWrapper.create(Change.remove(iSrc, nodeCount)),
+						ChangesetWrapper.create(Change.remove(iSrc, nodeCount, undefined /* revision */)),
 						tagFromIntention(removeIntention),
 					),
 					intention: removeIntention,
@@ -625,7 +647,9 @@ const generateChildStates: ChildStateGenerator<TestState, WrappedChange> = funct
 					},
 					mostRecentEdit: {
 						changeset: tagWrappedChangeInline(
-							ChangesetWrapper.create(Change.move(iSrc, nodeCount, iDst)),
+							ChangesetWrapper.create(
+								Change.move(iSrc, nodeCount, iDst, undefined /* revision */),
+							),
 							tagFromIntention(moveInIntention),
 						),
 						intention: moveInIntention,
@@ -742,58 +766,78 @@ export function testStateBasedRebaserAxioms() {
 export function testSandwichRebasing() {
 	describe("Sandwich Rebasing", () => {
 		it("Nested inserts rebasing", () => {
-			const insertA = tagChangeInline(Change.insert(0, 2), tag1);
-			const insertB = tagChangeInline(Change.insert(1, 1), tag2);
-			const inverseA = tagChangeInline(invert(insertA), tag3, insertA.revision);
+			const insertA = tagChangeInline(Change.insert(0, 2, undefined /* revision */), tag1);
+			const insertB = tagChangeInline(Change.insert(1, 1, undefined /* revision */), tag2);
+			const inverseA = tagChangeInline(
+				invert(insertA, undefined /* revision */),
+				tag3,
+				insertA.revision,
+			);
 			const insertB2 = rebaseTagged(insertB, inverseA);
 			const insertB3 = rebaseTagged(insertB2, insertA);
 			assertChangesetsEqual(insertB3.change, insertB.change);
 		});
 
 		it("(Insert, remove) ↷ adjacent insert", () => {
-			const insertT = tagChangeInline(Change.insert(0, 1), tag1);
-			const insertA = tagChangeInline(Change.insert(0, 1), tag2);
-			const removeB = tagChangeInline(Change.remove(0, 1), tag3);
+			const insertT = tagChangeInline(Change.insert(0, 1, undefined /* revision */), tag1);
+			const insertA = tagChangeInline(Change.insert(0, 1, undefined /* revision */), tag2);
+			const removeB = tagChangeInline(Change.remove(0, 1, undefined /* revision */), tag3);
 			const insertA2 = rebaseTagged(insertA, insertT);
-			const inverseA = tagChangeInline(invert(insertA), tag4, insertA.revision);
+			const inverseA = tagChangeInline(
+				invert(insertA, undefined /* revision */),
+				tag4,
+				insertA.revision,
+			);
 			const removeB2 = rebaseOverChanges(removeB, [inverseA, insertT, insertA2]);
 			assertChangesetsEqual(removeB2.change, removeB.change);
 		});
 
 		it("Nested inserts composition", () => {
-			const insertA = tagChangeInline(Change.insert(0, 2), tag1);
-			const insertB = tagChangeInline(Change.insert(1, 1), tag2);
-			const inverseA = tagChangeInline(invert(insertA), tag3, insertA.revision);
-			const inverseB = tagChangeInline(invert(insertB), tag4, insertB.revision);
+			const insertA = tagChangeInline(Change.insert(0, 2, undefined /* revision */), tag1);
+			const insertB = tagChangeInline(Change.insert(1, 1, undefined /* revision */), tag2);
+			const inverseA = tagChangeInline(
+				invert(insertA, undefined /* revision */),
+				tag3,
+				insertA.revision,
+			);
+			const inverseB = tagChangeInline(
+				invert(insertB, undefined /* revision */),
+				tag4,
+				insertB.revision,
+			);
 
 			const composed = compose([inverseB, inverseA, insertA, insertB]);
 			assertChangesetsEqual(composed, []);
 		});
 
 		it("Nested inserts ↷ adjacent insert", () => {
-			const insertX = tagChangeInline(Change.insert(0, 1), tag1);
-			const insertA = tagChangeInline(Change.insert(1, 2), tag2);
-			const insertB = tagChangeInline(Change.insert(2, 1), tag4);
-			const inverseA = tagChangeInline(invert(insertA), tag3, insertA.revision);
+			const insertX = tagChangeInline(Change.insert(0, 1, undefined /* revision */), tag1);
+			const insertA = tagChangeInline(Change.insert(1, 2, undefined /* revision */), tag2);
+			const insertB = tagChangeInline(Change.insert(2, 1, undefined /* revision */), tag4);
+			const inverseA = tagChangeInline(
+				invert(insertA, undefined /* revision */),
+				tag3,
+				insertA.revision,
+			);
 			const insertA2 = rebaseTagged(insertA, insertX);
 			const insertB2 = rebaseTagged(insertB, inverseA);
 			const insertB3 = rebaseTagged(insertB2, insertX);
 			const insertB4 = rebaseTagged(insertB3, insertA2);
 			assertChangesetsEqual(
 				insertB4.change,
-				tagChangeInline(Change.insert(3, 1), tag4).change,
+				tagChangeInline(Change.insert(3, 1, undefined /* revision */), tag4).change,
 			);
 		});
 
 		it("[Remove AC, Revive AC] ↷ Insert B", () => {
-			const addB = tagChangeInline(Change.insert(1, 1), tag1);
-			const delAC = tagChangeInline(Change.remove(0, 2), tag2);
+			const addB = tagChangeInline(Change.insert(1, 1, undefined /* revision */), tag1);
+			const delAC = tagChangeInline(Change.remove(0, 2, undefined /* revision */), tag2);
 			const revAC = tagChangeInline(
-				Change.revive(0, 2, { revision: tag2, localId: id0 }),
+				Change.revive(0, 2, { revision: tag2, localId: id0 }, undefined /* revision */),
 				tag4,
 			);
 			const delAC2 = rebaseTagged(delAC, addB);
-			const invDelAC = invert(delAC);
+			const invDelAC = invert(delAC, undefined /* revision */);
 			const revAC2 = rebaseTagged(revAC, tagChangeInline(invDelAC, tag3, delAC2.revision));
 			const revAC3 = rebaseTagged(revAC2, addB);
 			const revAC4 = rebaseTagged(revAC3, delAC2);
@@ -803,9 +847,13 @@ export function testSandwichRebasing() {
 		});
 
 		it("sandwich rebase [move, undo]", () => {
-			const move = tagChangeInline(Change.move(1, 1, 0), tag1);
-			const undo = tagChangeInline(invert(move, false), tag2);
-			const moveRollback = tagChangeInline(invert(move, true), tag3, tag1);
+			const move = tagChangeInline(Change.move(1, 1, 0, undefined /* revision */), tag1);
+			const undo = tagChangeInline(invert(move, undefined /* revision */, false), tag2);
+			const moveRollback = tagChangeInline(
+				invert(move, undefined /* revision */, true),
+				tag3,
+				tag1,
+			);
 			const rebasedUndo = rebaseOverChanges(undo, [moveRollback, move]);
 			assertChangesetsEqual(rebasedUndo.change, undo.change);
 		});
@@ -821,11 +869,19 @@ export function testSandwichRebasing() {
 
 			const rollbackTag2 = mintRevisionTag();
 			const changeB = tagChangeInline([Mark.insert(1, brand(0))], tag2);
-			const inverseB = tagChangeInline(invert(changeB), rollbackTag2, tag2);
+			const inverseB = tagChangeInline(
+				invert(changeB, undefined /* revision */),
+				rollbackTag2,
+				tag2,
+			);
 
 			const rollbackTag1 = mintRevisionTag();
 			const changeA = tagChangeInline([Mark.insert(1, brand(0))], tag1);
-			const inverseA = tagChangeInline(invert(changeA), rollbackTag1, tag1);
+			const inverseA = tagChangeInline(
+				invert(changeA, undefined /* revision */),
+				rollbackTag1,
+				tag1,
+			);
 
 			const revInfos: RevisionInfo[] = [
 				{ revision: rollbackTag2, rollbackOf: tag2 },
@@ -849,7 +905,7 @@ export function testSandwichRebasing() {
 			const insertT = tagChangeInline([Mark.insert(1, brand(0))], tag1);
 			const insertA = tagChangeInline([Mark.insert(1, brand(0))], tag2);
 			const insertA2 = rebaseOverChanges(insertA, [insertT]);
-			const inverseA = tagChangeInline(invert(insertA), tag4, tag2);
+			const inverseA = tagChangeInline(invert(insertA, undefined /* revision */), tag4, tag2);
 			const insertB = tagChangeInline([{ count: 1 }, Mark.insert(1, brand(0))], tag3);
 			const insertB2 = rebaseOverChanges(insertB, [inverseA, insertT, insertA2]);
 			const expected = [{ count: 1 }, Mark.insert(1, { revision: tag3, localId: brand(0) })];
@@ -862,7 +918,7 @@ export function testSandwichRebasing() {
 				tag2,
 			);
 			const insertB = tagChangeInline([Mark.skip(1), Mark.insert(1, brand(0))], tag3);
-			const inverseA = tagChangeInline(invert(reviveA), tag4, tag2);
+			const inverseA = tagChangeInline(invert(reviveA, undefined /* revision */), tag4, tag2);
 			const insertB2 = rebaseOverChanges(insertB, [inverseA, reviveA]);
 			const expected = [Mark.skip(1), Mark.insert(1, { revision: tag3, localId: brand(0) })];
 
@@ -875,7 +931,7 @@ export function testSandwichComposing() {
 	describe("Sandwich composing", () => {
 		it("insert ↷ redundant remove", () => {
 			const insertA = tagChangeInline([Mark.insert(1, { localId: brand(0) })], tag3);
-			const uninsertA = tagChangeInline(invert(insertA), tag4, tag3);
+			const uninsertA = tagChangeInline(invert(insertA, undefined /* revision */), tag4, tag3);
 			const redundantRemoveT = tagChangeInline(
 				[Mark.remove(1, brand(0), { cellId: { revision: tag1, localId: brand(0) } })],
 				tag2,
@@ -898,7 +954,7 @@ export function testSandwichComposing() {
 			const removeT = tagChangeInline([Mark.remove(1, brand(0))], tag1);
 			const insertA = tagChangeInline([Mark.skip(1), Mark.insert(1, brand(0))], tag2);
 			const insertA2 = rebaseTagged(insertA, removeT);
-			const inverseA = tagChangeInline(invert(insertA), tag4, tag2);
+			const inverseA = tagChangeInline(invert(insertA, undefined /* revision */), tag4, tag2);
 			const insertB = tagChangeInline([Mark.skip(1), Mark.insert(1, brand(0))], tag3);
 			const insertB2 = rebaseOverChanges(insertB, [inverseA, removeT, insertA2]);
 			const TAB = compose([removeT, insertA2, insertB2]);
@@ -931,9 +987,21 @@ export function testSandwichComposing() {
 				[Mark.revive(1, { revision: tag1, localId: brand(0) })],
 				tag4,
 			);
-			const inverseRemoveB = tagChangeInline(invert(removeB), tag5, removeB.revision);
-			const inverseReviveB = tagChangeInline(invert(reviveB), tag6, reviveB.revision);
-			const inverseReviveA = tagChangeInline(invert(reviveA), tag7, reviveA.revision);
+			const inverseRemoveB = tagChangeInline(
+				invert(removeB, undefined /* revision */),
+				tag5,
+				removeB.revision,
+			);
+			const inverseReviveB = tagChangeInline(
+				invert(reviveB, undefined /* revision */),
+				tag6,
+				reviveB.revision,
+			);
+			const inverseReviveA = tagChangeInline(
+				invert(reviveA, undefined /* revision */),
+				tag7,
+				reviveA.revision,
+			);
 
 			// The composition computation is broken up is steps that force us down more challenging code paths.
 			// Specifically, the composition of reviveB with the composition of parts 3 to 6.
@@ -952,10 +1020,22 @@ export function testSandwichComposing() {
 			const [mo3, mi3] = Mark.move(1, brand(3));
 			const move3 = tagChangeInline([mi3, mo3], tag4);
 			const del = tagChangeInline([Mark.remove(1, brand(0))], tag0);
-			const return1 = tagChangeInline(invert(move1), tag5, move1.revision);
-			const return2 = tagChangeInline(invert(move2), tag6, move2.revision);
-			const unMod = tagChangeInline(invert(mod), tag7, mod.revision);
-			const return3 = tagChangeInline(invert(move3), tag8, move3.revision);
+			const return1 = tagChangeInline(
+				invert(move1, undefined /* revision */),
+				tag5,
+				move1.revision,
+			);
+			const return2 = tagChangeInline(
+				invert(move2, undefined /* revision */),
+				tag6,
+				move2.revision,
+			);
+			const unMod = tagChangeInline(invert(mod, undefined /* revision */), tag7, mod.revision);
+			const return3 = tagChangeInline(
+				invert(move3, undefined /* revision */),
+				tag8,
+				move3.revision,
+			);
 			const move1Rebased = rebaseTagged(move1, del);
 			const changes = [return3, unMod, return2, return1, del, move1Rebased, move2, mod, move3];
 
@@ -970,9 +1050,13 @@ export function testSandwichComposing() {
 export function testComposedSandwichRebasing() {
 	describe("Composed sandwich rebasing", () => {
 		it("Nested inserts ↷ []", () => {
-			const insertA = tagChangeInline(Change.insert(0, 2), tag1);
-			const insertB = tagChangeInline(Change.insert(1, 1), tag2);
-			const inverseA = tagChangeInline(invert(insertA), tag3, insertA.revision);
+			const insertA = tagChangeInline(Change.insert(0, 2, undefined /* revision */), tag1);
+			const insertB = tagChangeInline(Change.insert(1, 1, undefined /* revision */), tag2);
+			const inverseA = tagChangeInline(
+				invert(insertA, undefined /* revision */),
+				tag3,
+				insertA.revision,
+			);
 			const sandwich = compose([inverseA, insertA]);
 			const insertB2 = rebaseTagged(insertB, makeAnonChange(sandwich));
 			assertChangesetsEqual(insertB2.change, insertB.change);
@@ -989,10 +1073,11 @@ export function testExamples() {
 			);
 			const concurrentRemove = tagChangeInline([Mark.remove(1, brand(42))], tag2);
 			const rebasedRevive = rebaseTagged(revive, concurrentRemove);
-			const redetach = invert(rebasedRevive);
+			const redetach = invert(rebasedRevive, undefined /* revision */);
 			const expected = [
 				Mark.remove(1, brand(0), {
 					idOverride: { revision: tag1, localId: brand(0) },
+					revision: undefined,
 				}),
 				Mark.tomb(tag2, brand(42)),
 			];

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.test.ts
@@ -51,7 +51,7 @@ const encodingTestData: EncodingTestData<Changeset, unknown, FieldChangeEncoding
 		["without child change", inlineRevision(Change.remove(2, 2, tag1), tag1), context],
 		[
 			"with a revive",
-			inlineRevision(Change.revive(0, 1, { revision: tag2, localId: brand(10) }, tag2), tag1),
+			inlineRevision(Change.revive(0, 1, { revision: tag2, localId: brand(10) }, tag1), tag1),
 			context,
 		],
 		...Object.entries(cases).map<TestCase>(([name, change]) => [

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.test.ts
@@ -48,13 +48,10 @@ const changes = TestNodeId.create({ localId: brand(2) }, TestChange.mint([], 1))
 const encodingTestData: EncodingTestData<Changeset, unknown, FieldChangeEncodingContext> = {
 	successes: [
 		["with child change", inlineRevision(Change.modify(1, changes), tag1), context],
-		["without child change", inlineRevision(Change.remove(2, 2), tag1), context],
+		["without child change", inlineRevision(Change.remove(2, 2, tag1), tag1), context],
 		[
 			"with a revive",
-			inlineRevision(
-				Change.revive(0, 1, { revision: mintRevisionTag(), localId: brand(10) }),
-				tag1,
-			),
+			inlineRevision(Change.revive(0, 1, { revision: tag2, localId: brand(10) }, tag2), tag1),
 			context,
 		],
 		...Object.entries(cases).map<TestCase>(([name, change]) => [

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldEditor.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldEditor.test.ts
@@ -27,20 +27,29 @@ export function testEditor() {
 		});
 
 		it("insert one node", () => {
-			const actual = SF.sequenceFieldEditor.insert(42, 1, id, mintRevisionTag());
-			const expected: SF.Changeset = [{ count: 42 }, Mark.revive(1, { localId: id })];
+			const revision = mintRevisionTag();
+			const actual = SF.sequenceFieldEditor.insert(42, 1, { localId: id, revision }, revision);
+			const expected: SF.Changeset = [
+				{ count: 42 },
+				Mark.revive(1, { localId: id, revision }, { revision }),
+			];
 			assert.deepEqual(actual, expected);
 		});
 
 		it("insert multiple nodes", () => {
-			const actual = SF.sequenceFieldEditor.insert(42, 2, id, mintRevisionTag());
-			const expected: SF.Changeset = [{ count: 42 }, Mark.insert(2, id)];
+			const revision = mintRevisionTag();
+			const actual = SF.sequenceFieldEditor.insert(42, 2, { localId: id, revision }, revision);
+			const expected: SF.Changeset = [
+				{ count: 42 },
+				Mark.insert(2, { localId: id, revision }, { revision }),
+			];
 			assert.deepEqual(actual, expected);
 		});
 
 		it("remove", () => {
-			const actual = SF.sequenceFieldEditor.remove(42, 3, id, mintRevisionTag());
-			const expected: SF.Changeset = [{ count: 42 }, Mark.remove(3, id)];
+			const revision = mintRevisionTag();
+			const actual = SF.sequenceFieldEditor.remove(42, 3, id, revision);
+			const expected: SF.Changeset = [{ count: 42 }, Mark.remove(3, id, { revision })];
 			assert.deepEqual(actual, expected);
 		});
 	});

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldEditor.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldEditor.test.ts
@@ -12,6 +12,7 @@ import { TestChange } from "../../testChange.js";
 import { TestNodeId } from "../../testNodeId.js";
 import { deepFreeze } from "@fluidframework/test-runtime-utils/internal";
 import { MarkMaker as Mark } from "./testEdits.js";
+import { mintRevisionTag } from "../../utils.js";
 
 const id: ChangesetLocalId = brand(0);
 
@@ -26,19 +27,19 @@ export function testEditor() {
 		});
 
 		it("insert one node", () => {
-			const actual = SF.sequenceFieldEditor.insert(42, 1, id);
+			const actual = SF.sequenceFieldEditor.insert(42, 1, id, mintRevisionTag());
 			const expected: SF.Changeset = [{ count: 42 }, Mark.revive(1, { localId: id })];
 			assert.deepEqual(actual, expected);
 		});
 
 		it("insert multiple nodes", () => {
-			const actual = SF.sequenceFieldEditor.insert(42, 2, id);
+			const actual = SF.sequenceFieldEditor.insert(42, 2, id, mintRevisionTag());
 			const expected: SF.Changeset = [{ count: 42 }, Mark.insert(2, id)];
 			assert.deepEqual(actual, expected);
 		});
 
 		it("remove", () => {
-			const actual = SF.sequenceFieldEditor.remove(42, 3, id);
+			const actual = SF.sequenceFieldEditor.remove(42, 3, id, mintRevisionTag());
 			const expected: SF.Changeset = [{ count: 42 }, Mark.remove(3, id)];
 			assert.deepEqual(actual, expected);
 		});

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.test.ts
@@ -77,7 +77,7 @@ export function testToDelta() {
 		it("insert", () => {
 			const changeset = Change.insert(0, 1, tag);
 			const expected = {
-				local: [{ count: 1, attach: { minor: 0 } }],
+				local: [{ count: 1, attach: { major: tag, minor: 0 } }],
 			};
 			const actual = toDelta(changeset);
 			assert.deepStrictEqual(actual, expected);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.test.ts
@@ -75,7 +75,7 @@ export function testToDelta() {
 		});
 
 		it("insert", () => {
-			const changeset = Change.insert(0, 1);
+			const changeset = Change.insert(0, 1, tag);
 			const expected = {
 				local: [{ count: 1, attach: { minor: 0 } }],
 			};
@@ -84,7 +84,7 @@ export function testToDelta() {
 		});
 
 		it("revive => restore", () => {
-			const changeset = Change.revive(0, 1, { revision: tag, localId: brand(0) });
+			const changeset = Change.revive(0, 1, { revision: tag, localId: brand(0) }, tag);
 			const actual = toDelta(changeset);
 			const expected: DeltaFieldChanges = {
 				local: [

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.test.ts
@@ -84,7 +84,7 @@ export function testToDelta() {
 		});
 
 		it("revive => restore", () => {
-			const changeset = Change.revive(0, 1, { revision: tag, localId: brand(0) }, tag);
+			const changeset = Change.revive(0, 1, { revision: tag, localId: brand(0) }, tag2);
 			const actual = toDelta(changeset);
 			const expected: DeltaFieldChanges = {
 				local: [

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -37,7 +37,7 @@ export const cases: {
 	transient_insert: SF.Changeset;
 } = {
 	no_change: [],
-	insert: createInsertChangeset(1, 2, brand(1)),
+	insert: createInsertChangeset(1, 2, undefined /* revision */, { localId: brand(1) }),
 	modify: SF.sequenceFieldEditor.buildChildChange(
 		0,
 		TestNodeId.create(nodeId1, TestChange.mint([], 1)),
@@ -48,11 +48,16 @@ export const cases: {
 			changes: TestNodeId.create(nodeId2, TestChange.mint([], 2)),
 		}),
 	],
-	remove: createRemoveChangeset(1, 3),
-	revive: createReviveChangeset(2, 2, { revision: tag, localId: brand(0) }),
+	remove: createRemoveChangeset(1, 3, undefined /* revision */),
+	revive: createReviveChangeset(
+		2,
+		2,
+		{ revision: tag, localId: brand(0) },
+		undefined /* revision */,
+	),
 	pin: [createPinMark(4, brand(0))],
 	rename: [createRenameMark(3, brand(2), brand(3))],
-	move: createMoveChangeset(1, 2, 4),
+	move: createMoveChangeset(1, 2, 4, undefined /* revision */),
 	moveAndRemove: [
 		createMoveOutMark(1, brand(0)),
 		createAttachAndDetachMark(createMoveInMark(1, brand(0)), createRemoveMark(1, brand(1))),
@@ -63,6 +68,7 @@ export const cases: {
 		0,
 		{ revision: tag, localId: brand(1) },
 		{ revision: tag, localId: brand(0) },
+		undefined /* revision */,
 	),
 	transient_insert: [
 		{ count: 1 },
@@ -73,30 +79,33 @@ export const cases: {
 function createInsertChangeset(
 	index: number,
 	count: number,
-	id?: ChangesetLocalId,
+	revision: RevisionTag | undefined,
+	firstId?: ChangeAtomId,
 ): SF.Changeset {
 	return SF.sequenceFieldEditor.insert(
 		index,
 		count,
-		{ localId: id ?? brand(0), revision: tag },
-		tag,
+		firstId ?? { localId: brand(0), revision },
+		revision,
 	);
 }
 
 function createRemoveChangeset(
 	startIndex: number,
 	size: number,
+	revision: RevisionTag | undefined,
 	id?: ChangesetLocalId,
 ): SF.Changeset {
-	return SF.sequenceFieldEditor.remove(startIndex, size, id ?? brand(0), tag);
+	return SF.sequenceFieldEditor.remove(startIndex, size, id ?? brand(0), revision);
 }
 
 function createRedundantRemoveChangeset(
 	index: number,
 	size: number,
 	detachEvent: ChangeAtomId,
+	revision: RevisionTag,
 ): SF.Changeset {
-	const changeset = createRemoveChangeset(index, size);
+	const changeset = createRemoveChangeset(index, size, revision, detachEvent.localId);
 	changeset[changeset.length - 1].cellId = detachEvent;
 	return changeset;
 }
@@ -105,8 +114,9 @@ function createPinChangeset(
 	startIndex: number,
 	count: number,
 	detachEvent: SF.CellId,
+	revision: RevisionTag | undefined,
 ): SF.Changeset {
-	const markList = SF.sequenceFieldEditor.revive(startIndex, count, detachEvent, tag);
+	const markList = SF.sequenceFieldEditor.revive(startIndex, count, detachEvent, revision);
 	const mark = markList[markList.length - 1];
 	delete mark.cellId;
 	return markList;
@@ -116,14 +126,16 @@ function createReviveChangeset(
 	startIndex: number,
 	count: number,
 	detachEvent: SF.CellId,
+	revision: RevisionTag | undefined,
 ): SF.Changeset {
-	return SF.sequenceFieldEditor.revive(startIndex, count, detachEvent, tag);
+	return SF.sequenceFieldEditor.revive(startIndex, count, detachEvent, revision);
 }
 
 function createMoveChangeset(
 	sourceIndex: number,
 	count: number,
 	destIndex: number,
+	revision: RevisionTag | undefined,
 	id: ChangesetLocalId = brand(0),
 ): SF.Changeset {
 	return SF.sequenceFieldEditor.move(
@@ -131,8 +143,8 @@ function createMoveChangeset(
 		count,
 		destIndex,
 		id,
-		{ localId: brand(id + count), revision: tag },
-		tag,
+		{ localId: brand(id + count), revision },
+		revision,
 	);
 }
 
@@ -142,6 +154,7 @@ function createReturnChangeset(
 	destIndex: number,
 	detachCellId: SF.CellId,
 	attachCellId: SF.CellId,
+	revision: RevisionTag | undefined,
 ): SF.Changeset {
 	return SF.sequenceFieldEditor.return(
 		sourceIndex,
@@ -149,7 +162,7 @@ function createReturnChangeset(
 		destIndex,
 		detachCellId,
 		attachCellId,
-		tag,
+		revision,
 	);
 }
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -75,7 +75,12 @@ function createInsertChangeset(
 	count: number,
 	id?: ChangesetLocalId,
 ): SF.Changeset {
-	return SF.sequenceFieldEditor.insert(index, count, id ?? brand(0), tag);
+	return SF.sequenceFieldEditor.insert(
+		index,
+		count,
+		{ localId: id ?? brand(0), revision: tag },
+		tag,
+	);
 }
 
 function createRemoveChangeset(
@@ -126,7 +131,7 @@ function createMoveChangeset(
 		count,
 		destIndex,
 		id,
-		brand(id + count),
+		{ localId: brand(id + count), revision: tag },
 		tag,
 	);
 }

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -75,7 +75,7 @@ function createInsertChangeset(
 	count: number,
 	id?: ChangesetLocalId,
 ): SF.Changeset {
-	return SF.sequenceFieldEditor.insert(index, count, id ?? brand(0));
+	return SF.sequenceFieldEditor.insert(index, count, id ?? brand(0), tag);
 }
 
 function createRemoveChangeset(
@@ -83,7 +83,7 @@ function createRemoveChangeset(
 	size: number,
 	id?: ChangesetLocalId,
 ): SF.Changeset {
-	return SF.sequenceFieldEditor.remove(startIndex, size, id ?? brand(0));
+	return SF.sequenceFieldEditor.remove(startIndex, size, id ?? brand(0), tag);
 }
 
 function createRedundantRemoveChangeset(
@@ -101,7 +101,7 @@ function createPinChangeset(
 	count: number,
 	detachEvent: SF.CellId,
 ): SF.Changeset {
-	const markList = SF.sequenceFieldEditor.revive(startIndex, count, detachEvent);
+	const markList = SF.sequenceFieldEditor.revive(startIndex, count, detachEvent, tag);
 	const mark = markList[markList.length - 1];
 	delete mark.cellId;
 	return markList;
@@ -112,7 +112,7 @@ function createReviveChangeset(
 	count: number,
 	detachEvent: SF.CellId,
 ): SF.Changeset {
-	return SF.sequenceFieldEditor.revive(startIndex, count, detachEvent);
+	return SF.sequenceFieldEditor.revive(startIndex, count, detachEvent, tag);
 }
 
 function createMoveChangeset(
@@ -121,7 +121,14 @@ function createMoveChangeset(
 	destIndex: number,
 	id: ChangesetLocalId = brand(0),
 ): SF.Changeset {
-	return SF.sequenceFieldEditor.move(sourceIndex, count, destIndex, id, brand(id + count));
+	return SF.sequenceFieldEditor.move(
+		sourceIndex,
+		count,
+		destIndex,
+		id,
+		brand(id + count),
+		tag,
+	);
 }
 
 function createReturnChangeset(
@@ -137,6 +144,7 @@ function createReturnChangeset(
 		destIndex,
 		detachCellId,
 		attachCellId,
+		tag,
 	);
 }
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -78,6 +78,7 @@ import {
 	assertIsSessionId,
 	defaultRevInfosFromChanges,
 	defaultRevisionMetadataFromChanges,
+	mintRevisionTag,
 } from "../../utils.js";
 
 import { ChangesetWrapper } from "../../changesetWrapper.js";
@@ -462,6 +463,7 @@ export function invert(change: TaggedChange<SF.Changeset>, isRollback = true): S
 		// Sequence fields should not generate IDs during invert
 		fakeIdAllocator,
 		table,
+		mintRevisionTag(),
 	);
 
 	if (table.isInvalidated) {
@@ -474,6 +476,7 @@ export function invert(change: TaggedChange<SF.Changeset>, isRollback = true): S
 			// Sequence fields should not generate IDs during invert
 			fakeIdAllocator,
 			table,
+			mintRevisionTag(),
 		);
 	}
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -78,7 +78,6 @@ import {
 	assertIsSessionId,
 	defaultRevInfosFromChanges,
 	defaultRevisionMetadataFromChanges,
-	mintRevisionTag,
 } from "../../utils.js";
 
 import { ChangesetWrapper } from "../../changesetWrapper.js";
@@ -450,11 +449,18 @@ function resetCrossFieldTable(table: CrossFieldTable) {
 	table.dstQueries.clear();
 }
 
-export function invertDeep(change: TaggedChange<WrappedChange>): WrappedChange {
-	return ChangesetWrapper.invert(change, (c) => invert(c));
+export function invertDeep(
+	change: TaggedChange<WrappedChange>,
+	revision: RevisionTag | undefined,
+): WrappedChange {
+	return ChangesetWrapper.invert(change, (c) => invert(c, revision), revision);
 }
 
-export function invert(change: TaggedChange<SF.Changeset>, isRollback = true): SF.Changeset {
+export function invert(
+	change: TaggedChange<SF.Changeset>,
+	revision: RevisionTag | undefined,
+	isRollback = true,
+): SF.Changeset {
 	deepFreeze(change.change);
 	const table = newCrossFieldTable();
 	let inverted = SF.invert(
@@ -463,7 +469,7 @@ export function invert(change: TaggedChange<SF.Changeset>, isRollback = true): S
 		// Sequence fields should not generate IDs during invert
 		fakeIdAllocator,
 		table,
-		mintRevisionTag(),
+		revision,
 	);
 
 	if (table.isInvalidated) {
@@ -476,7 +482,7 @@ export function invert(change: TaggedChange<SF.Changeset>, isRollback = true): S
 			// Sequence fields should not generate IDs during invert
 			fakeIdAllocator,
 			table,
-			mintRevisionTag(),
+			revision,
 		);
 	}
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -468,8 +468,8 @@ export function invert(
 		isRollback,
 		// Sequence fields should not generate IDs during invert
 		fakeIdAllocator,
-		table,
 		revision,
+		table,
 	);
 
 	if (table.isInvalidated) {
@@ -481,8 +481,8 @@ export function invert(
 			isRollback,
 			// Sequence fields should not generate IDs during invert
 			fakeIdAllocator,
-			table,
 			revision,
+			table,
 		);
 	}
 

--- a/packages/dds/tree/src/test/rebaserAxiomaticTests.ts
+++ b/packages/dds/tree/src/test/rebaserAxiomaticTests.ts
@@ -724,7 +724,7 @@ function verifyRebaseRightDistributivity<TChangeset>(
 
 	const editRebasedOverC = rebaseTagged(fieldRebaser.rebase, editA, [editC]);
 	const invertedEdit = tagRollbackInverse(
-		fieldRebaser.invert(editA, true),
+		fieldRebaser.invert(editA, undefined, true),
 		undefined,
 		editA.revision,
 	);
@@ -754,7 +754,7 @@ function verifyRebaseOverUndoRedoPair<TChangeset>(
 	const assertDeepEqual = getDefaultedEqualityAssert(fieldRebaser);
 	const editB = namedEditToRebaseOver.changeset;
 
-	const inverseEditB = fieldRebaser.invert(editB, true);
+	const inverseEditB = fieldRebaser.invert(editB, undefined, true);
 
 	// ((A ↷ B) ↷ B⁻¹) ↷ B
 	const actualChange = tagChange(
@@ -788,7 +788,7 @@ function verifyRebaseOverDoUndoPairIsNoOp<TChangeset>(
 	const assertDeepEqual = getDefaultedEqualityAssert(fieldRebaser);
 	const editB = namedEditToRebaseOver.changeset;
 
-	const invertedEditB = fieldRebaser.invert(editB, true);
+	const invertedEditB = fieldRebaser.invert(editB, undefined, true);
 	// (A ↷ B) ↷ B⁻¹
 	const actualChange = tagChange(
 		fieldRebaser.rebase(
@@ -852,7 +852,7 @@ function invert<TChangeset>(
 ): TaggedChange<TChangeset> {
 	const revision = `rollback-${change.revision}` as unknown as RevisionTag;
 	return tagRollbackInverse(
-		fieldRebaser.inlineRevision(fieldRebaser.invert(change, true), revision),
+		fieldRebaser.inlineRevision(fieldRebaser.invert(change, undefined, true), revision),
 		revision,
 		change.revision,
 	);

--- a/packages/dds/tree/src/test/rebaserAxiomaticTests.ts
+++ b/packages/dds/tree/src/test/rebaserAxiomaticTests.ts
@@ -179,7 +179,7 @@ export function runExhaustiveComposeRebaseSuite<TContent, TChangeset>(
 							const editToRebaseOver = namedEditToRebaseOver;
 							const sourceEdits = namedSourceEdits.map(({ changeset }) => changeset);
 
-							const rollbacks = sourceEdits.map((change) => invert(fieldRebaser, change));
+							const rollbacks = sourceEdits.map((change) => rollback(fieldRebaser, change));
 							rollbacks.reverse();
 
 							const rebasedEditsWithoutCompose = sandwichRebaseWithoutCompose(
@@ -644,7 +644,7 @@ function verifyComposeWithInverseEqualsEmpty<TChangeset>(
 	const metadata = defaultRevisionMetadataFromChanges([edit]);
 
 	const change = tagChange(edit.change, edit.revision);
-	const changeset = fieldRebaser.compose(change, invert(fieldRebaser, change), metadata);
+	const changeset = fieldRebaser.compose(change, rollback(fieldRebaser, change), metadata);
 	assert(fieldRebaser.isEmpty !== undefined);
 	fieldRebaser.isEmpty(changeset);
 }
@@ -723,11 +723,8 @@ function verifyRebaseRightDistributivity<TChangeset>(
 	);
 
 	const editRebasedOverC = rebaseTagged(fieldRebaser.rebase, editA, [editC]);
-	const invertedEdit = tagRollbackInverse(
-		fieldRebaser.invert(editA, undefined, true),
-		undefined,
-		editA.revision,
-	);
+	const invertedEdit = rollback(fieldRebaser, editA);
+
 	// (A ↷ C) ○ (B ↷ (A⁻¹ ○ C ○ (A ↷ C)))
 	const expectedChange = makeAnonChange(
 		fieldRebaser.compose(
@@ -754,7 +751,7 @@ function verifyRebaseOverUndoRedoPair<TChangeset>(
 	const assertDeepEqual = getDefaultedEqualityAssert(fieldRebaser);
 	const editB = namedEditToRebaseOver.changeset;
 
-	const inverseEditB = fieldRebaser.invert(editB, undefined, true);
+	const inverseEditB = rollback(fieldRebaser, editB);
 
 	// ((A ↷ B) ↷ B⁻¹) ↷ B
 	const actualChange = tagChange(
@@ -763,11 +760,7 @@ function verifyRebaseOverUndoRedoPair<TChangeset>(
 				edit,
 				fieldRebaser.rebase(
 					mapTaggedChange(edit, fieldRebaser.rebase(edit, editB)),
-					tagRollbackInverse(
-						inverseEditB,
-						`rollback-${editB.revision}` as unknown as RevisionTag,
-						editB.revision,
-					),
+					inverseEditB,
 				),
 			),
 			editB,
@@ -788,12 +781,12 @@ function verifyRebaseOverDoUndoPairIsNoOp<TChangeset>(
 	const assertDeepEqual = getDefaultedEqualityAssert(fieldRebaser);
 	const editB = namedEditToRebaseOver.changeset;
 
-	const invertedEditB = fieldRebaser.invert(editB, undefined, true);
+	const invertedEditB = rollback(fieldRebaser, editB);
 	// (A ↷ B) ↷ B⁻¹
 	const actualChange = tagChange(
 		fieldRebaser.rebase(
 			mapTaggedChange(edit, fieldRebaser.rebase(edit, editB)),
-			tagChange(invertedEditB, editB.revision),
+			invertedEditB,
 		),
 		edit.revision,
 	);
@@ -846,13 +839,13 @@ function composeArray<TChangeset>(
 	return composed;
 }
 
-function invert<TChangeset>(
+function rollback<TChangeset>(
 	fieldRebaser: BoundFieldChangeRebaser<TChangeset>,
 	change: TaggedChange<TChangeset>,
 ): TaggedChange<TChangeset> {
 	const revision = `rollback-${change.revision}` as unknown as RevisionTag;
 	return tagRollbackInverse(
-		fieldRebaser.inlineRevision(fieldRebaser.invert(change, undefined, true), revision),
+		fieldRebaser.inlineRevision(fieldRebaser.invert(change, revision, true), revision),
 		revision,
 		change.revision,
 	);

--- a/packages/dds/tree/src/test/shared-tree-core/defaultResubmitMachine.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/defaultResubmitMachine.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import type { GraphCommit, RevisionTag, TaggedChange } from "../../core/index.js";
-import { mintRevisionTag, testIdCompressor } from "../utils.js";
+import { testIdCompressor } from "../utils.js";
 import {
 	type ChangeEnricherMutableCheckout,
 	DefaultResubmitMachine,
@@ -81,11 +81,10 @@ export class MockChangeEnricher
 	}
 }
 
-export function inverter(
-	{ revision, change }: TaggedChange<MockEnrichableChange>,
-	isRollback: boolean,
-): MockEnrichableChange {
-	assert.equal(isRollback, true);
+export function inverter({
+	revision,
+	change,
+}: TaggedChange<MockEnrichableChange>): MockEnrichableChange {
 	assert.equal(revision, change.outputContext);
 	return {
 		inputContext: change.outputContext,
@@ -141,7 +140,7 @@ describe("DefaultResubmitMachine", () => {
 
 			MockChangeEnricher.resetCounters();
 			assert.equal(machine.isInResubmitPhase, false);
-			machine.prepareForResubmit([commit2], mintRevisionTag());
+			machine.prepareForResubmit([commit2]);
 			assert.equal(machine.isInResubmitPhase, true);
 			machine.onCommitSubmitted(commit2);
 			assert.equal(machine.isInResubmitPhase, false);
@@ -170,7 +169,7 @@ describe("DefaultResubmitMachine", () => {
 
 			MockChangeEnricher.resetCounters();
 			assert.equal(machine.isInResubmitPhase, false);
-			machine.prepareForResubmit([rebased2], mintRevisionTag());
+			machine.prepareForResubmit([rebased2]);
 			assert.equal(machine.isInResubmitPhase, true);
 			const enriched2Resubmit = machine.peekNextCommit();
 			machine.onCommitSubmitted(enriched2Resubmit);
@@ -198,7 +197,7 @@ describe("DefaultResubmitMachine", () => {
 
 			MockChangeEnricher.resetCounters();
 			assert.equal(machine.isInResubmitPhase, false);
-			machine.prepareForResubmit([], mintRevisionTag());
+			machine.prepareForResubmit([]);
 			assert.equal(machine.isInResubmitPhase, false);
 			// No new enrichment should be necessary
 			assert.equal(MockChangeEnricher.checkoutsCreated, 0);
@@ -219,7 +218,7 @@ describe("DefaultResubmitMachine", () => {
 
 			MockChangeEnricher.resetCounters();
 			assert.equal(machine.isInResubmitPhase, false);
-			machine.prepareForResubmit([commit1, commit2], mintRevisionTag());
+			machine.prepareForResubmit([commit1, commit2]);
 			assert.equal(machine.isInResubmitPhase, true);
 			const enriched1Resubmit = machine.onCommitSubmitted(commit1);
 			assert.equal(machine.isInResubmitPhase, true);
@@ -233,7 +232,7 @@ describe("DefaultResubmitMachine", () => {
 			assert.equal(MockChangeEnricher.commitsApplied, 0);
 
 			// Verify that the enricher can resubmit those commits again
-			machine.prepareForResubmit([commit1, commit2], mintRevisionTag());
+			machine.prepareForResubmit([commit1, commit2]);
 			assert.equal(machine.isInResubmitPhase, true);
 			assert.equal(machine.onCommitSubmitted(commit1), enriched1Resubmit);
 			assert.equal(machine.isInResubmitPhase, true);
@@ -272,7 +271,7 @@ describe("DefaultResubmitMachine", () => {
 				};
 				MockChangeEnricher.resetCounters();
 				assert.equal(machine.isInResubmitPhase, false);
-				machine.prepareForResubmit([rebased1, rebased2], mintRevisionTag());
+				machine.prepareForResubmit([rebased1, rebased2]);
 				assert.equal(machine.isInResubmitPhase, true);
 				const enriched1Resubmit = machine.peekNextCommit();
 				machine.onCommitSubmitted(enriched1Resubmit);
@@ -305,7 +304,7 @@ describe("DefaultResubmitMachine", () => {
 				assert.equal(MockChangeEnricher.commitsApplied, 3);
 
 				// Verify that the enricher can resubmit those commits again
-				machine.prepareForResubmit([rebased1, rebased2], mintRevisionTag());
+				machine.prepareForResubmit([rebased1, rebased2]);
 				assert.equal(machine.isInResubmitPhase, true);
 				assert.equal(machine.peekNextCommit(), enriched1Resubmit);
 				machine.onCommitSubmitted(enriched1Resubmit);
@@ -344,7 +343,7 @@ describe("DefaultResubmitMachine", () => {
 
 			MockChangeEnricher.resetCounters();
 			assert.equal(machine.isInResubmitPhase, false);
-			machine.prepareForResubmit([rebased1, rebased2, commit3], mintRevisionTag());
+			machine.prepareForResubmit([rebased1, rebased2, commit3]);
 			assert.equal(machine.isInResubmitPhase, true);
 			const enriched1Resubmit = machine.peekNextCommit();
 			machine.onCommitSubmitted(enriched1Resubmit);
@@ -383,7 +382,7 @@ describe("DefaultResubmitMachine", () => {
 			assert.equal(MockChangeEnricher.commitsApplied, 4);
 
 			// Verify that the enricher can resubmit those commits again
-			machine.prepareForResubmit([rebased1, rebased2, commit3], mintRevisionTag());
+			machine.prepareForResubmit([rebased1, rebased2, commit3]);
 			assert.equal(machine.isInResubmitPhase, true);
 			assert.equal(machine.peekNextCommit(), enriched1Resubmit);
 			machine.onCommitSubmitted(enriched1Resubmit);

--- a/packages/dds/tree/src/test/shared-tree-core/defaultResubmitMachine.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/defaultResubmitMachine.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import type { GraphCommit, RevisionTag, TaggedChange } from "../../core/index.js";
-import { testIdCompressor } from "../utils.js";
+import { mintRevisionTag, testIdCompressor } from "../utils.js";
 import {
 	type ChangeEnricherMutableCheckout,
 	DefaultResubmitMachine,
@@ -141,7 +141,7 @@ describe("DefaultResubmitMachine", () => {
 
 			MockChangeEnricher.resetCounters();
 			assert.equal(machine.isInResubmitPhase, false);
-			machine.prepareForResubmit([commit2]);
+			machine.prepareForResubmit([commit2], mintRevisionTag());
 			assert.equal(machine.isInResubmitPhase, true);
 			machine.onCommitSubmitted(commit2);
 			assert.equal(machine.isInResubmitPhase, false);
@@ -170,7 +170,7 @@ describe("DefaultResubmitMachine", () => {
 
 			MockChangeEnricher.resetCounters();
 			assert.equal(machine.isInResubmitPhase, false);
-			machine.prepareForResubmit([rebased2]);
+			machine.prepareForResubmit([rebased2], mintRevisionTag());
 			assert.equal(machine.isInResubmitPhase, true);
 			const enriched2Resubmit = machine.peekNextCommit();
 			machine.onCommitSubmitted(enriched2Resubmit);
@@ -198,7 +198,7 @@ describe("DefaultResubmitMachine", () => {
 
 			MockChangeEnricher.resetCounters();
 			assert.equal(machine.isInResubmitPhase, false);
-			machine.prepareForResubmit([]);
+			machine.prepareForResubmit([], mintRevisionTag());
 			assert.equal(machine.isInResubmitPhase, false);
 			// No new enrichment should be necessary
 			assert.equal(MockChangeEnricher.checkoutsCreated, 0);
@@ -219,7 +219,7 @@ describe("DefaultResubmitMachine", () => {
 
 			MockChangeEnricher.resetCounters();
 			assert.equal(machine.isInResubmitPhase, false);
-			machine.prepareForResubmit([commit1, commit2]);
+			machine.prepareForResubmit([commit1, commit2], mintRevisionTag());
 			assert.equal(machine.isInResubmitPhase, true);
 			const enriched1Resubmit = machine.onCommitSubmitted(commit1);
 			assert.equal(machine.isInResubmitPhase, true);
@@ -233,7 +233,7 @@ describe("DefaultResubmitMachine", () => {
 			assert.equal(MockChangeEnricher.commitsApplied, 0);
 
 			// Verify that the enricher can resubmit those commits again
-			machine.prepareForResubmit([commit1, commit2]);
+			machine.prepareForResubmit([commit1, commit2], mintRevisionTag());
 			assert.equal(machine.isInResubmitPhase, true);
 			assert.equal(machine.onCommitSubmitted(commit1), enriched1Resubmit);
 			assert.equal(machine.isInResubmitPhase, true);
@@ -272,7 +272,7 @@ describe("DefaultResubmitMachine", () => {
 				};
 				MockChangeEnricher.resetCounters();
 				assert.equal(machine.isInResubmitPhase, false);
-				machine.prepareForResubmit([rebased1, rebased2]);
+				machine.prepareForResubmit([rebased1, rebased2], mintRevisionTag());
 				assert.equal(machine.isInResubmitPhase, true);
 				const enriched1Resubmit = machine.peekNextCommit();
 				machine.onCommitSubmitted(enriched1Resubmit);
@@ -305,7 +305,7 @@ describe("DefaultResubmitMachine", () => {
 				assert.equal(MockChangeEnricher.commitsApplied, 3);
 
 				// Verify that the enricher can resubmit those commits again
-				machine.prepareForResubmit([rebased1, rebased2]);
+				machine.prepareForResubmit([rebased1, rebased2], mintRevisionTag());
 				assert.equal(machine.isInResubmitPhase, true);
 				assert.equal(machine.peekNextCommit(), enriched1Resubmit);
 				machine.onCommitSubmitted(enriched1Resubmit);
@@ -344,7 +344,7 @@ describe("DefaultResubmitMachine", () => {
 
 			MockChangeEnricher.resetCounters();
 			assert.equal(machine.isInResubmitPhase, false);
-			machine.prepareForResubmit([rebased1, rebased2, commit3]);
+			machine.prepareForResubmit([rebased1, rebased2, commit3], mintRevisionTag());
 			assert.equal(machine.isInResubmitPhase, true);
 			const enriched1Resubmit = machine.peekNextCommit();
 			machine.onCommitSubmitted(enriched1Resubmit);
@@ -383,7 +383,7 @@ describe("DefaultResubmitMachine", () => {
 			assert.equal(MockChangeEnricher.commitsApplied, 4);
 
 			// Verify that the enricher can resubmit those commits again
-			machine.prepareForResubmit([rebased1, rebased2, commit3]);
+			machine.prepareForResubmit([rebased1, rebased2, commit3], mintRevisionTag());
 			assert.equal(machine.isInResubmitPhase, true);
 			assert.equal(machine.peekNextCommit(), enriched1Resubmit);
 			machine.onCommitSubmitted(enriched1Resubmit);

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
@@ -276,10 +276,7 @@ describe("EditManager - Bench", () => {
 							const sequencedEdits: Commit<TestChange>[] = [];
 							for (let iChange = 0; iChange < count; iChange++) {
 								const revision = mintRevisionTag();
-								manager.localBranch.apply(
-									{ change: TestChange.emptyChange, revision },
-									revision,
-								);
+								manager.localBranch.apply({ change: TestChange.emptyChange, revision });
 								sequencedEdits.push({
 									change: TestChange.emptyChange,
 									revision,

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
@@ -276,7 +276,10 @@ describe("EditManager - Bench", () => {
 							const sequencedEdits: Commit<TestChange>[] = [];
 							for (let iChange = 0; iChange < count; iChange++) {
 								const revision = mintRevisionTag();
-								manager.localBranch.apply(TestChange.emptyChange, revision);
+								manager.localBranch.apply(
+									{ change: TestChange.emptyChange, revision },
+									revision,
+								);
 								sequencedEdits.push({
 									change: TestChange.emptyChange,
 									revision,

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
@@ -568,9 +568,20 @@ export function testCorrectness() {
 						rebaser: new NoOpChangeRebaser(),
 					});
 					const sequencedLocalChange = mintRevisionTag();
-					manager.localBranch.apply(TestChange.emptyChange, sequencedLocalChange);
-					manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
-					manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
+					manager.localBranch.apply(
+						{ change: TestChange.emptyChange, revision: sequencedLocalChange },
+						sequencedLocalChange,
+					);
+					const revision1 = mintRevisionTag();
+					manager.localBranch.apply(
+						{ change: TestChange.emptyChange, revision: revision1 },
+						revision1,
+					);
+					const revision2 = mintRevisionTag();
+					manager.localBranch.apply(
+						{ change: TestChange.emptyChange, revision: revision2 },
+						revision2,
+					);
 					manager.addSequencedChange(
 						{
 							change: TestChange.emptyChange,
@@ -596,8 +607,15 @@ export function testCorrectness() {
 						rebaser: new NoOpChangeRebaser(),
 					});
 					const sequencedLocalChange = mintRevisionTag();
-					manager.localBranch.apply(TestChange.emptyChange, sequencedLocalChange);
-					manager.localBranch.apply(TestChange.emptyChange, mintRevisionTag());
+					manager.localBranch.apply(
+						{ change: TestChange.emptyChange, revision: sequencedLocalChange },
+						sequencedLocalChange,
+					);
+					const revision1 = mintRevisionTag();
+					manager.localBranch.apply(
+						{ change: TestChange.emptyChange, revision: revision1 },
+						revision1,
+					);
 					manager.addSequencedChange(
 						{
 							change: TestChange.emptyChange,
@@ -683,9 +701,10 @@ function applyLocalCommit(
 	inputContext: readonly number[] = [],
 	intention: number | number[] = [],
 ): Commit<TestChange> {
+	const revision = mintRevisionTag();
 	const [_, commit] = manager.localBranch.apply(
-		TestChange.mint(inputContext, intention),
-		mintRevisionTag(),
+		{ change: TestChange.mint(inputContext, intention), revision },
+		revision,
 	);
 	return {
 		change: commit.change,

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
@@ -568,20 +568,14 @@ export function testCorrectness() {
 						rebaser: new NoOpChangeRebaser(),
 					});
 					const sequencedLocalChange = mintRevisionTag();
-					manager.localBranch.apply(
-						{ change: TestChange.emptyChange, revision: sequencedLocalChange },
-						sequencedLocalChange,
-					);
+					manager.localBranch.apply({
+						change: TestChange.emptyChange,
+						revision: sequencedLocalChange,
+					});
 					const revision1 = mintRevisionTag();
-					manager.localBranch.apply(
-						{ change: TestChange.emptyChange, revision: revision1 },
-						revision1,
-					);
+					manager.localBranch.apply({ change: TestChange.emptyChange, revision: revision1 });
 					const revision2 = mintRevisionTag();
-					manager.localBranch.apply(
-						{ change: TestChange.emptyChange, revision: revision2 },
-						revision2,
-					);
+					manager.localBranch.apply({ change: TestChange.emptyChange, revision: revision2 });
 					manager.addSequencedChange(
 						{
 							change: TestChange.emptyChange,
@@ -607,15 +601,12 @@ export function testCorrectness() {
 						rebaser: new NoOpChangeRebaser(),
 					});
 					const sequencedLocalChange = mintRevisionTag();
-					manager.localBranch.apply(
-						{ change: TestChange.emptyChange, revision: sequencedLocalChange },
-						sequencedLocalChange,
-					);
+					manager.localBranch.apply({
+						change: TestChange.emptyChange,
+						revision: sequencedLocalChange,
+					});
 					const revision1 = mintRevisionTag();
-					manager.localBranch.apply(
-						{ change: TestChange.emptyChange, revision: revision1 },
-						revision1,
-					);
+					manager.localBranch.apply({ change: TestChange.emptyChange, revision: revision1 });
 					manager.addSequencedChange(
 						{
 							change: TestChange.emptyChange,
@@ -702,10 +693,10 @@ function applyLocalCommit(
 	intention: number | number[] = [],
 ): Commit<TestChange> {
 	const revision = mintRevisionTag();
-	const [_, commit] = manager.localBranch.apply(
-		{ change: TestChange.mint(inputContext, intention), revision },
+	const [_, commit] = manager.localBranch.apply({
+		change: TestChange.mint(inputContext, intention),
 		revision,
-	);
+	});
 	return {
 		change: commit.change,
 		revision: commit.revision,

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
@@ -269,7 +269,7 @@ export function runUnitTestScenario(
 					localCommits.push(commit);
 					knownToLocal.push(seq);
 					// Local changes should always lead to a delta that is equivalent to the local change.
-					manager.localBranch.apply(changeset, revision);
+					manager.localBranch.apply({ change: changeset, revision }, revision);
 					assert.deepEqual(
 						asDelta(manager.localBranch.getHead().change.intentions),
 						asDelta([seq]),

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
@@ -269,7 +269,7 @@ export function runUnitTestScenario(
 					localCommits.push(commit);
 					knownToLocal.push(seq);
 					// Local changes should always lead to a delta that is equivalent to the local change.
-					manager.localBranch.apply({ change: changeset, revision }, revision);
+					manager.localBranch.apply({ change: changeset, revision });
 					assert.deepEqual(
 						asDelta(manager.localBranch.getHead().change.intentions),
 						asDelta([seq]),

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
@@ -124,7 +124,7 @@ export function rebaseLocalEditsOverTrunkEdits<TChange>(
 	manager.localBranch.on("afterChange", ({ change }) => {});
 	for (let iChange = 0; iChange < localEditCount; iChange++) {
 		const revision = mintRevisionTag();
-		manager.localBranch.apply({ change: mintChange(undefined), revision }, revision);
+		manager.localBranch.apply({ change: mintChange(undefined), revision });
 	}
 	const trunkEdits = makeArray(trunkEditCount, () => {
 		const revision = mintRevisionTag();

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
@@ -123,7 +123,8 @@ export function rebaseLocalEditsOverTrunkEdits<TChange>(
 	// Subscribe to the local branch to emulate the behavior of SharedTree
 	manager.localBranch.on("afterChange", ({ change }) => {});
 	for (let iChange = 0; iChange < localEditCount; iChange++) {
-		manager.localBranch.apply(mintChange(undefined), mintRevisionTag());
+		const revision = mintRevisionTag();
+		manager.localBranch.apply({ change: mintChange(undefined), revision }, revision);
 	}
 	const trunkEdits = makeArray(trunkEditCount, () => {
 		const revision = mintRevisionTag();

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -37,10 +37,6 @@ import {
 import { insert, makeTreeFromJsonSequence, remove } from "../sequenceRootUtils.js";
 import { SchemaFactory, stringSchema, toStoredSchema } from "../../simple-tree/index.js";
 import { JsonUnion, singleJsonCursor } from "../json/index.js";
-import { merge } from "../objMerge.js";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(globalThis as any).merge = merge;
 
 const rootField: FieldUpPath = {
 	parent: undefined,

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -37,6 +37,10 @@ import {
 import { insert, makeTreeFromJsonSequence, remove } from "../sequenceRootUtils.js";
 import { SchemaFactory, stringSchema, toStoredSchema } from "../../simple-tree/index.js";
 import { JsonUnion, singleJsonCursor } from "../json/index.js";
+import { merge } from "../objMerge.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).merge = merge;
 
 const rootField: FieldUpPath = {
 	parent: undefined,

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -3310,7 +3310,7 @@ describe("Editing", () => {
 		});
 	});
 
-	it("invert a composite change that include a mix of nested changes in a field that requires an amend pass", () => {
+	it.only("invert a composite change that include a mix of nested changes in a field that requires an amend pass", () => {
 		const tree = makeTreeFromJson({});
 
 		tree.transaction.start();

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -3310,7 +3310,7 @@ describe("Editing", () => {
 		});
 	});
 
-	it.only("invert a composite change that include a mix of nested changes in a field that requires an amend pass", () => {
+	it("invert a composite change that include a mix of nested changes in a field that requires an amend pass", () => {
 		const tree = makeTreeFromJson({});
 
 		tree.transaction.start();

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
@@ -47,6 +47,7 @@ import { Change } from "../feature-libraries/optional-field/optionalFieldUtils.j
 import {
 	failCodecFamily,
 	jsonTreeFromForest,
+	mintRevisionTag,
 	testIdCompressor,
 	testRevisionTagCodec,
 } from "../utils.js";
@@ -56,12 +57,13 @@ const content: JsonCompatible = { x: 42 };
 const modularFamily = new ModularChangeFamily(fieldKinds, failCodecFamily);
 
 const dataChanges: ModularChangeset[] = [];
-const defaultEditor = new DefaultEditBuilder(modularFamily, (change) =>
+const defaultEditor = new DefaultEditBuilder(modularFamily, mintRevisionTag, (change) =>
 	dataChanges.push(change),
 );
 const modularBuilder = new ModularEditBuilder(
 	modularFamily,
 	modularFamily.fieldKinds,
+	mintRevisionTag,
 	() => {},
 );
 
@@ -141,6 +143,7 @@ describe("SharedTreeChangeEnricher", () => {
 							field: { parent: undefined, field: rootFieldKey },
 							fieldKind: optional.identifier,
 							change: brand(restore),
+							revision: mintRevisionTag(),
 						},
 					]),
 				},

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
@@ -128,11 +128,11 @@ describe("SharedTreeChangeEnricher", () => {
 		const { fork } = setupEnricher();
 		fork.applyTipChange(removeRoot, revision1);
 
+		const tag = 0 as RevisionTag;
 		const restore = Change.atOnce(
-			Change.reserve("self", brand(0)),
-			Change.move({ localId: brand(0) }, "self"),
+			Change.reserve("self", { localId: brand(0), revision: tag }),
+			Change.move({ localId: brand(0), revision: tag }, "self"),
 		);
-		const tag = mintRevisionTag();
 		const restoreRoot: SharedTreeChange = {
 			changes: [
 				{
@@ -164,7 +164,7 @@ describe("SharedTreeChangeEnricher", () => {
 				.toArray()
 				.map(([[revision, id], value]) => [revision, id, value]);
 
-		assert.equal(refreshers[0][0], undefined);
+		assert.equal(refreshers[0][0], 0);
 		assert.equal(refreshers[0][1], 0);
 		const refreshedTree = mapCursorField(refreshers[0][2].cursor(), cursorToJsonObject);
 		assert.deepEqual(refreshedTree, [content]);

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
@@ -132,6 +132,7 @@ describe("SharedTreeChangeEnricher", () => {
 			Change.reserve("self", brand(0)),
 			Change.move({ localId: brand(0) }, "self"),
 		);
+		const tag = mintRevisionTag();
 		const restoreRoot: SharedTreeChange = {
 			changes: [
 				{
@@ -142,7 +143,7 @@ describe("SharedTreeChangeEnricher", () => {
 							field: { parent: undefined, field: rootFieldKey },
 							fieldKind: optional.identifier,
 							change: brand(restore),
-							revision: mintRevisionTag(),
+							revision: tag,
 						},
 					]),
 				},

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
@@ -57,8 +57,8 @@ const content: JsonCompatible = { x: 42 };
 const modularFamily = new ModularChangeFamily(fieldKinds, failCodecFamily);
 
 const dataChanges: ModularChangeset[] = [];
-const defaultEditor = new DefaultEditBuilder(modularFamily, mintRevisionTag, (change) =>
-	dataChanges.push(change),
+const defaultEditor = new DefaultEditBuilder(modularFamily, mintRevisionTag, (taggedChange) =>
+	dataChanges.push(taggedChange.change),
 );
 const modularBuilder = new ModularEditBuilder(
 	modularFamily,

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
@@ -63,7 +63,6 @@ const defaultEditor = new DefaultEditBuilder(modularFamily, mintRevisionTag, (ta
 const modularBuilder = new ModularEditBuilder(
 	modularFamily,
 	modularFamily.fieldKinds,
-	mintRevisionTag,
 	() => {},
 );
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
@@ -35,7 +35,7 @@ import type {
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../shared-tree/sharedTreeChangeTypes.js";
 import { ajvValidator } from "../codec/index.js";
-import { failCodecFamily, testRevisionTagCodec } from "../utils.js";
+import { failCodecFamily, mintRevisionTag, testRevisionTagCodec } from "../utils.js";
 import { singleJsonCursor } from "../json/index.js";
 
 const dataChanges: ModularChangeset[] = [];
@@ -46,7 +46,7 @@ const fieldBatchCodec = {
 };
 
 const modularFamily = new ModularChangeFamily(fieldKinds, failCodecFamily);
-const defaultEditor = new DefaultEditBuilder(modularFamily, (change) =>
+const defaultEditor = new DefaultEditBuilder(modularFamily, mintRevisionTag, (change) =>
 	dataChanges.push(change),
 );
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
@@ -46,8 +46,8 @@ const fieldBatchCodec = {
 };
 
 const modularFamily = new ModularChangeFamily(fieldKinds, failCodecFamily);
-const defaultEditor = new DefaultEditBuilder(modularFamily, mintRevisionTag, (change) =>
-	dataChanges.push(change),
+const defaultEditor = new DefaultEditBuilder(modularFamily, mintRevisionTag, (taggedChange) =>
+	dataChanges.push(taggedChange.change),
 );
 
 // Side effects results in `dataChanges` being populated

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
@@ -225,14 +225,25 @@ describe("SharedTreeChangeFamily", () => {
 
 		for (const isRollback of [true, false]) {
 			it(`when inverting (isRollback = ${isRollback})`, () => {
-				assert.deepEqual(sharedTreeFamily.invert(makeAnonChange(stDataChange1), isRollback), {
-					changes: [
-						{
-							type: "data",
-							innerChange: modularFamily.invert(makeAnonChange(dataChange1), isRollback),
-						},
-					],
-				});
+				assert.deepEqual(
+					sharedTreeFamily.invert(
+						makeAnonChange(stDataChange1),
+						isRollback,
+						mintRevisionTag(),
+					),
+					{
+						changes: [
+							{
+								type: "data",
+								innerChange: modularFamily.invert(
+									makeAnonChange(dataChange1),
+									isRollback,
+									mintRevisionTag(),
+								),
+							},
+						],
+					},
+				);
 			});
 		}
 	});

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
@@ -225,12 +225,9 @@ describe("SharedTreeChangeFamily", () => {
 
 		for (const isRollback of [true, false]) {
 			it(`when inverting (isRollback = ${isRollback})`, () => {
+				const tag = mintRevisionTag();
 				assert.deepEqual(
-					sharedTreeFamily.invert(
-						makeAnonChange(stDataChange1),
-						isRollback,
-						mintRevisionTag(),
-					),
+					sharedTreeFamily.invert(makeAnonChange(stDataChange1), isRollback, tag),
 					{
 						changes: [
 							{
@@ -238,7 +235,7 @@ describe("SharedTreeChangeFamily", () => {
 								innerChange: modularFamily.invert(
 									makeAnonChange(dataChange1),
 									isRollback,
-									mintRevisionTag(),
+									tag,
 								),
 							},
 						],

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -953,7 +953,8 @@ export function testChangeReceiver<TChange>(
 	getChanges: () => readonly TChange[],
 ] {
 	const changes: TChange[] = [];
-	const changeReceiver = (change: TChange): number => changes.push(change);
+	const changeReceiver = (taggedChange: TaggedChange<TChange>): number =>
+		changes.push(taggedChange.change);
 	return [changeReceiver, () => [...changes]];
 }
 

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -949,7 +949,7 @@ export function makeEncodingTestSuite<TDecoded, TEncoded, TContext>(
 export function testChangeReceiver<TChange>(
 	_changeFamily?: ChangeFamily<ChangeFamilyEditor, TChange>,
 ): [
-	changeReceiver: Parameters<ChangeFamily<ChangeFamilyEditor, TChange>["buildEditor"]>[0],
+	changeReceiver: Parameters<ChangeFamily<ChangeFamilyEditor, TChange>["buildEditor"]>[1],
 	getChanges: () => readonly TChange[],
 ] {
 	const changes: TChange[] = [];


### PR DESCRIPTION
## Description
When the default edit builder generates a change, it does not have a revision tag associated with it. The revision tag is added later by calling `ChangeRebaser.changeRevision`.  This PR updates these changes to have revision tag associated with it.
It also updates the `invert` function to generate changes with revision tags.

[AB#13508](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/13508)