### PR TITLE
change fuzz test config for summary load

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -87,7 +87,7 @@ describe("Fuzz - Top-Level", () => {
 				directory: failureDirectory,
 			},
 			clientJoinOptions: {
-				clientAddProbability: 0,
+				clientAddProbability: 1,
 				maxNumberOfClients: 3,
 			},
 			// AB#7162: enabling rehydrate in these tests hits 0x744 and 0x79d. Disabling rehydrate for now


### PR DESCRIPTION
## Description

Updates the `clientAddProbability` in top level fuzz test config to have coverage for loading summaries
