### PR TITLE
Flakey Test: Fix possible race condition

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -2188,6 +2188,10 @@ describeCompat(
 					// Container won't be connected yet, so no race here.
 					const container = await loader.resolve({ url }, pendingLocalState);
 					await container.deltaManager.outbound.pause();
+					assert(
+						container.connectionState === ConnectionState.Disconnected,
+						`PRECONDITION: ${loggingId} should be disconnected when we pause the outbound queue, to ensure we haven't sent the counter op yet`,
+					);
 
 					// Wait for the container to connect, and then pause the inbound queue
 					// This order matters - we need to process our inbound join op to finish connecting!

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -2188,9 +2188,10 @@ describeCompat(
 					// Container won't be connected yet, so no race here.
 					const container = await loader.resolve({ url }, pendingLocalState);
 					await container.deltaManager.outbound.pause();
-					assert(
-						container.connectionState === ConnectionState.Disconnected,
-						`PRECONDITION: ${loggingId} should be disconnected when we pause the outbound queue, to ensure we haven't sent the counter op yet`,
+					assert.notEqual(
+						container.connectionState,
+						ConnectionState.Connected,
+						`PRECONDITION: ${loggingId} should not be connected yet when we pause the outbound queue, to ensure we haven't sent the counter op yet`,
 					);
 
 					// Wait for the container to connect, and then pause the inbound queue

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -12,6 +12,7 @@ import {
 	IContainer,
 	IHostLoader,
 	LoaderHeader,
+	type ILoaderHeader,
 } from "@fluidframework/container-definitions/internal";
 import { ConnectionState } from "@fluidframework/container-loader";
 import { IContainerExperimental } from "@fluidframework/container-loader/internal";
@@ -2186,13 +2187,17 @@ describeCompat(
 				async function rehydrateConnectAndPause(loggingId: string) {
 					// Rehydrate and immediately pause outbound to ensure we don't send the ops yet
 					// Container won't be connected yet, so no race here.
-					const container = await loader.resolve({ url }, pendingLocalState);
-					await container.deltaManager.outbound.pause();
-					assert.notEqual(
-						container.connectionState,
-						ConnectionState.Connected,
-						`PRECONDITION: ${loggingId} should not be connected yet when we pause the outbound queue, to ensure we haven't sent the counter op yet`,
+					const container = await loader.resolve(
+						{
+							url,
+							headers: {
+								[LoaderHeader.loadMode]: { deltaConnection: "none" },
+							} satisfies Partial<ILoaderHeader>,
+						},
+						pendingLocalState,
 					);
+					await container.deltaManager.outbound.pause();
+					container.connect();
 
 					// Wait for the container to connect, and then pause the inbound queue
 					// This order matters - we need to process our inbound join op to finish connecting!


### PR DESCRIPTION
## Description

Fixes [AB#14900](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/14900).

The test `Parallel Forks: Closes (ForkedContainerError and DuplicateBatchError) when hydrating twice and submitting in parallel (via Counter DDS)` has had some recent failures when running against t9s.

Reading through the test again, the only idea I have so far is that maybe one of the containers manages to submit the stashed ops before it can pause the outbound queue after creation.

This PR aims to close that gap.