### PR TITLE
(docs): update untagged telemetry safeness statement

### DIFF
--- a/docs/content/docs/testing/telemetry.md
+++ b/docs/content/docs/testing/telemetry.md
@@ -130,8 +130,7 @@ either tagged (`ITaggedTelemetryPropertyType`) or untagged (`TelemetryEventPrope
 
 ### Understanding Tags
 
-Tags are strings used to classify the properties on telemetry events. By default, telemetry properties are untagged
-and untagged properties can be considered safe for general logging. However,
+Tags are strings used to classify the properties on telemetry events. By default, telemetry properties are untagged. However,
 the Fluid Framework may emit events with some properties tagged, so implementations of `ITelemetryBaseLogger` must be
 prepared to check for and interpret any tags.  Generally speaking, when logging to the user's console, tags can
 be ignored and tagged values logged plainly, but when transmitting tagged properties to a telemetry service,


### PR DESCRIPTION
Currently, there's an ongoing issue where untagged telemtry logs is producing HTML reponse with PII.
https://dev.azure.com/fluidframework/internal/_workitems/edit/14286
Until further investigation, updating docs to not explicitly state untagged telemtry is safe for logging.
