### PR TITLE
refactor(examples/ai-collab): Clean up imports

### DIFF
--- a/examples/apps/ai-collab/package.json
+++ b/examples/apps/ai-collab/package.json
@@ -43,7 +43,6 @@
 		"@fluidframework/build-tools": "^0.49.0",
 		"@fluidframework/devtools": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
-		"@fluidframework/fluid-static": "workspace:~",
 		"@fluidframework/odsp-client": "workspace:~",
 		"@fluidframework/tinylicious-client": "workspace:~",
 		"@fluidframework/tree": "workspace:~",

--- a/examples/apps/ai-collab/src/app/page.tsx
+++ b/examples/apps/ai-collab/src/app/page.tsx
@@ -5,8 +5,6 @@
 
 "use client";
 
-import type { IFluidContainer } from "@fluidframework/fluid-static";
-import { type TreeView } from "@fluidframework/tree";
 import {
 	Box,
 	Button,
@@ -17,6 +15,7 @@ import {
 	Tabs,
 	Typography,
 } from "@mui/material";
+import type { IFluidContainer, TreeView } from "fluid-framework";
 import React, { useEffect, useState } from "react";
 
 import { TaskGroup } from "@/components/TaskGroup";

--- a/examples/apps/ai-collab/src/app/spe.ts
+++ b/examples/apps/ai-collab/src/app/spe.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
+import type { ContainerSchema, IFluidContainer } from "fluid-framework";
 
 import { start } from "@/infra/authHelper"; // eslint-disable-line import/no-internal-modules
 

--- a/examples/apps/ai-collab/src/app/tinylicious.ts
+++ b/examples/apps/ai-collab/src/app/tinylicious.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidContainer, type ContainerSchema } from "@fluidframework/fluid-static";
 import { TinyliciousClient } from "@fluidframework/tinylicious-client";
+import { IFluidContainer, type ContainerSchema } from "fluid-framework";
 
 const tinyliciousClient = new TinyliciousClient({});
 

--- a/examples/apps/ai-collab/src/components/TaskCard.tsx
+++ b/examples/apps/ai-collab/src/components/TaskCard.tsx
@@ -11,7 +11,6 @@ import {
 	type DifferenceMove,
 	SharedTreeBranchManager,
 } from "@fluid-experimental/ai-collab";
-import { type TreeView } from "@fluidframework/tree";
 import { Icon } from "@iconify/react";
 import { LoadingButton } from "@mui/lab";
 import {
@@ -30,6 +29,7 @@ import {
 	Tooltip,
 	Typography,
 } from "@mui/material";
+import { type TreeView } from "fluid-framework";
 import { useSnackbar } from "notistack";
 import React, { useState, type ReactNode, type SetStateAction } from "react";
 

--- a/examples/apps/ai-collab/src/components/TaskGroup.tsx
+++ b/examples/apps/ai-collab/src/components/TaskGroup.tsx
@@ -4,7 +4,6 @@
  */
 
 import { type Difference, SharedTreeBranchManager } from "@fluid-experimental/ai-collab";
-import { type TreeView } from "@fluidframework/tree";
 import { type TreeBranch, type TreeBranchFork } from "@fluidframework/tree/alpha";
 import { Icon } from "@iconify/react";
 import { LoadingButton } from "@mui/lab";
@@ -19,6 +18,7 @@ import {
 	TextField,
 	Typography,
 } from "@mui/material";
+import { type TreeView } from "fluid-framework";
 import { useSnackbar } from "notistack";
 import React, { useState } from "react";
 

--- a/examples/apps/ai-collab/src/types/sharedTreeAppSchema.ts
+++ b/examples/apps/ai-collab/src/types/sharedTreeAppSchema.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { SchemaFactory, TreeViewConfiguration } from "@fluidframework/tree";
-import { SharedTree } from "fluid-framework";
+import { SharedTree, SchemaFactory, TreeViewConfiguration } from "fluid-framework";
 
 import type { Engineer, Task, TaskGroup } from "./task";
 

--- a/examples/apps/ai-collab/src/useFluidContainerNextjs.ts
+++ b/examples/apps/ai-collab/src/useFluidContainerNextjs.ts
@@ -5,7 +5,7 @@
 
 "use client";
 
-import { IFluidContainer, type ContainerSchema } from "@fluidframework/fluid-static";
+import { IFluidContainer, type ContainerSchema } from "fluid-framework";
 import { useEffect, useState } from "react";
 
 /**

--- a/examples/apps/ai-collab/src/useSharedTreeRerender.ts
+++ b/examples/apps/ai-collab/src/useSharedTreeRerender.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Tree, TreeNode } from "@fluidframework/tree";
+import { Tree, TreeNode } from "fluid-framework";
 import { useEffect, useState } from "react";
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,9 +393,6 @@ importers:
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.4.5)
-      '@fluidframework/fluid-static':
-        specifier: workspace:~
-        version: link:../../../packages/framework/fluid-static
       '@fluidframework/odsp-client':
         specifier: workspace:~
         version: link:../../../packages/service-clients/odsp-client


### PR DESCRIPTION
## Description

Cleans up imports in example app so it imports everything it can from `fluid-framework` instead of individual packages. It still needs to import from `@fluid-experimental/ai-collab` and `@fluidframework/tree` for `@alpha` APIs.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).