### PR TITLE
Treat t9s as local for refresh snapshot tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializerLifeCycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializerLifeCycle.spec.ts
@@ -167,7 +167,12 @@ describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider,
 				testConfig.timeoutRefreshInOriginalContainer ||
 				testConfig.timeoutRefreshInLoadedContainer
 			) {
-				snapshotRefreshTimeoutMs = provider.driver.type === "local" ? 100 : 1000;
+				snapshotRefreshTimeoutMs =
+					provider.driver.type === "local" ||
+					provider.driver.type === "t9s" ||
+					provider.driver.type === "tinylicious"
+						? 100
+						: 1000;
 			}
 			const getLatestSnapshotInfoP = new Deferred<void>();
 			const testContainerConfig = {


### PR DESCRIPTION
Following up https://github.com/microsoft/FluidFramework/pull/22871 PR, treat t9s as local to avoid possible timeouts or issues while running against it since we haven't seen any using current 100ms timeout