### PR TITLE
test: Skip container-runtime perf tests (#21952)

### DIFF
--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -141,7 +141,7 @@
 		"postpack": "tar -cf ./container-runtime.test-files.tar ./src/test ./dist/test ./lib/test",
 		"place:cjs:package-stub": "copyfiles -f ../../../common/build/build-common/src/cjs/package.json ./dist",
 		"test": "npm run test:mocha",
-		"test:benchmark:report": "mocha --timeout 999999 --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js \"./dist/**/*.perf.spec.*js\"",
+		"test:benchmark:report": "mocha --timeout 10s --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js \"./dist/**/*.perf.spec.*js\" --exit",
 		"test:coverage": "c8 npm test",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "mocha --recursive \"dist/test/**/*.spec.*js\" --exit",


### PR DESCRIPTION
## Description

This is a cherry-pick of [63164b72cdffc1bdcb8f4346cb684619c68389f9](https://github.com/microsoft/FluidFramework/pull/21952), which prevents a timeout in the container-runtime performance tests. Without this fix, any future patches into this branch (2.0) will cause CI to timeout during perf testing ([see here for example](https://dev.azure.com/fluidframework/internal/_build/results?buildId=296180&view=logs&j=96c48626-beae-58bd-70f1-ce94e154dbad&t=7c878d5b-0f52-57cc-3a3e-a5a81af8b7bd&l=42)) and will trigger an ICM incident. So, backporting this fix prevents such noise for ICM in the event that more patches do happen.
