### PR TITLE
Fix JSON format for service clients pipeline

### DIFF
--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -51,7 +51,7 @@ stages:
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       env:
         FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-        FLUID_LOGGER_PROPS: '{ "displayName": ${{variables.pipelineIdentifierForTelemetry}}}'
+        FLUID_LOGGER_PROPS: '{ "displayName": "${{variables.pipelineIdentifierForTelemetry}}"}'
         azure__fluid__relay__service__tenantId: $(azure-fluid-relay-service-tenantId)
         azure__fluid__relay__service__endpoint: $(azure-fluid-relay-service-endpoint)
         azure__fluid__relay__service__key: $(azure-fluid-relay-service-key)

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -68,7 +68,7 @@ stages:
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       env:
         FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-        FLUID_LOGGER_PROPS: '{ "displayName": ${{variables.pipelineIdentifierForTelemetry}}}'
+        FLUID_LOGGER_PROPS: '{ "displayName": "${{variables.pipelineIdentifierForTelemetry}}"}'
         # Disable colorization for tinylicious logs (not useful when printing to a file)
         logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
         logger__morganFormat: tiny
@@ -85,7 +85,7 @@ stages:
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       env:
         FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
-        FLUID_LOGGER_PROPS: '{ "displayName": ${{variables.pipelineIdentifierForTelemetry}}}'
+        FLUID_LOGGER_PROPS: '{ "displayName": "${{variables.pipelineIdentifierForTelemetry}}"}'
         odsp__client__clientId: $(odsp-client-clientId)
         odsp__client__siteUrl: $(odsp-client-siteUrl)
         odsp__client__driveId: $(odsp-client-driveId)


### PR DESCRIPTION
Add quotes to the new display name field in the FLUID_LOGGER_PROPS env variable. Related to #22901, where the lack of quotes led to malformed JSON. 