### PR TITLE
fix(client-presence): multiple `getStates` calls using overlapping schema

### DIFF
--- a/packages/framework/presence/src/exposedInternalTypes.ts
+++ b/packages/framework/presence/src/exposedInternalTypes.ts
@@ -108,13 +108,13 @@ export namespace InternalTypes {
 		TKey extends string,
 		TValue extends ValueDirectoryOrState<any>,
 		TManager,
-	> = (
+	> = { instanceBase: new (...args: any[]) => any } & ((
 		key: TKey,
 		datastoreHandle: StateDatastoreHandle<TKey, TValue>,
 	) => {
 		value?: TValue;
 		manager: StateValue<TManager>;
-	};
+	});
 
 	/**
 	 * @system

--- a/packages/framework/presence/src/latestMapValueManager.ts
+++ b/packages/framework/presence/src/latestMapValueManager.ts
@@ -470,13 +470,16 @@ export function LatestMap<
 				allowableUpdateLatency: 60,
 				forcedRefreshInterval: 0,
 			};
-	return (
+	const factory = (
 		key: RegistrationKey,
 		datastoreHandle: InternalTypes.StateDatastoreHandle<
 			RegistrationKey,
 			InternalTypes.MapValueState<T>
 		>,
-	) => ({
+	): {
+		value: typeof value;
+		manager: InternalTypes.StateValue<LatestMapValueManager<T, Keys>>;
+	} => ({
 		value,
 		manager: brandIVM<
 			LatestMapValueManagerImpl<T, RegistrationKey, Keys>,
@@ -491,4 +494,5 @@ export function LatestMap<
 			),
 		),
 	});
+	return Object.assign(factory, { instanceBase: LatestMapValueManagerImpl });
 }

--- a/packages/framework/presence/src/latestValueManager.ts
+++ b/packages/framework/presence/src/latestValueManager.ts
@@ -184,13 +184,16 @@ export function Latest<T extends object, Key extends string = string>(
 				allowableUpdateLatency: 60,
 				forcedRefreshInterval: 0,
 			};
-	return (
+	const factory = (
 		key: Key,
 		datastoreHandle: InternalTypes.StateDatastoreHandle<
 			Key,
 			InternalTypes.ValueRequiredState<T>
 		>,
-	) => ({
+	): {
+		value: typeof value;
+		manager: InternalTypes.StateValue<LatestValueManager<T>>;
+	} => ({
 		value,
 		manager: brandIVM<LatestValueManagerImpl<T, Key>, T, InternalTypes.ValueRequiredState<T>>(
 			new LatestValueManagerImpl(
@@ -201,4 +204,5 @@ export function Latest<T extends object, Key extends string = string>(
 			),
 		),
 	});
+	return Object.assign(factory, { instanceBase: LatestValueManagerImpl });
 }

--- a/packages/framework/presence/src/notificationsManager.ts
+++ b/packages/framework/presence/src/notificationsManager.ts
@@ -198,13 +198,15 @@ export function Notifications<
 	InternalTypes.ValueRequiredState<InternalTypes.NotificationType>,
 	NotificationsManager<T>
 > {
-	return (
+	const factory = (
 		key: Key,
 		datastoreHandle: InternalTypes.StateDatastoreHandle<
 			Key,
 			InternalTypes.ValueRequiredState<InternalTypes.NotificationType>
 		>,
-	) => ({
+	): {
+		manager: InternalTypes.StateValue<NotificationsManager<T>>;
+	} => ({
 		manager: brandIVM<
 			NotificationsManagerImpl<T, Key>,
 			InternalTypes.NotificationType,
@@ -217,4 +219,5 @@ export function Notifications<
 			),
 		),
 	});
+	return Object.assign(factory, { instanceBase: NotificationsManagerImpl });
 }

--- a/packages/framework/presence/src/presenceStates.ts
+++ b/packages/framework/presence/src/presenceStates.ts
@@ -303,7 +303,14 @@ class PresenceStatesImpl<TSchema extends PresenceStatesSchema>
 		content: TSchemaAdditional,
 	): PresenceStates<TSchema & TSchemaAdditional> {
 		for (const [key, nodeFactory] of Object.entries(content)) {
-			this.add(key, nodeFactory);
+			if (key in this.nodes) {
+				const node = unbrandIVM(this.nodes[key]);
+				if (!(node instanceof nodeFactory.instanceBase)) {
+					throw new TypeError(`State "${key}" previously created by different value manager.`);
+				}
+			} else {
+				this.add(key, nodeFactory);
+			}
 		}
 		return this as PresenceStates<TSchema & TSchemaAdditional>;
 	}

--- a/packages/framework/presence/src/test/presenceStates.spec.ts
+++ b/packages/framework/presence/src/test/presenceStates.spec.ts
@@ -20,7 +20,7 @@ describe("LatestValueManager", () => {
 
 declare function createValueManager<T, Key extends string>(
 	initial: JsonSerializable<T> & JsonDeserialized<T>,
-): (
+): { instanceBase: new () => unknown } & ((
 	key: Key,
 	datastoreHandle: InternalTypes.StateDatastoreHandle<
 		Key,
@@ -29,7 +29,7 @@ declare function createValueManager<T, Key extends string>(
 ) => {
 	value: InternalTypes.ValueRequiredState<T>;
 	manager: InternalTypes.StateValue<JsonDeserialized<T>>;
-};
+});
 
 // ---- test (example) code ----
 
@@ -41,11 +41,12 @@ export function checkCompiles(): void {
 	const presence = {} as IPresence;
 	const statesWorkspace = presence.getStates("name:testWorkspaceA", {
 		cursor: createValueManager({ x: 0, y: 0 }),
-		camera: () => ({
+		// eslint-disable-next-line prefer-object-spread
+		camera: Object.assign({ instanceBase: undefined as unknown as new () => unknown }, () => ({
 			value: { rev: 0, timestamp: Date.now(), value: { x: 0, y: 0, z: 0 } },
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 			manager: {} as InternalTypes.StateValue<{ x: number; y: number; z: number }>,
-		}),
+		})),
 	});
 	// Workaround ts(2775): Assertions require every name in the call target to be declared with an explicit type annotation.
 	const states: typeof statesWorkspace = statesWorkspace;


### PR DESCRIPTION
Check for presence of requested state:
- if found, check that instance type is minimally compatible (same manager class)
- if not, add state.