### PR TITLE
Add diagnostics to ConsensusQueue in handle validation tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
@@ -379,19 +379,20 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 					async readHandle(): Promise<unknown> {
 						const value = await timeoutAwait(
 							new Promise((resolve, reject) => {
-								const wasNonempty = queue
+								queue
 									.acquire(async (result: FluidObject) => {
 										resolve(result);
 										return ConsensusResult.Release;
 									})
+									.then((wasNonempty) => {
+										if (!wasNonempty) {
+											// This could happen if a test never calls `storeHandle` before attempting to read it.
+											// Other modes of failure are possible (e.g. correctness issues in ConsensusQueue causing it to have the wrong data).
+											// Resolving the promise with `undefined` here could be another reasonable option, but this gives slightly more information.
+											reject(new Error("No values found in consensus queue."));
+										}
+									})
 									.catch((error) => reject(error));
-
-								if (!wasNonempty) {
-									// This could happen if a test never calls `storeHandle` before attempting to read it.
-									// Other modes of failure are possible (e.g. correctness issues in ConsensusQueue causing it to have the wrong data).
-									// Resolving the promise with `undefined` here could be another reasonable option, but this gives slightly more information.
-									reject("No values found in consensus queue.");
-								}
 							}),
 							{ errorMsg: "Timeout waiting for acquiring value from consensus queue." },
 						);

--- a/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
@@ -39,6 +39,7 @@ import {
 	createAndAttachContainer,
 	ITestFluidObject,
 	type ITestObjectProvider,
+	timeoutAwait,
 } from "@fluidframework/test-utils/internal";
 import {
 	ITree,
@@ -376,14 +377,24 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 						await queue.add(handle);
 					},
 					async readHandle(): Promise<unknown> {
-						const value = await new Promise((resolve, reject) => {
-							queue
-								.acquire(async (result: FluidObject) => {
-									resolve(result);
-									return ConsensusResult.Release;
-								})
-								.catch((error) => reject(error));
-						});
+						const value = await timeoutAwait(
+							new Promise((resolve, reject) => {
+								const wasNonempty = queue
+									.acquire(async (result: FluidObject) => {
+										resolve(result);
+										return ConsensusResult.Release;
+									})
+									.catch((error) => reject(error));
+
+								if (!wasNonempty) {
+									// This could happen if a test never calls `storeHandle` before attempting to read it.
+									// Other modes of failure are possible (e.g. correctness issues in ConsensusQueue causing it to have the wrong data).
+									// Resolving the promise with `undefined` here could be another reasonable option, but this gives slightly more information.
+									reject("No values found in consensus queue.");
+								}
+							}),
+							{ errorMsg: "Timeout waiting for acquiring value from consensus queue." },
+						);
 						return value;
 					},
 					handle: queue.handle,


### PR DESCRIPTION
## Description

Modifies `ConsensusQueue`'s generic "store a piece of data" implementation in `handleValidation.ts` to give more information on a couple theoretical error methods. This test timed out on a recent tinylicious run where based on telemetry, it seems like the test got past the point of loading the 2nd container. Thus it was likely a deadlock awaiting this promise. I've been unable to reproduce this behavior locally. The goal here is to get information about the failure mode the next time this race condition happens.
