### PR TITLE
fix: Have alfred redirect requests to nexus when appropriate in local docker environment

### DIFF
--- a/server/routerlicious/nginx.conf
+++ b/server/routerlicious/nginx.conf
@@ -38,6 +38,13 @@ http {
     server {
         listen 3003;
 
+        location /socket.io {
+            proxy_pass http://docker-nexus;
+            proxy_redirect off;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
         location / {
             proxy_pass http://docker-alfred;
             proxy_redirect off;


### PR DESCRIPTION
## Description

This PR makes it so alfred redirects requests whose path starts with `/socket.io` to nexus for handling instead of trying to handle them itself, specifically in the case of a local routerlicious environment running in docker.

### Context

While trying to run our e2e tests against a local routerlicious environment running in docker I noticed that some compat tests with older versions (1.x) were failing consistently, and looking at the server logs I realized that requests for the delta stream were being received by alfred, who doesn't handle them anymore since https://github.com/microsoft/FluidFramework/pull/19227. That PR updated the kubernetes manifests so requests to alfred's URL where the path starts with `/socket.io` are actually routed to nexus now. I believe that was necessary because older versions of the driver would not understand new settings for the deltaStreamUrl. That makes things work for an AKS deployment, but we missed doing the same thing for the local docker environment, which this PR fixes.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I confirmed that the e2e tests that use older driver versions and were failing before this change, all pass after, and no others started failing. 