### PR TITLE
Revert "refactor(ci): Add `set -eux -o pipefail` to all bash@3 tasks"

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -226,7 +226,6 @@ extends:
       inputs:
         targetType: 'inline'
         script: |
-          set -eux -o pipefail
           echo Generating .env
           echo "DEVTOOLS_TELEMETRY_TOKEN=$(devtools-telemetry-key)" >> ./packages/tools/devtools/devtools-browser-extension/.env
 

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -174,7 +174,6 @@ stages:
             targetType: 'inline'
             workingDirectory: $(Build.SourcesDirectory)/docs
             script: |
-              set -eux -o pipefail
               pnpm i --frozen-lockfile
 
         - task: Npm@1
@@ -286,7 +285,6 @@ stages:
             targetType: 'inline'
             workingDirectory: $(Build.SourcesDirectory)/docs
             script: |
-              set -eux -o pipefail
               pnpm i --frozen-lockfile
 
         - task: Npm@1

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -74,7 +74,6 @@ extends:
             targetType: 'inline'
             workingDirectory: .
             script: |
-              set -eux -o pipefail
               # We only need to install the root dependencies
               pnpm install --workspace-root --frozen-lockfile
 
@@ -95,5 +94,4 @@ extends:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
               pnpm store prune

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -187,9 +187,6 @@ extends:
             targetType: 'inline'
             workingDirectory: ${{ parameters.buildDirectory }}
             script: |
-              # Note: deliberately not using `set -eux -o pipefail` because this script leverages the return code of grep
-              # even in an error case
-
               # Show all task group conditions
               echo "
               Pipeline Variables:
@@ -290,7 +287,6 @@ extends:
               targetType: 'inline'
               workingDirectory: ${{ parameters.buildDirectory }}
               script: |
-                set -eux -o pipefail
                 ${{ parameters.packageManagerInstallCommand }}
 
           - template: /tools/pipelines/templates/include-set-package-version.yml@self
@@ -307,7 +303,6 @@ extends:
             inputs:
               targetType: 'inline'
               script: |
-                set -eux -o pipefail
                 echo "$(containerTagSuffix)"
                 echo "##vso[task.setvariable variable=version;isOutput=true]$(containerTagSuffix)"
 
@@ -321,7 +316,6 @@ extends:
             targetType: 'inline'
             workingDirectory: $(Build.SourcesDirectory)
             script: |
-              set -eux -o pipefail
               cp ./CredScanSuppressions.json ${{ parameters.buildDirectory }}
 
         # The GitSSH Dockerfile does not have a 'base' target nor does it run pack/lint/test/docs tasks, so skip
@@ -351,7 +345,6 @@ extends:
               inputs:
                 targetType: 'inline'
                 script: |
-                  set -eux -o pipefail
                   mkdir -p $(hostPathToPackArtifact)
                   mkdir -p $(hostPathToTestResultsArtifact)
 
@@ -377,7 +370,6 @@ extends:
                 targetType: 'inline'
                 workingDirectory: ${{ parameters.buildDirectory }}
                 script: |
-                  set -eux -o pipefail
                   flub list --no-private $RELEASE_GROUP --tarball --feed public --outFile $STAGING_PATH/pack/packagePublishOrder-public.txt
                   flub list --no-private $RELEASE_GROUP --tarball --feed internal-build --outFile $STAGING_PATH/pack/packagePublishOrder-internal-build.txt
                   flub list --no-private $RELEASE_GROUP --tarball --feed internal-dev --outFile $STAGING_PATH/pack/packagePublishOrder-internal-dev.txt
@@ -449,7 +441,6 @@ extends:
                 targetType: 'inline'
                 workingDirectory: $(hostPathToTestResultsArtifact)
                 script: |
-                  set -eux -o pipefail
                   sudo chmod -R +r .
 
           # Docs
@@ -494,7 +485,6 @@ extends:
               targetType: 'inline'
               workingDirectory: ${{ parameters.buildDirectory }}
               script: |
-                set -eux -o pipefail
                 # containerTag should always be pushed
                 FINAL_TAG_LIST=$(containerTag)
 
@@ -520,7 +510,6 @@ extends:
               targetType: 'inline'
               workingDirectory: ${{ parameters.buildDirectory }}
               script: |
-                set -eux -o pipefail
                 pnpm store prune
 
         templateContext:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -234,9 +234,6 @@ extends:
                   targetType: inline
                   workingDirectory: '${{ parameters.buildDirectory }}'
                   script: |
-                    # Note: deliberately not using `set -eux -o pipefail` because this script leverages the return code of grep
-                    # even in an error case
-
                     # Show all task group conditions
 
                     echo "
@@ -382,7 +379,6 @@ extends:
                       inputs:
                         targetType: inline
                         script: |
-                          set -eux -o pipefail
                           PATH_TO_TINYLICIOUS_LOG=$(Build.SourcesDirectory)/packages/test/test-end-to-end-tests/tinylicious.log;
                           if [ -f $PATH_TO_TINYLICIOUS_LOG ] ; then
                             echo "Found file at '$PATH_TO_TINYLICIOUS_LOG'. Uploading.";
@@ -406,7 +402,6 @@ extends:
                           targetType: 'inline'
                           workingDirectory: '${{ parameters.buildDirectory }}'
                           script: |
-                            set -eux -o pipefail
                             test -d nyc/report && echo '##vso[task.setvariable variable=ReportDirExists;]true' || echo 'No nyc/report directory'
                       - task: Bash@3
                         displayName: Patch Coverage Results
@@ -415,7 +410,6 @@ extends:
                           targetType: 'inline'
                           workingDirectory: '${{ parameters.buildDirectory }}/nyc/report'
                           script: |
-                            set -eux -o pipefail
                             sed -e 's/\(filename=\".*[\\/]external .*\)"\(.*\)""/\1\&quot;\2\&quot;"/' cobertura-coverage.xml > cobertura-coverage-patched.xml
                       - task: PublishCodeCoverageResults@2
                         displayName: Publish Code Coverage
@@ -520,7 +514,6 @@ extends:
                           targetType: inline
                           workingDirectory: '${{ parameters.buildDirectory }}'
                           script: |
-                            set -eux -o pipefail
                             echo "Build Directory is ${{ parameters.buildDirectory }}";
                             BUNDLE_SIZE_TESTS_DIR="${{ parameters.buildDirectory }}/artifacts/bundleAnalysis/@fluid-example/bundle-size-tests";
                             echo "Contents of $BUNDLE_SIZE_TESTS_DIR:";
@@ -537,7 +530,6 @@ extends:
                           targetType: inline
                           workingDirectory: $(absolutePathToTelemetryGenerator)
                           script: |
-                            set -eux -o pipefail
                             echo "Writing the following performance tests results to Aria/Kusto"
                             echo "Report Size:"
                             ls -la '../../examples/utils/bundle-size-tests/bundleAnalysis/report.json';
@@ -574,7 +566,6 @@ extends:
                     targetType: inline
                     workingDirectory: '${{ parameters.buildDirectory }}'
                     script: |
-                      set -eux -o pipefail
                       git checkout HEAD -- pnpm-lock.yaml
 
                 # Prune the pnpm store before it's cached. This removes any deps that are not used by the current build.
@@ -584,7 +575,6 @@ extends:
                     targetType: inline
                     workingDirectory: '${{ parameters.buildDirectory }}'
                     script: |
-                      set -eux -o pipefail
                       pnpm store prune
 
               - task: Bash@3
@@ -592,8 +582,6 @@ extends:
                 inputs:
                   targetType: inline
                   script: |
-                    # Note: deliberately not using `set -eux -o pipefail` because this script leverages the return code of grep
-                    # even in an error case
                     git status | grep -v -E 'package.json|package-lock.json|packageVersion.ts|lerna.json|.npmrc|build-tools/.npmrc|\(use.*' | grep '^\s' > git_status.log
                     if [ `cat git_status.log | wc -l` != "0" ]; then
                       cat git_status.log
@@ -703,7 +691,6 @@ extends:
                 inputs:
                   targetType: inline
                   script: |
-                    set -eux -o pipefail
                     echo "Creating work folder '$WORK_FOLDER'";
                     mkdir -p $WORK_FOLDER;
 
@@ -720,7 +707,6 @@ extends:
                   targetType: inline
                   workingDirectory: $(absolutePathToTelemetryGenerator)
                   script: |
-                    set -eux -o pipefail
                     echo "Listing files in '$WORK_FOLDER'"
                     ls -laR $WORK_FOLDER;
                     node --require @ff-internal/aria-logger bin/run --handlerModule "$(absolutePathToTelemetryGenerator)/dist/handlers/stageTimingRetriever.js" --dir "$WORK_FOLDER";

--- a/tools/pipelines/templates/include-git-tag-steps.yml
+++ b/tools/pipelines/templates/include-git-tag-steps.yml
@@ -16,7 +16,6 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
-        set -eux -o pipefail
         tag=${{ parameters.tagName }}_v$(version)
         echo Tag=$tag
         git tag $tag

--- a/tools/pipelines/templates/include-install-build-tools.yml
+++ b/tools/pipelines/templates/include-install-build-tools.yml
@@ -37,7 +37,6 @@ steps:
         targetType: 'inline'
         workingDirectory: $(Build.SourcesDirectory)/build-tools
         script: |
-          set -eux -o pipefail
           pnpm i --frozen-lockfile
           pnpm build:compile
           cd packages/build-cli
@@ -55,7 +54,6 @@ steps:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          set -eux -o pipefail
           echo "${{ parameters.buildToolsVersionToInstall }}"
           npm install --global "@fluid-tools/build-cli@${{ parameters.buildToolsVersionToInstall }}"
 
@@ -66,7 +64,6 @@ steps:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
-        set -eux -o pipefail
         # Output the help and full command list for debugging purposes
         echo "which flub: $(which flub)"
         flub --help

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -44,7 +44,6 @@ steps:
     workingDirectory: ${{ parameters.buildDirectory }}
     # workspace-concurrency 0 means use use the CPU core count. This is better than the default (4) for larger agents.
     script: |
-      set -eux -o pipefail
       echo "Using node $(node --version)"
       sudo corepack enable
       echo "Using pnpm $(pnpm -v)"

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -8,12 +8,12 @@ parameters:
   type: string
 
 - name: buildDirectory
-  type: string
+  type: string 
 
 - name: packageManagerInstallCommand
   type: string
 
-steps:
+steps: 
   - ${{ if eq(parameters.packageManager, 'pnpm') }}:
     - template: include-install-pnpm.yml
       parameters:
@@ -25,5 +25,4 @@ steps:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
-        set -eux -o pipefail
         ${{ parameters.packageManagerInstallCommand }}

--- a/tools/pipelines/templates/include-policy-check.yml
+++ b/tools/pipelines/templates/include-policy-check.yml
@@ -44,9 +44,7 @@ stages:
       inputs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
-        script: |
-          set -eux -o pipefail
-          ${{ parameters.dependencyInstallCommand }}
+        script: ${{ parameters.dependencyInstallCommand }}
 
     - ${{ if ne(convertToJson(parameters.checks), '[]') }}:
       - ${{ each check in parameters.checks }}:
@@ -63,8 +61,6 @@ stages:
         inputs:
           targetType: 'inline'
           script: |
-            # Note: deliberately not using `set -eux -o pipefail` because this script leverages the return code of grep
-            # even in an error case
             git status | grep -v -E 'package.json|package-lock.json|packageVersion.ts|lerna.json|.npmrc|build-tools/.npmrc|\(use.*' | grep '^\s' > git_status.log
             if [ `cat git_status.log | wc -l` != "0" ]; then
               cat git_status.log

--- a/tools/pipelines/templates/include-publish-docker-service-steps.yml
+++ b/tools/pipelines/templates/include-publish-docker-service-steps.yml
@@ -48,7 +48,6 @@ jobs:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
               'docker pull ${{ parameters.containerTag }}'
 
         - task: Docker@1

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -28,7 +28,6 @@ steps:
     targetType: 'inline'
     workingDirectory: $(Pipeline.Workspace)/pack/${{ parameters.artifactPath }}
     script: |
-      set -eux -o pipefail
       echo Generating .npmrc for ${{ parameters.feedUrl }}
       echo "registry=${{ parameters.feedUrl }}" >> ./.npmrc
       echo "always-auth=true" >> ./.npmrc

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -56,7 +56,6 @@ steps:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}
     script: |
-      set -eux -o pipefail
       # expect lerna.json and package.json be in the current working directory
 
       echo VERSION_BUILDNUMBER=$VERSION_BUILDNUMBER
@@ -79,7 +78,6 @@ steps:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
-        set -eux -o pipefail
         # At this point in the pipeline the build hasn't been done, so we skip checking if the types files and other build outputs exist.
         flub release setPackageTypesField -g ${{ parameters.tagName }} --types ${{ parameters.packageTypesOverride }} --no-checkFileExists
 
@@ -102,8 +100,6 @@ steps:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}
     script: |
-      # Note: deliberately not using `set -eux -o pipefail` because this script leverages the return code of grep
-      # even in an error case
       grep -r -e "\^2.0.0-internal.\d*.\d*.\d*" `find . -type d -name node_modules -prune -o -name 'package.json' -print`
       if [[ $? == 0 ]]; then
         echo "##vso[task.logissue type=error]Fluid internal versions shouldn't use caret dependencies"
@@ -118,8 +114,6 @@ steps:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}
     script: |
-      # Note: deliberately not using `set -eux -o pipefail` because this script leverages the return code of grep
-      # even in an error case
       grep -r -e "\^2.0.0-dev.\d*.\d*.\d*.\d*" `find . -type d -name node_modules -prune -o -name 'package.json' -print`
       if [[ $? == 0 ]]; then
         echo "##vso[task.logissue type=error]Fluid internal dev versions shouldn't use caret dependencies"

--- a/tools/pipelines/templates/include-telemetry-setup.yml
+++ b/tools/pipelines/templates/include-telemetry-setup.yml
@@ -42,7 +42,6 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      set -eux -o pipefail
       echo "
       Parameters:
         pathToTelemetryGenerator=${{ parameters.pathToTelemetryGenerator }}
@@ -57,8 +56,6 @@ steps:
     workingDirectory: ${{ parameters.pathToTelemetryGenerator }}
     # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
     script: |
-      set -eux -o pipefail
-
       echo Initialize package
       npm init --yes
 
@@ -100,6 +97,5 @@ steps:
     targetType: 'inline'
     workingDirectory: ${{ parameters.pathToTelemetryGenerator }}
     script: |
-      set -eux -o pipefail
       npm i;
       npm run build:compile;

--- a/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
@@ -33,7 +33,6 @@ steps:
     # use the same name in the pipeline that includes this template.
     # Using isOutput=true variables was too complicated/dirty.
     script: |
-      set -eux -o pipefail
       echo "Setting local variables for yml template"
 
       # Doing the character replacements with sed at runtime because using replace() in ADO template expression (which
@@ -73,7 +72,6 @@ steps:
     targetType: 'inline'
     workingDirectory: ${{ parameters.installPath }}
     script: |
-      set -eux -o pipefail
       echo "Installing ${{ parameters.testPackageName }}"
 
       # Note that this path must match the path that the packed packages are saved to in the build pipeline.

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -40,7 +40,6 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      set -eux -o pipefail
       echo "
       Variables:
         artifactBuildId=${{ parameters.artifactBuildId }}
@@ -93,8 +92,6 @@ steps:
     targetType: 'inline'
     workingDirectory: ${{ parameters.testWorkspace }}
     script: |
-      set -eux -o pipefail
-
       echo Initialize package
       npm init --yes
 

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -171,7 +171,6 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                set -eux -o pipefail
 
                 # Extract public part from cert
                 openssl x509 -in $(downloadCertTask.secureFilePath) -out cert.crt
@@ -187,8 +186,6 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
-
               # Show all task group conditions
 
               echo "
@@ -238,8 +235,6 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
-
               mkdir ${{ parameters.testWorkspace }}
 
         - task: Bash@3
@@ -250,8 +245,6 @@ stages:
             workingDirectory: ${{ parameters.testWorkspace }}
             # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
             script: |
-              set -eux -o pipefail
-
               echo Initialize package
               npm init --yes
 
@@ -335,8 +328,6 @@ stages:
               workingDirectory: ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}
               targetType: 'inline'
               script: |
-                set -eux -o pipefail
-
                 TAR_PATH=$(Pipeline.Workspace)/test-files/${{ parameters.testFileTarName }}.test-files.tar
                 echo "Unpacking test files for ${{ parameters.testPackage }} from file '$TAR_PATH' in '$(pwd)'"
                 # Note: we could skip the last argument and have it unpack everything at once, but if we later change
@@ -354,8 +345,6 @@ stages:
               workingDirectory: ${{ parameters.testWorkspace }}
               targetType: 'inline'
               script: |
-                set -eux -o pipefail
-
                 testPkgJsonPath=${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/package.json
                 pkgJsonPath=${{ parameters.testWorkspace }}/package.json
                 node -e "
@@ -402,8 +391,6 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                set -eux -o pipefail
-
                 if [[ -d ${{ variables.testPackageDir }}/nyc ]]; then
                   echo "directory '${{ variables.testPackageDir }}/nyc' exists."
                   cd ${{ variables.testPackageDir }}/nyc

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -73,8 +73,6 @@ jobs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          set -eux -o pipefail
-
           # Show all task group conditions
 
           echo "
@@ -126,7 +124,6 @@ jobs:
             targetType: 'inline'
             workingDirectory: ${{ parameters.buildDirectory }}
             script: |
-              set -eux -o pipefail
               logFile=${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log
               echo "##vso[task.setvariable variable=LogExists]$(if [ -f "$logFile" ]; then echo "true"; else echo "false"; fi)"
           condition: and(failed(), contains('${{ taskTestStep }}', 'tinylicious'))

--- a/tools/pipelines/templates/include-upload-stage-telemetry.yml
+++ b/tools/pipelines/templates/include-upload-stage-telemetry.yml
@@ -60,8 +60,6 @@ stages:
       inputs:
         targetType: 'inline'
         script: |
-          set -eux -o pipefail
-
           echo "Creating output folder '$WORK_FOLDER'"
           mkdir -p $WORK_FOLDER
 
@@ -80,8 +78,6 @@ stages:
         targetType: 'inline'
         workingDirectory: $(absolutePathToTelemetryGenerator)
         script: |
-          set -eux -o pipefail
-
           echo "Listing files in '$WORK_FOLDER'"
           ls -laR $WORK_FOLDER;
 
@@ -98,7 +94,6 @@ stages:
         inputs:
           targetType: 'inline'
           script: |
-            set -eux -o pipefail
             echo "Fetching test pass rate data and saving into JSON files"
             node "$(Build.SourcesDirectory)/scripts/get-test-pass-rate.mjs"
 
@@ -113,7 +108,6 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
             echo "Listing files in '$WORK_FOLDER'"
             ls -laR $WORK_FOLDER;
 

--- a/tools/pipelines/templates/include-use-node-version.yml
+++ b/tools/pipelines/templates/include-use-node-version.yml
@@ -16,8 +16,6 @@ steps:
     targetType: 'inline'
     workingDirectory: $(Build.SourcesDirectory)
     script: |
-      set -eux -o pipefail
-
       # Output installed node versions
       n ls
       # Use the specified node version

--- a/tools/pipelines/templates/upload-dev-manifest.yml
+++ b/tools/pipelines/templates/upload-dev-manifest.yml
@@ -23,7 +23,6 @@ jobs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          set -eux -o pipefail
           mkdir generate_release_reports
           flub release report -g client -o generate_release_reports --baseFileName manifest
 
@@ -33,7 +32,6 @@ jobs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          set -eux -o pipefail
           mkdir upload_release_reports
           flub release report-unreleased --version $(version) --fullReportFilePath generate_release_reports/manifest.full.json --outDir upload_release_reports --branchName '$(Build.SourceBranch)'
 

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -131,7 +131,6 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
               TAR_FILENAME=${{ replace(replace(replace(replace(testPackage, '@fluidframework/', '' ), '@fluid-internal/', '' ),'@fluid-', '' ), '/', '-') }}
               TAR_PATH=$(testFilesPath)/$TAR_FILENAME.test-files.tar
               cd ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
@@ -183,7 +182,6 @@ stages:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/
             script: |
-              set -eux -o pipefail
               echo "Cleanup package ${{ testPackage }} from ${{ variables.testWorkspace }}/node_modules/"
               rm -rf ${{ testPackage }};
 
@@ -193,7 +191,6 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
             echo "Write the following benchmark output to Aria/Kusto"
             ls -laR ${{ variables.consolidatedTestsOutputFolder }};
             node --require @ff-internal/aria-logger bin/run --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/executionTimeTestHandler.js --dir '${{ variables.consolidatedTestsOutputFolder }}';
@@ -204,7 +201,6 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
             echo "Writing performance benchmark output to Azure App Insights..."
             ls -laR ${{ variables.consolidatedTestsOutputFolder }};
             node bin/run appInsights --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/appInsightsExecutionTimeTestHandler.js --dir '${{ variables.consolidatedTestsOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
@@ -266,7 +262,6 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
               TAR_FILENAME=${{ replace(replace(replace(replace(testPackage, '@fluidframework/', '' ), '@fluid-internal/', '' ),'@fluid-', '' ), '/', '-') }}
               TAR_PATH=$(testFilesPath)/$TAR_FILENAME.test-files.tar
               cd ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
@@ -318,7 +313,6 @@ stages:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/
             script: |
-              set -eux -o pipefail
               echo "Cleanup package ${{ testPackage }} from ${{ variables.testWorkspace }}/node_modules/"
               rm -rf ${{ testPackage }};
 
@@ -328,7 +322,6 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
             echo "Write the following benchmark output to Aria/Kusto";
             ls -laR ${{ variables.consolidatedTestsOutputFolder }};
             node --require @ff-internal/aria-logger bin/run --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/memoryUsageTestHandler.js --dir ${{ variables.consolidatedTestsOutputFolder }};
@@ -339,7 +332,6 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
             echo "Writing performance benchmark output to Azure App Insights..."
             ls -laR ${{ variables.consolidatedTestsOutputFolder }};
             node bin/run appInsights --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/appInsightsMemoryUsageTestHandler.js --dir '${{ variables.consolidatedTestsOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
@@ -401,7 +393,6 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
               TAR_FILENAME=${{ replace(replace(replace(replace(testPackage, '@fluidframework/', '' ), '@fluid-internal/', '' ),'@fluid-', '' ), '/', '-') }}
               TAR_PATH=$(testFilesPath)/$TAR_FILENAME.test-files.tar
               cd ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
@@ -453,7 +444,6 @@ stages:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/
             script: |
-              set -eux -o pipefail
               echo "Cleanup package ${{ testPackage }} from ${{ variables.testWorkspace }}/node_modules/"
               rm -rf ${{ testPackage }};
 
@@ -463,7 +453,6 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
             echo "Write the following benchmark output to Aria/Kusto";
             ls -laR ${{ variables.consolidatedTestsOutputFolder }};
             node --require @ff-internal/aria-logger bin/run --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/customBenchmarkHandler.js --dir ${{ variables.consolidatedTestsOutputFolder }};
@@ -474,7 +463,6 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
             echo "Writing performance benchmark output to Azure App Insights..."
             ls -laR ${{ variables.consolidatedTestsOutputFolder }};
             node bin/run appInsights --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/appInsightsCustomBenchmarkHandler.js --dir '${{ variables.consolidatedTestsOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
@@ -562,8 +550,6 @@ stages:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}
             script: |
-              # Note: we explicitly do not use 'set -eux -o pipefail' here because we want to run both sets of tests
-              # no matter what. Probably should be refactored later to use separate steps for each set of tests.
 
               echo "FLUID_LOGGER_PROPS = $FLUID_LOGGER_PROPS"
 
@@ -615,7 +601,6 @@ stages:
             targetType: 'inline'
             workingDirectory: $(absolutePathToTelemetryGenerator)
             script: |
-              set -eux -o pipefail
               echo "Writing the following performance tests results to Aria/Kusto - ${{ endpointObject.endpointName }}"
               ls -la ${{ variables.executionTimeTestOutputFolder }};
               node --require @ff-internal/aria-logger bin/run --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/executionTimeTestHandler.js --dir ${{ variables.executionTimeTestOutputFolder }};
@@ -629,7 +614,6 @@ stages:
             targetType: 'inline'
             workingDirectory: $(absolutePathToTelemetryGenerator)
             script: |
-              set -eux -o pipefail
               echo "Writing the following performance tests results to Aria/Kusto - ${{ endpointObject.endpointName }}"
               ls -la ${{ variables.memoryUsageTestOutputFolder }};
               node --require @ff-internal/aria-logger bin/run --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/memoryUsageTestHandler.js --dir ${{ variables.memoryUsageTestOutputFolder }};
@@ -643,7 +627,6 @@ stages:
             targetType: 'inline'
             workingDirectory: $(absolutePathToTelemetryGenerator)
             script: |
-              set -eux -o pipefail
               echo "Writing execution time performance benchmark output to Azure App Insights..."
               ls -laR ${{ variables.executionTimeTestOutputFolder }};
               node bin/run appInsights --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/appInsightsExecutionTimeTestHandler.js --dir '${{ variables.executionTimeTestOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
@@ -659,7 +642,6 @@ stages:
             targetType: 'inline'
             workingDirectory: $(absolutePathToTelemetryGenerator)
             script: |
-              set -eux -o pipefail
               echo "Writing memory usage performance benchmark output to Azure App Insights..."
               ls -laR ${{ variables.memoryUsageTestOutputFolder }};
               node bin/run appInsights --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/appInsightsMemoryUsageTestHandler.js --dir '${{ variables.memoryUsageTestOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
@@ -689,7 +671,6 @@ stages:
             targetType: 'inline'
             workingDirectory: $(absolutePathToTelemetryGenerator)
             script: |
-              set -eux -o pipefail
               ls -laR ${{ variables.executionTimeTestOutputFolder }};
               echo "Cleanup  ${{ variables.executionTimeTestOutputFolder }}"
               rm -rf ${{ variables.executionTimeTestOutputFolder }};


### PR DESCRIPTION
Reverts microsoft/FluidFramework#22659

Opening this PR since the commit in main after we merged it failed, so we want to have the revert PR start its build. I'm looking into it though, because I suspect we might have hit an unrelated issue with the build infra (new image used by the build agent, and that one somehow broke things).