### PR TITLE
Delay edit manager trunk eviction when detached

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -351,7 +351,13 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 				newRevision,
 				this.detachedRevision,
 			);
-			this.editManager.advanceMinimumSequenceNumber(newRevision);
+			// Schedule the advancement of the min sequence number to happen very soon, but not immediately.
+			// Advancing the minimum sequence number can cause the EditManager to evict old commits from its trunk.
+			// This function (submitCommit) is called in response to a change to the local branch, and we do not want
+			// to evict any commits until all other listeners of the branch have had a chance to process the change.
+			void Promise.resolve().then(() =>
+				this.editManager.advanceMinimumSequenceNumber(newRevision),
+			);
 			return undefined;
 		}
 		const message = this.messageCodec.encode(

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -3,16 +3,27 @@
  * Licensed under the MIT License.
  */
 
-import { type Revertible, type UpPath, rootFieldKey } from "../../core/index.js";
+import {
+	type FieldUpPath,
+	type Revertible,
+	type UpPath,
+	rootFieldKey,
+} from "../../core/index.js";
 import { singleJsonCursor } from "../json/index.js";
 import { SharedTreeFactory, type ITreeCheckout } from "../../shared-tree/index.js";
 import { type JsonCompatible, brand } from "../../util/index.js";
 import { createTestUndoRedoStacks, expectJsonTree, moveWithin } from "../utils.js";
-import { insert, makeTreeFromJsonSequence, remove } from "../sequenceRootUtils.js";
+import { insert, jsonSequenceRootSchema, remove } from "../sequenceRootUtils.js";
 import { createIdCompressor } from "@fluidframework/id-compressor/internal";
-import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
+import {
+	MockContainerRuntimeFactory,
+	MockFluidDataStoreRuntime,
+	MockStorage,
+} from "@fluidframework/test-runtime-utils/internal";
 import assert from "assert";
 import { SchemaFactory, TreeViewConfiguration } from "../../simple-tree/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { initialize } from "../../shared-tree/schematizeTree.js";
 
 const rootPath: UpPath = {
 	parent: undefined,
@@ -20,7 +31,7 @@ const rootPath: UpPath = {
 	parentIndex: 0,
 };
 
-const rootField = {
+const rootField: FieldUpPath = {
 	parent: undefined,
 	field: rootFieldKey,
 };
@@ -148,280 +159,282 @@ const testCases: {
 ];
 
 describe("Undo and redo", () => {
-	for (const {
-		name,
-		skip,
-		edit,
-		undoCount,
-		initialState,
-		editedState,
-		undoState,
-		mergeState,
-	} of testCases) {
-		const count = undoCount ?? 1;
-		const itFn = skip ? it.skip : it;
-		itFn(`${name} (act on fork undo on fork)`, () => {
-			const view = makeTreeFromJsonSequence(initialState);
-			const fork = view.branch();
+	for (const attached of [true, false]) {
+		const attachStr = attached ? "attached" : "detached";
+		for (const {
+			name,
+			skip,
+			edit,
+			undoCount,
+			initialState,
+			editedState,
+			undoState,
+			mergeState,
+		} of testCases) {
+			const count = undoCount ?? 1;
+			const itFn = skip ? it.skip : it;
+			itFn(`${name} (act on fork undo on fork - ${attachStr})`, () => {
+				const view = createCheckout(initialState, attached);
+				const fork = view.branch();
 
-			const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(fork.events);
-			edit(fork, view);
+				const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(fork.events);
+				edit(fork, view);
 
-			fork.rebaseOnto(view);
-			expectJsonTree(fork, editedState);
+				fork.rebaseOnto(view);
+				expectJsonTree(fork, editedState);
 
-			for (let i = 0; i < count; i++) {
-				undoStack.pop()?.revert();
-			}
+				for (let i = 0; i < count; i++) {
+					undoStack.pop()?.revert();
+				}
 
-			fork.rebaseOnto(view);
-			expectJsonTree(fork, undoState ?? initialState);
+				fork.rebaseOnto(view);
+				expectJsonTree(fork, undoState ?? initialState);
 
-			while (redoStack.length > 0) {
-				redoStack.pop()?.revert();
-			}
+				while (redoStack.length > 0) {
+					redoStack.pop()?.revert();
+				}
 
-			fork.rebaseOnto(view);
-			expectJsonTree(fork, editedState);
+				fork.rebaseOnto(view);
+				expectJsonTree(fork, editedState);
+				unsubscribe();
+			});
+
+			// TODO: unskip once forking revertibles is supported
+			it.skip(`${name} (act on view undo on fork - ${attachStr})`, () => {
+				const view = createCheckout(initialState, attached);
+				const fork = view.branch();
+
+				const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(fork.events);
+				edit(view, fork);
+
+				fork.rebaseOnto(view);
+				expectJsonTree(fork, editedState);
+
+				for (let i = 0; i < count; i++) {
+					undoStack.pop()?.revert();
+				}
+
+				fork.rebaseOnto(view);
+				expectJsonTree(fork, undoState ?? initialState);
+
+				while (redoStack.length > 0) {
+					redoStack.pop()?.revert();
+				}
+
+				fork.rebaseOnto(view);
+				expectJsonTree(fork, editedState);
+				unsubscribe();
+			});
+
+			itFn(`${name} (act on view undo on view - ${attachStr})`, () => {
+				const view = createCheckout(initialState, attached);
+				const fork = view.branch();
+
+				const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
+				edit(view, fork);
+
+				view.merge(fork, false);
+				expectJsonTree(view, editedState);
+
+				for (let i = 0; i < count; i++) {
+					undoStack.pop()?.revert();
+				}
+
+				view.merge(fork, false);
+				expectJsonTree(view, mergeState ?? initialState);
+
+				while (redoStack.length > 0) {
+					redoStack.pop()?.revert();
+				}
+
+				view.merge(fork);
+				expectJsonTree(view, editedState);
+				unsubscribe();
+			});
+
+			// TODO: unskip once forking revertibles is supported
+			it.skip(`${name} (act on fork undo on view - ${attachStr})`, () => {
+				const view = createCheckout(initialState, attached);
+				const fork = view.branch();
+
+				const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
+				edit(fork, view);
+
+				view.merge(fork, false);
+				expectJsonTree(view, editedState);
+
+				for (let i = 0; i < count; i++) {
+					undoStack.pop()?.revert();
+				}
+
+				view.merge(fork, false);
+				expectJsonTree(view, undoState ?? initialState);
+
+				while (redoStack.length > 0) {
+					redoStack.pop()?.revert();
+				}
+
+				view.merge(fork);
+				expectJsonTree(view, editedState);
+				unsubscribe();
+			});
+
+			it(`${name} multiple times (${attachStr})`, () => {
+				const tree = createCheckout(initialState, attached);
+				const fork = tree.branch();
+
+				const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
+				edit(tree, fork);
+
+				tree.merge(fork, false);
+				expectJsonTree(tree, editedState);
+				while (undoStack.length > 0) {
+					undoStack.pop()?.revert();
+				}
+				expectJsonTree(tree, mergeState ?? initialState);
+				while (redoStack.length > 0) {
+					redoStack.pop()?.revert();
+				}
+				expectJsonTree(tree, editedState);
+				while (undoStack.length > 0) {
+					undoStack.pop()?.revert();
+				}
+				expectJsonTree(tree, mergeState ?? initialState);
+				while (redoStack.length > 0) {
+					redoStack.pop()?.revert();
+				}
+				expectJsonTree(tree, editedState);
+				unsubscribe();
+			});
+		}
+
+		it(`can undo before and after rebasing a branch (${attachStr})`, () => {
+			const tree1 = createCheckout([0, 0, 0], attached);
+			const tree2 = tree1.branch();
+
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree2.events);
+			tree1.editor.sequenceField(rootField).insert(3, singleJsonCursor(1));
+			tree2.editor.sequenceField(rootField).insert(0, singleJsonCursor(2));
+			tree2.editor.sequenceField(rootField).insert(0, singleJsonCursor(3));
+			undoStack.pop()?.revert();
+			expectJsonTree(tree2, [2, 0, 0, 0]);
+			tree2.rebaseOnto(tree1);
+			expectJsonTree(tree2, [2, 0, 0, 0, 1]);
+			undoStack.pop()?.revert();
+			expectJsonTree(tree2, [0, 0, 0, 1]);
 			unsubscribe();
 		});
 
 		// TODO: unskip once forking revertibles is supported
-		it.skip(`${name} (act on view undo on fork)`, () => {
-			const view = makeTreeFromJsonSequence(initialState);
-			const fork = view.branch();
+		it.skip(`can undo after forking a branch (${attachStr})`, () => {
+			const tree1 = createCheckout(["A", "B", "C"], attached);
 
-			const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(fork.events);
-			edit(view, fork);
+			const { undoStack: undoStack1, unsubscribe: unsubscribe1 } = createTestUndoRedoStacks(
+				tree1.events,
+			);
+			tree1.editor.sequenceField(rootField).remove(0, 1);
+			tree1.editor.sequenceField(rootField).remove(1, 1);
 
-			fork.rebaseOnto(view);
-			expectJsonTree(fork, editedState);
-
-			for (let i = 0; i < count; i++) {
-				undoStack.pop()?.revert();
-			}
-
-			fork.rebaseOnto(view);
-			expectJsonTree(fork, undoState ?? initialState);
-
-			while (redoStack.length > 0) {
-				redoStack.pop()?.revert();
-			}
-
-			fork.rebaseOnto(view);
-			expectJsonTree(fork, editedState);
-			unsubscribe();
-		});
-
-		itFn(`${name} (act on view undo on view)`, () => {
-			const view = makeTreeFromJsonSequence(initialState);
-			const fork = view.branch();
-
-			const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
-			edit(view, fork);
-
-			view.merge(fork, false);
-			expectJsonTree(view, editedState);
-
-			for (let i = 0; i < count; i++) {
-				undoStack.pop()?.revert();
-			}
-
-			view.merge(fork, false);
-			expectJsonTree(view, mergeState ?? initialState);
-
-			while (redoStack.length > 0) {
-				redoStack.pop()?.revert();
-			}
-
-			view.merge(fork);
-			expectJsonTree(view, editedState);
-			unsubscribe();
+			const tree2 = tree1.branch();
+			const { undoStack: undoStack2, unsubscribe: unsubscribe2 } = createTestUndoRedoStacks(
+				tree2.events,
+			);
+			expectJsonTree(tree2, ["B"]);
+			undoStack1.pop()?.revert();
+			expectJsonTree(tree2, ["B", "C"]);
+			undoStack2.pop()?.revert();
+			expectJsonTree(tree2, ["A", "B", "C"]);
+			unsubscribe1();
+			unsubscribe2();
 		});
 
 		// TODO: unskip once forking revertibles is supported
-		it.skip(`${name} (act on fork undo on view)`, () => {
-			const view = makeTreeFromJsonSequence(initialState);
-			const fork = view.branch();
+		it.skip(`can redo after forking a branch (${attachStr})`, () => {
+			const tree1 = createCheckout(["B"], attached);
 
-			const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
-			edit(fork, view);
+			const { undoStack: undoStack1, unsubscribe: unsubscribe1 } = createTestUndoRedoStacks(
+				tree1.events,
+			);
+			tree1.editor.sequenceField(rootField).insert(0, singleJsonCursor("A"));
+			tree1.editor.sequenceField(rootField).insert(2, singleJsonCursor("C"));
+			undoStack1.pop()?.revert();
+			undoStack1.pop()?.revert();
 
-			view.merge(fork, false);
-			expectJsonTree(view, editedState);
-
-			for (let i = 0; i < count; i++) {
-				undoStack.pop()?.revert();
-			}
-
-			view.merge(fork, false);
-			expectJsonTree(view, undoState ?? initialState);
-
-			while (redoStack.length > 0) {
-				redoStack.pop()?.revert();
-			}
-
-			view.merge(fork);
-			expectJsonTree(view, editedState);
-			unsubscribe();
+			const tree2 = tree1.branch();
+			const { redoStack: redoStack2, unsubscribe: unsubscribe2 } = createTestUndoRedoStacks(
+				tree2.events,
+			);
+			expectJsonTree(tree2, ["B"]);
+			redoStack2.pop()?.revert();
+			expectJsonTree(tree2, ["A", "B"]);
+			redoStack2.pop()?.revert();
+			expectJsonTree(tree2, ["A", "B", "C"]);
+			unsubscribe1();
+			unsubscribe2();
 		});
 
-		it(`${name} multiple times`, () => {
-			const tree = makeTreeFromJsonSequence(initialState);
-			const fork = tree.branch();
+		it(`can undo/redo a transaction (${attachStr})`, () => {
+			const tree = createCheckout(["A", "B"], attached);
 
 			const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
-			edit(tree, fork);
+			tree.transaction.start();
+			tree.editor.sequenceField(rootField).insert(2, singleJsonCursor("C"));
+			tree.editor.sequenceField(rootField).remove(0, 1);
+			tree.transaction.commit();
 
-			tree.merge(fork, false);
-			expectJsonTree(tree, editedState);
-			while (undoStack.length > 0) {
-				undoStack.pop()?.revert();
-			}
-			expectJsonTree(tree, mergeState ?? initialState);
-			while (redoStack.length > 0) {
-				redoStack.pop()?.revert();
-			}
-			expectJsonTree(tree, editedState);
-			while (undoStack.length > 0) {
-				undoStack.pop()?.revert();
-			}
-			expectJsonTree(tree, mergeState ?? initialState);
-			while (redoStack.length > 0) {
-				redoStack.pop()?.revert();
-			}
-			expectJsonTree(tree, editedState);
+			expectJsonTree(tree, ["B", "C"]);
+			undoStack.pop()?.revert();
+			expectJsonTree(tree, ["A", "B"]);
+			redoStack.pop()?.revert();
+			expectJsonTree(tree, ["B", "C"]);
+			unsubscribe();
+		});
+
+		it(`can undo/redo a merge (${attachStr})`, () => {
+			const tree = createCheckout(["A", "B"], attached);
+
+			const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
+			const branch = tree.branch();
+			branch.editor.sequenceField(rootField).insert(2, singleJsonCursor("C"));
+			branch.editor.sequenceField(rootField).remove(0, 1);
+			tree.merge(branch);
+
+			expectJsonTree(tree, ["B", "C"]);
+			undoStack.pop()?.revert();
+			expectJsonTree(tree, ["A", "B", "C"]);
+			undoStack.pop()?.revert();
+			expectJsonTree(tree, ["A", "B"]);
+			redoStack.pop()?.revert();
+			expectJsonTree(tree, ["A", "B", "C"]);
+			redoStack.pop()?.revert();
+			expectJsonTree(tree, ["B", "C"]);
+			unsubscribe();
+		});
+
+		it(`can undo multiple merges (${attachStr})`, () => {
+			const tree = createCheckout(["A", "B"], attached);
+
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
+
+			const branch = tree.branch();
+
+			branch.editor.sequenceField(rootField).insert(2, singleJsonCursor("C"));
+			tree.merge(branch, false);
+			expectJsonTree(tree, ["A", "B", "C"]);
+			undoStack.pop()?.revert();
+			expectJsonTree(tree, ["A", "B"]);
+
+			branch.editor.sequenceField(rootField).insert(2, singleJsonCursor("C"));
+			tree.merge(branch);
+			expectJsonTree(tree, ["A", "B", "C"]);
+			undoStack.pop()?.revert();
+			expectJsonTree(tree, ["A", "B"]);
+
 			unsubscribe();
 		});
 	}
 
-	it("can undo before and after rebasing a branch", () => {
-		const tree1 = makeTreeFromJsonSequence([0, 0, 0]);
-		const tree2 = tree1.branch();
-
-		const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree2.events);
-		tree1.editor.sequenceField(rootField).insert(3, singleJsonCursor(1));
-		tree2.editor.sequenceField(rootField).insert(0, singleJsonCursor(2));
-		tree2.editor.sequenceField(rootField).insert(0, singleJsonCursor(3));
-		undoStack.pop()?.revert();
-		expectJsonTree(tree2, [2, 0, 0, 0]);
-		tree2.rebaseOnto(tree1);
-		expectJsonTree(tree2, [2, 0, 0, 0, 1]);
-		undoStack.pop()?.revert();
-		expectJsonTree(tree2, [0, 0, 0, 1]);
-		unsubscribe();
-	});
-
-	// TODO: unskip once forking revertibles is supported
-	it.skip("can undo after forking a branch", () => {
-		const tree1 = makeTreeFromJsonSequence(["A", "B", "C"]);
-
-		const { undoStack: undoStack1, unsubscribe: unsubscribe1 } = createTestUndoRedoStacks(
-			tree1.events,
-		);
-		tree1.editor.sequenceField(rootField).remove(0, 1);
-		tree1.editor.sequenceField(rootField).remove(1, 1);
-
-		const tree2 = tree1.branch();
-		const { undoStack: undoStack2, unsubscribe: unsubscribe2 } = createTestUndoRedoStacks(
-			tree2.events,
-		);
-		expectJsonTree(tree2, ["B"]);
-		undoStack1.pop()?.revert();
-		expectJsonTree(tree2, ["B", "C"]);
-		undoStack2.pop()?.revert();
-		expectJsonTree(tree2, ["A", "B", "C"]);
-		unsubscribe1();
-		unsubscribe2();
-	});
-
-	// TODO: unskip once forking revertibles is supported
-	it.skip("can redo after forking a branch", () => {
-		const tree1 = makeTreeFromJsonSequence(["B"]);
-
-		const { undoStack: undoStack1, unsubscribe: unsubscribe1 } = createTestUndoRedoStacks(
-			tree1.events,
-		);
-		tree1.editor.sequenceField(rootField).insert(0, singleJsonCursor("A"));
-		tree1.editor.sequenceField(rootField).insert(2, singleJsonCursor("C"));
-		undoStack1.pop()?.revert();
-		undoStack1.pop()?.revert();
-
-		const tree2 = tree1.branch();
-		const { redoStack: redoStack2, unsubscribe: unsubscribe2 } = createTestUndoRedoStacks(
-			tree2.events,
-		);
-		expectJsonTree(tree2, ["B"]);
-		redoStack2.pop()?.revert();
-		expectJsonTree(tree2, ["A", "B"]);
-		redoStack2.pop()?.revert();
-		expectJsonTree(tree2, ["A", "B", "C"]);
-		unsubscribe1();
-		unsubscribe2();
-	});
-
-	it("can undo/redo a transaction", () => {
-		const tree = makeTreeFromJsonSequence(["A", "B"]);
-
-		const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
-		tree.transaction.start();
-		tree.editor.sequenceField(rootField).insert(2, singleJsonCursor("C"));
-		tree.editor.sequenceField(rootField).remove(0, 1);
-		tree.transaction.commit();
-
-		expectJsonTree(tree, ["B", "C"]);
-		undoStack.pop()?.revert();
-		expectJsonTree(tree, ["A", "B"]);
-		redoStack.pop()?.revert();
-		expectJsonTree(tree, ["B", "C"]);
-		unsubscribe();
-	});
-
-	it("can undo/redo a merge", () => {
-		const tree = makeTreeFromJsonSequence(["A", "B"]);
-
-		const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
-		const branch = tree.branch();
-		branch.editor.sequenceField(rootField).insert(2, singleJsonCursor("C"));
-		branch.editor.sequenceField(rootField).remove(0, 1);
-		tree.merge(branch);
-
-		expectJsonTree(tree, ["B", "C"]);
-		undoStack.pop()?.revert();
-		expectJsonTree(tree, ["A", "B", "C"]);
-		undoStack.pop()?.revert();
-		expectJsonTree(tree, ["A", "B"]);
-		redoStack.pop()?.revert();
-		expectJsonTree(tree, ["A", "B", "C"]);
-		redoStack.pop()?.revert();
-		expectJsonTree(tree, ["B", "C"]);
-		unsubscribe();
-	});
-
-	it("can undo multiple merges", () => {
-		const tree = makeTreeFromJsonSequence(["A", "B"]);
-
-		const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
-
-		const branch = tree.branch();
-
-		branch.editor.sequenceField(rootField).insert(2, singleJsonCursor("C"));
-		tree.merge(branch, false);
-		expectJsonTree(tree, ["A", "B", "C"]);
-		undoStack.pop()?.revert();
-		expectJsonTree(tree, ["A", "B"]);
-
-		branch.editor.sequenceField(rootField).insert(2, singleJsonCursor("C"));
-		tree.merge(branch);
-		expectJsonTree(tree, ["A", "B", "C"]);
-		undoStack.pop()?.revert();
-		expectJsonTree(tree, ["A", "B"]);
-
-		unsubscribe();
-	});
-
-	// TODO:#20949: Enable when undo/redo is supported for detached trees (currently failing with error: "refresher data not found")
-	it.skip("can undo while detached", () => {
+	it("can undo while detached", () => {
 		const sf = new SchemaFactory(undefined);
 		class Schema extends sf.object("Object", { foo: sf.number }) {}
 		const sharedTreeFactory = new SharedTreeFactory();
@@ -441,3 +454,31 @@ describe("Undo and redo", () => {
 		assert.equal(view.root.foo, 1);
 	});
 });
+
+/**
+ * Create a checkout belonging to a SharedTree with the given JSON data.
+ * @param attachTree - whether or not the SharedTree should be attached to the Fluid runtime
+ */
+export function createCheckout(json: JsonCompatible[], attachTree: boolean): ITreeCheckout {
+	const sharedTreeFactory = new SharedTreeFactory();
+	const runtime = new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() });
+	const tree = sharedTreeFactory.create(runtime, "tree");
+	const runtimeFactory = new MockContainerRuntimeFactory();
+	runtimeFactory.createContainerRuntime(runtime);
+	initialize(tree.checkout, {
+		schema: jsonSequenceRootSchema,
+		initialTree: json.map(singleJsonCursor),
+	});
+
+	if (attachTree) {
+		tree.connect({
+			deltaConnection: runtime.createDeltaConnection(),
+			objectStorage: new MockStorage(),
+		});
+	}
+
+	temp = tree;
+	return tree.checkout;
+}
+
+let temp: unknown;

--- a/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
@@ -382,8 +382,8 @@ export function generateTestTrees(options: SharedTreeOptions) {
 		{
 			name: "attachment-tree",
 			runScenario: async (takeSnapshot) => {
-				// This test makes changes only while detached to test EditManager's optimization of omitting
-				// changes outside the collab window (which is all changes when detached).
+				// This test makes changes only while detached to test EditManager's optimization of evicting/trimming
+				// trunk commits outside of the collab window (which is all changes when detached).
 				const tree = treeTestFactory({
 					runtime: new MockFluidDataStoreRuntime({
 						clientId: "test-client",
@@ -403,6 +403,9 @@ export function generateTestTrees(options: SharedTreeOptions) {
 				view.initialize([]);
 				view.root.insertAtStart("a");
 				view.root.insertAtEnd("b");
+				// SharedTree does not trigger the EditManager's trunk commit eviction synchronously when detached - it schedules eviction in the JS microtask queue.
+				// Wait for the eviction to complete (by enqueuing ourselves at the end of the microtask queue) before taking the snapshot.
+				await Promise.resolve();
 				await takeSnapshot(tree, "final");
 			},
 		},


### PR DESCRIPTION
## Description

When a SharedTree is detached and submits a change, this schedules the subsequent advancement of the EditManager's minimum sequence number on the JS microtask queue rather than doing it immediately/synchronously. Doing it synchronously is problematic because advancing the minimum sequence number might cause trunk commits to be evicted, however, this is happening in an event callback context - `submitCommit` is being called as a result of the `afterChange` event being fired on the local branch. If trunk eviction were to occur immediately, it would mean that other listeners to the `afterChange` event might experience different trunks (some before trimming, others after trimming). In practice, this is a problem when generating revertibles, as revertibles respond to the `afterChange` event by creating branches - but the bases of these branches may or may not have already been trimmed by the aforementioned behavior. Delaying the trimming guarantees that all listeners to the `afterChange` event can safely reference any commits that they may already have handles to.