### PR TITLE
refactor(server): Remove deprecated version property from docker-compose files

### DIFF
--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     platform: linux/arm64/v8

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   alfred:
     image: ${REGISTRY_URL:-mcr.microsoft.com}/fluidframework/routerlicious/server:${ALFRED_IMAGE_TAG:-latest}

--- a/server/gitrest/docker-compose.dev.yml
+++ b/server/gitrest/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   gitrest:
     volumes:

--- a/server/gitrest/docker-compose.yml
+++ b/server/gitrest/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   gitrest:
     build:

--- a/server/routerlicious/docker-compose.debug.yml
+++ b/server/routerlicious/docker-compose.debug.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   alfred:
     ports:

--- a/server/routerlicious/docker-compose.dev.yml
+++ b/server/routerlicious/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   alfred:
     volumes:

--- a/server/routerlicious/docker-compose.yml
+++ b/server/routerlicious/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   proxy:
     image: nginx:latest


### PR DESCRIPTION
## Description

The version property in docker-compose files is deprecated and only used for backwards compatibility. When using the docker-compose files in ADO we get warnings like these:
![image](https://github.com/user-attachments/assets/d9ec81d5-7fc9-4ef7-80a4-8d20502f1e93)

I don't think we support using older versions of docker compose so removing the optional/deprecated property seems fine.

See https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-optional

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
