### PR TITLE
Increase snapshotRefreshTimeoutMs for non local drivers on e2e tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializerLifeCycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializerLifeCycle.spec.ts
@@ -162,6 +162,13 @@ describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider,
 			) {
 				return;
 			}
+			let snapshotRefreshTimeoutMs;
+			if (
+				testConfig.timeoutRefreshInOriginalContainer ||
+				testConfig.timeoutRefreshInLoadedContainer
+			) {
+				snapshotRefreshTimeoutMs = provider.driver.type === "local" ? 100 : 1000;
+			}
 			const getLatestSnapshotInfoP = new Deferred<void>();
 			const testContainerConfig = {
 				fluidDataObjectType: DataObjectFactoryType.Test,
@@ -186,11 +193,7 @@ describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider,
 						"Fluid.Container.enableOfflineSnapshotRefresh": true,
 						"Fluid.Container.UseLoadingGroupIdForSnapshotFetch":
 							testConfig.useLoadingGroupIdForSnapshotFetch,
-						"Fluid.Container.snapshotRefreshTimeoutMs":
-							testConfig.timeoutRefreshInOriginalContainer ||
-							testConfig.timeoutRefreshInLoadedContainer
-								? 100
-								: undefined,
+						"Fluid.Container.snapshotRefreshTimeoutMs": snapshotRefreshTimeoutMs,
 					}),
 				},
 			};


### PR DESCRIPTION
Refresh snapshot lifecycle tests are having timeout issues while running them against FRS and ODSP drivers. On debugging I was able to detect a throttling error while requesting updating the snapshot since the timeout to request a new snapshot was too short. On increasing such timeout to 1sec instead of 100ms, the throttling error disappear completely on local tests while running against ODSP without impacting on test duration (this could be subject to further calibration).

My hypothesis is that while running on the lab, snapshot refresh fails silently, and given we never refreshed, our deferred promises that awaits for it never resolves, ending in the timeout. 
