### PR TITLE
Preserve segmentGroup ordering of local segments 

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1510,11 +1510,11 @@ export class MergeTree {
 				}
 
 				this.updateRoot(splitNode);
-				saveIfLocal(newSegment);
 
 				insertPos += newSegment.cachedLength;
 
 				if (!this.options?.mergeTreeEnableObliterate || this.obliterates.empty()) {
+					saveIfLocal(newSegment);
 					continue;
 				}
 
@@ -1576,6 +1576,7 @@ export class MergeTree {
 						this.blockUpdatePathLengths(newSegment.parent, seq, clientId);
 					}
 				}
+				saveIfLocal(newSegment);
 			}
 		}
 	}


### PR DESCRIPTION
When inserting a new segment, `saveIfLocal` adds the segment to the list of pending segments. Rearranging the calls to this function ensures that the segments are added to the segment group in the correct order, and not in reverse order. 
split out from #22552 