### PR TITLE
Fix offline blob tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1515,7 +1515,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 	);
 
 	it("blob upload before loading", async function () {
-		// TODO: AB#19035: Blob upload from an offline state does not currently work before establishing a connection on ODSP due to epoch mismatch.
+		// TODO: AB#19035: Blob upload from an offline state does not currently work before establishing a connection on ODSP due to epoch not provided.
 		if (provider.driver.type === "odsp") {
 			this.skip();
 		}

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1515,7 +1515,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 	);
 
 	it("blob upload before loading", async function () {
-		// TODO: https://dev.azure.com/fluidframework/internal/_workitems/edit/19035
+		// TODO: AB#19035: Blob upload from an offline state does not currently work before establishing a connection on ODSP due to epoch mismatch.
 		if (provider.driver.type === "odsp") {
 			this.skip();
 		}

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1657,7 +1657,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		container.disconnect();
 
 		const handleP = dataStore.runtime.uploadBlob(stringToBuffer("blob contents", "utf8"));
-		// container.connect();
+		container.connect();
 		const handle = await timeoutAwait(handleP, {
 			errorMsg: "Timeout on waiting for ",
 		});

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1515,6 +1515,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 	);
 
 	it("blob upload before loading", async function () {
+		// TODO: https://dev.azure.com/fluidframework/internal/_workitems/edit/19035
 		if (provider.driver.type === "odsp") {
 			this.skip();
 		}


### PR DESCRIPTION
in ODSP, we can't load a container offline and send a server request to create a blob because our call would not be complete, specifically we would lack the epoch value which is set until we connect to the delta stream, ending up with a 'ODSP fetch error [400]' response.

Even though this problem is worth tackling separately I believe both affected tests are not specifically testing this behavior so I changed them slightly to send a createBlob request while being disconnected instead of using our loadOffline function. Both tests are connecting anyway after creating the blob and the relevant asserts happen after that part of those tests.

I added another test which replicates the issue and skip it in ODSP for now. If we want to solve the initial issue, we would need to stash the epoch info in our serialized state. [AB#19035](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/19035)