### PR TITLE
refactor: Remove unnecessary dep in `@fluid-tools/markdown-magic`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16349,9 +16349,6 @@ importers:
       markdown-magic-package-scripts:
         specifier: ^1.2.2
         version: 1.2.2
-      markdown-magic-template:
-        specifier: ^1.0.1
-        version: 1.0.1
       yargs:
         specifier: 17.7.2
         version: 17.7.2
@@ -32000,10 +31997,6 @@ packages:
     dependencies:
       p-locate: 6.0.0
 
-  /lodash._reinterpolate@3.0.0:
-    resolution: {integrity: sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==}
-    dev: false
-
   /lodash.capitalize@4.2.1:
     resolution: {integrity: sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==}
     dev: true
@@ -32078,19 +32071,6 @@ packages:
 
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
-
-  /lodash.template@4.5.0:
-    resolution: {integrity: sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==}
-    dependencies:
-      lodash._reinterpolate: 3.0.0
-      lodash.templatesettings: 4.2.0
-    dev: false
-
-  /lodash.templatesettings@4.2.0:
-    resolution: {integrity: sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==}
-    dependencies:
-      lodash._reinterpolate: 3.0.0
-    dev: false
 
   /lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
@@ -32317,17 +32297,6 @@ packages:
     dependencies:
       findup: 0.1.5
       sort-scripts: 1.0.1
-    dev: false
-
-  /markdown-magic-template@1.0.1:
-    resolution: {integrity: sha512-eoYa+jZHd7TIijM0xuBJWC7rEF75OgFnN0/cwNDbLsmeYCAprR5x0EvZFaHVl2deJN+ziBN3rQ9/m/TD7n4bAQ==}
-    peerDependencies:
-      markdown-magic: '>=0.1 <=2.x'
-    peerDependenciesMeta:
-      markdown-magic:
-        optional: true
-    dependencies:
-      lodash.template: 4.5.0
     dev: false
 
   /markdown-table@2.0.0:

--- a/tools/markdown-magic/package.json
+++ b/tools/markdown-magic/package.json
@@ -30,7 +30,6 @@
 		"@tylerbu/markdown-magic": "2.4.0-tylerbu-1",
 		"chalk": "^4.1.2",
 		"markdown-magic-package-scripts": "^1.2.2",
-		"markdown-magic-template": "^1.0.1",
 		"yargs": "17.7.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Description

`markdown-magic-template` is not used at all as far as I can tell, and it brings in a transitive dependency on `lodash.template: 4.5.0` which is flagged with a CVE that can't be addressed easily because `lodash` seems to have stopped publishing each of their functions as a separate package after 4.5.0.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).