### PR TITLE
(tree) Added a beta API to deep clone tree nodes

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -544,7 +544,8 @@ export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAl
 
 // @beta @sealed
 export const TreeBeta: {
-    readonly on: <K extends keyof TreeChangeEventsBeta<TNode>, TNode extends TreeNode>(node: TNode, eventName: K, listener: NoInfer<TreeChangeEventsBeta<TNode>[K]>) => () => void;
+    on<K extends keyof TreeChangeEventsBeta<TNode>, TNode extends TreeNode>(node: TNode, eventName: K, listener: NoInfer<TreeChangeEventsBeta<TNode>[K]>): () => void;
+    clone<TSchema extends ImplicitFieldSchema>(node: TreeFieldFromImplicitField<TSchema>): TreeFieldFromImplicitField<TSchema>;
 };
 
 // @alpha @sealed

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -421,7 +421,8 @@ export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAl
 
 // @beta @sealed
 export const TreeBeta: {
-    readonly on: <K extends keyof TreeChangeEventsBeta<TNode>, TNode extends TreeNode>(node: TNode, eventName: K, listener: NoInfer<TreeChangeEventsBeta<TNode>[K]>) => () => void;
+    on<K extends keyof TreeChangeEventsBeta<TNode>, TNode extends TreeNode>(node: TNode, eventName: K, listener: NoInfer<TreeChangeEventsBeta<TNode>[K]>): () => void;
+    clone<TSchema extends ImplicitFieldSchema>(node: TreeFieldFromImplicitField<TSchema>): TreeFieldFromImplicitField<TSchema>;
 };
 
 // @public @sealed

--- a/packages/dds/tree/src/simple-tree/api/treeApiBeta.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeApiBeta.ts
@@ -132,15 +132,16 @@ export const TreeBeta: {
 	clone<TSchema extends ImplicitFieldSchema>(
 		node: TreeFieldFromImplicitField<TSchema>,
 	): Unhydrated<TreeFieldFromImplicitField<TSchema>> {
-		// The only non-TreeNode cases are TreeLeafValue and undefined (for an empty optional field) which can be
-		// returned as is.
+		/** The only non-TreeNode cases are {@link Value} (for an empty optional field) which can be returned as is. */
 		if (!isTreeNode(node)) {
 			return node;
 		}
 
 		const kernel = getKernel(node);
-		// For unhydrated nodes, we can create a cursor by calling `cursorFromInsertable` because the node
-		// hasn't been inserted yet. We can then create a new node from the cursor.
+		/**
+		 * For unhydrated nodes, we can create a cursor by calling `cursorFromInsertable` because the node
+		 * hasn't been inserted yet. We can then create a new node from the cursor.
+		 */
 		if (!kernel.context.flexContext.isHydrated()) {
 			return createFromCursor(
 				kernel.schema,

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -29,7 +29,7 @@ import { fail } from "../../util/index.js";
 // TODO: decide how to deal with dependencies on flex-tree implementation.
 // eslint-disable-next-line import/no-internal-modules
 import { makeTree } from "../../feature-libraries/flex-tree/lazyNode.js";
-import { SimpleContextSlot, type Context } from "./context.js";
+import { SimpleContextSlot, type Context, type HydratedContext } from "./context.js";
 import { UnhydratedFlexTreeNode } from "./unhydratedFlexTree.js";
 
 const treeNodeToKernel = new WeakMap<TreeNode, TreeNodeKernel>();
@@ -267,12 +267,20 @@ export class TreeNodeKernel implements Listenable<KernelEvents> {
 		// TODO: go to the context and remove myself from withAnchors
 	}
 
-	public get anchorNode(): AnchorNode {
+	public isHydrated(): this is { anchorNode: AnchorNode; context: HydratedContext } {
+		return isHydrated(this.#hydrationState);
+	}
+
+	public get anchorNode2(): AnchorNode {
 		// If the kernel is unhydrated, it has no anchor node. It calls innerNode.anchorNode which
 		// throws an error.
 		return isHydrated(this.#hydrationState)
 			? this.#hydrationState.anchorNode
 			: this.innerNode.anchorNode;
+	}
+
+	public get anchorNode(): AnchorNode | undefined {
+		return isHydrated(this.#hydrationState) ? this.#hydrationState.anchorNode : undefined;
 	}
 
 	/**

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -270,8 +270,8 @@ export class TreeNodeKernel implements Listenable<KernelEvents> {
 	public get anchorNode(): AnchorNode {
 		// If the kernel is unhydrated, it has no anchor node. It calls innerNode.anchorNode which
 		// throws an error.
-		return this.#hydrated !== undefined
-			? this.#hydrated.anchorNode
+		return isHydrated(this.#hydrationState)
+			? this.#hydrationState.anchorNode
 			: this.innerNode.anchorNode;
 	}
 

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -271,14 +271,6 @@ export class TreeNodeKernel implements Listenable<KernelEvents> {
 		return isHydrated(this.#hydrationState);
 	}
 
-	public get anchorNode2(): AnchorNode {
-		// If the kernel is unhydrated, it has no anchor node. It calls innerNode.anchorNode which
-		// throws an error.
-		return isHydrated(this.#hydrationState)
-			? this.#hydrationState.anchorNode
-			: this.innerNode.anchorNode;
-	}
-
 	public get anchorNode(): AnchorNode | undefined {
 		return isHydrated(this.#hydrationState) ? this.#hydrationState.anchorNode : undefined;
 	}

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -267,6 +267,14 @@ export class TreeNodeKernel implements Listenable<KernelEvents> {
 		// TODO: go to the context and remove myself from withAnchors
 	}
 
+	public get anchorNode(): AnchorNode {
+		// If the kernel is unhydrated, it has no anchor node. It calls innerNode.anchorNode which
+		// throws an error.
+		return this.#hydrated !== undefined
+			? this.#hydrated.anchorNode
+			: this.innerNode.anchorNode;
+	}
+
 	/**
 	 * Retrieves the flex node associated with the given target via {@link setInnerNode}.
 	 * @remarks

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -919,7 +919,8 @@ export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAl
 
 // @beta @sealed
 export const TreeBeta: {
-    readonly on: <K extends keyof TreeChangeEventsBeta<TNode>, TNode extends TreeNode>(node: TNode, eventName: K, listener: NoInfer<TreeChangeEventsBeta<TNode>[K]>) => () => void;
+    on<K extends keyof TreeChangeEventsBeta<TNode>, TNode extends TreeNode>(node: TNode, eventName: K, listener: NoInfer<TreeChangeEventsBeta<TNode>[K]>): () => void;
+    clone<TSchema extends ImplicitFieldSchema>(node: TreeFieldFromImplicitField<TSchema>): TreeFieldFromImplicitField<TSchema>;
 };
 
 // @alpha @sealed

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -793,7 +793,8 @@ export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAl
 
 // @beta @sealed
 export const TreeBeta: {
-    readonly on: <K extends keyof TreeChangeEventsBeta<TNode>, TNode extends TreeNode>(node: TNode, eventName: K, listener: NoInfer<TreeChangeEventsBeta<TNode>[K]>) => () => void;
+    on<K extends keyof TreeChangeEventsBeta<TNode>, TNode extends TreeNode>(node: TNode, eventName: K, listener: NoInfer<TreeChangeEventsBeta<TNode>[K]>): () => void;
+    clone<TSchema extends ImplicitFieldSchema>(node: TreeFieldFromImplicitField<TSchema>): TreeFieldFromImplicitField<TSchema>;
 };
 
 // @public @sealed


### PR DESCRIPTION
## Description
Added a beta API to deep clone nodes in a tree. The properties of this API are:
- It deep clones all persisted data associated with the node and its subtree.
- It can clone primitive types as well.
- It can clone both hydrated and unhydrated nodes.

## Future considerations
One useful property of this API could be to replace identifiers in the node's subtree. However, I am choosing to not do this in the first iteration of this API. We can consider doing this as a follow up or when there is a customer ask which will give us more details into what the requirements are and how best to design it.

[AB#13000](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/13000)