### PR TITLE
Respect interval start & end side on ack

### DIFF
--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -1630,6 +1630,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	private getSlideToSegment(
 		lref: LocalReferencePosition,
+		slidingPreference: SlidingPreference,
 	): { segment: ISegment | undefined; offset: number | undefined } | undefined {
 		if (!this.client) {
 			throw new LoggingError("client does not exist");
@@ -1640,7 +1641,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 		}
 		const newSegoff = getSlideToSegoff(
 			segoff,
-			undefined,
+			slidingPreference,
 			this.options.mergeTreeReferencesCanSlideToEndpoint,
 		);
 		const value: { segment: ISegment | undefined; offset: number | undefined } | undefined =
@@ -1663,8 +1664,14 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			return;
 		}
 
-		const newStart = this.getSlideToSegment(interval.start);
-		const newEnd = this.getSlideToSegment(interval.end);
+		const newStart = this.getSlideToSegment(
+			interval.start,
+			startReferenceSlidingPreference(interval.stickiness),
+		);
+		const newEnd = this.getSlideToSegment(
+			interval.end,
+			endReferenceSlidingPreference(interval.stickiness),
+		);
 
 		const id = interval.properties[reservedIntervalIdKey];
 		const hasPendingStartChange = this.hasPendingChangeStart(id);

--- a/packages/dds/sequence/src/intervals/sequenceInterval.ts
+++ b/packages/dds/sequence/src/intervals/sequenceInterval.ts
@@ -509,7 +509,7 @@ function createPositionReference(
 				referenceSequenceNumber: op.referenceSequenceNumber,
 				clientId: op.clientId,
 			});
-			segoff = getSlideToSegoff(segoff, undefined, useNewSlidingBehavior);
+			segoff = getSlideToSegoff(segoff, slidingPreference, useNewSlidingBehavior);
 		}
 	} else {
 		assert(

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -560,7 +560,38 @@ describe("SharedString interval collections", () => {
 			assertSequenceIntervals(sharedString, collection1, [{ start: 1, end: 2 }]);
 		});
 
-		it("can slide intervals on create ack", () => {
+		describe("respects interval slide preference on create", () => {
+			for (const { testName, side, expectedPos } of [
+				{ testName: "Side.Before -> prefer forward", side: Side.Before, expectedPos: 1 },
+				{ testName: "Side.After -> prefer backward", side: Side.After, expectedPos: 0 },
+			]) {
+				it(testName, () => {
+					const collection1 = sharedString.getIntervalCollection("test");
+					sharedString.insertText(0, "ABCD");
+					containerRuntimeFactory.processAllMessages();
+					const collection2 = sharedString2.getIntervalCollection("test");
+					sharedString.removeRange(1, 3);
+
+					collection2.add({
+						start: { pos: 1, side },
+						end: { pos: 2, side },
+					});
+
+					containerRuntimeFactory.processAllMessages();
+					assert.strictEqual(sharedString.getText(), "AD");
+					assert.strictEqual(sharedString2.getText(), "AD");
+
+					assertSequenceIntervals(sharedString, collection1, [
+						{ start: expectedPos, end: expectedPos },
+					]);
+					assertSequenceIntervals(sharedString2, collection2, [
+						{ start: expectedPos, end: expectedPos },
+					]);
+				});
+			}
+		});
+
+		it("can slide intervals backward on create ack", () => {
 			// Create and connect a third SharedString.
 			const dataStoreRuntime3 = new MockFluidDataStoreRuntime({ clientId: "3" });
 			const containerRuntime3 =


### PR DESCRIPTION
## Description

Users of `IntervalCollection` can specify a start and end `side` when adding or changing an interval. Doing so changes the behavior for the resulting `start` and `end` local references put into the merge tree: using the default `Side.Before` causes references to slide forward when the segment they exist on is removed, whereas using `Side.After` causes references to slide backward.

In the common case, local reference positions sliding is initiated by removing a segment in merge-tree. However, `IntervalCollection` also reuses this slide logic when intervals are changed/added concurrently to a segment removal. This latter case did not correctly plumb through the sliding preference to the helper function it used, which gave undesirable merge semantics.

Resolves [AB#22191](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/22191).
