### PR TITLE
tree: Convert directly from simple to stored schema

### DIFF
--- a/packages/dds/tree/src/simple-tree/core/index.ts
+++ b/packages/dds/tree/src/simple-tree/core/index.ts
@@ -29,13 +29,7 @@ export {
 	type TreeNodeSchemaCore,
 	type TreeNodeSchemaBoth,
 } from "./treeNodeSchema.js";
-export {
-	getSimpleNodeSchema,
-	setFlexSchemaFromClassSchema,
-	tryGetSimpleNodeSchema,
-	cachedFlexSchemaFromClassSchema,
-	getSimpleNodeSchemaFromInnerNode,
-} from "./schemaCaching.js";
+export { getSimpleNodeSchemaFromInnerNode } from "./schemaCaching.js";
 export { walkAllowedTypes, type SchemaVisitor } from "./walkSchema.js";
 export { Context, HydratedContext, SimpleContextSlot } from "./context.js";
 export { getOrCreateNodeFromInnerNode } from "./getOrCreateNode.js";

--- a/packages/dds/tree/src/simple-tree/core/schemaCaching.ts
+++ b/packages/dds/tree/src/simple-tree/core/schemaCaching.ts
@@ -5,64 +5,12 @@
 
 import { assert } from "@fluidframework/core-utils/internal";
 
-import type { FlexTreeNodeSchema, TreeNodeSchemaBase } from "../../feature-libraries/index.js";
 import { fail } from "../../util/index.js";
 
 import type { TreeNodeSchema } from "./treeNodeSchema.js";
 import type { InnerNode } from "./treeNodeKernel.js";
 import { UnhydratedFlexTreeNode } from "./unhydratedFlexTree.js";
 import { SimpleContextSlot, type Context } from "./context.js";
-
-/**
- * A symbol for storing FlexTreeSchema on TreeNodeSchema.
- * Eagerly set on leaves, and lazily set for other cases.
- */
-const flexSchemaSymbol: unique symbol = Symbol(`flexSchema`);
-
-/**
- * A symbol for storing TreeNodeSchema on FlexTreeNode's schema.
- */
-const simpleNodeSchemaSymbol: unique symbol = Symbol(`simpleNodeSchema`);
-
-export function cachedFlexSchemaFromClassSchema(
-	schema: TreeNodeSchema,
-): TreeNodeSchemaBase | undefined {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	return (schema as any)[flexSchemaSymbol] as TreeNodeSchemaBase | undefined;
-}
-
-export function setFlexSchemaFromClassSchema(
-	simple: TreeNodeSchema,
-	flex: TreeNodeSchemaBase,
-): void {
-	assert(!(flexSchemaSymbol in simple), 0x91f /* simple schema already marked */);
-	assert(!(simpleNodeSchemaSymbol in flex), 0x920 /* flex schema already marked */);
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	(simple as any)[flexSchemaSymbol] = flex;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	(flex as any)[simpleNodeSchemaSymbol] = simple;
-}
-
-/**
- * Gets the {@link TreeNodeSchema} cached on the provided {@link FlexTreeNodeSchema | flexSchema}.
- * Returns `undefined` if no cached value is found.
- */
-export function tryGetSimpleNodeSchema(
-	flexSchema: FlexTreeNodeSchema,
-): TreeNodeSchema | undefined {
-	if (simpleNodeSchemaSymbol in flexSchema) {
-		return flexSchema[simpleNodeSchemaSymbol] as TreeNodeSchema;
-	}
-	return undefined;
-}
-
-/**
- * Gets the {@link TreeNodeSchema} cached on the provided {@link FlexTreeNodeSchema | flexSchema}.
- * Fails if no cached value is found.
- */
-export function getSimpleNodeSchema(flexSchema: FlexTreeNodeSchema): TreeNodeSchema {
-	return tryGetSimpleNodeSchema(flexSchema) ?? fail("missing simple schema");
-}
 
 /**
  * Gets the {@link TreeNodeSchema} for the {@link InnerNode}.

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -127,7 +127,7 @@ export {
 } from "./objectNode.js";
 export type { TreeMapNode, MapNodeInsertableData } from "./mapNode.js";
 export { mapTreeFromNodeData, type InsertableContent } from "./toMapTree.js";
-export { toStoredSchema, getStoredSchema, getFlexSchema } from "./toFlexSchema.js";
+export { toStoredSchema, getStoredSchema } from "./toFlexSchema.js";
 export {
 	numberSchema,
 	stringSchema,

--- a/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
@@ -7,17 +7,11 @@ import { assert } from "@fluidframework/core-utils/internal";
 
 import { type TreeValue, ValueSchema } from "../core/index.js";
 import {
-	LeafNodeSchema as FlexLeafNodeSchema,
 	type FlexTreeNode,
 	isFlexTreeNode,
 	valueSchemaAllows,
 } from "../feature-libraries/index.js";
-import {
-	setFlexSchemaFromClassSchema,
-	NodeKind,
-	type TreeNodeSchema,
-	type TreeNodeSchemaNonClass,
-} from "./core/index.js";
+import { NodeKind, type TreeNodeSchema, type TreeNodeSchemaNonClass } from "./core/index.js";
 
 /**
  * Instances of this class are schema for leaf nodes.
@@ -47,8 +41,6 @@ export class LeafNodeSchema<Name extends string, const T extends ValueSchema>
 	}
 
 	public constructor(name: Name, t: T) {
-		const schema: FlexLeafNodeSchema = new FlexLeafNodeSchema({ name: "makeLeaf" }, name, t);
-		setFlexSchemaFromClassSchema(this, schema);
 		this.identifier = name;
 		this.info = t;
 	}

--- a/packages/dds/tree/src/simple-tree/toFlexSchema.ts
+++ b/packages/dds/tree/src/simple-tree/toFlexSchema.ts
@@ -4,6 +4,7 @@
  */
 
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
 	EmptyKey,
@@ -41,6 +42,14 @@ export function toStoredSchema(root: ImplicitFieldSchema): TreeStoredSchema {
 	const nodeSchema: Map<TreeNodeSchemaIdentifier, TreeNodeStoredSchema> = new Map();
 	walkFieldSchema(root, {
 		node(schema) {
+			if (nodeSchema.has(brand(schema.identifier))) {
+				// Use JSON.stringify to quote and escape identifier string.
+				throw new UsageError(
+					`Multiple schema encountered with the identifier ${JSON.stringify(
+						schema.identifier,
+					)}. Remove or rename them to avoid the collision.`,
+				);
+			}
 			nodeSchema.set(brand(schema.identifier), convertNodeSchema(schema));
 		},
 	});

--- a/packages/dds/tree/src/simple-tree/toFlexSchema.ts
+++ b/packages/dds/tree/src/simple-tree/toFlexSchema.ts
@@ -4,106 +4,51 @@
  */
 
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
 	EmptyKey,
+	LeafNodeStoredSchema,
+	MapNodeStoredSchema,
+	ObjectNodeStoredSchema,
+	type FieldKey,
+	type FieldKindIdentifier,
+	type TreeFieldStoredSchema,
 	type TreeNodeSchemaIdentifier,
 	type TreeNodeStoredSchema,
 	type TreeStoredSchema,
+	type TreeTypeSet,
 } from "../core/index.js";
-import {
-	FieldKinds,
-	type FlexAllowedTypes,
-	type FlexFieldKind,
-	FlexFieldSchema,
-	FlexMapNodeSchema,
-	FlexObjectNodeSchema,
-	type FlexTreeNodeSchema,
-	type FlexTreeSchema,
-	TreeNodeSchemaBase,
-	defaultSchemaPolicy,
-	intoStoredSchemaCollection,
-	schemaIsLeaf,
-} from "../feature-libraries/index.js";
+import { FieldKinds, type FlexFieldKind } from "../feature-libraries/index.js";
 // TODO: once flex schema is gone, this code can move into simple-tree
 // eslint-disable-next-line import/no-internal-modules
 import { normalizeFlexListEager } from "../feature-libraries/typed-schema/index.js";
-import { brand, fail, isReadonlyArray, mapIterable } from "../util/index.js";
-import {
-	cachedFlexSchemaFromClassSchema,
-	setFlexSchemaFromClassSchema,
-	tryGetSimpleNodeSchema,
-	NodeKind,
-	type TreeNodeSchema,
-} from "./core/index.js";
+import { brand, fail, isReadonlyArray } from "../util/index.js";
+import { NodeKind, type TreeNodeSchema } from "./core/index.js";
 import {
 	FieldKind,
 	FieldSchema,
 	type ImplicitAllowedTypes,
 	type ImplicitFieldSchema,
-	getStoredKey,
 } from "./schemaTypes.js";
-
-interface SchemaInfo {
-	readonly toFlex: () => FlexTreeNodeSchema;
-	readonly original: TreeNodeSchema;
-}
-
-type SchemaMap = Map<TreeNodeSchemaIdentifier, SchemaInfo>;
-
-/**
- * Generate a {@link FlexTreeSchema} with `root` as the root field.
- *
- * This also has the side effect of populating the cached view schema on the class-based schema.
- */
-function toFlexSchema(root: ImplicitFieldSchema): FlexTreeSchema {
-	const schemaMap: SchemaMap = new Map();
-	const field = convertField(schemaMap, root);
-	const nodeSchema = new Map(
-		mapIterable(schemaMap, ([key, value]) => {
-			const schema = value.toFlex();
-			const classSchema = tryGetSimpleNodeSchema(schema);
-			if (classSchema === undefined) {
-				assert(schemaIsLeaf(schema), 0x83e /* invalid leaf */);
-			} else {
-				assert(
-					cachedFlexSchemaFromClassSchema(classSchema) === schema,
-					0x83f /* mismatched schema */,
-				);
-			}
-			return [key, schema];
-		}),
-	);
-
-	const typed: FlexTreeSchema = {
-		nodeSchema,
-		adapters: {},
-		rootFieldSchema: field,
-		policy: defaultSchemaPolicy,
-	};
-	return typed;
-}
+import { walkFieldSchema } from "./walkFieldSchema.js";
+import { LeafNodeSchema } from "./leafNodeSchema.js";
+import { isObjectNodeSchema } from "./objectNodeTypes.js";
 
 /**
  * Converts a {@link ImplicitFieldSchema} into a {@link TreeStoredSchema}.
  */
 export function toStoredSchema(root: ImplicitFieldSchema): TreeStoredSchema {
-	const flex = toFlexSchema(root);
-	return {
-		rootFieldSchema: flex.rootFieldSchema.stored,
-		...intoStoredSchemaCollection(flex),
-	};
-}
+	const nodeSchema: Map<TreeNodeSchemaIdentifier, TreeNodeStoredSchema> = new Map();
+	walkFieldSchema(root, {
+		node(schema) {
+			nodeSchema.set(brand(schema.identifier), convertNodeSchema(schema));
+		},
+	});
 
-/**
- * Return a flex schema for the provided class schema.
- *
- * This also has the side effect of populating the cached view schema on the class based schema.
- */
-export function getFlexSchema(root: TreeNodeSchema): FlexTreeNodeSchema {
-	const treeSchema = toFlexSchema(root);
-	return treeSchema.rootFieldSchema.monomorphicChildType ?? fail("root should be monomorphic");
+	return {
+		nodeSchema,
+		rootFieldSchema: convertField(root),
+	};
 }
 
 /**
@@ -112,27 +57,25 @@ export function getFlexSchema(root: TreeNodeSchema): FlexTreeNodeSchema {
  * This also has the side effect of populating the cached view schema on the class based schema.
  */
 export function getStoredSchema(root: TreeNodeSchema): TreeNodeStoredSchema {
-	return getFlexSchema(root).stored;
+	const stored = toStoredSchema(root);
+	return stored.nodeSchema.get(brand(root.identifier)) ?? fail("Missing schema");
 }
 
 /**
  * Normalizes an {@link ImplicitFieldSchema} into a {@link TreeFieldSchema}.
  */
-export function convertField(
-	schemaMap: SchemaMap,
-	schema: ImplicitFieldSchema,
-): FlexFieldSchema {
-	let kind: FlexFieldKind;
-	let types: ImplicitAllowedTypes;
+export function convertField(schema: ImplicitFieldSchema): TreeFieldStoredSchema {
+	let kind: FieldKindIdentifier;
+	let allowedTypes: ImplicitAllowedTypes;
 	if (schema instanceof FieldSchema) {
-		kind = convertFieldKind.get(schema.kind) ?? fail("Invalid field kind");
-		types = schema.allowedTypes;
+		kind = convertFieldKind.get(schema.kind)?.identifier ?? fail("Invalid field kind");
+		allowedTypes = schema.allowedTypes;
 	} else {
-		kind = FieldKinds.required;
-		types = schema;
+		kind = FieldKinds.required.identifier;
+		allowedTypes = schema;
 	}
-	const allowedTypes = convertAllowedTypes(schemaMap, types);
-	return FlexFieldSchema.create(kind, allowedTypes);
+	const types = convertAllowedTypes(allowedTypes);
+	return { kind, types };
 }
 
 const convertFieldKind = new Map<FieldKind, FlexFieldKind>([
@@ -144,17 +87,12 @@ const convertFieldKind = new Map<FieldKind, FlexFieldKind>([
 /**
  * Normalizes an {@link ImplicitAllowedTypes} into an {@link AllowedTypes}.
  */
-export function convertAllowedTypes(
-	schemaMap: SchemaMap,
-	schema: ImplicitAllowedTypes,
-): FlexAllowedTypes {
+export function convertAllowedTypes(schema: ImplicitAllowedTypes): TreeTypeSet {
 	if (isReadonlyArray(schema)) {
-		return normalizeFlexListEager(schema).map((item) => convertNodeSchema(schemaMap, item));
+		return new Set(normalizeFlexListEager(schema).map((item) => brand(item.identifier)));
 	}
-	return [convertNodeSchema(schemaMap, schema)];
+	return new Set([brand(schema.identifier)]);
 }
-
-const builder = { name: "simple schema" };
 
 /**
  * Converts a {@link TreeNodeSchema} into a {@link FlexTreeNodeSchema}.
@@ -164,101 +102,35 @@ const builder = { name: "simple schema" };
  * This laziness does NOT extend to adding entries to `schemaMap`:
  * all referenced types are added to it before this function returns.
  */
-export function convertNodeSchema(
-	schemaMap: SchemaMap,
-	schema: TreeNodeSchema,
-): () => FlexTreeNodeSchema {
-	const fromMap = schemaMap.get(brand(schema.identifier));
-	if (fromMap !== undefined) {
-		if (fromMap.original !== schema) {
-			// Use JSON.stringify to quote and escape identifier string.
-			throw new UsageError(
-				`Multiple schema encountered with the identifier ${JSON.stringify(
-					schema.identifier,
-				)}. Remove or rename them to avoid the collision.`,
-			);
+export function convertNodeSchema(schema: TreeNodeSchema): TreeNodeStoredSchema {
+	const kind = schema.kind;
+	switch (kind) {
+		case NodeKind.Leaf: {
+			assert(schema instanceof LeafNodeSchema, "invalid kind");
+			return new LeafNodeStoredSchema(schema.info);
 		}
-		return fromMap.toFlex;
+		case NodeKind.Map: {
+			const fieldInfo = schema.info as ImplicitAllowedTypes;
+			return new MapNodeStoredSchema(convertField(fieldInfo));
+		}
+		case NodeKind.Array: {
+			const fieldInfo = schema.info as ImplicitAllowedTypes;
+			const field = {
+				kind: FieldKinds.sequence.identifier,
+				types: convertAllowedTypes(fieldInfo),
+			};
+			const fields = new Map([[EmptyKey, field]]);
+			return new ObjectNodeStoredSchema(fields);
+		}
+		case NodeKind.Object: {
+			assert(isObjectNodeSchema(schema), "invalid kind");
+			const fields: Map<FieldKey, TreeFieldStoredSchema> = new Map();
+			for (const field of schema.flexKeyMap.values()) {
+				fields.set(field.storedKey, convertField(field.schema));
+			}
+			return new ObjectNodeStoredSchema(fields);
+		}
+		default:
+			unreachableCase(kind);
 	}
-
-	const toFlex = (): FlexTreeNodeSchema => {
-		let out: FlexTreeNodeSchema;
-		const kind = schema.kind;
-		switch (kind) {
-			case NodeKind.Leaf: {
-				const cached =
-					cachedFlexSchemaFromClassSchema(schema) ?? fail("leaf schema should be pre-cached");
-				assert(schemaIsLeaf(cached), 0x840 /* expected leaf */);
-				return cached;
-			}
-			case NodeKind.Map: {
-				const fieldInfo = schema.info as ImplicitAllowedTypes;
-				const field = FlexFieldSchema.create(
-					FieldKinds.optional,
-					convertAllowedTypes(schemaMap, fieldInfo),
-				);
-				// Lookup of cached schema is done here instead of before since walking the schema recursively to populate schemaMap is still required.
-				const cached = cachedFlexSchemaFromClassSchema(schema);
-				out =
-					cached ??
-					FlexMapNodeSchema.create(
-						builder,
-						brand<TreeNodeSchemaIdentifier>(schema.identifier),
-						field,
-					);
-				break;
-			}
-			case NodeKind.Array: {
-				const fieldInfo = schema.info as ImplicitAllowedTypes;
-				const field = FlexFieldSchema.create(
-					FieldKinds.sequence,
-					convertAllowedTypes(schemaMap, fieldInfo),
-				);
-				const cached = cachedFlexSchemaFromClassSchema(schema);
-				out =
-					cached ??
-					FlexObjectNodeSchema.create(builder, brand(schema.identifier), {
-						[EmptyKey]: field,
-					});
-				break;
-			}
-			case NodeKind.Object: {
-				const info = schema.info as Record<string, ImplicitFieldSchema>;
-				const fields: Record<string, FlexFieldSchema> = Object.create(null);
-				for (const [propertyKey, implicitFieldSchema] of Object.entries(info)) {
-					// If a `stored key` was provided, use it as the key in the flex schema.
-					// Otherwise, use the property key.
-					const flexKey = getStoredKey(propertyKey, implicitFieldSchema);
-
-					// This code has to be careful to avoid assigning to __proto__ or similar built-in fields.
-					Object.defineProperty(fields, flexKey, {
-						enumerable: true,
-						configurable: false,
-						writable: false,
-						value: convertField(schemaMap, implicitFieldSchema),
-					});
-				}
-				const cached = cachedFlexSchemaFromClassSchema(schema);
-				out = cached ?? FlexObjectNodeSchema.create(builder, brand(schema.identifier), fields);
-				break;
-			}
-			default:
-				unreachableCase(kind);
-		}
-		assert(out instanceof TreeNodeSchemaBase, 0x841 /* invalid schema produced */);
-		{
-			const cached = cachedFlexSchemaFromClassSchema(schema);
-			if (cached !== undefined) {
-				assert(
-					cachedFlexSchemaFromClassSchema(schema) === out,
-					0x842 /* incorrect flexSchemaSymbol */,
-				);
-			} else {
-				setFlexSchemaFromClassSchema(schema, out);
-			}
-		}
-		return out;
-	};
-	schemaMap.set(brand(schema.identifier), { original: schema, toFlex });
-	return toFlex;
 }

--- a/packages/dds/tree/src/simple-tree/toFlexSchema.ts
+++ b/packages/dds/tree/src/simple-tree/toFlexSchema.ts
@@ -111,7 +111,8 @@ export function convertNodeSchema(schema: TreeNodeSchema): TreeNodeStoredSchema 
 		}
 		case NodeKind.Map: {
 			const fieldInfo = schema.info as ImplicitAllowedTypes;
-			return new MapNodeStoredSchema(convertField(fieldInfo));
+			const types = convertAllowedTypes(fieldInfo);
+			return new MapNodeStoredSchema({ kind: FieldKinds.optional.identifier, types });
 		}
 		case NodeKind.Array: {
 			const fieldInfo = schema.info as ImplicitAllowedTypes;

--- a/packages/dds/tree/src/simple-tree/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/treeNodeValid.ts
@@ -8,7 +8,6 @@ import { assert } from "@fluidframework/core-utils/internal";
 import {
 	type TreeNodeSchema,
 	NodeKind,
-	tryGetSimpleNodeSchema,
 	isTreeNode,
 	TreeNodeKernel,
 	privateToken,
@@ -23,7 +22,6 @@ import { type FlexTreeNode, isFlexTreeNode, markEager } from "../feature-librari
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { fail } from "../util/index.js";
 
-import { getFlexSchema } from "./toFlexSchema.js";
 import { getSimpleNodeSchemaFromInnerNode } from "./core/index.js";
 
 /**
@@ -148,11 +146,6 @@ export abstract class TreeNodeValid<TInput> extends TreeNode {
 		const schema = this.constructor as typeof TreeNodeValid & TreeNodeSchema;
 		const cache = schema.markMostDerived();
 		if (cache.oneTimeInitialized === undefined) {
-			const flexSchema = getFlexSchema(schema);
-			assert(
-				tryGetSimpleNodeSchema(flexSchema) === schema,
-				0x961 /* Schema class not properly configured */,
-			);
 			cache.oneTimeInitialized = schema.oneTimeSetup();
 		}
 


### PR DESCRIPTION
## Description

Convert directly from simple to stored schema.
This removes the last known production use of flex-tree-schema.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


