### PR TITLE
AB#17366 Get summary size in code

### DIFF
--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -638,7 +638,9 @@ type SummaryGeneratorOptionalTelemetryProperties =
 	/** Optional Retry-After time in seconds. If specified, the client should wait this many seconds before retrying. */
 	| "nackRetryAfter"
 	/** The stage at which the submit summary method failed at. This can help determine what type of failure we have */
-	| "stage";
+	| "stage"
+	/** Size of current summary */
+	| "sizeOfSummary";
 
 export type SummaryGeneratorTelemetry = Pick<
 	ITelemetryBaseProperties,

--- a/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
@@ -509,7 +509,11 @@ export class SummaryGenerator {
 			this.pendingAckTimer.clear();
 		}
 	}
-
+	/** Helper function to get the size of the summary */
+	private getSizeOfVariable(variable: any): number {
+		const jsonString = JSON.stringify(variable);
+		return new TextEncoder().encode(jsonString).length;
+	}
 	private addSummaryDataToTelemetryProps(
 		summaryData: SubmitSummaryResult,
 		initialProps: SummaryGeneratorTelemetry,
@@ -546,6 +550,7 @@ export class SummaryGenerator {
 					opsSizesSinceLastSummary: this.heuristicData.totalOpsSize,
 					nonRuntimeOpsSinceLastSummary: this.heuristicData.numNonRuntimeOps,
 					runtimeOpsSinceLastSummary: this.heuristicData.numRuntimeOps,
+					sizeOfSummary: this.getSizeOfVariable(summaryData),
 				};
 
 			default:


### PR DESCRIPTION
## Description

Within the repository find a way to access the size of the summary. This can be before or after compression

Most probably needs to be done in summaryGenerator.ts



## Reviewer Guidance
I would like to see if this is the best way to do it. Let me know if you think there is a better process to find the size of the summary.

I created that function based on the fact that it returns the size in bytes of the variable and I decided to add it to the submit case because of different reasons:

- The summarizing process was successful.
- It can be uploaded to the telemetry.
- That is where all of the summary related info is placed.
