### PR TITLE
Fix applies stashed ops with no saved ops test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1977,9 +1977,6 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		const pendingState = JSON.parse(stashBlob);
 		// make sure the container loaded from summary and we have no saved ops
 		assert.strictEqual(pendingState.savedOps.length, 0);
-		assert(
-			pendingState.pendingRuntimeState.pending.pendingStates[0].referenceSequenceNumber > 0,
-		);
 
 		// load container with pending ops, which should resend the op not sent by previous container
 		const container2 = await loader.resolve({ url }, stashBlob);


### PR DESCRIPTION
In odsp, when you start a container in a paused state by using deltaConnection: none load mode, it does not load from the most recent summary (not sure if it is intermittent or not). For the purposes of e2e test "applies stashed ops with no saved ops" the base snapshot that is loading from does not necessarily needs to be the most recent one but only that we don't have save ops, which we are asserting correctly, so removing the unnecessary assert is making the test to consistently pass.