### PR TITLE
fix(generate:changelog): Calculate correct changeset version

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/changelog.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/changelog.ts
@@ -66,8 +66,9 @@ export default class GenerateChangeLogCommand extends BaseCommand<
 		const { directory, version: pkgVersion } = pkg;
 		const bumpType = this.bumpType ?? "patch";
 
-		// This is the version that the changesets tooling calculates by default. It does a bump of the highest semver type in the changesets on the current
-		// version. We search for that version in the generated changelog and replace it with the one that we want.
+		// This is the version that the changesets tooling calculates by default. It does a bump of the highest semver type
+		// in the changesets on the current version. We search for that version in the generated changelog and replace it
+		// with the one that we want.
 		const changesetsCalculatedVersion = isInternalVersionScheme(pkgVersion)
 			? bumpVersionScheme(pkgVersion, bumpType, "internal")
 			: inc(pkgVersion, bumpType);

--- a/build-tools/packages/build-cli/src/commands/generate/changelog.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/changelog.ts
@@ -60,13 +60,13 @@ export default class GenerateChangeLogCommand extends BaseCommand<
 	private async processPackage(pkg: Package): Promise<void> {
 		const { directory, version: pkgVersion } = pkg;
 
-		// This is the version that the changesets tooling calculates by default. It does a semver major bump on the current
+		// This is the version that the changesets tooling calculates by default. It does a semver minor bump on the current
 		// version. We search for that version in the generated changelog and replace it with the one that we want.
 		// For internal versions, bumping the semver major is the same as just taking the public version from the internal
 		// version and using it directly.
 		const changesetsCalculatedVersion = isInternalVersionScheme(pkgVersion)
 			? fromInternalScheme(pkgVersion)[0].version
-			: inc(pkgVersion, "major");
+			: inc(pkgVersion, "minor");
 		const versionToUse = this.flags.version?.version ?? pkgVersion;
 
 		// Replace the changeset version with the correct version.

--- a/build-tools/packages/build-cli/src/commands/generate/changelog.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/changelog.ts
@@ -66,10 +66,8 @@ export default class GenerateChangeLogCommand extends BaseCommand<
 		const { directory, version: pkgVersion } = pkg;
 		const bumpType = this.bumpType ?? "patch";
 
-		// This is the version that the changesets tooling calculates by default. It does a semver minor bump on the current
+		// This is the version that the changesets tooling calculates by default. It does a bump of the highest semver type in the changesets on the current
 		// version. We search for that version in the generated changelog and replace it with the one that we want.
-		// For internal versions, bumping the semver major is the same as just taking the public version from the internal
-		// version and using it directly.
 		const changesetsCalculatedVersion = isInternalVersionScheme(pkgVersion)
 			? bumpVersionScheme(pkgVersion, bumpType, "internal")
 			: inc(pkgVersion, bumpType);


### PR DESCRIPTION
We run `changeset version` during changelog generation, which causes changesets to be consumed and the package.json versions to be bumped. We need to calculate the same "target version" that the changesets tools calculate so we can correctly replace the output of the changelogs to the correct versions and do our other cleanup.

This change fixes the calculation to take into account the bump ranges in the changesets.