### PR TITLE
[bump] build-tools: 0.48.0 => 0.49.0 (minor)

### DIFF
--- a/build-tools/lerna.json
+++ b/build-tools/lerna.json
@@ -1,1 +1,1 @@
-{ "version": "0.48.0", "npmClient": "pnpm", "useWorkspaces": true }
+{ "version": "0.49.0", "npmClient": "pnpm", "useWorkspaces": true }

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "root",
-	"version": "0.48.0",
+	"version": "0.49.0",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/build-cli",
-	"version": "0.48.0",
+	"version": "0.49.0",
 	"description": "Build tools for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {
@@ -176,7 +176,6 @@
 		"eslint-config-prettier": "~9.1.0",
 		"jssm-viz-cli": "5.97.1",
 		"mocha": "^10.2.0",
-
 		"mocha-multi-reporters": "^1.5.1",
 		"moment": "^2.29.4",
 		"rimraf": "^4.4.1",

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/build-tools",
-	"version": "0.48.0",
+	"version": "0.49.0",
 	"description": "Fluid Build tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/bundle-size-tools",
-	"version": "0.48.0",
+	"version": "0.49.0",
 	"description": "Utility for analyzing bundle size regressions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/version-tools",
-	"version": "0.48.0",
+	"version": "0.49.0",
 	"description": "Versioning tools for Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {
@@ -104,7 +104,6 @@
 		"eslint-config-oclif-typescript": "^3.1.8",
 		"eslint-config-prettier": "~9.1.0",
 		"mocha": "^10.2.0",
-
 		"mocha-multi-reporters": "^1.5.1",
 		"moment": "^2.29.4",
 		"oclif": "^4.14.9",


### PR DESCRIPTION
Bumped build-tools from 0.48.0 to 0.49.0.