### PR TITLE
refactor(tree): Make properties of `FieldSchemaMetadata` readonly

### DIFF
--- a/.changeset/light-rectangles-rejoice.md
+++ b/.changeset/light-rectangles-rejoice.md
@@ -5,7 +5,7 @@
 section: tree
 ---
 
-Allow associating metadata with Field Schema.
+Allow associating metadata with Field Schema
 
 Users of TreeView can now specify metadata when creating Field Schema.
 This includes system-understood metadata, i.e., `description`.
@@ -29,7 +29,7 @@ Functionality like the experimental conversion of Tree Schema to [JSON Schema](h
 In the case of the `description` property, this is mapped directly to the `description` property supported by JSON Schema.
 
 Custom, user-defined properties can also be specified.
-These properties will not be leveraged by the system by default, but can be used as a handy means of associating common, application-specific properties with Field Schema.
+These properties will not be leveraged by the system by default, but can be used as a handy means of associating common application-specific properties with Field Schema.
 
 Example:
 

--- a/.changeset/light-rectangles-rejoice.md
+++ b/.changeset/light-rectangles-rejoice.md
@@ -1,0 +1,70 @@
+---
+"@fluidframework/tree": minor
+---
+---
+section: tree
+---
+
+Allow associating metadata with Field Schema.
+
+Users of TreeView can now specify metadata when creating Field Schema.
+This includes system-understood metadata, i.e., `description`.
+
+Example:
+
+```typescript
+
+class Point extends schemaFactory.object("Point", {
+	x: schemaFactory.required(schemaFactory.number, {
+		metadata: { description: "The horizontal component of the point." }
+	}),
+	y: schemaFactory.required(schemaFactory.number, {
+		metadata: { description: "The vertical component of the point." }
+	}),
+}) {}
+
+```
+
+Functionality like the experimental conversion of Tree Schema to [JSON Schema](https://json-schema.org/). (`getJsonSchema`) can leverage such system-understood metadata to generate useful information.
+In the case of the `description` property, this is mapped directly to the `description` property supported by JSON Schema.
+
+Custom, user-defined properties can also be specified.
+These properties will not be leveraged by the system by default, but can be used as a handy means of associating common, application-specific properties with Field Schema.
+
+Example:
+
+An application is implementing search functionality.
+By default, the app author wishes for all app content to be potentially indexable by search, unless otherwise specified.
+They can leverage schema metadata to decorate fields that should be ignored by search, and leverage that information when walking the tree during a search.
+
+```typescript
+
+interface AppMetadata {
+	/**
+	 * Whether or not the field should be ignored by search.
+	 * @defaultValue `false`
+	 */
+	searchIgnore?: boolean;
+}
+
+class Note extends schemaFactory.object("Note", {
+	position: schemaFactory.required(Point, {
+		metadata: {
+			description: "The position of the upper-left corner of the note."
+			custom: {
+				// Search doesn't care where the note is on the canvas.
+				// It only cares about the text content.
+				searchIgnore: true
+			}
+		}
+	}),
+	text: schemaFactory.required(schemaFactory.string, {
+		metadata: {
+			description: "The textual contents of the note."
+		}
+	}),
+}) {}
+
+```
+
+Search can then be implemented to look for the appropriate metadata, and leverage it to omit the unwanted position data from search.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -67,8 +67,8 @@ export class FieldSchema<out Kind extends FieldKind = FieldKind, out Types exten
 
 // @public @sealed
 export interface FieldSchemaMetadata<TCustomMetadata = unknown> {
-    custom?: TCustomMetadata;
-    description?: string | undefined;
+    readonly custom?: TCustomMetadata;
+    readonly description?: string | undefined;
 }
 
 // @public

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -67,8 +67,8 @@ export class FieldSchema<out Kind extends FieldKind = FieldKind, out Types exten
 
 // @public @sealed
 export interface FieldSchemaMetadata<TCustomMetadata = unknown> {
-    custom?: TCustomMetadata;
-    description?: string | undefined;
+    readonly custom?: TCustomMetadata;
+    readonly description?: string | undefined;
 }
 
 // @public

--- a/packages/dds/tree/api-report/tree.legacy.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.alpha.api.md
@@ -67,8 +67,8 @@ export class FieldSchema<out Kind extends FieldKind = FieldKind, out Types exten
 
 // @public @sealed
 export interface FieldSchemaMetadata<TCustomMetadata = unknown> {
-    custom?: TCustomMetadata;
-    description?: string | undefined;
+    readonly custom?: TCustomMetadata;
+    readonly description?: string | undefined;
 }
 
 // @public

--- a/packages/dds/tree/api-report/tree.legacy.public.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.public.api.md
@@ -67,8 +67,8 @@ export class FieldSchema<out Kind extends FieldKind = FieldKind, out Types exten
 
 // @public @sealed
 export interface FieldSchemaMetadata<TCustomMetadata = unknown> {
-    custom?: TCustomMetadata;
-    description?: string | undefined;
+    readonly custom?: TCustomMetadata;
+    readonly description?: string | undefined;
 }
 
 // @public

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -67,8 +67,8 @@ export class FieldSchema<out Kind extends FieldKind = FieldKind, out Types exten
 
 // @public @sealed
 export interface FieldSchemaMetadata<TCustomMetadata = unknown> {
-    custom?: TCustomMetadata;
-    description?: string | undefined;
+    readonly custom?: TCustomMetadata;
+    readonly description?: string | undefined;
 }
 
 // @public

--- a/packages/dds/tree/src/simple-tree/schemaTypes.ts
+++ b/packages/dds/tree/src/simple-tree/schemaTypes.ts
@@ -221,7 +221,7 @@ export interface FieldSchemaMetadata<TCustomMetadata = unknown> {
 	/**
 	 * User-defined metadata.
 	 */
-	custom?: TCustomMetadata;
+	readonly custom?: TCustomMetadata;
 
 	/**
 	 * The description of the field.
@@ -232,7 +232,7 @@ export interface FieldSchemaMetadata<TCustomMetadata = unknown> {
 	 * E.g., when converting a field schema to {@link https://json-schema.org/ | JSON Schema}, this description will be
 	 * used as the `description` field.
 	 */
-	description?: string | undefined;
+	readonly description?: string | undefined;
 }
 
 /**

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -108,8 +108,8 @@ export class FieldSchema<out Kind extends FieldKind = FieldKind, out Types exten
 
 // @public @sealed
 export interface FieldSchemaMetadata<TCustomMetadata = unknown> {
-    custom?: TCustomMetadata;
-    description?: string | undefined;
+    readonly custom?: TCustomMetadata;
+    readonly description?: string | undefined;
 }
 
 // @public

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -108,8 +108,8 @@ export class FieldSchema<out Kind extends FieldKind = FieldKind, out Types exten
 
 // @public @sealed
 export interface FieldSchemaMetadata<TCustomMetadata = unknown> {
-    custom?: TCustomMetadata;
-    description?: string | undefined;
+    readonly custom?: TCustomMetadata;
+    readonly description?: string | undefined;
 }
 
 // @public

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -111,8 +111,8 @@ export class FieldSchema<out Kind extends FieldKind = FieldKind, out Types exten
 
 // @public @sealed
 export interface FieldSchemaMetadata<TCustomMetadata = unknown> {
-    custom?: TCustomMetadata;
-    description?: string | undefined;
+    readonly custom?: TCustomMetadata;
+    readonly description?: string | undefined;
 }
 
 // @public

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -108,8 +108,8 @@ export class FieldSchema<out Kind extends FieldKind = FieldKind, out Types exten
 
 // @public @sealed
 export interface FieldSchemaMetadata<TCustomMetadata = unknown> {
-    custom?: TCustomMetadata;
-    description?: string | undefined;
+    readonly custom?: TCustomMetadata;
+    readonly description?: string | undefined;
 }
 
 // @public

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -108,8 +108,8 @@ export class FieldSchema<out Kind extends FieldKind = FieldKind, out Types exten
 
 // @public @sealed
 export interface FieldSchemaMetadata<TCustomMetadata = unknown> {
-    custom?: TCustomMetadata;
-    description?: string | undefined;
+    readonly custom?: TCustomMetadata;
+    readonly description?: string | undefined;
 }
 
 // @public


### PR DESCRIPTION
Follow-up to PR #22538. These properties were not intended to be mutable. While this change is technically breaking, the previous PR was made after the `2.3` release was cut, so this change is safe to make prior to `2.4`.

Also adds a changeset for the new functionality, which was also missed in the previous PR.