### PR TITLE
build: Remove references to deleted readme-command package

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,7 +18,6 @@ common/lib/**/lib
 common/build/eslint-config-fluid/printed-configs/
 build-tools/packages/*/docs/*.md
 build-tools/packages/build-cli/README.md
-build-tools/packages/readme-command/README.md
 build-tools/packages/version-tools/README.md
 **/src/**/test/types/*.generated.ts
 **/src/packageVersion.ts

--- a/build-tools/syncpack.config.cjs
+++ b/build-tools/syncpack.config.cjs
@@ -100,7 +100,6 @@ module.exports = {
 			label:
 				"Dependencies on other fluid packages within the workspace should use tilde dependency ranges",
 			dependencies: [
-				"@fluid-private/readme-command",
 				"@fluid-tools/build-cli",
 				"@fluid-tools/version-tools",
 				"@fluidframework/build-tools",

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -310,8 +310,6 @@ module.exports = {
 				"build-tools/packages/build-cli/bin/dev.js",
 				"build-tools/packages/build-cli/bin/run.js",
 				"build-tools/packages/build-cli/test/helpers/init.js",
-				"build-tools/packages/readme-command/bin/dev.js",
-				"build-tools/packages/readme-command/bin/run.js",
 				"build-tools/packages/version-tools/bin/dev.js",
 				"build-tools/packages/version-tools/bin/run.js",
 				"common/build/build-common/gen_version.js",

--- a/server/gitrest/.prettierignore
+++ b/server/gitrest/.prettierignore
@@ -20,7 +20,6 @@ common/lib/**/lib
 common/build/eslint-config-fluid/printed-configs/
 build-tools/packages/*/docs/*.md
 build-tools/packages/build-cli/README.md
-build-tools/packages/readme-command/README.md
 build-tools/packages/version-tools/README.md
 **/src/**/test/types/*
 **/src/packageVersion.ts

--- a/server/historian/.prettierignore
+++ b/server/historian/.prettierignore
@@ -20,7 +20,6 @@ common/lib/**/lib
 common/build/eslint-config-fluid/printed-configs/
 build-tools/packages/*/docs/*.md
 build-tools/packages/build-cli/README.md
-build-tools/packages/readme-command/README.md
 build-tools/packages/version-tools/README.md
 **/src/**/test/types/*
 **/src/packageVersion.ts

--- a/server/routerlicious/.prettierignore
+++ b/server/routerlicious/.prettierignore
@@ -20,7 +20,6 @@ common/lib/**/lib
 common/build/eslint-config-fluid/printed-configs/
 build-tools/packages/*/docs/*.md
 build-tools/packages/build-cli/README.md
-build-tools/packages/readme-command/README.md
 build-tools/packages/version-tools/README.md
 **/src/**/test/types/*
 **/src/packageVersion.ts


### PR DESCRIPTION
The readme-command package was deleted some time ago but there were still some references to it in configs and comments.