### PR TITLE
Update lengths before delta event in rollback

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2296,16 +2296,6 @@ export class MergeTree {
 				segment.removedSeq = undefined;
 				segment.localRemovedSeq = undefined;
 
-				// Note: optional chaining short-circuits:
-				// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#short-circuiting
-				this.mergeTreeDeltaCallback?.(
-					{ op: createInsertSegmentOp(this.findRollbackPosition(segment), segment) },
-					{
-						operation: MergeTreeDeltaType.INSERT,
-						deltaSegments: [{ segment }],
-					},
-				);
-
 				for (
 					let updateNode = segment.parent;
 					updateNode !== undefined;
@@ -2317,6 +2307,16 @@ export class MergeTree {
 						this.collabWindow.clientId,
 					);
 				}
+
+				// Note: optional chaining short-circuits:
+				// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#short-circuiting
+				this.mergeTreeDeltaCallback?.(
+					{ op: createInsertSegmentOp(this.findRollbackPosition(segment), segment) },
+					{
+						operation: MergeTreeDeltaType.INSERT,
+						deltaSegments: [{ segment }],
+					},
+				);
 			});
 		} else if (
 			op.type === MergeTreeDeltaType.INSERT ||


### PR DESCRIPTION
During rollback of delete from string, the delta callback is invoked before the lengths are updated, which results in the callback code seeing messed up string content. This fix swaps the order and adds testing for the events.