### PR TITLE
Re-enable message size test for t9s

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -631,7 +631,7 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 
 			it("Reconnects while sending chunks", async function () {
 				// This is not supported by the local server. See ADO:2690
-				if (provider.driver.type === "local" ) {
+				if (provider.driver.type === "local") {
 					this.skip();
 				}
 

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -631,8 +631,7 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 
 			it("Reconnects while sending chunks", async function () {
 				// This is not supported by the local server. See ADO:2690
-				// This test is flaky on tinylicious. See ADO:7669
-				if (provider.driver.type === "local" || provider.driver.type === "tinylicious") {
+				if (provider.driver.type === "local" ) {
 					this.skip();
 				}
 


### PR DESCRIPTION
Ran this test over 10k times and didn't see a single failure. We have a new flow that detects flaky tests, so I'll re-enable the test for t9s and let that workflow catch any future flakiness.

Fixes [AB#7669](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7669)