### PR TITLE
Allow quorum member removal when detached 

### DIFF
--- a/packages/framework/agent-scheduler/src/scheduler.ts
+++ b/packages/framework/agent-scheduler/src/scheduler.ts
@@ -267,10 +267,6 @@ export class AgentScheduler
 		// Probably okay for now to have every client try to do this.
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		quorum.on("removeMember", async (clientId: string) => {
-			assert(
-				this.runtime.objectsRoutingContext.isAttached,
-				0x11c /* "Detached object routing context" */,
-			);
 			// Cleanup only if connected. If not, cleanup will happen in initializeCore() that runs on connection.
 			if (this.isActive()) {
 				const tasks: Promise<any>[] = [];

--- a/packages/framework/agent-scheduler/src/scheduler.ts
+++ b/packages/framework/agent-scheduler/src/scheduler.ts
@@ -267,6 +267,7 @@ export class AgentScheduler
 		// Probably okay for now to have every client try to do this.
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		quorum.on("removeMember", async (clientId: string) => {
+			if (!this.runtime.objectsRoutingContext.isAttached) return;
 			// Cleanup only if connected. If not, cleanup will happen in initializeCore() that runs on connection.
 			if (this.isActive()) {
 				const tasks: Promise<any>[] = [];

--- a/packages/framework/agent-scheduler/src/scheduler.ts
+++ b/packages/framework/agent-scheduler/src/scheduler.ts
@@ -267,6 +267,7 @@ export class AgentScheduler
 		// Probably okay for now to have every client try to do this.
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		quorum.on("removeMember", async (clientId: string) => {
+			// TODO AB#19980: The scenario with a detached routing context is not fully supported.
 			if (!this.runtime.objectsRoutingContext.isAttached) return;
 			// Cleanup only if connected. If not, cleanup will happen in initializeCore() that runs on connection.
 			if (this.isActive()) {


### PR DESCRIPTION
When a quorum member is removed and we do the associated cleanup, the assumption was that the runtime was attached. This is not necessarily true, and causes this assert to fail in valid cases. 

[AB#19980](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/19980)