### PR TITLE
Add more portions of the path to r11s request errors

### DIFF
--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -186,7 +186,7 @@ export const socketIoPath = "socket.io";
  * Get a stripped version of a URL safe for r11s telemetry
  * @returns undefined if no appropriate hostName is provided
  */
-export function getUrlForTelemetry(hostName: string, path?: string): string | undefined {
+export function getUrlForTelemetry(hostName: string, path: string = ""): string | undefined {
 	// Strip off "http://" or "https://"
 	const hostNameMatch = hostName.match(/^(?:https?:\/\/)?([^/]+)/);
 	if (!hostNameMatch) {
@@ -195,31 +195,28 @@ export function getUrlForTelemetry(hostName: string, path?: string): string | un
 	const strippedHostName = hostNameMatch[1];
 
 	let extractedPath = "";
-	if (path !== undefined) {
-		// Extract portions of the path and explicitly match them to known path names
-		const portionArray: string[] = [];
-		for (const portion of path.split("/")) {
-			if (portion !== "") {
-				if (
-					[
-						socketIoPath,
-						"repos",
-						"deltas",
-						"documents",
-						"session",
-						"git",
-						"summaries",
-						"latest",
-					].includes(portion)
-				) {
-					portionArray.push(portion);
-				} else {
-					portionArray.push("REDACTED");
-				}
+	// Extract portions of the path and explicitly match them to known path names
+	for (const portion of path.split("/")) {
+		if (portion !== "") {
+			// eslint-disable-next-line unicorn/prefer-ternary
+			if (
+				[
+					socketIoPath,
+					"repos",
+					"deltas",
+					"documents",
+					"session",
+					"git",
+					"summaries",
+					"latest",
+				].includes(portion)
+			) {
+				extractedPath += `/${portion}`;
+			} else {
+				extractedPath += "/REDACTED";
 			}
 		}
-		extractedPath = portionArray.join("/");
 	}
 
-	return extractedPath !== "" ? `${strippedHostName}/${extractedPath}` : strippedHostName;
+	return `${strippedHostName}${extractedPath}`;
 }

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -209,6 +209,12 @@ export function getUrlForTelemetry(hostName: string, path: string = ""): string 
 					"git",
 					"summaries",
 					"latest",
+					"document",
+					"commits",
+					"blobs",
+					"refs",
+					"revokeToken",
+					"accesstoken",
 				].includes(portion)
 			) {
 				extractedPath += `/${portion}`;

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -194,16 +194,32 @@ export function getUrlForTelemetry(hostName: string, path?: string): string | un
 	}
 	const strippedHostName = hostNameMatch[1];
 
-	let extractedPath: string | undefined;
+	let extractedPath = "";
 	if (path !== undefined) {
-		// Extract the first portion of the path and explicitly match it to known path names
-		const pathMatch = path.match(/^\/?([^/]+)/);
-		if (pathMatch && [socketIoPath, "repos", "deltas", "documents"].includes(pathMatch[1])) {
-			extractedPath = pathMatch[1];
+		// Extract portions of the path and explicitly match them to known path names
+		const portionArray: string[] = [];
+		for (const portion of path.split("/")) {
+			if (portion !== "") {
+				if (
+					[
+						socketIoPath,
+						"repos",
+						"deltas",
+						"documents",
+						"session",
+						"git",
+						"summaries",
+						"latest",
+					].includes(portion)
+				) {
+					portionArray.push(portion);
+				} else {
+					portionArray.push("REDACTED");
+				}
+			}
 		}
+		extractedPath = portionArray.join("/");
 	}
 
-	return extractedPath !== undefined
-		? `${strippedHostName}/${extractedPath}`
-		: strippedHostName;
+	return extractedPath !== "" ? `${strippedHostName}/${extractedPath}` : strippedHostName;
 }

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -304,13 +304,18 @@ describe("ErrorUtils", () => {
 			["https://some.url.com/", "", "some.url.com"],
 			["something://some.url.com/", "", "something:"],
 			["some.url.com/path", undefined, "some.url.com"],
-			["some.url.com/", "randomPath", "some.url.com"],
+			["some.url.com/", "randomPath", "some.url.com/REDACTED"],
 			["some.url.com/", socketIoPath, `some.url.com/${socketIoPath}`],
 			["http://some.url.com/", "repos", "some.url.com/repos"],
 			["some.url.com/", "deltas", "some.url.com/deltas"],
 			["https://some.url.com", "documents", "some.url.com/documents"],
 			["https://some.url.com/", "/documents/", "some.url.com/documents"],
-			["https://some.url.com/", "documents/morePath", "some.url.com/documents"],
+			["https://some.url.com/", "documents/morePath", "some.url.com/documents/REDACTED"],
+			[
+				"https://some.url.com",
+				"documents/morePath/documents/latest/abc-123/",
+				"some.url.com/documents/REDACTED/documents/latest/REDACTED",
+			],
 		];
 
 		testCases.forEach((testCase) => {


### PR DESCRIPTION
We can add more portions of the URL path on r11s request errors. To protect against logging IDs in the URL, any path portion that does not explicitly match the list of known paths will be replaced with `REDACTED`.

Continuation of https://github.com/microsoft/FluidFramework/pull/22851

Fixes [AB#22156](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/22156)