### PR TITLE
moveToIndex bug

### DIFF
--- a/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
@@ -321,6 +321,13 @@ describe("ArrayNode", () => {
 					assert.deepEqual([...array2], [1, 3]);
 				});
 
+				it.only("moveToIndex bug", () => {
+					const array = init(schemaType, [0, 1, 2]);
+					array.moveToIndex(2, 0);
+					// Actual result is: [1, 0, 2], effectively doing a call of array.moveToIndex(1, 0)
+					assert.deepEqual([...array], [1, 2, 0]);
+				});
+
 				for (const specifySource of [false, true]) {
 					describe(`move within field ${
 						specifySource ? "(specified source)" : "(implicit source)"


### PR DESCRIPTION
Say we do the following:
1. arr = [0, 1, 2]
2. arr.moveToIndex(2, 0)
3. We expect a result of [1, 2, 0], but we actually get [1, 0, 2]

This seems to be the case regardless of what the "source" index is. As long as the destination index is the end of the array, it will only ever move it to the index just before the end.

[AB#16323](https://dev.azure.com/fluidframework/internal/_workitems/edit/16323)