### PR TITLE
Add flub setInterdependencyRange

### DIFF
--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -48,6 +48,7 @@ USAGE
 * [`flub release`](docs/release.md) - Release commands are used to manage the Fluid release process.
 * [`flub rename-types`](docs/rename-types.md) - Renames type declaration files from .d.ts to .d.mts.
 * [`flub run`](docs/run.md) - Generate a report from input bundle stats collected through the collect bundleStats command.
+* [`flub setInterdependencyRange`](docs/setInterdependencyRange.md) - Modifies the interdependency range used within a release group.
 * [`flub transform`](docs/transform.md) - Transform commands are used to transform code, docs, etc. into alternative forms.
 * [`flub typetests`](docs/typetests.md) - Updates configuration for type tests in package.json files. If the previous version changes after running preparation, then npm install must be run before building.
 

--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -20,8 +20,8 @@ ARGUMENTS
 
 FLAGS
   -d, --interdependencyRange=<option>
-      [Deprecated]: Use the "SetInterdependencyRange" instead. Controls the type of dependency that is used between
-      packages within the release group. Use "" (the empty string) to indicate exact dependencies. Use the
+      [Deprecated]: Use the "SetInterdependencyRange" command instead. Controls the type of dependency that is used
+      between packages within the release group. Use "" (the empty string) to indicate exact dependencies. Use the
       workspace:-prefixed values to set interdependencies using the workspace protocol. The interdependency range will be
       set to the workspace string specified.
       <options: ^|~||workspace:*|workspace:^|workspace:~>

--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -13,32 +13,38 @@ Bumps the version of a release group or package to the next minor, major, or pat
 ```
 USAGE
   $ flub bump PACKAGE_OR_RELEASE_GROUP [-v | --quiet] [-t major|minor|patch | --exact <value>] [--scheme
-    semver|internal|virtualPatch | ] [--exactDepType ^|~||workspace:*|workspace:^|workspace:~] [-d
-    ^|~||workspace:*|workspace:^|workspace:~] [-x | --install | --commit |  |  | ]
+    semver|internal|virtualPatch | ] [-d ^|~||workspace:*|workspace:^|workspace:~] [-x | --install | --commit |  |  | ]
 
 ARGUMENTS
   PACKAGE_OR_RELEASE_GROUP  The name of a package or a release group.
 
 FLAGS
-  -d, --interdependencyRange=<option>  Controls the type of dependency that is used between packages within the release
-                                       group. Use "" (the empty string) to indicate exact dependencies. Use the
-                                       workspace:-prefixed values to set interdependencies using the workspace protocol.
-                                       The interdependency range will be set to the workspace string specified.
-                                       <options: ^|~||workspace:*|workspace:^|workspace:~>
-  -t, --bumpType=<option>              Bump the release group or package to the next version according to this bump
-                                       type.
-                                       <options: major|minor|patch>
-  -x, --skipChecks                     Skip all checks.
-      --[no-]commit                    Commit changes to a new branch.
-      --exact=<value>                  An exact string to use as the version. The string must be a valid semver version
-                                       string.
-      --exactDepType=<option>          [DEPRECATED - Use interdependencyRange instead.] Controls the type of dependency
-                                       that is used between packages within the release group. Use "" to indicate exact
-                                       dependencies.
-                                       <options: ^|~||workspace:*|workspace:^|workspace:~>
-      --[no-]install                   Update lockfiles by running 'npm install' automatically.
-      --scheme=<option>                Override the version scheme used by the release group or package.
-                                       <options: semver|internal|virtualPatch>
+  -d, --interdependencyRange=<option>
+      [Deprecated]: Use the "SetInterdependencyRange" instead. Controls the type of dependency that is used between
+      packages within the release group. Use "" (the empty string) to indicate exact dependencies. Use the
+      workspace:-prefixed values to set interdependencies using the workspace protocol. The interdependency range will be
+      set to the workspace string specified.
+      <options: ^|~||workspace:*|workspace:^|workspace:~>
+
+  -t, --bumpType=<option>
+      Bump the release group or package to the next version according to this bump type.
+      <options: major|minor|patch>
+
+  -x, --skipChecks
+      Skip all checks.
+
+  --[no-]commit
+      Commit changes to a new branch.
+
+  --exact=<value>
+      An exact string to use as the version. The string must be a valid semver version string.
+
+  --[no-]install
+      Update lockfiles by running 'npm install' automatically.
+
+  --scheme=<option>
+      Override the version scheme used by the release group or package.
+      <options: semver|internal|virtualPatch>
 
 LOGGING FLAGS
   -v, --verbose  Enable verbose logging.

--- a/build-tools/packages/build-cli/docs/setInterdependencyRange.md
+++ b/build-tools/packages/build-cli/docs/setInterdependencyRange.md
@@ -14,7 +14,7 @@ USAGE
   $ flub setInterdependencyRange GROUP INTERDEPENDENCYRANGE [-v | --quiet]
 
 ARGUMENTS
-  GROUP                 The release group to modify. In a package is provided instead of a group, the command is a
+  GROUP                 The release group to modify. If a package is provided instead of a group, the command is a
                         no-op.
   INTERDEPENDENCYRANGE  (^|~||workspace:*|workspace:^|workspace:~) Controls the type of dependency that is used between
                         packages within the release group. Use "" (the empty string) to indicate exact dependencies.

--- a/build-tools/packages/build-cli/docs/setInterdependencyRange.md
+++ b/build-tools/packages/build-cli/docs/setInterdependencyRange.md
@@ -14,7 +14,8 @@ USAGE
   $ flub setInterdependencyRange GROUP INTERDEPENDENCYRANGE [-v | --quiet]
 
 ARGUMENTS
-  GROUP                 The release group to modify.
+  GROUP                 The release group to modify. In a package is provided instead of a group, the command is a
+                        no-op.
   INTERDEPENDENCYRANGE  (^|~||workspace:*|workspace:^|workspace:~) Controls the type of dependency that is used between
                         packages within the release group. Use "" (the empty string) to indicate exact dependencies.
 

--- a/build-tools/packages/build-cli/docs/setInterdependencyRange.md
+++ b/build-tools/packages/build-cli/docs/setInterdependencyRange.md
@@ -1,0 +1,31 @@
+`flub setInterdependencyRange`
+==============================
+
+Modifies the interdependency range used within a release group.
+
+* [`flub setInterdependencyRange GROUP INTERDEPENDENCYRANGE`](#flub-setinterdependencyrange-group-interdependencyrange)
+
+## `flub setInterdependencyRange GROUP INTERDEPENDENCYRANGE`
+
+Modifies the interdependency range used within a release group.
+
+```
+USAGE
+  $ flub setInterdependencyRange GROUP INTERDEPENDENCYRANGE [-v | --quiet]
+
+ARGUMENTS
+  GROUP                 The release group to modify.
+  INTERDEPENDENCYRANGE  (^|~||workspace:*|workspace:^|workspace:~) Controls the type of dependency that is used between
+                        packages within the release group. Use "" (the empty string) to indicate exact dependencies.
+
+LOGGING FLAGS
+  -v, --verbose  Enable verbose logging.
+      --quiet    Disable all logging.
+
+DESCRIPTION
+  Modifies the interdependency range used within a release group.
+
+  Used by the release process to set the interdependency range in published packages.
+```
+
+_See code: [src/commands/setInterdependencyRange.ts](https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/src/commands/setInterdependencyRange.ts)_

--- a/build-tools/packages/build-cli/src/commands/setInterdependencyRange.ts
+++ b/build-tools/packages/build-cli/src/commands/setInterdependencyRange.ts
@@ -27,7 +27,8 @@ export default class SetInterdependencyRangeCommand extends BaseCommand<
 
 	static readonly args = {
 		group: Args.string({
-			description: "The release group to modify.",
+			description:
+				"The release group to modify. If a package is provided instead of a group, the command is a no-op.",
 			required: true,
 		}),
 		interdependencyRange: Args.string({
@@ -43,8 +44,13 @@ export default class SetInterdependencyRangeCommand extends BaseCommand<
 
 		const context = await this.getContext();
 		const releaseRepo = findPackageOrReleaseGroup(args.group, context);
-		if (!(releaseRepo instanceof MonoRepo)) {
+		if (releaseRepo === undefined) {
 			this.error(`Release Group not found: ${args.group}`);
+		} else if (!(releaseRepo instanceof MonoRepo)) {
+			this.warning(
+				`Found package not release group. Since packages have no interdependencies no changes will be made.`,
+			);
+			return;
 		}
 
 		const newRange = `${args.interdependencyRange}${releaseRepo.version}`;

--- a/build-tools/packages/build-cli/src/commands/setInterdependencyRange.ts
+++ b/build-tools/packages/build-cli/src/commands/setInterdependencyRange.ts
@@ -1,0 +1,78 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Args } from "@oclif/core";
+import chalk from "chalk";
+
+import { MonoRepo } from "@fluidframework/build-tools";
+
+import {
+	RangeOperators,
+	WorkspaceRanges,
+	isInterdependencyRange,
+} from "@fluid-tools/version-tools";
+
+import { findPackageOrReleaseGroup } from "../args.js";
+import { BaseCommand } from "../library/index.js";
+import { type DependencyWithRange, setPackageDependencies } from "../library/index.js";
+
+export default class SetInterdependencyRangeCommand extends BaseCommand<
+	typeof SetInterdependencyRangeCommand
+> {
+	static readonly summary = "Modifies the interdependency range used within a release group.";
+	static readonly description =
+		`Used by the release process to set the interdependency range in published packages.`;
+
+	static readonly args = {
+		group: Args.string({
+			description: "The release group to modify.",
+			required: true,
+		}),
+		interdependencyRange: Args.string({
+			description:
+				'Controls the type of dependency that is used between packages within the release group. Use "" (the empty string) to indicate exact dependencies.',
+			options: [...RangeOperators, ...WorkspaceRanges],
+			required: true,
+		}),
+	} as const;
+
+	public async run(): Promise<void> {
+		const { args } = this;
+
+		const context = await this.getContext();
+		const releaseRepo = findPackageOrReleaseGroup(args.group, context);
+		if (!(releaseRepo instanceof MonoRepo)) {
+			this.error(`Release Group not found: ${args.group}`);
+		}
+
+		const newRange = `${args.interdependencyRange}${releaseRepo.version}`;
+
+		this.logHr();
+		this.log(`Release group: ${chalk.blueBright(releaseRepo.name)}`);
+		this.log(`Interdependency range: ${newRange}`);
+		if (!isInterdependencyRange(newRange)) {
+			this.error("Invalid Interdependency range");
+		}
+		this.logHr();
+
+		this.log(`Updating dependencies...`);
+
+		const dependencyVersionMap = new Map<string, DependencyWithRange>();
+		for (const pkg of releaseRepo.packages) {
+			dependencyVersionMap.set(pkg.name, { pkg, range: newRange });
+		}
+
+		await Promise.all(
+			releaseRepo.packages.map(async (pkg) =>
+				setPackageDependencies(
+					pkg,
+					dependencyVersionMap,
+					/* updateWithinSameReleaseGroup */ true,
+				),
+			),
+		);
+		this.log(`Update complete`);
+	}
+}

--- a/build-tools/packages/build-cli/src/library/index.ts
+++ b/build-tools/packages/build-cli/src/library/index.ts
@@ -46,6 +46,8 @@ export {
 	PreReleaseDependencies,
 	setVersion,
 	sortVersions,
+	setPackageDependencies,
+	type DependencyWithRange,
 } from "./package.js";
 export { difference } from "./sets.js";
 export { getIndent, indentString, readLines } from "./text.js";

--- a/build-tools/packages/build-cli/src/library/package.ts
+++ b/build-tools/packages/build-cli/src/library/package.ts
@@ -522,6 +522,12 @@ export async function setVersion(
 			stdio: "inherit",
 			shell: true,
 		};
+		// TODO:
+		// This should not exec flub.
+		// It can just call the same code flub uses to implement this.
+		// Doing so would be more efficient, more type safe and easier to debug.
+		// It would also enable this code to work when flub is not on the path, and ensure a matching version of the code is used.
+		// Also using `npm version` to edit one field of the the package.json file when we already have code below editing it directly (for dependencies) seems needlessly complex and inefficent.
 		cmds.push(
 			[
 				`flub`,
@@ -687,7 +693,7 @@ function getDependenciesRecord(
  * there are some cases where you need to forcefully change the dependency range of packages across the whole repo. For
  * example, when setting release group package versions in the CI release pipeline.
  */
-async function setPackageDependencies(
+export async function setPackageDependencies(
 	pkg: Package,
 	dependencyVersionMap: Map<string, DependencyWithRange>,
 	updateWithinSameReleaseGroup = false,

--- a/build-tools/packages/version-tools/api-report/version-tools.api.md
+++ b/build-tools/packages/version-tools/api-report/version-tools.api.md
@@ -58,7 +58,7 @@ export function getVersionRange(version: semver.SemVer | string, maxAutomaticBum
 export type InterdependencyRange = WorkspaceRange | RangeOperator | RangeOperatorWithVersion | semver.SemVer;
 
 // @public
-export function isInterdependencyRange(r: unknown): r is InterdependencyRange;
+export function isInterdependencyRange(r: string): r is Exclude<InterdependencyRange, semver.SemVer>;
 
 // @public
 export function isInternalTestVersion(version: semver.SemVer | string): boolean;

--- a/build-tools/packages/version-tools/src/bumpTypes.ts
+++ b/build-tools/packages/version-tools/src/bumpTypes.ts
@@ -86,17 +86,19 @@ export type InterdependencyRange =
  * excluding non-conforming strings than it does at finding valid ones. This appears to be sufficient for our needs,
  * which is good because I don't know how to fix it.
  */
-export function isInterdependencyRange(r: unknown): r is InterdependencyRange {
-	if ((typeof r === "string" || r instanceof semver.SemVer) && semver.valid(r) !== null) {
+export function isInterdependencyRange(
+	r: string,
+): r is Exclude<InterdependencyRange, semver.SemVer> {
+	if (semver.valid(r) !== null) {
+		return true;
+	}
+
+	if (semver.validRange(r) !== null) {
 		return true;
 	}
 
 	if (isRangeOperator(r) || isWorkspaceRange(r)) {
 		return true;
-	}
-
-	if ((typeof r === "string" || r instanceof semver.Range) && semver.validRange(r) === null) {
-		return false;
 	}
 
 	if (typeof r === "string") {

--- a/scripts/set-interdependency-range.sh
+++ b/scripts/set-interdependency-range.sh
@@ -1,0 +1,18 @@
+# This script is used in the "Update Package Version (flub)" step in our CI build pipelines.
+# It takes version data from environment variables and updates the interdependency ranges accordingly.
+# The environment variables are set earlier in the pipeline, in the "Set Package Version" step.
+
+set -eux -o pipefail
+
+echo RELEASE_GROUP=$RELEASE_GROUP
+echo INTERDEPENDENCY_RANGE="'$INTERDEPENDENCY_RANGE'"
+
+if [ "$VERSION_RELEASE" = "release" ]; then
+    echo "release group with '$INTERDEPENDENCY_RANGE' deps"
+    flub setInterdependencyRange $RELEASE_GROUP $SETVERSION_VERSION "$INTERDEPENDENCY_RANGE" -xv
+else
+  # this is a non-release build of a release group, so always use exact interdependencies, otherwise
+  # dev/test builds may accidentally bring in different versions.
+  echo "release group non-release build"
+  flub setInterdependencyRange $RELEASE_GROUP $SETVERSION_VERSION "" -xv
+fi

--- a/scripts/update-package-version.sh
+++ b/scripts/update-package-version.sh
@@ -1,6 +1,8 @@
-# This script is used in the "update package versions" step in our CI build pipelines.
+# This script is used in the "Update Package Version (flub)" step in our CI build pipelines.
 # It takes version data from environment variables and updates the package versions accordingly.
-# The environment variables are set earlier in the pipeline, in the "set package version" step.
+# The environment variables are set earlier in the pipeline, in the "Set Package Version" step.
+
+# This Script is deprecated. Once build tools are updated, scripts/set-interdependency-range.sh should be used instead.
 
 echo SETVERSION_VERSION=$SETVERSION_VERSION
 echo SETVERSION_CODEVERSION=$SETVERSION_CODEVERSION


### PR DESCRIPTION
## Description

Adds new command to flub `setInterdependencyRange` intended for use by release pipeline to replace its use of flub bump.

Also cleans up some related code in flub bump.

Once this is adopted, dependency modification support can be removed from `flub bump`, simplifying its responsibilities.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).