### PR TITLE
Don't run SharedTree memory usage test code during test discovery

### DIFF
--- a/packages/dds/tree/src/test/memory/tree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tree.spec.ts
@@ -82,11 +82,19 @@ describe("SharedTree memory usage", () => {
 		new (class implements IMemoryTestObject {
 			public readonly title = "Create empty SharedTree";
 
+			// Assign to this field so that JS GC does not collect the SharedTree instance.
+			private _sharedTree: TreeView<typeof RootNodeSchema> | undefined;
+
 			public async run(): Promise<void> {
-				createLocalSharedTree("testSharedTree");
+				this._sharedTree = createLocalSharedTree("testSharedTree");
 			}
 		})(),
 	);
+
+	benchmarkMemory({
+		title: "Create empty SharedTree",
+		run: async () => createLocalSharedTree("testSharedTree"),
+	});
 
 	const numbersOfEntriesForTests = isInPerformanceTestingMode
 		? [1000, 10_000, 100_000]

--- a/packages/dds/tree/src/test/memory/tree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tree.spec.ts
@@ -82,10 +82,8 @@ describe("SharedTree memory usage", () => {
 		new (class implements IMemoryTestObject {
 			public readonly title = "Create empty SharedTree";
 
-			private sharedTree: TreeView<typeof RootNodeSchema> | undefined;
-
 			public async run(): Promise<void> {
-				this.sharedTree = createLocalSharedTree("testSharedTree");
+				createLocalSharedTree("testSharedTree");
 			}
 		})(),
 	);
@@ -99,11 +97,10 @@ describe("SharedTree memory usage", () => {
 		benchmarkMemory(
 			new (class implements IMemoryTestObject {
 				public readonly title = `Set an integer property ${x} times in a local SharedTree`;
-				private sharedTree: TreeView<typeof RootNodeSchema> =
-					createLocalSharedTree("testSharedTree");
+				private sharedTree: TreeView<typeof RootNodeSchema> | undefined;
 
 				public async run(): Promise<void> {
-					assert(this.sharedTree.root.child !== undefined);
+					assert(this.sharedTree?.root.child !== undefined);
 
 					for (let i = 0; i < x; i++) {
 						this.sharedTree.root.child.propertyOne = x;
@@ -119,11 +116,9 @@ describe("SharedTree memory usage", () => {
 		benchmarkMemory(
 			new (class implements IMemoryTestObject {
 				public readonly title = `Set a string property ${x} times in a local SharedTree`;
-				private sharedTree: TreeView<typeof RootNodeSchema> =
-					createLocalSharedTree("testSharedTree");
-
+				private sharedTree: TreeView<typeof RootNodeSchema> | undefined;
 				public async run(): Promise<void> {
-					assert(this.sharedTree.root.child !== undefined);
+					assert(this.sharedTree?.root.child !== undefined);
 
 					for (let i = 0; i < x; i++) {
 						this.sharedTree.root.child.propertyTwo.itemOne = i.toString().padStart(6, "0");
@@ -140,11 +135,10 @@ describe("SharedTree memory usage", () => {
 			new (class implements IMemoryTestObject {
 				public readonly title =
 					`Set an optional integer property ${x} times in a local SharedTree, then clear it`;
-				private sharedTree: TreeView<typeof RootNodeSchema> =
-					createLocalSharedTree("testSharedTree");
+				private sharedTree: TreeView<typeof RootNodeSchema> | undefined;
 
 				public async run(): Promise<void> {
-					assert(this.sharedTree.root.child !== undefined);
+					assert(this.sharedTree?.root.child !== undefined);
 
 					for (let i = 0; i < x; i++) {
 						this.sharedTree.root.child.propertyOne = x;

--- a/packages/dds/tree/src/test/memory/tree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tree.spec.ts
@@ -81,9 +81,8 @@ describe("SharedTree memory usage", () => {
 	benchmarkMemory(
 		new (class implements IMemoryTestObject {
 			public readonly title = "Create empty SharedTree";
-
 			// Assign to this field so that JS GC does not collect the SharedTree instance.
-			private _sharedTree: TreeView<typeof RootNodeSchema> | undefined;
+			private _sharedTree?: TreeView<typeof RootNodeSchema>;
 
 			public async run(): Promise<void> {
 				this._sharedTree = createLocalSharedTree("testSharedTree");
@@ -105,7 +104,7 @@ describe("SharedTree memory usage", () => {
 		benchmarkMemory(
 			new (class implements IMemoryTestObject {
 				public readonly title = `Set an integer property ${x} times in a local SharedTree`;
-				private sharedTree: TreeView<typeof RootNodeSchema> | undefined;
+				private sharedTree?: TreeView<typeof RootNodeSchema>;
 
 				public async run(): Promise<void> {
 					assert(this.sharedTree?.root.child !== undefined);
@@ -124,7 +123,7 @@ describe("SharedTree memory usage", () => {
 		benchmarkMemory(
 			new (class implements IMemoryTestObject {
 				public readonly title = `Set a string property ${x} times in a local SharedTree`;
-				private sharedTree: TreeView<typeof RootNodeSchema> | undefined;
+				private sharedTree?: TreeView<typeof RootNodeSchema>;
 				public async run(): Promise<void> {
 					assert(this.sharedTree?.root.child !== undefined);
 
@@ -143,7 +142,7 @@ describe("SharedTree memory usage", () => {
 			new (class implements IMemoryTestObject {
 				public readonly title =
 					`Set an optional integer property ${x} times in a local SharedTree, then clear it`;
-				private sharedTree: TreeView<typeof RootNodeSchema> | undefined;
+				private sharedTree?: TreeView<typeof RootNodeSchema>;
 
 				public async run(): Promise<void> {
 					assert(this.sharedTree?.root.child !== undefined);


### PR DESCRIPTION
## Description

The tests unnecessarily initialize a SharedTree during test discovery. This exercises many common code paths in SharedTree (creation, editing, etc.). Breakpoints set in these areas will be hit during the discovery of these memory tests, even if the memory tests are not being run. This is annoying and confusing for development - for example, running any (unrelated) single SharedTree test from the test browser will also run the memory test initialization code and hit extraneous breakpoints.

This PR removes the unnecessary initialization code, which is (sneakily) happening in a property initializer.
