### PR TITLE
refactor(ci): Minor yml cleanup

### DIFF
--- a/tools/pipelines/templates/include-publish-docker-service-steps.yml
+++ b/tools/pipelines/templates/include-publish-docker-service-steps.yml
@@ -53,13 +53,13 @@ jobs:
         - task: Docker@1
           displayName: Tag image as '$(containerTagSuffix)'
           inputs:
-            command: 'tag'
+            command: 'Tag image'
             arguments: '${{ parameters.containerTag }} ${{ parameters.containerRegistryUrl }}/${{ parameters.containerName }}:$(containerTagSuffix)'
 
         - task: Docker@1
           displayName: Tag image as 'latest'
           inputs:
-            command: 'tag'
+            command: 'Tag image'
             arguments: '${{ parameters.containerTag }} ${{ parameters.containerRegistryUrl }}/${{ parameters.containerName }}:latest'
 
         - task: 1ES.PushContainerImage@1

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -389,7 +389,6 @@ stages:
             displayName: Filter skipped test from report
             condition: succeededOrFailed()
             inputs:
-              workingDir: ${{ variables.testPackageDir }}/nyc
               targetType: 'inline'
               script: |
                 if [[ -d ${{ variables.testPackageDir }}/nyc ]]; then


### PR DESCRIPTION
## Description

- Remove a `workingDir` node at the incorrect indentation level. The script itself checks if that directory exists before `cd`ing into it if applicable, so having it run in it from the start doesn't seem necessary (and might even fail if it doesn't exist?)
- Replace a few `tag` strings with the more explicit `Tag image` in `Docker@1` tasks, as listed [in the docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/docker-v1?view=azure-pipelines). `tag` works as an alias, but the explicit version helps so VSCode doesn't report problems/unexpected values in yml files.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
