### PR TITLE
Enable devtool: "source-map" in examples/utils/bundle-size-tests/webpack.config.cjs

### DIFF
--- a/examples/utils/bundle-size-tests/webpack.config.cjs
+++ b/examples/utils/bundle-size-tests/webpack.config.cjs
@@ -130,4 +130,7 @@ module.exports = {
 			file: path.resolve(process.cwd(), "bundleAnalysis/bundleStats.msp.gz"),
 		}),
 	],
+	// Enabling source maps allows using source-map-explorer to investigate bundle contents,
+	// which provides more fine grained details than BundleAnalyzerPlugin, so its nice for manual investigations.
+	devtool: "source-map",
 };


### PR DESCRIPTION
## Description

This enables another approach, source-map-explorer, for investigating bundle size which gives more detailed and precise results.

This change was extracted from https://github.com/microsoft/FluidFramework/pull/21336

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

