### PR TITLE
build(client): Update type test baselines to ~2.4.0

### DIFF
--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -97,7 +97,7 @@
 		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.49.0",
-		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@~2.3.0",
+		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.4.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -97,7 +97,7 @@
 		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.49.0",
-		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.4.0",
+		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@~2.4.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",

--- a/examples/apps/ai-collab/package.json
+++ b/examples/apps/ai-collab/package.json
@@ -70,6 +70,7 @@
 	},
 	"typeValidation": {
 		"disabled": true,
-		"broken": {}
+		"broken": {},
+		"entrypoint": "legacy"
 	}
 }

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -101,7 +101,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
-		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@~2.3.0",
+		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@2.4.0",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -101,7 +101,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
-		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@2.4.0",
+		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@~2.4.0",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -135,7 +135,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
-		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@~2.3.0",
+		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@2.4.0",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -135,7 +135,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
-		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@2.4.0",
+		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@~2.4.0",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -102,7 +102,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@~2.3.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"concurrently": "^8.2.1",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -102,7 +102,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.4.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"concurrently": "^8.2.1",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -98,7 +98,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.4.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/node": "^18.19.0",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -98,7 +98,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@~2.3.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/node": "^18.19.0",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -124,7 +124,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@2.4.0",
+		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -124,7 +124,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@~2.3.0",
+		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -97,7 +97,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@~2.3.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"concurrently": "^8.2.1",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -97,7 +97,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.4.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"concurrently": "^8.2.1",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -115,7 +115,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.4.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@~2.4.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -115,7 +115,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@~2.3.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.4.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/container-definitions": "workspace:~",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.4.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/container-definitions": "workspace:~",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@~2.3.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -147,7 +147,7 @@
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@~2.3.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -147,7 +147,7 @@
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.4.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@~2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -150,7 +150,7 @@
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.4.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@~2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@tiny-calc/micro": "0.0.0-alpha.5",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -150,7 +150,7 @@
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@~2.3.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@tiny-calc/micro": "0.0.0-alpha.5",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -156,7 +156,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@~2.3.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/diff": "^3.5.1",
@@ -177,20 +177,7 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"Interface_IMergeTreeDeltaOpArgs": {
-				"backCompat": false
-			},
-			"TypeAlias_IMergeTreeDeltaOp": {
-				"backCompat": false
-			},
-			"Interface_IMergeTreeGroupMsg": {
-				"backCompat": false
-			},
-			"TypeAlias_IMergeTreeOp": {
-				"backCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -156,7 +156,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.4.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@~2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/diff": "^3.5.1",

--- a/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
+++ b/packages/dds/merge-tree/src/test/types/validateMergeTreePrevious.generated.ts
@@ -652,7 +652,6 @@ declare type old_as_current_for_Interface_IMergeTreeDeltaOpArgs = requireAssigna
  * typeValidation.broken:
  * "Interface_IMergeTreeDeltaOpArgs": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IMergeTreeDeltaOpArgs = requireAssignableTo<TypeOnly<current.IMergeTreeDeltaOpArgs>, TypeOnly<old.IMergeTreeDeltaOpArgs>>
 
 /*
@@ -671,7 +670,6 @@ declare type old_as_current_for_Interface_IMergeTreeGroupMsg = requireAssignable
  * typeValidation.broken:
  * "Interface_IMergeTreeGroupMsg": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IMergeTreeGroupMsg = requireAssignableTo<TypeOnly<current.IMergeTreeGroupMsg>, TypeOnly<old.IMergeTreeGroupMsg>>
 
 /*
@@ -727,6 +725,24 @@ declare type old_as_current_for_Interface_IMergeTreeObliterateMsg = requireAssig
  * "Interface_IMergeTreeObliterateMsg": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_IMergeTreeObliterateMsg = requireAssignableTo<TypeOnly<current.IMergeTreeObliterateMsg>, TypeOnly<old.IMergeTreeObliterateMsg>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IMergeTreeObliterateSidedMsg": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IMergeTreeObliterateSidedMsg = requireAssignableTo<TypeOnly<old.IMergeTreeObliterateSidedMsg>, TypeOnly<current.IMergeTreeObliterateSidedMsg>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IMergeTreeObliterateSidedMsg": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_IMergeTreeObliterateSidedMsg = requireAssignableTo<TypeOnly<current.IMergeTreeObliterateSidedMsg>, TypeOnly<old.IMergeTreeObliterateSidedMsg>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -1077,7 +1093,6 @@ declare type old_as_current_for_TypeAlias_IMergeTreeDeltaOp = requireAssignableT
  * typeValidation.broken:
  * "TypeAlias_IMergeTreeDeltaOp": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_IMergeTreeDeltaOp = requireAssignableTo<TypeOnly<current.IMergeTreeDeltaOp>, TypeOnly<old.IMergeTreeDeltaOp>>
 
 /*
@@ -1096,7 +1111,6 @@ declare type old_as_current_for_TypeAlias_IMergeTreeOp = requireAssignableTo<Typ
  * typeValidation.broken:
  * "TypeAlias_IMergeTreeOp": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_IMergeTreeOp = requireAssignableTo<TypeOnly<current.IMergeTreeOp>, TypeOnly<old.IMergeTreeOp>>
 
 /*

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -137,7 +137,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@~2.3.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -137,7 +137,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.4.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@~2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.4.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@~2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@~2.3.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -160,7 +160,7 @@
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.4.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@~2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/diff": "^3.5.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -160,7 +160,7 @@
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@~2.3.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/diff": "^3.5.1",
@@ -192,20 +192,7 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassStatics_SequenceMaintenanceEvent": {
-				"backCompat": false
-			},
-			"Class_SequenceMaintenanceEvent": {
-				"backCompat": false
-			},
-			"ClassStatics_SequenceDeltaEvent": {
-				"backCompat": false
-			},
-			"Class_SequenceDeltaEvent": {
-				"backCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
@@ -67,7 +67,6 @@ declare type old_as_current_for_Class_SequenceDeltaEvent = requireAssignableTo<T
  * typeValidation.broken:
  * "Class_SequenceDeltaEvent": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_SequenceDeltaEvent = requireAssignableTo<TypeOnly<current.SequenceDeltaEvent>, TypeOnly<old.SequenceDeltaEvent>>
 
 /*
@@ -122,7 +121,6 @@ declare type old_as_current_for_Class_SequenceMaintenanceEvent = requireAssignab
  * typeValidation.broken:
  * "Class_SequenceMaintenanceEvent": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_SequenceMaintenanceEvent = requireAssignableTo<TypeOnly<current.SequenceMaintenanceEvent>, TypeOnly<old.SequenceMaintenanceEvent>>
 
 /*
@@ -222,7 +220,6 @@ declare type current_as_old_for_ClassStatics_Marker = requireAssignableTo<TypeOn
  * typeValidation.broken:
  * "ClassStatics_SequenceDeltaEvent": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_SequenceDeltaEvent = requireAssignableTo<TypeOnly<typeof current.SequenceDeltaEvent>, TypeOnly<typeof old.SequenceDeltaEvent>>
 
 /*
@@ -250,7 +247,6 @@ declare type current_as_old_for_ClassStatics_SequenceInterval = requireAssignabl
  * typeValidation.broken:
  * "ClassStatics_SequenceMaintenanceEvent": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_SequenceMaintenanceEvent = requireAssignableTo<TypeOnly<typeof current.SequenceMaintenanceEvent>, TypeOnly<typeof old.SequenceMaintenanceEvent>>
 
 /*

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -140,7 +140,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.4.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@~2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -140,7 +140,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@~2.3.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -134,7 +134,7 @@
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@~2.3.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -134,7 +134,7 @@
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.4.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@~2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.4.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@~2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@~2.3.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -185,7 +185,7 @@
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tree-previous": "npm:@fluidframework/tree@2.4.0",
+		"@fluidframework/tree-previous": "npm:@fluidframework/tree@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/diff": "^3.5.1",
 		"@types/easy-table": "^0.0.32",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -185,7 +185,7 @@
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tree-previous": "npm:@fluidframework/tree@~2.3.0",
+		"@fluidframework/tree-previous": "npm:@fluidframework/tree@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/diff": "^3.5.1",
 		"@types/easy-table": "^0.0.32",
@@ -227,26 +227,7 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"TypeAlias_MapNodeInsertableData": {
-				"backCompat": false
-			},
-			"Interface_InternalTypes_TreeNodeSchemaNonClass": {
-				"backCompat": false
-			},
-			"Interface_FieldSchemaUnsafe": {
-				"forwardCompat": false
-			},
-			"Interface_ITreeViewConfiguration": {
-				"forwardCompat": false
-			},
-			"TypeAlias_ImplicitFieldSchema": {
-				"forwardCompat": false
-			},
-			"TypeAlias_ImplicitAllowedTypes": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/packages/dds/tree/src/test/types/validateTreePrevious.generated.ts
+++ b/packages/dds/tree/src/test/types/validateTreePrevious.generated.ts
@@ -223,13 +223,21 @@ declare type old_as_current_for_Interface_FieldProps = requireAssignableTo<TypeO
 declare type current_as_old_for_Interface_FieldProps = requireAssignableTo<TypeOnly<current.FieldProps>, TypeOnly<old.FieldProps>>
 
 /*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_FieldSchemaMetadata": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_FieldSchemaMetadata = requireAssignableTo<TypeOnly<current.FieldSchemaMetadata>, TypeOnly<old.FieldSchemaMetadata>>
+
+/*
  * Validate forward compatibility by using the old type in place of the current type.
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
  * "Interface_FieldSchemaUnsafe": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_FieldSchemaUnsafe = requireAssignableTo<TypeOnly<old.FieldSchemaUnsafe<any,any>>, TypeOnly<current.FieldSchemaUnsafe<any,any>>>
 
 /*
@@ -309,16 +317,6 @@ declare type current_as_old_for_Interface_InternalTypes_TreeMapNodeUnsafe = requ
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "Interface_InternalTypes_TreeNodeSchemaNonClass": {"backCompat": false}
- */
-// @ts-expect-error compatibility expected to be broken
-declare type current_as_old_for_Interface_InternalTypes_TreeNodeSchemaNonClass = requireAssignableTo<TypeOnly<current.InternalTypes.TreeNodeSchemaNonClass>, TypeOnly<old.InternalTypes.TreeNodeSchemaNonClass>>
-
-/*
- * Validate backward compatibility by using the current type in place of the old type.
- * If this test starts failing, it indicates a change that is not backward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
  * "Interface_ITree": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_ITree = requireAssignableTo<TypeOnly<current.ITree>, TypeOnly<old.ITree>>
@@ -348,7 +346,6 @@ declare type current_as_old_for_Interface_ITreeConfigurationOptions = requireAss
  * typeValidation.broken:
  * "Interface_ITreeViewConfiguration": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ITreeViewConfiguration = requireAssignableTo<TypeOnly<old.ITreeViewConfiguration>, TypeOnly<current.ITreeViewConfiguration>>
 
 /*
@@ -500,6 +497,15 @@ declare type current_as_old_for_Interface_TreeNodeSchemaCore = requireAssignable
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Interface_TreeNodeSchemaNonClass": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_TreeNodeSchemaNonClass = requireAssignableTo<TypeOnly<current.TreeNodeSchemaNonClass>, TypeOnly<old.TreeNodeSchemaNonClass>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Interface_TreeView": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_TreeView = requireAssignableTo<TypeOnly<current.TreeView<any>>, TypeOnly<old.TreeView<any>>>
@@ -512,6 +518,15 @@ declare type current_as_old_for_Interface_TreeView = requireAssignableTo<TypeOnl
  * "Interface_TreeViewEvents": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_TreeViewEvents = requireAssignableTo<TypeOnly<current.TreeViewEvents>, TypeOnly<old.TreeViewEvents>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ViewableTree": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_ViewableTree = requireAssignableTo<TypeOnly<current.ViewableTree>, TypeOnly<old.ViewableTree>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
@@ -547,7 +562,6 @@ declare type current_as_old_for_TypeAlias_AllowedTypes = requireAssignableTo<Typ
  * typeValidation.broken:
  * "TypeAlias_ImplicitAllowedTypes": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_ImplicitAllowedTypes = requireAssignableTo<TypeOnly<old.ImplicitAllowedTypes>, TypeOnly<current.ImplicitAllowedTypes>>
 
 /*
@@ -566,7 +580,6 @@ declare type current_as_old_for_TypeAlias_ImplicitAllowedTypes = requireAssignab
  * typeValidation.broken:
  * "TypeAlias_ImplicitFieldSchema": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_ImplicitFieldSchema = requireAssignableTo<TypeOnly<old.ImplicitFieldSchema>, TypeOnly<current.ImplicitFieldSchema>>
 
 /*
@@ -1143,7 +1156,6 @@ declare type old_as_current_for_TypeAlias_MapNodeInsertableData = requireAssigna
  * typeValidation.broken:
  * "TypeAlias_MapNodeInsertableData": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_MapNodeInsertableData = requireAssignableTo<TypeOnly<current.MapNodeInsertableData<any>>, TypeOnly<old.MapNodeInsertableData<any>>>
 
 /*
@@ -1199,6 +1211,24 @@ declare type old_as_current_for_TypeAlias_RestrictiveReadonlyRecord = requireAss
  * "TypeAlias_RestrictiveReadonlyRecord": {"backCompat": false}
  */
 declare type current_as_old_for_TypeAlias_RestrictiveReadonlyRecord = requireAssignableTo<TypeOnly<current.RestrictiveReadonlyRecord<any,any>>, TypeOnly<old.RestrictiveReadonlyRecord<any,any>>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "TypeAlias_RestrictiveStringRecord": {"forwardCompat": false}
+ */
+declare type old_as_current_for_TypeAlias_RestrictiveStringRecord = requireAssignableTo<TypeOnly<old.RestrictiveStringRecord<any>>, TypeOnly<current.RestrictiveStringRecord<any>>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "TypeAlias_RestrictiveStringRecord": {"backCompat": false}
+ */
+declare type current_as_old_for_TypeAlias_RestrictiveStringRecord = requireAssignableTo<TypeOnly<current.RestrictiveStringRecord<any>>, TypeOnly<old.RestrictiveStringRecord<any>>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -96,7 +96,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.4.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -96,7 +96,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@~2.3.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -113,7 +113,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@~2.3.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -113,7 +113,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.4.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -103,7 +103,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.4.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/jest": "29.5.3",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -103,7 +103,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@~2.3.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/jest": "29.5.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@~2.3.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/node": "^18.19.0",
 		"concurrently": "^8.2.1",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.4.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/node": "^18.19.0",
 		"concurrently": "^8.2.1",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -142,7 +142,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.4.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -142,7 +142,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@~2.3.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -97,7 +97,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.4.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -97,7 +97,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@~2.3.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@~2.3.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.4.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -90,7 +90,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@~2.3.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -90,7 +90,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.4.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@~2.3.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.4.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.4.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@~2.3.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -88,7 +88,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.4.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/nconf": "^0.10.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -88,7 +88,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@~2.3.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/nconf": "^0.10.0",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -89,7 +89,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.4.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -89,7 +89,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@~2.3.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^9.1.1",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -105,7 +105,7 @@
 		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.49.0",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.4.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@~2.4.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -105,7 +105,7 @@
 		"@arethetypeswrong/cli": "^0.16.4",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.49.0",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@~2.3.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.4.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -136,7 +136,7 @@
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.49.0",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.4.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@~2.4.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -136,7 +136,7 @@
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.49.0",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@~2.3.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.4.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -121,7 +121,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@~2.3.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.4.0",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -121,7 +121,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.4.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@~2.4.0",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -130,7 +130,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.4.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^9.1.1",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -130,7 +130,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@~2.3.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^9.1.1",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -129,7 +129,7 @@
 		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/runtime-utils": "workspace:~",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@~2.3.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -129,7 +129,7 @@
 		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/runtime-utils": "workspace:~",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.4.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -113,7 +113,7 @@
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.4.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^9.1.1",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -113,7 +113,7 @@
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@~2.3.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^9.1.1",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -192,7 +192,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.4.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/debug": "^4.1.5",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -192,7 +192,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@~2.3.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/debug": "^4.1.5",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -133,7 +133,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.4.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -133,7 +133,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@~2.3.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -92,7 +92,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.4.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -92,7 +92,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@~2.3.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -208,7 +208,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.4.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -208,7 +208,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@~2.3.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",
@@ -231,11 +231,7 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"Function_isRuntimeMessage": {
-				"backCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -93,7 +93,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.4.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -93,7 +93,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@~2.3.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -139,7 +139,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.4.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -139,7 +139,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@~2.3.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.47.8",

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -147,7 +147,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.4.0",
+		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -147,7 +147,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@~2.3.0",
+		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -100,7 +100,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@~2.3.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -100,7 +100,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.4.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@~2.3.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.4.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.4.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^9.1.1",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@~2.3.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^9.1.1",

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -111,7 +111,7 @@
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.4.0",
+		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@~2.4.0",
 		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -111,7 +111,7 @@
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@~2.3.0",
+		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.4.0",
 		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -111,7 +111,7 @@
 		"@fluidframework/container-runtime-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@~2.3.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -111,7 +111,7 @@
 		"@fluidframework/container-runtime-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.4.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -147,7 +147,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@~2.3.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -147,7 +147,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.4.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -133,7 +133,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@2.4.0",
+		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/id-compressor": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -133,7 +133,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@~2.3.0",
+		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/id-compressor": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -129,7 +129,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@~2.3.0",
+		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/chai": "^4.0.0",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -129,7 +129,7 @@
 		"@fluid-tools/build-cli": "^0.49.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
-		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@2.4.0",
+		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@~2.4.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/chai": "^4.0.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -52,7 +52,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.49.0",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.4.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@~2.4.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -52,7 +52,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-tools/build-cli": "^0.49.0",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@~2.3.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.4.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -137,7 +137,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.4.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -137,7 +137,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@~2.3.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -134,7 +134,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@~2.3.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -134,7 +134,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.4.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@~2.3.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^9.1.1",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.4.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^9.1.1",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -116,7 +116,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@~2.3.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^9.1.1",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -116,7 +116,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.4.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@~2.4.0",
 		"@microsoft/api-extractor": "7.47.8",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^9.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,7 +177,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-service-utils-previous':
-        specifier: npm:@fluidframework/azure-service-utils@2.4.0
+        specifier: npm:@fluidframework/azure-service-utils@~2.4.0
         version: /@fluidframework/azure-service-utils@2.4.0
       '@fluidframework/build-common':
         specifier: ^2.0.3
@@ -6395,7 +6395,7 @@ importers:
         specifier: ~1.8.3
         version: 1.8.3
       '@fluid-experimental/attributable-map-previous':
-        specifier: npm:@fluid-experimental/attributable-map@2.4.0
+        specifier: npm:@fluid-experimental/attributable-map@~2.4.0
         version: /@fluid-experimental/attributable-map@2.4.0
       '@fluid-internal/mocha-test-setup':
         specifier: workspace:~
@@ -7192,7 +7192,7 @@ importers:
         specifier: ~1.8.3
         version: 1.8.3
       '@fluid-internal/client-utils-previous':
-        specifier: npm:@fluid-internal/client-utils@2.4.0
+        specifier: npm:@fluid-internal/client-utils@~2.4.0
         version: /@fluid-internal/client-utils@2.4.0
       '@fluid-internal/mocha-test-setup':
         specifier: workspace:~
@@ -7325,7 +7325,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/container-definitions-previous':
-        specifier: npm:@fluidframework/container-definitions@2.4.0
+        specifier: npm:@fluidframework/container-definitions@~2.4.0
         version: /@fluidframework/container-definitions@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -7373,7 +7373,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/core-interfaces-previous':
-        specifier: npm:@fluidframework/core-interfaces@2.4.0
+        specifier: npm:@fluidframework/core-interfaces@~2.4.0
         version: /@fluidframework/core-interfaces@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -7427,7 +7427,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/core-utils-previous':
-        specifier: npm:@fluidframework/core-utils@2.4.0
+        specifier: npm:@fluidframework/core-utils@~2.4.0
         version: /@fluidframework/core-utils@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -7506,7 +7506,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/driver-definitions-previous':
-        specifier: npm:@fluidframework/driver-definitions@2.4.0
+        specifier: npm:@fluidframework/driver-definitions@~2.4.0
         version: /@fluidframework/driver-definitions@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -7579,7 +7579,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/cell-previous':
-        specifier: npm:@fluidframework/cell@2.4.0
+        specifier: npm:@fluidframework/cell@~2.4.0
         version: /@fluidframework/cell@2.4.0
       '@fluidframework/container-definitions':
         specifier: workspace:~
@@ -7682,7 +7682,7 @@ importers:
         specifier: workspace:~
         version: link:../../common/container-definitions
       '@fluidframework/counter-previous':
-        specifier: npm:@fluidframework/counter@2.4.0
+        specifier: npm:@fluidframework/counter@~2.4.0
         version: /@fluidframework/counter@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -7909,7 +7909,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/map-previous':
-        specifier: npm:@fluidframework/map@2.4.0
+        specifier: npm:@fluidframework/map@~2.4.0
         version: /@fluidframework/map@2.4.0(debug@4.3.7)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
@@ -8042,7 +8042,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/matrix-previous':
-        specifier: npm:@fluidframework/matrix@2.4.0
+        specifier: npm:@fluidframework/matrix@~2.4.0
         version: /@fluidframework/matrix@2.4.0
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
@@ -8172,7 +8172,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/merge-tree-previous':
-        specifier: npm:@fluidframework/merge-tree@2.4.0
+        specifier: npm:@fluidframework/merge-tree@~2.4.0
         version: /@fluidframework/merge-tree@2.4.0(debug@4.3.7)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
@@ -8287,7 +8287,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/ordered-collection-previous':
-        specifier: npm:@fluidframework/ordered-collection@2.4.0
+        specifier: npm:@fluidframework/ordered-collection@~2.4.0
         version: /@fluidframework/ordered-collection@2.4.0
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
@@ -8496,7 +8496,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/register-collection-previous':
-        specifier: npm:@fluidframework/register-collection@2.4.0
+        specifier: npm:@fluidframework/register-collection@~2.4.0
         version: /@fluidframework/register-collection@2.4.0
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
@@ -8620,7 +8620,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/sequence-previous':
-        specifier: npm:@fluidframework/sequence@2.4.0
+        specifier: npm:@fluidframework/sequence@~2.4.0
         version: /@fluidframework/sequence@2.4.0
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
@@ -8750,7 +8750,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/shared-object-base-previous':
-        specifier: npm:@fluidframework/shared-object-base@2.4.0
+        specifier: npm:@fluidframework/shared-object-base@~2.4.0
         version: /@fluidframework/shared-object-base@2.4.0(debug@4.3.7)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
@@ -8859,7 +8859,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/shared-summary-block-previous':
-        specifier: npm:@fluidframework/shared-summary-block@2.4.0
+        specifier: npm:@fluidframework/shared-summary-block@~2.4.0
         version: /@fluidframework/shared-summary-block@2.4.0
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
@@ -8977,7 +8977,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/task-manager-previous':
-        specifier: npm:@fluidframework/task-manager@2.4.0
+        specifier: npm:@fluidframework/task-manager@~2.4.0
         version: /@fluidframework/task-manager@2.4.0
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
@@ -9234,7 +9234,7 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tree-previous':
-        specifier: npm:@fluidframework/tree@2.4.0
+        specifier: npm:@fluidframework/tree@~2.4.0
         version: /@fluidframework/tree@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -9343,7 +9343,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/debugger-previous':
-        specifier: npm:@fluidframework/debugger@2.4.0
+        specifier: npm:@fluidframework/debugger@~2.4.0
         version: /@fluidframework/debugger@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -9413,7 +9413,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/driver-base-previous':
-        specifier: npm:@fluidframework/driver-base@2.4.0
+        specifier: npm:@fluidframework/driver-base@~2.4.0
         version: /@fluidframework/driver-base@2.4.0(debug@4.3.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -9498,7 +9498,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/driver-web-cache-previous':
-        specifier: npm:@fluidframework/driver-web-cache@2.4.0
+        specifier: npm:@fluidframework/driver-web-cache@~2.4.0
         version: /@fluidframework/driver-web-cache@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -9577,7 +9577,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/file-driver-previous':
-        specifier: npm:@fluidframework/file-driver@2.4.0
+        specifier: npm:@fluidframework/file-driver@~2.4.0
         version: /@fluidframework/file-driver@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -9674,7 +9674,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/local-driver-previous':
-        specifier: npm:@fluidframework/local-driver@2.4.0
+        specifier: npm:@fluidframework/local-driver@~2.4.0
         version: /@fluidframework/local-driver@2.4.0(debug@4.3.7)
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -9789,7 +9789,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-driver-previous':
-        specifier: npm:@fluidframework/odsp-driver@2.4.0
+        specifier: npm:@fluidframework/odsp-driver@~2.4.0
         version: /@fluidframework/odsp-driver@2.4.0(debug@4.3.7)
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -9871,7 +9871,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-driver-definitions-previous':
-        specifier: npm:@fluidframework/odsp-driver-definitions@2.4.0
+        specifier: npm:@fluidframework/odsp-driver-definitions@~2.4.0
         version: /@fluidframework/odsp-driver-definitions@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -9941,7 +9941,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-urlresolver-previous':
-        specifier: npm:@fluidframework/odsp-urlresolver@2.4.0
+        specifier: npm:@fluidframework/odsp-urlresolver@~2.4.0
         version: /@fluidframework/odsp-urlresolver@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -10023,7 +10023,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/replay-driver-previous':
-        specifier: npm:@fluidframework/replay-driver@2.4.0
+        specifier: npm:@fluidframework/replay-driver@~2.4.0
         version: /@fluidframework/replay-driver@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -10117,7 +10117,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/routerlicious-driver-previous':
-        specifier: npm:@fluidframework/routerlicious-driver@2.4.0
+        specifier: npm:@fluidframework/routerlicious-driver@~2.4.0
         version: /@fluidframework/routerlicious-driver@2.4.0(debug@4.3.7)
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -10217,7 +10217,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/routerlicious-urlresolver-previous':
-        specifier: npm:@fluidframework/routerlicious-urlresolver@2.4.0
+        specifier: npm:@fluidframework/routerlicious-urlresolver@~2.4.0
         version: /@fluidframework/routerlicious-urlresolver@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -10308,7 +10308,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/tinylicious-driver-previous':
-        specifier: npm:@fluidframework/tinylicious-driver@2.4.0
+        specifier: npm:@fluidframework/tinylicious-driver@~2.4.0
         version: /@fluidframework/tinylicious-driver@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -10399,7 +10399,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0(@types/node@18.19.54)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/agent-scheduler-previous':
-        specifier: npm:@fluidframework/agent-scheduler@2.4.0
+        specifier: npm:@fluidframework/agent-scheduler@~2.4.0
         version: /@fluidframework/agent-scheduler@2.4.0
       '@fluidframework/build-common':
         specifier: ^2.0.3
@@ -10572,7 +10572,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0(@types/node@18.19.54)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/aqueduct-previous':
-        specifier: npm:@fluidframework/aqueduct@2.4.0
+        specifier: npm:@fluidframework/aqueduct@~2.4.0
         version: /@fluidframework/aqueduct@2.4.0(debug@4.3.7)
       '@fluidframework/build-common':
         specifier: ^2.0.3
@@ -11245,7 +11245,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/fluid-static-previous':
-        specifier: npm:@fluidframework/fluid-static@2.4.0
+        specifier: npm:@fluidframework/fluid-static@~2.4.0
         version: /@fluidframework/fluid-static@2.4.0
       '@fluidframework/map':
         specifier: workspace:~
@@ -11518,7 +11518,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/request-handler-previous':
-        specifier: npm:@fluidframework/request-handler@2.4.0
+        specifier: npm:@fluidframework/request-handler@~2.4.0
         version: /@fluidframework/request-handler@2.4.0(debug@4.3.7)
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -11606,7 +11606,7 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/runtime-utils
       '@fluidframework/synthesize-previous':
-        specifier: npm:@fluidframework/synthesize@2.4.0
+        specifier: npm:@fluidframework/synthesize@~2.4.0
         version: /@fluidframework/synthesize@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -11694,7 +11694,7 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
       '@fluidframework/undo-redo-previous':
-        specifier: npm:@fluidframework/undo-redo@2.4.0
+        specifier: npm:@fluidframework/undo-redo@~2.4.0
         version: /@fluidframework/undo-redo@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -11809,7 +11809,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/container-loader-previous':
-        specifier: npm:@fluidframework/container-loader@2.4.0
+        specifier: npm:@fluidframework/container-loader@~2.4.0
         version: /@fluidframework/container-loader@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -11921,7 +11921,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/driver-utils-previous':
-        specifier: npm:@fluidframework/driver-utils@2.4.0
+        specifier: npm:@fluidframework/driver-utils@~2.4.0
         version: /@fluidframework/driver-utils@2.4.0(debug@4.3.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -12112,7 +12112,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/container-runtime-previous':
-        specifier: npm:@fluidframework/container-runtime@2.4.0
+        specifier: npm:@fluidframework/container-runtime@~2.4.0
         version: /@fluidframework/container-runtime@2.4.0(debug@4.3.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -12206,7 +12206,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/container-runtime-definitions-previous':
-        specifier: npm:@fluidframework/container-runtime-definitions@2.4.0
+        specifier: npm:@fluidframework/container-runtime-definitions@~2.4.0
         version: /@fluidframework/container-runtime-definitions@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -12291,7 +12291,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/datastore-previous':
-        specifier: npm:@fluidframework/datastore@2.4.0
+        specifier: npm:@fluidframework/datastore@~2.4.0
         version: /@fluidframework/datastore@2.4.0(debug@4.3.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -12382,7 +12382,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/datastore-definitions-previous':
-        specifier: npm:@fluidframework/datastore-definitions@2.4.0
+        specifier: npm:@fluidframework/datastore-definitions@~2.4.0
         version: /@fluidframework/datastore-definitions@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -12458,7 +12458,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/id-compressor-previous':
-        specifier: npm:@fluidframework/id-compressor@2.4.0
+        specifier: npm:@fluidframework/id-compressor@~2.4.0
         version: /@fluidframework/id-compressor@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -12543,7 +12543,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/runtime-definitions-previous':
-        specifier: npm:@fluidframework/runtime-definitions@2.4.0
+        specifier: npm:@fluidframework/runtime-definitions@~2.4.0
         version: /@fluidframework/runtime-definitions@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -12625,7 +12625,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/runtime-utils-previous':
-        specifier: npm:@fluidframework/runtime-utils@2.4.0
+        specifier: npm:@fluidframework/runtime-utils@~2.4.0
         version: /@fluidframework/runtime-utils@2.4.0(debug@4.3.7)
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -12746,7 +12746,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils-previous':
-        specifier: npm:@fluidframework/test-runtime-utils@2.4.0
+        specifier: npm:@fluidframework/test-runtime-utils@~2.4.0
         version: /@fluidframework/test-runtime-utils@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -12846,7 +12846,7 @@ importers:
         specifier: workspace:~
         version: link:../../framework/aqueduct
       '@fluidframework/azure-client-previous':
-        specifier: npm:@fluidframework/azure-client@2.4.0
+        specifier: npm:@fluidframework/azure-client@~2.4.0
         version: /@fluidframework/azure-client@2.4.0
       '@fluidframework/azure-local-service':
         specifier: workspace:~
@@ -13342,7 +13342,7 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tinylicious-client-previous':
-        specifier: npm:@fluidframework/tinylicious-client@2.4.0
+        specifier: npm:@fluidframework/tinylicious-client@~2.4.0
         version: /@fluidframework/tinylicious-client@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -14600,7 +14600,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/test-utils-previous':
-        specifier: npm:@fluidframework/test-utils@2.4.0
+        specifier: npm:@fluidframework/test-utils@~2.4.0
         version: /@fluidframework/test-utils@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -14924,7 +14924,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/devtools-previous':
-        specifier: npm:@fluidframework/devtools@2.4.0
+        specifier: npm:@fluidframework/devtools@~2.4.0
         version: /@fluidframework/devtools@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -15259,7 +15259,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/devtools-core-previous':
-        specifier: npm:@fluidframework/devtools-core@2.4.0
+        specifier: npm:@fluidframework/devtools-core@~2.4.0
         version: /@fluidframework/devtools-core@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
@@ -15778,7 +15778,7 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0(@types/node@18.19.54)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluid-tools/fetch-tool-previous':
-        specifier: npm:@fluid-tools/fetch-tool@2.4.0
+        specifier: npm:@fluid-tools/fetch-tool@~2.4.0
         version: /@fluid-tools/fetch-tool@2.4.0
       '@fluidframework/build-common':
         specifier: ^2.0.3
@@ -15863,7 +15863,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/fluid-runner-previous':
-        specifier: npm:@fluidframework/fluid-runner@2.4.0
+        specifier: npm:@fluidframework/fluid-runner@~2.4.0
         version: /@fluidframework/fluid-runner@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -16084,7 +16084,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-doclib-utils-previous':
-        specifier: npm:@fluidframework/odsp-doclib-utils@2.4.0
+        specifier: npm:@fluidframework/odsp-doclib-utils@~2.4.0
         version: /@fluidframework/odsp-doclib-utils@2.4.0(debug@4.3.7)
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -16172,7 +16172,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/telemetry-utils-previous':
-        specifier: npm:@fluidframework/telemetry-utils@2.4.0
+        specifier: npm:@fluidframework/telemetry-utils@~2.4.0
         version: /@fluidframework/telemetry-utils@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
@@ -16278,7 +16278,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/tool-utils-previous':
-        specifier: npm:@fluidframework/tool-utils@2.4.0
+        specifier: npm:@fluidframework/tool-utils@~2.4.0
         version: /@fluidframework/tool-utils@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,8 +177,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-service-utils-previous':
-        specifier: npm:@fluidframework/azure-service-utils@~2.3.0
-        version: /@fluidframework/azure-service-utils@2.3.1
+        specifier: npm:@fluidframework/azure-service-utils@2.4.0
+        version: /@fluidframework/azure-service-utils@2.4.0
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -6395,8 +6395,8 @@ importers:
         specifier: ~1.8.3
         version: 1.8.3
       '@fluid-experimental/attributable-map-previous':
-        specifier: npm:@fluid-experimental/attributable-map@~2.3.0
-        version: /@fluid-experimental/attributable-map@2.3.1
+        specifier: npm:@fluid-experimental/attributable-map@2.4.0
+        version: /@fluid-experimental/attributable-map@2.4.0
       '@fluid-internal/mocha-test-setup':
         specifier: workspace:~
         version: link:../../../packages/test/mocha-test-setup
@@ -7192,8 +7192,8 @@ importers:
         specifier: ~1.8.3
         version: 1.8.3
       '@fluid-internal/client-utils-previous':
-        specifier: npm:@fluid-internal/client-utils@~2.3.0
-        version: /@fluid-internal/client-utils@2.3.1
+        specifier: npm:@fluid-internal/client-utils@2.4.0
+        version: /@fluid-internal/client-utils@2.4.0
       '@fluid-internal/mocha-test-setup':
         specifier: workspace:~
         version: link:../../test/mocha-test-setup
@@ -7325,8 +7325,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/container-definitions-previous':
-        specifier: npm:@fluidframework/container-definitions@~2.3.0
-        version: /@fluidframework/container-definitions@2.3.1
+        specifier: npm:@fluidframework/container-definitions@2.4.0
+        version: /@fluidframework/container-definitions@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7373,8 +7373,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/core-interfaces-previous':
-        specifier: npm:@fluidframework/core-interfaces@~2.3.0
-        version: /@fluidframework/core-interfaces@2.3.1
+        specifier: npm:@fluidframework/core-interfaces@2.4.0
+        version: /@fluidframework/core-interfaces@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7427,8 +7427,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/core-utils-previous':
-        specifier: npm:@fluidframework/core-utils@~2.3.0
-        version: /@fluidframework/core-utils@2.3.1
+        specifier: npm:@fluidframework/core-utils@2.4.0
+        version: /@fluidframework/core-utils@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7506,8 +7506,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/driver-definitions-previous':
-        specifier: npm:@fluidframework/driver-definitions@~2.3.0
-        version: /@fluidframework/driver-definitions@2.3.1
+        specifier: npm:@fluidframework/driver-definitions@2.4.0
+        version: /@fluidframework/driver-definitions@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7579,8 +7579,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/cell-previous':
-        specifier: npm:@fluidframework/cell@~2.3.0
-        version: /@fluidframework/cell@2.3.1
+        specifier: npm:@fluidframework/cell@2.4.0
+        version: /@fluidframework/cell@2.4.0
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -7682,8 +7682,8 @@ importers:
         specifier: workspace:~
         version: link:../../common/container-definitions
       '@fluidframework/counter-previous':
-        specifier: npm:@fluidframework/counter@~2.3.0
-        version: /@fluidframework/counter@2.3.1
+        specifier: npm:@fluidframework/counter@2.4.0
+        version: /@fluidframework/counter@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -7909,8 +7909,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/map-previous':
-        specifier: npm:@fluidframework/map@~2.3.0
-        version: /@fluidframework/map@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/map@2.4.0
+        version: /@fluidframework/map@2.4.0(debug@4.3.7)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8042,8 +8042,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/matrix-previous':
-        specifier: npm:@fluidframework/matrix@~2.3.0
-        version: /@fluidframework/matrix@2.3.1
+        specifier: npm:@fluidframework/matrix@2.4.0
+        version: /@fluidframework/matrix@2.4.0
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8172,8 +8172,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/merge-tree-previous':
-        specifier: npm:@fluidframework/merge-tree@~2.3.0
-        version: /@fluidframework/merge-tree@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/merge-tree@2.4.0
+        version: /@fluidframework/merge-tree@2.4.0(debug@4.3.7)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8287,8 +8287,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/ordered-collection-previous':
-        specifier: npm:@fluidframework/ordered-collection@~2.3.0
-        version: /@fluidframework/ordered-collection@2.3.1
+        specifier: npm:@fluidframework/ordered-collection@2.4.0
+        version: /@fluidframework/ordered-collection@2.4.0
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8496,8 +8496,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/register-collection-previous':
-        specifier: npm:@fluidframework/register-collection@~2.3.0
-        version: /@fluidframework/register-collection@2.3.1
+        specifier: npm:@fluidframework/register-collection@2.4.0
+        version: /@fluidframework/register-collection@2.4.0
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8620,8 +8620,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/sequence-previous':
-        specifier: npm:@fluidframework/sequence@~2.3.0
-        version: /@fluidframework/sequence@2.3.1
+        specifier: npm:@fluidframework/sequence@2.4.0
+        version: /@fluidframework/sequence@2.4.0
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8750,8 +8750,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/shared-object-base-previous':
-        specifier: npm:@fluidframework/shared-object-base@~2.3.0
-        version: /@fluidframework/shared-object-base@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/shared-object-base@2.4.0
+        version: /@fluidframework/shared-object-base@2.4.0(debug@4.3.7)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8859,8 +8859,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/shared-summary-block-previous':
-        specifier: npm:@fluidframework/shared-summary-block@~2.3.0
-        version: /@fluidframework/shared-summary-block@2.3.1
+        specifier: npm:@fluidframework/shared-summary-block@2.4.0
+        version: /@fluidframework/shared-summary-block@2.4.0
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8977,8 +8977,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/task-manager-previous':
-        specifier: npm:@fluidframework/task-manager@~2.3.0
-        version: /@fluidframework/task-manager@2.3.1
+        specifier: npm:@fluidframework/task-manager@2.4.0
+        version: /@fluidframework/task-manager@2.4.0
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9234,8 +9234,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tree-previous':
-        specifier: npm:@fluidframework/tree@~2.3.0
-        version: /@fluidframework/tree@2.3.1
+        specifier: npm:@fluidframework/tree@2.4.0
+        version: /@fluidframework/tree@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -9343,8 +9343,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/debugger-previous':
-        specifier: npm:@fluidframework/debugger@~2.3.0
-        version: /@fluidframework/debugger@2.3.1
+        specifier: npm:@fluidframework/debugger@2.4.0
+        version: /@fluidframework/debugger@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9413,8 +9413,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/driver-base-previous':
-        specifier: npm:@fluidframework/driver-base@~2.3.0
-        version: /@fluidframework/driver-base@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/driver-base@2.4.0
+        version: /@fluidframework/driver-base@2.4.0(debug@4.3.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9498,8 +9498,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/driver-web-cache-previous':
-        specifier: npm:@fluidframework/driver-web-cache@~2.3.0
-        version: /@fluidframework/driver-web-cache@2.3.1
+        specifier: npm:@fluidframework/driver-web-cache@2.4.0
+        version: /@fluidframework/driver-web-cache@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -9577,8 +9577,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/file-driver-previous':
-        specifier: npm:@fluidframework/file-driver@~2.3.0
-        version: /@fluidframework/file-driver@2.3.1
+        specifier: npm:@fluidframework/file-driver@2.4.0
+        version: /@fluidframework/file-driver@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -9674,8 +9674,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/local-driver-previous':
-        specifier: npm:@fluidframework/local-driver@~2.3.0
-        version: /@fluidframework/local-driver@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/local-driver@2.4.0
+        version: /@fluidframework/local-driver@2.4.0(debug@4.3.7)
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -9789,8 +9789,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-driver-previous':
-        specifier: npm:@fluidframework/odsp-driver@~2.3.0
-        version: /@fluidframework/odsp-driver@2.3.1
+        specifier: npm:@fluidframework/odsp-driver@2.4.0
+        version: /@fluidframework/odsp-driver@2.4.0(debug@4.3.7)
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -9871,8 +9871,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-driver-definitions-previous':
-        specifier: npm:@fluidframework/odsp-driver-definitions@~2.3.0
-        version: /@fluidframework/odsp-driver-definitions@2.3.1
+        specifier: npm:@fluidframework/odsp-driver-definitions@2.4.0
+        version: /@fluidframework/odsp-driver-definitions@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -9941,8 +9941,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-urlresolver-previous':
-        specifier: npm:@fluidframework/odsp-urlresolver@~2.3.0
-        version: /@fluidframework/odsp-urlresolver@2.3.1
+        specifier: npm:@fluidframework/odsp-urlresolver@2.4.0
+        version: /@fluidframework/odsp-urlresolver@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -10023,8 +10023,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/replay-driver-previous':
-        specifier: npm:@fluidframework/replay-driver@~2.3.0
-        version: /@fluidframework/replay-driver@2.3.1
+        specifier: npm:@fluidframework/replay-driver@2.4.0
+        version: /@fluidframework/replay-driver@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -10117,8 +10117,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/routerlicious-driver-previous':
-        specifier: npm:@fluidframework/routerlicious-driver@~2.3.0
-        version: /@fluidframework/routerlicious-driver@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/routerlicious-driver@2.4.0
+        version: /@fluidframework/routerlicious-driver@2.4.0(debug@4.3.7)
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -10217,8 +10217,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/routerlicious-urlresolver-previous':
-        specifier: npm:@fluidframework/routerlicious-urlresolver@~2.3.0
-        version: /@fluidframework/routerlicious-urlresolver@2.3.1
+        specifier: npm:@fluidframework/routerlicious-urlresolver@2.4.0
+        version: /@fluidframework/routerlicious-urlresolver@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -10308,8 +10308,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/tinylicious-driver-previous':
-        specifier: npm:@fluidframework/tinylicious-driver@~2.3.0
-        version: /@fluidframework/tinylicious-driver@2.3.1
+        specifier: npm:@fluidframework/tinylicious-driver@2.4.0
+        version: /@fluidframework/tinylicious-driver@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -10399,8 +10399,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0(@types/node@18.19.54)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/agent-scheduler-previous':
-        specifier: npm:@fluidframework/agent-scheduler@~2.3.0
-        version: /@fluidframework/agent-scheduler@2.3.1
+        specifier: npm:@fluidframework/agent-scheduler@2.4.0
+        version: /@fluidframework/agent-scheduler@2.4.0
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10572,8 +10572,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0(@types/node@18.19.54)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/aqueduct-previous':
-        specifier: npm:@fluidframework/aqueduct@~2.3.0
-        version: /@fluidframework/aqueduct@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/aqueduct@2.4.0
+        version: /@fluidframework/aqueduct@2.4.0(debug@4.3.7)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -11245,8 +11245,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/fluid-static-previous':
-        specifier: npm:@fluidframework/fluid-static@~2.3.0
-        version: /@fluidframework/fluid-static@2.3.1
+        specifier: npm:@fluidframework/fluid-static@2.4.0
+        version: /@fluidframework/fluid-static@2.4.0
       '@fluidframework/map':
         specifier: workspace:~
         version: link:../../dds/map
@@ -11518,8 +11518,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/request-handler-previous':
-        specifier: npm:@fluidframework/request-handler@~2.3.0
-        version: /@fluidframework/request-handler@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/request-handler@2.4.0
+        version: /@fluidframework/request-handler@2.4.0(debug@4.3.7)
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -11606,8 +11606,8 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/runtime-utils
       '@fluidframework/synthesize-previous':
-        specifier: npm:@fluidframework/synthesize@~2.3.0
-        version: /@fluidframework/synthesize@2.3.1
+        specifier: npm:@fluidframework/synthesize@2.4.0
+        version: /@fluidframework/synthesize@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -11694,8 +11694,8 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
       '@fluidframework/undo-redo-previous':
-        specifier: npm:@fluidframework/undo-redo@~2.3.0
-        version: /@fluidframework/undo-redo@2.3.1
+        specifier: npm:@fluidframework/undo-redo@2.4.0
+        version: /@fluidframework/undo-redo@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -11809,8 +11809,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/container-loader-previous':
-        specifier: npm:@fluidframework/container-loader@~2.3.0
-        version: /@fluidframework/container-loader@2.3.1
+        specifier: npm:@fluidframework/container-loader@2.4.0
+        version: /@fluidframework/container-loader@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -11921,8 +11921,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/driver-utils-previous':
-        specifier: npm:@fluidframework/driver-utils@~2.3.0
-        version: /@fluidframework/driver-utils@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/driver-utils@2.4.0
+        version: /@fluidframework/driver-utils@2.4.0(debug@4.3.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12112,8 +12112,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/container-runtime-previous':
-        specifier: npm:@fluidframework/container-runtime@~2.3.0
-        version: /@fluidframework/container-runtime@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/container-runtime@2.4.0
+        version: /@fluidframework/container-runtime@2.4.0(debug@4.3.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12206,8 +12206,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/container-runtime-definitions-previous':
-        specifier: npm:@fluidframework/container-runtime-definitions@~2.3.0
-        version: /@fluidframework/container-runtime-definitions@2.3.1
+        specifier: npm:@fluidframework/container-runtime-definitions@2.4.0
+        version: /@fluidframework/container-runtime-definitions@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12291,8 +12291,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/datastore-previous':
-        specifier: npm:@fluidframework/datastore@~2.3.0
-        version: /@fluidframework/datastore@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/datastore@2.4.0
+        version: /@fluidframework/datastore@2.4.0(debug@4.3.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12382,8 +12382,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/datastore-definitions-previous':
-        specifier: npm:@fluidframework/datastore-definitions@~2.3.0
-        version: /@fluidframework/datastore-definitions@2.3.1
+        specifier: npm:@fluidframework/datastore-definitions@2.4.0
+        version: /@fluidframework/datastore-definitions@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -12458,8 +12458,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/id-compressor-previous':
-        specifier: npm:@fluidframework/id-compressor@~2.3.0
-        version: /@fluidframework/id-compressor@2.3.1
+        specifier: npm:@fluidframework/id-compressor@2.4.0
+        version: /@fluidframework/id-compressor@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -12543,8 +12543,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/runtime-definitions-previous':
-        specifier: npm:@fluidframework/runtime-definitions@~2.3.0
-        version: /@fluidframework/runtime-definitions@2.3.1
+        specifier: npm:@fluidframework/runtime-definitions@2.4.0
+        version: /@fluidframework/runtime-definitions@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -12625,8 +12625,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/runtime-utils-previous':
-        specifier: npm:@fluidframework/runtime-utils@~2.3.0
-        version: /@fluidframework/runtime-utils@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/runtime-utils@2.4.0
+        version: /@fluidframework/runtime-utils@2.4.0(debug@4.3.7)
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -12746,8 +12746,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils-previous':
-        specifier: npm:@fluidframework/test-runtime-utils@~2.3.0
-        version: /@fluidframework/test-runtime-utils@2.3.1
+        specifier: npm:@fluidframework/test-runtime-utils@2.4.0
+        version: /@fluidframework/test-runtime-utils@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -12846,8 +12846,8 @@ importers:
         specifier: workspace:~
         version: link:../../framework/aqueduct
       '@fluidframework/azure-client-previous':
-        specifier: npm:@fluidframework/azure-client@~2.3.0
-        version: /@fluidframework/azure-client@2.3.1
+        specifier: npm:@fluidframework/azure-client@2.4.0
+        version: /@fluidframework/azure-client@2.4.0
       '@fluidframework/azure-local-service':
         specifier: workspace:~
         version: link:../../../azure/packages/azure-local-service
@@ -13342,8 +13342,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tinylicious-client-previous':
-        specifier: npm:@fluidframework/tinylicious-client@~2.3.0
-        version: /@fluidframework/tinylicious-client@2.3.1
+        specifier: npm:@fluidframework/tinylicious-client@2.4.0
+        version: /@fluidframework/tinylicious-client@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -14600,8 +14600,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/test-utils-previous':
-        specifier: npm:@fluidframework/test-utils@~2.3.0
-        version: /@fluidframework/test-utils@2.3.1
+        specifier: npm:@fluidframework/test-utils@2.4.0
+        version: /@fluidframework/test-utils@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -14924,8 +14924,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/devtools-previous':
-        specifier: npm:@fluidframework/devtools@~2.3.0
-        version: /@fluidframework/devtools@2.3.1
+        specifier: npm:@fluidframework/devtools@2.4.0
+        version: /@fluidframework/devtools@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -15259,8 +15259,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0
       '@fluidframework/devtools-core-previous':
-        specifier: npm:@fluidframework/devtools-core@~2.3.0
-        version: /@fluidframework/devtools-core@2.3.1
+        specifier: npm:@fluidframework/devtools-core@2.4.0
+        version: /@fluidframework/devtools-core@2.4.0
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
@@ -15778,8 +15778,8 @@ importers:
         specifier: ^0.49.0
         version: 0.49.0(@types/node@18.19.54)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluid-tools/fetch-tool-previous':
-        specifier: npm:@fluid-tools/fetch-tool@~2.3.0
-        version: /@fluid-tools/fetch-tool@2.3.1
+        specifier: npm:@fluid-tools/fetch-tool@2.4.0
+        version: /@fluid-tools/fetch-tool@2.4.0
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -15863,8 +15863,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/fluid-runner-previous':
-        specifier: npm:@fluidframework/fluid-runner@~2.3.0
-        version: /@fluidframework/fluid-runner@2.3.1
+        specifier: npm:@fluidframework/fluid-runner@2.4.0
+        version: /@fluidframework/fluid-runner@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -16084,8 +16084,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-doclib-utils-previous':
-        specifier: npm:@fluidframework/odsp-doclib-utils@~2.3.0
-        version: /@fluidframework/odsp-doclib-utils@2.3.1(debug@4.3.7)
+        specifier: npm:@fluidframework/odsp-doclib-utils@2.4.0
+        version: /@fluidframework/odsp-doclib-utils@2.4.0(debug@4.3.7)
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -16172,8 +16172,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/telemetry-utils-previous':
-        specifier: npm:@fluidframework/telemetry-utils@~2.3.0
-        version: /@fluidframework/telemetry-utils@2.3.1
+        specifier: npm:@fluidframework/telemetry-utils@2.4.0
+        version: /@fluidframework/telemetry-utils@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -16278,8 +16278,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/tool-utils-previous':
-        specifier: npm:@fluidframework/tool-utils@~2.3.0
-        version: /@fluidframework/tool-utils@2.3.1
+        specifier: npm:@fluidframework/tool-utils@2.4.0
+        version: /@fluidframework/tool-utils@2.4.0
       '@microsoft/api-extractor':
         specifier: 7.47.8
         version: 7.47.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.54)
@@ -19235,29 +19235,29 @@ packages:
       tslib: 2.7.0
     dev: false
 
-  /@fluid-experimental/attributable-map@2.3.1:
-    resolution: {integrity: sha512-ZXpN9roT4GbrphJem3hwzKJJt5+84elYT66WsF9RykJPJb8lJaawmT9w4JQEXErwNgwCYr/vu5U4yH1MY+uZCw==}
+  /@fluid-experimental/attributable-map@2.4.0:
+    resolution: {integrity: sha512-V/pp6WUEOX8D49S92fi2QKKzWtv0VDfPkjiF8lTJQKtHF2PP/M5xqPwE2sTKxQZUK8In7VfD8RVBPSGw1jvonw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-internal/client-utils@2.3.1:
-    resolution: {integrity: sha512-iXuJ8eSnwixisOW8em9IzMBeAUT4ZTFOplPTFN4Oi3cl/kMMzqG9bot9KgLGPHxRvBIc/O9fWJt7gCOt8RzlhQ==}
+  /@fluid-internal/client-utils@2.4.0:
+    resolution: {integrity: sha512-/WIRn90yUclI05awdqn9sNR44I1s4EcrIffezn4eyS2yHaZyMHAeMJxx/1xQyIRgYjUSQj8UeTQeyEKVDrIGHw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
       '@types/events_pkg': /@types/events@3.0.3
       base64-js: 1.5.1
       buffer: 6.0.3
@@ -19276,11 +19276,11 @@ packages:
       - supports-color
       - typescript
 
-  /@fluid-internal/test-driver-definitions@2.3.1:
-    resolution: {integrity: sha512-NOI2q5zRIJDuT2sg4EKp1u3zoRHBCRg6mjXY+LTnZx3sCSg/2c+byekfFqR0HyPsh6tSJ/KdaT9Qq6YBMJDnBQ==}
+  /@fluid-internal/test-driver-definitions@2.4.0:
+    resolution: {integrity: sha512-bx/h8LQ6T0AUfm2WfyQp/W3vrlPZ8MXxBXL1Tq1PS2+UBrMb63nYglm0JstgpJsuHT6oqZSSS8DmpEWAAo0Y1w==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
     dev: true
 
   /@fluid-tools/benchmark@0.50.0:
@@ -19454,26 +19454,26 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/fetch-tool@2.3.1:
-    resolution: {integrity: sha512-8Y7ncBm6l7xhdMXP9Tn2+KaB2B+lSneFwwo3GStJkNy6EeZV+YO2FICuVi7BbTGJDTrYW5jUSC2rLBr6jJK3TQ==}
+  /@fluid-tools/fetch-tool@2.4.0:
+    resolution: {integrity: sha512-mu7gcA8232MXn5LdrvlLE5ivhsw4SvoUs5T2bRb/O3ZMGgVejuTca7Av6AjzVD/DISifRcRHb1xirfeujqxjhg==}
     hasBin: true
     dependencies:
       '@azure/identity': 4.4.1
       '@azure/identity-cache-persistence': 1.1.1
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/container-runtime': 2.3.1(debug@4.3.7)
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore': 2.3.1(debug@4.3.7)
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/odsp-doclib-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/odsp-driver': 2.3.1
-      '@fluidframework/odsp-driver-definitions': 2.3.1
-      '@fluidframework/odsp-urlresolver': 2.3.1
-      '@fluidframework/routerlicious-driver': 2.3.1(debug@4.3.7)
-      '@fluidframework/routerlicious-urlresolver': 2.3.1
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/tool-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/container-runtime': 2.4.0(debug@4.3.7)
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore': 2.4.0(debug@4.3.7)
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/odsp-doclib-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/odsp-driver': 2.4.0(debug@4.3.7)
+      '@fluidframework/odsp-driver-definitions': 2.4.0
+      '@fluidframework/odsp-urlresolver': 2.4.0
+      '@fluidframework/routerlicious-driver': 2.4.0(debug@4.3.7)
+      '@fluidframework/routerlicious-urlresolver': 2.4.0
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/tool-utils': 2.4.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -19498,20 +19498,20 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluidframework/agent-scheduler@2.3.1:
-    resolution: {integrity: sha512-ica848TaxZMaAocB77m5MbsUUtrbqM6moR9rs8RrUSJhSaHlDxnsqpZIim12j/BnT5VbrU84UzEQ12z2AH9tOQ==}
+  /@fluidframework/agent-scheduler@2.4.0:
+    resolution: {integrity: sha512-YiTGTr1kuSN8nLjHr/6/nUxxXm9GRowpRGwGhAgTFoqF9RsBB3XCIRJTqvTAQGqT/UQ/xfGnWEjLv4iQ/1aCGg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore': 2.3.1(debug@4.3.7)
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/map': 2.3.1(debug@4.3.7)
-      '@fluidframework/register-collection': 2.3.1
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore': 2.4.0(debug@4.3.7)
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/map': 2.4.0(debug@4.3.7)
+      '@fluidframework/register-collection': 2.4.0
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
@@ -19542,23 +19542,23 @@ packages:
       - supports-color
     dev: false
 
-  /@fluidframework/aqueduct@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-4IbRHVvDbTWs9I/lx8emuQ3bJVzDWW87yA4ZbjxvKW/5vAEnyIq/+0XC0RFhVynZVJXQqkwLV8SsGc/bdIH/dA==}
+  /@fluidframework/aqueduct@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-pUptq5htEXURujfK+NRzNNOXL1wcutAiY3v4a2mqF3f9zaVmGTmMqcPO8gnFcc9S9Sn2IPoNH4yICmcSdDEQtw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/container-runtime': 2.3.1(debug@4.3.7)
-      '@fluidframework/container-runtime-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore': 2.3.1(debug@4.3.7)
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/map': 2.3.1(debug@4.3.7)
-      '@fluidframework/request-handler': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
-      '@fluidframework/synthesize': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/container-runtime': 2.4.0(debug@4.3.7)
+      '@fluidframework/container-runtime-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore': 2.4.0(debug@4.3.7)
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/map': 2.4.0(debug@4.3.7)
+      '@fluidframework/request-handler': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
+      '@fluidframework/synthesize': 2.4.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -19595,20 +19595,20 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@fluidframework/azure-client@2.3.1:
-    resolution: {integrity: sha512-TvOgnJ5IZb3BQ4QHJOql1x1cciHOfY2/r+Q6pBiePFa3RmDe+nJCAbpza+fJ48vynPfY1ThYrNrPqRlpdRpXvg==}
+  /@fluidframework/azure-client@2.4.0:
+    resolution: {integrity: sha512-Xs1J7t7WmG0Mqx9JcHG6bQd1fO9GhA6e9XXTTTmY5g5qbLewpJqUTWTXw65tcLIr6TRtQ4GRTZi7K8SalFKK/w==}
     dependencies:
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/container-loader': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/fluid-static': 2.3.1
-      '@fluidframework/map': 2.3.1(debug@4.3.7)
-      '@fluidframework/routerlicious-driver': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/container-loader': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/fluid-static': 2.4.0
+      '@fluidframework/map': 2.4.0(debug@4.3.7)
+      '@fluidframework/routerlicious-driver': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -19617,10 +19617,10 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/azure-service-utils@2.3.1:
-    resolution: {integrity: sha512-Dze6JPCnxdb4XBESYXs6A+ioL153G7R4gMrgMJyzDNpuCPs+zcWQ0Lyq/JMvE863xz0hPqNTskJ0joj999pCRw==}
+  /@fluidframework/azure-service-utils@2.4.0:
+    resolution: {integrity: sha512-bYejUU9YBXt6+Y5eD8Rkp+Mk6K4LBuZK29NTxqwRsnMi4SKofHRKcuol6BJZSnw9jdD31qMe75pmI6enNGI3Qg==}
     dependencies:
-      '@fluidframework/driver-definitions': 2.3.1
+      '@fluidframework/driver-definitions': 2.4.0
       jsrsasign: 11.1.0
       uuid: 9.0.1
     dev: true
@@ -19679,16 +19679,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/cell@2.3.1:
-    resolution: {integrity: sha512-EBV/JxgjHyK7nWlH9VfZ+vBmRIyHBaUsTOE6cu8uL6ry9zMxVePUKWClVyFkcJ103Tr9XAVwd4FMc1ZOXMb5iA==}
+  /@fluidframework/cell@2.4.0:
+    resolution: {integrity: sha512-4WFGL1e+Q+dIMngkhEi+YoFDKXIPFiBMT2onl5ATudYwM0loFYcW6onrcOOEFqIS2ZKEd2QHYxJitPg2rhY3Qw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -19746,11 +19746,11 @@ packages:
       events: 3.3.0
     dev: false
 
-  /@fluidframework/container-definitions@2.3.1:
-    resolution: {integrity: sha512-GBQsHs7o0wbPxwFeyqRX85SqI9ygeptYHrA++I6W2yKZvmDDm1oY97W/MAZ6B8yYJkzcXduNratxJOF2lfmDwg==}
+  /@fluidframework/container-definitions@2.4.0:
+    resolution: {integrity: sha512-Q8ayKIxUFANdUk7FjpIc3GGDf7B4RjlxPAeAmfe5X2wyPZWOhSd0Lf8UeU/CIOcPjnd0kjWNOGqKy3eaculgJQ==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
     dev: true
 
   /@fluidframework/container-loader@1.4.0:
@@ -19777,16 +19777,16 @@ packages:
       - supports-color
     dev: false
 
-  /@fluidframework/container-loader@2.3.1:
-    resolution: {integrity: sha512-lZpHPVkHiOkEMu3TgIbtw7Z8Kl5cVC9qIrjqpc7aUFPERglZuPN9C4ky0tQA9cQLFqkRx0D+mHxIJh+yAl8h+Q==}
+  /@fluidframework/container-loader@2.4.0:
+    resolution: {integrity: sha512-BEVDrMqNCpbV492XJKRkTE8l53eM6lfgOJ+LBe0w+JYInKNf4H+c+BGYFI5JBT7lZHhqUKYe7JQgEYFqMimmdQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
       '@types/events_pkg': /@types/events@3.0.3
       '@ungap/structured-clone': 1.2.0
       debug: 4.3.7(supports-color@8.1.1)
@@ -19808,13 +19808,13 @@ packages:
       '@fluidframework/runtime-definitions': 1.4.0
     dev: false
 
-  /@fluidframework/container-runtime-definitions@2.3.1:
-    resolution: {integrity: sha512-3o9tQlsLIoTViuxDabxdLGFvghfdhLCyu7PX8FLiTkziiW3wUhnT/iw78xiH/Cvybb+FArSATENg8CQ2+0Twew==}
+  /@fluidframework/container-runtime-definitions@2.4.0:
+    resolution: {integrity: sha512-lyiirgnTFEllddwNZ65zpYkAiCR+4RG16OpUCGCafj+3zM1VIow01Ud4LgTb3RMyJnoOVR0D+c274Kws4VVwWQ==}
     dependencies:
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/runtime-definitions': 2.3.1
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/runtime-definitions': 2.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -19845,21 +19845,21 @@ packages:
       - supports-color
     dev: false
 
-  /@fluidframework/container-runtime@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-6f7nbyOL9VYXOvSZNQEiDqKX9ejeng4Bnf4puamGnwHBVmk7rikfofu7GZrqAPNTreJATIw9GY9M7TuVqOTaXA==}
+  /@fluidframework/container-runtime@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-JtPXueIkt05LKqHII/mo+qZaEecO+kPDk46cj9LS5K4aRLtbzz4RJW1jCdxLJlW9y9dHUGTIFCXXkAbzzFHIwA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/container-runtime-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore': 2.3.1(debug@4.3.7)
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/id-compressor': 2.3.1
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/container-runtime-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore': 2.4.0(debug@4.3.7)
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/id-compressor': 2.4.0
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
       '@tylerbu/sorted-btree-es6': 1.8.0
       double-ended-queue: 2.1.0-0
       lz4js: 0.2.0
@@ -19885,24 +19885,24 @@ packages:
     resolution: {integrity: sha512-PDIglmsa9BgFh7Xhfs32KA3Q34/arTVHF4m3M0IuAByP4z8Oi2lVuNENZnBEk+IJMcrUhUDk5Q9LH8KGfoAw+Q==}
     dev: false
 
-  /@fluidframework/core-interfaces@2.3.1:
-    resolution: {integrity: sha512-kvPrJsBEoMuPZNzofSrzMWZ2JhpUEQy7wsJ4Be4fayfiFaLF/ZCjciHgqtqx19pgjBqACYcKaP1yzFF5pldSdA==}
+  /@fluidframework/core-interfaces@2.4.0:
+    resolution: {integrity: sha512-VoEa4QGfR9Dtwnz2hIvcXft/K37r0k2Ian2hZV03X/mlBeFh7W7kroQUMq3ymdY+qC5WQUEynr143DT30NN/lg==}
     dev: true
 
-  /@fluidframework/core-utils@2.3.1:
-    resolution: {integrity: sha512-hzBeIYQvPXmLmmUjyG1LxHFzR3v0r97teQS1wO7Og/otQC1PCFwUNxPtOgMzYQxdnXsBxhLTlWRY+1ON8JF5JA==}
+  /@fluidframework/core-utils@2.4.0:
+    resolution: {integrity: sha512-vUFehDNFHdAc+h+wV4KI69DUXOAIpYaqb8teKxtQltnHMdx5RxgN0w28ECoeHTxSdr4sU7vTWov7AhqH51HxfA==}
     dev: true
 
-  /@fluidframework/counter@2.3.1:
-    resolution: {integrity: sha512-Kb95TR89qAHm/fy5XNlk1fdJXyx69hN4V9Rq0pBFS1oLehoOMiagmXGZHrhDVgNl/GEJlJIbLpsYZ0OpE4fE9g==}
+  /@fluidframework/counter@2.4.0:
+    resolution: {integrity: sha512-PfK6DnXGt2y5pTFSgGDi3dHhlwG/9hJWcuyU9DamAm7n4lTOI+p2btXwToDytreXiyMfgKNxOeVvTk2kEVhycA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -19919,14 +19919,14 @@ packages:
       '@fluidframework/runtime-definitions': 1.4.0
     dev: false
 
-  /@fluidframework/datastore-definitions@2.3.1:
-    resolution: {integrity: sha512-f5KK6BxzE1rTJJoS/OtnNdURuuKDOEf0ikXmLhbB1SPZ7Uqy/lq2+nBU9c2JQlirvM0t6VeMXreHuI4NgyPV6Q==}
+  /@fluidframework/datastore-definitions@2.4.0:
+    resolution: {integrity: sha512-P2E/S5fuOo6CCy3beJAFuzyvqdvR+oyHuqnxTMUy7IqhRr4Og+YKuRnmIf4Ieb+hKJYdblJIOXlgJ+SYC+Y44Q==}
     dependencies:
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/id-compressor': 2.3.1
-      '@fluidframework/runtime-definitions': 2.3.1
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/id-compressor': 2.4.0
+      '@fluidframework/runtime-definitions': 2.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -19955,68 +19955,68 @@ packages:
       - supports-color
     dev: false
 
-  /@fluidframework/datastore@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-WUTTlgZRBSzGJalhS42Pc0uMtBeZu42mGdJe4c4McqxRQsj2Lsuvr8/6cLKgzQZMPttCWTpi26oedlqVQr8JTA==}
+  /@fluidframework/datastore@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-gapyHUKqI951iROJY8B46H1vvB5hg5+794lvmsy+esYv87hA0VZP0rO1Zwp9mbjWPOQ0dYZRKYE3uRYwhuwoqA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/id-compressor': 2.3.1
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/id-compressor': 2.4.0
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/debugger@2.3.1:
-    resolution: {integrity: sha512-VkeyCgABLZRcQ5ELxfcjNO3Nv1Gf4r4aLhtTadCVPr5uqxKJo0tbjviZyaYf4Xph6XfasyfVNHT6eVUhANPQAA==}
+  /@fluidframework/debugger@2.4.0:
+    resolution: {integrity: sha512-fMqcIMp0sU95vZd4s0GHxkl5XGtAHyf0iMLemMjEHEq2GwbwA1x0YT6xYvupEkRUBZ6BaZfXYBF6B7/9ReStRg==}
     dependencies:
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/replay-driver': 2.3.1
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/replay-driver': 2.4.0
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/devtools-core@2.3.1:
-    resolution: {integrity: sha512-z0gZXxwoqdD5gOcEVIMvi8WMV9ROWHcgCTakJcUVdFX4w/WBOxTDMMD0hiOK8RQiL25TLiqP+tUQgC7/5pgogg==}
+  /@fluidframework/devtools-core@2.4.0:
+    resolution: {integrity: sha512-p40lpQABOBQdcaMtpLLai7/dm2706bLaWoIMVLmRc6790l64QaD+GBnsmwATLoa7489Z+tn+pSEsmEW2AZwtZw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/cell': 2.3.1
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/container-loader': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/counter': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/map': 2.3.1(debug@4.3.7)
-      '@fluidframework/matrix': 2.3.1
-      '@fluidframework/sequence': 2.3.1
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
-      '@fluidframework/tree': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/cell': 2.4.0
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/container-loader': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/counter': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/map': 2.4.0(debug@4.3.7)
+      '@fluidframework/matrix': 2.4.0
+      '@fluidframework/sequence': 2.4.0
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
+      '@fluidframework/tree': 2.4.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/devtools@2.3.1:
-    resolution: {integrity: sha512-A8vC5uj8ClHpZGDVJCEOR0y2ndEpuxIU+gt/Bb+7WDZ0XDgbt7lEwyVa8nK2IGyzvl5fCpvch7/AoF0TEbaG/w==}
+  /@fluidframework/devtools@2.4.0:
+    resolution: {integrity: sha512-oj3TXUGCdHNyZYySCYoJVg7+UglcqF3bveuMALPWjf3jyEvrCedeHzN/L0HjwWZkEGHW/yQqHLIGu+QIvfkoqg==}
     dependencies:
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/devtools-core': 2.3.1
-      '@fluidframework/fluid-static': 2.3.1
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/devtools-core': 2.4.0
+      '@fluidframework/fluid-static': 2.4.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -20036,15 +20036,15 @@ packages:
       - supports-color
     dev: false
 
-  /@fluidframework/driver-base@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-NJNAXA9NbA6IAbfCNxVsQ8hGd0mOX1ACqz6X8Uo8hTIofG6x8p5bXKgGAny3O411vzj+sRnay2u01RvGKVMt+w==}
+  /@fluidframework/driver-base@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-jr8G7z7SvZGDViONsZ+lh8HsETdxefd8dgxVyVDlfLRwOiQFK6qB1exgqNo6kTYmhovs7GworzFV780kcyMmCA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -20058,10 +20058,10 @@ packages:
       '@fluidframework/protocol-definitions': 0.1028.2000
     dev: false
 
-  /@fluidframework/driver-definitions@2.3.1:
-    resolution: {integrity: sha512-yRpzyjYKmg4B4rIh8e8ba2Gij2ndTJ1ckFl2zAGaE6GuRJ6Loj77Yi9NlVBD0BJJ35XrlWsDgvsPx/h6aPULAw==}
+  /@fluidframework/driver-definitions@2.4.0:
+    resolution: {integrity: sha512-0IYc/iJtUMU/4+vNJMjBTN6SKgrvsghRsPBgZGnr5vPP1TaPDN9pM8WkrzoLXv+gZahXjBf6HiDkJd/ikiIR0w==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.3.1
+      '@fluidframework/core-interfaces': 2.4.0
     dev: true
 
   /@fluidframework/driver-utils@1.4.0:
@@ -20082,14 +20082,14 @@ packages:
       - supports-color
     dev: false
 
-  /@fluidframework/driver-utils@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-xmUZZhJjMRHWlINXV6/aBEqP59FVmsjyklVMow6JXVSvGWo2Scre/5vkCYNLSFqM3SwRzATg0wk0/TOSLyOEeg==}
+  /@fluidframework/driver-utils@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-aXan9NYRQq51shRcVMAhot32VNMlH2jFLAwJucRyAsyrweny3kFmMrk6fzb6d21K2ey0CP12fbxAInIFr3HQ5w==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/telemetry-utils': 2.4.0
       axios: 1.7.7(debug@4.3.7)
       lz4js: 0.2.0
       uuid: 9.0.1
@@ -20098,13 +20098,13 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-web-cache@2.3.1:
-    resolution: {integrity: sha512-iqbrkFjFW1FN4ApCe1eBENqlsQ5ElWMf+EmJ1YUQ84L4C4dhtVJCjFq/ev0fweom2s/hCygqb9Gpuu5JjtJBow==}
+  /@fluidframework/driver-web-cache@2.4.0:
+    resolution: {integrity: sha512-3JCJodBU4pqTBmIvYISdvVnFbeEBv7eW/srtOTidcBr3GATW62oAoXwLad3df/vFrEndQcXkx0s8Fk8/tuet+g==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/odsp-driver-definitions': 2.3.1
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/odsp-driver-definitions': 2.4.0
+      '@fluidframework/telemetry-utils': 2.4.0
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -20139,32 +20139,32 @@ packages:
       - supports-color
       - typescript
 
-  /@fluidframework/file-driver@2.3.1:
-    resolution: {integrity: sha512-cxRCUTT0v4QYxKG+A3HCy+Dnaq/QZ1kLSrTogq8ezmbhUJtLD9kVOOTHFIK/AOIxwUfqbzOI2TVDjPW1/qyCMA==}
+  /@fluidframework/file-driver@2.4.0:
+    resolution: {integrity: sha512-vGEarSzIDIo/8LtAx/fjiAgmBG/3TOyI2kN4Q/RIa6qg02EPCYH71ss2nEpnPlwn7edOTXlKGZvOsuwDrRQNsw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/replay-driver': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/replay-driver': 2.4.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/fluid-runner@2.3.1:
-    resolution: {integrity: sha512-8ZytbFkIlfJ719rKTUtQEPrHHe0rV5krKiWI9j6A4o8PgqTDcK3meVotTLowC3dC7TbHv+KPiuw9O+PVvhjI6w==}
+  /@fluidframework/fluid-runner@2.4.0:
+    resolution: {integrity: sha512-2ChK0IcolwgerFJTXMpyPLWAKgrix8fDyhtbCCfwJbIWNQaAfmJrbZskSldZ4JufKmvYuwFEKDJ21TUVHfTPMw==}
     hasBin: true
     dependencies:
-      '@fluidframework/aqueduct': 2.3.1(debug@4.3.7)
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/container-loader': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/odsp-driver': 2.3.1
-      '@fluidframework/odsp-driver-definitions': 2.3.1
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluidframework/aqueduct': 2.4.0(debug@4.3.7)
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/container-loader': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/odsp-driver': 2.4.0(debug@4.3.7)
+      '@fluidframework/odsp-driver-definitions': 2.4.0
+      '@fluidframework/telemetry-utils': 2.4.0
       json2csv: 5.0.7
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -20195,23 +20195,23 @@ packages:
       - supports-color
     dev: false
 
-  /@fluidframework/fluid-static@2.3.1:
-    resolution: {integrity: sha512-n3706urSiO32H4DwaNE1sRKL+b07W+zOmRhB6Gdy2IH2jIOKolGtTsLIAG4PWEsbaQTFRQtQDOmS301KJB1CtQ==}
+  /@fluidframework/fluid-static@2.4.0:
+    resolution: {integrity: sha512-pLoxSSEytRMEDgTRMkieURxNFw6oXz0xvYdvtxHVtLvApQ4F6ZaSf43+lTWIdZFuHt9ke5poN8ODcnzfNm31sg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/aqueduct': 2.3.1(debug@4.3.7)
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/container-loader': 2.3.1
-      '@fluidframework/container-runtime': 2.3.1(debug@4.3.7)
-      '@fluidframework/container-runtime-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/request-handler': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/aqueduct': 2.4.0(debug@4.3.7)
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/container-loader': 2.4.0
+      '@fluidframework/container-runtime': 2.4.0(debug@4.3.7)
+      '@fluidframework/container-runtime-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/request-handler': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -20232,35 +20232,35 @@ packages:
   /@fluidframework/gitresources@5.0.0:
     resolution: {integrity: sha512-nfam1KT+EUqFCENHcxrU9VwUfbhUC83UcLuOsdLpn9I7VuClL+w8KMWosoYauZraO9gDhTo2kCErjgQji5GzGA==}
 
-  /@fluidframework/id-compressor@2.3.1:
-    resolution: {integrity: sha512-CrxPHftCg4daNcgBI8sdGogE1XZrf8fyIhLaV6pQucNtUXSfuZMlSbBseikvdk4/aUQyfPRViE7RRW4jp9446w==}
+  /@fluidframework/id-compressor@2.4.0:
+    resolution: {integrity: sha512-xOfD3UMLbNHVvPRKco4NJJnXrvMg+yGsgGQZsJX4KwVbtjf142eFD+TFVh6OdHcHlWbYDQTtg5zkSX+CTXNAOA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/telemetry-utils': 2.4.0
       '@tylerbu/sorted-btree-es6': 1.8.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/local-driver@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-Bd4KZ7hWfHXa3KPgUd/Wlstl1h466AlDbt1xUOwIeVOqugX5X+4fjGWmpHIwZ2PlFk4+0zP620J4XK/P6rVY7A==}
+  /@fluidframework/local-driver@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-AZV/qBsdl3cSua93vM1BS+n/oqxw1sfAELCxozUtPkAEJKbOrsBkJtJ5se6lDwzaKQ1tYEFI7u9HHeaxbBSrQg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-base': 2.3.1(debug@4.3.7)
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-base': 2.4.0(debug@4.3.7)
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
       '@fluidframework/protocol-base': 5.0.0
-      '@fluidframework/routerlicious-driver': 2.3.1(debug@4.3.7)
+      '@fluidframework/routerlicious-driver': 2.4.0(debug@4.3.7)
       '@fluidframework/server-local-server': 5.0.0
       '@fluidframework/server-services-client': 5.0.0
       '@fluidframework/server-services-core': 5.0.0
       '@fluidframework/server-test-utils': 5.0.0
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluidframework/telemetry-utils': 2.4.0
       jsrsasign: 11.1.0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -20290,40 +20290,40 @@ packages:
       - supports-color
     dev: false
 
-  /@fluidframework/map@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-O+hLdr25WA8gngmV0zUAzpWbbPc0kdFspvziat7ouIZaKUFTyWBlSgptDh6luG51817of0C3FG/8EcEuHU4X1w==}
+  /@fluidframework/map@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-VOIbEdoZwu9YKe4RiIWyRG8HjqtTilP+Zi7aeIbrK5GP2qX+DN9buOMI3MkgVbVy/96acBcnB878OsECjboKdg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/merge-tree': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/merge-tree': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/matrix@2.3.1:
-    resolution: {integrity: sha512-NxH69Es0/30XCCf6N6iJ8ZlbHsOB6EJY5W7MQLQfDvBbhW7otEE9vGkN4nG1Obswfj46aHCwRFssTPR8F5/deQ==}
+  /@fluidframework/matrix@2.4.0:
+    resolution: {integrity: sha512-qgId7H/aPgyH3Zzs2uUbSuMamIiHdHwO3KDPTs+cehFFYiZJ/xbuy71G84JGEBe/EF383njhwHMvW9FEQIMIDg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/merge-tree': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/merge-tree': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
       '@tiny-calc/nano': 0.0.0-alpha.5
       double-ended-queue: 2.1.0-0
       tslib: 1.14.1
@@ -20332,34 +20332,34 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/merge-tree@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-mUMvZhUwdlS7s/NtggX/UwbugrgFfSd41+mxDGDHMoJmtgZcEVG0xGr6EJTtqDlGoFmMaiOqebM2m8OvVW/J2A==}
+  /@fluidframework/merge-tree@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-dVEwFPxUbitYVfk14Htt+A7GjiLsg3+5kEpgh6Ux8/Kv3EBIHviMtDlNHMxtDr7R9H/IxAPpJ0h/4E/5YwH6TA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-XYv7ye1G4imWGSRWtj5IOEf7H8DVIbOl7Gn/yBmri/kMTOvWlmwhu/iAut/q+RrUVMx4IONQhsTIQIPNGucYWw==}
+  /@fluidframework/odsp-doclib-utils@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-UYz3IEIZQdOs/EucCB2Syw7ppDLGPMCcmioQbVhe+3Hd3uhPDXsbKi3r4+ukImRmpTA64vSmMV/7mhw8jWW1+Q==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/odsp-driver-definitions': 2.3.1
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/odsp-driver-definitions': 2.4.0
+      '@fluidframework/telemetry-utils': 2.4.0
       isomorphic-fetch: 3.0.0
     transitivePeerDependencies:
       - debug
@@ -20367,24 +20367,24 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-driver-definitions@2.3.1:
-    resolution: {integrity: sha512-ucNtGPb+WSkww+DXn+dE5XKmepUHpRpf9GzLHKdQKx5yZcjv4N08Md9Lu+u7PjQZ6+WipofGXcPJvFkKnl/fIA==}
+  /@fluidframework/odsp-driver-definitions@2.4.0:
+    resolution: {integrity: sha512-/IcKFf9yuLwPc2Ej1DrhJZoy1IXdiDbGLVNg9SmXAmaNuiRnur4Yk4/GLcnU0Agngftl1rz5IDgHoSaiNHh7MA==}
     dependencies:
-      '@fluidframework/driver-definitions': 2.3.1
+      '@fluidframework/driver-definitions': 2.4.0
     dev: true
 
-  /@fluidframework/odsp-driver@2.3.1:
-    resolution: {integrity: sha512-2rd0ZoY6TSnEMamLwLbhj91xXUU51Ms2eVIR4KbSjq40mXpfsOpb6SimKh1+inIaZ6af/UQq7ww8esVSbnaMpA==}
+  /@fluidframework/odsp-driver@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-rfmfDCgOaLmZ9ZgLN2Ge7I4kT40lt6DY/ibluaX80ZVJeniVmygHhkl3tXUnjCDhph9Jhqjg8ralpjcjgu+JIQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-base': 2.3.1(debug@4.3.7)
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/odsp-doclib-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/odsp-driver-definitions': 2.3.1
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-base': 2.4.0(debug@4.3.7)
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/odsp-doclib-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/odsp-driver-definitions': 2.4.0
+      '@fluidframework/telemetry-utils': 2.4.0
       node-fetch: 2.7.0
       socket.io-client: 4.7.5
       uuid: 9.0.1
@@ -20396,15 +20396,15 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-urlresolver@2.3.1:
-    resolution: {integrity: sha512-XE9gKZDbEAgiZ8OlJvfPdb/tR4V35drglolsUavQZKMwY6M/c0HcHG8onn99nVwd7WXz6o5ZXpuMg1wXmGoTYA==}
+  /@fluidframework/odsp-urlresolver@2.4.0:
+    resolution: {integrity: sha512-/zDPZmbedfd1+6SmFHsZJ0y2GtkNuc3uKOdYOeeYXSNLCeDdzKxVCkSw3zJAdRGBa9YYUUL1VQExDhqQKiqFkA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/odsp-driver': 2.3.1
-      '@fluidframework/odsp-driver-definitions': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/odsp-driver': 2.4.0(debug@4.3.7)
+      '@fluidframework/odsp-driver-definitions': 2.4.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -20413,18 +20413,18 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/ordered-collection@2.3.1:
-    resolution: {integrity: sha512-OThTRI2cWiYXzfvc4/FS8nGJdF4G0Xffjp74nthX5aoAkt2Fju8BGnDmcAsEokuYtRwXBbXW9LGt3gFeTOAt5w==}
+  /@fluidframework/ordered-collection@2.4.0:
+    resolution: {integrity: sha512-3hxBBMUirM70CJi7N+ikU0mKgOMAomWmUui83Y9SuRr6s3VNrnoU1Nyhyxt+dyiiqh+Klvdrit1k9wDNGPXYXQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
@@ -20463,31 +20463,31 @@ packages:
   /@fluidframework/protocol-definitions@3.2.0:
     resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
 
-  /@fluidframework/register-collection@2.3.1:
-    resolution: {integrity: sha512-ZsQ/tz+66Fkj41vM3cca0jRMb2rnLBVfd5Y7MlxO+SZQXQjJhdO+C/BU20m7xHfYkK4psk45kzmyFXcYa9AMQw==}
+  /@fluidframework/register-collection@2.4.0:
+    resolution: {integrity: sha512-PXBTpeZqrYb4gv4gVu/s9gsCov198WS8D7+r1fLY1seIZMu6a1dUe8FcWRfJsQCUxtj6AWTcWd1L1qXPsuwypA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/replay-driver@2.3.1:
-    resolution: {integrity: sha512-42HoK2OqwnB1e5cTS1KqJ13fpDgjww9qzl6I5lq4T6CUHVj7GlJewAI4qy8qyAqQtcEOHtPA8dOv8ej4dz0F9w==}
+  /@fluidframework/replay-driver@2.4.0:
+    resolution: {integrity: sha512-oEVVQg1fYrtJztk1DB1++aT36YNLDhTcGS4Lj7Do70UgIrqCTWMhtkHNtaVx0rhRz7GNYpakuJJywCPPjAI4tw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -20505,14 +20505,14 @@ packages:
       - supports-color
     dev: false
 
-  /@fluidframework/request-handler@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-CbhcxuVQwg9Lqt6xHWFsL0hkzV82C/vnT9REX0rG7jNspllyYB0haN/dgcGbzg4JyM1IT6/Zw7p9NOmSf5hF+w==}
+  /@fluidframework/request-handler@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-VhnzmOMhsrSoWhBu55DG6x1FV273WS8NlHlaGUUMDBggzFU86u5AJHvp2v7B+r3LZRCfN/lAQvHuc8SlfFAV4g==}
     dependencies:
-      '@fluidframework/container-runtime-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
+      '@fluidframework/container-runtime-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -20545,17 +20545,17 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@fluidframework/routerlicious-driver@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-PBpiCn68We2m+kS04SZkEjAgqRoiB7MgEIhHnN5bWoJ9b+uHVKohiX2kLL4rinJ03NtxjihRQUCifN6hLJ9Sxg==}
+  /@fluidframework/routerlicious-driver@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-WcY2rNtNZN3p6GH1BlB1ZpHh8V2vTsGKagITLtFl3sHmLw+rTqLEHHI+KNzf5ZoKB3E98+yBsp0jAmnHbnxkoQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-base': 2.3.1(debug@4.3.7)
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-base': 2.4.0(debug@4.3.7)
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
       '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluidframework/telemetry-utils': 2.4.0
       cross-fetch: 3.1.8
       json-stringify-safe: 5.0.1
       socket.io-client: 4.7.5
@@ -20568,12 +20568,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-urlresolver@2.3.1:
-    resolution: {integrity: sha512-Hv/aC2aSasVP6nKaKXTtbPsL/BFD6KpzthGbIZ4AVqIJnxJ2S1spx2MSZFn6a1ag3gXgOrOH1rUuFvXXLG2Qqw==}
+  /@fluidframework/routerlicious-urlresolver@2.4.0:
+    resolution: {integrity: sha512-SDfcnHq2s3q6i7UqC/V15aLSL20l58N20tejgScUNQO8w7pTrYLVjnNTIHu4f7jfhBLdZb0bEvHHEE8NYvobfQ==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
       nconf: 0.12.1
     dev: true
 
@@ -20588,14 +20588,14 @@ packages:
       '@fluidframework/protocol-definitions': 0.1028.2000
     dev: false
 
-  /@fluidframework/runtime-definitions@2.3.1:
-    resolution: {integrity: sha512-xIaogKkg5onQofxVFY9we/rouBfxKKRk/G/1i8WPCpqM57b1WaMrSFGte3zPOYaBCO/PQHX76drIuR6fZM3lnQ==}
+  /@fluidframework/runtime-definitions@2.4.0:
+    resolution: {integrity: sha512-5Vxt6qcVO9F+0WAUrSPX2LvnxF2QNx6TFELmUDTHkUtUEO8Sh1x/h34oINeQKVsD58J6K7sjSGodz8vzTX+aOw==}
     dependencies:
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/id-compressor': 2.3.1
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/id-compressor': 2.4.0
+      '@fluidframework/telemetry-utils': 2.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -20618,37 +20618,37 @@ packages:
       - supports-color
     dev: false
 
-  /@fluidframework/runtime-utils@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-BOMUJYPKDZ1aGRBEdpJyGq6MShYf3ZXHRvPpUYwB7Qz+xqsC5LScW6qHE3K1D0ZoX5DavGlyYylYRwSmtm/m6w==}
+  /@fluidframework/runtime-utils@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-xJ2dKxmRgrk7MuMYcNjGOKM5viGyyME6V2YrOcC4h41nzN8Nl29mMrsZDy9ftV2e5oyKsYRC8I9aw9iS3/97ug==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/container-runtime-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/container-runtime-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/telemetry-utils': 2.4.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/sequence@2.3.1:
-    resolution: {integrity: sha512-iNoPkObX1gbpuiaPOjZLCvYHGFu+hT4pJ2EyDYM/LkhxD4Zy0mreOwRgw1gH03tbCQitoyT3pfRAtCrCHI71nA==}
+  /@fluidframework/sequence@2.4.0:
+    resolution: {integrity: sha512-V9WhgPQgUe/vo3H2riXvT3caXIi47LRBJ3xmRfsXwcvlCpYjYV+Alxr4qKxaBINreMeAlLGhJcHi/5bS5E4h1A==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/merge-tree': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/merge-tree': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
       double-ended-queue: 2.1.0-0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -20909,35 +20909,35 @@ packages:
       - supports-color
     dev: false
 
-  /@fluidframework/shared-object-base@2.3.1(debug@4.3.7):
-    resolution: {integrity: sha512-dBWaHLStAfXuhdoXKJamC5RBu6HhcRZmzPY7V/0MpJEtS6sutanURfEQ27Oxq6JWh+RWmMdtZ1YFZromITL+6A==}
+  /@fluidframework/shared-object-base@2.4.0(debug@4.3.7):
+    resolution: {integrity: sha512-RCCy/D4cxkWRLTt0LRUtEdGPYXAlExizTcZZOtfARgpTABwfE4KXGpwRnQwey7yB0DqY6yKf855jYVhF1yKGJA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/container-runtime': 2.3.1(debug@4.3.7)
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore': 2.3.1(debug@4.3.7)
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/container-runtime': 2.4.0(debug@4.3.7)
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore': 2.4.0(debug@4.3.7)
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-summary-block@2.3.1:
-    resolution: {integrity: sha512-DSK0NQhGkcemukSH6/tTJYfXpj7OmdowZJFqTvuz/lfNPcb7zgFywJgjGsgoX/EPT+Om0CqV+wbOQC/XIhqgVA==}
+  /@fluidframework/shared-summary-block@2.4.0:
+    resolution: {integrity: sha512-Ty8FN4yjdasCCFgBzOVqifSZ4SZW3BqT6ekNdTR5YPd1olFvhmvZJR/HkdUOmvRR4Sr8rRj7pbHKJszOWXtwHQ==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -20947,25 +20947,25 @@ packages:
     resolution: {integrity: sha512-0pdq28pZ/cA/OVOp7KiUv8/bDxltwQy2ca7UJQGuyRDF9n1QcXoWC98liu2fB3/imahdfDi5pZ6l2vw/nIiFkA==}
     dev: false
 
-  /@fluidframework/synthesize@2.3.1:
-    resolution: {integrity: sha512-IRrNxO7/oSp5qHs4DyuH1ukd8WKUiCm/dmoqA75Bmv7RI0sPO2OIcJtgYRiBeC93HuI/bLDVC/lCJqgOhmmgyw==}
+  /@fluidframework/synthesize@2.4.0:
+    resolution: {integrity: sha512-DiaYGuHv17WsVZHiBqVw/IcQNnZBOfw50LPPvX9QSOKFXyXO4gM/KrDVmk1trCklC4lfFP3RQ+B81MWBKJKcuQ==}
     dependencies:
-      '@fluidframework/core-utils': 2.3.1
+      '@fluidframework/core-utils': 2.4.0
     dev: true
 
-  /@fluidframework/task-manager@2.3.1:
-    resolution: {integrity: sha512-RCvtHx+YUaJqx7h+GtQ/EXQSShHCkI5Knucw+LJnzzdiCx9wADTUBE6QL32WZD0rJQDQZRLCswAoF2YOe8RhUw==}
+  /@fluidframework/task-manager@2.4.0:
+    resolution: {integrity: sha512-OB5tL6fzDZadnOa864fTCWTDq1ZqPvqM+YJXKaOqXDzsvE2Tc1ZRA0nSB7aBHk7ks5IjDWkhumkch7VmtGFa6A==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/container-runtime-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/container-runtime-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -20983,34 +20983,34 @@ packages:
       - supports-color
     dev: false
 
-  /@fluidframework/telemetry-utils@2.3.1:
-    resolution: {integrity: sha512-yK3tEQZCjn9LPYb/n5ON3EsCo/vYjJfETwsniEZWoNL7QEuHSUOFc8g6eQszpDu5n9s0XHZpih9t8IooEN27vg==}
+  /@fluidframework/telemetry-utils@2.4.0:
+    resolution: {integrity: sha512-T2jxXURiEEi0+yc/KBxc4a9ySkuTcYQltgi9OVxvhq/ZLGe2zeOYdffnf61xday+Z9tPV+psuHk44bzDxD3MpA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
       debug: 4.3.7(supports-color@8.1.1)
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/test-runtime-utils@2.3.1:
-    resolution: {integrity: sha512-pCD7ap6r94sdR4F6cfnQZrC3QOaK/3tshXDqL2sek8ypFaFDKjFUYIH+ddq7S/CHghWORW6Rv1gtFwf5dQNfFA==}
+  /@fluidframework/test-runtime-utils@2.4.0:
+    resolution: {integrity: sha512-tvcv+RGkXLY+f7xN1lJy9BT46irG163NflSqwfB8CBYnOH/5imuj6ByG9vzmfH+gByPe6S5iLaIim2Xlb3NiHw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/container-runtime-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/id-compressor': 2.3.1
-      '@fluidframework/routerlicious-driver': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/container-runtime-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/id-compressor': 2.4.0
+      '@fluidframework/routerlicious-driver': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
       jsrsasign: 11.1.0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -21026,28 +21026,29 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/test-utils@2.3.1:
-    resolution: {integrity: sha512-K7zZmOKCUIxlgjDfLeGSa/jwvafYUsC6CG9QG2nlheJNmxV6qjAs0dvh5r4VN956AAhhG8ioAOnRoxXlBrKZRQ==}
+  /@fluidframework/test-utils@2.4.0:
+    resolution: {integrity: sha512-Xl+Huf65IFsWbZu1z4Op3s4GAgKVee+cIgXAZ2yhZREatmsYxkYpijAHOsCkPxRFL40E5o2J1POP7+8urA4k7A==}
     dependencies:
-      '@fluid-internal/test-driver-definitions': 2.3.1
-      '@fluidframework/aqueduct': 2.3.1(debug@4.3.7)
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/container-loader': 2.3.1
-      '@fluidframework/container-runtime': 2.3.1(debug@4.3.7)
-      '@fluidframework/container-runtime-definitions': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore': 2.3.1(debug@4.3.7)
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/local-driver': 2.3.1(debug@4.3.7)
-      '@fluidframework/map': 2.3.1(debug@4.3.7)
-      '@fluidframework/request-handler': 2.3.1(debug@4.3.7)
-      '@fluidframework/routerlicious-driver': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/test-driver-definitions': 2.4.0
+      '@fluidframework/aqueduct': 2.4.0(debug@4.3.7)
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/container-loader': 2.4.0
+      '@fluidframework/container-runtime': 2.4.0(debug@4.3.7)
+      '@fluidframework/container-runtime-definitions': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore': 2.4.0(debug@4.3.7)
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/local-driver': 2.4.0(debug@4.3.7)
+      '@fluidframework/map': 2.4.0(debug@4.3.7)
+      '@fluidframework/odsp-driver': 2.4.0(debug@4.3.7)
+      '@fluidframework/request-handler': 2.4.0(debug@4.3.7)
+      '@fluidframework/routerlicious-driver': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
       best-random: 1.0.3
       debug: 4.3.7(supports-color@8.1.1)
       mocha: 10.7.3
@@ -21059,21 +21060,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-client@2.3.1:
-    resolution: {integrity: sha512-ChTMqlF82OaHYyWfGQBXeu4q6XCvXJAnCrhwLfc+EG3iAX3airgekL9IDijCg/Ww96tihvfXjy5VJHbBwt017w==}
+  /@fluidframework/tinylicious-client@2.4.0:
+    resolution: {integrity: sha512-ikbxrw7yWPy7PlUYJ/0pZue9ulTZn+Q+c1LkSqWj6Qp3SUEMrV4hSDlkaQ4JfRiySGJAHS0ALP9kkKIDDzSaQA==}
     dependencies:
-      '@fluidframework/container-definitions': 2.3.1
-      '@fluidframework/container-loader': 2.3.1
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/fluid-static': 2.3.1
-      '@fluidframework/map': 2.3.1(debug@4.3.7)
-      '@fluidframework/routerlicious-driver': 2.3.1(debug@4.3.7)
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
-      '@fluidframework/tinylicious-driver': 2.3.1
+      '@fluidframework/container-definitions': 2.4.0
+      '@fluidframework/container-loader': 2.4.0
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/fluid-static': 2.4.0
+      '@fluidframework/map': 2.4.0(debug@4.3.7)
+      '@fluidframework/routerlicious-driver': 2.4.0(debug@4.3.7)
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
+      '@fluidframework/tinylicious-driver': 2.4.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -21082,13 +21083,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver@2.3.1:
-    resolution: {integrity: sha512-4BlyWJuYAeiDlUpGQzC8KgozOfPWEn9ShvRjxJTPQFMEoZoY7im4IpjDhCDFvsjaNo3b1D4uAAm2jyQuXpGD8w==}
+  /@fluidframework/tinylicious-driver@2.4.0:
+    resolution: {integrity: sha512-u6SvkuSdkJfBZCsLLdFujabqd0AELUO/B8aTCGuU5QOD0k1ZBtxnqglJqw916VlJ4qHoZvc14/hsdCvP62jw9w==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/routerlicious-driver': 2.3.1(debug@4.3.7)
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/routerlicious-driver': 2.4.0(debug@4.3.7)
       jsrsasign: 11.1.0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -21099,13 +21100,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tool-utils@2.3.1:
-    resolution: {integrity: sha512-zy7hEDhGT9wrYeO8MntcN6OLDxWtaWXQeN0U609MFseX1sgLxp7+rfShGwu+Nrtm/dcfKyqkfkJb5K8p2D28TQ==}
+  /@fluidframework/tool-utils@2.4.0:
+    resolution: {integrity: sha512-KjD0Bby1PfffAt19aSNSYtBXa9JQoo5cKJ2n+R52KC6EUNKw5K2NDknV1td1wDf0Ny9ff2A7Ns2EKBY5KumaJg==}
     dependencies:
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/driver-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/odsp-doclib-utils': 2.3.1(debug@4.3.7)
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/driver-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/odsp-doclib-utils': 2.4.0(debug@4.3.7)
       async-mutex: 0.3.2
       debug: 4.3.7(supports-color@8.1.1)
       jwt-decode: 4.0.0
@@ -21115,20 +21116,20 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/tree@2.3.1:
-    resolution: {integrity: sha512-rnj6p2VCaV27rRgWbcH3cdVHpTrMVZRa21qEG5UiwIL0ulFCjW0GMm5L5xo0v201GUMaPUCkb7GxRpyFusQEzg==}
+  /@fluidframework/tree@2.4.0:
+    resolution: {integrity: sha512-te/yXq9Vpd3gmy9+HgCuAgzgFqRG1f8O0oubMoknAXpMTmZtf9ZWdd5+RadJ15HqNRT0H/LPnKt/MDrs1lhNJQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/container-runtime': 2.3.1(debug@4.3.7)
-      '@fluidframework/core-interfaces': 2.3.1
-      '@fluidframework/core-utils': 2.3.1
-      '@fluidframework/datastore-definitions': 2.3.1
-      '@fluidframework/driver-definitions': 2.3.1
-      '@fluidframework/id-compressor': 2.3.1
-      '@fluidframework/runtime-definitions': 2.3.1
-      '@fluidframework/runtime-utils': 2.3.1(debug@4.3.7)
-      '@fluidframework/shared-object-base': 2.3.1(debug@4.3.7)
-      '@fluidframework/telemetry-utils': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/container-runtime': 2.4.0(debug@4.3.7)
+      '@fluidframework/core-interfaces': 2.4.0
+      '@fluidframework/core-utils': 2.4.0
+      '@fluidframework/datastore-definitions': 2.4.0
+      '@fluidframework/driver-definitions': 2.4.0
+      '@fluidframework/id-compressor': 2.4.0
+      '@fluidframework/runtime-definitions': 2.4.0
+      '@fluidframework/runtime-utils': 2.4.0(debug@4.3.7)
+      '@fluidframework/shared-object-base': 2.4.0(debug@4.3.7)
+      '@fluidframework/telemetry-utils': 2.4.0
       '@sinclair/typebox': 0.32.35
       '@tylerbu/sorted-btree-es6': 1.8.0
       '@ungap/structured-clone': 1.2.0
@@ -21138,14 +21139,14 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/undo-redo@2.3.1:
-    resolution: {integrity: sha512-87JnFYeGkE6rHmNVAynbE/pBEMB7Q8cCnBJ9/JdJyWOr6s0dtZtBUWrrGhHvc8hFiaAY2oAycS+kZ11Ls/T7RA==}
+  /@fluidframework/undo-redo@2.4.0:
+    resolution: {integrity: sha512-iApcS2Wef628dEF54J2nxx14/V/sVcjUs/1niAtOP2ExqOm7wRgI4fhan71ncyu6QdVXxJYbBIAINJFCBHHudg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.3.1
-      '@fluidframework/map': 2.3.1(debug@4.3.7)
-      '@fluidframework/matrix': 2.3.1
-      '@fluidframework/merge-tree': 2.3.1(debug@4.3.7)
-      '@fluidframework/sequence': 2.3.1
+      '@fluid-internal/client-utils': 2.4.0
+      '@fluidframework/map': 2.4.0(debug@4.3.7)
+      '@fluidframework/matrix': 2.4.0
+      '@fluidframework/merge-tree': 2.4.0(debug@4.3.7)
+      '@fluidframework/sequence': 2.4.0
     transitivePeerDependencies:
       - debug
       - supports-color


### PR DESCRIPTION
Commands used:

```shell
pnpm exec flub typetests -g client --reset --normalize --exact '~2.4.0'
pnpm i --no-frozen-lockfile
pnpm run typetests:gen
```