### PR TITLE
fix(fluid-build): Sort donefile file hashes deterministically

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -621,6 +621,11 @@ export abstract class LeafWithFileStatDoneFileTask extends LeafWithDoneFileTask 
 			const dstHashesP = Promise.all(dstFiles.map(mapHash));
 
 			const [srcHashes, dstHashes] = await Promise.all([srcHashesP, dstHashesP]);
+
+			// sort by name for determinism
+			srcHashes.sort(sortByName);
+			dstHashes.sort(sortByName);
+
 			const output = JSON.stringify({
 				srcHashes,
 				dstHashes,
@@ -632,4 +637,14 @@ export abstract class LeafWithFileStatDoneFileTask extends LeafWithDoneFileTask 
 			return undefined;
 		}
 	}
+}
+
+function sortByName(a: { name: string }, b: { name: string }): number {
+	if (a.name < b.name) {
+		return -1;
+	}
+	if (a.name > b.name) {
+		return 1;
+	}
+	return 0;
 }


### PR DESCRIPTION
While testing #22663, I found that the output of the donefile when using hashes was not always ordered the same. This may be more likely to happen with the changes in #22663 since the task handling is more dynamic. Regardless, the bug existed prior to those changes.