### PR TITLE
Make DEFAULT_INTERDEPENDENCY_RANGE  "workspace:~"

### DIFF
--- a/build-tools/packages/build-cli/src/config.ts
+++ b/build-tools/packages/build-cli/src/config.ts
@@ -4,11 +4,7 @@
  */
 
 import { statSync } from "node:fs";
-import {
-	DEFAULT_INTERDEPENDENCY_RANGE,
-	InterdependencyRange,
-	VersionBumpType,
-} from "@fluid-tools/version-tools";
+import { InterdependencyRange, VersionBumpType } from "@fluid-tools/version-tools";
 import { MonoRepo } from "@fluidframework/build-tools";
 import { cosmiconfigSync } from "cosmiconfig";
 import { Context } from "./library/index.js";
@@ -378,3 +374,8 @@ export function getDefaultInterdependencyRange(
 
 	return interdependencyRange ?? DEFAULT_INTERDEPENDENCY_RANGE;
 }
+
+/**
+ * The default interdependency range we use when one is not provided.
+ */
+const DEFAULT_INTERDEPENDENCY_RANGE: InterdependencyRange = "workspace:~";

--- a/build-tools/packages/build-cli/src/library/bump.ts
+++ b/build-tools/packages/build-cli/src/library/bump.ts
@@ -3,19 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import {
-	DEFAULT_INTERDEPENDENCY_RANGE,
-	InterdependencyRange,
-	VersionChangeType,
-	VersionScheme,
-	bumpVersionScheme,
-	isVersionBumpType,
-} from "@fluid-tools/version-tools";
-import { Logger, MonoRepo, Package } from "@fluidframework/build-tools";
-import { Context } from "./context.js";
-
-import { setVersion } from "./package.js";
-
 /**
  * A type representing the types of dependency updates that can be done. This type is intended to match the type
  * npm-check-updates uses for its `target` argument.
@@ -43,38 +30,4 @@ export function isDependencyUpdateType(str: string | undefined): str is Dependen
 	}
 
 	return str.startsWith("@");
-}
-
-/**
- * Bumps a release group or standalone package by the bumpType.
- *
- * @param context - The {@link Context}.
- * @param releaseGroupOrPackage - A release group repo or package to bump.
- * @param bumpType - The bump type. Can be a SemVer object to set an exact version.
- * @param scheme - The version scheme to use.
- * @param interdependencyRange - The type of dependency to use on packages within the release group.
- * @param log - A logger to use.
- *
- * @internal
- */
-// eslint-disable-next-line max-params
-export async function bumpReleaseGroup(
-	context: Context,
-	releaseGroupOrPackage: MonoRepo | Package,
-	bumpType: VersionChangeType,
-	scheme?: VersionScheme,
-	interdependencyRange: InterdependencyRange = DEFAULT_INTERDEPENDENCY_RANGE,
-	log?: Logger,
-): Promise<void> {
-	const translatedVersion = isVersionBumpType(bumpType)
-		? bumpVersionScheme(releaseGroupOrPackage.version, bumpType, scheme)
-		: bumpType;
-
-	await setVersion(
-		context,
-		releaseGroupOrPackage,
-		translatedVersion,
-		interdependencyRange,
-		log,
-	);
 }

--- a/build-tools/packages/build-cli/src/library/index.ts
+++ b/build-tools/packages/build-cli/src/library/index.ts
@@ -16,7 +16,7 @@ export {
 	generateReleaseBranchName,
 } from "./branches.js";
 export { getDisplayDate, getDisplayDateRelative } from "./dates.js";
-export { bumpReleaseGroup, DependencyUpdateType, isDependencyUpdateType } from "./bump.js";
+export { DependencyUpdateType, isDependencyUpdateType } from "./bump.js";
 export {
 	DEFAULT_CHANGESET_PATH,
 	fluidCustomChangeSetMetadataDefaults,

--- a/build-tools/packages/version-tools/api-report/version-tools.api.md
+++ b/build-tools/packages/version-tools/api-report/version-tools.api.md
@@ -16,9 +16,6 @@ export function bumpVersionScheme(version: string | semver.SemVer | undefined, b
 export function changePreReleaseIdentifier(version: semver.SemVer | string, newIdentifier: string): string;
 
 // @public
-export const DEFAULT_INTERDEPENDENCY_RANGE: InterdependencyRange;
-
-// @public
 export const DEFAULT_PRERELEASE_IDENTIFIER = "internal";
 
 // @public

--- a/build-tools/packages/version-tools/src/bumpTypes.ts
+++ b/build-tools/packages/version-tools/src/bumpTypes.ts
@@ -8,7 +8,7 @@ import * as semver from "semver";
 /**
  * The default interdependency range we use when one is not provided.
  */
-export const DEFAULT_INTERDEPENDENCY_RANGE: InterdependencyRange = "^";
+export const DEFAULT_INTERDEPENDENCY_RANGE: InterdependencyRange = "workspace:~";
 
 /**
  * A type alias for strings that represent package versions.

--- a/build-tools/packages/version-tools/src/bumpTypes.ts
+++ b/build-tools/packages/version-tools/src/bumpTypes.ts
@@ -6,11 +6,6 @@
 import * as semver from "semver";
 
 /**
- * The default interdependency range we use when one is not provided.
- */
-export const DEFAULT_INTERDEPENDENCY_RANGE: InterdependencyRange = "workspace:~";
-
-/**
  * A type alias for strings that represent package versions.
  */
 export type ReleaseVersion = string;

--- a/build-tools/packages/version-tools/src/index.ts
+++ b/build-tools/packages/version-tools/src/index.ts
@@ -9,7 +9,6 @@ export {
 	isVersionBumpType,
 	isVersionBumpTypeExtended,
 	isWorkspaceRange,
-	DEFAULT_INTERDEPENDENCY_RANGE,
 	InterdependencyRange,
 	RangeOperator,
 	RangeOperators,


### PR DESCRIPTION
## Description

flub bump has two use cases: 

1. Setting the dependency versions during release via tools/pipelines/templates/include-set-package-version.yml which uses `update-package-version.sh`. This case sets --interdependencyRange unconditionally and should not be impacted by the default.
2. running `flub bump` to update the version for releases (usually via flub release). This wants to leave the dependencies unchanged.

Since dependencies in main use "workspace:~", this second case has been making unwanted modifications when trying to just bump the version.

Future changes should separate these two use cases into a tool that bumps versions and a tool which sets the inter dependency ranges.

While evaluating use of DEFAULT_INTERDEPENDENCY_RANGE, bumpReleaseGroup which uses it was found, but is dead code and was deleted.

DEFAULT_INTERDEPENDENCY_RANGE was then moved next to its only remaining use `getDefaultInterdependencyRange`.

## Breaking Changes

Anything that relies on the current getDefaultInterdependencyRange will be impacted.

Since that is a InterdependencyRange meaning it only applies to "dependencies between packages within the same release group." this change seems like it's an improvement.

The only other user of `getDefaultInterdependencyRange`  is `doReleaseGroupBump`, which seems like it should fix previously unknown issue where it has the same issue, so this is likely fine.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
