### PR TITLE
refactor(ci): Fix for ADO logging commands and fix for robustness

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -226,7 +226,7 @@ extends:
       inputs:
         targetType: 'inline'
         script: |
-          set -eux -o pipefail
+          set -eu -o pipefail
           echo Generating .env
           echo "DEVTOOLS_TELEMETRY_TOKEN=$(devtools-telemetry-key)" >> ./packages/tools/devtools/devtools-browser-extension/.env
 

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -174,7 +174,7 @@ stages:
             targetType: 'inline'
             workingDirectory: $(Build.SourcesDirectory)/docs
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               pnpm i --frozen-lockfile
 
         - task: Npm@1
@@ -286,7 +286,7 @@ stages:
             targetType: 'inline'
             workingDirectory: $(Build.SourcesDirectory)/docs
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               pnpm i --frozen-lockfile
 
         - task: Npm@1

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -74,7 +74,7 @@ extends:
             targetType: 'inline'
             workingDirectory: .
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               # We only need to install the root dependencies
               pnpm install --workspace-root --frozen-lockfile
 
@@ -95,5 +95,5 @@ extends:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               pnpm store prune

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -187,7 +187,7 @@ extends:
             targetType: 'inline'
             workingDirectory: ${{ parameters.buildDirectory }}
             script: |
-              # Note: deliberately not using `set -eux -o pipefail` because this script leverages the return code of grep
+              # Note: deliberately not using `set -eu -o pipefail` because this script leverages the return code of grep
               # even in an error case
 
               # Show all task group conditions
@@ -290,7 +290,7 @@ extends:
               targetType: 'inline'
               workingDirectory: ${{ parameters.buildDirectory }}
               script: |
-                set -eux -o pipefail
+                set -eu -o pipefail
                 ${{ parameters.packageManagerInstallCommand }}
 
           - template: /tools/pipelines/templates/include-set-package-version.yml@self
@@ -307,7 +307,7 @@ extends:
             inputs:
               targetType: 'inline'
               script: |
-                set -eux -o pipefail
+                set -eu -o pipefail
                 echo "$(containerTagSuffix)"
                 echo "##vso[task.setvariable variable=version;isOutput=true]$(containerTagSuffix)"
 
@@ -321,7 +321,7 @@ extends:
             targetType: 'inline'
             workingDirectory: $(Build.SourcesDirectory)
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               cp ./CredScanSuppressions.json ${{ parameters.buildDirectory }}
 
         # The GitSSH Dockerfile does not have a 'base' target nor does it run pack/lint/test/docs tasks, so skip
@@ -351,7 +351,7 @@ extends:
               inputs:
                 targetType: 'inline'
                 script: |
-                  set -eux -o pipefail
+                  set -eu -o pipefail
                   mkdir -p $(hostPathToPackArtifact)
                   mkdir -p $(hostPathToTestResultsArtifact)
 
@@ -377,7 +377,7 @@ extends:
                 targetType: 'inline'
                 workingDirectory: ${{ parameters.buildDirectory }}
                 script: |
-                  set -eux -o pipefail
+                  set -eu -o pipefail
                   flub list --no-private $RELEASE_GROUP --tarball --feed public --outFile $STAGING_PATH/pack/packagePublishOrder-public.txt
                   flub list --no-private $RELEASE_GROUP --tarball --feed internal-build --outFile $STAGING_PATH/pack/packagePublishOrder-internal-build.txt
                   flub list --no-private $RELEASE_GROUP --tarball --feed internal-dev --outFile $STAGING_PATH/pack/packagePublishOrder-internal-dev.txt
@@ -449,7 +449,7 @@ extends:
                 targetType: 'inline'
                 workingDirectory: $(hostPathToTestResultsArtifact)
                 script: |
-                  set -eux -o pipefail
+                  set -eu -o pipefail
                   sudo chmod -R +r .
 
           # Docs
@@ -494,7 +494,7 @@ extends:
               targetType: 'inline'
               workingDirectory: ${{ parameters.buildDirectory }}
               script: |
-                set -eux -o pipefail
+                set -eu -o pipefail
                 # containerTag should always be pushed
                 FINAL_TAG_LIST=$(containerTag)
 
@@ -520,7 +520,7 @@ extends:
               targetType: 'inline'
               workingDirectory: ${{ parameters.buildDirectory }}
               script: |
-                set -eux -o pipefail
+                set -eu -o pipefail
                 pnpm store prune
 
         templateContext:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -234,7 +234,7 @@ extends:
                   targetType: inline
                   workingDirectory: '${{ parameters.buildDirectory }}'
                   script: |
-                    # Note: deliberately not using `set -eux -o pipefail` because this script leverages the return code of grep
+                    # Note: deliberately not using `set -eu -o pipefail` because this script leverages the return code of grep
                     # even in an error case
 
                     # Show all task group conditions
@@ -382,7 +382,7 @@ extends:
                       inputs:
                         targetType: inline
                         script: |
-                          set -eux -o pipefail
+                          set -eu -o pipefail
                           PATH_TO_TINYLICIOUS_LOG=$(Build.SourcesDirectory)/packages/test/test-end-to-end-tests/tinylicious.log;
                           if [ -f $PATH_TO_TINYLICIOUS_LOG ] ; then
                             echo "Found file at '$PATH_TO_TINYLICIOUS_LOG'. Uploading.";
@@ -406,7 +406,7 @@ extends:
                           targetType: 'inline'
                           workingDirectory: '${{ parameters.buildDirectory }}'
                           script: |
-                            set -eux -o pipefail
+                            set -eu -o pipefail
                             test -d nyc/report && echo '##vso[task.setvariable variable=ReportDirExists;]true' || echo 'No nyc/report directory'
                       - task: Bash@3
                         displayName: Patch Coverage Results
@@ -415,7 +415,7 @@ extends:
                           targetType: 'inline'
                           workingDirectory: '${{ parameters.buildDirectory }}/nyc/report'
                           script: |
-                            set -eux -o pipefail
+                            set -eu -o pipefail
                             sed -e 's/\(filename=\".*[\\/]external .*\)"\(.*\)""/\1\&quot;\2\&quot;"/' cobertura-coverage.xml > cobertura-coverage-patched.xml
                       - task: PublishCodeCoverageResults@2
                         displayName: Publish Code Coverage
@@ -446,7 +446,7 @@ extends:
                           targetType: inline
                           workingDirectory: '${{ parameters.buildDirectory }}'
                           script: |
-                            set -eux -o pipefail
+                            set -eu -o pipefail
                             echo "Github Repository Name: $GITHUB_REPOSITORY_NAME"
                             echo "Github PR number: $GITHUB_PR_NUMBER"
                             echo "ADO Build Number: $ADO_BUILD_ID"
@@ -520,7 +520,7 @@ extends:
                           targetType: inline
                           workingDirectory: '${{ parameters.buildDirectory }}'
                           script: |
-                            set -eux -o pipefail
+                            set -eu -o pipefail
                             echo "Build Directory is ${{ parameters.buildDirectory }}";
                             BUNDLE_SIZE_TESTS_DIR="${{ parameters.buildDirectory }}/artifacts/bundleAnalysis/@fluid-example/bundle-size-tests";
                             echo "Contents of $BUNDLE_SIZE_TESTS_DIR:";
@@ -537,7 +537,7 @@ extends:
                           targetType: inline
                           workingDirectory: $(absolutePathToTelemetryGenerator)
                           script: |
-                            set -eux -o pipefail
+                            set -eu -o pipefail
                             echo "Writing the following performance tests results to Aria/Kusto"
                             echo "Report Size:"
                             ls -la '../../examples/utils/bundle-size-tests/bundleAnalysis/report.json';
@@ -574,7 +574,7 @@ extends:
                     targetType: inline
                     workingDirectory: '${{ parameters.buildDirectory }}'
                     script: |
-                      set -eux -o pipefail
+                      set -eu -o pipefail
                       git checkout HEAD -- pnpm-lock.yaml
 
                 # Prune the pnpm store before it's cached. This removes any deps that are not used by the current build.
@@ -584,7 +584,7 @@ extends:
                     targetType: inline
                     workingDirectory: '${{ parameters.buildDirectory }}'
                     script: |
-                      set -eux -o pipefail
+                      set -eu -o pipefail
                       pnpm store prune
 
               - task: Bash@3
@@ -592,7 +592,7 @@ extends:
                 inputs:
                   targetType: inline
                   script: |
-                    # Note: deliberately not using `set -eux -o pipefail` because this script leverages the return code of grep
+                    # Note: deliberately not using `set -eu -o pipefail` because this script leverages the return code of grep
                     # even in an error case
                     git status | grep -v -E 'package.json|package-lock.json|packageVersion.ts|lerna.json|.npmrc|build-tools/.npmrc|\(use.*' | grep '^\s' > git_status.log
                     if [ `cat git_status.log | wc -l` != "0" ]; then
@@ -703,7 +703,7 @@ extends:
                 inputs:
                   targetType: inline
                   script: |
-                    set -eux -o pipefail
+                    set -eu -o pipefail
                     echo "Creating work folder '$WORK_FOLDER'";
                     mkdir -p $WORK_FOLDER;
 
@@ -720,7 +720,7 @@ extends:
                   targetType: inline
                   workingDirectory: $(absolutePathToTelemetryGenerator)
                   script: |
-                    set -eux -o pipefail
+                    set -eu -o pipefail
                     echo "Listing files in '$WORK_FOLDER'"
                     ls -laR $WORK_FOLDER;
                     node --require @ff-internal/aria-logger bin/run --handlerModule "$(absolutePathToTelemetryGenerator)/dist/handlers/stageTimingRetriever.js" --dir "$WORK_FOLDER";

--- a/tools/pipelines/templates/include-git-tag-steps.yml
+++ b/tools/pipelines/templates/include-git-tag-steps.yml
@@ -16,7 +16,7 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
-        set -eux -o pipefail
+        set -eu -o pipefail
         tag=${{ parameters.tagName }}_v$(version)
         echo Tag=$tag
         git tag $tag

--- a/tools/pipelines/templates/include-install-build-tools.yml
+++ b/tools/pipelines/templates/include-install-build-tools.yml
@@ -37,7 +37,7 @@ steps:
         targetType: 'inline'
         workingDirectory: $(Build.SourcesDirectory)/build-tools
         script: |
-          set -eux -o pipefail
+          set -eu -o pipefail
           pnpm i --frozen-lockfile
           pnpm build:compile
           cd packages/build-cli
@@ -55,7 +55,7 @@ steps:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          set -eux -o pipefail
+          set -eu -o pipefail
           echo "${{ parameters.buildToolsVersionToInstall }}"
           npm install --global "@fluid-tools/build-cli@${{ parameters.buildToolsVersionToInstall }}"
 
@@ -66,7 +66,7 @@ steps:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
-        set -eux -o pipefail
+        set -eu -o pipefail
         # Output the help and full command list for debugging purposes
         echo "which flub: $(which flub)"
         flub --help

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -44,7 +44,7 @@ steps:
     workingDirectory: ${{ parameters.buildDirectory }}
     # workspace-concurrency 0 means use use the CPU core count. This is better than the default (4) for larger agents.
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
       echo "Using node $(node --version)"
       sudo corepack enable
       echo "Using pnpm $(pnpm -v)"

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -25,5 +25,5 @@ steps:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
-        set -eux -o pipefail
+        set -eu -o pipefail
         ${{ parameters.packageManagerInstallCommand }}

--- a/tools/pipelines/templates/include-policy-check.yml
+++ b/tools/pipelines/templates/include-policy-check.yml
@@ -45,7 +45,7 @@ stages:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          set -eux -o pipefail
+          set -eu -o pipefail
           ${{ parameters.dependencyInstallCommand }}
 
     - ${{ if ne(convertToJson(parameters.checks), '[]') }}:
@@ -63,7 +63,7 @@ stages:
         inputs:
           targetType: 'inline'
           script: |
-            # Note: deliberately not using `set -eux -o pipefail` because this script leverages the return code of grep
+            # Note: deliberately not using `set -eu -o pipefail` because this script leverages the return code of grep
             # even in an error case
             git status | grep -v -E 'package.json|package-lock.json|packageVersion.ts|lerna.json|.npmrc|build-tools/.npmrc|\(use.*' | grep '^\s' > git_status.log
             if [ `cat git_status.log | wc -l` != "0" ]; then

--- a/tools/pipelines/templates/include-publish-docker-service-steps.yml
+++ b/tools/pipelines/templates/include-publish-docker-service-steps.yml
@@ -48,7 +48,7 @@ jobs:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               'docker pull ${{ parameters.containerTag }}'
 
         - task: Docker@1

--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -28,7 +28,7 @@ steps:
     targetType: 'inline'
     workingDirectory: $(Pipeline.Workspace)/pack/${{ parameters.artifactPath }}
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
       echo Generating .npmrc for ${{ parameters.feedUrl }}
       echo "registry=${{ parameters.feedUrl }}" >> ./.npmrc
       echo "always-auth=true" >> ./.npmrc
@@ -44,7 +44,7 @@ steps:
     targetType: 'inline'
     workingDirectory: $(Pipeline.Workspace)/pack/${{ parameters.artifactPath }}
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
 
       echo "Artifact path: ${{ parameters.artifactPath }}"
       tag="--tag rc"
@@ -83,7 +83,7 @@ steps:
     targetType: 'inline'
     workingDirectory: $(Pipeline.Workspace)/pack/${{ parameters.artifactPath }}
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
       echo "Artifact path: ${{ parameters.artifactPath }}"
       orderFile=$(Pipeline.Workspace)/pack/packagePublishOrder-${{ parameters.feedKind }}.txt
 

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -56,7 +56,7 @@ steps:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
       # expect lerna.json and package.json be in the current working directory
 
       echo VERSION_BUILDNUMBER=$VERSION_BUILDNUMBER
@@ -79,7 +79,7 @@ steps:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
-        set -eux -o pipefail
+        set -eu -o pipefail
         # At this point in the pipeline the build hasn't been done, so we skip checking if the types files and other build outputs exist.
         flub release setPackageTypesField -g ${{ parameters.tagName }} --types ${{ parameters.packageTypesOverride }} --no-checkFileExists
 
@@ -102,7 +102,7 @@ steps:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}
     script: |
-      # Note: deliberately not using `set -eux -o pipefail` because this script leverages the return code of grep
+      # Note: deliberately not using `set -eu -o pipefail` because this script leverages the return code of grep
       # even in an error case
       grep -r -e "\^2.0.0-internal.\d*.\d*.\d*" `find . -type d -name node_modules -prune -o -name 'package.json' -print`
       if [[ $? == 0 ]]; then
@@ -118,7 +118,7 @@ steps:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}
     script: |
-      # Note: deliberately not using `set -eux -o pipefail` because this script leverages the return code of grep
+      # Note: deliberately not using `set -eu -o pipefail` because this script leverages the return code of grep
       # even in an error case
       grep -r -e "\^2.0.0-dev.\d*.\d*.\d*.\d*" `find . -type d -name node_modules -prune -o -name 'package.json' -print`
       if [[ $? == 0 ]]; then

--- a/tools/pipelines/templates/include-telemetry-setup.yml
+++ b/tools/pipelines/templates/include-telemetry-setup.yml
@@ -42,7 +42,7 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
       echo "
       Parameters:
         pathToTelemetryGenerator=${{ parameters.pathToTelemetryGenerator }}
@@ -57,7 +57,7 @@ steps:
     workingDirectory: ${{ parameters.pathToTelemetryGenerator }}
     # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
 
       echo Initialize package
       npm init --yes
@@ -100,6 +100,6 @@ steps:
     targetType: 'inline'
     workingDirectory: ${{ parameters.pathToTelemetryGenerator }}
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
       npm i;
       npm run build:compile;

--- a/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
@@ -33,7 +33,7 @@ steps:
     # use the same name in the pipeline that includes this template.
     # Using isOutput=true variables was too complicated/dirty.
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
       echo "Setting local variables for yml template"
 
       # Doing the character replacements with sed at runtime because using replace() in ADO template expression (which
@@ -73,7 +73,7 @@ steps:
     targetType: 'inline'
     workingDirectory: ${{ parameters.installPath }}
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
       echo "Installing ${{ parameters.testPackageName }}"
 
       # Note that this path must match the path that the packed packages are saved to in the build pipeline.

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -40,7 +40,7 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
       echo "
       Variables:
         artifactBuildId=${{ parameters.artifactBuildId }}
@@ -93,7 +93,7 @@ steps:
     targetType: 'inline'
     workingDirectory: ${{ parameters.testWorkspace }}
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
 
       echo Initialize package
       npm init --yes

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -171,7 +171,7 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                set -eux -o pipefail
+                set -eu -o pipefail
 
                 # Extract public part from cert
                 openssl x509 -in $(downloadCertTask.secureFilePath) -out cert.crt
@@ -187,7 +187,7 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
 
               # Show all task group conditions
 
@@ -238,7 +238,7 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
 
               mkdir ${{ parameters.testWorkspace }}
 
@@ -250,7 +250,7 @@ stages:
             workingDirectory: ${{ parameters.testWorkspace }}
             # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
 
               echo Initialize package
               npm init --yes
@@ -335,7 +335,7 @@ stages:
               workingDirectory: ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}
               targetType: 'inline'
               script: |
-                set -eux -o pipefail
+                set -eu -o pipefail
 
                 TAR_PATH=$(Pipeline.Workspace)/test-files/${{ parameters.testFileTarName }}.test-files.tar
                 echo "Unpacking test files for ${{ parameters.testPackage }} from file '$TAR_PATH' in '$(pwd)'"
@@ -354,7 +354,7 @@ stages:
               workingDirectory: ${{ parameters.testWorkspace }}
               targetType: 'inline'
               script: |
-                set -eux -o pipefail
+                set -eu -o pipefail
 
                 testPkgJsonPath=${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/package.json
                 pkgJsonPath=${{ parameters.testWorkspace }}/package.json
@@ -402,7 +402,7 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                set -eux -o pipefail
+                set -eu -o pipefail
 
                 if [[ -d ${{ variables.testPackageDir }}/nyc ]]; then
                   echo "directory '${{ variables.testPackageDir }}/nyc' exists."

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -73,7 +73,7 @@ jobs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          set -eux -o pipefail
+          set -eu -o pipefail
 
           # Show all task group conditions
 
@@ -126,7 +126,7 @@ jobs:
             targetType: 'inline'
             workingDirectory: ${{ parameters.buildDirectory }}
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               logFile=${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log
               echo "##vso[task.setvariable variable=LogExists]$(if [ -f "$logFile" ]; then echo "true"; else echo "false"; fi)"
           condition: and(failed(), contains('${{ taskTestStep }}', 'tinylicious'))

--- a/tools/pipelines/templates/include-upload-stage-telemetry.yml
+++ b/tools/pipelines/templates/include-upload-stage-telemetry.yml
@@ -60,7 +60,7 @@ stages:
       inputs:
         targetType: 'inline'
         script: |
-          set -eux -o pipefail
+          set -eu -o pipefail
 
           echo "Creating output folder '$WORK_FOLDER'"
           mkdir -p $WORK_FOLDER
@@ -80,7 +80,7 @@ stages:
         targetType: 'inline'
         workingDirectory: $(absolutePathToTelemetryGenerator)
         script: |
-          set -eux -o pipefail
+          set -eu -o pipefail
 
           echo "Listing files in '$WORK_FOLDER'"
           ls -laR $WORK_FOLDER;
@@ -98,7 +98,7 @@ stages:
         inputs:
           targetType: 'inline'
           script: |
-            set -eux -o pipefail
+            set -eu -o pipefail
             echo "Fetching test pass rate data and saving into JSON files"
             node "$(Build.SourcesDirectory)/scripts/get-test-pass-rate.mjs"
 
@@ -113,7 +113,7 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
+            set -eu -o pipefail
             echo "Listing files in '$WORK_FOLDER'"
             ls -laR $WORK_FOLDER;
 

--- a/tools/pipelines/templates/include-use-node-version.yml
+++ b/tools/pipelines/templates/include-use-node-version.yml
@@ -16,7 +16,7 @@ steps:
     targetType: 'inline'
     workingDirectory: $(Build.SourcesDirectory)
     script: |
-      set -eux -o pipefail
+      set -eu -o pipefail
 
       # Output installed node versions
       n ls

--- a/tools/pipelines/templates/upload-dev-manifest.yml
+++ b/tools/pipelines/templates/upload-dev-manifest.yml
@@ -24,7 +24,7 @@ jobs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          set -eux -o pipefail
+          set -eu -o pipefail
           mkdir generate_release_reports
           flub release report -g client -o generate_release_reports --baseFileName manifest
 
@@ -34,7 +34,7 @@ jobs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}
         script: |
-          set -eux -o pipefail
+          set -eu -o pipefail
           mkdir upload_release_reports
           flub release report-unreleased --version $(version) --fullReportFilePath generate_release_reports/manifest.full.json --outDir upload_release_reports --branchName '$(Build.SourceBranch)'
 

--- a/tools/pipelines/templates/upload-dev-manifest.yml
+++ b/tools/pipelines/templates/upload-dev-manifest.yml
@@ -13,7 +13,8 @@ jobs:
     - name: version
       value: $[stageDependencies.build.build.outputs['SetVersion.version']]
     steps:
-    - template: include-install-build-tools.yml
+    - template: /tools/pipelines/templates/include-use-node-version.yml@self
+    - template: /tools/pipelines/templates/include-install-build-tools.yml@self
       parameters:
         buildDirectory: ${{ parameters.buildDirectory }}
 

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -131,7 +131,7 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               TAR_FILENAME=${{ replace(replace(replace(replace(testPackage, '@fluidframework/', '' ), '@fluid-internal/', '' ),'@fluid-', '' ), '/', '-') }}
               TAR_PATH=$(testFilesPath)/$TAR_FILENAME.test-files.tar
               cd ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
@@ -183,7 +183,7 @@ stages:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               echo "Cleanup package ${{ testPackage }} from ${{ variables.testWorkspace }}/node_modules/"
               rm -rf ${{ testPackage }};
 
@@ -193,7 +193,7 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
+            set -eu -o pipefail
             echo "Write the following benchmark output to Aria/Kusto"
             ls -laR ${{ variables.consolidatedTestsOutputFolder }};
             node --require @ff-internal/aria-logger bin/run --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/executionTimeTestHandler.js --dir '${{ variables.consolidatedTestsOutputFolder }}';
@@ -204,7 +204,7 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
+            set -eu -o pipefail
             echo "Writing performance benchmark output to Azure App Insights..."
             ls -laR ${{ variables.consolidatedTestsOutputFolder }};
             node bin/run appInsights --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/appInsightsExecutionTimeTestHandler.js --dir '${{ variables.consolidatedTestsOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
@@ -266,7 +266,7 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               TAR_FILENAME=${{ replace(replace(replace(replace(testPackage, '@fluidframework/', '' ), '@fluid-internal/', '' ),'@fluid-', '' ), '/', '-') }}
               TAR_PATH=$(testFilesPath)/$TAR_FILENAME.test-files.tar
               cd ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
@@ -318,7 +318,7 @@ stages:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               echo "Cleanup package ${{ testPackage }} from ${{ variables.testWorkspace }}/node_modules/"
               rm -rf ${{ testPackage }};
 
@@ -328,7 +328,7 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
+            set -eu -o pipefail
             echo "Write the following benchmark output to Aria/Kusto";
             ls -laR ${{ variables.consolidatedTestsOutputFolder }};
             node --require @ff-internal/aria-logger bin/run --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/memoryUsageTestHandler.js --dir ${{ variables.consolidatedTestsOutputFolder }};
@@ -339,7 +339,7 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
+            set -eu -o pipefail
             echo "Writing performance benchmark output to Azure App Insights..."
             ls -laR ${{ variables.consolidatedTestsOutputFolder }};
             node bin/run appInsights --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/appInsightsMemoryUsageTestHandler.js --dir '${{ variables.consolidatedTestsOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
@@ -401,7 +401,7 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               TAR_FILENAME=${{ replace(replace(replace(replace(testPackage, '@fluidframework/', '' ), '@fluid-internal/', '' ),'@fluid-', '' ), '/', '-') }}
               TAR_PATH=$(testFilesPath)/$TAR_FILENAME.test-files.tar
               cd ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
@@ -453,7 +453,7 @@ stages:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               echo "Cleanup package ${{ testPackage }} from ${{ variables.testWorkspace }}/node_modules/"
               rm -rf ${{ testPackage }};
 
@@ -463,7 +463,7 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
+            set -eu -o pipefail
             echo "Write the following benchmark output to Aria/Kusto";
             ls -laR ${{ variables.consolidatedTestsOutputFolder }};
             node --require @ff-internal/aria-logger bin/run --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/customBenchmarkHandler.js --dir ${{ variables.consolidatedTestsOutputFolder }};
@@ -474,7 +474,7 @@ stages:
           targetType: 'inline'
           workingDirectory: $(absolutePathToTelemetryGenerator)
           script: |
-            set -eux -o pipefail
+            set -eu -o pipefail
             echo "Writing performance benchmark output to Azure App Insights..."
             ls -laR ${{ variables.consolidatedTestsOutputFolder }};
             node bin/run appInsights --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/appInsightsCustomBenchmarkHandler.js --dir '${{ variables.consolidatedTestsOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
@@ -562,7 +562,7 @@ stages:
             targetType: 'inline'
             workingDirectory: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}
             script: |
-              # Note: we explicitly do not use 'set -eux -o pipefail' here because we want to run both sets of tests
+              # Note: we explicitly do not use 'set -eu -o pipefail' here because we want to run both sets of tests
               # no matter what. Probably should be refactored later to use separate steps for each set of tests.
 
               echo "FLUID_LOGGER_PROPS = $FLUID_LOGGER_PROPS"
@@ -615,7 +615,7 @@ stages:
             targetType: 'inline'
             workingDirectory: $(absolutePathToTelemetryGenerator)
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               echo "Writing the following performance tests results to Aria/Kusto - ${{ endpointObject.endpointName }}"
               ls -la ${{ variables.executionTimeTestOutputFolder }};
               node --require @ff-internal/aria-logger bin/run --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/executionTimeTestHandler.js --dir ${{ variables.executionTimeTestOutputFolder }};
@@ -629,7 +629,7 @@ stages:
             targetType: 'inline'
             workingDirectory: $(absolutePathToTelemetryGenerator)
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               echo "Writing the following performance tests results to Aria/Kusto - ${{ endpointObject.endpointName }}"
               ls -la ${{ variables.memoryUsageTestOutputFolder }};
               node --require @ff-internal/aria-logger bin/run --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/memoryUsageTestHandler.js --dir ${{ variables.memoryUsageTestOutputFolder }};
@@ -643,7 +643,7 @@ stages:
             targetType: 'inline'
             workingDirectory: $(absolutePathToTelemetryGenerator)
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               echo "Writing execution time performance benchmark output to Azure App Insights..."
               ls -laR ${{ variables.executionTimeTestOutputFolder }};
               node bin/run appInsights --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/appInsightsExecutionTimeTestHandler.js --dir '${{ variables.executionTimeTestOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
@@ -659,7 +659,7 @@ stages:
             targetType: 'inline'
             workingDirectory: $(absolutePathToTelemetryGenerator)
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               echo "Writing memory usage performance benchmark output to Azure App Insights..."
               ls -laR ${{ variables.memoryUsageTestOutputFolder }};
               node bin/run appInsights --handlerModule $(absolutePathToTelemetryGenerator)/dist/handlers/appInsightsMemoryUsageTestHandler.js --dir '${{ variables.memoryUsageTestOutputFolder }}' --connectionString '$(fluid-interal-app-insights-connection-string)';
@@ -689,7 +689,7 @@ stages:
             targetType: 'inline'
             workingDirectory: $(absolutePathToTelemetryGenerator)
             script: |
-              set -eux -o pipefail
+              set -eu -o pipefail
               ls -laR ${{ variables.executionTimeTestOutputFolder }};
               echo "Cleanup  ${{ variables.executionTimeTestOutputFolder }}"
               rm -rf ${{ variables.executionTimeTestOutputFolder }};


### PR DESCRIPTION
## Description

- It's [documented](https://learn.microsoft.com/en-us/azure/devops/pipelines/troubleshooting/troubleshooting?view=azure-devops#variables-having--single-quote-appended) that ADO logging commands (`echo ##vso[<something>]`) don't interact well with `set -x`, so undoing that part of https://github.com/microsoft/FluidFramework/pull/22659 because we use them in several places. I could have wrapped each use in `set +x; <command>; set -x` but I think that would warrant a comment every time. We have lived forever without having each command in a script printed back to us, so I think it's fine to keep that behavior.
- Adds steps to install the correct node version in the job to upload dev manifests. It wasn't using it, and since the build agent image made node 18 available by default (by coincidence?) when installing the several versions that we install in our image, everything worked. But in the latest version of the image, re-generated automatically, node 16 seems to be the default (unsure why, separate topic I'm looking into), and that uncovered this missing step.

The second bullet point is highlighted with a comment below. Everything else in the PR is about the first one.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).