### PR TITLE
Reupload expired blobs

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -276,7 +276,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 					expired,
 				});
 				if (expired) {
-					// Instead of returning a promise, handle reupload asynchronously
+					// handle reupload asynchronously
 					this.reuploadBlobAndSendOp(localId, pendingEntry);
 					return; // Return void to avoid promise violation
 				}
@@ -288,8 +288,8 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 
 	private reuploadBlobAndSendOp(localId: string, pendingEntry: PendingBlob): void {
 		(async () => {
-			// Reupload the blob and update the pending entry
 			await this.uploadBlob(localId, pendingEntry.blob).then(() =>
+				// uploadBlob and onUploadResolve will not send another blob attach so we need to do it here
 				this.sendBlobAttachOp(localId, pendingEntry.storageId),
 			);
 			// Once the blob is re-uploaded, proceed with sending the BlobAttachOp
@@ -299,7 +299,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 				eventName: "BlobReuploadFailed",
 				error,
 				localId,
-			}); // Immediately invoke the async function
+			});
 		});
 	}
 

--- a/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
@@ -214,7 +214,7 @@ describe("getPendingLocalState", () => {
 		const runtime2 = new MockRuntime(mc, summaryData, false, pendingState);
 		await runtime2.attach();
 		await runtime2.connect();
-		await runtime2.processAll();
+		await runtime2.processAllWithReupload();
 
 		const summaryData2 = validateSummary(runtime2);
 		assert.strictEqual(summaryData2.ids.length, 1);

--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializerLifeCycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializerLifeCycle.spec.ts
@@ -162,6 +162,13 @@ describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider,
 			) {
 				return;
 			}
+			let snapshotRefreshTimeoutMs;
+			if (
+				testConfig.timeoutRefreshInOriginalContainer ||
+				testConfig.timeoutRefreshInLoadedContainer
+			) {
+				snapshotRefreshTimeoutMs = provider.driver.type === "local" ? 100 : 1000;
+			}
 			const getLatestSnapshotInfoP = new Deferred<void>();
 			const testContainerConfig = {
 				fluidDataObjectType: DataObjectFactoryType.Test,
@@ -186,11 +193,7 @@ describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider,
 						"Fluid.Container.enableOfflineSnapshotRefresh": true,
 						"Fluid.Container.UseLoadingGroupIdForSnapshotFetch":
 							testConfig.useLoadingGroupIdForSnapshotFetch,
-						"Fluid.Container.snapshotRefreshTimeoutMs":
-							testConfig.timeoutRefreshInOriginalContainer ||
-							testConfig.timeoutRefreshInLoadedContainer
-								? 100
-								: undefined,
+						"Fluid.Container.snapshotRefreshTimeoutMs": snapshotRefreshTimeoutMs,
 					}),
 				},
 			};

--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializerLifeCycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializerLifeCycle.spec.ts
@@ -162,13 +162,6 @@ describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider,
 			) {
 				return;
 			}
-			let snapshotRefreshTimeoutMs;
-			if (
-				testConfig.timeoutRefreshInOriginalContainer ||
-				testConfig.timeoutRefreshInLoadedContainer
-			) {
-				snapshotRefreshTimeoutMs = provider.driver.type === "local" ? 100 : 1000;
-			}
 			const getLatestSnapshotInfoP = new Deferred<void>();
 			const testContainerConfig = {
 				fluidDataObjectType: DataObjectFactoryType.Test,
@@ -193,7 +186,11 @@ describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider,
 						"Fluid.Container.enableOfflineSnapshotRefresh": true,
 						"Fluid.Container.UseLoadingGroupIdForSnapshotFetch":
 							testConfig.useLoadingGroupIdForSnapshotFetch,
-						"Fluid.Container.snapshotRefreshTimeoutMs": snapshotRefreshTimeoutMs,
+						"Fluid.Container.snapshotRefreshTimeoutMs":
+							testConfig.timeoutRefreshInOriginalContainer ||
+							testConfig.timeoutRefreshInLoadedContainer
+								? 100
+								: undefined,
 					}),
 				},
 			};


### PR DESCRIPTION
we could be more resilient to blob expiration which could happen on resubmitting blob attach ops. Instead of closing the container, we now can reupload the same blob and kickstart the same process we had before. 

