### PR TITLE
Add ability to skip coverage check in code coverage module

### DIFF
--- a/build-tools/packages/build-cli/docs/codeCoverageDetails.md
+++ b/build-tools/packages/build-cli/docs/codeCoverageDetails.md
@@ -91,3 +91,16 @@ The code coverage PR checks will fail in the following cases:
 - If the code coverage(line and branch) for a newly added package is < 50%.
 
 The enforcement code is in the function `isCodeCoverageCriteriaPassed`.
+
+### What to do if the code coverage check fails:
+
+- In the code coverage summary, a checkbox will appear which will not allow the code coverage check to fail the build.
+  Now, if the regression is due to removal of tests, removal of code with lots of tests or any other valid reason,
+  please tick the checkbox and trigger the build again. This till it will still do the comparison, but will not fail
+  the build due to regression.
+- You can again uncheck the checkbox, to fail the build on regression before triggering the build.
+- You can also add more tets to increase the code coverage for the package which showed the regression in the summary.
+- You may sometimes want to check which lines are covered or not covered by your tests, you can follow these steps:
+  - Go to the PR ADO build.
+  - Then, go to the published artifacts. You will see a `codeCoverageAnalysis` named artifact, which you can expand to reach to a particular file's coverage html which will show which lines are covered/not covered by your tests.
+  - You can also run different kind of tests locally with `:coverage` tests commands to find out the coverage.

--- a/build-tools/packages/build-cli/docs/codeCoverageDetails.md
+++ b/build-tools/packages/build-cli/docs/codeCoverageDetails.md
@@ -91,16 +91,3 @@ The code coverage PR checks will fail in the following cases:
 - If the code coverage(line and branch) for a newly added package is < 50%.
 
 The enforcement code is in the function `isCodeCoverageCriteriaPassed`.
-
-### What to do if the code coverage check fails:
-
-- In the code coverage summary, a checkbox will appear which will not allow the code coverage check to fail the build.
-  Now, if the regression is due to removal of tests, removal of code with lots of tests or any other valid reason,
-  please tick the checkbox and trigger the build again. This till it will still do the comparison, but will not fail
-  the build due to regression.
-- You can again uncheck the checkbox, to fail the build on regression before triggering the build.
-- You can also add more tets to increase the code coverage for the package which showed the regression in the summary.
-- You may sometimes want to check which lines are covered or not covered by your tests, you can follow these steps:
-  - Go to the PR ADO build.
-  - Then, go to the published artifacts. You will see a `codeCoverageAnalysis` named artifact, which you can expand to reach to a particular file's coverage html which will show which lines are covered/not covered by your tests.
-  - You can also run different kind of tests locally with `:coverage` tests commands to find out the coverage.

--- a/build-tools/packages/build-cli/docs/report.md
+++ b/build-tools/packages/build-cli/docs/report.md
@@ -12,9 +12,9 @@ Run comparison of code coverage stats
 ```
 USAGE
   $ flub report codeCoverage --adoBuildId <value> --adoApiToken <value> --githubApiToken <value>
-    --adoCIBuildDefinitionIdBaseline <value> --adoCIBuildDefinitionIdPR <value>
-    --codeCoverageAnalysisArtifactNameBaseline <value> --codeCoverageAnalysisArtifactNamePR <value> --githubPRNumber
-    <value> --githubRepositoryName <value> --githubRepositoryOwner <value> --targetBranchName <value> [-v | --quiet]
+    --adoCIBuildDefinitionIdBaseline <value> --adoCIBuildDefinitionIdPR <value> --githubPRNumber <value>
+    --githubRepositoryName <value> --githubRepositoryOwner <value> --targetBranchName <value> [-v | --quiet]
+    [--codeCoverageAnalysisArtifactNameBaseline <value>] [--codeCoverageAnalysisArtifactNamePR <value>]
 
 FLAGS
   --adoApiToken=<value>                               (required) Token to get auth for accessing ADO builds.
@@ -22,8 +22,8 @@ FLAGS
   --adoCIBuildDefinitionIdBaseline=<value>            (required) Build definition/pipeline number/id for the baseline
                                                       build.
   --adoCIBuildDefinitionIdPR=<value>                  (required) Build definition/pipeline number/id for the PR build.
-  --codeCoverageAnalysisArtifactNameBaseline=<value>  (required) Code coverage artifact name for the baseline build.
-  --codeCoverageAnalysisArtifactNamePR=<value>        (required) Code coverage artifact name for the PR build.
+  --codeCoverageAnalysisArtifactNameBaseline=<value>  Code coverage artifact name for the baseline build.
+  --codeCoverageAnalysisArtifactNamePR=<value>        Code coverage artifact name for the PR build.
   --githubApiToken=<value>                            (required) Token to get auth for accessing Github PR.
   --githubPRNumber=<value>                            (required) Github PR number.
   --githubRepositoryName=<value>                      (required) Github repository name.

--- a/build-tools/packages/build-cli/docs/report.md
+++ b/build-tools/packages/build-cli/docs/report.md
@@ -14,21 +14,17 @@ USAGE
   $ flub report codeCoverage --adoBuildId <value> --adoApiToken <value> --githubApiToken <value>
     --adoCIBuildDefinitionIdBaseline <value> --adoCIBuildDefinitionIdPR <value> --githubPRNumber <value>
     --githubRepositoryName <value> --githubRepositoryOwner <value> --targetBranchName <value> [-v | --quiet]
-    [--codeCoverageAnalysisArtifactNameBaseline <value>] [--codeCoverageAnalysisArtifactNamePR <value>]
 
 FLAGS
-  --adoApiToken=<value>                               (required) Token to get auth for accessing ADO builds.
-  --adoBuildId=<value>                                (required) Azure DevOps build ID.
-  --adoCIBuildDefinitionIdBaseline=<value>            (required) Build definition/pipeline number/id for the baseline
-                                                      build.
-  --adoCIBuildDefinitionIdPR=<value>                  (required) Build definition/pipeline number/id for the PR build.
-  --codeCoverageAnalysisArtifactNameBaseline=<value>  Code coverage artifact name for the baseline build.
-  --codeCoverageAnalysisArtifactNamePR=<value>        Code coverage artifact name for the PR build.
-  --githubApiToken=<value>                            (required) Token to get auth for accessing Github PR.
-  --githubPRNumber=<value>                            (required) Github PR number.
-  --githubRepositoryName=<value>                      (required) Github repository name.
-  --githubRepositoryOwner=<value>                     (required) Github repository owner.
-  --targetBranchName=<value>                          (required) Target branch name.
+  --adoApiToken=<value>                     (required) Token to get auth for accessing ADO builds.
+  --adoBuildId=<value>                      (required) Azure DevOps build ID.
+  --adoCIBuildDefinitionIdBaseline=<value>  (required) Build definition/pipeline number/id for the baseline build.
+  --adoCIBuildDefinitionIdPR=<value>        (required) Build definition/pipeline number/id for the PR build.
+  --githubApiToken=<value>                  (required) Token to get auth for accessing Github PR.
+  --githubPRNumber=<value>                  (required) Github PR number.
+  --githubRepositoryName=<value>            (required) Github repository name.
+  --githubRepositoryOwner=<value>           (required) Github repository owner.
+  --targetBranchName=<value>                (required) Target branch name.
 
 LOGGING FLAGS
   -v, --verbose  Enable verbose logging.

--- a/build-tools/packages/build-cli/src/codeCoverage/getCommentForCodeCoverage.ts
+++ b/build-tools/packages/build-cli/src/codeCoverage/getCommentForCodeCoverage.ts
@@ -87,14 +87,14 @@ const getCodeCoverageSummary = (
 const getCodeCoverageSummaryForPackages = (coverageReport: CodeCoverageComparison): string => {
 	const metrics = codeCoverageDetailsHeader + getMetricRows(coverageReport);
 
-	return `<details><summary><b>${getColorGlyph(coverageReport.branchCoverageDiff + coverageReport.lineCoverageDiff)} ${
+	return `<details><summary><b>${getGlyphForHtml(coverageReport.branchCoverageDiff + coverageReport.lineCoverageDiff)} ${
 		coverageReport.packagePath
 	}:</b> <br> Line Coverage Change: ${formatDiff(coverageReport.lineCoverageDiff)}&nbsp;&nbsp;&nbsp;&nbsp;Branch Coverage Change: ${formatDiff(
 		coverageReport.branchCoverageDiff,
 	)}</summary>${metrics}</table></details>`;
 };
 
-const getColorGlyph = (codeCoverageDiff: number): string => {
+const getGlyphForHtml = (codeCoverageDiff: number): string => {
 	if (codeCoverageDiff === 0) {
 		return "&rarr;";
 	}
@@ -103,7 +103,7 @@ const getColorGlyph = (codeCoverageDiff: number): string => {
 		return "&uarr;";
 	}
 
-	return "&darr;&darr;";
+	return "&darr;";
 };
 
 const formatDiff = (coverageDiff: number): string => {
@@ -114,8 +114,8 @@ const formatDiff = (coverageDiff: number): string => {
 };
 
 const getMetricRows = (codeCoverageComparisonReport: CodeCoverageComparison): string => {
-	const glyphForLineCoverage = getColorGlyph(codeCoverageComparisonReport.lineCoverageDiff);
-	const glyphForBranchCoverage = getColorGlyph(
+	const glyphForLineCoverage = getGlyphForHtml(codeCoverageComparisonReport.lineCoverageDiff);
+	const glyphForBranchCoverage = getGlyphForHtml(
 		codeCoverageComparisonReport.branchCoverageDiff,
 	);
 

--- a/build-tools/packages/build-cli/src/codeCoverage/getCommentForCodeCoverage.ts
+++ b/build-tools/packages/build-cli/src/codeCoverage/getCommentForCodeCoverage.ts
@@ -54,7 +54,7 @@ export function getCommentForCodeCoverageDiff(
 		getSummaryFooter(baselineBuildInfo),
 		success
 			? "### Code coverage comparison check passed!!"
-			: "### Code coverage comparison check failed!!",
+			: "### Code coverage comparison check failed!!<br>More Details: [Readme](https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/docs/codeCoverageDetails.md#success-criteria)",
 	].join("\n\n");
 }
 
@@ -89,21 +89,21 @@ const getCodeCoverageSummaryForPackages = (coverageReport: CodeCoverageCompariso
 
 	return `<details><summary><b>${getColorGlyph(coverageReport.branchCoverageDiff + coverageReport.lineCoverageDiff)} ${
 		coverageReport.packagePath
-	}:</b> <br> Line Coverage Change: ${formatDiff(coverageReport.lineCoverageDiff)}  Branch Coverage Change: ${formatDiff(
+	}:</b> <br> Line Coverage Change: ${formatDiff(coverageReport.lineCoverageDiff)}&nbsp;&nbsp;&nbsp;&nbsp;Branch Coverage Change: ${formatDiff(
 		coverageReport.branchCoverageDiff,
 	)}</summary>${metrics}</table></details>`;
 };
 
 const getColorGlyph = (codeCoverageDiff: number): string => {
 	if (codeCoverageDiff === 0) {
-		return "■";
+		return "&rarr;";
 	}
 
 	if (codeCoverageDiff > 0) {
-		return "⯅";
+		return "&uarr;";
 	}
 
-	return "⯅⯅";
+	return "&darr;&darr;";
 };
 
 const formatDiff = (coverageDiff: number): string => {

--- a/build-tools/packages/build-cli/src/commands/report/codeCoverage.ts
+++ b/build-tools/packages/build-cli/src/commands/report/codeCoverage.ts
@@ -183,10 +183,10 @@ export default class ReportCodeCoverageCommand extends BaseCommand<
 
 const summaryFooterOnFailure =
 	"### What to do if the code coverage check fails:\n" +
-	"- In the code coverage summary, a checkbox will appear which will not allow the code coverage check to fail the build. Now, if the regression is due to removal of tests, removal of code with lots of tests or any other valid reason, please tick the checkbox and trigger the build again. This till it will still do the comparison, but will not fail the build due to regression.\n" +
-	"- You can again uncheck the checkbox, to fail the build on regression before triggering the build.\n" +
-	"- You can also add more tets to increase the code coverage for the package which showed the regression in the summary.\n" +
-	"- You may sometimes want to check which lines are covered or not covered by your tests, you can follow these steps:\n" +
-	"  - Go to the PR ADO build.\n" +
-	"  - Then, go to the published artifacts. You will see a `codeCoverageAnalysis` named artifact, which you can expand to reach to a particular file's coverage html which will show which lines are covered/not covered by your tests.\n" +
-	"  - You can also run different kind of tests locally with `:coverage` tests commands to find out the coverage.\n";
+	"Ideally, add more tests to increase the code coverage for the package(s) whose code-coverage regressed.\n\n" +
+	"If a regression is causing the build to fail and is due to removal of tests, removal of code with lots of tests or any other valid reason, there is a checkbox further up in this comment that determines if the code coverage check should fail the build or not. You can check the box by editing this comment and trigger the build again. The test coverage analysis will still be done, but it will not fail the build if a regression is detected.\n" +
+	"Unchecking the checkbox (again by editing the comment) and triggering another build should go back to failing the build if a test-coverage regression is detected.\n\n" +
+	"You can check which lines are covered or not covered by your tests with these steps:\n" +
+	"- Go to the PR ADO build.\n" +
+	"- Click on the link to see its published artifacts. You will see an artifact named `codeCoverageAnalysis`, which you can expand to reach to a particular source file's coverage html which will show which lines are covered/not covered by your tests.\n" +
+	"- You can also run different kind of tests locally with `:coverage` tests commands to find out the coverage.\n";

--- a/build-tools/packages/build-cli/src/commands/report/codeCoverage.ts
+++ b/build-tools/packages/build-cli/src/commands/report/codeCoverage.ts
@@ -183,10 +183,10 @@ export default class ReportCodeCoverageCommand extends BaseCommand<
 
 const summaryFooterOnFailure =
 	"### What to do if the code coverage check fails:\n" +
-	"Ideally, add more tests to increase the code coverage for the package(s) whose code-coverage regressed.\n\n" +
-	"If a regression is causing the build to fail and is due to removal of tests, removal of code with lots of tests or any other valid reason, there is a checkbox further up in this comment that determines if the code coverage check should fail the build or not. You can check the box by editing this comment and trigger the build again. The test coverage analysis will still be done, but it will not fail the build if a regression is detected.\n" +
-	"Unchecking the checkbox (again by editing the comment) and triggering another build should go back to failing the build if a test-coverage regression is detected.\n\n" +
-	"You can check which lines are covered or not covered by your tests with these steps:\n" +
-	"- Go to the PR ADO build.\n" +
-	"- Click on the link to see its published artifacts. You will see an artifact named `codeCoverageAnalysis`, which you can expand to reach to a particular source file's coverage html which will show which lines are covered/not covered by your tests.\n" +
-	"- You can also run different kind of tests locally with `:coverage` tests commands to find out the coverage.\n";
+	"- Ideally, add more tests to increase the code coverage for the package(s) whose code-coverage regressed.\n" +
+	"- If a regression is causing the build to fail and is due to removal of tests, removal of code with lots of tests or any other valid reason, there is a checkbox further up in this comment that determines if the code coverage check should fail the build or not. You can check the box and trigger the build again. The test coverage analysis will still be done, but it will not fail the build if a regression is detected.\n" +
+	"- Unchecking the checkbox and triggering another build should go back to failing the build if a test-coverage regression is detected.\n\n" +
+	"- You can check which lines are covered or not covered by your tests with these steps:\n" +
+	"  - Go to the PR ADO build.\n" +
+	"  - Click on the link to see its published artifacts. You will see an artifact named `codeCoverageAnalysis`, which you can expand to reach to a particular source file's coverage html which will show which lines are covered/not covered by your tests.\n" +
+	"  - You can also run different kind of tests locally with `:coverage` tests commands to find out the coverage.\n";

--- a/build-tools/packages/build-cli/src/commands/report/codeCoverage.ts
+++ b/build-tools/packages/build-cli/src/commands/report/codeCoverage.ts
@@ -162,7 +162,7 @@ export default class ReportCodeCoverageCommand extends BaseCommand<
 		if (!success) {
 			messageContentWithIdentifier = shouldFailBuildOnRegression
 				? `${messageContentWithIdentifier}\n\n- [ ] Skip This Check!!`
-				: `${messageContentWithIdentifier}\n\n- [x] Check is skipped!`;
+				: `${messageContentWithIdentifier}\n\n- [x] Skip This Check!!`;
 
 			messageContentWithIdentifier = `${messageContentWithIdentifier}\n${summaryFooterOnFailure}`;
 		}

--- a/build-tools/packages/build-cli/src/commands/report/codeCoverage.ts
+++ b/build-tools/packages/build-cli/src/commands/report/codeCoverage.ts
@@ -137,7 +137,6 @@ export default class ReportCodeCoverageCommand extends BaseCommand<
 		).catch((error: Error) => {
 			commentMessage = "## Code Coverage Summary\n\nError getting code coverage report";
 			this.logger.errorLog(`Error getting code coverage report: ${error}`);
-			return undefined;
 		});
 
 		// Don't fail if we can not compare the code coverage due to an error.

--- a/build-tools/packages/build-cli/src/library/githubRest.ts
+++ b/build-tools/packages/build-cli/src/library/githubRest.ts
@@ -167,6 +167,39 @@ export async function createOrUpdateCommentOnPr(
 }
 
 /**
+ * Retrieves body of the comment if commentIdentifier identifies the comment.
+ *
+ * @param github - Details about the GitHub repo and auth to use.
+ * @param prNumber - Pull request number.
+ * @param commentIdentifier - unique identifier for the comment to be updated.
+ *
+ * @returns body of the comment identified by commentIdentifier.
+ */
+export async function getCommentBody(
+	{ owner, repo, token }: GitHubProps,
+	prNumber: number,
+	commentIdentifier: string,
+): Promise<string | undefined> {
+	const octokit = new Octokit({ auth: token });
+
+	// List of review comments for the pull request
+	const { data: comments } = await octokit.pulls.listReviews({
+		owner,
+		repo,
+		pull_number: prNumber,
+	});
+
+	let commentBody: string | undefined;
+	// Check the comments to find the comment with the identifier.
+	for (const comment of comments) {
+		if (comment.body.startsWith(commentIdentifier)) {
+			return comment.body;
+		}
+	}
+	return undefined;
+}
+
+/**
  * Api to get the changed file paths in a PR. The paths are relative to the root of the repo.
  * @param github - Details about the GitHub repo and auth to use.
  * @param prNumber - Pr number for which the changed files paths are to be fetched


### PR DESCRIPTION
## Description

AB#22793
This PR includes small improvements in the code coverage module.
1.) Add ability to skip coverage check in code coverage module in case of regression.
2.) Fix glyph and use unicode characters for arrows.
3.) Improve code coverage readme.
4.) Add more details to the code coverage summary.
