### PR TITLE
Avoid two leading slashes in the request to create a new file

### DIFF
--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -164,13 +164,17 @@ function extractShareLinkData(
 	return shareLinkInfo;
 }
 
+function ensureStartsWithSlash(path: string): string {
+	return path.startsWith("/") ? path : `/${path}`;
+}
+
 export async function createNewEmptyFluidFile(
 	getAuthHeader: InstrumentedStorageTokenFetcher,
 	newFileInfo: INewFileInfo,
 	logger: ITelemetryLoggerExt,
 	epochTracker: EpochTracker,
 ): Promise<string> {
-	const filePath = newFileInfo.filePath ? encodeURIComponent(`/${newFileInfo.filePath}`) : "";
+	const filePath = newFileInfo.filePath ? encodeURIComponent(ensureStartsWithSlash(newFileInfo.filePath)) : "";
 	// add .tmp extension to empty file (host is expected to rename)
 	const encodedFilename = encodeURIComponent(`${newFileInfo.filename}.tmp`);
 	const initialUrl = `${getApiRoot(new URL(newFileInfo.siteUrl))}/drives/${
@@ -234,7 +238,7 @@ export async function createNewFluidFileFromSummary(
 	epochTracker: EpochTracker,
 	forceAccessTokenViaAuthorizationHeader: boolean,
 ): Promise<ICreateFileResponse> {
-	const filePath = newFileInfo.filePath ? encodeURIComponent(`/${newFileInfo.filePath}`) : "";
+	const filePath = newFileInfo.filePath ? encodeURIComponent(ensureStartsWithSlash(newFileInfo.filePath)) : "";
 	const encodedFilename = encodeURIComponent(newFileInfo.filename);
 	const baseUrl =
 		`${getApiRoot(new URL(newFileInfo.siteUrl))}/drives/${newFileInfo.driveId}/items/root:` +

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -174,7 +174,9 @@ export async function createNewEmptyFluidFile(
 	logger: ITelemetryLoggerExt,
 	epochTracker: EpochTracker,
 ): Promise<string> {
-	const filePath = newFileInfo.filePath ? encodeURIComponent(ensureStartsWithSlash(newFileInfo.filePath)) : "";
+	const filePath = newFileInfo.filePath
+		? encodeURIComponent(ensureStartsWithSlash(newFileInfo.filePath))
+		: "";
 	// add .tmp extension to empty file (host is expected to rename)
 	const encodedFilename = encodeURIComponent(`${newFileInfo.filename}.tmp`);
 	const initialUrl = `${getApiRoot(new URL(newFileInfo.siteUrl))}/drives/${
@@ -238,7 +240,9 @@ export async function createNewFluidFileFromSummary(
 	epochTracker: EpochTracker,
 	forceAccessTokenViaAuthorizationHeader: boolean,
 ): Promise<ICreateFileResponse> {
-	const filePath = newFileInfo.filePath ? encodeURIComponent(ensureStartsWithSlash(newFileInfo.filePath)) : "";
+	const filePath = newFileInfo.filePath
+		? encodeURIComponent(ensureStartsWithSlash(newFileInfo.filePath))
+		: "";
 	const encodedFilename = encodeURIComponent(newFileInfo.filename);
 	const baseUrl =
 		`${getApiRoot(new URL(newFileInfo.siteUrl))}/drives/${newFileInfo.driveId}/items/root:` +

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -164,8 +164,13 @@ function extractShareLinkData(
 	return shareLinkInfo;
 }
 
-function ensureStartsWithSlash(path: string): string {
-	return path.startsWith("/") ? path : `/${path}`;
+/**
+ * Encodes file path so it can be embedded in the request url
+ * @param path - path to encode
+ * @returns encoded path or "" if path is undefined
+ */
+function encodeFilePath(path: string | undefined): string {
+	return path ? encodeURIComponent(path.startsWith("/") ? path : `/${path}`) : "";
 }
 
 export async function createNewEmptyFluidFile(
@@ -174,9 +179,7 @@ export async function createNewEmptyFluidFile(
 	logger: ITelemetryLoggerExt,
 	epochTracker: EpochTracker,
 ): Promise<string> {
-	const filePath = newFileInfo.filePath
-		? encodeURIComponent(ensureStartsWithSlash(newFileInfo.filePath))
-		: "";
+	const filePath = encodeFilePath(newFileInfo.filePath);
 	// add .tmp extension to empty file (host is expected to rename)
 	const encodedFilename = encodeURIComponent(`${newFileInfo.filename}.tmp`);
 	const initialUrl = `${getApiRoot(new URL(newFileInfo.siteUrl))}/drives/${
@@ -240,9 +243,7 @@ export async function createNewFluidFileFromSummary(
 	epochTracker: EpochTracker,
 	forceAccessTokenViaAuthorizationHeader: boolean,
 ): Promise<ICreateFileResponse> {
-	const filePath = newFileInfo.filePath
-		? encodeURIComponent(ensureStartsWithSlash(newFileInfo.filePath))
-		: "";
+	const filePath = encodeFilePath(newFileInfo.filePath);
 	const encodedFilename = encodeURIComponent(newFileInfo.filename);
 	const baseUrl =
 		`${getApiRoot(new URL(newFileInfo.siteUrl))}/drives/${newFileInfo.driveId}/items/root:` +


### PR DESCRIPTION
## Description
When using PFT+POP auth with ODSP, ODSP fails to validate the `p` field in the token when we have two leading slashes in the path. This is likely a bug in ODSP but it does result in cryptic 401 failure of the request.

## Breaking Changes
None

## Reviewer Guidance

None