### PR TITLE
improvement(client-presence): Use audience for session client connection status 

### DIFF
--- a/packages/framework/presence/src/internalTypes.ts
+++ b/packages/framework/presence/src/internalTypes.ts
@@ -43,7 +43,7 @@ export const brandedObjectEntries = Object.entries as <K extends string, T>(
  */
 export type IEphemeralRuntime = Pick<
 	(IContainerRuntime & IRuntimeInternal) | IFluidDataStoreRuntime,
-	"clientId" | "connected" | "getQuorum" | "off" | "on" | "submitSignal"
+	"clientId" | "connected" | "getAudience" | "getQuorum" | "off" | "on" | "submitSignal"
 > &
 	Partial<Pick<IFluidDataStoreRuntime, "logger">>;
 

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -267,7 +267,11 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 			// Direct to the appropriate Presence Workspace, if present.
 			const workspace = this.workspaces.get(workspaceAddress);
 			if (workspace) {
-				workspace.internal.processUpdate(received, timeModifier, remoteDatastore);
+				workspace.internal.processUpdate(
+					received,
+					timeModifier,
+					remoteDatastore,
+				);
 			} else {
 				// All broadcast state is kept even if not currently registered, unless a value
 				// notes itself to be ignored.

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -267,11 +267,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 			// Direct to the appropriate Presence Workspace, if present.
 			const workspace = this.workspaces.get(workspaceAddress);
 			if (workspace) {
-				workspace.internal.processUpdate(
-					received,
-					timeModifier,
-					remoteDatastore,
-				);
+				workspace.internal.processUpdate(received, timeModifier, remoteDatastore);
 			} else {
 				// All broadcast state is kept even if not currently registered, unless a value
 				// notes itself to be ignored.

--- a/packages/framework/presence/src/presenceManager.ts
+++ b/packages/framework/presence/src/presenceManager.ts
@@ -167,6 +167,7 @@ function setupSubComponents(
 		clientSessionId,
 		systemWorkspaceDatastore,
 		events,
+		runtime,
 	);
 	const datastoreManager = new PresenceDatastoreManagerImpl(
 		clientSessionId,

--- a/packages/framework/presence/src/systemWorkspace.ts
+++ b/packages/framework/presence/src/systemWorkspace.ts
@@ -222,7 +222,7 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 				order,
 				connectionId,
 				getStatus: () => {
-					throw new Error("Connection status unkonown");
+					throw new Error("Connection status unknown");
 				},
 			};
 			this.attendees.set(clientSessionId, attendee);

--- a/packages/framework/presence/src/systemWorkspace.ts
+++ b/packages/framework/presence/src/systemWorkspace.ts
@@ -220,6 +220,8 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 			// Update the order and current connection id.
 			attendee.order = order;
 			attendee.connectionId = connectionId;
+			attendee.getStatus = () => SessionClientStatus.Connected;
+			isNew = true;
 		}
 		// Always update entry for the connection id. (Okay if already set.)
 		this.attendees.set(clientConnectionId, attendee);

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -133,7 +133,7 @@ describe("Presence", () => {
 						newAttendee.getStatus(),
 						SessionClientStatus.Connected,
 						"Attendee has wrong status",
-					)
+					);
 				});
 
 				it("is not announced via attendeeDisconnected when unknown connection is removed", () => {
@@ -144,7 +144,7 @@ describe("Presence", () => {
 
 					// Act & Verify - remove unknown connection id
 					presence.removeClientConnectionId("unknownConnectionId");
-				})
+				});
 
 				describe("disconnects", () => {
 					let disconnectedAttendee: ISessionClient | undefined;
@@ -226,7 +226,11 @@ describe("Presence", () => {
 								const attendee = presence.getAttendee(id);
 								// Verify
 								assert.equal(attendee, newAttendee, "getAttendee returned wrong attendee");
-								assert.equal(attendee.getStatus(), SessionClientStatus.Connected, "getAttendee returned attendee with wrong status");
+								assert.equal(
+									attendee.getStatus(),
+									SessionClientStatus.Connected,
+									"getAttendee returned attendee with wrong status",
+								);
 							});
 
 							it('with status "Disconnected" after disconnect', () => {
@@ -236,7 +240,11 @@ describe("Presence", () => {
 
 								// Verify
 								assert.equal(attendee, newAttendee, "getAttendee returned wrong attendee");
-								assert.equal(attendee.getStatus(), SessionClientStatus.Disconnected, "getAttendee returned attendee with wrong status");
+								assert.equal(
+									attendee.getStatus(),
+									SessionClientStatus.Disconnected,
+									"getAttendee returned attendee with wrong status",
+								);
 							});
 						});
 					}
@@ -249,7 +257,11 @@ describe("Presence", () => {
 							// Act
 							const attendees = presence.getAttendees();
 							assert(attendees.has(newAttendee), "getAttendees set does not contain attendee");
-							assert.equal(newAttendee.getStatus(), SessionClientStatus.Connected, "getAttendees set contains attendee with wrong status");
+							assert.equal(
+								newAttendee.getStatus(),
+								SessionClientStatus.Connected,
+								"getAttendees set contains attendee with wrong status",
+							);
 						});
 						it('with status "Disconnected"', () => {
 							// Setup
@@ -261,7 +273,11 @@ describe("Presence", () => {
 							// Verify
 							const attendees = presence.getAttendees();
 							assert(attendees.has(newAttendee), "getAttendees set does not contain attendee");
-							assert.equal(newAttendee.getStatus(), SessionClientStatus.Disconnected, "getAttendees set contains attendee with wrong status");
+							assert.equal(
+								newAttendee.getStatus(),
+								SessionClientStatus.Disconnected,
+								"getAttendees set contains attendee with wrong status",
+							);
 						});
 					});
 

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -146,58 +146,6 @@ describe("Presence", () => {
 					presence.removeClientConnectionId("unknownConnectionId");
 				});
 
-				describe("disconnects", () => {
-					let disconnectedAttendee: ISessionClient | undefined;
-					beforeEach(() => {
-						disconnectedAttendee = undefined;
-						afterCleanUp.push(
-							presence.events.on("attendeeDisconnected", (attendee) => {
-								assert(
-									disconnectedAttendee === undefined,
-									"Only one attendee should be disconnected",
-								);
-								disconnectedAttendee = attendee;
-							}),
-						);
-						// Setup - simulate join message from client
-						presence.processSignal("", initialAttendeeSignal, false);
-
-						// Act - remove client connection id
-						presence.removeClientConnectionId(initialAttendeeConnectionId);
-					});
-
-					it("is announced via `attendeeDisconnected` when audience member leaves", () => {
-						// Verify
-						assert(
-							disconnectedAttendee !== undefined,
-							"No attendee was disconnected in beforeEach",
-						);
-						assert.equal(
-							disconnectedAttendee.sessionId,
-							newAttendeeSessionId,
-							"Disconnected attendee has wrong session id",
-						);
-						assert.equal(
-							disconnectedAttendee.connectionId(),
-							initialAttendeeConnectionId,
-							"Disconnected attendee has wrong client connection id",
-						);
-					});
-
-					it("changes the session client status to `Disconnected`", () => {
-						// Verify
-						assert(
-							disconnectedAttendee !== undefined,
-							"No attendee was disconnected in beforeEach",
-						);
-						assert.equal(
-							disconnectedAttendee.getStatus(),
-							SessionClientStatus.Disconnected,
-							"Disconnected attendee has wrong status",
-						);
-					});
-				});
-
 				describe("already known", () => {
 					let disconnectedAttendee: ISessionClient | undefined;
 					beforeEach(() => {

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -98,13 +98,6 @@ describe("Presence", () => {
 				beforeEach(() => {
 					runtime.submitSignal = () => {};
 					newAttendee = undefined;
-					afterCleanUp.push(
-						presence.events.on("attendeeJoined", (attendee) => {
-							assert(newAttendee === undefined, "Only one attendee should be announced");
-							newAttendee = attendee;
-						}),
-					);
-
 					initialAttendeeSignal = generateBasicClientJoin(clock.now - 50, {
 						averageLatency: 50,
 						clientSessionId: newAttendeeSessionId,
@@ -113,156 +106,179 @@ describe("Presence", () => {
 					});
 				});
 
-				it('is announced via `attendeeJoined`  with status "Connected" when new', () => {
-					// Act - simulate join message from client
-					presence.processSignal("", initialAttendeeSignal, false);
-
-					// Verify
-					assert(newAttendee !== undefined, "No attendee was announced");
-					assert.equal(
-						newAttendee.sessionId,
-						newAttendeeSessionId,
-						"Attendee has wrong session id",
-					);
-					assert.equal(
-						newAttendee.connectionId(),
-						initialAttendeeConnectionId,
-						"Attendee has wrong client connection id",
-					);
-					assert.equal(
-						newAttendee.getStatus(),
-						SessionClientStatus.Connected,
-						"Attendee has wrong status",
-					);
-				});
-
-				it("is not announced via attendeeDisconnected when unknown connection is removed", () => {
-					// Setup
-					presence.events.on("attendeeDisconnected", () => {
-						assert.fail("No attendee should be disconnected in beforeEach");
-					});
-
-					// Act & Verify - remove unknown connection id
-					presence.removeClientConnectionId("unknownConnectionId");
-				});
-
-				describe("already known", () => {
-					let disconnectedAttendee: ISessionClient | undefined;
+				describe("that joined", () => {
 					beforeEach(() => {
-						disconnectedAttendee = undefined;
 						afterCleanUp.push(
-							presence.events.on("attendeeDisconnected", (attendee) => {
-								assert(
-									disconnectedAttendee === undefined,
-									"Only one attendee should be disconnected",
-								);
-								disconnectedAttendee = attendee;
+							presence.events.on("attendeeJoined", (attendee) => {
+								assert(newAttendee === undefined, "Only one attendee should be announced");
+								newAttendee = attendee;
 							}),
 						);
+					});
+					it('is announced via `attendeeJoined`  with status "Connected" when new', () => {
+						// Act - simulate join message from client
+						presence.processSignal("", initialAttendeeSignal, false);
+
+						// Verify
+						assert(newAttendee !== undefined, "No attendee was announced");
+						assert.equal(
+							newAttendee.sessionId,
+							newAttendeeSessionId,
+							"Attendee has wrong session id",
+						);
+						assert.equal(
+							newAttendee.connectionId(),
+							initialAttendeeConnectionId,
+							"Attendee has wrong client connection id",
+						);
+						assert.equal(
+							newAttendee.getStatus(),
+							SessionClientStatus.Connected,
+							"Attendee has wrong status",
+						);
+					});
+
+					it("is not announced via attendeeDisconnected when unknown connection is removed", () => {
+						// Setup
+						presence.events.on("attendeeDisconnected", () => {
+							assert.fail("No attendee should be disconnected in beforeEach");
+						});
+
+						// Act & Verify - remove unknown connection id
+						presence.removeClientConnectionId("unknownConnectionId");
+					});
+
+					describe("already known", () => {
+						let disconnectedAttendee: ISessionClient | undefined;
+						beforeEach(() => {
+							disconnectedAttendee = undefined;
+							afterCleanUp.push(
+								presence.events.on("attendeeDisconnected", (attendee) => {
+									assert(
+										disconnectedAttendee === undefined,
+										"Only one attendee should be disconnected",
+									);
+									disconnectedAttendee = attendee;
+								}),
+							);
+							// Setup - simulate join message from client
+							presence.processSignal("", initialAttendeeSignal, false);
+							assert(newAttendee !== undefined, "No attendee was announced in setup");
+						});
+
+						for (const [desc, id] of [
+							["connection id", initialAttendeeConnectionId] as const,
+							["session id", newAttendeeSessionId] as const,
+						]) {
+							describe(`is available from \`getAttendee\` by ${desc}`, () => {
+								it('with status "Connected"', () => {
+									// Act
+									const attendee = presence.getAttendee(id);
+									// Verify
+									assert.equal(attendee, newAttendee, "getAttendee returned wrong attendee");
+									assert.equal(
+										attendee.getStatus(),
+										SessionClientStatus.Connected,
+										"getAttendee returned attendee with wrong status",
+									);
+								});
+
+								it('with status "Disconnected" after disconnect', () => {
+									// Act - remove client connection id
+									presence.removeClientConnectionId(initialAttendeeConnectionId);
+									const attendee = presence.getAttendee(id);
+
+									// Verify
+									assert.equal(attendee, newAttendee, "getAttendee returned wrong attendee");
+									assert.equal(
+										attendee.getStatus(),
+										SessionClientStatus.Disconnected,
+										"getAttendee returned attendee with wrong status",
+									);
+								});
+							});
+						}
+
+						describe("is available from `getAttendees`", () => {
+							it('with status "Connected"', () => {
+								// Setup
+								assert(newAttendee !== undefined, "No attendee was set in beforeEach");
+
+								// Act
+								const attendees = presence.getAttendees();
+								assert(
+									attendees.has(newAttendee),
+									"getAttendees set does not contain attendee",
+								);
+								assert.equal(
+									newAttendee.getStatus(),
+									SessionClientStatus.Connected,
+									"getAttendees set contains attendee with wrong status",
+								);
+							});
+							it('with status "Disconnected"', () => {
+								// Setup
+								assert(newAttendee !== undefined, "No attendee was set in beforeEach");
+
+								// Act - remove client connection id
+								presence.removeClientConnectionId(initialAttendeeConnectionId);
+
+								// Verify
+								const attendees = presence.getAttendees();
+								assert(
+									attendees.has(newAttendee),
+									"getAttendees set does not contain attendee",
+								);
+								assert.equal(
+									newAttendee.getStatus(),
+									SessionClientStatus.Disconnected,
+									"getAttendees set contains attendee with wrong status",
+								);
+							});
+						});
+
+						it("is announced via `attendeeDisconnected` when its connection is removed", () => {
+							// Act - remove client connection id
+							presence.removeClientConnectionId(initialAttendeeConnectionId);
+
+							// Verify
+							assert(
+								disconnectedAttendee !== undefined,
+								"No attendee was disconnected in beforeEach",
+							);
+							assert.equal(
+								disconnectedAttendee.sessionId,
+								newAttendeeSessionId,
+								"Disconnected attendee has wrong session id",
+							);
+							assert.equal(
+								disconnectedAttendee.connectionId(),
+								initialAttendeeConnectionId,
+								"Disconnected attendee has wrong client connection id",
+							);
+							assert.equal(
+								disconnectedAttendee.getStatus(),
+								SessionClientStatus.Disconnected,
+								"Disconnected attendee has wrong status",
+							);
+						});
+					});
+				});
+
+				describe("that rejoined", () => {
+					beforeEach(() => {
+						afterCleanUp.push(
+							presence.events.on("attendeeJoined", (attendee) => {
+								newAttendee = attendee;
+							}),
+						);
+
 						// Setup - simulate join message from client
 						presence.processSignal("", initialAttendeeSignal, false);
 						assert(newAttendee !== undefined, "No attendee was announced in setup");
 					});
 
-					for (const [desc, id] of [
-						["connection id", initialAttendeeConnectionId] as const,
-						["session id", newAttendeeSessionId] as const,
-					]) {
-						describe(`is available from \`getAttendee\` by ${desc}`, () => {
-							it('with status "Connected"', () => {
-								// Act
-								const attendee = presence.getAttendee(id);
-								// Verify
-								assert.equal(attendee, newAttendee, "getAttendee returned wrong attendee");
-								assert.equal(
-									attendee.getStatus(),
-									SessionClientStatus.Connected,
-									"getAttendee returned attendee with wrong status",
-								);
-							});
-
-							it('with status "Disconnected" after disconnect', () => {
-								// Act - remove client connection id
-								presence.removeClientConnectionId(initialAttendeeConnectionId);
-								const attendee = presence.getAttendee(id);
-
-								// Verify
-								assert.equal(attendee, newAttendee, "getAttendee returned wrong attendee");
-								assert.equal(
-									attendee.getStatus(),
-									SessionClientStatus.Disconnected,
-									"getAttendee returned attendee with wrong status",
-								);
-							});
-						});
-					}
-
-					describe("is available from `getAttendees`", () => {
-						it('with status "Connected"', () => {
-							// Setup
-							assert(newAttendee !== undefined, "No attendee was set in beforeEach");
-
-							// Act
-							const attendees = presence.getAttendees();
-							assert(attendees.has(newAttendee), "getAttendees set does not contain attendee");
-							assert.equal(
-								newAttendee.getStatus(),
-								SessionClientStatus.Connected,
-								"getAttendees set contains attendee with wrong status",
-							);
-						});
-						it('with status "Disconnected"', () => {
-							// Setup
-							assert(newAttendee !== undefined, "No attendee was set in beforeEach");
-
-							// Act - remove client connection id
-							presence.removeClientConnectionId(initialAttendeeConnectionId);
-
-							// Verify
-							const attendees = presence.getAttendees();
-							assert(attendees.has(newAttendee), "getAttendees set does not contain attendee");
-							assert.equal(
-								newAttendee.getStatus(),
-								SessionClientStatus.Disconnected,
-								"getAttendees set contains attendee with wrong status",
-							);
-						});
-					});
-
-					it("is announced via `attendeeDisconnected` when its connection is removed", () => {
-						// Act - remove client connection id
-						presence.removeClientConnectionId(initialAttendeeConnectionId);
-
-						// Verify
-						assert(
-							disconnectedAttendee !== undefined,
-							"No attendee was disconnected in beforeEach",
-						);
-						assert.equal(
-							disconnectedAttendee.sessionId,
-							newAttendeeSessionId,
-							"Disconnected attendee has wrong session id",
-						);
-						assert.equal(
-							disconnectedAttendee.connectionId(),
-							initialAttendeeConnectionId,
-							"Disconnected attendee has wrong client connection id",
-						);
-						assert.equal(
-							disconnectedAttendee.getStatus(),
-							SessionClientStatus.Disconnected,
-							"Disconnected attendee has wrong status",
-						);
-					});
-
-					it("is NOT announced when rejoined with same connection (duplicate signal)", () => {
-						clock.tick(10);
-
-						// Act & Verify - simulate duplicate join message from client
-						presence.processSignal("", initialAttendeeSignal, false);
-					});
-
-					it("is NOT announced when rejoined with different connection and current information is updated", () => {
+					it("is announced when rejoined with different connection and current information is updated", () => {
 						// Setup
 						assert(newAttendee !== undefined, "No attendee was set in beforeEach");
 


### PR DESCRIPTION
## Description
Updated SystemWorkspace to use audience for session client connection status.

Added and edited existing attendee connection unit tests.
