### PR TITLE
build(build-cli): Upgrade jssm-viz and remove patch

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -163,12 +163,6 @@
 				"type-fest",
 				"typescript"
 			]
-		},
-		"patchedDependenciesComments": [
-			"jssm-viz is a dependency of jssm-viz-cli, but doesn't work with the latest jssm and TypeScript. This patch contains the changes from https://github.com/StoneCypher/jssm-viz/pull/54, which fixes the problem."
-		],
-		"patchedDependencies": {
-			"jssm-viz@5.101.0": "patches/jssm-viz@5.101.0.patch"
 		}
 	}
 }

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -171,7 +171,7 @@
 		"eslint-config-oclif": "^5.2.1",
 		"eslint-config-oclif-typescript": "^3.1.12",
 		"eslint-config-prettier": "~9.1.0",
-		"jssm-viz-cli": "5.101.0",
+		"jssm-viz-cli": "^5.101.0",
 		"mocha": "^10.7.3",
 		"mocha-multi-reporters": "^1.5.1",
 		"mocked-env": "^1.3.5",

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -12,11 +12,6 @@ overrides:
   oclif>@aws-sdk/client-cloudfront: npm:empty-npm-package@1.0.0
   oclif>@aws-sdk/client-s3: npm:empty-npm-package@1.0.0
 
-patchedDependencies:
-  jssm-viz@5.101.0:
-    hash: jq5upu46ffypomxpz6yk2iwhaa
-    path: patches/jssm-viz@5.101.0.patch
-
 importers:
 
   .:
@@ -365,7 +360,7 @@ importers:
         specifier: ~9.1.0
         version: 9.1.0(eslint@8.57.0)
       jssm-viz-cli:
-        specifier: 5.101.0
+        specifier: ^5.101.0
         version: 5.101.0
       mocha:
         specifier: ^10.7.3
@@ -8433,13 +8428,13 @@ packages:
       better_git_changelog: 1.6.2
       commander: 4.1.1
       glob: 7.2.3
-      jssm-viz: 5.101.0(patch_hash=jq5upu46ffypomxpz6yk2iwhaa)
+      jssm-viz: 5.101.0
       sharp: 0.33.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /jssm-viz@5.101.0(patch_hash=jq5upu46ffypomxpz6yk2iwhaa):
+  /jssm-viz@5.101.0:
     resolution: {integrity: sha512-dOmdBRnrVHECOmVuDFgPnmbwNXU9MO3U19+5KuyxYr8bJNizeV424Ez609+G23pmGY8NwCs3w4qRYcSyOPdcpA==}
     dependencies:
       better_git_changelog: 1.6.2
@@ -8450,7 +8445,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-    patched: true
 
   /jssm@5.104.1:
     resolution: {integrity: sha512-YpW2Y5Wlln8GqULzGE40B05oiiZKeIhzZLR2eymRg8cVoGan+jMQ/cRuVa1AxP3J72olx6/4RwRsEchDw0HPbw==}

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -8428,14 +8428,14 @@ packages:
       better_git_changelog: 1.6.2
       commander: 4.1.1
       glob: 7.2.3
-      jssm-viz: 5.101.0
+      jssm-viz: 5.104.1
       sharp: 0.33.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /jssm-viz@5.101.0:
-    resolution: {integrity: sha512-dOmdBRnrVHECOmVuDFgPnmbwNXU9MO3U19+5KuyxYr8bJNizeV424Ez609+G23pmGY8NwCs3w4qRYcSyOPdcpA==}
+  /jssm-viz@5.104.1:
+    resolution: {integrity: sha512-Nv8Oj6qKa+r3Oty/UOEuX5Y2/uqaX8sfTqPnLzLDwZlLgWFV6Qi5SHPnlci86hjI73rvd6zsO7AY03Ycy08Stg==}
     dependencies:
       better_git_changelog: 1.6.2
       eslint: 8.57.0

--- a/build-tools/syncpack.config.cjs
+++ b/build-tools/syncpack.config.cjs
@@ -72,7 +72,7 @@ module.exports = {
 
 		{
 			label: "Must use exact dependency ranges",
-			dependencies: ["jssm-viz-cli", "sort-package-json"],
+			dependencies: ["sort-package-json"],
 			packages: ["**"],
 			range: "",
 		},


### PR DESCRIPTION
Upgrades the transitive jssm-viz dependency in build-cli to the latest version, and removes the patch that we were using.

The upgrade was completed using the following command:

```
flub modify lockfile -g build-tools --dependencyName jssm-viz --version 5.104.1
```

[AB#21632](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21632)