### PR TITLE
Include all tests for code covergae in the artifact same as client build pipeline

### DIFF
--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -23,6 +23,8 @@ extends:
       - ci:test:mocha
       - ci:test:jest
       - ci:test:realsvc:local
+      - ci:test:realsvc:tinylicious
+      - ci:test:stress:tinylicious
       - test:copyresults
     testResultDirs:
       - nyc/examples


### PR DESCRIPTION
## Description

Include all tests for code covergae in the artifact same as client build pipeline. This should be same as the tests that we run in build-clinet.yaml so that we can compare apples to apples in the code coverage comparison.