### PR TITLE
Disable code coverage for internal pipeline runs

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -188,7 +188,7 @@ extends:
     interdependencyRange: ${{ parameters.interdependencyRange }}
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm
-    testCoverage: true
+    testCoverage: ${{ eq(variables['System.TeamProject'], 'public' ) }} # disabling code coverage for internal project since we don't use it
     reportCodeCoverageComparison: ${{ eq(variables['Build.Reason'], 'PullRequest') }}
     buildDirectory: .
     tagName: client


### PR DESCRIPTION
Disabling code coverage in internal pipelines to save time since we don't use this data currently. (We can re-enable this if we end up needing it later.) I made this change per Alex's suggestion here: https://github.com/microsoft/FluidFramework/pull/22762/files#r1804966589.

These are the times for the Build stage in my test runs (9m 12s saved on average):
1. With code coverage: 53m 41s, 58m 3s, 52m 8s, 50m 37s
2. Without code coverage: 46m 35s, 43m 42s, 44m 6s, 43m 16s

See runs for test/nocc branch (ignoring first one since CodeQL Finalize step takes super long the first time in a branch).