### PR TITLE
test(api-markdown-documenter): Add multi-line fenced code block tests

### DIFF
--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/FencedCodeBlockToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/FencedCodeBlockToHtml.test.ts
@@ -4,8 +4,14 @@
  */
 
 import { h } from "hastscript";
-import { FencedCodeBlockNode, PlainTextNode } from "../../documentation-domain/index.js";
+import {
+	FencedCodeBlockNode,
+	LineBreakNode,
+	PlainTextNode,
+} from "../../documentation-domain/index.js";
 import { assertTransformation } from "./Utilities.js";
+
+const brElement = h("br");
 
 describe("FencedCodeBlock HTML rendering tests", () => {
 	it("Simple FencedCodeBlock", () => {
@@ -16,6 +22,30 @@ describe("FencedCodeBlock HTML rendering tests", () => {
 
 		// Note: HTML <code> elements don't support a language specification like Markdown fenced code blocks do.
 		const expected = h("code", [{ type: "text", value: "console.log('hello world');" }]);
+
+		assertTransformation(input, expected);
+	});
+
+	it("Multi-line FencedCodeBlock", () => {
+		const input = new FencedCodeBlockNode(
+			[
+				new PlainTextNode('const foo = "Hello world!'),
+				LineBreakNode.Singleton,
+				new PlainTextNode("console.log(foo);"),
+				LineBreakNode.Singleton,
+				new PlainTextNode("return foo;"),
+			],
+			"typescript",
+		);
+
+		// Note: HTML <code> elements don't support a language specification like Markdown fenced code blocks do.
+		const expected = h("code", [
+			{ type: "text", value: 'const foo = "Hello world!' },
+			brElement,
+			{ type: "text", value: "console.log(foo);" },
+			brElement,
+			{ type: "text", value: "return foo;" },
+		]);
 
 		assertTransformation(input, expected);
 	});

--- a/tools/api-markdown-documenter/src/renderers/html-renderer/test/RenderFencedCodeBlock.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/html-renderer/test/RenderFencedCodeBlock.test.ts
@@ -5,7 +5,11 @@
 
 import { expect } from "chai";
 
-import { FencedCodeBlockNode, PlainTextNode } from "../../../documentation-domain/index.js";
+import {
+	FencedCodeBlockNode,
+	LineBreakNode,
+	PlainTextNode,
+} from "../../../documentation-domain/index.js";
 import { testRender } from "./Utilities.js";
 
 describe("FencedCodeBlock HTML rendering tests", () => {
@@ -17,6 +21,33 @@ describe("FencedCodeBlock HTML rendering tests", () => {
 		const result = testRender(input);
 
 		const expected = ["<code>", "  console.log('hello world');", "</code>", ""].join("\n");
+
+		expect(result).to.equal(expected);
+	});
+
+	it("Multi-line FencedCodeBlock", () => {
+		const input = new FencedCodeBlockNode(
+			[
+				new PlainTextNode('const foo = "Hello world!"'),
+				LineBreakNode.Singleton,
+				new PlainTextNode("console.log(foo);"),
+				LineBreakNode.Singleton,
+				new PlainTextNode("return foo;"),
+			],
+			"typescript",
+		);
+		const result = testRender(input);
+
+		const expected = [
+			"<code>",
+			"  const foo = &quot;Hello world!&quot;",
+			"  <br>",
+			"  console.log(foo);",
+			"  <br>",
+			"  return foo;",
+			"</code>",
+			"",
+		].join("\n");
 
 		expect(result).to.equal(expected);
 	});

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderFencedCodeBlock.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderFencedCodeBlock.test.ts
@@ -5,33 +5,99 @@
 
 import { expect } from "chai";
 
-import { FencedCodeBlockNode, PlainTextNode } from "../../../documentation-domain/index.js";
+import {
+	FencedCodeBlockNode,
+	LineBreakNode,
+	PlainTextNode,
+} from "../../../documentation-domain/index.js";
 import { testRender } from "./Utilities.js";
 
 describe("FencedCodeBlock Markdown rendering tests", () => {
-	it("Simple FencedCodeBlock (standard context)", () => {
-		const input = new FencedCodeBlockNode(
-			[new PlainTextNode("console.log('hello world');")],
-			"typescript",
-		);
-		const result = testRender(input);
+	describe("Standard context", () => {
+		it("Simple FencedCodeBlock", () => {
+			const input = new FencedCodeBlockNode(
+				[new PlainTextNode("console.log('hello world');")],
+				"typescript",
+			);
+			const result = testRender(input);
 
-		const expected = ["", "```typescript", "console.log('hello world');", "```", "", ""].join(
-			"\n",
-		);
+			const expected = [
+				"",
+				"```typescript",
+				"console.log('hello world');",
+				"```",
+				"",
+				"",
+			].join("\n");
 
-		expect(result).to.equal(expected);
+			expect(result).to.equal(expected);
+		});
+
+		it("Multi-line FencedCodeBlock", () => {
+			const input = new FencedCodeBlockNode(
+				[
+					new PlainTextNode('const foo = "Hello world!"'),
+					LineBreakNode.Singleton,
+					new PlainTextNode("console.log(foo);"),
+					LineBreakNode.Singleton,
+					new PlainTextNode("return foo;"),
+				],
+				"typescript",
+			);
+			const result = testRender(input);
+
+			const expected = [
+				"",
+				"```typescript",
+				'const foo = "Hello world!"',
+				"console.log(foo);",
+				"return foo;",
+				"```",
+				"",
+				"",
+			].join("\n");
+
+			expect(result).to.equal(expected);
+		});
 	});
 
-	it("Simple FencedCodeBlock (table context)", () => {
-		const input = new FencedCodeBlockNode(
-			[new PlainTextNode("console.log('hello world');")],
-			"typescript",
-		);
-		const result = testRender(input, { insideTable: true });
+	describe("Table context", () => {
+		it("Simple FencedCodeBlock", () => {
+			const input = new FencedCodeBlockNode(
+				[new PlainTextNode("console.log('hello world');")],
+				"typescript",
+			);
+			const result = testRender(input, { insideTable: true });
 
-		const expected = ["<code>", "console.log('hello world');", "</code>"].join("");
+			const expected = ["<code>", "console.log('hello world');", "</code>"].join("");
 
-		expect(result).to.equal(expected);
+			expect(result).to.equal(expected);
+		});
+
+		it("Multi-line FencedCodeBlock", () => {
+			const input = new FencedCodeBlockNode(
+				[
+					new PlainTextNode('const foo = "Hello world!"'),
+					LineBreakNode.Singleton,
+					new PlainTextNode("console.log(foo);"),
+					LineBreakNode.Singleton,
+					new PlainTextNode("return foo;"),
+				],
+				"typescript",
+			);
+			const result = testRender(input, { insideTable: true });
+
+			const expected = [
+				"<code>",
+				"const foo = &quot;Hello world!&quot;",
+				"<br>",
+				"console.log(foo);",
+				"<br>",
+				"return foo;",
+				"</code>",
+			].join("");
+
+			expect(result).to.equal(expected);
+		});
 	});
 });

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace.html
@@ -46,7 +46,13 @@
             <p>
             </p>
             <code>
-              const foo = bar;
+              const foo: Foo = {
+              <br>
+              	bar: &quot;Hello world!&quot;;
+              <br>
+              	baz = 42;
+              <br>
+              };
             </code>
           </p>
         </section>
@@ -58,7 +64,13 @@
             <p>
             </p>
             <code>
-              const bar = foo
+              const foo = {
+              <br>
+              	bar: &quot;Hello world!&quot;;
+              <br>
+              	baz = 42;
+              <br>
+              };
             </code>
           </p>
         </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
@@ -2990,7 +2990,13 @@
               <p>
               </p>
               <code>
-                const foo = bar;
+                const foo: Foo = {
+                <br>
+                	bar: &quot;Hello world!&quot;;
+                <br>
+                	baz = 42;
+                <br>
+                };
               </code>
             </p>
           </section>
@@ -3002,7 +3008,13 @@
               <p>
               </p>
               <code>
-                const bar = foo
+                const foo = {
+                <br>
+                	bar: &quot;Hello world!&quot;;
+                <br>
+                	baz = 42;
+                <br>
+                };
               </code>
             </p>
           </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-namespace.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-namespace.html
@@ -41,7 +41,13 @@
             <p>
             </p>
             <code>
-              const foo = bar;
+              const foo: Foo = {
+              <br>
+              	bar: &quot;Hello world!&quot;;
+              <br>
+              	baz = 42;
+              <br>
+              };
             </code>
           </p>
         </section>
@@ -53,7 +59,13 @@
             <p>
             </p>
             <code>
-              const bar = foo
+              const foo = {
+              <br>
+              	bar: &quot;Hello world!&quot;;
+              <br>
+              	baz = 42;
+              <br>
+              };
             </code>
           </p>
         </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace.md
@@ -19,13 +19,19 @@ Here are some remarks about the namespace
 ### Example: TypeScript Example {#testnamespace-example1}
 
 ```typescript
-const foo = bar;
+const foo: Foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
 ```
 
 ### Example: JavaScript Example {#testnamespace-example2}
 
 ```javascript
-const bar = foo
+const foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
 ```
 
 ## Interfaces

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
@@ -1056,13 +1056,19 @@ Here are some remarks about the namespace
 #### Example: TypeScript Example {#testnamespace-example1}
 
 ```typescript
-const foo = bar;
+const foo: Foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
 ```
 
 #### Example: JavaScript Example {#testnamespace-example2}
 
 ```javascript
-const bar = foo
+const foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
 ```
 
 ### Classes

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-namespace.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-namespace.md
@@ -17,13 +17,19 @@ Here are some remarks about the namespace
 #### Example: TypeScript Example {#testnamespace-example1}
 
 ```typescript
-const foo = bar;
+const foo: Foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
 ```
 
 #### Example: JavaScript Example {#testnamespace-example2}
 
 ```javascript
-const bar = foo
+const foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
 ```
 
 ### Classes

--- a/tools/api-markdown-documenter/src/test/test-data/simple-suite-test/test-suite-a.api.json
+++ b/tools/api-markdown-documenter/src/test/test-data/simple-suite-test/test-suite-a.api.json
@@ -1855,7 +1855,7 @@
 				{
 					"kind": "Namespace",
 					"canonicalReference": "test-suite-a!TestNamespace:namespace",
-					"docComment": "/**\n * Test Namespace\n *\n * @remarks\n *\n * Here are some remarks about the namespace\n *\n * @example TypeScript Example\n * ```typescript\n * const foo = bar;\n * ```\n *\n * @example JavaScript Example\n *\n * ```javascript\n * const bar = foo\n * ```\n *\n * @public\n */\n",
+					"docComment": "/**\n * Test Namespace\n *\n * @remarks\n *\n * Here are some remarks about the namespace\n *\n * @example TypeScript Example\n * ```typescript\n * const foo: Foo = {\n * \tbar: \"Hello world!\";\n * \tbaz = 42;\n * };\n * ```\n *\n * @example JavaScript Example\n * ```javascript\n * const foo = {\n * \tbar: \"Hello world!\";\n * \tbaz = 42;\n * };\n * ```\n *\n * @public\n */\n",
 					"excerptTokens": [
 						{
 							"kind": "Content",


### PR DESCRIPTION
Adds some missing test coverage around fenced code blocks. All of our existing test cases were single-line.