### PR TITLE
improvement(fluid-build): Optimize timer calls

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
@@ -139,13 +139,12 @@ async function main() {
 		log(`Other switches with no explicit build script, not building.`);
 	}
 
+	const totalTime = timer.getTotalTime();
 	const timeInMinutes =
-		timer.getTotalTime() > 60000
-			? ` (${Math.floor(timer.getTotalTime() / 60000)}m ${(
-					(timer.getTotalTime() % 60000) / 1000
-				).toFixed(3)}s)`
+	totalTime > 60000
+			? ` (${Math.floor(totalTime / 60000)}m ${((totalTime % 60000) / 1000).toFixed(3)}s)`
 			: "";
-	log(`Total time: ${(timer.getTotalTime() / 1000).toFixed(3)}s${timeInMinutes}`);
+	log(`Total time: ${(totalTime / 1000).toFixed(3)}s${timeInMinutes}`);
 
 	if (failureSummary !== "") {
 		log(`\n${failureSummary}`);

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
@@ -141,7 +141,7 @@ async function main() {
 
 	const totalTime = timer.getTotalTime();
 	const timeInMinutes =
-	totalTime > 60000
+		totalTime > 60000
 			? ` (${Math.floor(totalTime / 60000)}m ${((totalTime % 60000) / 1000).toFixed(3)}s)`
 			: "";
 	log(`Total time: ${(totalTime / 1000).toFixed(3)}s${timeInMinutes}`);


### PR DESCRIPTION
fluid-build's main function was unnecessarily calling timer.getTotalTime() repeatedly.