### PR TITLE
refactor(devtools): Remove unnecessary explicit dependency

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -129,7 +129,6 @@
 		"good-fences": "^1.1.1",
 		"html-webpack-plugin": "^5.6.0",
 		"jest": "^29.6.2",
-		"jest-dev-server": "^9.0.2",
 		"jest-environment-puppeteer": "^9.0.2",
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",

--- a/packages/tools/devtools/devtools-example/package.json
+++ b/packages/tools/devtools/devtools-example/package.json
@@ -96,7 +96,6 @@
 		"eslint-plugin-react-hooks": "~4.6.0",
 		"html-webpack-plugin": "^5.6.0",
 		"jest": "^29.6.2",
-		"jest-dev-server": "^9.0.2",
 		"jest-environment-jsdom": "^29.6.2",
 		"jest-environment-puppeteer": "^9.0.2",
 		"jest-junit": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15152,9 +15152,6 @@ importers:
       jest:
         specifier: ^29.6.2
         version: 29.7.0(@types/node@18.19.54)(ts-node@10.9.2)
-      jest-dev-server:
-        specifier: ^9.0.2
-        version: 9.0.2
       jest-environment-puppeteer:
         specifier: ^9.0.2
         version: 9.0.2(typescript@5.4.5)
@@ -15487,9 +15484,6 @@ importers:
       jest:
         specifier: ^29.6.2
         version: 29.7.0(@types/node@18.19.54)(ts-node@10.9.2)
-      jest-dev-server:
-        specifier: ^9.0.2
-        version: 9.0.2
       jest-environment-jsdom:
         specifier: ^29.6.2
         version: 29.7.0


### PR DESCRIPTION
## Description

We do not use `jest-dev-server` directly. Other things depend on it so it doesn't disappear from the lockfile, but no need for the explicit direct dependency. I confirmed the jest tests still pass in both packages.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).