### PR TITLE
fix(build-cli): Load interdependency ranges from fluid-build config for back-compat

### DIFF
--- a/build-tools/packages/build-cli/src/config.ts
+++ b/build-tools/packages/build-cli/src/config.ts
@@ -361,20 +361,34 @@ export function getFlubConfig(configPath: string, noCache = false): FlubConfig {
 }
 
 /**
- * Convenience function to extract the default interdependency range for a release group from the flub config.
+ * Convenience function to extract the default interdependency range for a release group from the flub config. For
+ * back-compat, it will also load the relevant setting from the fluid-build config.
  */
 export function getDefaultInterdependencyRange(
 	releaseGroup: ReleaseGroup | MonoRepo,
 	context: Context,
 ): InterdependencyRange {
 	const releaseGroupName = releaseGroup instanceof MonoRepo ? releaseGroup.name : releaseGroup;
-	const interdependencyRangeDefaults = context.flubConfig.bump?.defaultInterdependencyRange;
-	if (interdependencyRangeDefaults === undefined) {
-		return DEFAULT_INTERDEPENDENCY_RANGE;
+
+	// Prefer to use the configuration in the flub config if available.
+	const flubConfigRanges = context.flubConfig.bump?.defaultInterdependencyRange;
+	const interdependencyRangeFromFlubConfig: InterdependencyRange | undefined =
+		flubConfigRanges?.[releaseGroupName as ReleaseGroup];
+
+	// Return early if the flub config had a range configured - no need to check/load other configs.
+	if (interdependencyRangeFromFlubConfig !== undefined) {
+		return interdependencyRangeFromFlubConfig;
 	}
 
-	const interdependencyRange =
-		interdependencyRangeDefaults?.[releaseGroupName as ReleaseGroup];
+	// For back-compat with earlier configs, try to load the default interdependency range from the fluid-build config.
+	// This can be removed once we are no longer supporting release branches older than release/client/2.4
+	const fbConfig = context.fluidBuildConfig.repoPackages?.[releaseGroupName];
+	const interdependencyRangeFromFluidBuildConfig =
+		fbConfig !== undefined && typeof fbConfig === "object" && !Array.isArray(fbConfig)
+			? fbConfig.defaultInterdependencyRange
+			: undefined;
 
-	return interdependencyRange ?? DEFAULT_INTERDEPENDENCY_RANGE;
+	// Once the back-compat code above is removed, this should change to
+	// return interdependencyRangeFromFlubConfig ?? DEFAULT_INTERDEPENDENCY_RANGE
+	return interdependencyRangeFromFluidBuildConfig ?? DEFAULT_INTERDEPENDENCY_RANGE;
 }

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -39,6 +39,7 @@
 		"tsc": "tsc"
 	},
 	"dependencies": {
+		"@fluid-tools/version-tools": "workspace:~",
 		"@manypkg/get-packages": "^2.2.0",
 		"async": "^3.2.4",
 		"chalk": "^2.4.2",

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidBuildConfig.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidBuildConfig.ts
@@ -59,7 +59,7 @@ export interface IFluidBuildDir {
 	 * @deprecated This property is now configured in the bump.defaultInterdependencyRange setting in the flub config.
 	 * This property will be removed in a future release.
 	 */
-	defaultInterdependencyRange?: InterdependencyRange,
+	defaultInterdependencyRange?: InterdependencyRange;
 }
 
 export type IFluidBuildDirEntry = string | IFluidBuildDir | (string | IFluidBuildDir)[];

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidBuildConfig.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidBuildConfig.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import type { InterdependencyRange } from "@fluid-tools/version-tools";
 import { TaskDefinitionsOnDisk } from "./fluidTaskDefinitions";
 
 /**
@@ -50,6 +51,15 @@ export interface IFluidBuildDir {
 	 * An array of paths under `directory` that should be ignored.
 	 */
 	ignoredDirs?: string[];
+
+	/**
+	 * For backwards compatibility, the defaultInterdependencyRange for a release group can be configured here in the
+	 * fluid-build config. This property should no longer be used and will be removed in a future release.
+	 *
+	 * @deprecated This property is now configured in the bump.defaultInterdependencyRange setting in the flub config.
+	 * This property will be removed in a future release.
+	 */
+	defaultInterdependencyRange?: InterdependencyRange,
 }
 
 export type IFluidBuildDirEntry = string | IFluidBuildDir | (string | IFluidBuildDir)[];

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -391,6 +391,9 @@ importers:
 
   packages/build-tools:
     dependencies:
+      '@fluid-tools/version-tools':
+        specifier: workspace:~
+        version: link:../version-tools
       '@manypkg/get-packages':
         specifier: ^2.2.0
         version: 2.2.0


### PR DESCRIPTION
## Summary

`flub bump` can be configured to use different default settings for different release groups. Those settings are in the root flub config - which historically has been the same as the fluid-build config file. This change updates the code to add back-compat handling. If the settings in the flub config are not found, the fluid-build config will be checked. This back-compat code can be removed as soon as we no longer support any release branches without the new config.

This change does unfortunately add back a dependency between build-tools and version-tools. Fortunately, that can be removed once we no longer need to support the older configs.

#22630 removes the need for this change by updating the config - but this change is still needed for back-compat with earlier configs.

## Background

When the fluid-build and flub configs were split in #21967, it didn't take into account the config settings in the fluid-build config that control the default interdependency range for each release group. Those settings are intended to be in the `bump` section of the flub config, but the fluidBuild config file in the repo doesn't include those settings, and there was no back-compat code that loaded them as far as I can tell.

In #21967, though, the settings were removed from the old fluid-build config types (see the removal of lines 330-335 in fluidRepo.ts: [change](https://github.com/microsoft/FluidFramework/commit/f667535a3f4f893115c3360a78d07acfa9d24456?diff=split&w=0#diff-9a0994a9d2ddb86f6f1e53fef4e8de22cf87ced6dd81bd0e8866784c2679f450L330)

That was an unintended breaking change because the old settings are not loaded when using new versions of flub. This change adds the missing back-compat code to load those settings.
