### PR TITLE
odspDocumentDeltaConnection targetClientId check

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -664,16 +664,20 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 				super.addTrackedListener(
 					event,
 					(msg: ISignalMessage | ISignalMessage[], documentId?: string) => {
-						const targetClientId = Array.isArray(msg)
-							? msg[0].targetClientId
-							: msg.targetClientId;
-						if (
-							!this.enableMultiplexing ||
-							!documentId ||
-							(!targetClientId && this.documentId === documentId) ||
-							(targetClientId && this.clientId === targetClientId)
-						) {
+						if (!this.enableMultiplexing || !documentId) {
 							listener(msg, documentId);
+							return;
+						}
+
+						const msgs = Array.isArray(msg) ? msg : [msg];
+						const filteredMsgs = msgs.filter(
+							(m) =>
+								(!m.targetClientId && documentId === this.documentId) ||
+								(m.targetClientId && m.targetClientId === this.clientId),
+						);
+
+						if (filteredMsgs.length > 0) {
+							listener(filteredMsgs, documentId);
 						}
 					},
 				);

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -665,16 +665,15 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 					event,
 					(msg: ISignalMessage | ISignalMessage[], documentId?: string) => {
 						const msgs = Array.isArray(msg) ? msg : [msg];
-						if (!this.enableMultiplexing || !documentId) {
-							if (!documentId) {
-								assert(
-									msgs.every((m) => !m.targetClientId),
-									"targetClientId defined while documentId is not",
-								);
-							}
+						if (!this.enableMultiplexing) {
 							listener(msg, documentId);
 							return;
 						}
+
+						assert(
+							documentId !== undefined,
+							"documentId is required when multiplexing is enabled.",
+						);
 
 						if (documentId !== this.documentId) {
 							return;

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -664,7 +664,6 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 				super.addTrackedListener(
 					event,
 					(msg: ISignalMessage | ISignalMessage[], documentId?: string) => {
-						const msgs = Array.isArray(msg) ? msg : [msg];
 						if (!this.enableMultiplexing) {
 							listener(msg, documentId);
 							return;
@@ -679,12 +678,14 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 							return;
 						}
 
+						const msgs = Array.isArray(msg) ? msg : [msg];
+
 						const filteredMsgs = msgs.filter(
 							(m) => !m.targetClientId || m.targetClientId === this.clientId,
 						);
 
 						if (filteredMsgs.length > 0) {
-							listener(filteredMsgs, documentId);
+							listener(filteredMsgs.length === 1 ? filteredMsgs[0] : filteredMsgs, documentId);
 						}
 					},
 				);

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -672,8 +672,8 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 						const msgs = Array.isArray(msg) ? msg : [msg];
 						const filteredMsgs = msgs.filter(
 							(m) =>
-								(!m.targetClientId && documentId === this.documentId) ||
-								(m.targetClientId && m.targetClientId === this.clientId),
+								documentId === this.documentId &&
+								(!m.targetClientId || m.targetClientId === this.clientId),
 						);
 
 						if (filteredMsgs.length > 0) {

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -668,7 +668,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 						if (!this.enableMultiplexing || !documentId) {
 							if (!documentId) {
 								assert(
-									msgs.some((m) => m.targetClientId !== undefined),
+									msgs.every((m) => !m.targetClientId),
 									"targetClientId defined while documentId is not",
 								);
 							}

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -668,7 +668,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 							? msg[0].targetClientId
 							: msg.targetClientId;
 						if (
-							!this.enableMultiplexing || !documentId || targetClientId
+							!this.enableMultiplexing || !documentId || targetClientId !== undefined
 								? targetClientId === this.clientId
 								: documentId === this.documentId
 						) {

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -664,7 +664,14 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 				super.addTrackedListener(
 					event,
 					(msg: ISignalMessage | ISignalMessage[], documentId?: string) => {
-						if (!this.enableMultiplexing || !documentId || documentId === this.documentId) {
+						const targetClientId = Array.isArray(msg)
+							? msg[0].targetClientId
+							: msg.targetClientId;
+						if (
+							!this.enableMultiplexing || !documentId || targetClientId
+								? targetClientId === this.clientId
+								: documentId === this.documentId
+						) {
 							listener(msg, documentId);
 						}
 					},

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -676,10 +676,12 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 							return;
 						}
 
+						if (documentId !== this.documentId) {
+							return;
+						}
+
 						const filteredMsgs = msgs.filter(
-							(m) =>
-								documentId === this.documentId &&
-								(!m.targetClientId || m.targetClientId === this.clientId),
+							(m) => !m.targetClientId || m.targetClientId === this.clientId,
 						);
 
 						if (filteredMsgs.length > 0) {

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -668,9 +668,10 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 							? msg[0].targetClientId
 							: msg.targetClientId;
 						if (
-							!this.enableMultiplexing || !documentId || targetClientId !== undefined
-								? targetClientId === this.clientId
-								: documentId === this.documentId
+							!this.enableMultiplexing ||
+							!documentId ||
+							(!targetClientId && this.documentId === documentId) ||
+							(targetClientId && this.clientId === targetClientId)
 						) {
 							listener(msg, documentId);
 						}

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -664,12 +664,18 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 				super.addTrackedListener(
 					event,
 					(msg: ISignalMessage | ISignalMessage[], documentId?: string) => {
+						const msgs = Array.isArray(msg) ? msg : [msg];
 						if (!this.enableMultiplexing || !documentId) {
+							if (!documentId) {
+								assert(
+									msgs.some((m) => m.targetClientId !== undefined),
+									"targetClientId defined while documentId is not",
+								);
+							}
 							listener(msg, documentId);
 							return;
 						}
 
-						const msgs = Array.isArray(msg) ? msg : [msg];
 						const filteredMsgs = msgs.filter(
 							(m) =>
 								documentId === this.documentId &&

--- a/packages/drivers/odsp-driver/src/test/socketTests/deltaConnectionUpdateTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/deltaConnectionUpdateTests.spec.ts
@@ -180,7 +180,7 @@ describe("DeltaConnectionMetadata update tests", () => {
 
 		service.on("metadataUpdate", handler);
 
-		socket.emit("signal", signalMessage1);
+		socket.emit("signal", signalMessage1, joinSessionResponse.id);
 		assert(eventRaised, "event2 should have been raised");
 		service.off("metadataUpdate", handler);
 

--- a/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
@@ -271,7 +271,7 @@ describeCompat("Targeted Signals", "NoCompat", (getTestObjectProvider) => {
 		 *
 		 * TODO: Re-enable tests once {@link https://dev.azure.com/fluidframework/internal/_workitems/edit/19030} is completed.
 		 */
-		if (provider.driver.type === "odsp") {
+		if (provider.driver.endpointName === "odsp") {
 			this.skip();
 		}
 


### PR DESCRIPTION
ODSP driver reuses sockets for clients connected on the same node process. When signals are received on the shared socket, we must filter based on `targetClientId` property to make sure *only* the specified client receives the signal.