### PR TITLE
Add socker error handling for r11s

### DIFF
--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -86,7 +86,7 @@
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
-		"test:mocha": "npm run test:mocha:esm && npm run test:mocha:cjs",
+		"test:mocha": "npm run test:mocha:cjs && echo \"ADO #7404 - ESM modules cannot be stubbed - npm run test:mocha:esm\"",
 		"test:mocha:cjs": "mocha --recursive \"dist/test/**/*.spec.*js\" --exit",
 		"test:mocha:esm": "mocha --recursive \"lib/test/**/*.spec.*js\" --exit",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",

--- a/packages/drivers/routerlicious-driver/src/contracts.ts
+++ b/packages/drivers/routerlicious-driver/src/contracts.ts
@@ -59,3 +59,10 @@ export interface INormalizedWholeSnapshot {
 	sequenceNumber: number | undefined;
 	id: string;
 }
+
+/**
+ * Error code for when the service drains a cluster to which the socket connection is connected to and it disconnects
+ * all the clients in that cluster.
+ * @internal
+ */
+export const R11sServiceClusterDrainingErrorCode = "ClusterDraining";

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -11,10 +11,10 @@ import {
 	IConnect,
 } from "@fluidframework/driver-definitions/internal";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
-import type { io as SocketIOClientStatic } from "socket.io-client";
 
 import { IR11sSocketError, errorObjectFromSocketError } from "./errorUtils.js";
 import { pkgVersion as driverVersion } from "./packageVersion.js";
+import { SocketIOClientStatic } from "./socketModule.js";
 
 const protocolVersions = ["^0.4.0", "^0.3.0", "^0.2.0", "^0.1.0"];
 

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -13,8 +13,9 @@ import {
 	GenericNetworkError,
 	NonRetryableError,
 	createGenericNetworkError,
+	type DriverErrorTelemetryProps,
 } from "@fluidframework/driver-utils/internal";
-import { IFluidErrorBase } from "@fluidframework/telemetry-utils/internal";
+import { IFluidErrorBase, LoggingError } from "@fluidframework/telemetry-utils/internal";
 
 import { pkgVersion as driverVersion } from "./packageVersion.js";
 
@@ -31,12 +32,25 @@ export const RouterliciousErrorTypes = {
 	 * SSL Certificate Error.
 	 */
 	sslCertError: "sslCertError",
+
+	/**
+	 * Error for when the service drains a cluster to which the socket connection is connected to and it disconnects
+	 * all the clients in that cluster.
+	 */
+	clusterDrainingError: "clusterDrainingError",
 } as const;
 /**
  * @internal
  */
 export type RouterliciousErrorTypes =
 	(typeof RouterliciousErrorTypes)[keyof typeof RouterliciousErrorTypes];
+
+/**
+ * Error code for when the service drains a cluster to which the socket connection is connected to and it disconnects
+ * all the clients in that cluster.
+ * @internal
+ */
+export const R11sServiceClusterDrainingErrorCode = "ClusterDraining";
 
 /**
  * Interface for error responses for the WebSocket connection
@@ -66,6 +80,24 @@ export interface IR11sSocketError {
 	 * The client should wait this many milliseconds before retrying its request.
 	 */
 	retryAfterMs?: number;
+
+	/**
+	 * Optional internalErrorCode to specify the specific error code for the error within the main code above.
+	 */
+	internalErrorCode?: string | number;
+}
+
+export class ClusterDrainingError extends LoggingError implements IFluidErrorBase {
+	readonly errorType = RouterliciousErrorTypes.clusterDrainingError;
+	readonly canRetry = true;
+
+	constructor(
+		message: string,
+		readonly retryAfterSeconds: number,
+		props: DriverErrorTelemetryProps,
+	) {
+		super(message, props);
+	}
 }
 
 export interface IR11sError extends Omit<IDriverErrorBase, "errorType"> {
@@ -78,6 +110,7 @@ export function createR11sNetworkError(
 	errorMessage: string,
 	statusCode: number,
 	retryAfterMs?: number,
+	internalErrorCode?: string | number,
 ): IFluidErrorBase & R11sError {
 	let error: IFluidErrorBase & R11sError;
 	const props = { statusCode, driverVersion };
@@ -99,6 +132,15 @@ export function createR11sNetworkError(
 		case 502:
 			error = new GenericNetworkError(errorMessage, true, props);
 			break;
+		case 503:
+			if (internalErrorCode === R11sServiceClusterDrainingErrorCode) {
+				error = new ClusterDrainingError(
+					errorMessage,
+					retryAfterMs !== undefined ? retryAfterMs / 1000 : 660,
+					props,
+				);
+				break;
+			}
 		default:
 			const retryInfo = { canRetry: retryAfterMs !== undefined, retryAfterMs };
 			error = createGenericNetworkError(errorMessage, retryInfo, props);
@@ -127,5 +169,16 @@ export function errorObjectFromSocketError(
 ): R11sError {
 	// pre-0.58 error message prefix: R11sSocketError
 	const message = `R11s socket error (${handler}): ${socketError.message}`;
-	return createR11sNetworkError(message, socketError.code, socketError.retryAfterMs);
+	const error = createR11sNetworkError(
+		message,
+		socketError.code,
+		socketError.retryAfterMs,
+		socketError.internalErrorCode,
+	);
+	error.addTelemetryProperties({
+		relayServiceError: true,
+		scenarioName: handler,
+		internalErrorCode: socketError.internalErrorCode,
+	});
+	return error;
 }

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -17,6 +17,7 @@ import {
 } from "@fluidframework/driver-utils/internal";
 import { IFluidErrorBase, LoggingError } from "@fluidframework/telemetry-utils/internal";
 
+import { R11sServiceClusterDrainingErrorCode } from "./contracts.js";
 import { pkgVersion as driverVersion } from "./packageVersion.js";
 
 /**
@@ -44,13 +45,6 @@ export const RouterliciousErrorTypes = {
  */
 export type RouterliciousErrorTypes =
 	(typeof RouterliciousErrorTypes)[keyof typeof RouterliciousErrorTypes];
-
-/**
- * Error code for when the service drains a cluster to which the socket connection is connected to and it disconnects
- * all the clients in that cluster.
- * @internal
- */
-export const R11sServiceClusterDrainingErrorCode = "ClusterDraining";
 
 /**
  * Interface for error responses for the WebSocket connection

--- a/packages/drivers/routerlicious-driver/src/socketModule.ts
+++ b/packages/drivers/routerlicious-driver/src/socketModule.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { io } from "socket.io-client";
+
+// Import is required for side-effects.
+export const SocketIOClientStatic = io;

--- a/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
@@ -143,11 +143,6 @@ describe("R11s Socket Tests", () => {
 			(error as any).internalErrorCode === "TokenRevoked",
 			"Error internal code should be TokenRevoked",
 		);
-		assert(
-			// eslint-disable-next-line @typescript-eslint/dot-notation
-			documentService["refreshTokenOnConnect"],
-			"Token should be set to refresh on connect",
-		);
 	});
 
 	it("connect_document_error with Cluster Draining error", async () => {

--- a/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
@@ -14,13 +14,11 @@ import {
 import { stub } from "sinon";
 import { Socket } from "socket.io-client";
 
+import { R11sServiceClusterDrainingErrorCode } from "../contracts.js";
 import { DefaultTokenProvider } from "../defaultTokenProvider.js";
 import { DocumentService } from "../documentService.js";
 import { RouterliciousDocumentServiceFactory } from "../documentServiceFactory.js";
-import {
-	R11sServiceClusterDrainingErrorCode,
-	RouterliciousErrorTypes,
-} from "../errorUtils.js";
+import { RouterliciousErrorTypes } from "../errorUtils.js";
 import * as socketModule from "../socketModule.js";
 // eslint-disable-next-line import/no-internal-modules
 import { ClientSocketMock } from "../test/socketTestUtils.ts/socketMock.js";

--- a/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
@@ -85,28 +85,17 @@ describe("R11s Socket Tests", () => {
 			connect_document: { eventToEmit: errorEventName, errorToThrow },
 		});
 
-		let errorOccurred = false;
-		try {
-			await mockSocket(socket as unknown as Socket, async () =>
+		await assert.rejects(
+			mockSocket(socket as unknown as Socket, async () =>
 				documentService.connectToDeltaStream(client),
-			);
-		} catch (error) {
-			errorOccurred = true;
-			const anyDriverError = error as IAnyDriverError;
-			assert(
-				anyDriverError.errorType === DriverErrorTypes.authorizationError,
-				"Error type should be authorizationError",
-			);
-			assert(
-				anyDriverError.scenarioName === "connect_document_error",
-				"Error scenario name should be connect_document_error",
-			);
-			assert(
-				(anyDriverError as any).internalErrorCode === "TokenRevoked",
-				"Error internal code should be TokenRevoked",
-			);
-		}
-		assert(errorOccurred, "Error should have occurred");
+			),
+			{
+				errorType: DriverErrorTypes.authorizationError,
+				scenarioName: "connect_document_error",
+				internalErrorCode: "TokenRevoked",
+			},
+			"Error should have occurred",
+		);
 	});
 
 	it("Socket error with Token Revoked error", async () => {
@@ -159,28 +148,17 @@ describe("R11s Socket Tests", () => {
 			connect_document: { eventToEmit: errorEventName, errorToThrow },
 		});
 
-		let errorOccurred = false;
-		try {
-			await mockSocket(socket as unknown as Socket, async () =>
+		await assert.rejects(
+			mockSocket(socket as unknown as Socket, async () =>
 				documentService.connectToDeltaStream(client),
-			);
-		} catch (error) {
-			errorOccurred = true;
-			const anyDriverError = error as IAnyDriverError;
-			assert(
-				anyDriverError.errorType === RouterliciousErrorTypes.clusterDrainingError,
-				"Error type should be clusterDrainingError",
-			);
-			assert(
-				anyDriverError.scenarioName === "connect_document_error",
-				"Error scenario name should be connect_document_error",
-			);
-			assert(
-				(anyDriverError as any).internalErrorCode === R11sServiceClusterDrainingErrorCode,
-				"Error internal code should be R11sServiceClusterDrainingErrorCode",
-			);
-		}
-		assert(errorOccurred, "Error should have occurred");
+			),
+			{
+				errorType: RouterliciousErrorTypes.clusterDrainingError,
+				scenarioName: "connect_document_error",
+				internalErrorCode: R11sServiceClusterDrainingErrorCode,
+			},
+			"Error should have occurred",
+		);
 	});
 
 	it("Socket error with Cluster Draining error", async () => {

--- a/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
@@ -1,0 +1,226 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { IClient } from "@fluidframework/driver-definitions";
+import {
+	DriverErrorTypes,
+	IResolvedUrl,
+	type IAnyDriverError,
+} from "@fluidframework/driver-definitions/internal";
+import { stub } from "sinon";
+import { Socket } from "socket.io-client";
+
+import { DefaultTokenProvider } from "../defaultTokenProvider.js";
+import { DocumentService } from "../documentService.js";
+import { RouterliciousDocumentServiceFactory } from "../documentServiceFactory.js";
+import {
+	R11sServiceClusterDrainingErrorCode,
+	RouterliciousErrorTypes,
+} from "../errorUtils.js";
+import * as socketModule from "../socketModule.js";
+// eslint-disable-next-line import/no-internal-modules
+import { ClientSocketMock } from "../test/socketTestUtils.ts/socketMock.js";
+
+describe("R11s Socket Tests", () => {
+	let documentService: DocumentService;
+	let routerliciousDocumentServiceFactory: RouterliciousDocumentServiceFactory;
+	// let deltaConnection: R11sDocumentDeltaConnection;
+	let resolvedUrl: IResolvedUrl;
+	let socket: ClientSocketMock | undefined;
+
+	async function mockSocket<T>(_response: Socket, callback: () => Promise<T>): Promise<T> {
+		const getSocketCreationStub = stub(socketModule, "SocketIOClientStatic");
+		getSocketCreationStub.returns(_response);
+		try {
+			return await callback();
+		} finally {
+			getSocketCreationStub.restore();
+		}
+	}
+
+	const client: IClient = {
+		mode: "read",
+		details: { capabilities: { interactive: true } },
+		permission: [],
+		user: { id: "id" },
+		scopes: [],
+	};
+
+	beforeEach(async () => {
+		routerliciousDocumentServiceFactory = new RouterliciousDocumentServiceFactory(
+			new DefaultTokenProvider("jwt"),
+		);
+		resolvedUrl = {
+			type: "fluid",
+			id: "id",
+			url: "https://mock.url/tenantId/documentId",
+			endpoints: {
+				ordererUrl: "ordererUrl",
+				storageUrl: "storageUrl",
+				deltaStorageUrl: "deltaStorageUrl",
+				deltaStreamUrl: "deltaStreamUrl",
+			},
+			tokens: {},
+		};
+		documentService = (await routerliciousDocumentServiceFactory.createDocumentService(
+			resolvedUrl,
+		)) as DocumentService;
+	});
+
+	it("connect_document_error with Token Revoked error", async () => {
+		const errorToThrow = {
+			code: 403,
+			message: "TokenRevokedError",
+			retryAfterMs: 10,
+			internalErrorCode: "TokenRevoked",
+			errorType: DriverErrorTypes.authorizationError,
+			canRetry: false,
+		};
+		const errorEventName = "connect_document_error";
+		socket = new ClientSocketMock({
+			connect_document: { eventToEmit: errorEventName, errorToThrow },
+		});
+
+		let errorOccurred = false;
+		try {
+			await mockSocket(socket as unknown as Socket, async () =>
+				documentService.connectToDeltaStream(client),
+			);
+		} catch (error) {
+			errorOccurred = true;
+			const anyDriverError = error as IAnyDriverError;
+			assert(
+				anyDriverError.errorType === DriverErrorTypes.authorizationError,
+				"Error type should be authorizationError",
+			);
+			assert(
+				anyDriverError.scenarioName === "connect_document_error",
+				"Error scenario name should be connect_document_error",
+			);
+			assert(
+				(anyDriverError as any).internalErrorCode === "TokenRevoked",
+				"Error internal code should be TokenRevoked",
+			);
+		}
+		assert(errorOccurred, "Error should have occurred");
+	});
+
+	it("Socket error with Token Revoked error", async () => {
+		const errorToThrow = {
+			code: 403,
+			message: "TokenRevokedError",
+			retryAfterMs: 10,
+			internalErrorCode: "TokenRevoked",
+			errorType: DriverErrorTypes.authorizationError,
+			canRetry: false,
+		};
+		const errorEventName = "connect_document_success";
+		socket = new ClientSocketMock({
+			connect_document: { eventToEmit: errorEventName },
+		});
+
+		const connection = await mockSocket(socket as unknown as Socket, async () =>
+			documentService.connectToDeltaStream(client),
+		);
+		let error: IAnyDriverError | undefined;
+		connection.on("disconnect", (reason: IAnyDriverError) => {
+			error = reason;
+		});
+
+		// Send Token Revoked error
+		socket.sendErrorEvent(errorToThrow);
+
+		assert(
+			error?.errorType === DriverErrorTypes.authorizationError,
+			"Error type should be authorizationError",
+		);
+		assert(error.scenarioName === "error", "Error scenario name should be error");
+		assert(
+			(error as any).internalErrorCode === "TokenRevoked",
+			"Error internal code should be TokenRevoked",
+		);
+		assert(
+			// eslint-disable-next-line @typescript-eslint/dot-notation
+			documentService["refreshTokenOnConnect"],
+			"Token should be set to refresh on connect",
+		);
+	});
+
+	it("connect_document_error with Cluster Draining error", async () => {
+		const errorToThrow = {
+			code: 503,
+			message: "ClusterDrainingError",
+			retryAfterMs: 1000,
+			internalErrorCode: R11sServiceClusterDrainingErrorCode,
+			errorType: RouterliciousErrorTypes.clusterDrainingError,
+			canRetry: true,
+		};
+		const errorEventName = "connect_document_error";
+		socket = new ClientSocketMock({
+			connect_document: { eventToEmit: errorEventName, errorToThrow },
+		});
+
+		let errorOccurred = false;
+		try {
+			await mockSocket(socket as unknown as Socket, async () =>
+				documentService.connectToDeltaStream(client),
+			);
+		} catch (error) {
+			errorOccurred = true;
+			const anyDriverError = error as IAnyDriverError;
+			assert(
+				anyDriverError.errorType === RouterliciousErrorTypes.clusterDrainingError,
+				"Error type should be clusterDrainingError",
+			);
+			assert(
+				anyDriverError.scenarioName === "connect_document_error",
+				"Error scenario name should be connect_document_error",
+			);
+			assert(
+				(anyDriverError as any).internalErrorCode === R11sServiceClusterDrainingErrorCode,
+				"Error internal code should be R11sServiceClusterDrainingErrorCode",
+			);
+		}
+		assert(errorOccurred, "Error should have occurred");
+	});
+
+	it("Socket error with Cluster Draining error", async () => {
+		const errorToThrow = {
+			code: 503,
+			message: "ClusterDrainingError",
+			retryAfterMs: 1000,
+			internalErrorCode: R11sServiceClusterDrainingErrorCode,
+			errorType: RouterliciousErrorTypes.clusterDrainingError,
+			canRetry: true,
+		};
+		const errorEventName = "connect_document_success";
+		socket = new ClientSocketMock({
+			connect_document: { eventToEmit: errorEventName },
+		});
+
+		const connection = await mockSocket(socket as unknown as Socket, async () =>
+			documentService.connectToDeltaStream(client),
+		);
+		let error: IAnyDriverError | undefined;
+		connection.on("disconnect", (reason: IAnyDriverError) => {
+			error = reason;
+		});
+
+		// Send Token Revoked error
+		socket.sendErrorEvent(errorToThrow);
+
+		assert(
+			error?.errorType === RouterliciousErrorTypes.clusterDrainingError,
+			"Error type should be clusterDrainingError",
+		);
+		assert(error.scenarioName === "error", "Error scenario name should be error");
+		assert(
+			(error as any).internalErrorCode === R11sServiceClusterDrainingErrorCode,
+			"Error internal code should be R11sServiceClusterDrainingErrorCode",
+		);
+	});
+});

--- a/packages/drivers/routerlicious-driver/src/test/socketTestUtils.ts/socketMock.ts
+++ b/packages/drivers/routerlicious-driver/src/test/socketTestUtils.ts/socketMock.ts
@@ -1,0 +1,153 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { TypedEventEmitter } from "@fluid-internal/client-utils";
+import { IEvent } from "@fluidframework/core-interfaces";
+import {
+	IAnyDriverError,
+	IConnect,
+	IConnected,
+	ScopeType,
+} from "@fluidframework/driver-definitions/internal";
+import { createGenericNetworkError } from "@fluidframework/driver-utils/internal";
+import { v4 as uuid } from "uuid";
+
+import { pkgVersion as driverVersion } from "../../packageVersion.js";
+
+export interface SocketMockEvents extends IEvent {
+	(event: "disconnect", listener: (reason?: IAnyDriverError, details?: unknown) => void): void;
+	(event: "error", listener: (error?: IAnyDriverError) => void): void;
+}
+
+export interface IMockSocketConnectResponse {
+	connect_document:
+		| {
+				eventToEmit: "connect_document_success";
+				connectMessage?: IConnected;
+		  }
+		| {
+				eventToEmit: "connect_document_error";
+				errorToThrow?: IAnyDriverError;
+		  }
+		| {
+				eventToEmit: "connect_error";
+				errorToThrow?: IAnyDriverError;
+		  }
+		| {
+				eventToEmit: "connect_timeout";
+		  };
+}
+
+/**
+ * Class to mock the client socket connection. It can intercepts the events made on the socket
+ * and then do its custom logic and can also send events to the client back.
+ * @internal
+ */
+export class ClientSocketMock extends TypedEventEmitter<SocketMockEvents> {
+	public disconnected = false;
+	constructor(
+		private readonly mockSocketConnectResponse: IMockSocketConnectResponse = {
+			connect_document: { eventToEmit: "connect_document_success" },
+		},
+	) {
+		super();
+	}
+
+	public get connected(): boolean {
+		return !this.disconnected;
+	}
+
+	public close(): void {
+		this.disconnect();
+	}
+
+	public disconnect(): void {
+		this.disconnected = true;
+	}
+
+	public get io(): {
+		reconnection: () => boolean;
+		reconnectionAttempts: () => number;
+	} {
+		return {
+			reconnection: () => false,
+			reconnectionAttempts: () => 0,
+		};
+	}
+
+	public sendDisconnectEvent(
+		reason?: IAnyDriverError,
+		details?: { context: { type?: string; code?: number } },
+	): void {
+		const error =
+			reason ?? createGenericNetworkError("TestError", { canRetry: false }, { driverVersion });
+		this.emit("disconnect", error, details);
+	}
+
+	public sendErrorEvent(error?: IAnyDriverError): void {
+		this.emit(
+			"error",
+			error ?? createGenericNetworkError("TestError", { canRetry: false }, { driverVersion }),
+		);
+	}
+
+	public emit(eventName: string, ...args: unknown[]): boolean {
+		switch (eventName) {
+			case "connect_document": {
+				const connectMessage = args[0] as IConnect;
+				switch (this.mockSocketConnectResponse.connect_document.eventToEmit) {
+					case "connect_document_error":
+					case "connect_error": {
+						const errorToThrow =
+							this.mockSocketConnectResponse.connect_document.errorToThrow ??
+							createGenericNetworkError("TestError", { canRetry: false }, { driverVersion });
+						this.emit(
+							this.mockSocketConnectResponse.connect_document.eventToEmit,
+							errorToThrow,
+						);
+						break;
+					}
+					case "connect_document_success": {
+						const iConnected: IConnected = this.mockSocketConnectResponse.connect_document
+							.connectMessage ?? {
+							clientId: uuid(),
+							existing: true,
+							initialClients: [],
+							initialMessages: [],
+							initialSignals: [],
+							maxMessageSize: 1000,
+							mode: connectMessage.mode,
+							version: connectMessage.versions[0]!,
+							serviceConfiguration: { maxMessageSize: 1000, blockSize: 1000 },
+							claims: {
+								documentId: connectMessage.id,
+								scopes: [ScopeType.DocWrite, ScopeType.DocRead, ScopeType.SummaryWrite],
+								tenantId: connectMessage.tenantId,
+								ver: "1.0.0",
+								iat: 10,
+								exp: 10,
+								user: connectMessage.client.user,
+							},
+							supportedVersions: connectMessage.versions,
+							epoch: "testEpoch",
+						};
+						this.emit("connect_document_success", iConnected);
+						break;
+					}
+					case "connect_timeout": {
+						this.emit("connect_timeout");
+						break;
+					}
+					default: // No-op
+				}
+				return true;
+			}
+			default: {
+				super.emit(eventName, ...args);
+				return true;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

[AB#18937](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/18937)

Implement error handling for the following errors sent by AFR over the socket.

1.) For Cluster Draining:
error =  {
code: 503,
canRetry?: true;
message?: "Cluster is not available. Please retry later.";
retryAfter?: number;
retryAfterMs?: number;
internalErrorCode?:ClusterDraining;
}

2.) Token Revoked:
error =  {
code: 401/403,
canRetry?: false;
message?: "Permission denied. Token has been revoked.";
internalErrorCode?:TokenRevoked;
}