### PR TITLE
Ai planner app layout update v2

### DIFF
--- a/examples/apps/ai-collab/src/app/page.tsx
+++ b/examples/apps/ai-collab/src/app/page.tsx
@@ -77,7 +77,7 @@ export default function TasksListPage(): JSX.Element {
 	return (
 		<Container
 			sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
-			maxWidth={"lg"}
+			maxWidth={false}
 		>
 			<Typography variant="h2" sx={{ my: 3 }}>
 				My Work Items

--- a/examples/apps/ai-collab/src/components/TaskCard.tsx
+++ b/examples/apps/ai-collab/src/components/TaskCard.tsx
@@ -129,7 +129,7 @@ export function TaskCard(props: {
 				position: "relative",
 				backgroundColor: cardColor,
 				width: "400px",
-				height: "245px"
+				height: "245px",
 			}}
 			key={`${task.title}`}
 		>
@@ -314,8 +314,7 @@ export function TaskCard(props: {
 					<IconButton
 						onClick={(event) => {
 							setDiffOldValue(
-								fieldDifferences.changes.description
-									?.oldValue as SetStateAction<ReactNode>,
+								fieldDifferences.changes.description?.oldValue as SetStateAction<ReactNode>,
 							);
 							setDiffOldValuePopoverAnchor(event.currentTarget);
 						}}
@@ -325,8 +324,8 @@ export function TaskCard(props: {
 				)}
 			</Stack>
 
-			<Stack direction='row' spacing={2} width='100%'>
-				<Stack spacing={2} width='50%'>
+			<Stack direction="row" spacing={2} width="100%">
+				<Stack spacing={2} width="50%">
 					<Stack direction="row" spacing={1} alignItems="center">
 						<FormControl fullWidth>
 							<InputLabel id="select-priority-label-id">
@@ -415,7 +414,7 @@ export function TaskCard(props: {
 					</Stack>
 				</Stack>
 
-				<Stack spacing={2} width='50%'>
+				<Stack spacing={2} width="50%">
 					<Stack direction="row" spacing={1} alignItems="center">
 						<FormControl fullWidth>
 							<InputLabel id="select-assignee-label-id">
@@ -481,10 +480,6 @@ export function TaskCard(props: {
 					</Stack>
 				</Stack>
 			</Stack>
-
-
-
-
 		</Card>
 	);
 }

--- a/examples/apps/ai-collab/src/components/TaskCard.tsx
+++ b/examples/apps/ai-collab/src/components/TaskCard.tsx
@@ -127,8 +127,9 @@ export function TaskCard(props: {
 			sx={{
 				p: 4,
 				position: "relative",
-				width: "100%",
 				backgroundColor: cardColor,
+				width: "400px",
+				height: "245px"
 			}}
 			key={`${task.title}`}
 		>
@@ -288,46 +289,44 @@ export function TaskCard(props: {
 				</Popover>
 			)}
 
-			<Stack direction="row" sx={{ width: "100%" }} spacing={2}>
-				<Stack sx={{ flexGrow: 1, direction: "row" }}>
-					<Stack direction="row">
-						<TextField
-							id="input-description-label-id"
-							label="Description"
-							value={task.description}
-							onChange={(e) => (props.sharedTreeTask.description = e.target.value)}
-							sx={{ height: "100%", width: "100%" }}
-							slotProps={{
-								input: {
-									multiline: true,
-									sx: {
-										alignItems: "flex-start",
-										backgroundColor:
-											fieldDifferences.changes.description === undefined ? "white" : "#a4dbfc",
-									},
-								},
-								inputLabel: {
-									sx: { fontWeight: "bold" },
-								},
-							}}
-						/>
-						{fieldDifferences.changes.description !== undefined && (
-							<IconButton
-								onClick={(event) => {
-									setDiffOldValue(
-										fieldDifferences.changes.description
-											?.oldValue as SetStateAction<ReactNode>,
-									);
-									setDiffOldValuePopoverAnchor(event.currentTarget);
-								}}
-							>
-								<Icon icon="clarity:info-standard-line" width={20} height={20} />
-							</IconButton>
-						)}
-					</Stack>
-				</Stack>
+			<Stack direction="row" sx={{ mb: 2 }}>
+				<TextField
+					id="input-description-label-id"
+					label="Description"
+					value={task.description}
+					onChange={(e) => (props.sharedTreeTask.description = e.target.value)}
+					sx={{ height: "100%", width: "100%" }}
+					slotProps={{
+						input: {
+							multiline: true,
+							sx: {
+								alignItems: "flex-start",
+								backgroundColor:
+									fieldDifferences.changes.description === undefined ? "white" : "#a4dbfc",
+							},
+						},
+						inputLabel: {
+							sx: { fontWeight: "bold" },
+						},
+					}}
+				/>
+				{fieldDifferences.changes.description !== undefined && (
+					<IconButton
+						onClick={(event) => {
+							setDiffOldValue(
+								fieldDifferences.changes.description
+									?.oldValue as SetStateAction<ReactNode>,
+							);
+							setDiffOldValuePopoverAnchor(event.currentTarget);
+						}}
+					>
+						<Icon icon="clarity:info-standard-line" width={20} height={20} />
+					</IconButton>
+				)}
+			</Stack>
 
-				<Stack spacing={1} minWidth={180}>
+			<Stack direction='row' spacing={2}>
+				<Stack spacing={2} >
 					<Stack direction="row" spacing={1} alignItems="center">
 						<FormControl fullWidth>
 							<InputLabel id="select-priority-label-id">
@@ -414,7 +413,9 @@ export function TaskCard(props: {
 							</Select>
 						</FormControl>
 					</Stack>
+				</Stack>
 
+				<Stack spacing={2} >
 					<Stack direction="row" spacing={1} alignItems="center">
 						<FormControl fullWidth>
 							<InputLabel id="select-assignee-label-id">
@@ -480,6 +481,10 @@ export function TaskCard(props: {
 					</Stack>
 				</Stack>
 			</Stack>
+
+
+
+
 		</Card>
 	);
 }

--- a/examples/apps/ai-collab/src/components/TaskCard.tsx
+++ b/examples/apps/ai-collab/src/components/TaskCard.tsx
@@ -325,8 +325,8 @@ export function TaskCard(props: {
 				)}
 			</Stack>
 
-			<Stack direction='row' spacing={2}>
-				<Stack spacing={2} >
+			<Stack direction='row' spacing={2} width='100%'>
+				<Stack spacing={2} width='50%'>
 					<Stack direction="row" spacing={1} alignItems="center">
 						<FormControl fullWidth>
 							<InputLabel id="select-priority-label-id">
@@ -415,7 +415,7 @@ export function TaskCard(props: {
 					</Stack>
 				</Stack>
 
-				<Stack spacing={2} >
+				<Stack spacing={2} width='50%'>
 					<Stack direction="row" spacing={1} alignItems="center">
 						<FormControl fullWidth>
 							<InputLabel id="select-assignee-label-id">

--- a/examples/apps/ai-collab/src/components/TaskGroup.tsx
+++ b/examples/apps/ai-collab/src/components/TaskGroup.tsx
@@ -57,11 +57,10 @@ export function TaskGroup(props: {
 	useSharedTreeRerender({ sharedTreeNode: props.sharedTreeTaskGroup, logId: "TaskGroup" });
 
 	return (
-
 		<Card
 			sx={{
 				p: 7,
-				width: '90%',
+				width: "90%",
 				background: "rgba(255, 255, 255, 0.5)",
 				borderRadius: "16px",
 				boxShadow: "0 4px 30px rgba(0, 0, 0, 0.1)",
@@ -293,7 +292,7 @@ export function TaskGroup(props: {
 			</Stack>
 
 			{/* Render Task Card list */}
-			<Stack direction='row' spacing={{ xs: 1, sm: 2 }} useFlexGap sx={{ flexWrap: 'wrap' }}>
+			<Stack direction="row" spacing={{ xs: 1, sm: 2 }} useFlexGap sx={{ flexWrap: "wrap" }}>
 				{props.sharedTreeTaskGroup.tasks.map((task) => {
 					const taskDiffs: Difference[] = [];
 					for (const diff of props.branchDifferences ?? []) {
@@ -325,7 +324,7 @@ export function TaskGroup(props: {
 				Engineers
 			</Typography>
 
-			<Stack direction='row' spacing={{ xs: 1, sm: 2 }} sx={{ flexWrap: 'wrap' }}>
+			<Stack direction="row" spacing={{ xs: 1, sm: 2 }} sx={{ flexWrap: "wrap" }}>
 				{props.sharedTreeTaskGroup.engineers.map((engineer) => {
 					const engineerCapacity = props.sharedTreeTaskGroup.tasks
 						.filter((task) => task.assignee === engineer.name)
@@ -363,8 +362,6 @@ export function TaskGroup(props: {
 				})}
 			</Stack>
 		</Card>
-
-
 	);
 }
 

--- a/examples/apps/ai-collab/src/components/TaskGroup.tsx
+++ b/examples/apps/ai-collab/src/components/TaskGroup.tsx
@@ -57,9 +57,11 @@ export function TaskGroup(props: {
 	useSharedTreeRerender({ sharedTreeNode: props.sharedTreeTaskGroup, logId: "TaskGroup" });
 
 	return (
+
 		<Card
 			sx={{
 				p: 7,
+				width: '90%',
 				background: "rgba(255, 255, 255, 0.5)",
 				borderRadius: "16px",
 				boxShadow: "0 4px 30px rgba(0, 0, 0, 0.1)",
@@ -291,7 +293,7 @@ export function TaskGroup(props: {
 			</Stack>
 
 			{/* Render Task Card list */}
-			<Stack spacing={2} sx={{ alignItems: "center" }}>
+			<Stack direction='row' spacing={{ xs: 1, sm: 2 }} useFlexGap sx={{ flexWrap: 'wrap' }}>
 				{props.sharedTreeTaskGroup.tasks.map((task) => {
 					const taskDiffs: Difference[] = [];
 					for (const diff of props.branchDifferences ?? []) {
@@ -323,7 +325,7 @@ export function TaskGroup(props: {
 				Engineers
 			</Typography>
 
-			<Stack spacing={1}>
+			<Stack direction='row' spacing={{ xs: 1, sm: 2 }} sx={{ flexWrap: 'wrap' }}>
 				{props.sharedTreeTaskGroup.engineers.map((engineer) => {
 					const engineerCapacity = props.sharedTreeTaskGroup.tasks
 						.filter((task) => task.assignee === engineer.name)
@@ -332,7 +334,7 @@ export function TaskGroup(props: {
 					const capacityColor = engineerCapacity > engineer.maxCapacity ? "red" : "green";
 
 					return (
-						<Card sx={{ p: 2, width: 600 }} key={engineer.name}>
+						<Card sx={{ p: 2, width: 400 }} key={engineer.name}>
 							<Box mb={2}>
 								<Typography variant="h1" fontSize={24}>
 									{engineer.name}
@@ -361,6 +363,8 @@ export function TaskGroup(props: {
 				})}
 			</Stack>
 		</Card>
+
+
 	);
 }
 

--- a/examples/apps/ai-collab/src/types/sharedTreeAppSchema.ts
+++ b/examples/apps/ai-collab/src/types/sharedTreeAppSchema.ts
@@ -11,9 +11,11 @@ import type { Engineer, Task, TaskGroup } from "./task";
 // The string passed to the SchemaFactory should be unique
 const sf = new SchemaFactory("ai-collab-sample-application");
 
+// NOTE that there is currently a bug with the ai-collab library that requires us to rearrance the keys of each type to not have the same first key.
+
 export class SharedTreeTask extends sf.object("Task", {
-	id: sf.identifier,
 	title: sf.string,
+	id: sf.identifier,
 	description: sf.string,
 	priority: sf.string,
 	complexity: sf.number,
@@ -24,8 +26,8 @@ export class SharedTreeTask extends sf.object("Task", {
 export class SharedTreeTaskList extends sf.array("TaskList", SharedTreeTask) {}
 
 export class SharedTreeEngineer extends sf.object("Engineer", {
-	id: sf.identifier,
 	name: sf.string,
+	id: sf.identifier,
 	skills: sf.string,
 	maxCapacity: sf.number,
 }) {}
@@ -33,9 +35,9 @@ export class SharedTreeEngineer extends sf.object("Engineer", {
 export class SharedTreeEngineerList extends sf.array("EngineerList", SharedTreeEngineer) {}
 
 export class SharedTreeTaskGroup extends sf.object("TaskGroup", {
+	description: sf.string,
 	id: sf.identifier,
 	title: sf.string,
-	description: sf.string,
 	tasks: SharedTreeTaskList,
 	engineers: SharedTreeEngineerList,
 }) {}

--- a/examples/apps/ai-collab/src/types/sharedTreeAppSchema.ts
+++ b/examples/apps/ai-collab/src/types/sharedTreeAppSchema.ts
@@ -35,7 +35,7 @@ export class SharedTreeTask extends sf.object("Task", {
 			description: `The complexity of the task as a fibonacci number`,
 		},
 	}),
-	status: sf.required(sf.number, {
+	status: sf.required(sf.string, {
 		metadata: {
 			description: `The status of the task as either "todo", "in-progress", or "done"`,
 		},

--- a/examples/apps/ai-collab/src/types/sharedTreeAppSchema.ts
+++ b/examples/apps/ai-collab/src/types/sharedTreeAppSchema.ts
@@ -14,38 +14,94 @@ const sf = new SchemaFactory("ai-collab-sample-application");
 // NOTE that there is currently a bug with the ai-collab library that requires us to rearrance the keys of each type to not have the same first key.
 
 export class SharedTreeTask extends sf.object("Task", {
-	title: sf.string,
+	title: sf.required(sf.string, {
+		metadata: {
+			description: `The title of the task`,
+		},
+	}),
 	id: sf.identifier,
-	description: sf.string,
-	priority: sf.string,
-	complexity: sf.number,
-	status: sf.string,
-	assignee: sf.optional(sf.string),
+	description: sf.required(sf.string, {
+		metadata: {
+			description: `The description of the task`,
+		},
+	}),
+	priority: sf.required(sf.string, {
+		metadata: {
+			description: `The priority of the task in three levels, "low", "medium", "high"`,
+		},
+	}),
+	complexity: sf.required(sf.number, {
+		metadata: {
+			description: `The complexity of the task as a fibonacci number`,
+		},
+	}),
+	status: sf.required(sf.number, {
+		metadata: {
+			description: `The status of the task as either "todo", "in-progress", or "done"`,
+		},
+	}),
+	assignee: sf.required(sf.string, {
+		metadata: {
+			description: `The name of the tasks assignee e.g. "Bob" or "Alice"`,
+		},
+	}),
 }) {}
 
 export class SharedTreeTaskList extends sf.array("TaskList", SharedTreeTask) {}
 
 export class SharedTreeEngineer extends sf.object("Engineer", {
-	name: sf.string,
+	name: sf.required(sf.string, {
+		metadata: {
+			description: `The name of an engineer whom can be assigned to a task`,
+		},
+	}),
 	id: sf.identifier,
-	skills: sf.string,
-	maxCapacity: sf.number,
+	skills: sf.required(sf.string, {
+		metadata: {
+			description: `A description of the engineers skills which influence what types of tasks they should be assigned to.`,
+		},
+	}),
+	maxCapacity: sf.required(sf.number, {
+		metadata: {
+			description: `The maximum capacity of tasks this engineer can handle measured in in task complexity points.`,
+		},
+	}),
 }) {}
 
 export class SharedTreeEngineerList extends sf.array("EngineerList", SharedTreeEngineer) {}
 
 export class SharedTreeTaskGroup extends sf.object("TaskGroup", {
-	description: sf.string,
+	description: sf.required(sf.string, {
+		metadata: {
+			description: `The description of the task group, which is a collection of tasks and engineers that can be assigned to said tasks.`,
+		},
+	}),
 	id: sf.identifier,
-	title: sf.string,
-	tasks: SharedTreeTaskList,
-	engineers: SharedTreeEngineerList,
+	title: sf.required(sf.string, {
+		metadata: {
+			description: `The title of the task group.`,
+		},
+	}),
+	tasks: sf.required(SharedTreeTaskList, {
+		metadata: {
+			description: `The lists of tasks within this task group.`,
+		},
+	}),
+	engineers: sf.required(SharedTreeEngineerList, {
+		metadata: {
+			description: `The lists of engineers within this task group which can be assigned to tasks.`,
+		},
+	}),
 }) {}
 
 export class SharedTreeTaskGroupList extends sf.array("TaskGroupList", SharedTreeTaskGroup) {}
 
 export class SharedTreeAppState extends sf.object("AppState", {
-	taskGroups: SharedTreeTaskGroupList,
+	taskGroups: sf.required(SharedTreeTaskGroupList, {
+		metadata: {
+			description: `The list of task groups that are being managed by this task management application.`,
+		},
+	}),
 }) {}
 
 export const INITIAL_APP_STATE = {

--- a/examples/apps/ai-collab/src/types/sharedTreeAppSchema.ts
+++ b/examples/apps/ai-collab/src/types/sharedTreeAppSchema.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { SharedTree, SchemaFactory, TreeViewConfiguration } from "fluid-framework";
+import { SchemaFactory, TreeViewConfiguration } from "@fluidframework/tree";
+import { SharedTree } from "fluid-framework";
 
 import type { Engineer, Task, TaskGroup } from "./task";
 
@@ -50,58 +51,6 @@ export const INITIAL_APP_STATE = {
 		{
 			title: "My First Task Group",
 			description: "Placeholder for first task group",
-			tasks: [
-				{
-					assignee: "Alice",
-					title: "Task #1",
-					description:
-						"This is the first task. Blah Blah blah Blah Blah blahBlah Blah blahBlah Blah blahBlah Blah blah",
-					priority: "low",
-					complexity: 1,
-					status: "todo",
-				},
-				{
-					assignee: "Bob",
-					title: "Task #2",
-					description:
-						"This is the second task.  Blah Blah blah Blah Blah blahBlah Blah blahBlah Blah blahBlah Blah blah",
-					priority: "medium",
-					complexity: 2,
-					status: "in-progress",
-				},
-				{
-					assignee: "Charlie",
-					title: "Task #3",
-					description:
-						"This is the third task!  Blah Blah blah Blah Blah blahBlah Blah blahBlah Blah blahBlah Blah blah",
-					priority: "high",
-					complexity: 3,
-					status: "done",
-				},
-			],
-			engineers: [
-				{
-					name: "Alice",
-					maxCapacity: 15,
-					skills:
-						"Senior engineer capable of handling complex tasks. Versed in most languages",
-				},
-				{
-					name: "Bob",
-					maxCapacity: 12,
-					skills:
-						"Mid-level engineer capable of handling medium complexity tasks. Versed in React, Node.JS",
-				},
-				{
-					name: "Charlie",
-					maxCapacity: 7,
-					skills: "Junior engineer capable of handling simple tasks. Versed in Node.JS",
-				},
-			],
-		},
-		{
-			title: "My Second Task Group",
-			description: "Placeholder for second task group",
 			tasks: [
 				{
 					assignee: "Alice",

--- a/examples/apps/ai-collab/src/types/sharedTreeAppSchema.ts
+++ b/examples/apps/ai-collab/src/types/sharedTreeAppSchema.ts
@@ -11,7 +11,7 @@ import type { Engineer, Task, TaskGroup } from "./task";
 // The string passed to the SchemaFactory should be unique
 const sf = new SchemaFactory("ai-collab-sample-application");
 
-// NOTE that there is currently a bug with the ai-collab library that requires us to rearrance the keys of each type to not have the same first key.
+// NOTE that there is currently a bug with the ai-collab library that requires us to rearrange the keys of each type to not have the same first key.
 
 export class SharedTreeTask extends sf.object("Task", {
 	title: sf.required(sf.string, {


### PR DESCRIPTION
## This is a redo of this branch because it is broken with githubs building for some reason https://github.com/microsoft/FluidFramework/pull/22873

## Description

- Updates ai example app layout to be more compact
- removes second task group from initial tree.
- Adds metadata descriptions to app schema


![image](https://github.com/user-attachments/assets/b1f09183-8b56-457d-abb2-5132460fd87a)



