### PR TITLE
mergetree: Remove exposure of overwrite property

### DIFF
--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -501,7 +501,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 				clientArgs.referenceSequenceNumber,
 				clientArgs.clientId,
 				clientArgs.sequenceNumber,
-				false,
 				opArgs,
 			);
 		} else {
@@ -516,7 +515,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 				clientArgs.referenceSequenceNumber,
 				clientArgs.clientId,
 				clientArgs.sequenceNumber,
-				false,
 				opArgs,
 			);
 		}
@@ -541,7 +539,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 			clientArgs.referenceSequenceNumber,
 			clientArgs.clientId,
 			clientArgs.sequenceNumber,
-			false,
 			opArgs,
 		);
 	}

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1487,7 +1487,6 @@ export class MergeTree {
 			_pos: number,
 			context: InsertContext,
 			// Keeping this function within the scope of blockInsert for readability.
-			// eslint-disable-next-line unicorn/consistent-function-scoping
 		): ISegmentChanges => {
 			const segmentChanges: ISegmentChanges = {};
 			if (segment) {
@@ -1932,7 +1931,6 @@ export class MergeTree {
 		refSeq: number,
 		clientId: number,
 		seq: number,
-		overwrite: boolean = false,
 		opArgs: IMergeTreeDeltaOpArgs,
 	): void {
 		const startPos = start.side === Side.Before ? start.pos : start.pos + 1;
@@ -1941,7 +1939,7 @@ export class MergeTree {
 		this.ensureIntervalBoundary(startPos, refSeq, clientId);
 		this.ensureIntervalBoundary(endPos, refSeq, clientId);
 
-		let _overwrite = overwrite;
+		let _overwrite = false;
 		const localOverlapWithRefs: ISegmentLeaf[] = [];
 		const movedSegments: IMergeTreeSegmentDelta[] = [];
 		const localSeq =
@@ -2138,7 +2136,6 @@ export class MergeTree {
 		refSeq: number,
 		clientId: number,
 		seq: number,
-		overwrite: boolean = false,
 		opArgs: IMergeTreeDeltaOpArgs,
 	): void {
 		errorIfOptionNotTrue(this.options, "mergeTreeEnableObliterate");
@@ -2147,7 +2144,7 @@ export class MergeTree {
 				typeof start === "object" && typeof end === "object",
 				"Start and end must be of type InteriorSequencePlace if mergeTreeEnableSidedObliterate is enabled.",
 			);
-			this.obliterateRangeSided(start, end, refSeq, clientId, seq, overwrite, opArgs);
+			this.obliterateRangeSided(start, end, refSeq, clientId, seq, opArgs);
 		} else {
 			assert(
 				typeof start === "number" && typeof end === "number",
@@ -2159,7 +2156,6 @@ export class MergeTree {
 				refSeq,
 				clientId,
 				seq,
-				overwrite,
 				opArgs,
 			);
 		}
@@ -2171,10 +2167,9 @@ export class MergeTree {
 		refSeq: number,
 		clientId: number,
 		seq: number,
-		overwrite = false,
 		opArgs: IMergeTreeDeltaOpArgs,
 	): void {
-		let _overwrite = overwrite;
+		let _overwrite = false;
 		this.ensureIntervalBoundary(start, refSeq, clientId);
 		this.ensureIntervalBoundary(end, refSeq, clientId);
 		// eslint-disable-next-line import/no-deprecated
@@ -2354,7 +2349,6 @@ export class MergeTree {
 						UniversalSequenceNumber,
 						this.collabWindow.clientId,
 						UniversalSequenceNumber,
-						false,
 						{ op: removeOp },
 					);
 				} /* op.type === MergeTreeDeltaType.ANNOTATE */ else {

--- a/packages/dds/merge-tree/src/test/beastTest.spec.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.spec.ts
@@ -355,7 +355,6 @@ function checkMarkRemoveMergeTree(
 		UniversalSequenceNumber,
 		LocalClientId,
 		UniversalSequenceNumber,
-		false,
 		{ op: createRemoveRangeOp(start, end) },
 	);
 	accumTime += elapsedMicroseconds(clockStart);
@@ -464,7 +463,6 @@ export function mergeTreeLargeTest(): void {
 			UniversalSequenceNumber,
 			LocalClientId,
 			UniversalSequenceNumber,
-			false,
 			undefined as never,
 		);
 		accumTime += elapsedMicroseconds(clockStart);
@@ -1543,7 +1541,6 @@ function findReplacePerf(filename: string): void {
 					UniversalSequenceNumber,
 					client.getClientId(),
 					1,
-					false,
 					undefined as never,
 				);
 				insertText({

--- a/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -160,7 +160,6 @@ const treeFactories: ITestTreeFactory[] = [
 				UniversalSequenceNumber,
 				localClientId,
 				UniversalSequenceNumber,
-				false,
 				undefined as never,
 			);
 			initialText = initialText.slice(Math.max(0, remove));
@@ -172,7 +171,6 @@ const treeFactories: ITestTreeFactory[] = [
 				UniversalSequenceNumber,
 				localClientId,
 				UniversalSequenceNumber,
-				false,
 				undefined as never,
 			);
 			initialText = initialText.slice(0, Math.max(0, initialText.length - remove));

--- a/packages/dds/merge-tree/src/test/obliterate.partialLength.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.partialLength.spec.ts
@@ -121,7 +121,6 @@ describe("obliterate partial lengths", () => {
 				refSeq,
 				clientId: remoteClientId,
 				seq: refSeq + 1,
-				overwrite: false,
 				opArgs: undefined as never,
 			});
 
@@ -183,7 +182,6 @@ describe("obliterate partial lengths", () => {
 				refSeq,
 				clientId: remoteClientId + 1,
 				seq: refSeq + 2,
-				overwrite: false,
 				opArgs: undefined as never,
 			});
 
@@ -225,7 +223,6 @@ describe("obliterate partial lengths", () => {
 				refSeq,
 				clientId: remoteClientId,
 				seq: refSeq + 1,
-				overwrite: false,
 				opArgs: undefined as never,
 			});
 
@@ -257,7 +254,6 @@ describe("obliterate partial lengths", () => {
 				refSeq,
 				clientId: remoteClientId,
 				seq: refSeq + 1,
-				overwrite: false,
 				opArgs: undefined as never,
 			});
 			const localObliterateOp = client.obliterateRangeLocal(0, "hello".length);

--- a/packages/dds/merge-tree/src/test/obliterate.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.spec.ts
@@ -48,7 +48,6 @@ describe("obliterate", () => {
 				refSeq,
 				clientId: remoteClientId,
 				seq: refSeq + 1,
-				overwrite: false,
 				opArgs: undefined as never,
 			});
 			insertText({
@@ -81,7 +80,6 @@ describe("obliterate", () => {
 				refSeq,
 				clientId: remoteClientId,
 				seq: refSeq + 2,
-				overwrite: false,
 				opArgs: undefined as never,
 			});
 			assert.equal(client.getText(), "");
@@ -104,7 +102,6 @@ describe("obliterate", () => {
 				refSeq,
 				clientId: remoteClientId,
 				seq: refSeq + 2,
-				overwrite: false,
 				opArgs: undefined as never,
 			});
 			assert.equal(client.getText(), "h");
@@ -120,7 +117,6 @@ describe("obliterate", () => {
 				refSeq,
 				clientId: remoteClientId,
 				seq: refSeq + 1,
-				overwrite: false,
 				opArgs: undefined as never,
 			});
 			insertText({
@@ -143,7 +139,6 @@ describe("obliterate", () => {
 				refSeq,
 				clientId: remoteClientId,
 				seq: refSeq + 1,
-				overwrite: false,
 				opArgs: undefined as never,
 			});
 			insertText({
@@ -193,7 +188,6 @@ describe("obliterate", () => {
 				refSeq,
 				clientId: remoteClientId,
 				seq: refSeq + 1,
-				overwrite: false,
 				opArgs: undefined as never,
 			});
 			insertText({

--- a/packages/dds/merge-tree/src/test/testUtils.ts
+++ b/packages/dds/merge-tree/src/test/testUtils.ts
@@ -147,10 +147,9 @@ export function markRangeRemoved({
 	refSeq,
 	clientId,
 	seq,
-	overwrite = false,
 	opArgs,
 }: MarkRangeRemovedArgs): void {
-	mergeTree.markRangeRemoved(start, end, refSeq, clientId, seq, overwrite, opArgs);
+	mergeTree.markRangeRemoved(start, end, refSeq, clientId, seq, opArgs);
 }
 
 export function obliterateRange({
@@ -160,7 +159,6 @@ export function obliterateRange({
 	refSeq,
 	clientId,
 	seq,
-	overwrite = false,
 	opArgs,
 }: {
 	mergeTree: MergeTree;
@@ -169,10 +167,9 @@ export function obliterateRange({
 	refSeq: number;
 	clientId: number;
 	seq: number;
-	overwrite?: boolean;
 	opArgs: IMergeTreeDeltaOpArgs;
 }): void {
-	mergeTree.obliterateRange(start, end, refSeq, clientId, seq, overwrite, opArgs);
+	mergeTree.obliterateRange(start, end, refSeq, clientId, seq, opArgs);
 }
 
 export function nodeOrdinalsHaveIntegrity(block: MergeBlock): boolean {


### PR DESCRIPTION
Instead of passing the overwrite property through the merge tree tests and various functions, only use it within the functions when necessary. The previous default value of `false` is used to initialize the variable in these cases. 

[AB#15995](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/15995)