### PR TITLE
fix(client-presence): Rename ISessionClient so that function/property naming is consistent

### DIFF
--- a/examples/service-clients/azure-client/external-controller/src/view.ts
+++ b/examples/service-clients/azure-client/external-controller/src/view.ts
@@ -167,7 +167,7 @@ function makePresenceView(
 	logContentDiv.style.border = "1px solid black";
 	if (audience !== undefined) {
 		presenceConfig.presence.events.on("attendeeJoined", (attendee) => {
-			const name = audience.getMembers().get(attendee.connectionId())?.name;
+			const name = audience.getMembers().get(attendee.getConnectionId())?.name;
 			const update = `client ${name === undefined ? "(unnamed)" : `named ${name}`} with id ${attendee.sessionId} joined`;
 			addLogEntry(logContentDiv, update);
 		});

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -38,9 +38,9 @@ export interface IPresence {
 // @alpha @sealed
 export interface ISessionClient<SpecificSessionClientId extends ClientSessionId = ClientSessionId> {
     connectionId(): ClientConnectionId;
-    getStatus(): SessionClientStatus;
     // (undocumented)
     readonly sessionId: SpecificSessionClientId;
+    status(): SessionClientStatus;
 }
 
 // @alpha

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -38,9 +38,11 @@ export interface IPresence {
 // @alpha @sealed
 export interface ISessionClient<SpecificSessionClientId extends ClientSessionId = ClientSessionId> {
     getConnectionId(): ClientConnectionId;
-    getStatus(): SessionClientStatus;
+    getConnectionStatus(): SessionClientStatus;
     // (undocumented)
     readonly sessionId: SpecificSessionClientId;
+    setConnectionId(connectionId: ClientConnectionId): void;
+    setConnectionStatus(connected: boolean): void;
 }
 
 // @alpha

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -37,10 +37,10 @@ export interface IPresence {
 
 // @alpha @sealed
 export interface ISessionClient<SpecificSessionClientId extends ClientSessionId = ClientSessionId> {
-    connectionId(): ClientConnectionId;
+    getConnectionId(): ClientConnectionId;
+    getStatus(): SessionClientStatus;
     // (undocumented)
     readonly sessionId: SpecificSessionClientId;
-    status(): SessionClientStatus;
 }
 
 // @alpha

--- a/packages/framework/presence/src/baseTypes.ts
+++ b/packages/framework/presence/src/baseTypes.ts
@@ -10,7 +10,7 @@
  * Each client connection is given a unique identifier for the duration of the
  * connection. If a client disconnects and reconnects, it will be given a new
  * identifier. Prefer use of {@link ISessionClient} as a way to identify clients
- * in a session. {@link ISessionClient.connectionId} will provide the current
+ * in a session. {@link ISessionClient.getConnectionId} will provide the current
  * connection identifier for a logical session client.
  *
  * @privateRemarks

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -79,7 +79,7 @@ export interface ISessionClient<
 	 * @remarks
 	 * Connection id will change on reconnect.
 	 *
-	 * If {@link ISessionClient.getStatus} is {@link (SessionClientStatus:variable).Disconnected}, this will represent the last known connection id.
+	 * If {@link ISessionClient.getConnectionStatus} is {@link (SessionClientStatus:variable).Disconnected}, this will represent the last known connection id.
 	 */
 	getConnectionId(): ClientConnectionId;
 
@@ -89,7 +89,21 @@ export interface ISessionClient<
 	 * @returns Status of session client.
 	 *
 	 */
-	getStatus(): SessionClientStatus;
+	getConnectionStatus(): SessionClientStatus;
+
+	/**
+	 * Set current client connection id.
+	 *
+	 * @param connectionId - New connection id.
+	 */
+	setConnectionId(connectionId: ClientConnectionId): void;
+
+	/**
+	 * Set status of session client.
+	 *
+	 * @param connected - True if client is connected.
+	 */
+	setConnectionStatus(connected: boolean): void;
 }
 
 /**

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -79,7 +79,7 @@ export interface ISessionClient<
 	 * @remarks
 	 * Connection id will change on reconnect.
 	 *
-	 * If {@link ISessionClient.getStatus} is {@link (SessionClientStatus:variable).Disconnected}, this will represent the last known connection id.
+	 * If {@link ISessionClient.status} is {@link (SessionClientStatus:variable).Disconnected}, this will represent the last known connection id.
 	 */
 	connectionId(): ClientConnectionId;
 
@@ -89,7 +89,7 @@ export interface ISessionClient<
 	 * @returns Status of session client.
 	 *
 	 */
-	getStatus(): SessionClientStatus;
+	status(): SessionClientStatus;
 }
 
 /**

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -84,9 +84,9 @@ export interface ISessionClient<
 	getConnectionId(): ClientConnectionId;
 
 	/**
-	 * Get status of session client.
+	 * Get connection status of session client.
 	 *
-	 * @returns Status of session client.
+	 * @returns Connection status of session client.
 	 *
 	 */
 	getConnectionStatus(): SessionClientStatus;
@@ -99,7 +99,7 @@ export interface ISessionClient<
 	setConnectionId(connectionId: ClientConnectionId): void;
 
 	/**
-	 * Set status of session client.
+	 * Set connection status of session client.
 	 *
 	 * @param connected - True if client is connected.
 	 */

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -79,9 +79,9 @@ export interface ISessionClient<
 	 * @remarks
 	 * Connection id will change on reconnect.
 	 *
-	 * If {@link ISessionClient.status} is {@link (SessionClientStatus:variable).Disconnected}, this will represent the last known connection id.
+	 * If {@link ISessionClient.getStatus} is {@link (SessionClientStatus:variable).Disconnected}, this will represent the last known connection id.
 	 */
-	connectionId(): ClientConnectionId;
+	getConnectionId(): ClientConnectionId;
 
 	/**
 	 * Get status of session client.
@@ -89,7 +89,7 @@ export interface ISessionClient<
 	 * @returns Status of session client.
 	 *
 	 */
-	status(): SessionClientStatus;
+	getStatus(): SessionClientStatus;
 }
 
 /**

--- a/packages/framework/presence/src/systemWorkspace.ts
+++ b/packages/framework/presence/src/systemWorkspace.ts
@@ -92,7 +92,7 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 			connectionId: () => {
 				throw new Error("Client has never been connected");
 			},
-			getStatus: () => SessionClientStatus.Disconnected,
+			status: () => SessionClientStatus.Disconnected,
 		};
 		this.attendees.set(clientSessionId, this.selfAttendee);
 	}
@@ -151,7 +151,7 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 		};
 
 		this.selfAttendee.connectionId = () => clientConnectionId;
-		this.selfAttendee.getStatus = () => SessionClientStatus.Connected;
+		this.selfAttendee.status = () => SessionClientStatus.Connected;
 		this.attendees.set(clientConnectionId, this.selfAttendee);
 	}
 
@@ -165,7 +165,7 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 		// therefore we should not change the attendee connection status or emit a disconnect event.
 		const attendeeReconnected = attendee.connectionId() !== clientConnectionId;
 		if (!attendeeReconnected) {
-			attendee.getStatus = () => SessionClientStatus.Disconnected;
+			attendee.status = () => SessionClientStatus.Disconnected;
 			this.events.emit("attendeeDisconnected", attendee);
 		}
 	}
@@ -211,7 +211,7 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 				sessionId: clientSessionId,
 				order,
 				connectionId,
-				getStatus: () => SessionClientStatus.Connected,
+				status: () => SessionClientStatus.Connected,
 			};
 			this.attendees.set(clientSessionId, attendee);
 			isNew = true;

--- a/packages/framework/presence/src/systemWorkspace.ts
+++ b/packages/framework/presence/src/systemWorkspace.ts
@@ -33,7 +33,7 @@ export interface SystemWorkspaceDatastore {
 /**
  * There is no implementation class for this interface.
  * It is a simple structure. Most complicated aspect is that
- * `connectionId()` member is replaced with a new
+ * `getConnectionId()` member is replaced with a new
  * function when a more recent connection is added.
  *
  * See {@link SystemWorkspaceImpl.ensureAttendee}.
@@ -89,10 +89,10 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 		this.selfAttendee = {
 			sessionId: clientSessionId,
 			order: 0,
-			connectionId: () => {
+			getConnectionId: () => {
 				throw new Error("Client has never been connected");
 			},
-			status: () => SessionClientStatus.Disconnected,
+			getStatus: () => SessionClientStatus.Disconnected,
 		};
 		this.attendees.set(clientSessionId, this.selfAttendee);
 	}
@@ -150,8 +150,8 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 			value: this.selfAttendee.sessionId,
 		};
 
-		this.selfAttendee.connectionId = () => clientConnectionId;
-		this.selfAttendee.status = () => SessionClientStatus.Connected;
+		this.selfAttendee.getConnectionId = () => clientConnectionId;
+		this.selfAttendee.getStatus = () => SessionClientStatus.Connected;
 		this.attendees.set(clientConnectionId, this.selfAttendee);
 	}
 
@@ -163,9 +163,9 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 
 		// If the last known connectionID is different from the connection id being removed, the attendee has reconnected,
 		// therefore we should not change the attendee connection status or emit a disconnect event.
-		const attendeeReconnected = attendee.connectionId() !== clientConnectionId;
+		const attendeeReconnected = attendee.getConnectionId() !== clientConnectionId;
 		if (!attendeeReconnected) {
-			attendee.status = () => SessionClientStatus.Disconnected;
+			attendee.getStatus = () => SessionClientStatus.Disconnected;
 			this.events.emit("attendeeDisconnected", attendee);
 		}
 	}
@@ -210,8 +210,8 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 			attendee = {
 				sessionId: clientSessionId,
 				order,
-				connectionId,
-				status: () => SessionClientStatus.Connected,
+				getConnectionId: connectionId,
+				getStatus: () => SessionClientStatus.Connected,
 			};
 			this.attendees.set(clientSessionId, attendee);
 			isNew = true;
@@ -219,7 +219,7 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 			// The given association is newer than the one we have.
 			// Update the order and current connection id.
 			attendee.order = order;
-			attendee.connectionId = connectionId;
+			attendee.getConnectionId = connectionId;
 		}
 		// Always update entry for the connection id. (Okay if already set.)
 		this.attendees.set(clientConnectionId, attendee);

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -176,7 +176,7 @@ describe("Presence", () => {
 							"No attendee was disconnected in beforeEach",
 						);
 						assert.equal(
-							disconnectedAttendee.getStatus(),
+							disconnectedAttendee.status(),
 							SessionClientStatus.Disconnected,
 							"Disconnected attendee has wrong status",
 						);

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -125,7 +125,7 @@ describe("Presence", () => {
 						"Attendee has wrong session id",
 					);
 					assert.equal(
-						newAttendee.connectionId(),
+						newAttendee.getConnectionId(),
 						initialAttendeeConnectionId,
 						"Attendee has wrong client connection id",
 					);
@@ -163,7 +163,7 @@ describe("Presence", () => {
 							"Disconnected attendee has wrong session id",
 						);
 						assert.equal(
-							disconnectedAttendee.connectionId(),
+							disconnectedAttendee.getConnectionId(),
 							initialAttendeeConnectionId,
 							"Disconnected attendee has wrong client connection id",
 						);
@@ -176,7 +176,7 @@ describe("Presence", () => {
 							"No attendee was disconnected in beforeEach",
 						);
 						assert.equal(
-							disconnectedAttendee.status(),
+							disconnectedAttendee.getStatus(),
 							SessionClientStatus.Disconnected,
 							"Disconnected attendee has wrong status",
 						);
@@ -251,7 +251,7 @@ describe("Presence", () => {
 						);
 						// Current connection id is updated
 						assert(
-							newAttendee.connectionId() === updatedClientConnectionId,
+							newAttendee.getConnectionId() === updatedClientConnectionId,
 							"Attendee does not have updated client connection id",
 						);
 						// Attendee is available via new connection id

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -176,7 +176,7 @@ describe("Presence", () => {
 							"No attendee was disconnected in beforeEach",
 						);
 						assert.equal(
-							disconnectedAttendee.getStatus(),
+							disconnectedAttendee.getConnectionStatus(),
 							SessionClientStatus.Disconnected,
 							"Disconnected attendee has wrong status",
 						);


### PR DESCRIPTION
## Description
ISessionClient functions/properties must be consistent. From what I can gather from [API naming discussion](https://teams.microsoft.com/l/message/19:50292e8934024fc19d6ca2080dd7681e@thread.skype/1729788089085?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=9ce27575-2f82-4689-abdb-bcff07e8063b&parentMessageId=1729788089085&teamName=Fluid%20Framework&channelName=Dev&createdTime=1729788089085 
), getStatus and getClientConnectionId is the preferred naming.

We also create a SessionClient class to get and set connection ID and connection status
