### PR TITLE
Fix SharedTreeCore detached sequence numbers when loading into a detached tree

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -27,6 +27,7 @@ import type { ICodecOptions, IJsonCodec } from "../codec/index.js";
 import {
 	type ChangeFamily,
 	type ChangeFamilyEditor,
+	findAncestor,
 	type GraphCommit,
 	type RevisionTag,
 	RevisionTagCodec,
@@ -80,7 +81,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 	public readonly breaker: Breakable = new Breakable("Shared Tree");
 
 	private readonly editManager: EditManager<TEditor, TChange, ChangeFamily<TEditor, TChange>>;
-	private readonly summarizables: readonly Summarizable[];
+	private readonly summarizables: readonly [EditManagerSummarizer<TChange>, ...Summarizable[]];
 	/**
 	 * The sequence number that this instance is at.
 	 * This number is artificial in that it is made up by this instance as opposed to being provided by the runtime.
@@ -308,14 +309,42 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 	}
 
 	protected async loadCore(services: IChannelStorageService): Promise<void> {
-		const loadSummaries = this.summarizables.map(async (summaryElement) =>
-			summaryElement.load(
-				scopeStorageService(services, summarizablesTreeKey, summaryElement.key),
-				(contents) => this.serializer.parse(contents),
-			),
+		const [editManagerSummarizer, ...summarizables] = this.summarizables;
+		const loadEditManager = this.loadSummarizable(editManagerSummarizer, services);
+		const loadSummarizables = summarizables.map(async (s) =>
+			this.loadSummarizable(s, services),
 		);
 
-		await Promise.all(loadSummaries);
+		if (this.detachedRevision !== undefined) {
+			// If we are detached but loading from a summary, then we need to update our detached revision to ensure that it is ahead of all detached revisions in the summary.
+			// First, finish loading the edit manager so that we can inspect the sequence numbers of the commits on the trunk.
+			await loadEditManager;
+			// Find the most recent detached revision in the summary trunk...
+			let latestDetachedSequenceNumber: SeqNumber | undefined;
+			findAncestor(this.editManager.getTrunkHead(), (c) => {
+				const sequenceNumber = this.editManager.getSequenceNumber(c);
+				if (sequenceNumber !== undefined && sequenceNumber < 0) {
+					latestDetachedSequenceNumber = sequenceNumber;
+					return true;
+				}
+				return false;
+			});
+			// ...and set our detached revision to be as it would be if we had been already created that revision.
+			this.detachedRevision = latestDetachedSequenceNumber ?? this.detachedRevision;
+			await Promise.all(loadSummarizables);
+		} else {
+			await Promise.all([loadEditManager, ...loadSummarizables]);
+		}
+	}
+
+	private async loadSummarizable(
+		summarizable: Summarizable,
+		services: IChannelStorageService,
+	): Promise<void> {
+		return summarizable.load(
+			scopeStorageService(services, summarizablesTreeKey, summarizable.key),
+			(contents) => this.serializer.parse(contents),
+		);
 	}
 
 	/**
@@ -351,13 +380,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 				newRevision,
 				this.detachedRevision,
 			);
-			// Schedule the advancement of the min sequence number to happen very soon, but not immediately.
-			// Advancing the minimum sequence number can cause the EditManager to evict old commits from its trunk.
-			// This function (submitCommit) is called in response to a change to the local branch, and we do not want
-			// to evict any commits until all other listeners of the branch have had a chance to process the change.
-			void Promise.resolve().then(() =>
-				this.editManager.advanceMinimumSequenceNumber(newRevision),
-			);
+			this.editManager.advanceMinimumSequenceNumber(newRevision, false);
 			return undefined;
 		}
 		const message = this.messageCodec.encode(

--- a/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
@@ -403,9 +403,6 @@ export function generateTestTrees(options: SharedTreeOptions) {
 				view.initialize([]);
 				view.root.insertAtStart("a");
 				view.root.insertAtEnd("b");
-				// SharedTree does not trigger the EditManager's trunk commit eviction synchronously when detached - it schedules eviction in the JS microtask queue.
-				// Wait for the eviction to complete (by enqueuing ourselves at the end of the microtask queue) before taking the snapshot.
-				await Promise.resolve();
 				await takeSnapshot(tree, "final");
 			},
 		},


### PR DESCRIPTION
## Description

It is possible to load a summary into a detached SharedTree. In this case, the detached revision that is used to generate sequence IDs for commits while detached must be updated to ensure that it doesn't duplicate any of the sequence IDs already used in the summary. This PR fixes the issue and also adds an assert when sequencing in the EditManager to ensure that we don't sequence regressive sequence IDs.

This fix also allows us to trim the trunk when summarizing (without breaking our fuzz tests), which reduces summary sizes especially for detached trees with many synchronous edits.