### PR TITLE
fix(server): Remove bad comma in server configmap

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -157,7 +157,7 @@ data:
             "enableCollaborationSessionTracking": {{ .Values.nexus.enableCollaborationSessionTracking }},
             "enableCollaborationSessionPruning": {{ .Values.nexus.enableCollaborationSessionPruning }},
             "redisCollaborationSessionManagerOptions": {
-                "maxScanBatchSize": {{ .Values.nexus.redisCollaborationSessionManagerOptions.maxScanBatchSize }},
+                "maxScanBatchSize": {{ .Values.nexus.redisCollaborationSessionManagerOptions.maxScanBatchSize }}
             }
         },
         "client": {


### PR DESCRIPTION
## Description

Removes a trailing comma that results in an invalid JSON config and kubernetes pods crashing trying to load it. Introduced recently in https://github.com/microsoft/FluidFramework/pull/22442.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
