### PR TITLE
tree: reduce "rebasing commits" benchmarks when not in perf mode

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -369,7 +369,7 @@ describe("SharedTree benchmarks", () => {
 		// - generating 5 edits per second with a 2000ms round-trip time
 		// - generating 10 edits per second with a 1000ms round-trip time
 		// - generating 100 edits per second with a 100ms round-trip time
-		const commitCounts = [1, 5, 10];
+		const commitCounts = isInPerformanceTestingMode ? [1, 5, 10] : [1, 2];
 		for (const peerCount of peerCounts) {
 			for (const commitCount of commitCounts) {
 				const test = benchmark({


### PR DESCRIPTION
## Description

In October 2023, one of the "rebasing commits" tests timed out during test stability testing.

For me locally these tests run as follows:

  SharedTree benchmarks
    rebasing commits
      ✔ @Benchmark @Measurement @ExecutionTime for 1 commits per peer for 2 peers (45ms)
      ✔ @Benchmark @Measurement @ExecutionTime for 5 commits per peer for 2 peers (56ms)
      ✔ @Benchmark @Measurement @ExecutionTime for 10 commits per peer for 2 peers (89ms)
      ✔ @Benchmark @Measurement @ExecutionTime for 1 commits per peer for 4 peers (72ms)
      ✔ @Benchmark @Measurement @ExecutionTime for 5 commits per peer for 4 peers (196ms)
      ✔ @Benchmark @Measurement @ExecutionTime for 10 commits per peer for 4 peers (398ms)

Since my system is much faster than CI, and CI has a default timeout of 2 seconds, its plausible that this could be an issue if CI has a really slow run sometime.

This change reduces the size of test cases run when not in performance testing mode so that the run now look like:

  SharedTree benchmarks
    rebasing commits
      ✔ @Benchmark @Measurement @ExecutionTime for 1 commits per peer for 2 peers (52ms)
      ✔ @Benchmark @Measurement @ExecutionTime for 2 commits per peer for 2 peers (40ms)
      ✔ @Benchmark @Measurement @ExecutionTime for 1 commits per peer for 4 peers (88ms)
      ✔ @Benchmark @Measurement @ExecutionTime for 2 commits per peer for 4 peers (132ms)

With this the worst case is now more than twice as fast.

This should have no impact on the tests when run as performance tests.

Tracked internally by https://dev.azure.com/fluidframework/internal/_workitems/edit/6003

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

