### PR TITLE
test(client): Disable ODSP targeted signal tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
@@ -261,8 +261,20 @@ describeCompat("Targeted Signals", "NoCompat", (getTestObjectProvider) => {
 	let clients: SignalClient[];
 	let provider: ITestObjectProvider;
 
-	beforeEach("setup containers", async () => {
+	beforeEach("setup containers", async function () {
 		provider = getTestObjectProvider();
+
+		/**
+		 * Skip targeted signal test for ODSP driver as targeting signals for clients
+		 * that share the same websocket connection is not yet supported.
+		 * See {@link https://dev.azure.com/fluidframework/internal/_workitems/edit/18261}
+		 *
+		 * TODO: Re-enable tests once {@link https://dev.azure.com/fluidframework/internal/_workitems/edit/19030} is completed.
+		 */
+		if (provider.driver.type === "odsp") {
+			this.skip();
+		}
+
 		clients = [];
 		for (let i = 0; i < numberOfClients; i++) {
 			const container = await (i === 0


### PR DESCRIPTION
ODSP targeted signal tests are consistently failing due to reuse of socket references in ODSP driver. These tests can be re-enabled once targetClientId is included in the return signal from PushChannel.