### PR TITLE
Move msn forward in mocks to fix fuzz snapshotting

### DIFF
--- a/packages/dds/test-dds-utils/src/clientLoading.ts
+++ b/packages/dds/test-dds-utils/src/clientLoading.ts
@@ -72,7 +72,7 @@ export function createLoadData(
 ): ClientLoadData {
 	const compressor = client.dataStoreRuntime.idCompressor;
 	return {
-		minimumSequenceNumber: client.dataStoreRuntime.deltaManagerInternal.lastSequenceNumber,
+		minimumSequenceNumber: client.dataStoreRuntime.deltaManagerInternal.minimumSequenceNumber,
 		summaries: {
 			summary: client.channel.getAttachSummary().summary,
 			idCompressorSummary:

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -632,6 +632,12 @@ export class MockContainerRuntimeFactory {
 		while (this.messages.length > 0) {
 			this.processFirstMessage();
 		}
+		this.runtimes.forEach((r) => {
+			r.deltaManager.minimumSequenceNumber = r.deltaManager.lastSequenceNumber;
+			if (this.minSeq.has(r.clientId)) {
+				this.minSeq.set(r.clientId, r.deltaManager.minimumSequenceNumber);
+			}
+		});
 	}
 }
 


### PR DESCRIPTION
This change adds updating the msn for all the runtimes of the mock container runtime factory when all messages are processed, which is used in synchronization in the fuzz tests. Before the msn would lag, which created problems in the sequence fuzz tests, as the sequence's snapshot format is highly dependent on an accurate msn.