### PR TITLE
Fix 0x314 assert in Container close/dispose flow

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1045,8 +1045,7 @@ export class Container
 	}
 
 	public dispose(error?: ICriticalContainerError): void {
-		this._deltaManager.dispose(error);
-		this.verifyClosed();
+		this.trackCloseDisposeReentry(() => this._deltaManager.dispose(error));
 	}
 
 	public close(error?: ICriticalContainerError): void {
@@ -1054,20 +1053,30 @@ export class Container
 		// 2. We need to ensure that we deliver disconnect event to runtime properly. See connectionStateChanged
 		//    handler. We only deliver events if container fully loaded. Transitioning from "loading" ->
 		//    "closing" will lose that info (can also solve by tracking extra state).
-		this._deltaManager.close(error);
-		this.verifyClosed();
+		this.trackCloseDisposeReentry(() => this._deltaManager.close(error));
 	}
 
-	private verifyClosed(): void {
-		assert(
-			this.connectionState === ConnectionState.Disconnected,
-			0x0cf /* "disconnect event was not raised!" */,
-		);
+	private trackCloseDisposeReentryCalls = 0;
+	private trackCloseDisposeReentry(callback: () => void): void {
+		this.trackCloseDisposeReentryCalls++;
+		try {
+			callback();
+		} finally {
+			this.trackCloseDisposeReentryCalls--;
+		}
 
-		assert(
-			this._lifecycleState === "closed" || this._lifecycleState === "disposed",
-			0x314 /* Container properly closed */,
-		);
+		// We only want to verify connectionState and lifecycleState after close/dispose has fully finished
+		if (this.trackCloseDisposeReentryCalls === 0) {
+			assert(
+				this.connectionState === ConnectionState.Disconnected,
+				0x0cf /* "disconnect event was not raised!" */,
+			);
+
+			assert(
+				this._lifecycleState === "closed" || this._lifecycleState === "disposed",
+				0x314 /* Container properly closed */,
+			);
+		}
 	}
 
 	private closeCore(error?: ICriticalContainerError): void {

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -756,7 +756,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 		it("Closing container", async () => {
 			const container = await createConnectedContainer();
 			container.deltaManager.on("disconnect", () => {
-				// Assert 0x314 would appear in "after each" unexpected errors (see DeltaManager ctor)
+				// Assert 0x314 would appear in "after each" unexpected errors (see "super" call in DeltaManager ctor)
 				container.close();
 			});
 			container.close();
@@ -765,7 +765,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 		it("Disposing container", async () => {
 			const container = await createConnectedContainer();
 			container.deltaManager.on("disconnect", () => {
-				// Assert 0x314 would appear in "after each" unexpected errors (see DeltaManager ctor)
+				// Assert 0x314 would appear in "after each" unexpected errors (see "super" call in DeltaManager ctor)
 				container.dispose();
 			});
 			container.dispose();
@@ -774,7 +774,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 		it("Mix and match", async () => {
 			const container = await createConnectedContainer();
 			container.on("disconnected", () => {
-				// Assert 0x314 would appear in "after each" unexpected errors (see Container ctor)
+				// Assert 0x314 would appear in "after each" unexpected errors (see "super" call in Container ctor)
 				container.close();
 			});
 			container.dispose();

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -752,6 +752,35 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 		},
 	);
 
+	describe("0x314 assert", () => {
+		it("Closing container", async () => {
+			const container = await createConnectedContainer();
+			container.deltaManager.on("disconnect", () => {
+				// Assert 0x314 would appear in "after each" unexpected errors (see DeltaManager ctor)
+				container.close();
+			});
+			container.close();
+		});
+
+		it("Disposing container", async () => {
+			const container = await createConnectedContainer();
+			container.deltaManager.on("disconnect", () => {
+				// Assert 0x314 would appear in "after each" unexpected errors (see DeltaManager ctor)
+				container.dispose();
+			});
+			container.dispose();
+		});
+
+		it("Mix and match", async () => {
+			const container = await createConnectedContainer();
+			container.on("disconnected", () => {
+				// Assert 0x314 would appear in "after each" unexpected errors (see Container ctor)
+				container.close();
+			});
+			container.dispose();
+		});
+	});
+
 	// Temporary disable since we reverted the fix that caused an increase in loader bundle size.
 	// Tracking alternative fix in AB#4129.
 	it.skip("clientDetailsOverride does not cause client details of other containers with the same loader to change", async function () {


### PR DESCRIPTION
The `0x314` assert can sometimes hit on weird conditions by calling `Container.close(...)` or `Container.dispose(...)` while in the middle of closing/disposing. One easy way to do this is by listening to the DeltaManager's `"disconnect"` event or the Container's `"disconnected"` event, and then calling close/dispose on the Container.

```
container.on("disconnected", () => {
	container.close();
});
container.close();
```

Fixes [AB#17087](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/17087)