### PR TITLE
Fix libCheck

### DIFF
--- a/.changeset/clever-birds-wear.md
+++ b/.changeset/clever-birds-wear.md
@@ -1,0 +1,30 @@
+---
+"@fluidframework/merge-tree": minor
+"@fluidframework/tree": minor
+"fluid-framework": minor
+---
+---
+"section": fix
+---
+
+Fix compiler errors when building with libCheck
+
+Compiling code using Fluid Framework when using TypeScript's `libCheck` (meaning without [skipLibCheck](https://www.typescriptlang.org/tsconfig/#skipLibCheck)), two compile errors can be encountered:
+
+```
+> tsc
+
+node_modules/@fluidframework/merge-tree/lib/client.d.ts:124:18 - error TS2368: Type parameter name cannot be 'undefined'.
+
+124     walkSegments<undefined>(handler: ISegmentAction<undefined>, start?: number, end?: number, accum?: undefined, splitRange?: boolean): void;
+                     ~~~~~~~~~
+
+node_modules/@fluidframework/tree/lib/util/utils.d.ts:5:29 - error TS7016: Could not find a declaration file for module '@ungap/structured-clone'. 'node_modules/@ungap/structured-clone/esm/index.js' implicitly has an 'any' type.
+  Try `npm i --save-dev @types/ungap__structured-clone` if it exists or add a new declaration (.d.ts) file containing `declare module '@ungap/structured-clone';`
+
+5 import structuredClone from "@ungap/structured-clone";
+                              ~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+While neither of these compile errors are in the `@public` API surface, they could impact customers using the public API due to how `libCheck` works and how Fluid Framework handles it's API exports.
+This change fixes these errors which should allow `libCheck` to be reenabled.

--- a/.changeset/clever-birds-wear.md
+++ b/.changeset/clever-birds-wear.md
@@ -26,5 +26,9 @@ node_modules/@fluidframework/tree/lib/util/utils.d.ts:5:29 - error TS7016: Could
                               ~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
-While neither of these compile errors are in the `@public` API surface, they could impact customers using the public API due to how `libCheck` works and how Fluid Framework handles it's API exports.
-This change fixes these errors which should allow `libCheck` to be reenabled.
+The first error impacts projects using TypeScript 5.5 or greater and either of the `fluid-framework` or `@fluidframework/merge-tree` packages.
+The second error impacts projects using the `noImplicitAny` tsconfig setting and the `fluid-framework` or `@fluidframework/tree` packages.
+
+Both have been fixed.
+
+This should allow `libCheck` to be reenabled in any impacted projects.

--- a/packages/dds/merge-tree/api-report/merge-tree.legacy.alpha.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.legacy.alpha.api.md
@@ -169,7 +169,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
     // (undocumented)
     walkSegments<TClientData>(handler: ISegmentAction<TClientData>, start: number | undefined, end: number | undefined, accum: TClientData, splitRange?: boolean): void;
     // (undocumented)
-    walkSegments<undefined>(handler: ISegmentAction<undefined>, start?: number, end?: number, accum?: undefined, splitRange?: boolean): void;
+    walkSegments(handler: ISegmentAction<undefined>, start?: number, end?: number, accum?: undefined, splitRange?: boolean): void;
 }
 
 // @alpha @deprecated (undocumented)

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -322,7 +322,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		accum: TClientData,
 		splitRange?: boolean,
 	): void;
-	public walkSegments<undefined>(
+	public walkSegments(
 		handler: ISegmentAction<undefined>,
 		start?: number,
 		end?: number,

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -166,6 +166,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@sinclair/typebox": "^0.32.29",
 		"@tylerbu/sorted-btree-es6": "^1.8.0",
+		"@types/ungap__structured-clone": "^1.2.0",
 		"@ungap/structured-clone": "^1.2.0",
 		"uuid": "^9.0.0"
 	},
@@ -191,7 +192,6 @@
 		"@types/easy-table": "^0.0.32",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",
-		"@types/ungap__structured-clone": "^1.2.0",
 		"@types/uuid": "^9.0.2",
 		"ajv": "^8.12.0",
 		"ajv-formats": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9184,6 +9184,9 @@ importers:
       '@tylerbu/sorted-btree-es6':
         specifier: ^1.8.0
         version: 1.8.0
+      '@types/ungap__structured-clone':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@ungap/structured-clone':
         specifier: ^1.2.0
         version: 1.2.0
@@ -9254,9 +9257,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.54
-      '@types/ungap__structured-clone':
-        specifier: ^1.2.0
-        version: 1.2.0
       '@types/uuid':
         specifier: ^9.0.2
         version: 9.0.8
@@ -24271,7 +24271,6 @@ packages:
 
   /@types/ungap__structured-clone@1.2.0:
     resolution: {integrity: sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA==}
-    dev: true
 
   /@types/unist@2.0.11:
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}


### PR DESCRIPTION
## Description

While neither of these compile errors are in the `@public` API surface, they could impact customers using the public API due to how `libCheck` works and how Fluid Framework handles it's API exports.

See changeset for details.

I have filed https://dev.azure.com/fluidframework/internal/_workitems/edit/21856 to internally track that this was not detected by the CI of FF or FF examples.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
