### PR TITLE
Update blob upload to use managed identity

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -151,7 +151,6 @@ stages:
             - template: templates/upload-json-steps.yml
               parameters:
                 STORAGE_ACCOUNT: $(STORAGE_ACCOUNT)
-                STORAGE_KEY: $(STORAGE_KEY)
                 uploadAsLatest: ${{ variables.isMain }}
 
     - job: build_site

--- a/tools/pipelines/templates/upload-dev-manifest.yml
+++ b/tools/pipelines/templates/upload-dev-manifest.yml
@@ -51,7 +51,7 @@ jobs:
         scriptLocation: inlineScript
         inlineScript: |
           for file in upload_release_reports/*; do
-              az storage blob upload -f "$file" -c 'manifest-files' -n "$(basename "$file")" --account-name $(STORAGE_ACCOUNT) --account-key $(STORAGE_KEY) --overwrite true --verbose
+              az storage blob upload -f "$file" -c 'manifest-files' -n "$(basename "$file")" --account-name $(STORAGE_ACCOUNT) --auth-mode login --overwrite true --verbose
           done
           # Delete generate_release_reports and upload_release_reports folder
           rm -r generate_release_reports upload_release_reports

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -7,9 +7,6 @@ parameters:
 - name: STORAGE_ACCOUNT
   type: string
 
-- name: STORAGE_KEY
-  type: string
-
 - name: uploadAsLatest
   type: boolean
   default: false

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -22,39 +22,39 @@ steps:
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - common-definitions
-    branchName: ${{ variables['Build.SourceBranch'] }}
+    branchName: refs/heads/main
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - common-utils
-    branchName: ${{ variables['Build.SourceBranch'] }}
+    branchName: refs/heads/main
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - container-definitions
-    branchName: ${{ variables['Build.SourceBranch'] }}
+    branchName: refs/heads/main
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - core-interfaces
-    branchName: ${{ variables['Build.SourceBranch'] }}
+    branchName: refs/heads/main
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - driver-definitions
-    branchName: ${{ variables['Build.SourceBranch'] }}
+    branchName: refs/heads/main
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - protocol-definitions
-    branchName: ${{ variables['Build.SourceBranch'] }}
+    branchName: refs/heads/main
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - azure
-    branchName: ${{ variables['Build.SourceBranch'] }}
+    branchName: refs/heads/main
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - client packages
-    branchName: ${{ variables['Build.SourceBranch'] }}
+    branchName: refs/heads/main
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: server-routerlicious
-    branchName: ${{ variables['Build.SourceBranch'] }}
+    branchName: refs/heads/main
 
 # Copy and merge the api-extractor outputs to a central location
 - task: CopyFiles@2

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -22,39 +22,39 @@ steps:
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - common-definitions
-    branchName: refs/heads/main
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - common-utils
-    branchName: refs/heads/main
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - container-definitions
-    branchName: refs/heads/main
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - core-interfaces
-    branchName: refs/heads/main
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - driver-definitions
-    branchName: refs/heads/main
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - protocol-definitions
-    branchName: refs/heads/main
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - azure
-    branchName: refs/heads/main
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - client packages
-    branchName: refs/heads/main
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: server-routerlicious
-    branchName: refs/heads/main
+    branchName: ${{ variables['Build.SourceBranch'] }}
 
 # Copy and merge the api-extractor outputs to a central location
 - task: CopyFiles@2

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -93,7 +93,7 @@ steps:
     scriptType: bash
     scriptLocation: inlineScript
     inlineScript: |
-      az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n $(Build.SourceVersion).tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --account-key ${{ parameters.STORAGE_KEY }} --verbose
+      az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n $(Build.SourceVersion).tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --verbose
 
 - ${{ if eq(parameters.uploadAsLatest, true) }}:
   - task: AzureCLI@2
@@ -104,4 +104,4 @@ steps:
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest.tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --account-key ${{ parameters.STORAGE_KEY }} --overwrite --verbose
+        az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest.tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --overwrite --verbose

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -93,7 +93,7 @@ steps:
     scriptType: bash
     scriptLocation: inlineScript
     inlineScript: |
-      az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n $(Build.SourceVersion).tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --verbose
+      az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n $(Build.SourceVersion).tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --auth-mode login --verbose
 
 - ${{ if eq(parameters.uploadAsLatest, true) }}:
   - task: AzureCLI@2
@@ -104,4 +104,4 @@ steps:
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest.tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --overwrite --verbose
+        az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest.tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --auth-mode login --overwrite --verbose


### PR DESCRIPTION
## Description

Updates usages of `az storage` to leverage login information for the service principal that our pipelines assume.

A successful test run for api report upload can be found [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=296024&view=logs&j=897f79ef-2c90-5d46-29c0-b0ed22a2d39c&t=9305981a-7602-52ec-3c74-5436202de3b9) (requires internal project access).

[This run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=296015&view=logs&j=897f79ef-2c90-5d46-29c0-b0ed22a2d39c&t=9305981a-7602-52ec-3c74-5436202de3b9) used the same code but was triggered before I gave the service principal associated with our service connection storage blob contributor permissions. The fact that this failed gives a bit more confidence that this change is working as intended.

[This run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=296052&view=logs&j=c719ff29-64ed-5818-044d-14407c6a65d1&t=660fdca3-7237-5adb-817c-3d74f278c44a) verifies dev releases upload as expected.
