### PR TITLE
Merge tree: add sidedness to obliterate ops in conflict farm tests

### DIFF
--- a/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -78,6 +78,7 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 				name: "with obliterate",
 				config: {
 					...opts,
+					generateSidedObliterates: true,
 					operations: [...opts.operations, obliterateRange],
 				},
 			},
@@ -85,7 +86,12 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 			it(`${name}: ConflictFarm_${minLength}`, async () => {
 				const random = makeRandom(0xdeadbeef, 0xfeedbed, minLength, extraSeed ?? 0);
 
-				const clients: TestClient[] = [new TestClient({ mergeTreeEnableObliterate: true })];
+				const clients: TestClient[] = [
+					new TestClient({
+						mergeTreeEnableObliterate: true,
+						mergeTreeEnableSidedObliterate: config.generateSidedObliterates ?? false,
+					}),
+				];
 				for (const [i, c] of clients.entries()) c.startOrUpdateCollaboration(clientNames[i]);
 
 				let seq = 0;

--- a/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -78,7 +78,6 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 				name: "with obliterate",
 				config: {
 					...opts,
-					generateSidedObliterates: true,
 					operations: [...opts.operations, obliterateRange],
 				},
 			},
@@ -89,7 +88,7 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 				const clients: TestClient[] = [
 					new TestClient({
 						mergeTreeEnableObliterate: true,
-						mergeTreeEnableSidedObliterate: config.generateSidedObliterates ?? false,
+						mergeTreeEnableSidedObliterate: true,
 					}),
 				];
 				for (const [i, c] of clients.entries()) c.startOrUpdateCollaboration(clientNames[i]);

--- a/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -14,7 +14,6 @@ import {
 	generateClientNames,
 	insertAtRefPos,
 	obliterateRange,
-	obliterateRangeSided,
 	removeRange,
 	runMergeTreeOperationRunner,
 } from "./mergeTreeOperationRunner.js";
@@ -82,13 +81,14 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 					operations: [...opts.operations, obliterateRange],
 				},
 			},
-			{
-				name: "obliterate with sided endpoints",
-				config: {
-					...opts,
-					operations: [...opts.operations, obliterateRange, obliterateRangeSided],
-				},
-			},
+			// TODO: AB#15630
+			// {
+			// 	name: "obliterate with sided endpoints",
+			// 	config: {
+			// 		...opts,
+			// 		operations: [...opts.operations, obliterateRange, obliterateRangeSided],
+			// 	},
+			// },
 		])
 			it(`${name}: ConflictFarm_${minLength}`, async () => {
 				const random = makeRandom(0xdeadbeef, 0xfeedbed, minLength, extraSeed ?? 0);

--- a/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -14,6 +14,7 @@ import {
 	generateClientNames,
 	insertAtRefPos,
 	obliterateRange,
+	obliterateRangeSided,
 	removeRange,
 	runMergeTreeOperationRunner,
 } from "./mergeTreeOperationRunner.js";
@@ -75,10 +76,17 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 				config: { ...opts, applyOpDuringGeneration: true },
 			},
 			{
-				name: "with obliterate",
+				name: "obliterate with number endpoints",
 				config: {
 					...opts,
 					operations: [...opts.operations, obliterateRange],
+				},
+			},
+			{
+				name: "obliterate with sided endpoints",
+				config: {
+					...opts,
+					operations: [...opts.operations, obliterateRange, obliterateRangeSided],
 				},
 			},
 		])

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -50,10 +50,10 @@ export const obliterateRangeSided: TestOperation = (
 	let endSide: Side;
 
 	const oblEnd = random.integer(opStart, client.getLength() - 1);
-	// TODO: this should allow creation of zero length obliterate ops.
-	// These ops do not work in all cases, but it is unclear how/why due to the
-	// other existing bugs.
-	if (oblEnd - opStart < 1) {
+	// TODO: to create zero length obliterate ops, change '<=' to '<'.
+	// Doing so may cause different failures than those without zero length.
+	// AB#19930
+	if (oblEnd - opStart <= 1) {
 		startSide = Side.Before;
 		endSide = Side.After;
 	} else {

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -38,28 +38,30 @@ export const obliterateRange: TestOperation = (
 	client: TestClient,
 	opStart: number,
 	opEnd: number,
+) => client.obliterateRangeLocal(opStart, opEnd);
+
+export const obliterateRangeSided: TestOperation = (
+	client: TestClient,
+	opStart: number,
+	opEnd: number,
 	random: IRandom,
 ) => {
-	if (random.bool()) {
-		return client.obliterateRangeLocal(opStart, opEnd);
+	let startSide: Side;
+	let endSide: Side;
+
+	const oblEnd = random.integer(opStart, client.getLength() - 1);
+
+	if (oblEnd - opStart <= 1) {
+		startSide = Side.Before;
+		endSide = Side.After;
 	} else {
-		let startSide: Side;
-		let endSide: Side;
-
-		const oblEnd = random.integer(opStart, client.getLength() - 1);
-
-		if (oblEnd - opStart <= 1) {
-			startSide = Side.Before;
-			endSide = Side.After;
-		} else {
-			startSide = random.pick([Side.Before, Side.After]);
-			endSide = random.pick([Side.Before, Side.After]);
-		}
-
-		const start = { pos: opStart, side: startSide };
-		const end = { pos: oblEnd, side: endSide };
-		return client.obliterateRangeLocal(start, end);
+		startSide = random.pick([Side.Before, Side.After]);
+		endSide = random.pick([Side.Before, Side.After]);
 	}
+
+	const start = { pos: opStart, side: startSide };
+	const end = { pos: oblEnd, side: endSide };
+	return client.obliterateRangeLocal(start, end);
 };
 
 export const annotateRange: TestOperation = (

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -40,22 +40,26 @@ export const obliterateRange: TestOperation = (
 	opEnd: number,
 	random: IRandom,
 ) => {
-	let startSide: Side;
-	let endSide: Side;
-
-	const oblEnd = random.integer(opStart, client.getLength() - 1);
-
-	if (oblEnd - opStart <= 1) {
-		startSide = Side.Before;
-		endSide = Side.After;
+	if (random.bool()) {
+		return client.obliterateRangeLocal(opStart, opEnd);
 	} else {
-		startSide = random.pick([Side.Before, Side.After]);
-		endSide = random.pick([Side.Before, Side.After]);
-	}
+		let startSide: Side;
+		let endSide: Side;
 
-	const start = { pos: opStart, side: startSide };
-	const end = { pos: oblEnd, side: endSide };
-	return client.obliterateRangeLocal(start, end);
+		const oblEnd = random.integer(opStart, client.getLength() - 1);
+
+		if (oblEnd - opStart <= 1) {
+			startSide = Side.Before;
+			endSide = Side.After;
+		} else {
+			startSide = random.pick([Side.Before, Side.After]);
+			endSide = random.pick([Side.Before, Side.After]);
+		}
+
+		const start = { pos: opStart, side: startSide };
+		const end = { pos: oblEnd, side: endSide };
+		return client.obliterateRangeLocal(start, end);
+	}
 };
 
 export const annotateRange: TestOperation = (
@@ -235,7 +239,6 @@ export interface IMergeTreeOperationRunnerConfig {
 	readonly incrementalLog?: boolean;
 	readonly operations: readonly TestOperation[];
 	readonly applyOpDuringGeneration?: boolean;
-	readonly generateSidedObliterates?: boolean;
 	growthFunc(input: number): number;
 	resultsFilePostfix?: string;
 }

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -50,8 +50,10 @@ export const obliterateRangeSided: TestOperation = (
 	let endSide: Side;
 
 	const oblEnd = random.integer(opStart, client.getLength() - 1);
-
-	if (oblEnd - opStart <= 1) {
+	// TODO: this should allow creation of zero length obliterate ops.
+	// These ops do not work in all cases, but it is unclear how/why due to the
+	// other existing bugs.
+	if (oblEnd - opStart < 1) {
 		startSide = Side.Before;
 		endSide = Side.After;
 	} else {


### PR DESCRIPTION
Functionally the same as #22615, but on a clean branch. 

[AB#15963](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/15963)