### PR TITLE
Update static asset URLs to use CDN endpoint

### DIFF
--- a/docs/content/docs/testing/devtools.md
+++ b/docs/content/docs/testing/devtools.md
@@ -24,12 +24,12 @@ Once you have completed the above steps, you can simply launch your Fluid applic
 
 DevTools shows the containers that were specified in the initialization, their current state (connected, attached, disconnected) and allows developers to modify the state (disconnect, close). Developers can also see a lot of container state changes with timestamps.
 
-![A screenshot showing container information](https://fluidframework.blob.core.windows.net/static/images/container_info.png)
+![A screenshot showing container information](https://storage.fluidframework.com/static/images/container_info.png)
 
 -   **Disconnect/Reconnect Container** button disconnects it from the Fluid service
 -   **Close Container** button stops the container, including disconnecting it from the Fluid service
 
-![A screenshot showing container state changes](https://fluidframework.blob.core.windows.net/static/images/container_states.png)
+![A screenshot showing container state changes](https://storage.fluidframework.com/static/images/container_states.png)
 
 These buttons can be used to test the following scenarios:
 
@@ -41,7 +41,7 @@ These buttons can be used to test the following scenarios:
 
 DevTool shows the current container data including all the DDSs that are part of the container. Currently, the DevTool supports renderers for `SharedTree`, `SharedMap`, `SharedString`, `SharedCounter` and `Sequences`. Because of the extensible model of the framework, you can also build and add renderers for custom DDSs.
 
-![A screenshot showing container data visualization](https://fluidframework.blob.core.windows.net/static/images/container_data_viz.png)
+![A screenshot showing container data visualization](https://storage.fluidframework.com/static/images/container_data_viz.png)
 
 The DDS visualizer updates in real-time as local and remote changes impact the container data. Getting a peek at the underlying data and checking it against what's rendered in your app should allow you to look for any inconsistencies between the data and your app UI.
 
@@ -49,14 +49,14 @@ The DDS visualizer updates in real-time as local and remote changes impact the c
 
 DevTool displays a list of clients that are connected to the container(s) in the application and their connection type (read-only or read/write). The tool also shows a log of clients joining and leaving the container. This can be used to debug user presence indicators in your apps.
 
-![A screenshot showing container audience information](https://fluidframework.blob.core.windows.net/static/images/container_audience_states.png)
+![A screenshot showing container audience information](https://storage.fluidframework.com/static/images/container_audience_states.png)
 
 ## Framework Event Logs
 
 DevTool outputs a log of events happening in the framework including info, performance (e.g. Ops latency) and errors.
 These logs provide a peek at the inner workings of Fluid that you can use to monitor your apps
 
-![A screenshot showing container event logs](https://fluidframework.blob.core.windows.net/static/images/container_events.png)
+![A screenshot showing container event logs](https://storage.fluidframework.com/static/images/container_events.png)
 
 ## Ops Latency Telemetry Graph
 
@@ -66,6 +66,6 @@ DevTool shows a graph of the operations it generates to handle real-time collabo
 -   **Network duration** - roundtrip network time
 -   **Inbound duration** - time Fluid took to process the response **after receiving a server response**
 
-![A screenshot showing container latency telemetry](https://fluidframework.blob.core.windows.net/static/images/container_latency.png)
+![A screenshot showing container latency telemetry](https://storage.fluidframework.com/static/images/container_latency.png)
 
 This graph should help you debug latency issues and pinpoint where the delays are happening when used in conjunction with your app's own telemetry.

--- a/docs/content/docs/testing/telemetry.md
+++ b/docs/content/docs/testing/telemetry.md
@@ -260,7 +260,7 @@ async function start(): Promise<void> {
 Now, whenever a telemetry event is encountered, the custom `send()` method gets called and will print out the entire
 event object.
 
-<img src="https://fluidframework.blob.core.windows.net/static/images/consoleLogger_telemetry_in_action.png" alt="The
+<img src="https://storage.fluidframework.com/static/images/consoleLogger_telemetry_in_action.png" alt="The
   ConsoleLogger sends telemetry events to the browser console for display.">
 
 {{% callout warning %}}

--- a/docs/content/docs/testing/typed-telemetry.md
+++ b/docs/content/docs/testing/typed-telemetry.md
@@ -161,7 +161,7 @@ Going into more detail, A `Session` or `Collaborative Session` is defined as a p
 
 Before we can query, we must first navigate to your Azure App Insights telemetry page. To do this, go to your Azure App Insights Instance and click on the `Logs` tab under Monitoring.
 
-![Logs on App Insights Portal](https://fluidframework.blob.core.windows.net/static/images/telemetry_1.png)
+![Logs on App Insights Portal](https://storage.fluidframework.com/static/images/telemetry_1.png)
 
 Now, close out the `Queries` pane if it showed up for you and you will be in the view where we can execute our queries. Note that if you are using the Fluid Azure App Insights logger, your telemetry data will be available in the `customEvents` table.
 
@@ -188,7 +188,7 @@ customEvents
 | project SessionId, containerId , NumCollaborators, PeriodDurationInMinutes, StartTime, EndTime
 ```
 
-![Query result](https://fluidframework.blob.core.windows.net/static/images/telemetry_2.png)
+![Query result](https://storage.fluidframework.com/static/images/telemetry_2.png)
 
 1. Total number of sessions over time period
 
@@ -217,7 +217,7 @@ customEvents
 | render timechart with (title = "Total Number of Sessions Occurring Over 1 Hour Intervals")
 ```
 
-![Total sessions over time period](https://fluidframework.blob.core.windows.net/static/images/telemetry_3.png)
+![Total sessions over time period](https://storage.fluidframework.com/static/images/telemetry_3.png)
 
 1. Average number of sessions over time period
 
@@ -246,7 +246,7 @@ customEvents
 | render timechart with (title = "Average Number of Sessions Occurring Over 1 Hour Intervals")
 ```
 
-![Average number of sessions over time period](https://fluidframework.blob.core.windows.net/static/images/telemetry_4.png)
+![Average number of sessions over time period](https://storage.fluidframework.com/static/images/telemetry_4.png)
 
 1. Average number of containers per session over a time period
 
@@ -275,7 +275,7 @@ customEvents
 | render timechart with (title = "Approximate Average Number Of Container Per Session Over 1 Hour Intervals")
 ```
 
-![Average number of containers per session over time period](https://fluidframework.blob.core.windows.net/static/images/telemetry_5.png)
+![Average number of containers per session over time period](https://storage.fluidframework.com/static/images/telemetry_5.png)
 
 1. Length of Individual Sessions in Minutes
 
@@ -307,7 +307,7 @@ customEvents
 
 ```
 
-![Length of Individual Sessions in Minutes](https://fluidframework.blob.core.windows.net/static/images/telemetry_6.png)
+![Length of Individual Sessions in Minutes](https://storage.fluidframework.com/static/images/telemetry_6.png)
 
 ##### General Query Adjustments
 
@@ -315,7 +315,7 @@ customEvents
 
     To adjust the time span of this query, simply use the Time Range dropdown provided by azure. You do not need to modify the query directly. By default, these queries will query against all logs you have available.
 
-    ![Adjusting date](https://fluidframework.blob.core.windows.net/static/images/telemetry_time_period.png)
+    ![Adjusting date](https://storage.fluidframework.com/static/images/telemetry_time_period.png)
 
 2. Adjusting the gap of time that defines a session
 

--- a/docs/download-apis.js
+++ b/docs/download-apis.js
@@ -33,7 +33,7 @@ try {
 			// condition, it'll correctly use _api-extractor-temp-v1
 			const versionPostfix =
 				version === currentVersion && docVersions.length > 1 ? "" : `-${version}`;
-			const url = `https://fluidframework.blob.core.windows.net/api-extractor-json/latest${versionPostfix}.tar.gz`;
+			const url = `https://storage.fluidframework.com/api-extractor-json/latest${versionPostfix}.tar.gz`;
 
 			const destination = path.resolve(dirname, "_doc-models", version);
 

--- a/docs/layouts/shortcodes/fluid_bundle_loader.html
+++ b/docs/layouts/shortcodes/fluid_bundle_loader.html
@@ -90,7 +90,7 @@
     }
 </style>
 
-<script async src="https://fluidframework.blob.core.windows.net/static/js/{{ $bundleName }}"></script>
+<script async src="https://storage.fluidframework.com/static/js/{{ $bundleName }}"></script>
 
 <script>
     (() => {

--- a/docs/themes/thxvscode/layouts/partials/footer.html
+++ b/docs/themes/thxvscode/layouts/partials/footer.html
@@ -43,10 +43,10 @@
                 <div class="copyright">
                     <a id="footer-microsoft-link" class="logo" href="https://www.microsoft.com">
                         <img class="microsoft-logo"
-                            src="https://fluidframework-docs-cdn.azureedge.net/static/images/microsoft-logo.png"
+                            src="https://storage.fluidframework.com/static/images/microsoft-logo.png"
                             height="20" alt="Microsoft homepage" />
                         <img class="microsoft-logo-inverted"
-                            src="https://fluidframework-docs-cdn.azureedge.net/static/images/microsoft-logo-inverted.png"
+                            src="https://storage.fluidframework.com/static/images/microsoft-logo-inverted.png"
                             height="20" alt="Microsoft homepage" />
                     </a>
                     <span>&copy; {{ now.Format "2006" }} <span itemprop="publisher" itemscope


### PR DESCRIPTION
## Description

The CDN serving `fluidframework.com` has been set up with routes that allow it to serve static content from our storage account. This updates direct links to the storage account to use those routes instead, which unblocks removing anonymous access to the storage account (a security requirement as per recent MSFT initiatives). As a side benefit, this should be a performance improvement for commonly served content (e.g. images referenced on https://fluidframework.com)
