### PR TITLE
Circuit breaker implementation in scriptorium

### DIFF
--- a/server/routerlicious/.changeset/great-plums-repair.md
+++ b/server/routerlicious/.changeset/great-plums-repair.md
@@ -1,0 +1,12 @@
+---
+"@fluidframework/server-lambdas": major
+"@fluidframework/server-lambdas-driver": major
+"@fluidframework/server-memory-orderer": major
+"@fluidframework/server-services-core": major
+"@fluidframework/server-services-ordering-rdkafka": major
+"@fluidframework/server-test-utils": major
+---
+
+Added pause and resume methods for lambdas
+
+Added pause and resume methods for context, documentContext, partition, partitionManager, kakfaRunner, rdKafkaConsumer, and lambda. They are used to pause/resume the incoming messages during various circuitBreaker states.

--- a/server/routerlicious/.changeset/rare-tires-yawn.md
+++ b/server/routerlicious/.changeset/rare-tires-yawn.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/server-routerlicious-base": major
+"@fluidframework/server-services": major
+"@fluidframework/server-services-core": major
+---
+
+Added healthCheck for mongo database
+
+Exposed a healthCheck property from MongoManager class, and added a healthCheck method to the MongoDb class.

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -74,7 +74,8 @@ data:
                 {{- range $i, $tenant := .Values.kafka.customRestartOnKafkaErrorCodes }}
                 {{ toJson . }}{{- if ne $i $lastIndex -}}, {{ end }}
                 {{- end }}
-            ]
+            ],
+            "seekTimeoutAfterPause": {{ .Values.kafka.seekTimeoutAfterPause }}
         },
         "zookeeper": {
             "endpoint": "{{ .Values.zookeeper.url }}"
@@ -243,7 +244,22 @@ data:
             "checkpointTimeIntervalMsec": 1000,
             "restartOnCheckpointFailure": {{ .Values.scriptorium.restartOnCheckpointFailure }},
             "logSavedOpsTimeIntervalMs": {{ .Values.scriptorium.logSavedOpsTimeIntervalMs }},
-            "opsCountTelemetryEnabled": {{ .Values.scriptorium.opsCountTelemetryEnabled }}
+            "opsCountTelemetryEnabled": {{ .Values.scriptorium.opsCountTelemetryEnabled }},
+            "circuitBreakerEnabled": {{ .Values.scriptorium.circuitBreakerEnabled }},
+            "circuitBreakerOptions": {
+                "errorThresholdPercentage": {{ .Values.scriptorium.circuitBreakerOptions.errorThresholdPercentage }},
+                "resetTimeout": {{ .Values.scriptorium.circuitBreakerOptions.resetTimeout }},
+                "timeout": {{ .Values.scriptorium.circuitBreakerOptions.timeout }},
+                "rollingCountTimeout": {{ .Values.scriptorium.circuitBreakerOptions.rollingCountTimeout }},
+                "rollingCountBuckets": {{ .Values.scriptorium.circuitBreakerOptions.rollingCountBuckets }},
+                "fallbackToRestartTimeoutMs": {{ .Values.scriptorium.circuitBreakerOptions.fallbackToRestartTimeoutMs }},
+                "filterOnErrors": [
+                    {{- $lastIndex := sub (len .Values.scriptorium.circuitBreakerOptions.filterOnErrors) 1}}
+                    {{- range $i, $error := .Values.scriptorium.circuitBreakerOptions.filterOnErrors }}
+                    {{ toJson . }}{{- if ne $i $lastIndex -}}, {{ end }}
+                    {{- end }}
+                ]
+            }
         },
         "riddler": {
             "port": 5000

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -100,13 +100,13 @@ scriptorium:
   opsCountTelemetryEnabled: false
   circuitBreakerEnabled: false
   circuitBreakerOptions:
-			errorThresholdPercentage: 0.001
-			resetTimeout: 30000
-			timeout: false
-			rollingCountTimeout: 1000
-			rollingCountBuckets: 1000
-			fallbackToRestartTimeoutMs: 180000
-			filterOnErrors: []
+    errorThresholdPercentage: 0.001
+    resetTimeout: 30000
+    timeout: false
+    rollingCountTimeout: 1000
+    rollingCountBuckets: 1000
+    fallbackToRestartTimeoutMs: 180000
+    filterOnErrors: []
 
 scribe:
   name: scribe

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -98,6 +98,15 @@ scriptorium:
   restartOnCheckpointFailure: true
   logSavedOpsTimeIntervalMs: 60000
   opsCountTelemetryEnabled: false
+  circuitBreakerEnabled: false
+  circuitBreakerOptions:
+			errorThresholdPercentage: 0.001
+			resetTimeout: 30000
+			timeout: false
+			rollingCountTimeout: 1000
+			rollingCountBuckets: 1000
+			fallbackToRestartTimeoutMs: 180000
+			filterOnErrors: []
 
 scribe:
   name: scribe
@@ -182,6 +191,7 @@ kafka:
   url: kafka_url:port
   libname: rdkafka
   customRestartOnKafkaErrorCodes: [-195, -192, -187, -185, -181, 14]
+  seekTimeoutAfterPause: 1000
 
 ingress:
   class: nginx-prod

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -83,6 +83,16 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_DocumentContext": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_KafkaRunner": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_PartitionManager": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -109,4 +109,12 @@ export class DocumentContext extends EventEmitter implements IContext {
 	public getContextError() {
 		return this.contextError;
 	}
+
+	public pause(offset: number, reason?: any) {
+		this.emit("pause", offset, reason); // TODO add listeners to pause the partition for circuit breaker functionality
+	}
+
+	public resume() {
+		this.emit("resume"); // TODO add listeners to pause the partition for circuit breaker functionality
+	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -111,10 +111,10 @@ export class DocumentContext extends EventEmitter implements IContext {
 	}
 
 	public pause(offset: number, reason?: any) {
-		this.emit("pause", offset, reason); // TODO add listeners to pause the partition for circuit breaker functionality
+		this.emit("pause", offset, reason);
 	}
 
 	public resume() {
-		this.emit("resume"); // TODO add listeners to resume the partition for circuit breaker functionality
+		this.emit("resume");
 	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -115,6 +115,6 @@ export class DocumentContext extends EventEmitter implements IContext {
 	}
 
 	public resume() {
-		this.emit("resume"); // TODO add listeners to pause the partition for circuit breaker functionality
+		this.emit("resume"); // TODO add listeners to resume the partition for circuit breaker functionality
 	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
@@ -61,4 +61,18 @@ export class Context extends EventEmitter implements IContext {
 
 		this.removeAllListeners();
 	}
+
+	/**
+	 * Pauses the context
+	 */
+	public pause(offset: number, reason?: any): void {
+		this.emit("pause", offset, reason);
+	}
+
+	/**
+	 * Resumes the context
+	 */
+	public resume(): void {
+		this.emit("resume");
+	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -152,7 +152,7 @@ export class Partition extends EventEmitter {
 		this.paused = true;
 
 		this.q.pause();
-		this.q.kill(); // flush all the messages in the queue since kafka consumer will resume from last successful offset
+		this.q.remove(() => true); // flush all the messages in the queue since kafka consumer will resume from last successful offset
 
 		if (this.lambda?.pause) {
 			this.lambda.pause();

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -146,7 +146,7 @@ export class Partition extends EventEmitter {
 
 	public pause(): void {
 		if (this.paused) {
-			Lumberjack.info(`PartitionId ${this.id} already paused, returning early.`);
+			Lumberjack.info(`Partition already paused, returning early.`, { partitionId: this.id });
 			return;
 		}
 		this.paused = true;
@@ -157,18 +157,18 @@ export class Partition extends EventEmitter {
 		if (this.lambda?.pause) {
 			this.lambda.pause();
 		}
-		Lumberjack.info(`PartitionId ${this.id} paused`);
+		Lumberjack.info(`Partition paused`, { partitionId: this.id });
 	}
 
 	public resume(): void {
 		if(!this.paused) {
-			Lumberjack.info(`PartitionId ${this.id} resumed, returning early.`);
+			Lumberjack.info(`Partition already resumed, returning early.`, { partitionId: this.id });
 			return;
 		}
 		this.paused = false;
 
 		this.q.resume();
-		Lumberjack.info(`PartitionId ${this.id} resumed`);
+		Lumberjack.info(`Partition resumed`, { partitionId: this.id });
 	}
 
 	/**

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -88,7 +88,7 @@ export class Partition extends EventEmitter {
 
 				const errorData: IContextErrorData = {
 					restart: true,
-					errorLabel: "partition:lambdaFactory.create"
+					errorLabel: "partition:lambdaFactory.create",
 				};
 				this.emit("error", error, errorData);
 				this.q.kill();
@@ -161,8 +161,10 @@ export class Partition extends EventEmitter {
 	}
 
 	public resume(): void {
-		if(!this.paused) {
-			Lumberjack.info(`Partition already resumed, returning early.`, { partitionId: this.id });
+		if (!this.paused) {
+			Lumberjack.info(`Partition already resumed, returning early.`, {
+				partitionId: this.id,
+			});
 			return;
 		}
 		this.paused = false;

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -122,6 +122,24 @@ export class PartitionManager extends EventEmitter {
 		this.removeAllListeners();
 	}
 
+	public pause(partitionId: number): void {
+		const partition = this.partitions.get(partitionId);
+		if (partition) {
+			partition.pause();
+		} else {
+			throw new Error(`PartitionId ${partitionId} not found for pause`);
+		}
+	}
+
+	public resume(partitionId: number): void {
+		const partition = this.partitions.get(partitionId);
+		if (partition) {
+			partition.resume();
+		} else {
+			throw new Error(`PartitionId ${partitionId} not found for resume`);
+		}
+	}
+
 	private process(message: IQueuedMessage) {
 		if (this.stopped) {
 			return;
@@ -230,6 +248,14 @@ export class PartitionManager extends EventEmitter {
 				}
 				Lumberjack.verbose("Emitting error from partitionManager, partition error event");
 				this.emit("error", error, errorData);
+			});
+
+			newPartition.on("pause", (partitionId: number, offset: number, reason?: any) => {
+				this.emit("pause", partitionId, offset, reason);
+			});
+
+			newPartition.on("resume", (partitionId: number) => {
+				this.emit("resume", partitionId);
 			});
 
 			this.partitions.set(partition.partition, newPartition);

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -108,9 +108,42 @@ export class KafkaRunner implements IRunner {
 			}
 		});
 
+		this.partitionManager.on("pause", (partitionId: number, offset: number, reason?: any) => {
+			this.pause(partitionId, offset).then(() => {
+				Lumberjack.info("KafkaRunner paused", { partitionId, offset, reason });
+			}).catch((error) => {
+				Lumberjack.error("KafkaRunner encountered an error during pause", { partitionId, offset, reason }, error);
+			});
+		});
+
+		this.partitionManager.on("resume", (partitionId: number) => {
+			this.resume(partitionId).then(() => {
+				Lumberjack.info("KafkaRunner resumed", { partitionId });
+			}).catch((error) => {
+				Lumberjack.error("KafkaRunner encountered an error during resume", { partitionId }, error);
+			});
+		});
+
 		this.stopped = false;
 
 		return this.deferred.promise;
+	}
+
+	public async pause(partitionId: number, offset: number): Promise<void> {
+		Lumberjack.info(`KafkaRunner.pause starting for partitionId ${partitionId}, offset ${offset}.`);
+		if (this.consumer.pauseFetching) {
+			const seekTimeout = this.config?.get("kafka:seekTimeoutAfterPause") ?? 1000;
+			await this.consumer.pauseFetching(partitionId, seekTimeout, offset);
+		}
+		this.partitionManager?.pause(partitionId);
+	}
+
+	public async resume(partitionId: number): Promise<void> {
+		Lumberjack.info(`KafkaRunner.resume starting for partitionId ${partitionId}.`);
+		if (this.consumer.resumeFetching) {
+			await this.consumer.resumeFetching(partitionId);
+		}
+		this.partitionManager?.resume(partitionId);
 	}
 
 	/**

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -109,19 +109,35 @@ export class KafkaRunner implements IRunner {
 		});
 
 		this.partitionManager.on("pause", (partitionId: number, offset: number, reason?: any) => {
-			this.pause(partitionId, offset).then(() => {
-				Lumberjack.info("KafkaRunner paused", { partitionId, offset, reason: serializeError(reason) });
-			}).catch((error) => {
-				Lumberjack.error("KafkaRunner encountered an error during pause", { partitionId, offset, reason }, error);
-			});
+			this.pause(partitionId, offset)
+				.then(() => {
+					Lumberjack.info("KafkaRunner paused", {
+						partitionId,
+						offset,
+						reason: serializeError(reason),
+					});
+				})
+				.catch((error) => {
+					Lumberjack.error(
+						"KafkaRunner encountered an error during pause",
+						{ partitionId, offset, reason },
+						error,
+					);
+				});
 		});
 
 		this.partitionManager.on("resume", (partitionId: number) => {
-			this.resume(partitionId).then(() => {
-				Lumberjack.info("KafkaRunner resumed", { partitionId });
-			}).catch((error) => {
-				Lumberjack.error("KafkaRunner encountered an error during resume", { partitionId }, error);
-			});
+			this.resume(partitionId)
+				.then(() => {
+					Lumberjack.info("KafkaRunner resumed", { partitionId });
+				})
+				.catch((error) => {
+					Lumberjack.error(
+						"KafkaRunner encountered an error during resume",
+						{ partitionId },
+						error,
+					);
+				});
 		});
 
 		this.stopped = false;

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -110,7 +110,7 @@ export class KafkaRunner implements IRunner {
 
 		this.partitionManager.on("pause", (partitionId: number, offset: number, reason?: any) => {
 			this.pause(partitionId, offset).then(() => {
-				Lumberjack.info("KafkaRunner paused", { partitionId, offset, reason });
+				Lumberjack.info("KafkaRunner paused", { partitionId, offset, reason: serializeError(reason) });
 			}).catch((error) => {
 				Lumberjack.error("KafkaRunner encountered an error during pause", { partitionId, offset, reason }, error);
 			});
@@ -130,7 +130,7 @@ export class KafkaRunner implements IRunner {
 	}
 
 	public async pause(partitionId: number, offset: number): Promise<void> {
-		Lumberjack.info(`KafkaRunner.pause starting for partitionId ${partitionId}, offset ${offset}.`);
+		Lumberjack.info(`KafkaRunner.pause starting`, { partitionId, offset });
 		if (this.consumer.pauseFetching) {
 			const seekTimeout = this.config?.get("kafka:seekTimeoutAfterPause") ?? 1000;
 			await this.consumer.pauseFetching(partitionId, seekTimeout, offset);
@@ -139,7 +139,7 @@ export class KafkaRunner implements IRunner {
 	}
 
 	public async resume(partitionId: number): Promise<void> {
-		Lumberjack.info(`KafkaRunner.resume starting for partitionId ${partitionId}.`);
+		Lumberjack.info(`KafkaRunner.resume starting`, { partitionId });
 		if (this.consumer.resumeFetching) {
 			await this.consumer.resumeFetching(partitionId);
 		}

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/contextManager.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/contextManager.spec.ts
@@ -26,6 +26,14 @@ class TestContext implements IContext {
 		throw new Error("Method not implemented.");
 	}
 
+	public pause(reason?: any) {
+		throw new Error("Method not implemented.");
+	}
+
+	public resume() {
+		throw new Error("Method not implemented.");
+	}
+
 	public readonly log: ILogger = DebugLogger.create("fluid-server:TestContextManager");
 }
 

--- a/server/routerlicious/packages/lambdas-driver/src/test/types/validateServerLambdasDriverPrevious.generated.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/types/validateServerLambdasDriverPrevious.generated.ts
@@ -33,6 +33,7 @@ declare function get_old_ClassDeclaration_DocumentContext():
 declare function use_current_ClassDeclaration_DocumentContext(
     use: TypeOnly<current.DocumentContext>): void;
 use_current_ClassDeclaration_DocumentContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_DocumentContext());
 
 /*
@@ -105,6 +106,7 @@ declare function get_old_ClassDeclaration_KafkaRunner():
 declare function use_current_ClassDeclaration_KafkaRunner(
     use: TypeOnly<current.KafkaRunner>): void;
 use_current_ClassDeclaration_KafkaRunner(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_KafkaRunner());
 
 /*
@@ -153,6 +155,7 @@ declare function get_old_ClassDeclaration_PartitionManager():
 declare function use_current_ClassDeclaration_PartitionManager(
     use: TypeOnly<current.PartitionManager>): void;
 use_current_ClassDeclaration_PartitionManager(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_PartitionManager());
 
 /*

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -70,7 +70,9 @@
 		"json-stringify-safe": "^5.0.1",
 		"lodash": "^4.17.21",
 		"nconf": "^0.12.0",
+		"opossum": "^8.1.4",
 		"semver": "^7.5.3",
+		"serialize-error": "^8.1.0",
 		"sha.js": "^2.4.11",
 		"uuid": "^9.0.0"
 	},
@@ -102,6 +104,10 @@
 		"webpack": "^5.94.0"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_ScriptoriumLambda": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -335,7 +335,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 		const sequenceNumberRanges = convertSortedNumberArrayToRanges(sequenceNumbers);
 		const insertBatchSize = dbOps.length;
 		const runWithRetryArgs: [
-			() => Promise<void>,
+			() => Promise<any>,
 			string,
 			number,
 			number,
@@ -347,7 +347,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 			boolean,
 			boolean
 		] = [
-			async (): Promise<void> => this.opCollection.insertMany(dbOps, false),
+			async (): Promise<any> => this.opCollection.insertMany(dbOps, false),
 			"insertOpScriptorium",
 			3 /* maxRetries */,
 			1000 /* retryAfterMs */,

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -23,6 +23,7 @@ import {
 	CommonProperties,
 } from "@fluidframework/server-services-telemetry";
 import { convertSortedNumberArrayToRanges } from "@fluidframework/server-services-client";
+import { circuitBreakerOptions, LambdaCircuitBreaker } from "../utils";
 
 enum ScriptoriumStatus {
 	Processing = "Processing",
@@ -48,11 +49,16 @@ export class ScriptoriumLambda implements IPartitionLambda {
 	private readonly logSavedOpsTimeIntervalMs: number;
 	private readonly opsCountTelemetryEnabled: boolean;
 	private savedOpsCount: number = 0;
+	private lastSuccessfulOffset: number | undefined;
+	private readonly dbCircuitBreaker: LambdaCircuitBreaker | undefined;
+	private readonly circuitBreakerEnabled: boolean;
+	private readonly circuitBreakerOptions: Record<string, any>;
 
 	constructor(
 		private readonly opCollection: ICollection<any>,
 		protected context: IContext,
 		private readonly providerConfig: Record<string, any> | undefined,
+		private readonly dbHealthCheckFunction: ((...args: any[]) => Promise<any>),
 	) {
 		this.clientFacadeRetryEnabled = isRetryEnabled(this.opCollection);
 		this.telemetryEnabled = this.providerConfig?.enableTelemetry;
@@ -62,6 +68,28 @@ export class ScriptoriumLambda implements IPartitionLambda {
 		this.restartOnCheckpointFailure = this.providerConfig?.restartOnCheckpointFailure;
 		this.logSavedOpsTimeIntervalMs = this.providerConfig?.logSavedOpsTimeIntervalMs ?? 60000;
 		this.opsCountTelemetryEnabled = this.providerConfig?.opsCountTelemetryEnabled;
+		this.circuitBreakerEnabled = this.providerConfig?.circuitBreakerEnabled;
+		this.circuitBreakerOptions = this.providerConfig?.circuitBreakerOptions;
+
+		// setup circuit breaker
+		if (this.circuitBreakerEnabled) {
+			try {
+				const dbCircuitBreakerOptions: circuitBreakerOptions = {
+					errorThresholdPercentage: this.circuitBreakerOptions.errorThresholdPercentage ?? 0.001, // Percentage of errors before opening the circuit
+					resetTimeout: this.circuitBreakerOptions.resetTimeout ?? 30000, // Time in milliseconds before attempting to close the circuit after it has been opened
+					timeout: this.circuitBreakerOptions.timeout ?? false, // Time in milliseconds before a request is considered timed out
+					rollingCountTimeout: this.circuitBreakerOptions.rollingCountTimeout ?? 1000, // Time in milliseconds before the rolling window resets
+					rollingCountBuckets: this.circuitBreakerOptions.rollingCountBuckets ?? 1000, // Number of buckets in the rolling window
+					errorFilter: this.errorFilterForCircuitBreaker.bind(this), // Function to filter errors - if it returns true for certain errors, they will not open the circuit
+					fallbackToRestartTimeoutMs: this.circuitBreakerOptions.fallbackToRestartTimeoutMs ?? 180000,
+				}
+
+				this.dbCircuitBreaker = new LambdaCircuitBreaker(dbCircuitBreakerOptions, this.context, "MongoDB", runWithRetry, this.dbHealthCheckFunction);
+			} catch (error) {
+				Lumberjack.error("Error while creating circuit breaker in scriptorium", {}, error);
+				throw error; // will be caught in partition.ts during factory.create and it will restart the service
+			}
+		}
 	}
 
 	/**
@@ -101,6 +129,11 @@ export class ScriptoriumLambda implements IPartitionLambda {
 		}
 
 		this.pendingOffset = message;
+
+		// initialize last successful offset
+		if (this.lastSuccessfulOffset === undefined) {
+			this.lastSuccessfulOffset = message.offset - 1;
+		}
 
 		if (this.telemetryEnabled && this.pending.size > 0) {
 			if (this.pendingMetric === undefined) {
@@ -143,6 +176,23 @@ export class ScriptoriumLambda implements IPartitionLambda {
 	public close(): void {
 		this.pending.clear();
 		this.current.clear();
+		this.dbCircuitBreaker?.shutdown();
+	}
+
+	public pause(): void {
+		this.current.clear();
+		this.pending.clear();
+		this.pendingMetric = undefined;
+		Lumberjack.info("ScriptoriumLambda paused");
+	}
+
+	private errorFilterForCircuitBreaker(error: any): boolean {
+		for (const errorFilter of this.circuitBreakerOptions.filterOnErrors ?? []) {
+			if (error?.message?.toString()?.indexOf(errorFilter) >= 0 || error?.stack?.toString()?.indexOf(errorFilter) >= 0) {
+				return false; // circuit breaker will open and pause the lambda
+			}
+		}
+		return true; // do not open the circuit for other errors, and let scriptorium restart
 	}
 
 	private sendPending(): void {
@@ -200,6 +250,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 
 				// checkpoint batch offset
 				try {
+					this.lastSuccessfulOffset = batchOffset?.offset;
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					this.context.checkpoint(batchOffset!, this.restartOnCheckpointFailure);
 					status = ScriptoriumStatus.CheckpointComplete;
@@ -228,11 +279,21 @@ export class ScriptoriumLambda implements IPartitionLambda {
 				// catches error if any of the promises failed in Promise.all, i.e. any of the ops failed to write to db
 				status = ScriptoriumStatus.ProcessingFailed;
 				metric?.setProperty("timestampProcessingFailed", new Date().toISOString());
-				const errorMessage = "Scriptorium failed to process batch, going to restart";
-				this.logErrorTelemetry(errorMessage, error, status, batchOffset?.offset, metric);
 
-				// Restart scriptorium
-				this.context.error(error, { restart: true });
+				if (error.circuitBreakerOpen === true && this.lastSuccessfulOffset !== undefined) {
+					const errorMessage = "Scriptorium failed to process batch, circuit breaker is opened and pausing lambda";
+					this.logErrorTelemetry(errorMessage, error, status, batchOffset?.offset, metric);
+
+					// Circuit breaker is open, pause lambda. It will be resumed when circuit breaker closes after some time.
+					this.context.pause(this.lastSuccessfulOffset + 1, error);
+					return;
+				} else {
+					const errorMessage = "Scriptorium failed to process batch, going to restart";
+					this.logErrorTelemetry(errorMessage, error, status, batchOffset?.offset, metric);
+
+					// Restart scriptorium
+					this.context.error(error, { restart: true });
+				}
 			});
 	}
 
@@ -273,9 +334,20 @@ export class ScriptoriumLambda implements IPartitionLambda {
 		const sequenceNumbers = messages.map((message) => message.operation.sequenceNumber);
 		const sequenceNumberRanges = convertSortedNumberArrayToRanges(sequenceNumbers);
 		const insertBatchSize = dbOps.length;
-
-		return runWithRetry(
-			async () => this.opCollection.insertMany(dbOps, false),
+		const runWithRetryArgs: [
+			() => Promise<void>,
+			string,
+			number,
+			number,
+			Map<string, any> | Record<string, any> | undefined,
+			((error: any) => boolean) | undefined,
+			((error: any) => boolean) | undefined,
+			((error: any, numRetries: number, retryAfterInterval: number) => number) | undefined,
+			((error: any) => void) | undefined,
+			boolean,
+			boolean
+		] = [
+			async (): Promise<void> => this.opCollection.insertMany(dbOps, false),
 			"insertOpScriptorium",
 			3 /* maxRetries */,
 			1000 /* retryAfterMs */,
@@ -285,14 +357,15 @@ export class ScriptoriumLambda implements IPartitionLambda {
 				insertBatchSize,
 				scriptoriumMetricId,
 			},
-			(error) =>
+			(error): boolean =>
 				error.code === 11000 ||
 				error.message?.toString()?.indexOf("E11000 duplicate key") >= 0,
-			(error) => !this.clientFacadeRetryEnabled /* shouldRetry */,
+			(error): boolean => !this.clientFacadeRetryEnabled /* shouldRetry */,
 			undefined /* calculateIntervalMs */,
 			undefined /* onErrorFn */,
 			this.telemetryEnabled,
 			this.shouldLogInitialSuccessVerbose,
-		);
+		]
+		return this.dbCircuitBreaker ? this.dbCircuitBreaker.execute(runWithRetryArgs) : runWithRetry(...runWithRetryArgs);
 	}
 }

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambdaFactory.ts
@@ -28,7 +28,7 @@ export class ScriptoriumLambdaFactory extends EventEmitter implements IPartition
 	public async create(config: undefined, context: IContext): Promise<IPartitionLambda> {
 		// Takes in the io as well as the collection. I can probably keep the same lambda but only ever give it stuff
 		// from a single document
-		return new ScriptoriumLambda(this.opCollection, context, this.providerConfig);
+		return new ScriptoriumLambda(this.opCollection, context, this.providerConfig, this.mongoManager.healthCheck);
 	}
 
 	public async dispose(): Promise<void> {

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambdaFactory.ts
@@ -28,7 +28,12 @@ export class ScriptoriumLambdaFactory extends EventEmitter implements IPartition
 	public async create(config: undefined, context: IContext): Promise<IPartitionLambda> {
 		// Takes in the io as well as the collection. I can probably keep the same lambda but only ever give it stuff
 		// from a single document
-		return new ScriptoriumLambda(this.opCollection, context, this.providerConfig, this.mongoManager.healthCheck);
+		return new ScriptoriumLambda(
+			this.opCollection,
+			context,
+			this.providerConfig,
+			this.mongoManager.healthCheck,
+		);
 	}
 
 	public async dispose(): Promise<void> {

--- a/server/routerlicious/packages/lambdas/src/test/scriptorium/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/scriptorium/lambda.spec.ts
@@ -33,7 +33,7 @@ describe("Routerlicious", () => {
 				testCollection = new TestCollection([]);
 				testContext = new TestContext();
 
-				lambda = new ScriptoriumLambda(testCollection, testContext, undefined);
+				lambda = new ScriptoriumLambda(testCollection, testContext, undefined, undefined);
 			});
 
 			describe(".handler()", () => {

--- a/server/routerlicious/packages/lambdas/src/test/types/validateServerLambdasPrevious.generated.ts
+++ b/server/routerlicious/packages/lambdas/src/test/types/validateServerLambdasPrevious.generated.ts
@@ -705,6 +705,7 @@ declare function get_old_ClassDeclaration_ScriptoriumLambda():
 declare function use_current_ClassDeclaration_ScriptoriumLambda(
     use: TypeOnly<current.ScriptoriumLambda>): void;
 use_current_ClassDeclaration_ScriptoriumLambda(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_ScriptoriumLambda());
 
 /*

--- a/server/routerlicious/packages/lambdas/src/test/utils/circuitBreaker.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/utils/circuitBreaker.spec.ts
@@ -1,0 +1,156 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { TestContext } from "@fluidframework/server-test-utils";
+import { LambdaCircuitBreaker, circuitBreakerOptions } from "../../utils/circuitBreaker";
+
+describe("Lambda CircuitBreaker", () => {
+	let circuitBreaker: LambdaCircuitBreaker;
+	const resetTimeout = 1000;
+	const options: circuitBreakerOptions = {
+		errorThresholdPercentage: 0.001,
+		resetTimeout: resetTimeout,
+		timeout: false,
+		rollingCountTimeout: 1000,
+		rollingCountBuckets: 1000,
+	};
+	const testContext = new TestContext();
+
+	const dependencyName = "dummyDependency";
+	const successfulResponse = "Dummy action completed";
+	const errorResponse = "Dummy action failed";
+	const healthCheckSuccessResponse = "Health check successful";
+	const healthCheckFailedResponse = "Health check failed";
+	const dummyFunction = async (success = true, timeoutMs = 0) => {
+		if (timeoutMs > 0) {
+			await new Promise((resolve) => setTimeout(resolve, timeoutMs));
+		}
+		return success ? Promise.resolve(successfulResponse) : Promise.reject(new Error(errorResponse));
+	}
+	const dummyHealthCheck = async (success = true) => {
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		return success ? Promise.resolve(healthCheckSuccessResponse) : Promise.reject(new Error(healthCheckFailedResponse));
+	}
+
+
+	afterEach(() => {
+		circuitBreaker["circuitBreaker"].close();
+		circuitBreaker.shutdown();
+	});
+
+	it("should execute the function successfully when the circuit is closed", async () => {
+		circuitBreaker = new LambdaCircuitBreaker(options, testContext, dependencyName, dummyFunction, dummyHealthCheck);
+		const response = await circuitBreaker.execute([]);
+		assert.strictEqual(response, successfulResponse);
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+		assert.strictEqual(circuitBreaker.getCurrentState(), "closed");
+	});
+
+	it("should open the circuit when execution fails, and fail immediately for further requests", async () => {
+		circuitBreaker = new LambdaCircuitBreaker(options, testContext, dependencyName, dummyFunction, dummyHealthCheck);
+
+		await assert.rejects(circuitBreaker.execute([false]), { message: errorResponse, circuitBreakerOpen: true });
+		assert.strictEqual(circuitBreaker.getCurrentState(), "opened");
+
+		// Execute the function again, this time it should reject immediately without calling the action
+		await circuitBreaker.execute([]).catch((error) => {
+			assert.notEqual(error.message, errorResponse); // indicates that the action was not called
+			assert.strictEqual(error.circuitBreakerOpen, true);
+		});
+		assert.strictEqual(circuitBreaker.getCurrentState(), "opened");
+	});
+
+	it("should not open the circuit breaker if errorFilter returns true even though the function returned an error", async () => {
+		circuitBreaker = new LambdaCircuitBreaker(
+			{...options, errorFilter: (_) => {
+				return true;
+			}},
+			testContext,
+			dependencyName,
+			dummyFunction,
+			dummyHealthCheck
+		);
+		try {
+			await circuitBreaker.execute([false]);
+		} catch (error) {
+			assert.strictEqual(error["message"], errorResponse);
+			assert.strictEqual(error["circuitBreakerOpen"], undefined);
+		}
+		assert.strictEqual(circuitBreaker.getCurrentState(), "closed");
+		// requests are successful confirming the closed state
+		const response = await circuitBreaker.execute([]);
+		assert.strictEqual(response, successfulResponse);
+	});
+
+	it("should halfOpen the circuit after resetTimeout and close the circuit if healthCheck is successful", async () => {
+		circuitBreaker = new LambdaCircuitBreaker(options, testContext, dependencyName, dummyFunction, dummyHealthCheck);
+
+		await assert.rejects(circuitBreaker.execute([false]), { message: errorResponse, circuitBreakerOpen: true });
+		assert.strictEqual(circuitBreaker.getCurrentState(), "opened");
+
+		await new Promise((resolve) => setTimeout(resolve, resetTimeout));
+		assert.strictEqual(circuitBreaker.getCurrentState(), "halfOpen");
+		await new Promise((resolve) => setTimeout(resolve, 100)); // let health check complete
+
+		assert.strictEqual(circuitBreaker.getCurrentState(), "closed");
+		const response = await circuitBreaker.execute([]);
+		assert.strictEqual(response, successfulResponse);
+	});
+
+	it("should halfOpen the circuit after resetTimeout and open the circuit if healthCheck is failing", async () => {
+		circuitBreaker = new LambdaCircuitBreaker(options, testContext, dependencyName, dummyFunction, dummyHealthCheck, [false]);
+
+		await assert.rejects(circuitBreaker.execute([false]), { message: errorResponse, circuitBreakerOpen: true });
+		assert.strictEqual(circuitBreaker.getCurrentState(), "opened");
+
+		await new Promise((resolve) => setTimeout(resolve, resetTimeout));
+		assert.strictEqual(circuitBreaker.getCurrentState(), "halfOpen");
+		await new Promise((resolve) => setTimeout(resolve, 100)); // let health check complete
+
+		assert.strictEqual(circuitBreaker.getCurrentState(), "opened");
+		await circuitBreaker.execute([]).catch((error) => {
+			assert.notEqual(error.message, errorResponse); // indicates that the action was not called
+			assert.strictEqual(error.circuitBreakerOpen, true);
+		});
+	});
+
+	it("should open the circuit if any one out of multiple parallel calls fail and pending requests resolving should not close the circuit", async () => {
+		circuitBreaker = new LambdaCircuitBreaker(options, testContext, dependencyName, dummyFunction, dummyHealthCheck);
+		const promises = [];
+
+		// successful case
+		promises.push(circuitBreaker.execute([true, 100]).then(response => {
+			assert.strictEqual(response, successfulResponse);
+		}));
+
+		// failure case - this should open the circuit
+		promises.push(circuitBreaker.execute([false, 0]).then(_ => {
+			assert.fail("Should not reach here");
+		}).catch(error => {
+			assert.strictEqual(error.message, errorResponse);
+			assert.strictEqual(error.circuitBreakerOpen, true);
+			assert.strictEqual(circuitBreaker.getCurrentState(), "opened");
+		}));
+
+		// circuit should remain opened even when the successful case resolved
+		Promise.all(promises).then(_ => {
+			assert.strictEqual(circuitBreaker.getCurrentState(), "opened");
+		});
+	});
+
+	it("should fallback to restart if not closed for a long time", async () => {
+		circuitBreaker = new LambdaCircuitBreaker({ ...options, resetTimeout: 100, fallbackToRestartTimeoutMs: 1000 }, testContext, dependencyName, dummyFunction, dummyHealthCheck, [false]);
+
+		testContext.on("error", (error, errorData) => {
+			assert.strictEqual(error.message, errorResponse);
+			assert.strictEqual(errorData.restart, true);
+		});
+
+		await assert.rejects(circuitBreaker.execute([false]), { message: errorResponse, circuitBreakerOpen: true });
+		assert.strictEqual(circuitBreaker.getCurrentState(), "opened");
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+	});
+});

--- a/server/routerlicious/packages/lambdas/src/utils/circuitBreaker.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/circuitBreaker.ts
@@ -1,0 +1,188 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import CircuitBreaker from 'opossum';
+import { serializeError } from "serialize-error";
+import { IContext } from "@fluidframework/server-services-core";
+import {
+	Lumberjack,
+	Lumber,
+	LumberEventName,
+} from "@fluidframework/server-services-telemetry";
+
+export interface circuitBreakerOptions {
+	errorThresholdPercentage: number; // Percentage of errors before opening the circuit
+	resetTimeout: number; // Time in milliseconds before attempting to close the circuit after it has been opened, i.e. it will go to halfOpen state after resetTimeout
+	timeout: boolean; // Time in milliseconds before a request is considered timed out, if it is set to false, timeout will be disabled
+	rollingCountTimeout: number; // Time in milliseconds before the rolling window resets for errorThresholdPercentage calculation
+	rollingCountBuckets: number; // Number of buckets in the rolling window for errorThresholdPercentage calculation
+	errorFilter?: (error: any) => boolean; // Function to filter errors - if it returns true for certain errors, they will not open the circuit
+	fallbackToRestartTimeoutMs?: number; // Time in milliseconds to wait before restarting the service if the circuit breaker is not closed
+}
+
+// executes `functionCall` with `args`
+async function wrapperCircuitBreakerAction (functionCall: (...args: any[]) => Promise<any>, args: any[]): Promise<any> {
+	return functionCall(...args);
+}
+
+export class LambdaCircuitBreaker {
+	private readonly circuitBreaker: CircuitBreaker;
+	private readonly context: IContext;
+	private readonly dependencyName: string;
+	private readonly executeFunction: (...args: any[]) => Promise<any>
+	private readonly healthCheckFunction: ((...args: any[]) => Promise<any>);
+	private readonly healthCheckParams: any[] = [];
+	private readonly fallbackToRestartTimeoutMs: number = 180000; // 3 minutes by default
+
+	// following properties are used for telemetry and reset when the circuit breaker is closed
+	private circuitBreakerMetric: Lumber<LumberEventName.CircuitBreaker> | undefined;
+	private circuitBreakerOpenCount: number = 0;
+	private error: any;
+	private fallbackToRestartTimeout: NodeJS.Timeout | undefined; // timeout to restart the service if the circuit breaker is not closed for more than fallbackToRestartTimeoutMs
+
+	constructor(
+		circuitBreakerOptions: circuitBreakerOptions,
+		context: IContext,
+		dependencyName: string,
+		executeFunction: (...args: any[]) => Promise<any>,
+		healthCheckFunction: (...args: any[]) => Promise<any>,
+		healthCheckParams?: any[]
+	) {
+		this.context = context;
+		this.dependencyName = dependencyName;
+		this.executeFunction = executeFunction;
+		this.healthCheckFunction = healthCheckFunction;
+		this.healthCheckParams = healthCheckParams ?? [];
+		this.fallbackToRestartTimeoutMs = circuitBreakerOptions.fallbackToRestartTimeoutMs ?? this.fallbackToRestartTimeoutMs;
+
+		const lambdaErrorFilter = circuitBreakerOptions.errorFilter;
+
+		this.circuitBreaker = new CircuitBreaker(wrapperCircuitBreakerAction, {
+			errorThresholdPercentage: circuitBreakerOptions.errorThresholdPercentage,
+			resetTimeout: circuitBreakerOptions.resetTimeout,
+			timeout: circuitBreakerOptions.timeout,
+			rollingCountTimeout: circuitBreakerOptions.rollingCountTimeout,
+			rollingCountBuckets: circuitBreakerOptions.rollingCountBuckets,
+			errorFilter: (error): boolean => {
+				if (error.healthCheckFailed) { // open the circuit breaker if health check fails with any error, else use lambdaErrorFilter
+					return false;
+				}
+				return lambdaErrorFilter ? lambdaErrorFilter(error) : false;
+			}
+		});
+
+		this.circuitBreaker.on("open", () => this.openCallback());
+		this.circuitBreaker.on("close", () => this.closeCallback());
+		this.circuitBreaker.on("halfOpen", () => this.halfOpenCallback());
+		this.circuitBreaker.on("failure", (err) => this.failureCallback(err)); // Emitted when the circuit breaker action fails
+		this.circuitBreaker.on("reject", (err) => this.rejectCallback(err)); // Emitted when the circuit breaker is in open state (failing fast) and action is fired
+	}
+
+	public async execute(params: any[], doHealthCheck?: boolean): Promise<void> {
+		const functionToFire = doHealthCheck && this.healthCheckFunction ? this.healthCheckFunction : this.executeFunction;
+		return this.circuitBreaker.fire(functionToFire, params); // calls wrapperCircuitBreakerAction with these params
+	}
+
+	public getCurrentState(): string {
+		return this.circuitBreaker.opened ? "opened" : this.circuitBreaker.halfOpen ? "halfOpen" : "closed";
+	}
+
+	public shutdown(): void {
+		this.circuitBreaker.shutdown();
+	}
+
+	private openCallback(): void {
+		// telemetry for circuit breaker open
+		this.circuitBreakerOpenCount++;
+		if (this.circuitBreakerMetric) { // opening the circuit agan after halfOpen state
+			this.circuitBreakerMetric.setProperty("openCount", this.circuitBreakerOpenCount);
+		} else { // opening the circuit first time, create new metric
+			this.circuitBreakerMetric = Lumberjack.newLumberMetric(LumberEventName.CircuitBreaker, {
+				timestampOpened: new Date().toISOString(),
+				dependencyName: this.dependencyName,
+				error: serializeError(this.error),
+				openCount: this.circuitBreakerOpenCount
+			});
+
+			// setup the fallback to restart the service if the circuit breaker is not closed for more than fallbackToRestartTimeoutMs
+			this.setupRestartFallback(this.error);
+		}
+		Lumberjack.info("Circuit breaker opened", {
+			metricId: this.circuitBreakerMetric.id,
+			error: serializeError(this.error)
+		});
+	}
+
+	private closeCallback(): void {
+		// resume lambda.
+		this.context.resume();
+
+		// telemetry for circuit breaker closed
+		const metricProperties = {
+			timestampClosed: new Date().toISOString(),
+			openCount: this.circuitBreakerOpenCount,
+			state: this.circuitBreaker.toJSON()?.state,
+		};
+		if (this.circuitBreakerMetric) {
+			this.circuitBreakerMetric?.setProperties(metricProperties);
+			this.circuitBreakerMetric?.success("Circuit breaker closed");
+		} else {
+			Lumberjack.info("Circuit breaker closed", metricProperties);
+		}
+
+		// Reset the circuit breaker telemetry and fallback
+		this.resetTelemetryAndFallback();
+	}
+
+	private halfOpenCallback(): void {
+		Lumberjack.info("Circuit breaker halfOpen", {
+			metricId: this.circuitBreakerMetric?.id
+		});
+
+		// check the health of the dependency service, and let circuit breaker change its state accordingly
+		this.execute(this.healthCheckParams, true).catch((error) => {
+			Lumberjack.error("Circuit breaker health check failed in halfOpen state, circuit will remain open.", {metricId: this.circuitBreakerMetric?.id}, error);
+		});
+	}
+
+	private failureCallback(error: any): void {
+		this.error = error;
+		error.circuitBreakerOpen = true;
+	}
+
+	private rejectCallback(error: any): void {
+		error.circuitBreakerOpen = true;
+	}
+
+	private setupRestartFallback(initialError: any): void {
+		this.fallbackToRestartTimeout = setTimeout(() => {
+			if (!this.circuitBreaker.closed) {
+				this.circuitBreakerMetric?.setProperties({
+					openCount: this.circuitBreakerOpenCount,
+					timestampFallbackToRestart: new Date().toISOString(),
+					state: this.circuitBreaker.toJSON()?.state,
+					fallbackToRestartTimeoutMs: this.fallbackToRestartTimeoutMs
+				});
+				this.circuitBreakerMetric?.error("Circuit breaker not closed for a long time, going to restart the service");
+				this.context.error(initialError, { restart: true, errorLabel: "circuitBreaker:fallbackToRestartTimeout" });
+			}
+		}, this.fallbackToRestartTimeoutMs);
+	}
+
+	private resetTelemetryAndFallback(): void {
+		// clear the fallback to restart timeout
+		if (this.fallbackToRestartTimeout !== undefined) {
+			clearTimeout(this.fallbackToRestartTimeout);
+			this.fallbackToRestartTimeout = undefined;
+		}
+
+		// reset the circuit breaker metric and count
+		this.circuitBreakerMetric = undefined;
+		this.circuitBreakerOpenCount = 0;
+
+		// reset the error
+		this.error = undefined;
+	}
+}

--- a/server/routerlicious/packages/lambdas/src/utils/index.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/index.ts
@@ -17,3 +17,4 @@ export { isDocumentSessionValid, isDocumentValid } from "./validateDocument";
 export { CheckpointReason, ICheckpoint } from "./checkpointHelper";
 export { IServerMetadata } from "./serverMetadata";
 export { DocumentCheckpointManager } from "./documentLambdaCheckpointManager";
+export { circuitBreakerOptions, LambdaCircuitBreaker } from "./circuitBreaker";

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -101,6 +101,15 @@
 			},
 			"ClassDeclaration_LocalOrderer": {
 				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IKafkaSubscriber": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_LocalContext": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_LocalLambdaController": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/memory-orderer/src/localContext.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localContext.ts
@@ -23,4 +23,12 @@ export class LocalContext implements IContext {
 	public error(error: any, errorData: IContextErrorData) {
 		return;
 	}
+
+	public pause(offset: number, reason?: any) {
+		return;
+	}
+
+	public resume() {
+		return;
+	}
 }

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -241,7 +241,7 @@ export class LocalOrderer implements IOrderer {
 			this.scriptoriumContext,
 			async (lambdaSetup, context) => {
 				const deltasCollection = await lambdaSetup.deltaCollectionP();
-				return new ScriptoriumLambda(deltasCollection, context, undefined);
+				return new ScriptoriumLambda(deltasCollection, context, undefined, undefined);
 			},
 		);
 

--- a/server/routerlicious/packages/memory-orderer/src/test/types/validateServerMemoryOrdererPrevious.generated.ts
+++ b/server/routerlicious/packages/memory-orderer/src/test/types/validateServerMemoryOrdererPrevious.generated.ts
@@ -129,6 +129,7 @@ declare function get_old_InterfaceDeclaration_IKafkaSubscriber():
 declare function use_current_InterfaceDeclaration_IKafkaSubscriber(
     use: TypeOnly<current.IKafkaSubscriber>): void;
 use_current_InterfaceDeclaration_IKafkaSubscriber(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IKafkaSubscriber());
 
 /*
@@ -321,6 +322,7 @@ declare function get_old_ClassDeclaration_LocalContext():
 declare function use_current_ClassDeclaration_LocalContext(
     use: TypeOnly<current.LocalContext>): void;
 use_current_ClassDeclaration_LocalContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_LocalContext());
 
 /*
@@ -370,6 +372,7 @@ declare function get_old_ClassDeclaration_LocalLambdaController():
 declare function use_current_ClassDeclaration_LocalLambdaController(
     use: TypeOnly<current.LocalLambdaController>): void;
 use_current_ClassDeclaration_LocalLambdaController(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_LocalLambdaController());
 
 /*

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -139,6 +139,9 @@
 			},
 			"ClassDeclaration_AlfredResources": {
 				"forwardCompat": false
+			},
+			"ClassDeclaration_RiddlerResources": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/routerlicious-base/src/test/types/validateServerRouterliciousBasePrevious.generated.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/types/validateServerRouterliciousBasePrevious.generated.ts
@@ -516,6 +516,7 @@ declare function get_old_ClassDeclaration_RiddlerResources():
 declare function use_current_ClassDeclaration_RiddlerResources(
     use: TypeOnly<current.RiddlerResources>): void;
 use_current_ClassDeclaration_RiddlerResources(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_RiddlerResources());
 
 /*

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -60,7 +60,8 @@
 			"rdkafkaConsumeTimeout": 5,
 			"rdkafkaMaxConsumerCommitRetries": 10
 		},
-		"customRestartOnKafkaErrorCodes": [-195, -192, -187, -185, -181, 14]
+		"customRestartOnKafkaErrorCodes": [-195, -192, -187, -185, -181, 14],
+		"seekTimeoutAfterPause": 1000
 	},
 	"zookeeper": {
 		"endpoint": "zookeeper:2181"
@@ -271,7 +272,17 @@
 		"maxDbBatchSize": 1000,
 		"restartOnCheckpointFailure": true,
 		"logSavedOpsTimeIntervalMs": 60000,
-		"opsCountTelemetryEnabled": true
+		"opsCountTelemetryEnabled": true,
+		"circuitBreakerEnabled": false,
+		"circuitBreakerOptions": {
+			"errorThresholdPercentage": 0.001,
+			"resetTimeout": 30000,
+			"timeout": false,
+			"rollingCountTimeout": 1000,
+			"rollingCountBuckets": 1000,
+			"fallbackToRestartTimeoutMs": 180000,
+			"filterOnErrors": []
+		}
 	},
 	"copier": {
 		"topic": "rawdeltas",

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -48,6 +48,9 @@ export async function create(
 		(config.get("scriptorium:logSavedOpsTimeIntervalMs") as number) ?? 60000;
 	const opsCountTelemetryEnabled =
 		(config.get("scriptorium:opsCountTelemetryEnabled") as boolean) ?? false;
+	const circuitBreakerEnabled =
+		(config.get("scriptorium:circuitBreakerEnabled") as boolean) ?? false;
+	const circuitBreakerOptions = config.get("scriptorium:circuitBreakerOptions") as Record<string, any> ?? {};
 
 	const factory = await services.getDbFactory(config);
 
@@ -132,5 +135,7 @@ export async function create(
 		shouldLogInitialSuccessVerbose,
 		logSavedOpsTimeIntervalMs,
 		opsCountTelemetryEnabled,
+		circuitBreakerEnabled,
+		circuitBreakerOptions,
 	});
 }

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -50,7 +50,8 @@ export async function create(
 		(config.get("scriptorium:opsCountTelemetryEnabled") as boolean) ?? false;
 	const circuitBreakerEnabled =
 		(config.get("scriptorium:circuitBreakerEnabled") as boolean) ?? false;
-	const circuitBreakerOptions = config.get("scriptorium:circuitBreakerOptions") as Record<string, any> ?? {};
+	const circuitBreakerOptions =
+		(config.get("scriptorium:circuitBreakerOptions") as Record<string, any>) ?? {};
 
 	const factory = await services.getDbFactory(config);
 

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -73,6 +73,12 @@
 			},
 			"InterfaceDeclaration_IOrdererConnection": {
 				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IContext": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_MongoManager": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-core/src/combinedContext.ts
+++ b/server/routerlicious/packages/services-core/src/combinedContext.ts
@@ -27,6 +27,12 @@ export class CombinedContext {
 			log: this.context.log,
 			checkpoint: (message) => this.checkpoint(id, message),
 			error: (error, errorData) => this.error(id, error, errorData),
+			pause: (offset, reason) => {
+				this.context.pause(offset, reason);
+			},
+			resume: () => {
+				this.context.resume();
+			},
 		};
 	}
 

--- a/server/routerlicious/packages/services-core/src/database.ts
+++ b/server/routerlicious/packages/services-core/src/database.ts
@@ -291,6 +291,12 @@ export interface IDb {
 	 * The method also removes any indexes associated with the dropped collection.
 	 */
 	dropCollection?(name: string): Promise<boolean>;
+
+	/**
+	 * Send a ping command to the database to check its health.
+	 * @param dbName - database name
+	 */
+	healthCheck?(dbName?: string): Promise<void>;
 }
 
 /**

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -94,6 +94,18 @@ export interface IContext {
 	 * Used to log events / errors.
 	 */
 	readonly log: ILogger | undefined;
+
+	/**
+	 * Pauses the context
+	 * @param offset - The offset to pause at. This is the offset from which it will be resumed.
+	 * @param reason - The reason for pausing
+	 */
+	pause(offset: number, reason?: any): void;
+
+	/**
+	 * Resumes the context
+	 */
+	resume(): void;
 }
 
 /**
@@ -117,6 +129,11 @@ export interface IPartitionLambda {
 	 * any deferred work.
 	 */
 	close(closeType: LambdaCloseType): void;
+
+	/**
+	 * Pauses the lambda. It should clear any pending work.
+	 */
+	pause?(): void;
 }
 
 /**

--- a/server/routerlicious/packages/services-core/src/mongo.ts
+++ b/server/routerlicious/packages/services-core/src/mongo.ts
@@ -26,7 +26,7 @@ export class MongoManager {
 		this.healthCheck = async (): Promise<void> => {
 			const database = await this.databaseP;
 			return database.healthCheck();
-		}
+		};
 	}
 
 	/**

--- a/server/routerlicious/packages/services-core/src/mongo.ts
+++ b/server/routerlicious/packages/services-core/src/mongo.ts
@@ -14,6 +14,7 @@ import { debug } from "./debug";
  */
 export class MongoManager {
 	private databaseP: Promise<IDb>;
+	public healthCheck: () => Promise<void>;
 
 	constructor(
 		private readonly factory: IDbFactory,
@@ -22,6 +23,10 @@ export class MongoManager {
 		private readonly global = false,
 	) {
 		this.databaseP = this.connect(this.global);
+		this.healthCheck = async (): Promise<void> => {
+			const database = await this.databaseP;
+			return database.healthCheck();
+		}
 	}
 
 	/**

--- a/server/routerlicious/packages/services-core/src/queue.ts
+++ b/server/routerlicious/packages/services-core/src/queue.ts
@@ -55,6 +55,16 @@ export interface IConsumer {
 	resume(): Promise<void>;
 
 	/**
+	 * Pauses retrieval of new messages without a rebalance, and seeks the offset to the specified value.
+	 */
+	pauseFetching?(partitionId: number, seekTimeout: number, offset?: number): Promise<void>;
+
+	/**
+	 * Resumes retrieval of messages without a rebalance.
+	 */
+	resumeFetching?(partitionId: number): Promise<void>;
+
+	/**
 	 * Commits consumer checkpoint offset.
 	 */
 	commitCheckpoint(partitionId: number, queuedMessage: IQueuedMessage): Promise<void>;

--- a/server/routerlicious/packages/services-core/src/runner.ts
+++ b/server/routerlicious/packages/services-core/src/runner.ts
@@ -21,6 +21,16 @@ export interface IRunner {
 	 * Stops the runner
 	 */
 	stop(caller?: string, uncaughtException?: any): Promise<void>;
+
+	/**
+	 * Pauses the runner
+	 */
+	pause?(partitionId: number, offset: number): Promise<void>;
+
+	/**
+	 * Resumes the runner
+	 */
+	resume?(partitionId: number): Promise<void>;
 }
 
 /**

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -610,6 +610,7 @@ declare function get_old_InterfaceDeclaration_IContext():
 declare function use_current_InterfaceDeclaration_IContext(
     use: TypeOnly<current.IContext>): void;
 use_current_InterfaceDeclaration_IContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContext());
 
 /*
@@ -3133,6 +3134,7 @@ declare function get_old_ClassDeclaration_MongoManager():
 declare function use_current_ClassDeclaration_MongoManager(
     use: TypeOnly<current.MongoManager>): void;
 use_current_ClassDeclaration_MongoManager(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MongoManager());
 
 /*

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -65,6 +65,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_RdkafkaConsumer": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -466,10 +466,11 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			return Promise.reject(new Error(`Consumer pause called for unassigned partitionId ${partitionId}`));
 		}
 		if (this.paused.get(partitionId) === true) {
-			Lumberjack.info(`Consumer partitionId ${partitionId} already paused, returning early.`);
+			Lumberjack.info(`Consumer partition already paused, returning early.`, { partitionId });
 			return Promise.resolve();
 		}
 		this.consumer?.pause([{topic: this.topic, partition: partitionId}]);
+		Lumberjack.info(`Consumer paused`, { partitionId, offset });
 		if (offset !== undefined) {
 			this.consumer?.seek({ topic: this.topic, partition: partitionId, offset }, seekTimeout, (err) => {
 				if (err) {
@@ -479,11 +480,11 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 					});
 				}
 			});
+			Lumberjack.info(`Consumer seeked to paused offset`, { partitionId, offset });
 			this.pausedOffsets.set(partitionId, offset);
 		}
 		this.paused.set(partitionId, true);
 		this.emit("pauseFetching");
-		Lumberjack.info(`Consumer paused`, { partitionId, offset });
 		return Promise.resolve();
 	}
 
@@ -493,17 +494,17 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 	 */
 	public async resumeFetching(partitionId: number): Promise<void> {
 		if (!this.assignedPartitions.has(partitionId)) {
-			return Promise.reject(new Error(`Consumer resume called for unassigned partitionId ${partitionId}`));
+			return Promise.reject(new Error(`Consumer resume called for unassigned partition ${partitionId}`));
 		}
 		if (this.paused.get(partitionId) !== true) {
-			Lumberjack.info(`Consumer partitionId ${partitionId} already resumed, returning early.`);
+			Lumberjack.info(`Consumer partition already resumed, returning early.`, { partitionId });
 			return;
 		}
 		this.consumer?.resume([{topic: this.topic, partition: partitionId}]);
+		Lumberjack.info(`Consumer resumed`, { partitionId });
 		this.pausedOffsets.delete(partitionId);
 		this.paused.set(partitionId, false);
 		this.emit("resumeFetching");
-		Lumberjack.info(`Consumer resumed`, { partitionId });
 		return Promise.resolve();
 	}
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -56,6 +56,8 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 	private readonly pendingCommits: Map<number, Deferred<void>> = new Map();
 	private readonly pendingMessages: Map<number, kafkaTypes.Message[]> = new Map();
 	private readonly latestOffsets: Map<number, number> = new Map();
+	private readonly paused: Map<number, boolean> = new Map();
+	private readonly pausedOffsets: Map<number, number> = new Map();
 
 	constructor(
 		endpoints: IKafkaEndpoints,
@@ -271,6 +273,14 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 							// clear latest offset
 							this.latestOffsets.delete(partition);
 
+							// clear paused offset if it exists
+							if (this.pausedOffsets.has(partition)) {
+								this.pausedOffsets.delete(partition);
+							}
+							if (this.paused.has(partition)) {
+								this.paused.delete(partition);
+							}
+
 							// reject pending commit
 							const deferredCommit = this.pendingCommits.get(partition);
 							if (deferredCommit) {
@@ -354,6 +364,8 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		this.assignedPartitions.clear();
 		this.pendingCommits.clear();
 		this.latestOffsets.clear();
+		this.paused.clear();
+		this.pausedOffsets.clear();
 
 		if (this.closed) {
 			this.emit("closed");
@@ -445,6 +457,58 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 	}
 
 	/**
+	 * Pauses retrieval of new messages without a rebalance
+	 * @param partition - The partition to pause fetching
+	 * @param offset - The offset to seek to after pausing
+	 */
+	public async pauseFetching(partitionId: number, seekTimeout: number, offset?: number): Promise<void> {
+		if (!this.assignedPartitions.has(partitionId)) {
+			return Promise.reject(new Error(`Consumer pause called for unassigned partitionId ${partitionId}`));
+		}
+		if (this.paused.get(partitionId) === true) {
+			Lumberjack.info(`Consumer partitionId ${partitionId} already paused, returning early.`);
+			return Promise.resolve();
+		}
+		this.consumer?.pause([{topic: this.topic, partition: partitionId}]);
+		if (offset !== undefined) {
+			this.consumer?.seek({ topic: this.topic, partition: partitionId, offset }, seekTimeout, (err) => {
+				if (err) {
+					this.error(err, {
+						restart: true,
+						errorLabel: "rdkafkaConsumer:pauseFetching.seek"
+					});
+				}
+			});
+			this.pausedOffsets.set(partitionId, offset);
+		}
+		this.paused.set(partitionId, true);
+		this.emit("pauseFetching");
+		Lumberjack.info(`Consumer paused`, { partitionId, offset });
+		return Promise.resolve();
+	}
+
+	/**
+	 * Resumes retrieval of messages without a rebalance
+	 * @param partition - The partition to resume fetching
+	 */
+	public async resumeFetching(partitionId: number): Promise<void> {
+		if (!this.assignedPartitions.has(partitionId)) {
+			return Promise.reject(new Error(`Consumer resume called for unassigned partitionId ${partitionId}`));
+		}
+		if (this.paused.get(partitionId) !== true) {
+			Lumberjack.info(`Consumer partitionId ${partitionId} already resumed, returning early.`);
+			return;
+		}
+		this.consumer?.resume([{topic: this.topic, partition: partitionId}]);
+		this.pausedOffsets.delete(partitionId);
+		this.paused.set(partitionId, false);
+		this.emit("resumeFetching");
+		Lumberjack.info(`Consumer resumed`, { partitionId });
+		return Promise.resolve();
+	}
+
+
+	/**
 	 * Saves the latest offset for the partition and emits the data event with the message.
 	 * If we are in the middle of rebalancing and the message was sent for a partition we will own,
 	 * the message will be saved and processed after rebalancing is completed.
@@ -525,6 +589,14 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 						// ensure we continue reading from our current offset
 						// + 1 so we do not read the latest message again
 						(assignment as kafkaTypes.TopicPartitionOffset).offset = offset + 1;
+					}
+					if (this.paused.get(assignment.partition) && this.topic === assignment.topic) {
+						// if the partition was paused, we need to pause it again
+						consumer.pause([{topic: assignment.topic, partition: assignment.partition}]);
+						// ensure that we continue reading from the paused offset
+						if (this.pausedOffsets.has(assignment.partition) && this.pausedOffsets.get(assignment.partition) !== undefined) {
+							(assignment as kafkaTypes.TopicPartitionOffset).offset = this.pausedOffsets.get(assignment.partition)?? 0;
+						}
 					}
 				}
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -458,7 +458,8 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 
 	/**
 	 * Pauses retrieval of new messages without a rebalance
-	 * @param partition - The partition to pause fetching
+	 * @param partitionId - The partition to pause fetching
+	 * @param seekTimeout - The timeout value for consumer.seek in ms
 	 * @param offset - The offset to seek to after pausing
 	 */
 	public async pauseFetching(partitionId: number, seekTimeout: number, offset?: number): Promise<void> {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/test/types/validateServerServicesOrderingRdkafkaPrevious.generated.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/test/types/validateServerServicesOrderingRdkafkaPrevious.generated.ts
@@ -153,6 +153,7 @@ declare function get_old_ClassDeclaration_RdkafkaConsumer():
 declare function use_current_ClassDeclaration_RdkafkaConsumer(
     use: TypeOnly<current.RdkafkaConsumer>): void;
 use_current_ClassDeclaration_RdkafkaConsumer(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_RdkafkaConsumer());
 
 /*

--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -67,4 +67,5 @@ export enum LumberEventName {
 	StartupProbe = "StartupProbe",
 	LivenessProbe = "LivenessProbe",
 	ReadinessProbe = "ReadinessProbe",
+	CircuitBreaker = "CircuitBreaker",
 }

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -109,6 +109,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_MongoDb": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -581,10 +581,13 @@ export class MongoDb implements core.IDb {
 	}
 
 	public async healthCheck(dbName = "admin"): Promise<void> {
-		await this.client.db(dbName).command({ ping: 1 }).catch((error) => {
-			error.healthCheckFailed = true;
-			throw error;
-		});
+		await this.client
+			.db(dbName)
+			.command({ ping: 1 })
+			.catch((error) => {
+				error.healthCheckFailed = true;
+				throw error;
+			});
 	}
 
 	public async dropCollection(name: string, dbName = "admin"): Promise<boolean> {

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -580,6 +580,13 @@ export class MongoDb implements core.IDb {
 		);
 	}
 
+	public async healthCheck(dbName = "admin"): Promise<void> {
+		await this.client.db(dbName).command({ ping: 1 }).catch((error) => {
+			error.healthCheckFailed = true;
+			throw error;
+		});
+	}
+
 	public async dropCollection(name: string, dbName = "admin"): Promise<boolean> {
 		return this.client.db(dbName).dropCollection(name);
 	}

--- a/server/routerlicious/packages/services/src/test/types/validateServerServicesPrevious.generated.ts
+++ b/server/routerlicious/packages/services/src/test/types/validateServerServicesPrevious.generated.ts
@@ -369,6 +369,7 @@ declare function get_old_ClassDeclaration_MongoDb():
 declare function use_current_ClassDeclaration_MongoDb(
     use: TypeOnly<current.MongoDb>): void;
 use_current_ClassDeclaration_MongoDb(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MongoDb());
 
 /*

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -93,6 +93,9 @@
 		"broken": {
 			"ClassDeclaration_TestProducer": {
 				"forwardCompat": false
+			},
+			"ClassDeclaration_TestContext": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
@@ -249,6 +249,7 @@ declare function get_old_ClassDeclaration_TestContext():
 declare function use_current_ClassDeclaration_TestContext(
     use: TypeOnly<current.TestContext>): void;
 use_current_ClassDeclaration_TestContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TestContext());
 
 /*

--- a/server/routerlicious/packages/test-utils/src/testContext.ts
+++ b/server/routerlicious/packages/test-utils/src/testContext.ts
@@ -68,4 +68,12 @@ export class TestContext extends EventEmitter implements IContext {
 	public getContextError() {
 		return;
 	}
+
+	public pause(offset: number, reason?: any): void {
+		this.emit("pause", offset, reason);
+	}
+
+	public resume(): void {
+		this.emit("resume");
+	}
 }

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -205,9 +205,15 @@ importers:
       nconf:
         specifier: ^0.12.0
         version: 0.12.0
+      opossum:
+        specifier: ^8.1.4
+        version: 8.1.4
       semver:
         specifier: ^7.5.3
         version: 7.5.3
+      serialize-error:
+        specifier: ^8.1.0
+        version: 8.1.0
       sha.js:
         specifier: ^2.4.11
         version: 2.4.11
@@ -12478,6 +12484,11 @@ packages:
     dependencies:
       mimic-fn: 2.1.0
     dev: true
+
+  /opossum@8.1.4:
+    resolution: {integrity: sha512-ktDDCD2MKX7yx8ZLtt57JrUE0IyYJthmTyXtaF4dEdPYHvX0kkWRiKkQkhEjtZnTNN5y1ErMriKNqOLqgpYXtQ==}
+    engines: {node: ^22 || ^21 || ^20 || ^18 || ^16}
+    dev: false
 
   /optional@0.1.4:
     resolution: {integrity: sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==}


### PR DESCRIPTION
## Description

This PR is to add circuit breaker functionality for scriptorium lambda. It is to handle the exceptions where service restart is not helpful and instead, we want to wait and retry again. For example, when mongo db is unavailable/down, and scriptorium is not able to write ops to the db, restarting the service doesnt help, instead we would wait and retry after some time. Circuit Breaker pattern helps in such cases by maintaining open/closed/halfOpen state. 

So in scriptorium, all the calls to db are wrapped by the circuit breaker, and in case of such errors, the circuit will open and pause the lambda (i.e. pause the incoming messages). After some time, the circuit will go to halfOpen state and call a healthCheck function - if it succeeds, the circuit will close and resume the incoming messages, else it will stay open and paused.

We can configure various options, like error threshold, reset timeout, the errors for which we want to engage the circuit breaker, etc. Also if the circuit is not able to close or resume for some time (configurable), we will fallback to restarting the service to avoid being in an endless state of waiting.

This PR is for scriptorium, and once we validate and roll this out in production, we will add the same pattern for document lambdas too.

Summary of changes made in this PR: 
- Circuit Breaker Implementation: Adds a circuit breaker pattern to scriptorium->db calls, with various configuration options for error thresholds, reset timeouts, and error filters.
- Pause and Resume Methods: Adds pause and resume methods for lambdas, context, documentContext, partition, partitionManager, kafkaRunner, rdKafkaConsumer, and lambda to manage message flow during circuit breaker states.
- Health Check for MongoDB: Adds a health check method to the MongoDB class and exposes a healthCheck property from the MongoManager class.

## Testing

- [X] Added unit tests for circuit breaker.
- [X] Tested the scriptorium end to end functionality locally by forcing the db to be unavailable in the local setup.
- [x] Tested in dev cluster by changing mongo db settings to replicate a networking error.

We will roll this out slowly by testing in each ring.