### PR TITLE
MergeTree: Initialize DoublyLinkedList from Values

### DIFF
--- a/packages/dds/merge-tree/src/collections/list.ts
+++ b/packages/dds/merge-tree/src/collections/list.ts
@@ -87,6 +87,12 @@ export class DoublyLinkedList<T>
 		// try to match array signature and semantics where possible
 		Pick<ListNode<T>[], "pop" | "shift" | "length" | "includes">
 {
+	constructor(values?: Iterable<T>) {
+		if (values !== undefined) {
+			this.push(...values);
+		}
+	}
+
 	find(
 		predicate: (value: ListNode<T>, obj: DoublyLinkedList<T>) => unknown,
 	): ListNode<T> | undefined {


### PR DESCRIPTION
Small change from a bigger change that adds a constructor to the DoublyLinkedList class so it can easily be initialized with values