### PR TITLE
refactor: Disable CodeQL in test pipelines

### DIFF
--- a/tools/pipelines/test-dds-stress.yml
+++ b/tools/pipelines/test-dds-stress.yml
@@ -25,6 +25,9 @@ variables:
 - name: absolutePathToTelemetryGenerator
   value: $(Build.SourcesDirectory)/tools/telemetry-generator
   readonly: true
+# This is a test pipeline, not a build one, so we don't need to run CodeQL tasks
+- name: DisableCodeQL
+  value: true
 
 parameters:
 - name: packages

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -84,6 +84,9 @@ variables:
   - name: pipelineIdentifierForTelemetry
     value: 'PerformanceBenchmark'
     readonly: true
+  # This is a test pipeline, not a build one, so we don't need to run CodeQL tasks
+  - name: DisableCodeQL
+    value: true
 
 lockBehavior: sequential
 stages:

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -33,6 +33,9 @@ variables:
 - name: pipelineIdentifierForTelemetry
   value: 'RealStressService'
   readonly: true
+# This is a test pipeline, not a build one, so we don't need to run CodeQL tasks
+- name: DisableCodeQL
+  value: true
 
 lockBehavior: sequential
 stages:

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -33,6 +33,9 @@ variables:
 - name: pipelineIdentifierForTelemetry
   value: 'EndToEndTests'
   readonly: true
+# This is a test pipeline, not a build one, so we don't need to run CodeQL tasks
+- name: DisableCodeQL
+  value: true
 
 lockBehavior: sequential
 stages:

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -33,6 +33,9 @@ variables:
 - name: pipelineIdentifierForTelemetry
   value: 'ServiceClientsEndToEndTests'
   readonly: true
+# This is a test pipeline, not a build one, so we don't need to run CodeQL tasks
+- name: DisableCodeQL
+  value: true
 
 stages:
   # Run Azure Client FRS Tests

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -142,6 +142,9 @@ variables:
   value: 1
 - name: pnpmStorePath
   value: $(Pipeline.Workspace)/.pnpm-store
+# This is a test pipeline, not a build one, so we don't need to run CodeQL tasks
+- name: DisableCodeQL
+  value: true
 
 stages:
   - ${{ each stageName in parameters.stageNames }}:


### PR DESCRIPTION
## Description

Disables the auto-injection of CodeQL tasks in our test pipelines. The CodeQL tasks always "fail" (the ADO step still succeeds but the task can't find source code so it can't run CodeQL and logs warnings) in the test pipelines for which we don't checkout the repo, which is the case for our test pipelines. [Example](https://dev.azure.com/fluidframework/internal/_build/results?buildId=300062&view=logs&j=26483432-40f5-552c-5792-70aed8cde738&t=fb288d9b-a668-57e8-da86-3cec1930f710&l=55) (msft internal). The task itself says that it should only run for build pipelines (where source code exists).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[This sample run of the e2e tests pipeline](https://dev.azure.com/fluidframework/internal/_build/results?buildId=300172&view=logs&j=26483432-40f5-552c-5792-70aed8cde738&t=7b39a799-b703-51a7-8f49-14ff3f143f8f) (msft internal) from a test branch with these changes shows that the "Initialize CodeQL (auto-injected)" and "Finalize CodeQL (auto-injected)" tasks don't show up anymore (compare to the example linked above). Note: the failure of the step further down is expected because I didn't run Build - client packages for the test branch, so no packages with the appropriate version were published and the actual tests can't run in that scenario.