### PR TITLE
[port 2.3]: Avoid two leading slashes in the request to create a new file (#22563)

### DIFF
--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -164,13 +164,22 @@ function extractShareLinkData(
 	return shareLinkInfo;
 }
 
+/**
+ * Encodes file path so it can be embedded in the request url
+ * @param path - path to encode
+ * @returns encoded path or "" if path is undefined
+ */
+function encodeFilePath(path: string | undefined): string {
+	return path ? encodeURIComponent(path.startsWith("/") ? path : `/${path}`) : "";
+}
+
 export async function createNewEmptyFluidFile(
 	getAuthHeader: InstrumentedStorageTokenFetcher,
 	newFileInfo: INewFileInfo,
 	logger: ITelemetryLoggerExt,
 	epochTracker: EpochTracker,
 ): Promise<string> {
-	const filePath = newFileInfo.filePath ? encodeURIComponent(`/${newFileInfo.filePath}`) : "";
+	const filePath = encodeFilePath(newFileInfo.filePath);
 	// add .tmp extension to empty file (host is expected to rename)
 	const encodedFilename = encodeURIComponent(`${newFileInfo.filename}.tmp`);
 	const initialUrl = `${getApiRoot(new URL(newFileInfo.siteUrl))}/drives/${
@@ -234,7 +243,7 @@ export async function createNewFluidFileFromSummary(
 	epochTracker: EpochTracker,
 	forceAccessTokenViaAuthorizationHeader: boolean,
 ): Promise<ICreateFileResponse> {
-	const filePath = newFileInfo.filePath ? encodeURIComponent(`/${newFileInfo.filePath}`) : "";
+	const filePath = encodeFilePath(newFileInfo.filePath);
 	const encodedFilename = encodeURIComponent(newFileInfo.filename);
 	const baseUrl =
 		`${getApiRoot(new URL(newFileInfo.siteUrl))}/drives/${newFileInfo.driveId}/items/root:` +


### PR DESCRIPTION
Cherry-pick: https://github.com/microsoft/FluidFramework/pull/22563