### PR TITLE
[release/2.1] Update blob upload to use managed identity (#22647)

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -151,7 +151,6 @@ stages:
             - template: templates/upload-json-steps.yml
               parameters:
                 STORAGE_ACCOUNT: $(STORAGE_ACCOUNT)
-                STORAGE_KEY: $(STORAGE_KEY)
                 uploadAsLatest: ${{ variables.isMain }}
 
     - job: build_site

--- a/tools/pipelines/templates/upload-dev-manifest.yml
+++ b/tools/pipelines/templates/upload-dev-manifest.yml
@@ -51,7 +51,7 @@ jobs:
         scriptLocation: inlineScript
         inlineScript: |
           for file in upload_release_reports/*; do
-              az storage blob upload -f "$file" -c 'manifest-files' -n "$(basename "$file")" --account-name $(STORAGE_ACCOUNT) --account-key $(STORAGE_KEY) --overwrite true --verbose
+              az storage blob upload -f "$file" -c 'manifest-files' -n "$(basename "$file")" --account-name $(STORAGE_ACCOUNT) --auth-mode login --overwrite true --verbose
           done
           # Delete generate_release_reports and upload_release_reports folder
           rm -r generate_release_reports upload_release_reports

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -7,9 +7,6 @@ parameters:
 - name: STORAGE_ACCOUNT
   type: string
 
-- name: STORAGE_KEY
-  type: string
-
 - name: uploadAsLatest
   type: boolean
   default: false
@@ -93,7 +90,7 @@ steps:
     scriptType: bash
     scriptLocation: inlineScript
     inlineScript: |
-      az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n $(Build.SourceVersion).tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --account-key ${{ parameters.STORAGE_KEY }} --verbose
+      az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n $(Build.SourceVersion).tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --auth-mode login --verbose
 
 - ${{ if eq(parameters.uploadAsLatest, true) }}:
   - task: AzureCLI@2
@@ -104,4 +101,4 @@ steps:
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest.tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --account-key ${{ parameters.STORAGE_KEY }} --overwrite --verbose
+        az storage blob upload -f '$(Pipeline.Workspace)/$(Build.SourceVersion).tar.gz' -c 'api-extractor-json' -n latest.tar.gz --account-name ${{ parameters.STORAGE_ACCOUNT }} --auth-mode login --overwrite --verbose


### PR DESCRIPTION
## Description

Updates the blob upload steps to use the pipeline's identity as authentication rather than a storage key.

Cherry-pick of #22647 