### PR TITLE
build(client): Upgrade are-the-types-wrong to latest version (0.16.4)

### DIFF
--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -94,7 +94,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@~2.3.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -89,7 +89,7 @@
 		"debug": "^4.3.4"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/test-version-utils": "workspace:~",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -78,7 +78,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/examples/utils/migration-tools/package.json
+++ b/examples/utils/migration-tools/package.json
@@ -81,7 +81,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/examples/utils/webpack-fluid-loader/package.json
+++ b/examples/utils/webpack-fluid-loader/package.json
@@ -111,7 +111,7 @@
 		"webpack-dev-server": "~4.15.2"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -89,7 +89,7 @@
 		"traverse": "0.6.6"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluidframework/build-common": "^2.0.3",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -75,7 +75,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-experimental/property-common": "workspace:~",
 		"@fluid-internal/mocha-test-setup": "workspace:~",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -97,7 +97,7 @@
 		"path-browserify": "^1.0.1"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@~2.3.0",
 		"@fluid-internal/mocha-test-setup": "workspace:~",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -91,7 +91,7 @@
 		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -91,7 +91,7 @@
 		"ot-json1": "^1.0.1"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -92,7 +92,7 @@
 		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -91,7 +91,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -61,7 +61,7 @@
 		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -61,7 +61,7 @@
 		"@fluidframework/shared-summary-block": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/experimental/framework/tree-react-api/package.json
+++ b/experimental/framework/tree-react-api/package.json
@@ -105,7 +105,7 @@
 		"react": "^18.3.1"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -131,7 +131,7 @@
 		"sha.js": "^2.4.11"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@~2.3.0",
 		"@fluid-internal/mocha-test-setup": "workspace:~",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -97,7 +97,7 @@
 		"@fluidframework/driver-definitions": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -93,7 +93,7 @@
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -117,7 +117,7 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/benchmark": "^0.50.0",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -92,7 +92,7 @@
 		"@fluidframework/core-interfaces": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -106,7 +106,7 @@
 		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -124,7 +124,7 @@
 		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -93,7 +93,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -134,7 +134,7 @@
 		"path-browserify": "^1.0.1"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -133,7 +133,7 @@
 		"tslib": "^1.10.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -144,7 +144,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -127,7 +127,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",

--- a/packages/dds/pact-map/package.json
+++ b/packages/dds/pact-map/package.json
@@ -92,7 +92,7 @@
 		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -125,7 +125,7 @@
 		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -147,7 +147,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -130,7 +130,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/test-pairwise-generator": "workspace:~",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -124,7 +124,7 @@
 		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -127,7 +127,7 @@
 		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -97,7 +97,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -168,7 +168,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -91,7 +91,7 @@
 		"jsonschema": "^1.2.6"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -105,7 +105,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -98,7 +98,7 @@
 		"idb": "^6.1.2"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -74,7 +74,7 @@
 		"@fluidframework/replay-driver": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -133,7 +133,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -91,7 +91,7 @@
 		"@fluidframework/driver-definitions": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -129,7 +129,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/odsp-driver-definitions": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -74,7 +74,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -129,7 +129,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -81,7 +81,7 @@
 		"nconf": "^0.12.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -82,7 +82,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -102,7 +102,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@~2.3.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -130,7 +130,7 @@
 		"@fluidframework/synthesize": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -98,7 +98,7 @@
 		"lz4js": "^0.2.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -91,7 +91,7 @@
 		"@ungap/structured-clone": "^1.2.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -102,7 +102,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/client-utils": "workspace:~",
 		"@fluid-internal/mocha-test-setup": "workspace:~",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -91,7 +91,7 @@
 		"@fluidframework/sequence": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -111,7 +111,7 @@
 		"@fluidframework/tree": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -112,7 +112,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -112,7 +112,7 @@
 		"@fluidframework/driver-definitions": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-private/test-dds-utils": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -130,7 +130,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -121,7 +121,7 @@
 		"@fluidframework/runtime-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -117,7 +117,7 @@
 		"@fluidframework/core-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -103,7 +103,7 @@
 		"@fluidframework/sequence": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -182,7 +182,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/client-utils": "workspace:~",
 		"@fluid-internal/mocha-test-setup": "workspace:~",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -125,7 +125,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -57,7 +57,7 @@
 		"@fluidframework/driver-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -87,7 +87,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -197,7 +197,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -88,7 +88,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -131,7 +131,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -136,7 +136,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -94,7 +94,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -126,7 +126,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -129,7 +129,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -107,7 +107,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/aqueduct": "workspace:~",

--- a/packages/service-clients/odsp-client/package.json
+++ b/packages/service-clients/odsp-client/package.json
@@ -118,7 +118,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -101,7 +101,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/aqueduct": "workspace:~",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -63,7 +63,7 @@
 		"source-map-support": "^0.5.21"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -97,7 +97,7 @@
 		"best-random": "^1.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/benchmark": "^0.50.0",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -55,7 +55,7 @@
 		"@fluidframework/driver-definitions": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -75,7 +75,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -83,7 +83,7 @@
 		"random-js": "^2.1.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -140,7 +140,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -106,7 +106,7 @@
 		"semver": "^7.5.3"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -127,7 +127,7 @@
 		"@fluidframework/tree": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -83,7 +83,7 @@
 		"recharts": "^2.7.2"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -123,7 +123,7 @@
 		"@fluidframework/fluid-static": "workspace:~"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -128,7 +128,7 @@
 		"yargs": "17.7.2"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -78,7 +78,7 @@
 		"json-stable-stringify": "^1.0.1"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.48.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -125,7 +125,7 @@
 		"isomorphic-fetch": "^3.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -123,7 +123,7 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -107,7 +107,7 @@
 		"proper-lockfile": "^4.1.2"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.15.2",
+		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.48.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -3495,8 +3495,8 @@ importers:
         version: 4.3.7(supports-color@8.1.1)
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -4495,8 +4495,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -4601,8 +4601,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -4725,8 +4725,8 @@ importers:
         version: 4.15.2(webpack-cli@5.1.4)(webpack@5.95.0)
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -5828,8 +5828,8 @@ importers:
         version: 0.6.6
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -6060,8 +6060,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -6278,8 +6278,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -6387,8 +6387,8 @@ importers:
         version: link:../../../../packages/dds/shared-object-base
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -6484,8 +6484,8 @@ importers:
         version: 1.0.2
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -6578,8 +6578,8 @@ importers:
         version: link:../../../packages/dds/shared-object-base
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -6708,8 +6708,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -6838,8 +6838,8 @@ importers:
         version: link:../../../packages/dds/shared-object-base
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -6908,8 +6908,8 @@ importers:
         version: link:../../../packages/dds/shared-summary-block
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -6978,8 +6978,8 @@ importers:
         version: 18.3.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -7075,8 +7075,8 @@ importers:
         version: 2.4.11
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -7199,8 +7199,8 @@ importers:
         version: link:../driver-definitions
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -7247,8 +7247,8 @@ importers:
   packages/common/core-interfaces:
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -7295,8 +7295,8 @@ importers:
   packages/common/core-utils:
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -7380,8 +7380,8 @@ importers:
         version: link:../core-interfaces
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -7447,8 +7447,8 @@ importers:
         version: link:../shared-object-base
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -7550,8 +7550,8 @@ importers:
         version: link:../shared-object-base
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -7650,8 +7650,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -7765,8 +7765,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -7898,8 +7898,8 @@ importers:
         version: 1.14.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -8031,8 +8031,8 @@ importers:
         version: link:../../utils/telemetry-utils
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -8152,8 +8152,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -8258,8 +8258,8 @@ importers:
         version: link:../shared-object-base
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -8361,8 +8361,8 @@ importers:
         version: link:../shared-object-base
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -8476,8 +8476,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -8615,8 +8615,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -8724,8 +8724,8 @@ importers:
         version: link:../shared-object-base
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -8839,8 +8839,8 @@ importers:
         version: link:../shared-object-base
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -8963,8 +8963,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -9078,8 +9078,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -9217,8 +9217,8 @@ importers:
         version: 1.4.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -9284,8 +9284,8 @@ importers:
         version: link:../../utils/telemetry-utils
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -9372,8 +9372,8 @@ importers:
         version: 6.1.5
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -9448,8 +9448,8 @@ importers:
         version: link:../replay-driver
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -9542,8 +9542,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -9657,8 +9657,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -9742,8 +9742,8 @@ importers:
         version: link:../../common/driver-definitions
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -9809,8 +9809,8 @@ importers:
         version: link:../odsp-driver-definitions
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -9894,8 +9894,8 @@ importers:
         version: link:../../utils/telemetry-utils
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -9985,8 +9985,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -10085,8 +10085,8 @@ importers:
         version: 0.12.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -10176,8 +10176,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -10279,8 +10279,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -10373,8 +10373,8 @@ importers:
         version: link:../synthesize
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -10482,8 +10482,8 @@ importers:
         version: 0.2.0
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -10570,8 +10570,8 @@ importers:
         version: 1.2.0
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -10664,8 +10664,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -10782,8 +10782,8 @@ importers:
         version: link:../../dds/shared-object-base
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -10843,8 +10843,8 @@ importers:
         version: link:../../dds/sequence
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -10949,8 +10949,8 @@ importers:
         version: link:../../dds/tree
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -11037,8 +11037,8 @@ importers:
         version: link:../../utils/telemetry-utils
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -11128,8 +11128,8 @@ importers:
         version: link:../../common/driver-definitions
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -11219,8 +11219,8 @@ importers:
         version: link:../../utils/telemetry-utils
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -11310,8 +11310,8 @@ importers:
         version: link:../../runtime/runtime-utils
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -11389,8 +11389,8 @@ importers:
         version: link:../../common/core-utils
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -11483,8 +11483,8 @@ importers:
         version: link:../../dds/sequence
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -11601,8 +11601,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -11716,8 +11716,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -11807,8 +11807,8 @@ importers:
         version: link:../driver-utils
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -11898,8 +11898,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -12004,8 +12004,8 @@ importers:
         version: link:../runtime-definitions
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -12086,8 +12086,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -12180,8 +12180,8 @@ importers:
         version: link:../runtime-definitions
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -12244,8 +12244,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -12338,8 +12338,8 @@ importers:
         version: link:../../utils/telemetry-utils
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -12417,8 +12417,8 @@ importers:
         version: link:../../utils/telemetry-utils
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -12538,8 +12538,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -12647,8 +12647,8 @@ importers:
         version: link:../../utils/telemetry-utils
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -13022,8 +13022,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -13125,8 +13125,8 @@ importers:
         version: link:../../drivers/tinylicious-driver
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -13508,8 +13508,8 @@ importers:
         version: 0.5.21
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -13684,8 +13684,8 @@ importers:
         version: 1.0.3
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -13763,8 +13763,8 @@ importers:
         version: link:../../common/driver-definitions
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -13866,8 +13866,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -14129,8 +14129,8 @@ importers:
         version: 2.1.0
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -14392,8 +14392,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -14564,8 +14564,8 @@ importers:
         version: 7.6.3
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -14719,8 +14719,8 @@ importers:
         version: link:../../../framework/fluid-static
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -15054,8 +15054,8 @@ importers:
         version: link:../../../dds/tree
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -15386,8 +15386,8 @@ importers:
         version: 2.12.7(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -15655,8 +15655,8 @@ importers:
         version: 17.7.2
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -15809,8 +15809,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -15876,8 +15876,8 @@ importers:
         version: 3.0.0
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -15964,8 +15964,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -16070,8 +16070,8 @@ importers:
         version: 4.1.2
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.15.2
-        version: 0.15.4
+        specifier: ^0.16.4
+        version: 0.16.4
       '@biomejs/biome':
         specifier: ~1.8.3
         version: 1.8.3
@@ -16193,12 +16193,12 @@ packages:
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
     dev: true
 
-  /@arethetypeswrong/cli@0.15.4:
-    resolution: {integrity: sha512-YDbImAi1MGkouT7f2yAECpUMFhhA1J0EaXzIqoC5GGtK0xDgauLtcsZezm8tNq7d3wOFXH7OnY+IORYcG212rw==}
+  /@arethetypeswrong/cli@0.16.4:
+    resolution: {integrity: sha512-qMmdVlJon5FtA+ahn0c1oAVNxiq4xW5lqFiTZ21XHIeVwAVIQ+uRz4UEivqRMsjVV1grzRgJSKqaOrq1MvlVyQ==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      '@arethetypeswrong/core': 0.15.1
+      '@arethetypeswrong/core': 0.16.4
       chalk: 4.1.2
       cli-table3: 0.6.5
       commander: 10.0.1
@@ -16207,15 +16207,16 @@ packages:
       semver: 7.6.3
     dev: true
 
-  /@arethetypeswrong/core@0.15.1:
-    resolution: {integrity: sha512-FYp6GBAgsNz81BkfItRz8RLZO03w5+BaeiPma1uCfmxTnxbtuMrI/dbzGiOk8VghO108uFI0oJo0OkewdSHw7g==}
+  /@arethetypeswrong/core@0.16.4:
+    resolution: {integrity: sha512-RI3HXgSuKTfcBf1hSEg1P9/cOvmI0flsMm6/QL3L3wju4AlHDqd55JFPfXs4pzgEAgy5L9pul4/HPPz99x2GvA==}
     engines: {node: '>=18'}
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
+      cjs-module-lexer: 1.4.1
       fflate: 0.8.2
+      lru-cache: 10.4.3
       semver: 7.6.3
-      ts-expose-internals-conditionally: 1.0.0-empty.0
-      typescript: 5.3.3
+      typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
     dev: true
 
@@ -37233,10 +37234,6 @@ packages:
     resolution: {integrity: sha512-JBFCmNenZdUCc+TRNCtXVM6N8y/nDQHAcpj5BlwXG/gnogjam1NunulB9ia68mnqYI446giMfpqeBFFkOleh+g==}
     engines: {node: '>=14.13.1'}
 
-  /ts-expose-internals-conditionally@1.0.0-empty.0:
-    resolution: {integrity: sha512-F8m9NOF6ZhdOClDVdlM8gj3fDCav4ZIFSs/EI3ksQbAAXVSCN/Jh5OCJDDZWBuBy9psFc6jULGDlPwjMYMhJDw==}
-    dev: true
-
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
@@ -37592,12 +37589,6 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.3.3:
-    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
-
   /typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
@@ -37608,6 +37599,12 @@ packages:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /typescript@5.6.1-rc:
+    resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
 
   /typeson-registry@1.0.0-alpha.39:
     resolution: {integrity: sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==}


### PR DESCRIPTION
Upgrades are-the-types-wrong to version 0.16.4.

No known issues with the current version - just keeping us up-to-date.