### PR TITLE
Remove duplicate code for Audience population from snapshot

### DIFF
--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -73,9 +73,6 @@ export class ProtocolHandler extends ProtocolOpHandler implements IProtocolHandl
 			audience.addMember(clientId, details.client),
 		);
 		this.quorum.on("removeMember", (clientId) => audience.removeMember(clientId));
-		for (const [clientId, details] of this.quorum.getMembers()) {
-			this.audience.addMember(clientId, details.client);
-		}
 	}
 
 	public processMessage(


### PR DESCRIPTION
## Description
In protocol handler, we have duplicate for loops that populates Audience from Quorum members (lines 67-69 already do this). This PR deletes the duplicate code. 