### PR TITLE
docs(tree): improve docs for move destination index argument

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -474,14 +474,14 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     insertAtStart(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveToEnd(sourceIndex: number): void;
     moveToEnd(sourceIndex: number, source: TMoveFrom): void;
-    moveToIndex(index: number, sourceIndex: number): void;
-    moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
+    moveToIndex(destinationGap: number, sourceIndex: number): void;
+    moveToIndex(destinationGap: number, sourceIndex: number, source: TMoveFrom): void;
     moveToStart(sourceIndex: number): void;
     moveToStart(sourceIndex: number, source: TMoveFrom): void;
     removeAt(index: number): void;

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -400,14 +400,14 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     insertAtStart(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveToEnd(sourceIndex: number): void;
     moveToEnd(sourceIndex: number, source: TMoveFrom): void;
-    moveToIndex(index: number, sourceIndex: number): void;
-    moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
+    moveToIndex(destinationGap: number, sourceIndex: number): void;
+    moveToIndex(destinationGap: number, sourceIndex: number, source: TMoveFrom): void;
     moveToStart(sourceIndex: number): void;
     moveToStart(sourceIndex: number, source: TMoveFrom): void;
     removeAt(index: number): void;

--- a/packages/dds/tree/api-report/tree.legacy.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.alpha.api.md
@@ -398,14 +398,14 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     insertAtStart(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveToEnd(sourceIndex: number): void;
     moveToEnd(sourceIndex: number, source: TMoveFrom): void;
-    moveToIndex(index: number, sourceIndex: number): void;
-    moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
+    moveToIndex(destinationGap: number, sourceIndex: number): void;
+    moveToIndex(destinationGap: number, sourceIndex: number, source: TMoveFrom): void;
     moveToStart(sourceIndex: number): void;
     moveToStart(sourceIndex: number, source: TMoveFrom): void;
     removeAt(index: number): void;

--- a/packages/dds/tree/api-report/tree.legacy.public.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.public.api.md
@@ -395,14 +395,14 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     insertAtStart(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveToEnd(sourceIndex: number): void;
     moveToEnd(sourceIndex: number, source: TMoveFrom): void;
-    moveToIndex(index: number, sourceIndex: number): void;
-    moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
+    moveToIndex(destinationGap: number, sourceIndex: number): void;
+    moveToIndex(destinationGap: number, sourceIndex: number, source: TMoveFrom): void;
     moveToStart(sourceIndex: number): void;
     moveToStart(sourceIndex: number, source: TMoveFrom): void;
     removeAt(index: number): void;

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -395,14 +395,14 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     insertAtStart(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveToEnd(sourceIndex: number): void;
     moveToEnd(sourceIndex: number, source: TMoveFrom): void;
-    moveToIndex(index: number, sourceIndex: number): void;
-    moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
+    moveToIndex(destinationGap: number, sourceIndex: number): void;
+    moveToIndex(destinationGap: number, sourceIndex: number, source: TMoveFrom): void;
     moveToStart(sourceIndex: number): void;
     moveToStart(sourceIndex: number, source: TMoveFrom): void;
     removeAt(index: number): void;

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -134,30 +134,30 @@ export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
 	 * Moves the specified item to the desired location in the array.
 	 *
 	 * WARNING - This API is easily misused.
-	 * Please read the documentation for the `destinationIndex` parameter carefully.
+	 * Please read the documentation for the `destinationGap` parameter carefully.
 	 *
-	 * @param destinationIndex - The index to move the item to in the range [0, `array.length`].
+	 * @param destinationGap - The location *between* existing items that the moved item should be moved to.
 	 *
-	 * WARNING - `destinationIndex` is interpreted based on the state of the array *before* the move operation is applied.
+	 * WARNING - `destinationGap` describes a location between existing items *prior to applying the move operation*.
 	 *
-	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationIndex` must be one of the following:
+	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationGap` must be one of the following:
 	 *
 	 * - `0` (between the start of the array and `A`'s original position)
 	 * - `1` (between `A`'s original position and `B`'s original position)
 	 * - `2` (between `B`'s original position and `C`'s original position)
 	 * - `3` (between `C`'s original position and the end of the array)
 	 *
-	 * So moving `A` between `B` and `C` would require `destinationIndex` to be `2`.
+	 * So moving `A` between `B` and `C` would require `destinationGap` to be `2`.
 	 *
-	 * This interpretation of `destinationIndex` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
+	 * This interpretation of `destinationGap` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
 	 * or relative to the start or end of the array:
 	 *
 	 * - Move to the start of the array: `array.moveToIndex(0, ...)` (see also `moveToStart`)
-	 * - Move to before some item Foo: `array.moveToIndex(indexOfFoo, ...)`
-	 * - Move to after some item Foo: `array.moveToIndex(indexOfFoo + 1`, ...)
+	 * - Move to before some item X: `array.moveToIndex(indexOfX, ...)`
+	 * - Move to after some item X: `array.moveToIndex(indexOfX + 1`, ...)
 	 * - Move to the end of the array: `array.moveToIndex(array.length, ...)` (see also `moveToEnd`)
 	 *
-	 * This interpretation of `destinationIndex` does however make it less obvious how to move an item relative to its current position:
+	 * This interpretation of `destinationGap` does however make it less obvious how to move an item relative to its current position:
 	 *
 	 * - Move item B before its predecessor: `array.moveToIndex(indexOfB - 1, ...)`
 	 * - Move item B after its successor: `array.moveToIndex(indexOfB + 2, ...)`
@@ -170,36 +170,36 @@ export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
 	 * @param sourceIndex - The index of the item to move.
 	 * @throws Throws if any of the input indices are not in the range [0, `array.length`).
 	 */
-	moveToIndex(destinationIndex: number, sourceIndex: number): void;
+	moveToIndex(destinationGap: number, sourceIndex: number): void;
 
 	/**
 	 * Moves the specified item to the desired location in the array.
 	 *
 	 * WARNING - This API is easily misused.
-	 * Please read the documentation for the `destinationIndex` parameter carefully.
+	 * Please read the documentation for the `destinationGap` parameter carefully.
 	 *
-	 * @param destinationIndex - The index to move the item to in the range [0, `array.length`].
+	 * @param destinationGap - The location *between* existing items that the moved item should be moved to.
 	 *
-	 * WARNING - `destinationIndex` is interpreted based on the state of the array *before* the move operation is applied.
+	 * WARNING - `destinationGap` describes a location between existing items *prior to applying the move operation*.
 	 *
-	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationIndex` must be one of the following:
+	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationGap` must be one of the following:
 	 *
 	 * - `0` (between the start of the array and `A`'s original position)
 	 * - `1` (between `A`'s original position and `B`'s original position)
 	 * - `2` (between `B`'s original position and `C`'s original position)
 	 * - `3` (between `C`'s original position and the end of the array)
 	 *
-	 * So moving `A` between `B` and `C` would require `destinationIndex` to be `2`.
+	 * So moving `A` between `B` and `C` would require `destinationGap` to be `2`.
 	 *
-	 * This interpretation of `destinationIndex` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
+	 * This interpretation of `destinationGap` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
 	 * or relative to the start or end of the array:
 	 *
 	 * - Move to the start of the array: `array.moveToIndex(0, ...)` (see also `moveToStart`)
-	 * - Move to before some item Foo: `array.moveToIndex(indexOfFoo, ...)`
-	 * - Move to after some item Foo: `array.moveToIndex(indexOfFoo + 1`, ...)
+	 * - Move to before some item X: `array.moveToIndex(indexOfX, ...)`
+	 * - Move to after some item X: `array.moveToIndex(indexOfX + 1`, ...)
 	 * - Move to the end of the array: `array.moveToIndex(array.length, ...)` (see also `moveToEnd`)
 	 *
-	 * This interpretation of `destinationIndex` does however make it less obvious how to move an item relative to its current position:
+	 * This interpretation of `destinationGap` does however make it less obvious how to move an item relative to its current position:
 	 *
 	 * - Move item B before its predecessor: `array.moveToIndex(indexOfB - 1, ...)`
 	 * - Move item B after its successor: `array.moveToIndex(indexOfB + 2, ...)`
@@ -214,7 +214,7 @@ export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
 	 * @throws Throws if any of the source index is not in the range [0, `array.length`),
 	 * or if the index is not in the range [0, `array.length`].
 	 */
-	moveToIndex(destinationIndex: number, sourceIndex: number, source: TMoveFrom): void;
+	moveToIndex(destinationGap: number, sourceIndex: number, source: TMoveFrom): void;
 
 	/**
 	 * Moves the specified items to the start of the array.
@@ -260,30 +260,30 @@ export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
 	 * Moves the specified items to the desired location within the array.
 	 *
 	 * WARNING - This API is easily misused.
-	 * Please read the documentation for the `destinationIndex` parameter carefully.
+	 * Please read the documentation for the `destinationGap` parameter carefully.
 	 *
-	 * @param destinationIndex - The index to move the item to in the range [0, `array.length`].
+	 * @param destinationGap - The location *between* existing items that the moved item should be moved to.
 	 *
-	 * WARNING - `destinationIndex` is interpreted based on the state of the array *before* the move operation is applied.
+	 * WARNING - `destinationGap` describes a location between existing items *prior to applying the move operation*.
 	 *
-	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationIndex` must be one of the following:
+	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationGap` must be one of the following:
 	 *
 	 * - `0` (between the start of the array and `A`'s original position)
 	 * - `1` (between `A`'s original position and `B`'s original position)
 	 * - `2` (between `B`'s original position and `C`'s original position)
 	 * - `3` (between `C`'s original position and the end of the array)
 	 *
-	 * So moving `A` between `B` and `C` would require `destinationIndex` to be `2`.
+	 * So moving `A` between `B` and `C` would require `destinationGap` to be `2`.
 	 *
-	 * This interpretation of `destinationIndex` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
+	 * This interpretation of `destinationGap` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
 	 * or relative to the start or end of the array:
 	 *
 	 * - Move to the start of the array: `array.moveToIndex(0, ...)` (see also `moveToStart`)
-	 * - Move to before some item Foo: `array.moveToIndex(indexOfFoo, ...)`
-	 * - Move to after some item Foo: `array.moveToIndex(indexOfFoo + 1`, ...)
+	 * - Move to before some item X: `array.moveToIndex(indexOfX, ...)`
+	 * - Move to after some item X: `array.moveToIndex(indexOfX + 1`, ...)
 	 * - Move to the end of the array: `array.moveToIndex(array.length, ...)` (see also `moveToEnd`)
 	 *
-	 * This interpretation of `destinationIndex` does however make it less obvious how to move an item relative to its current position:
+	 * This interpretation of `destinationGap` does however make it less obvious how to move an item relative to its current position:
 	 *
 	 * - Move item B before its predecessor: `array.moveToIndex(indexOfB - 1, ...)`
 	 * - Move item B after its successor: `array.moveToIndex(indexOfB + 2, ...)`
@@ -298,36 +298,36 @@ export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
 	 * @throws Throws if any of the input indices are not in the range [0, `array.length`) or if `sourceStart` is greater than `sourceEnd`.
 	 * if any of the input indices are not in the range [0, `array.length`], or if `sourceStart` is greater than `sourceEnd`.
 	 */
-	moveRangeToIndex(destinationIndex: number, sourceStart: number, sourceEnd: number): void;
+	moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number): void;
 
 	/**
 	 * Moves the specified items to the desired location within the array.
 	 *
 	 * WARNING - This API is easily misused.
-	 * Please read the documentation for the `destinationIndex` parameter carefully.
+	 * Please read the documentation for the `destinationGap` parameter carefully.
 	 *
-	 * @param destinationIndex - The index to move the item to in the range [0, `array.length`].
+	 * @param destinationGap - The location *between* existing items that the moved item should be moved to.
 	 *
-	 * WARNING - `destinationIndex` is interpreted based on the state of the array *before* the move operation is applied.
+	 * WARNING - `destinationGap` describes a location between existing items *prior to applying the move operation*.
 	 *
-	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationIndex` must be one of the following:
+	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationGap` must be one of the following:
 	 *
 	 * - `0` (between the start of the array and `A`'s original position)
 	 * - `1` (between `A`'s original position and `B`'s original position)
 	 * - `2` (between `B`'s original position and `C`'s original position)
 	 * - `3` (between `C`'s original position and the end of the array)
 	 *
-	 * So moving `A` between `B` and `C` would require `destinationIndex` to be `2`.
+	 * So moving `A` between `B` and `C` would require `destinationGap` to be `2`.
 	 *
-	 * This interpretation of `destinationIndex` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
+	 * This interpretation of `destinationGap` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
 	 * or relative to the start or end of the array:
 	 *
 	 * - Move to the start of the array: `array.moveToIndex(0, ...)` (see also `moveToStart`)
-	 * - Move to before some item Foo: `array.moveToIndex(indexOfFoo, ...)`
-	 * - Move to after some item Foo: `array.moveToIndex(indexOfFoo + 1`, ...)
+	 * - Move to before some item X: `array.moveToIndex(indexOfX, ...)`
+	 * - Move to after some item X: `array.moveToIndex(indexOfX + 1`, ...)
 	 * - Move to the end of the array: `array.moveToIndex(array.length, ...)` (see also `moveToEnd`)
 	 *
-	 * This interpretation of `destinationIndex` does however make it less obvious how to move an item relative to its current position:
+	 * This interpretation of `destinationGap` does however make it less obvious how to move an item relative to its current position:
 	 *
 	 * - Move item B before its predecessor: `array.moveToIndex(indexOfB - 1, ...)`
 	 * - Move item B after its successor: `array.moveToIndex(indexOfB + 2, ...)`
@@ -344,7 +344,7 @@ export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
 	 * if any of the input indices are not in the range [0, `array.length`], or if `sourceStart` is greater than `sourceEnd`.
 	 */
 	moveRangeToIndex(
-		destinationIndex: number,
+		destinationGap: number,
 		sourceStart: number,
 		sourceEnd: number,
 		source: TMoveFrom,
@@ -914,16 +914,16 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		this.moveRangeToIndex(this.length, sourceIndex, sourceIndex + 1, source);
 	}
 	public moveToIndex(
-		destinationIndex: number,
+		destinationGap: number,
 		sourceIndex: number,
 		source?: TreeArrayNode,
 	): void {
 		const sourceArray = source ?? this;
 		const sourceField = getSequenceField(sourceArray);
 		const destinationField = getSequenceField(this);
-		validateIndex(destinationIndex, destinationField, "moveToIndex", true);
+		validateIndex(destinationGap, destinationField, "moveToIndex", true);
 		validateIndex(sourceIndex, sourceField, "moveToIndex");
-		this.moveRangeToIndex(destinationIndex, sourceIndex, sourceIndex + 1, source);
+		this.moveRangeToIndex(destinationGap, sourceIndex, sourceIndex + 1, source);
 	}
 	public moveRangeToStart(
 		sourceStart: number,
@@ -948,7 +948,7 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		this.moveRangeToIndex(this.length, sourceStart, sourceEnd, source);
 	}
 	public moveRangeToIndex(
-		destinationIndex: number,
+		destinationGap: number,
 		sourceStart: number,
 		sourceEnd: number,
 		source?: TreeArrayNode,
@@ -956,7 +956,7 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		const destinationField = getSequenceField(this);
 		const sourceField = source !== undefined ? getSequenceField(source) : destinationField;
 
-		validateIndex(destinationIndex, destinationField, "moveRangeToIndex", true);
+		validateIndex(destinationGap, destinationField, "moveRangeToIndex", true);
 		validateIndexRange(sourceStart, sourceEnd, source ?? destinationField, "moveRangeToIndex");
 
 		// TODO: determine support for move across different sequence types
@@ -977,14 +977,14 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 				);
 			}
 
-			if (sourceField !== destinationField || destinationIndex < sourceStart) {
+			if (sourceField !== destinationField || destinationGap < sourceStart) {
 				destinationField.editor.insert(
-					destinationIndex,
+					destinationGap,
 					sourceField.editor.remove(sourceStart, movedCount),
 				);
-			} else if (destinationIndex > sourceStart + movedCount) {
+			} else if (destinationGap > sourceStart + movedCount) {
 				destinationField.editor.insert(
-					destinationIndex - movedCount,
+					destinationGap - movedCount,
 					sourceField.editor.remove(sourceStart, movedCount),
 				);
 			}
@@ -1003,7 +1003,7 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 				sourceStart,
 				movedCount,
 				destinationField.getFieldPath(),
-				destinationIndex,
+				destinationGap,
 			);
 		}
 	}

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -132,23 +132,89 @@ export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
 
 	/**
 	 * Moves the specified item to the desired location in the array.
-	 * @param index - The index to move the item to.
-	 * This is based on the state of the array before moving the source item.
+	 *
+	 * WARNING - This API is easily misused.
+	 * Please read the documentation for the `destinationIndex` parameter carefully.
+	 *
+	 * @param destinationIndex - The index to move the item to in the range [0, `array.length`].
+	 *
+	 * WARNING - `destinationIndex` is interpreted based on the state of the array *before* the move operation is applied.
+	 *
+	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationIndex` must be one of the following:
+	 *
+	 * - `0` (between the start of the array and `A`'s original position)
+	 * - `1` (between `A`'s original position and `B`'s original position)
+	 * - `2` (between `B`'s original position and `C`'s original position)
+	 * - `3` (between `C`'s original position and the end of the array)
+	 *
+	 * So moving `A` between `B` and `C` would require `destinationIndex` to be `2`.
+	 *
+	 * This interpretation of `destinationIndex` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
+	 * or relative to the start or end of the array:
+	 *
+	 * - Move to the start of the array: `array.moveToIndex(0, ...)` (see also `moveToStart`)
+	 * - Move to before some item Foo: `array.moveToIndex(indexOfFoo, ...)`
+	 * - Move to after some item Foo: `array.moveToIndex(indexOfFoo + 1`, ...)
+	 * - Move to the end of the array: `array.moveToIndex(array.length, ...)` (see also `moveToEnd`)
+	 *
+	 * This interpretation of `destinationIndex` does however make it less obvious how to move an item relative to its current position:
+	 *
+	 * - Move item B before its predecessor: `array.moveToIndex(indexOfB - 1, ...)`
+	 * - Move item B after its successor: `array.moveToIndex(indexOfB + 2, ...)`
+	 *
+	 * Notice the asymmetry between `-1` and `+2` in the above examples.
+	 * In such scenarios, it can often be easier to approach such edits by swapping adjacent items:
+	 * If items A and B are adjacent, such that A precedes B,
+	 * then they can be swapped with `array.moveToIndex(indexOfA, indexOfB)`.
+	 *
 	 * @param sourceIndex - The index of the item to move.
 	 * @throws Throws if any of the input indices are not in the range [0, `array.length`).
 	 */
-	moveToIndex(index: number, sourceIndex: number): void;
+	moveToIndex(destinationIndex: number, sourceIndex: number): void;
 
 	/**
 	 * Moves the specified item to the desired location in the array.
-	 * @param index - The index to move the item to in the range [0, `array.length`].
-	 * This is based on the state of the array before moving the source item.
+	 *
+	 * WARNING - This API is easily misused.
+	 * Please read the documentation for the `destinationIndex` parameter carefully.
+	 *
+	 * @param destinationIndex - The index to move the item to in the range [0, `array.length`].
+	 *
+	 * WARNING - `destinationIndex` is interpreted based on the state of the array *before* the move operation is applied.
+	 *
+	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationIndex` must be one of the following:
+	 *
+	 * - `0` (between the start of the array and `A`'s original position)
+	 * - `1` (between `A`'s original position and `B`'s original position)
+	 * - `2` (between `B`'s original position and `C`'s original position)
+	 * - `3` (between `C`'s original position and the end of the array)
+	 *
+	 * So moving `A` between `B` and `C` would require `destinationIndex` to be `2`.
+	 *
+	 * This interpretation of `destinationIndex` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
+	 * or relative to the start or end of the array:
+	 *
+	 * - Move to the start of the array: `array.moveToIndex(0, ...)` (see also `moveToStart`)
+	 * - Move to before some item Foo: `array.moveToIndex(indexOfFoo, ...)`
+	 * - Move to after some item Foo: `array.moveToIndex(indexOfFoo + 1`, ...)
+	 * - Move to the end of the array: `array.moveToIndex(array.length, ...)` (see also `moveToEnd`)
+	 *
+	 * This interpretation of `destinationIndex` does however make it less obvious how to move an item relative to its current position:
+	 *
+	 * - Move item B before its predecessor: `array.moveToIndex(indexOfB - 1, ...)`
+	 * - Move item B after its successor: `array.moveToIndex(indexOfB + 2, ...)`
+	 *
+	 * Notice the asymmetry between `-1` and `+2` in the above examples.
+	 * In such scenarios, it can often be easier to approach such edits by swapping adjacent items:
+	 * If items A and B are adjacent, such that A precedes B,
+	 * then they can be swapped with `array.moveToIndex(indexOfA, indexOfB)`.
+	 *
 	 * @param sourceIndex - The index of the item to move.
 	 * @param source - The source array to move the item out of.
 	 * @throws Throws if any of the source index is not in the range [0, `array.length`),
 	 * or if the index is not in the range [0, `array.length`].
 	 */
-	moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
+	moveToIndex(destinationIndex: number, sourceIndex: number, source: TMoveFrom): void;
 
 	/**
 	 * Moves the specified items to the start of the array.
@@ -192,18 +258,85 @@ export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
 
 	/**
 	 * Moves the specified items to the desired location within the array.
-	 * @param index - The index to move the items to.
-	 * This is based on the state of the array before moving the source items.
+	 *
+	 * WARNING - This API is easily misused.
+	 * Please read the documentation for the `destinationIndex` parameter carefully.
+	 *
+	 * @param destinationIndex - The index to move the item to in the range [0, `array.length`].
+	 *
+	 * WARNING - `destinationIndex` is interpreted based on the state of the array *before* the move operation is applied.
+	 *
+	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationIndex` must be one of the following:
+	 *
+	 * - `0` (between the start of the array and `A`'s original position)
+	 * - `1` (between `A`'s original position and `B`'s original position)
+	 * - `2` (between `B`'s original position and `C`'s original position)
+	 * - `3` (between `C`'s original position and the end of the array)
+	 *
+	 * So moving `A` between `B` and `C` would require `destinationIndex` to be `2`.
+	 *
+	 * This interpretation of `destinationIndex` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
+	 * or relative to the start or end of the array:
+	 *
+	 * - Move to the start of the array: `array.moveToIndex(0, ...)` (see also `moveToStart`)
+	 * - Move to before some item Foo: `array.moveToIndex(indexOfFoo, ...)`
+	 * - Move to after some item Foo: `array.moveToIndex(indexOfFoo + 1`, ...)
+	 * - Move to the end of the array: `array.moveToIndex(array.length, ...)` (see also `moveToEnd`)
+	 *
+	 * This interpretation of `destinationIndex` does however make it less obvious how to move an item relative to its current position:
+	 *
+	 * - Move item B before its predecessor: `array.moveToIndex(indexOfB - 1, ...)`
+	 * - Move item B after its successor: `array.moveToIndex(indexOfB + 2, ...)`
+	 *
+	 * Notice the asymmetry between `-1` and `+2` in the above examples.
+	 * In such scenarios, it can often be easier to approach such edits by swapping adjacent items:
+	 * If items A and B are adjacent, such that A precedes B,
+	 * then they can be swapped with `array.moveToIndex(indexOfA, indexOfB)`.
+	 *
 	 * @param sourceStart - The starting index of the range to move (inclusive).
 	 * @param sourceEnd - The ending index of the range to move (exclusive)
 	 * @throws Throws if any of the input indices are not in the range [0, `array.length`) or if `sourceStart` is greater than `sourceEnd`.
 	 * if any of the input indices are not in the range [0, `array.length`], or if `sourceStart` is greater than `sourceEnd`.
 	 */
-	moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
+	moveRangeToIndex(destinationIndex: number, sourceStart: number, sourceEnd: number): void;
 
 	/**
 	 * Moves the specified items to the desired location within the array.
-	 * @param index - The index to move the items to.
+	 *
+	 * WARNING - This API is easily misused.
+	 * Please read the documentation for the `destinationIndex` parameter carefully.
+	 *
+	 * @param destinationIndex - The index to move the item to in the range [0, `array.length`].
+	 *
+	 * WARNING - `destinationIndex` is interpreted based on the state of the array *before* the move operation is applied.
+	 *
+	 * For example, if the array contains items `[A, B, C]` before the move, the `destinationIndex` must be one of the following:
+	 *
+	 * - `0` (between the start of the array and `A`'s original position)
+	 * - `1` (between `A`'s original position and `B`'s original position)
+	 * - `2` (between `B`'s original position and `C`'s original position)
+	 * - `3` (between `C`'s original position and the end of the array)
+	 *
+	 * So moving `A` between `B` and `C` would require `destinationIndex` to be `2`.
+	 *
+	 * This interpretation of `destinationIndex` makes it easy to specify the desired destination relative to a sibling item that is not being moved,
+	 * or relative to the start or end of the array:
+	 *
+	 * - Move to the start of the array: `array.moveToIndex(0, ...)` (see also `moveToStart`)
+	 * - Move to before some item Foo: `array.moveToIndex(indexOfFoo, ...)`
+	 * - Move to after some item Foo: `array.moveToIndex(indexOfFoo + 1`, ...)
+	 * - Move to the end of the array: `array.moveToIndex(array.length, ...)` (see also `moveToEnd`)
+	 *
+	 * This interpretation of `destinationIndex` does however make it less obvious how to move an item relative to its current position:
+	 *
+	 * - Move item B before its predecessor: `array.moveToIndex(indexOfB - 1, ...)`
+	 * - Move item B after its successor: `array.moveToIndex(indexOfB + 2, ...)`
+	 *
+	 * Notice the asymmetry between `-1` and `+2` in the above examples.
+	 * In such scenarios, it can often be easier to approach such edits by swapping adjacent items:
+	 * If items A and B are adjacent, such that A precedes B,
+	 * then they can be swapped with `array.moveToIndex(indexOfA, indexOfB)`.
+	 *
 	 * @param sourceStart - The starting index of the range to move (inclusive).
 	 * @param sourceEnd - The ending index of the range to move (exclusive)
 	 * @param source - The source array to move items out of.
@@ -211,7 +344,7 @@ export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
 	 * if any of the input indices are not in the range [0, `array.length`], or if `sourceStart` is greater than `sourceEnd`.
 	 */
 	moveRangeToIndex(
-		index: number,
+		destinationIndex: number,
 		sourceStart: number,
 		sourceEnd: number,
 		source: TMoveFrom,

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -846,14 +846,14 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     insertAtStart(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveToEnd(sourceIndex: number): void;
     moveToEnd(sourceIndex: number, source: TMoveFrom): void;
-    moveToIndex(index: number, sourceIndex: number): void;
-    moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
+    moveToIndex(destinationGap: number, sourceIndex: number): void;
+    moveToIndex(destinationGap: number, sourceIndex: number, source: TMoveFrom): void;
     moveToStart(sourceIndex: number): void;
     moveToStart(sourceIndex: number, source: TMoveFrom): void;
     removeAt(index: number): void;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -772,14 +772,14 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     insertAtStart(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveToEnd(sourceIndex: number): void;
     moveToEnd(sourceIndex: number, source: TMoveFrom): void;
-    moveToIndex(index: number, sourceIndex: number): void;
-    moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
+    moveToIndex(destinationGap: number, sourceIndex: number): void;
+    moveToIndex(destinationGap: number, sourceIndex: number, source: TMoveFrom): void;
     moveToStart(sourceIndex: number): void;
     moveToStart(sourceIndex: number, source: TMoveFrom): void;
     removeAt(index: number): void;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -1164,14 +1164,14 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     insertAtStart(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveToEnd(sourceIndex: number): void;
     moveToEnd(sourceIndex: number, source: TMoveFrom): void;
-    moveToIndex(index: number, sourceIndex: number): void;
-    moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
+    moveToIndex(destinationGap: number, sourceIndex: number): void;
+    moveToIndex(destinationGap: number, sourceIndex: number, source: TMoveFrom): void;
     moveToStart(sourceIndex: number): void;
     moveToStart(sourceIndex: number, source: TMoveFrom): void;
     removeAt(index: number): void;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -807,14 +807,14 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     insertAtStart(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveToEnd(sourceIndex: number): void;
     moveToEnd(sourceIndex: number, source: TMoveFrom): void;
-    moveToIndex(index: number, sourceIndex: number): void;
-    moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
+    moveToIndex(destinationGap: number, sourceIndex: number): void;
+    moveToIndex(destinationGap: number, sourceIndex: number, source: TMoveFrom): void;
     moveToStart(sourceIndex: number): void;
     moveToStart(sourceIndex: number, source: TMoveFrom): void;
     removeAt(index: number): void;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -767,14 +767,14 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     insertAtStart(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number): void;
     moveRangeToEnd(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number): void;
-    moveRangeToIndex(index: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number): void;
+    moveRangeToIndex(destinationGap: number, sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number): void;
     moveRangeToStart(sourceStart: number, sourceEnd: number, source: TMoveFrom): void;
     moveToEnd(sourceIndex: number): void;
     moveToEnd(sourceIndex: number, source: TMoveFrom): void;
-    moveToIndex(index: number, sourceIndex: number): void;
-    moveToIndex(index: number, sourceIndex: number, source: TMoveFrom): void;
+    moveToIndex(destinationGap: number, sourceIndex: number): void;
+    moveToIndex(destinationGap: number, sourceIndex: number, source: TMoveFrom): void;
     moveToStart(sourceIndex: number): void;
     moveToStart(sourceIndex: number, source: TMoveFrom): void;
     removeAt(index: number): void;


### PR DESCRIPTION
## Description

Most users of the move APIs have reported confusion about its semantics. While a better API is desirable, it will take some time to arrive (and the current API will remain available for back-compat), so this PR attempts to clarify the semantics of the existing API.

## Breaking Changes

None

## Reviewer Guidance

The doc changes are the same across all 4 versions of this method, so reviewing one should be sufficient.
