### PR TITLE
Simplify and protect GraphCommit objects

### DIFF
--- a/packages/dds/tree/src/core/rebase/index.ts
+++ b/packages/dds/tree/src/core/rebase/index.ts
@@ -24,7 +24,6 @@ export {
 	taggedOptAtomId,
 	offsetChangeAtomId,
 	replaceAtomRevisions,
-	replaceChange,
 } from "./types.js";
 export { RevisionTagCodec } from "./revisionTagCodec.js";
 export {
@@ -49,4 +48,5 @@ export {
 	revisionMetadataSourceFromInfo,
 	type RebaseStats,
 	type RebaseStatsWithDuration,
+	replaceChange,
 } from "./utils.js";

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -18,7 +18,6 @@ import {
 	brandedNumberType,
 	brandedStringType,
 } from "../../util/index.js";
-import type { TaggedChange } from "./changeRebaser.js";
 
 /**
  * The identifier for a particular session/user/client that can generate `GraphCommit`s
@@ -154,8 +153,6 @@ export interface GraphCommit<TChange> {
 	readonly change: TChange;
 	/** The parent of this commit, on whose change this commit's change is based */
 	readonly parent?: GraphCommit<TChange>;
-	/** The rollback of this commit */
-	rollback?: TaggedChange<TChange, RevisionTag>;
 }
 
 /**
@@ -206,13 +203,4 @@ export function mintCommit<TChange>(
 		change,
 		parent,
 	};
-}
-
-export function replaceChange<TChange>(
-	commit: GraphCommit<TChange>,
-	change: TChange,
-): GraphCommit<TChange> {
-	const output = { ...commit, change };
-	delete output.rollback;
-	return output;
 }

--- a/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
@@ -11,8 +11,6 @@ import { validateAssertionError } from "@fluidframework/test-runtime-utils/inter
 import type {
 	EncodedRevisionTag,
 	GraphCommit,
-	RevisionTag,
-	TaggedChange,
 	ChangeEncodingContext,
 } from "../../core/index.js";
 import { typeboxValidator } from "../../external-utilities/index.js";
@@ -146,17 +144,13 @@ describe("message codec", () => {
 		);
 
 		const sessionId: SessionId = "sessionId" as SessionId;
-		it("Drops inverse and parent commit fields on encode", () => {
+		it("Drops parent commit fields on encode", () => {
 			const revision = testIdCompressor.generateCompressedId();
 			const message: DecodedMessage<TestChange> = {
 				sessionId,
 				commit: {
 					revision,
 					change: TestChange.mint([], 1),
-					rollback: "Extra field that should be dropped" as unknown as TaggedChange<
-						TestChange,
-						RevisionTag
-					>,
 					parent: "Extra field that should be dropped" as unknown as GraphCommit<TestChange>,
 				},
 			};


### PR DESCRIPTION
## Description

This PR improves GraphCommits in a couple of ways.

1. It adds a protective assert to the properties of commits that have been trimmed by the EditManager. This prevents any part of our system from accessing those commits without immediately throwing an error. This will catch any bugs that try to hold on to stale graph commits much sooner than they would otherwise be caught.
2. It removes the rollback property from GraphCommit and implements it via a WeakMap instead. This is appropriate because the rollback property is only used by a single scoped feature, so it need not be a property that is visible to all other code that works with GraphCommits.
