### PR TITLE
build(client): Move flub bump config settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -181,6 +181,23 @@
 			"args": ["test-only-filter", "--all"],
 		},
 		{
+			"name": "flub bump build-tools",
+			"program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev.js",
+			"cwd": "${workspaceFolder}",
+			"request": "launch",
+			"skipFiles": ["<node_internals>/**"],
+			"type": "node",
+			"args": [
+				"bump",
+				"build-tools",
+				"-t",
+				"patch",
+				"--verbose",
+				"--no-commit",
+				"--no-install",
+			],
+		},
+		{
 			"name": "flub bump deps",
 			"program": "${workspaceFolder}/build-tools/packages/build-cli/bin/dev.js",
 			"cwd": "${workspaceFolder}",

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -16,7 +16,7 @@ const tscDependsOn = ["^tsc", "^api", "build:genver", "ts2esm"];
  * See https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-tools/src/common/fluidTaskDefinitions.ts
  * for details on the task and dependency definition format.
  *
- * @type {import("@fluidframework/build-tools").IFluidBuildConfig}
+ * @type {import("@fluidframework/build-tools").IFluidBuildConfig & import("@fluid-tools/build-cli").FlubConfig}
  */
 module.exports = {
 	version: 1,
@@ -167,19 +167,15 @@ module.exports = {
 		},
 		"build-tools": {
 			directory: "build-tools",
-			defaultInterdependencyRange: "workspace:~",
 		},
 		"server": {
 			directory: "server/routerlicious",
-			defaultInterdependencyRange: "workspace:~",
 		},
 		"gitrest": {
 			directory: "server/gitrest",
-			defaultInterdependencyRange: "^",
 		},
 		"historian": {
 			directory: "server/historian",
-			defaultInterdependencyRange: "^",
 		},
 
 		// Independent packages
@@ -532,6 +528,18 @@ module.exports = {
 		assertionFunctions: {
 			assert: 1,
 		},
+	},
+
+	// `flub bump` config. These settings influence `flub bump` behavior for a release group. These settings can be
+	// overridden usig explicit CLI flags like `--interdependencyRange`.
+	bump: {
+		defaultInterdependencyRange: {
+			"client": "workspace:~",
+			"build-tools": "workspace:~",
+			"server": "workspace:~",
+			"gitrest": "^",
+			"historian": "^",
+		}
 	},
 
 	// This defines the branch release types for type tests. It applies only to the client release group. Settings for

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -539,7 +539,7 @@ module.exports = {
 			"server": "workspace:~",
 			"gitrest": "^",
 			"historian": "^",
-		}
+		},
 	},
 
 	// This defines the branch release types for type tests. It applies only to the client release group. Settings for


### PR DESCRIPTION
The defaultInterdependencyRange setting in the fluid-build config is no longer where settings for `flub bump` should be stored. Instead, they should be defined in a `bump` setting in the flub config.

This change is related to #22628. This change will make the changes in #22628 irrelevant in main and future release branches, but they are still needed so the tools work against release branches without this change (2.3 client and before).