### PR TITLE
Modify codecoverageAnalysis name to include job attempt number

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -637,7 +637,7 @@ extends:
                     displayName: Publish Artifacts - code-coverage
                     condition: and( succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
                     targetPath: $(Build.ArtifactStagingDirectory)/codeCoverageAnalysis
-                    artifactName: codeCoverageAnalysis
+                    artifactName: 'codeCoverageAnalysis-$(System.JobAttempt)'
                     sbomEnabled: false
                     publishLocation: pipeline
 


### PR DESCRIPTION
## Description

Modify codecoverageAnalysis name to include job attempt number. This is because the reupload attempts fails, if the folder already exists.