### PR TITLE
Revert "Client support for targeted signals"

### DIFF
--- a/packages/common/core-interfaces/src/messages.ts
+++ b/packages/common/core-interfaces/src/messages.ts
@@ -5,13 +5,6 @@
 
 /**
  * @internal
- *
- * @privateRemarks
- * `IRuntimeSignalEnvelope` is an interface that mirrors `ISignalEnvelope` for signals that come from an external
- * caller (not sent by a client—so no `clientBroadcastSignalSequenceNumber`) and are always addressed
- * to the Container (so no `address`).
- *
- * See at `server/routerlicious/packages/lambdas/src/utils/messageGenerator.ts`.
  */
 export interface ISignalEnvelope {
 	/**
@@ -20,9 +13,9 @@ export interface ISignalEnvelope {
 	address?: string;
 
 	/**
-	 * Signal tracking identifier for self submitted broadcast signals.
+	 * Identifier for the signal being submitted.
 	 */
-	clientBroadcastSignalSequenceNumber?: number;
+	clientSignalSequenceNumber: number;
 
 	/**
 	 * The contents of the envelope

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -78,6 +78,13 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 	}
 
 	/**
+	 * Submits a new signal to the server
+	 */
+	public submitSignal(message: string): void {
+		this.emitMessages("submitSignal", [[message]]);
+	}
+
+	/**
 	 * Send a "disconnect" message on the socket.
 	 * @param disconnectReason - The reason of the disconnection.
 	 */

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -36,6 +36,7 @@ import { SocketIOClientStatic } from "./socketModule.js";
 const protocolVersions = ["^0.4.0", "^0.3.0", "^0.2.0", "^0.1.0"];
 const feature_get_ops = "api_get_ops";
 const feature_flush_ops = "api_flush_ops";
+const feature_submit_signals_v2 = "submit_signals_v2";
 
 export interface FlushResult {
 	lastPersistedSequenceNumber?: number;
@@ -295,7 +296,9 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 			relayUserAgent: [client.details.environment, ` driverVersion:${pkgVersion}`].join(";"),
 		};
 
-		connectMessage.supportedFeatures = {};
+		connectMessage.supportedFeatures = {
+			[feature_submit_signals_v2]: true,
+		};
 
 		// Reference to this client supporting get_ops flow.
 		if (mc.config.getBoolean("Fluid.Driver.Odsp.GetOpsEnabled") !== false) {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -480,9 +480,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			if (this.handler === undefined) {
 				throw new Error("Attempted to process an inbound signal without a handler attached");
 			}
-
 			this.handler.processSignal({
-				...message,
+				clientId: message.clientId,
 				content: JSON.parse(message.content as string),
 			});
 		});

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -440,24 +440,10 @@ class OpPerfTelemetry {
 }
 export interface IPerfSignalReport {
 	/**
-	 * Identifier to track broadcast signals being submitted in order to
+	 * Identifier for the signal being submitted in order to
 	 * allow collection of data around the roundtrip of signal messages.
 	 */
-	broadcastSignalSequenceNumber: number;
-
-	/**
-	 * Accumulates the total number of broadcast signals sent during the current signal latency measurement window.
-	 * This value represents the total number of signals sent since the latency measurement began and is used
-	 * logged in telemetry when the latency measurement completes.
-	 */
-	totalSignalsSentInLatencyWindow: number;
-
-	/**
-	 * Counts the number of broadcast signals sent since the last latency measurement was initiated.
-	 * This counter increments with each broadcast signal sent. When a new latency measurement starts,
-	 * this counter is added to `totalSignalsSentInLatencyWindow` and then reset to zero.
-	 */
-	signalsSentSinceLastLatencyMeasurement: number;
+	signalSequenceNumber: number;
 
 	/**
 	 * Number of signals that were expected but not received.
@@ -478,6 +464,11 @@ export interface IPerfSignalReport {
 	 * Signal we will trace for roundtrip latency.
 	 */
 	roundTripSignalSequenceNumber: number | undefined;
+
+	/**
+	 * The lower bound of the upcoming (now current) tracking group
+	 */
+	baseSignalTrackingGroupSequenceNumber: number | undefined;
 
 	/**
 	 * Next expected signal sequence number to be received.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1322,14 +1322,13 @@ export class ContainerRuntime
 	private readonly closeSummarizerDelayMs: number;
 	private readonly defaultTelemetrySignalSampleCount = 100;
 	private readonly _signalTracking: IPerfSignalReport = {
-		totalSignalsSentInLatencyWindow: 0,
 		signalsLost: 0,
 		signalsOutOfOrder: 0,
-		signalsSentSinceLastLatencyMeasurement: 0,
-		broadcastSignalSequenceNumber: 0,
+		signalSequenceNumber: 0,
 		signalTimestamp: 0,
 		roundTripSignalSequenceNumber: undefined,
 		trackingSignalSequenceNumber: undefined,
+		baseSignalTrackingGroupSequenceNumber: undefined,
 		minimumTrackingSignalSequenceNumber: undefined,
 	};
 
@@ -2641,11 +2640,10 @@ export class ContainerRuntime
 			this._signalTracking.signalsLost = 0;
 			this._signalTracking.signalsOutOfOrder = 0;
 			this._signalTracking.signalTimestamp = 0;
-			this._signalTracking.signalsSentSinceLastLatencyMeasurement = 0;
-			this._signalTracking.totalSignalsSentInLatencyWindow = 0;
 			this._signalTracking.roundTripSignalSequenceNumber = undefined;
 			this._signalTracking.trackingSignalSequenceNumber = undefined;
 			this._signalTracking.minimumTrackingSignalSequenceNumber = undefined;
+			this._signalTracking.baseSignalTrackingGroupSequenceNumber = undefined;
 		} else {
 			assert(
 				this.attachState === AttachState.Attached,
@@ -3004,21 +3002,30 @@ export class ContainerRuntime
 
 	/**
 	 * Emits the Signal event and update the perf signal data.
+	 * @param clientSignalSequenceNumber - is the client signal sequence number to be uploaded.
 	 */
-	private sendSignalTelemetryEvent() {
+	private sendSignalTelemetryEvent(clientSignalSequenceNumber: number) {
 		const duration = Date.now() - this._signalTracking.signalTimestamp;
+		const signalsSent =
+			this._signalTracking.baseSignalTrackingGroupSequenceNumber !== undefined
+				? clientSignalSequenceNumber -
+					this._signalTracking.baseSignalTrackingGroupSequenceNumber +
+					1
+				: -1;
+
 		this.mc.logger.sendPerformanceEvent({
 			eventName: "SignalLatency",
 			duration, // Roundtrip duration of the tracked signal in milliseconds.
-			signalsSent: this._signalTracking.totalSignalsSentInLatencyWindow, // Signals sent since the last logged SignalLatency event.
+			signalsSent, // Signals sent since the last logged SignalLatency event.
 			signalsLost: this._signalTracking.signalsLost, // Signals lost since the last logged SignalLatency event.
 			outOfOrderSignals: this._signalTracking.signalsOutOfOrder, // Out of order signals since the last logged SignalLatency event.
 			reconnectCount: this.consecutiveReconnects, // Container reconnect count.
 		});
+		this._signalTracking.baseSignalTrackingGroupSequenceNumber =
+			clientSignalSequenceNumber + 1;
 		this._signalTracking.signalsLost = 0;
 		this._signalTracking.signalsOutOfOrder = 0;
 		this._signalTracking.signalTimestamp = 0;
-		this._signalTracking.totalSignalsSentInLatencyWindow = 0;
 	}
 
 	public processSignal(message: ISignalMessage, local: boolean) {
@@ -3027,26 +3034,21 @@ export class ContainerRuntime
 			clientId: message.clientId,
 			content: envelope.contents.content,
 			type: envelope.contents.type,
-			targetClientId: message.targetClientId,
 		};
 
-		// Only collect signal telemetry for broadcast messages sent by the current client.
-		if (
-			message.clientId === this.clientId &&
-			this.connected &&
-			envelope.clientBroadcastSignalSequenceNumber !== undefined
-		) {
+		// Only collect signal telemetry for messages sent by the current client.
+		if (message.clientId === this.clientId && this.connected) {
 			if (
 				this._signalTracking.trackingSignalSequenceNumber !== undefined &&
 				this._signalTracking.minimumTrackingSignalSequenceNumber !== undefined
 			) {
 				if (
-					envelope.clientBroadcastSignalSequenceNumber >=
+					envelope.clientSignalSequenceNumber >=
 					this._signalTracking.trackingSignalSequenceNumber
 				) {
 					// Calculate the number of signals lost and log the event.
 					const signalsLost =
-						envelope.clientBroadcastSignalSequenceNumber -
+						envelope.clientSignalSequenceNumber -
 						this._signalTracking.trackingSignalSequenceNumber;
 					if (signalsLost > 0) {
 						this._signalTracking.signalsLost += signalsLost;
@@ -3054,15 +3056,14 @@ export class ContainerRuntime
 							eventName: "SignalLost",
 							signalsLost, // Number of lost signals detected.
 							trackingSequenceNumber: this._signalTracking.trackingSignalSequenceNumber, // The next expected signal sequence number.
-							clientBroadcastSignalSequenceNumber:
-								envelope.clientBroadcastSignalSequenceNumber, // Actual signal sequence number received.
+							clientSignalSequenceNumber: envelope.clientSignalSequenceNumber, // Actual signal sequence number received.
 						});
 					}
 					// Update the tracking signal sequence number to the next expected signal in the sequence.
 					this._signalTracking.trackingSignalSequenceNumber =
-						envelope.clientBroadcastSignalSequenceNumber + 1;
+						envelope.clientSignalSequenceNumber + 1;
 				} else if (
-					envelope.clientBroadcastSignalSequenceNumber >=
+					envelope.clientSignalSequenceNumber >=
 					this._signalTracking.minimumTrackingSignalSequenceNumber
 				) {
 					this._signalTracking.signalsOutOfOrder++;
@@ -3070,23 +3071,23 @@ export class ContainerRuntime
 						eventName: "SignalOutOfOrder",
 						type: envelope.contents.type, // Type of signal that was received out of order.
 						trackingSequenceNumber: this._signalTracking.trackingSignalSequenceNumber, // The next expected signal sequence number.
-						clientBroadcastSignalSequenceNumber: envelope.clientBroadcastSignalSequenceNumber, // Sequence number of the out of order signal.
+						clientSignalSequenceNumber: envelope.clientSignalSequenceNumber, // Sequence number of the out of order signal.
 					});
 				}
 				if (
 					this._signalTracking.roundTripSignalSequenceNumber !== undefined &&
-					envelope.clientBroadcastSignalSequenceNumber >=
+					envelope.clientSignalSequenceNumber >=
 						this._signalTracking.roundTripSignalSequenceNumber
 				) {
 					if (
-						envelope.clientBroadcastSignalSequenceNumber ===
+						envelope.clientSignalSequenceNumber ===
 						this._signalTracking.roundTripSignalSequenceNumber
 					) {
 						// Latency tracked signal has been received.
 						// We now log the roundtrip duration of the tracked signal.
 						// This telemetry event also logs metrics for signals sent, signals lost, and out of order signals received.
 						// These metrics are reset after logging the telemetry event.
-						this.sendSignalTelemetryEvent();
+						this.sendSignalTelemetryEvent(envelope.clientSignalSequenceNumber);
 					}
 					this._signalTracking.roundTripSignalSequenceNumber = undefined;
 				}
@@ -3337,45 +3338,32 @@ export class ContainerRuntime
 		address: string | undefined,
 		type: string,
 		content: any,
-		targetClientId?: string,
 	): ISignalEnvelope {
+		const newSequenceNumber = ++this._signalTracking.signalSequenceNumber;
+
+		// Initialize tracking to expect the first signal sent by the connected client.
+		if (
+			this._signalTracking.minimumTrackingSignalSequenceNumber === undefined ||
+			this._signalTracking.trackingSignalSequenceNumber === undefined
+		) {
+			this._signalTracking.minimumTrackingSignalSequenceNumber = newSequenceNumber;
+			this._signalTracking.trackingSignalSequenceNumber = newSequenceNumber;
+			this._signalTracking.baseSignalTrackingGroupSequenceNumber = newSequenceNumber;
+		}
+
 		const newEnvelope: ISignalEnvelope = {
 			address,
+			clientSignalSequenceNumber: newSequenceNumber,
 			contents: { type, content },
 		};
 
-		const isBroadcastSignal = targetClientId === undefined;
-
-		if (isBroadcastSignal) {
-			const clientBroadcastSignalSequenceNumber = ++this._signalTracking
-				.broadcastSignalSequenceNumber;
-			newEnvelope.clientBroadcastSignalSequenceNumber = clientBroadcastSignalSequenceNumber;
-			this._signalTracking.signalsSentSinceLastLatencyMeasurement++;
-
-			if (
-				this._signalTracking.minimumTrackingSignalSequenceNumber === undefined ||
-				this._signalTracking.trackingSignalSequenceNumber === undefined
-			) {
-				// Signal monitoring window is undefined
-				// Initialize tracking to expect the next signal sent by the connected client.
-				this._signalTracking.minimumTrackingSignalSequenceNumber =
-					clientBroadcastSignalSequenceNumber;
-				this._signalTracking.trackingSignalSequenceNumber =
-					clientBroadcastSignalSequenceNumber;
-			}
-
-			// We should not track the round trip of a new signal in the case we are already tracking one.
-			if (
-				clientBroadcastSignalSequenceNumber % this.defaultTelemetrySignalSampleCount === 1 &&
-				this._signalTracking.roundTripSignalSequenceNumber === undefined
-			) {
-				this._signalTracking.signalTimestamp = Date.now();
-				this._signalTracking.roundTripSignalSequenceNumber =
-					clientBroadcastSignalSequenceNumber;
-				this._signalTracking.totalSignalsSentInLatencyWindow +=
-					this._signalTracking.signalsSentSinceLastLatencyMeasurement;
-				this._signalTracking.signalsSentSinceLastLatencyMeasurement = 0;
-			}
+		// We should not track the round trip of a new signal in the case we are already tracking one.
+		if (
+			newSequenceNumber % this.defaultTelemetrySignalSampleCount === 1 &&
+			this._signalTracking.roundTripSignalSequenceNumber === undefined
+		) {
+			this._signalTracking.signalTimestamp = Date.now();
+			this._signalTracking.roundTripSignalSequenceNumber = newSequenceNumber;
 		}
 
 		return newEnvelope;
@@ -3386,21 +3374,10 @@ export class ContainerRuntime
 	 * @param type - Type of the signal.
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
-	 *
-	 * @remarks
-	 *
-	 * The `targetClientId` parameter here is currently intended for internal testing purposes only.
-	 * Support for this option at container runtime is planned to be deprecated in the future.
-	 *
 	 */
 	public submitSignal(type: string, content: unknown, targetClientId?: string) {
 		this.verifyNotClosed();
-		const envelope = this.createNewSignalEnvelope(
-			undefined /* address */,
-			type,
-			content,
-			targetClientId,
-		);
+		const envelope = this.createNewSignalEnvelope(undefined /* address */, type, content);
 		return this.submitSignalFn(envelope, targetClientId);
 	}
 

--- a/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
@@ -7,89 +7,29 @@ import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
-import type {
-	IContainerRuntimeBase,
-	IInboundSignalMessage,
-} from "@fluidframework/runtime-definitions/internal";
+import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 import {
 	DataObjectFactoryType,
 	ITestContainerConfig,
 	ITestFluidObject,
 	ITestObjectProvider,
 	getContainerEntryPointBackCompat,
-	timeoutPromise as timeoutPromiseUnnamed,
-	TimeoutWithError,
-	TimeoutWithValue,
+	timeoutPromise,
 } from "@fluidframework/test-utils/internal";
-
-type IContainerRuntimeBaseWithClientId = IContainerRuntimeBase & {
-	clientId?: string | undefined;
-};
-
-enum RuntimeLayer {
-	dataStoreRuntime = "dataStoreRuntime",
-	containerRuntime = "containerRuntime",
-}
-
-interface SignalClient {
-	dataStoreRuntime: IFluidDataStoreRuntime;
-	containerRuntime: IContainerRuntimeBaseWithClientId;
-	signalReceivedCount: number;
-	clientId: string | undefined;
-}
 
 const testContainerConfig: ITestContainerConfig = {
 	fluidDataObjectType: DataObjectFactoryType.Test,
 };
 
-async function timeoutPromise<T = void>(
-	executor: (controller: {
-		resolve: (value: T | PromiseLike<T>) => void;
-		reject: (reason?: any) => void;
-	}) => void,
-	timeoutOptions: TimeoutWithError | TimeoutWithValue<T> = {},
-): Promise<T> {
-	return timeoutPromiseUnnamed(
-		(resolve, reject) => executor({ resolve, reject }),
-		timeoutOptions,
-	);
-}
-async function waitForSignal(...signallers: { once(e: "signal", l: () => void): void }[]) {
-	return Promise.all(
+const waitForSignal = async (...signallers: { once(e: "signal", l: () => void): void }[]) =>
+	Promise.all(
 		signallers.map(async (signaller, index) =>
-			timeoutPromise(({ resolve }) => signaller.once("signal", () => resolve()), {
+			timeoutPromise((resolve) => signaller.once("signal", () => resolve()), {
 				durationMs: 2000,
 				errorMsg: `Signaller[${index}] Timeout`,
 			}),
 		),
 	);
-}
-
-async function waitForTargetedSignal(
-	targetedSignaller: { once(e: "signal", l: () => void): void },
-	otherSignallers: { once(e: "signal", l: () => void): void }[],
-): Promise<[void, ...string[]]> {
-	return Promise.all([
-		timeoutPromise(({ resolve }) => targetedSignaller.once("signal", () => resolve()), {
-			durationMs: 2000,
-			errorMsg: `Targeted Signaller Timeout`,
-		}),
-		...otherSignallers.map(async (signaller, index) =>
-			timeoutPromise(
-				({ reject }) =>
-					signaller.once("signal", () =>
-						reject(`Signaller[${index}] should not have received a signal`),
-					),
-				{
-					durationMs: 100,
-					value: "No Signal Received",
-					reject: false,
-				},
-			),
-		),
-	]);
-}
 
 describeCompat("TestSignals", "FullCompat", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
@@ -250,134 +190,4 @@ describeCompat("TestSignals", "FullCompat", (getTestObjectProvider) => {
 			"client 2 did not receive signal on data store runtime",
 		);
 	});
-});
-
-describeCompat("Targeted Signals", "NoCompat", (getTestObjectProvider) => {
-	const numberOfClients = 3;
-	assert(numberOfClients >= 2, "Need at least 2 clients for targeted signals");
-	let clients: SignalClient[];
-	let provider: ITestObjectProvider;
-
-	beforeEach("setup containers", async () => {
-		provider = getTestObjectProvider();
-		clients = [];
-		for (let i = 0; i < numberOfClients; i++) {
-			const container = await (i === 0
-				? provider.makeTestContainer(testContainerConfig)
-				: provider.loadTestContainer(testContainerConfig));
-			const dataObject = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
-
-			if (container.connectionState !== ConnectionState.Connected) {
-				await new Promise((resolve) => container.once("connected", resolve));
-			}
-
-			clients.push({
-				dataStoreRuntime: dataObject.runtime,
-				containerRuntime: dataObject.context.containerRuntime,
-				signalReceivedCount: 0,
-				clientId: container.clientId,
-			});
-		}
-	});
-	async function sendAndVerifySignalToRemoteClient(runtime: RuntimeLayer) {
-		clients.forEach((client) => {
-			client[runtime].on("signal", (message: IInboundSignalMessage, local: boolean) => {
-				assert.equal(local, false, "Signal should be remote");
-				assertSignalProperties(message, client.clientId);
-				client.signalReceivedCount += 1;
-			});
-		});
-
-		for (let i = 0; i < clients.length; i++) {
-			const targetClient = clients[(i + 1) % clients.length];
-			clients[i][runtime].submitSignal(
-				"Test Signal Type",
-				"Test Signal Content",
-				targetClient.clientId,
-			);
-			const targetedSignalPromise = await waitForTargetedSignal(
-				targetClient[runtime],
-				clients.filter((c) => c !== targetClient).map((c) => c[runtime]),
-			);
-
-			const [targetedSignalResult, ...otherResults] = targetedSignalPromise;
-			otherResults.forEach((result) => {
-				assert.equal(
-					result,
-					"No Signal Received",
-					"Non-targeted client should not receive signal",
-				);
-			});
-		}
-
-		clients.forEach((client, index) => {
-			assert.equal(
-				client.signalReceivedCount,
-				1,
-				`client ${index + 1} did not receive signal`,
-			);
-		});
-	}
-
-	async function sendAndVerifySignalToSelf(runtime: RuntimeLayer) {
-		clients.forEach((client) => {
-			client[runtime].on("signal", (message: IInboundSignalMessage, local: boolean) => {
-				assert.equal(local, true, "Signal should be local");
-				assertSignalProperties(message, client.clientId);
-				client.signalReceivedCount += 1;
-			});
-		});
-
-		for (const client of clients) {
-			client[runtime].submitSignal("Test Signal Type", "Test Signal Content", client.clientId);
-			const targetedSignalPromise = await waitForTargetedSignal(
-				client[runtime],
-				clients.filter((c) => c !== client).map((c) => c[runtime]),
-			);
-
-			const [targetedSignalResult, ...otherResults] = targetedSignalPromise;
-			otherResults.forEach((result) => {
-				assert.equal(
-					result,
-					"No Signal Received",
-					"Non-targeted client should not receive signal",
-				);
-			});
-		}
-
-		clients.forEach((client, index) => {
-			assert.equal(
-				client.signalReceivedCount,
-				1,
-				`client ${index + 1} did not receive signal`,
-			);
-		});
-	}
-
-	function assertSignalProperties(
-		message: IInboundSignalMessage,
-		clientId: string | undefined,
-	) {
-		assert.equal(message.type, "Test Signal Type", "signal type mismatch");
-		assert.equal(message.content, "Test Signal Content", "signal content mismatch");
-		assert.equal(message.targetClientId, clientId, "Signal should be targeted to this client");
-	}
-
-	[RuntimeLayer.containerRuntime, RuntimeLayer.dataStoreRuntime].forEach((layer) =>
-		describe(`when sent from ${layer}`, () => {
-			it("should correctly deliver a targeted message to a specific remote client, identified by their client ID", async () => {
-				// This test verifies that when a signal is sent to a specific remote client using their client ID,
-				// only that client receives the signal. This is tested by sending a signal from each client to all other clients,
-				// and then verifying that each client received exactly one signal
-				await sendAndVerifySignalToRemoteClient(layer);
-			});
-
-			it("should correctly deliver a targeted message to itself, identified by their own client ID", async () => {
-				// This test verifies that when a client targets a signal to itself using its own client ID
-				// the signal is correctly received only by the local client. This is tested by sending a signal from each client to itself,
-				// and then verifying that each client received exactly one signal with matching type and content.
-				await sendAndVerifySignalToSelf(layer);
-			});
-		}),
-	);
 });

--- a/server/routerlicious/packages/lambdas/src/utils/messageGenerator.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/messageGenerator.ts
@@ -67,7 +67,7 @@ export const createRoomLeaveMessage = (clientId: string): ISignalMessage => ({
 
 /**
  * Mirrors ISignalEnvelope from runtime definitions, for signals that come from an external
- * caller (not sent by a client (so no 'clientBroadcastSignalSequenceNumber') and are always addressed
+ * caller (not sent by a client (so no 'clientSignalSequenceNumber') and are always addressed
  * to the Container (so no 'address').
  * @internal
  */


### PR DESCRIPTION
Reverts microsoft/FluidFramework#22321

This is prompted by the realization that this PR introduced new errors:

- Signal should be targeted to this client
- Signal should be local
- Signal should be remote

@jason-ha (after a short investigation) mentioned that this PR likely enabled a new feature that is broken with ODSP.

Reverting for now.

[ICM](https://portal.microsofticm.com/imp/v5/incidents/details/544296805/summary)