### PR TITLE
When trimming the EditManager trunk, avoid mutating revision and change of the new trunk base commit

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -54,6 +54,14 @@ const minimumPossibleSequenceId: SequenceId = {
 };
 
 /**
+ * A special revision tag for the initial {@link EditManager.trunkBase} commit.
+ * @remarks This tag is used to supply the _initial_ trunk base with a known revision.
+ * The trunk base may advance over time, after which point the trunk base will have a different revision.
+ * When {@link EditManager.getSummaryData | serializing} and deserializing, peer branches that include the trunk base commit in their history will always use this tag.
+ */
+const rootRevision = "root" as const satisfies RevisionTag;
+
+/**
  * Max number of telemetry log call that may be aggregated before being sent.
  */
 const maxRebaseStatsAggregationCount = 1000;
@@ -152,7 +160,7 @@ export class EditManager<
 		logger?: ITelemetryLoggerExt,
 	) {
 		this.trunkBase = {
-			revision: "root",
+			revision: rootRevision,
 			change: changeFamily.rebaser.compose([]),
 		};
 		this.sequenceMap.set(minimumPossibleSequenceId, this.trunkBase);
@@ -363,11 +371,6 @@ export class EditManager<
 				newTrunkBase,
 				this.trunkBase,
 			).map((c) => c.revision);
-			// Copying the revision of the old trunk base into the new trunk base means we don't need to write out the original
-			// revision to summaries. All clients agree that the trunk base always has the same hardcoded revision.
-			newTrunkBase.revision = this.trunkBase.revision;
-			// Overwriting the change is not strictly necessary, but done here for consistency (so all trunk bases are deeply equal).
-			newTrunkBase.change = this.trunkBase.change;
 			// Dropping the parent field removes (transitively) all references to the evicted commits so they can be garbage collected.
 			delete newTrunkBase.parent;
 			this.trunkBase = newTrunkBase;
@@ -442,6 +445,7 @@ export class EditManager<
 
 		const trunk = getPathFromBase(this.trunk.getHead(), oldestCommitInCollabWindow).map(
 			(c) => {
+				assert(c !== this.trunkBase, "Serialized trunk should not include the trunk base");
 				const metadata =
 					this.trunkMetadata.get(c.revision) ?? fail("Expected metadata for trunk commit");
 				const commit: SequencedCommit<TChangeset> = {
@@ -464,11 +468,16 @@ export class EditManager<
 					findCommonAncestor([branch.getHead(), branchPath], this.trunk.getHead()) ??
 					fail("Expected branch to be based on trunk");
 
+				const base = ancestor === this.trunkBase ? rootRevision : ancestor.revision;
 				return [
 					sessionId,
 					{
-						base: ancestor.revision,
+						base,
 						commits: branchPath.map((c) => {
+							assert(
+								c !== this.trunkBase,
+								"Serialized branch should not include the trunk base",
+							);
 							const commit: Commit<TChangeset> = {
 								change: c.change,
 								revision: c.revision,

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -516,6 +516,8 @@ export class TreeCheckout implements ITreeCheckoutFork {
 					event.type === "append" ||
 					(event.type === "replace" && getChangeReplaceType(event) === "transactionCommit")
 				) {
+					// TODO:#20949: When the SharedTree is detached, these commits will already have been garbage collected.
+					//       Figure out a way to generate revertibles before the commits are garbage collected.
 					for (const commit of event.newCommits) {
 						const kind = event.type === "append" ? event.kind : CommitKind.Default;
 						const { change, revision } = commit;


### PR DESCRIPTION
## Description

This gets rid of unnecessary mutations of the commit that becomes the trunk base commit during trunk trimming in the EditManager. The mutation of the `revision` property was done to avoid an additional check in the `getSummaryData()` codepath, and the mutation of the `change` property was done merely for consistency. This gets rid of both in favor of just doing the simple check in `getSummaryData()`, since it is best to avoid mutating objects that are otherwise considered to be immutable.

This PR also:
* adds a test for a scenario that is currently failing - namely, reverting a commit (e.g. via an undo) when the SharedTree is detached. This will be fixed in a follow-up PR.
* adds documentation for the special `"root"` revision tag.
