### PR TITLE
Rename and Unexport isRuntimeMessage Task 10256

### DIFF
--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -230,7 +230,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Function_isRuntimeMessage": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "internal"
 	}
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -634,7 +634,7 @@ const defaultCloseSummarizerDelayMs = 5000; // 5 seconds
 /**
  * Checks whether a message.type is one of the values in ContainerMessageType
  */
-export function isRuntimeMessage(message: ISequencedDocumentMessage): boolean {
+export function isUnpackedRuntimeMessage(message: ISequencedDocumentMessage): boolean {
 	return (Object.values(ContainerMessageType) as string[]).includes(message.type);
 }
 
@@ -2806,7 +2806,7 @@ export class ContainerRuntime
 				{ batchStart: true, batchEnd: true }, // Single message
 				local,
 				savedOp,
-				isRuntimeMessage(messageCopy) /* runtimeBatch */,
+				isUnpackedRuntimeMessage(messageCopy) /* runtimeBatch */,
 			);
 		}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -633,8 +633,6 @@ const defaultCloseSummarizerDelayMs = 5000; // 5 seconds
 
 /**
  * Checks whether a message.type is one of the values in ContainerMessageType
- * @deprecated please use version in driver-utils
- * @internal
  */
 export function isRuntimeMessage(message: ISequencedDocumentMessage): boolean {
 	return (Object.values(ContainerMessageType) as string[]).includes(message.type);

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -12,7 +12,6 @@ export {
 	IContainerRuntimeOptions,
 	loadContainerRuntime,
 	LoadContainerRuntimeParams,
-	isRuntimeMessage,
 	agentSchedulerId,
 	ContainerRuntime,
 	DeletedResponseHeaderKey,

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -382,6 +382,7 @@ declare type current_as_old_for_Function_detectOutboundReferences = requireAssig
  * typeValidation.broken:
  * "Function_isRuntimeMessage": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Function_isRuntimeMessage = requireAssignableTo<TypeOnly<typeof current.isRuntimeMessage>, TypeOnly<typeof old.isRuntimeMessage>>
 
 /*


### PR DESCRIPTION



## Description

Rename and unexport `isRuntimeMessage` function from containerRuntime.ts
isRuntimeMessage was renamed to isUnpackedRuntimeMessage


