### PR TITLE
improvement(client): deprecation cleanup

### DIFF
--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -12,6 +12,7 @@ import {
 	IChannelServices,
 	type IChannel,
 } from "@fluidframework/datastore-definitions/internal";
+import type { ISegmentInternal } from "@fluidframework/merge-tree/internal";
 import {
 	MockContainerRuntimeFactory,
 	MockContainerRuntimeFactoryForReconnection,
@@ -967,7 +968,7 @@ describe("Matrix1", () => {
 
 				function findVectorReferenceCount(vector: PermutationVector): number {
 					let count = 0;
-					vector.walkSegments((segment) => {
+					vector.walkSegments((segment: ISegmentInternal) => {
 						count += [...(segment.localRefs ?? [])].length;
 						return true;
 					});

--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -42,6 +42,7 @@ export {
 	AttributionPolicy,
 	IMergeTreeAttributionOptions,
 	IMergeTreeOptions,
+	IMergeTreeOptionsInternal,
 	getSlideToSegoff,
 } from "./mergeTree.js";
 export {

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -7,7 +7,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { DoublyLinkedList, ListNode, walkList } from "./collections/index.js";
-import { ISegmentInternal, type ISegment } from "./mergeTreeNodes.js";
+import type { ISegmentInternal, ISegment } from "./mergeTreeNodes.js";
 import { TrackingGroup, TrackingGroupCollection } from "./mergeTreeTracking.js";
 import { ReferenceType } from "./ops.js";
 import { PropertySet, addProperties } from "./properties.js";
@@ -79,10 +79,6 @@ export interface LocalReferencePosition extends ReferencePosition {
 	addProperties(newProps: PropertySet): void;
 }
 
-/**
- * @privateRemarks This should not be exported outside merge tree.
- * @internal
- */
 class LocalReference implements LocalReferencePosition {
 	public properties: PropertySet | undefined;
 

--- a/packages/dds/merge-tree/src/mergeTreeTracking.ts
+++ b/packages/dds/merge-tree/src/mergeTreeTracking.ts
@@ -5,7 +5,6 @@
 
 import { LocalReferencePosition } from "./localReference.js";
 import { ISegment } from "./mergeTreeNodes.js";
-// eslint-disable-next-line import/no-deprecated
 import { SortedSegmentSet } from "./sortedSegmentSet.js";
 
 /**
@@ -31,11 +30,9 @@ export interface ITrackingGroup {
  * @alpha
  */
 export class TrackingGroup implements ITrackingGroup {
-	// eslint-disable-next-line import/no-deprecated
 	private readonly trackedSet: SortedSegmentSet<Trackable>;
 
 	constructor() {
-		// eslint-disable-next-line import/no-deprecated
 		this.trackedSet = new SortedSegmentSet<Trackable>();
 	}
 

--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -21,10 +21,8 @@ import {
 	toRemovalInfo,
 	type MergeBlock,
 } from "./mergeTreeNodes.js";
-// eslint-disable-next-line import/no-deprecated
 import { SortedSet } from "./sortedSet.js";
 
-// eslint-disable-next-line import/no-deprecated
 class PartialSequenceLengthsSet extends SortedSet<PartialSequenceLength, number> {
 	protected getKey(item: PartialSequenceLength): number {
 		return item.seq;

--- a/packages/dds/merge-tree/src/sortedSegmentSet.ts
+++ b/packages/dds/merge-tree/src/sortedSegmentSet.ts
@@ -5,11 +5,9 @@
 
 import { LocalReferencePosition } from "./localReference.js";
 import { ISegment } from "./mergeTreeNodes.js";
-// eslint-disable-next-line import/no-deprecated
 import { SortedSet } from "./sortedSet.js";
 
 /**
- * @deprecated This functionality was not meant to be exported and will be removed in a future release
  * @internal
  */
 export type SortedSegmentSetItem =
@@ -29,7 +27,7 @@ export type SortedSegmentSetItem =
  *
  * @internal
  */
-// eslint-disable-next-line import/no-deprecated
+
 export class SortedSegmentSet<T extends SortedSegmentSetItem = ISegment> extends SortedSet<
 	T,
 	string

--- a/packages/dds/merge-tree/src/sortedSet.ts
+++ b/packages/dds/merge-tree/src/sortedSet.ts
@@ -4,7 +4,6 @@
  */
 
 /**
- * @deprecated This functionality was not meant to be exported and will be removed in a future release
  * @internal
  */
 export abstract class SortedSet<T, U extends string | number> {

--- a/packages/dds/merge-tree/src/test/index.ts
+++ b/packages/dds/merge-tree/src/test/index.ts
@@ -39,7 +39,12 @@ export {
 	runMergeTreeOperationRunner,
 	TestOperation,
 } from "./mergeTreeOperationRunner.js";
-export { LRUSegment, MergeTree } from "../mergeTree.js";
+export {
+	LRUSegment,
+	MergeTree,
+	IMergeTreeOptions,
+	IMergeTreeOptionsInternal,
+} from "../mergeTree.js";
 export { MergeTreeTextHelper } from "../MergeTreeTextHelper.js";
 export { SnapshotLegacy } from "../snapshotlegacy.js";
 export {
@@ -90,7 +95,6 @@ export {
 	Marker,
 	matchProperties,
 	maxReferencePosition,
-	MergeNode,
 	MergeTreeDeltaOperationType,
 	MergeTreeDeltaOperationTypes,
 	MergeTreeDeltaRevertible,
@@ -116,7 +120,6 @@ export {
 	reservedTileLabelsKey,
 	revertMergeTreeDeltaRevertibles,
 	SegmentGroup,
-	SegmentGroupCollection,
 	SortedSegmentSet,
 	SortedSegmentSetItem,
 	SortedSet,

--- a/packages/dds/merge-tree/src/test/mergeTree.annotate.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.annotate.spec.ts
@@ -615,7 +615,7 @@ describe("MergeTree", () => {
 						currentSequenceNumber,
 						localClientId,
 					);
-					assert(segmentInfo.segment?.segmentGroups?.empty);
+					assert(segmentInfo.segment?.segmentGroups?.empty !== false);
 
 					mergeTree.annotateRange(
 						annotateStart,
@@ -627,7 +627,7 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					assert.equal(segmentInfo.segment?.segmentGroups.size, 1);
+					assert.equal(segmentInfo.segment?.segmentGroups?.size, 1);
 
 					mergeTree.ackPendingSegment({
 						op: {
@@ -641,7 +641,7 @@ describe("MergeTree", () => {
 						} as unknown as ISequencedDocumentMessage,
 					});
 
-					assert(segmentInfo.segment?.segmentGroups.empty);
+					assert(segmentInfo.segment?.segmentGroups?.empty);
 					assert.equal(segmentInfo.segment?.properties?.propertySource, "local");
 					assert.equal(segmentInfo.segment?.properties?.remoteProperty, 1);
 				});

--- a/packages/dds/merge-tree/src/test/segmentGroupCollection.spec.ts
+++ b/packages/dds/merge-tree/src/test/segmentGroupCollection.spec.ts
@@ -5,43 +5,46 @@
 
 import { strict as assert } from "node:assert";
 
-import { ISegment } from "../mergeTreeNodes.js";
+import type { ISegmentLeaf } from "../mergeTreeNodes.js";
+import { SegmentGroupCollection } from "../segmentGroupCollection.js";
 import { TextSegment } from "../textSegment.js";
 
 describe("segmentGroupCollection", () => {
-	let segment: ISegment;
+	let segment: ISegmentLeaf;
+	let segmentGroups: SegmentGroupCollection;
 	beforeEach(() => {
 		segment = TextSegment.make("abc");
+		segmentGroups = segment.segmentGroups = new SegmentGroupCollection(segment);
 	});
 	it(".empty", () => {
-		assert(segment.segmentGroups.empty);
+		assert(segmentGroups.empty);
 	});
 
 	it(".size", () => {
-		assert.equal(segment.segmentGroups.size, 0);
+		assert.equal(segmentGroups.size, 0);
 	});
 
 	it(".enqueue", () => {
 		const segmentGroup = { segments: [], localSeq: 1, refSeq: 0 };
-		segment.segmentGroups.enqueue(segmentGroup);
+		segmentGroups.enqueue(segmentGroup);
 
-		assert(!segment.segmentGroups.empty);
-		assert.equal(segment.segmentGroups.size, 1);
+		assert(!segmentGroups.empty);
+		assert.equal(segmentGroups.size, 1);
 		assert.equal(segmentGroup.segments.length, 1);
 		assert.equal(segmentGroup.segments[0], segment);
 	});
 
 	it(".dequeue", () => {
 		const segmentGroup = { segments: [], localSeq: 1, refSeq: 0 };
-		segment.segmentGroups.enqueue(segmentGroup);
+		segmentGroups.enqueue(segmentGroup);
 		const segmentGroupCount = 6;
-		while (segment.segmentGroups.size < segmentGroupCount) {
-			segment.segmentGroups.enqueue({ segments: [], localSeq: 1, refSeq: 0 });
+		while (segmentGroups.size < segmentGroupCount) {
+			segmentGroups.enqueue({ segments: [], localSeq: 1, refSeq: 0 });
 		}
 
-		const dequeuedSegmentGroup = segment.segmentGroups.dequeue();
+		const dequeuedSegmentGroup = segmentGroups.dequeue();
 
-		assert.equal(segment.segmentGroups.size, segmentGroupCount - 1);
+		assert.equal(segmentGroups.size, segmentGroupCount - 1);
 		assert.equal(dequeuedSegmentGroup?.segments.length, 1);
 		assert.equal(dequeuedSegmentGroup.segments[0], segment);
 		assert.equal(dequeuedSegmentGroup, segmentGroup);
@@ -49,19 +52,22 @@ describe("segmentGroupCollection", () => {
 
 	it(".copyTo", () => {
 		const segmentGroupCount = 6;
-		while (segment.segmentGroups.size < segmentGroupCount) {
-			segment.segmentGroups.enqueue({ segments: [], localSeq: 1, refSeq: 0 });
+		while (segmentGroups.size < segmentGroupCount) {
+			segmentGroups.enqueue({ segments: [], localSeq: 1, refSeq: 0 });
 		}
 
-		const segmentCopy = TextSegment.make("");
-		segment.segmentGroups.copyTo(segmentCopy);
+		// Note: type as ISegmentLeaf to make segmentGroups mutable
+		const segmentCopy: ISegmentLeaf = TextSegment.make("");
+		const segmentGroupCopy = new SegmentGroupCollection(segmentCopy);
+		segmentCopy.segmentGroups = segmentGroupCopy;
+		segmentGroups.copyTo(segmentCopy);
 
-		assert.equal(segment.segmentGroups.size, segmentGroupCount);
-		assert.equal(segmentCopy.segmentGroups.size, segmentGroupCount);
+		assert.equal(segmentGroups.size, segmentGroupCount);
+		assert.equal(segmentGroupCopy.size, segmentGroupCount);
 
-		while (!segment.segmentGroups.empty || !segmentCopy.segmentGroups.empty) {
-			const segmentGroup = segment.segmentGroups.dequeue();
-			const copySegmentGroup = segmentCopy.segmentGroups.dequeue();
+		while (!segmentGroups.empty || !segmentGroupCopy.empty) {
+			const segmentGroup = segmentGroups.dequeue();
+			const copySegmentGroup = segmentGroupCopy.dequeue();
 
 			assert.equal(segmentGroup, copySegmentGroup);
 			assert.equal(segmentGroup?.segments.length, 2);

--- a/packages/dds/merge-tree/src/test/snapshot.spec.ts
+++ b/packages/dds/merge-tree/src/test/snapshot.spec.ts
@@ -9,12 +9,12 @@ import {
 	createInsertOnlyAttributionPolicy,
 	createPropertyTrackingAttributionPolicyFactory,
 } from "../attributionPolicy.js";
-import { IMergeTreeOptions } from "../mergeTree.js";
+import type { IMergeTreeOptionsInternal } from "../mergeTree.js";
 import { SnapshotV1 } from "../snapshotV1.js";
 
 import { TestString, loadSnapshot } from "./snapshot.utils.js";
 
-function makeSnapshotSuite(options?: IMergeTreeOptions): void {
+function makeSnapshotSuite(options?: IMergeTreeOptionsInternal): void {
 	describe("from an empty initial state", () => {
 		let str: TestString;
 		beforeEach(() => {

--- a/packages/dds/merge-tree/src/test/snapshot.utils.ts
+++ b/packages/dds/merge-tree/src/test/snapshot.utils.ts
@@ -12,7 +12,7 @@ import { ISummaryTree } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { MockStorage } from "@fluidframework/test-runtime-utils/internal";
 
-import { IMergeTreeOptions } from "../mergeTree.js";
+import type { IMergeTreeOptionsInternal } from "../mergeTree.js";
 import { ISegment } from "../mergeTreeNodes.js";
 import { IMergeTreeOp, ReferenceType } from "../ops.js";
 import { PropertySet } from "../properties.js";
@@ -25,7 +25,7 @@ import { TestSerializer } from "./testSerializer.js";
 // Reconstitutes a MergeTree client from a summary
 export async function loadSnapshot(
 	summary: ISummaryTree,
-	options?: IMergeTreeOptions,
+	options?: IMergeTreeOptionsInternal,
 ): Promise<TestClient> {
 	const services = MockStorage.createFromSummary(summary);
 	const client2 = new TestClient(options);
@@ -52,7 +52,7 @@ export class TestString {
 
 	constructor(
 		id: string,
-		private readonly options?: IMergeTreeOptions,
+		private readonly options?: IMergeTreeOptionsInternal,
 		initialState: string = "",
 	) {
 		this.client = createClientsAtInitialState({ initialState, options }, id)[id];
@@ -109,7 +109,7 @@ export class TestString {
 	}
 
 	// Ensures the MergeTree client's contents successfully roundtrip through a snapshot.
-	public async checkSnapshot(options?: IMergeTreeOptions): Promise<void> {
+	public async checkSnapshot(options?: IMergeTreeOptionsInternal): Promise<void> {
 		this.applyPendingOps();
 		const expectedAttributionKeys = this.client.getAllAttributionSeqs();
 		const summary = this.getSummary();

--- a/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
+++ b/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
@@ -185,7 +185,7 @@ export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationT
 export interface ISerializableInterval extends IInterval {
     // @deprecated (undocumented)
     addProperties(props: PropertySet, collaborating?: boolean, seq?: number): PropertySet | undefined;
-    getIntervalId(): string | undefined;
+    getIntervalId(): string;
     properties: PropertySet;
     // @deprecated (undocumented)
     propertyManager: PropertiesManager;
@@ -297,13 +297,18 @@ export { reservedMarkerIdKey }
 export function revertSharedStringRevertibles(sharedString: ISharedString, revertibles: SharedStringRevertible[]): void;
 
 // @alpha
-export class SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
-    // @deprecated
-    constructor(opArgs: IMergeTreeDeltaOpArgs, deltaArgs: IMergeTreeDeltaCallbackArgs, mergeTreeClient: Client);
+export interface SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
+    // (undocumented)
     readonly isLocal: boolean;
     // (undocumented)
     readonly opArgs: IMergeTreeDeltaOpArgs;
 }
+
+// @alpha (undocumented)
+export const SequenceDeltaEvent: {
+    new (opArgs: IMergeTreeDeltaOpArgs, deltaArgs: IMergeTreeDeltaCallbackArgs, mergeTreeClient: Client): SequenceDeltaEvent;
+    prototype: SequenceDeltaEvent;
+};
 
 // @alpha
 export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
@@ -320,14 +325,8 @@ export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTy
 }
 
 // @alpha
-export class SequenceInterval implements ISerializableInterval {
-    // @deprecated
-    constructor(client: Client,
-    start: LocalReferencePosition,
-    end: LocalReferencePosition, intervalType: IntervalType, props?: PropertySet, startSide?: Side, endSide?: Side);
+export interface SequenceInterval extends ISerializableInterval {
     addPositionChangeListeners(beforePositionChange: () => void, afterPositionChange: () => void): void;
-    // (undocumented)
-    addProperties(newProps: PropertySet, collab?: boolean, seq?: number): PropertySet | undefined;
     // (undocumented)
     clone(): SequenceInterval;
     compare(b: SequenceInterval): number;
@@ -336,7 +335,6 @@ export class SequenceInterval implements ISerializableInterval {
     end: LocalReferencePosition;
     // (undocumented)
     readonly endSide: Side;
-    getIntervalId(): string;
     // (undocumented)
     intervalType: IntervalType;
     modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedDocumentMessage, localSeq?: number, useNewSlidingBehavior?: boolean): SequenceInterval;
@@ -344,12 +342,7 @@ export class SequenceInterval implements ISerializableInterval {
     overlaps(b: SequenceInterval): boolean;
     // (undocumented)
     overlapsPos(bstart: number, bend: number): boolean;
-    properties: PropertySet;
-    // (undocumented)
-    propertyManager: PropertiesManager;
     removePositionChangeListeners(): void;
-    // (undocumented)
-    serialize(): ISerializedInterval;
     start: LocalReferencePosition;
     // (undocumented)
     readonly startSide: Side;
@@ -358,13 +351,23 @@ export class SequenceInterval implements ISerializableInterval {
     union(b: SequenceInterval): SequenceInterval;
 }
 
+// @alpha (undocumented)
+export const SequenceInterval: {
+    new (client: Client, start: LocalReferencePosition, end: LocalReferencePosition, intervalType: IntervalType, props?: PropertySet, startSide?: Side, endSide?: Side): SequenceInterval;
+    prototype: SequenceInterval;
+};
+
 // @alpha
-export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenanceType> {
-    // @deprecated
-    constructor(
-    opArgs: IMergeTreeDeltaOpArgs | undefined, deltaArgs: IMergeTreeMaintenanceCallbackArgs, mergeTreeClient: Client);
+export interface SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenanceType> {
+    // (undocumented)
     readonly opArgs: IMergeTreeDeltaOpArgs | undefined;
 }
+
+// @alpha (undocumented)
+export const SequenceMaintenanceEvent: {
+    new (opArgs: IMergeTreeDeltaOpArgs | undefined, deltaArgs: IMergeTreeMaintenanceCallbackArgs, mergeTreeClient: Client): SequenceMaintenanceEvent;
+    prototype: SequenceMaintenanceEvent;
+};
 
 export { SequencePlace }
 

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -29,6 +29,8 @@ import {
 	Side,
 	SequencePlace,
 	endpointPosAndSide,
+	PropertiesManager,
+	type ISegmentInternal,
 } from "@fluidframework/merge-tree/internal";
 import { LoggingError, UsageError } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
@@ -50,6 +52,7 @@ import {
 	OverlappingIntervalsIndex,
 	createIdIntervalIndex,
 } from "./intervalIndex/index.js";
+import type { ISerializableIntervalPrivate, SequenceInterval } from "./intervals/index.js";
 import {
 	CompressedSerializedInterval,
 	IIntervalHelpers,
@@ -59,7 +62,7 @@ import {
 	IntervalOpType,
 	IntervalStickiness,
 	IntervalType,
-	SequenceInterval,
+	SequenceIntervalClass,
 	SerializedIntervalDelta,
 	createInterval,
 	createPositionReferenceFromSegoff,
@@ -313,7 +316,7 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 	}
 
 	private linkEndpointsToInterval(interval: TInterval): void {
-		if (interval instanceof SequenceInterval) {
+		if (interval instanceof SequenceIntervalClass) {
 			interval.start.addProperties({ interval });
 			interval.end.addProperties({ interval });
 		}
@@ -382,15 +385,15 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 				ref.canSlideToEndpoint,
 			);
 		};
-		if (interval instanceof SequenceInterval) {
-			let previousInterval: (TInterval & SequenceInterval) | undefined;
+		if (interval instanceof SequenceIntervalClass) {
+			let previousInterval: (TInterval & SequenceIntervalClass) | undefined;
 			let pendingChanges = 0;
 			interval.addPositionChangeListeners(
 				() => {
 					pendingChanges++;
 					// Note: both start and end can change and invoke beforeSlide on each endpoint before afterSlide.
 					if (!previousInterval) {
-						previousInterval = interval.clone() as TInterval & SequenceInterval;
+						previousInterval = interval.clone() as TInterval & SequenceIntervalClass;
 						previousInterval.start = cloneRef(previousInterval.start);
 						previousInterval.end = cloneRef(previousInterval.end);
 						this.removeIntervalFromIndexes(interval);
@@ -413,7 +416,7 @@ export class LocalIntervalCollection<TInterval extends ISerializableInterval> {
 	}
 
 	private removeIntervalListeners(interval: TInterval) {
-		if (interval instanceof SequenceInterval) {
+		if (interval instanceof SequenceIntervalClass) {
 			interval.removePositionChangeListeners();
 		}
 	}
@@ -731,7 +734,7 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval>
 	 * @param end - interval end position (exclusive)
 	 * @param props - properties of the interval
 	 * @returns - the created interval
-	 * @remarks See documentation on {@link SequenceInterval} for comments on
+	 * @remarks See documentation on {@link (SequenceInterval:interface)} for comments on
 	 * interval endpoint semantics: there are subtleties with how the current
 	 * half-open behavior is represented.
 	 *
@@ -1147,7 +1150,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 		// is restored as single-endpoint changes re-use previous references.
 		let startRefType: ReferenceType;
 		let endRefType: ReferenceType;
-		if (previousInterval instanceof SequenceInterval) {
+		if (previousInterval instanceof SequenceIntervalClass) {
 			startRefType = previousInterval.start.refType;
 			endRefType = previousInterval.end.refType;
 			previousInterval.start.refType = ReferenceType.Transient;
@@ -1165,7 +1168,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 	/**
 	 * {@inheritdoc IIntervalCollection.getIntervalById}
 	 */
-	public getIntervalById(id: string): TInterval | undefined {
+	public getIntervalById(id: string): ISerializableIntervalPrivate<TInterval> | undefined {
 		if (!this.localCollection) {
 			throw new LoggingError("attach must be called before accessing intervals");
 		}
@@ -1221,7 +1224,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 		);
 
 		if (interval) {
-			if (!this.isCollaborating && interval instanceof SequenceInterval) {
+			if (!this.isCollaborating && interval instanceof SequenceIntervalClass) {
 				setSlideOnRemove(interval.start);
 				setSlideOnRemove(interval.end);
 			}
@@ -1324,15 +1327,17 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			let deltaProps: PropertySet | undefined;
 			let newInterval: TInterval | undefined;
 			if (props !== undefined) {
-				deltaProps = interval.addProperties(
+				interval.properties ??= new PropertiesManager();
+				deltaProps = interval.propertyManager?.addProperties(
+					interval.properties,
 					props,
-					true,
 					this.isCollaborating ? UnassignedSequenceNumber : UniversalSequenceNumber,
+					true,
 				);
 			}
 			if (start !== undefined && end !== undefined) {
 				newInterval = this.localCollection.changeInterval(interval, start, end);
-				if (!this.isCollaborating && newInterval instanceof SequenceInterval) {
+				if (!this.isCollaborating && newInterval instanceof SequenceIntervalClass) {
 					setSlideOnRemove(newInterval.start);
 					setSlideOnRemove(newInterval.end);
 				}
@@ -1370,7 +1375,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			if (newInterval) {
 				this.addPendingChange(id, serializedInterval);
 				this.emitChange(newInterval, interval, true, false);
-				if (interval instanceof SequenceInterval) {
+				if (interval instanceof SequenceIntervalClass) {
 					this.client?.removeLocalReferencePosition(interval.start);
 					this.client?.removeLocalReferencePosition(interval.end);
 				}
@@ -1476,15 +1481,17 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 		// strip it out of the properties here.
 		const { [reservedIntervalIdKey]: id, ...newProps } = serializedInterval.properties ?? {};
 		assert(id !== undefined, 0x3fe /* id must exist on the interval */);
-		const interval: TInterval | undefined = this.getIntervalById(id);
+		const interval: ISerializableIntervalPrivate<TInterval> | undefined =
+			this.getIntervalById(id);
 		if (!interval) {
 			// The interval has been removed locally; no-op.
 			return;
 		}
 
 		if (local) {
+			interval.propertyManager ??= new PropertiesManager();
 			// Let the propertyManager prune its pending change-properties set.
-			interval.propertyManager?.ackPendingProperties({
+			interval.propertyManager.ackPendingProperties({
 				type: MergeTreeDeltaType.ANNOTATE,
 				props: serializedInterval.properties ?? {},
 			});
@@ -1515,7 +1522,13 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 						op,
 					) ?? interval;
 			}
-			const deltaProps = newInterval.addProperties(newProps, true, op.sequenceNumber);
+			newInterval.propertyManager ??= new PropertiesManager();
+			const deltaProps = newInterval.propertyManager.addProperties(
+				newInterval.properties,
+				newProps,
+				op.sequenceNumber,
+				true,
+			);
 			if (this.onDeserialize) {
 				this.onDeserialize(newInterval);
 			}
@@ -1611,7 +1624,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 		if (localInterval !== undefined) {
 			// we know we must be using `SequenceInterval` because `this.client` exists
 			assert(
-				localInterval instanceof SequenceInterval,
+				localInterval instanceof SequenceIntervalClass,
 				0x3a0 /* localInterval must be `SequenceInterval` when used with client */,
 			);
 			// The rebased op may place this interval's endpoints on different segments. Calling `changeInterval` here
@@ -1634,7 +1647,10 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 		if (!this.client) {
 			throw new LoggingError("client does not exist");
 		}
-		const segoff = { segment: lref.getSegment(), offset: lref.getOffset() };
+		const segoff: { segment: ISegmentInternal | undefined; offset: number | undefined } = {
+			segment: lref.getSegment(),
+			offset: lref.getOffset(),
+		};
 		if (segoff.segment?.localRefs?.has(lref) !== true) {
 			return undefined;
 		}
@@ -1652,7 +1668,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	private ackInterval(interval: TInterval, op: ISequencedDocumentMessage): void {
 		// Only SequenceIntervals need potential sliding
-		if (!(interval instanceof SequenceInterval)) {
+		if (!(interval instanceof SequenceIntervalClass)) {
 			return;
 		}
 
@@ -1712,7 +1728,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 				if (props) {
 					interval.start.addProperties(props);
 				}
-				const oldSeg = oldInterval.start.getSegment();
+				const oldSeg: ISegmentInternal | undefined = oldInterval.start.getSegment();
 				// remove and rebuild start interval as transient for event
 				this.client.removeLocalReferencePosition(oldInterval.start);
 				oldInterval.start.refType = ReferenceType.Transient;
@@ -1734,7 +1750,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 					interval.end.addProperties(props);
 				}
 				// remove and rebuild end interval as transient for event
-				const oldSeg = oldInterval.end.getSegment();
+				const oldSeg: ISegmentInternal | undefined = oldInterval.end.getSegment();
 				this.client.removeLocalReferencePosition(oldInterval.end);
 				oldInterval.end.refType = ReferenceType.Transient;
 				oldSeg?.localRefs?.addLocalRef(oldInterval.end, oldInterval.end.getOffset());

--- a/packages/dds/sequence/src/intervalIndex/overlappingSequenceIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingSequenceIntervalsIndex.ts
@@ -13,9 +13,10 @@ import {
 	reservedRangeLabelsKey,
 } from "@fluidframework/merge-tree/internal";
 
+import type { SequenceInterval } from "../intervals/index.js";
 import {
 	IntervalType,
-	SequenceInterval,
+	SequenceIntervalClass,
 	createPositionReferenceFromSegoff,
 	sequenceIntervalHelpers,
 } from "../intervals/index.js";
@@ -56,7 +57,7 @@ class OverlappingSequenceIntervalsIndex
 			return [];
 		}
 
-		const transientInterval = new SequenceInterval(
+		const transientInterval = new SequenceIntervalClass(
 			this.client,
 			startLref,
 			endLref,

--- a/packages/dds/sequence/src/intervals/index.ts
+++ b/packages/dds/sequence/src/intervals/index.ts
@@ -7,6 +7,7 @@ export {
 	IInterval,
 	ISerializedInterval,
 	ISerializableInterval,
+	ISerializableIntervalPrivate,
 	IntervalOpType,
 	IntervalType,
 	IntervalDeltaOpType,
@@ -20,6 +21,7 @@ export {
 export { Interval, createInterval, intervalHelpers } from "./interval.js";
 export {
 	SequenceInterval,
+	SequenceIntervalClass,
 	createSequenceInterval,
 	createPositionReferenceFromSegoff,
 	sequenceIntervalHelpers,

--- a/packages/dds/sequence/src/intervals/interval.ts
+++ b/packages/dds/sequence/src/intervals/interval.ts
@@ -38,9 +38,6 @@ export class Interval implements ISerializableInterval {
 	/***/
 	public auxProps: PropertySet[] | undefined;
 
-	/**
-	 * {@inheritDoc ISerializableInterval.propertyManager}
-	 */
 	public readonly propertyManager: PropertiesManager = new PropertiesManager();
 
 	constructor(

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -179,11 +179,14 @@ export interface ISerializableInterval extends IInterval {
 	 * Gets the id associated with this interval.
 	 * When the interval is used as part of an interval collection, this id can be used to modify or remove the
 	 * interval.
-	 * @remarks This signature includes `undefined` strictly for backwards-compatibility reasons, as older versions
-	 * of Fluid didn't always write interval ids.
 	 */
-	getIntervalId(): string | undefined;
+	getIntervalId(): string;
 }
+
+export type ISerializableIntervalPrivate<T extends ISerializableInterval> = T & {
+	// eslint-disable-next-line import/no-deprecated
+	propertyManager?: PropertiesManager;
+};
 
 /**
  * Represents a change that should be applied to an existing interval.

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -13,7 +13,7 @@ import {
 	MergeTreeDeltaType,
 	PropertySet,
 	ReferenceType,
-	SlidingPreference, // eslint-disable-next-line import/no-deprecated
+	SlidingPreference,
 	SortedSet,
 	appendToMergeTreeDeltaRevertibles,
 	discardMergeTreeDeltaRevertible,
@@ -26,7 +26,8 @@ import {
 	type ISegmentInternal,
 } from "@fluidframework/merge-tree/internal";
 
-import { IntervalOpType, SequenceInterval } from "./intervals/index.js";
+import type { SequenceInterval } from "./intervals/index.js";
+import { IntervalOpType, SequenceIntervalClass } from "./intervals/index.js";
 import { ISequenceDeltaRange, SequenceDeltaEvent } from "./sequenceDeltaEvent.js";
 import { ISharedString, SharedStringSegment } from "./sharedString.js";
 
@@ -244,13 +245,13 @@ function addIfIntervalEndpoint(
 ) {
 	if (refTypeIncludesFlag(ref.refType, ReferenceType.RangeBegin)) {
 		const interval = ref.properties?.interval;
-		if (interval && interval instanceof SequenceInterval) {
+		if (interval && interval instanceof SequenceIntervalClass) {
 			startIntervals.push({ offset: segmentLengths + interval.start.getOffset(), interval });
 			return true;
 		}
 	} else if (refTypeIncludesFlag(ref.refType, ReferenceType.RangeEnd)) {
 		const interval = ref.properties?.interval;
-		if (interval && interval instanceof SequenceInterval) {
+		if (interval && interval instanceof SequenceIntervalClass) {
 			endIntervals.push({ offset: segmentLengths + interval.end.getOffset(), interval });
 			return true;
 		}
@@ -584,7 +585,6 @@ interface RangeInfo {
 	length: number;
 }
 
-// eslint-disable-next-line import/no-deprecated
 class SortedRangeSet extends SortedSet<RangeInfo, string> {
 	protected getKey(item: RangeInfo): string {
 		return item.ranges[0].segment.ordinal;

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -80,8 +80,12 @@ import {
 	IValueChanged,
 	type SequenceOptions,
 } from "./intervalCollectionMapInterfaces.js";
-import { SequenceInterval } from "./intervals/index.js";
-import { SequenceDeltaEvent, SequenceMaintenanceEvent } from "./sequenceDeltaEvent.js";
+import type { SequenceInterval } from "./intervals/index.js";
+import type { SequenceDeltaEvent, SequenceMaintenanceEvent } from "./sequenceDeltaEvent.js";
+import {
+	SequenceDeltaEventClass,
+	SequenceMaintenanceEventClass,
+} from "./sequenceDeltaEvent.js";
 import { ISharedIntervalCollection } from "./sharedIntervalCollection.js";
 
 const snapshotFileName = "header";
@@ -534,7 +538,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 		);
 
 		this.client.prependListener("delta", (opArgs, deltaArgs) => {
-			const event = new SequenceDeltaEvent(opArgs, deltaArgs, this.client);
+			const event = new SequenceDeltaEventClass(opArgs, deltaArgs, this.client);
 			if (event.isLocal) {
 				this.submitSequenceMessage(opArgs.op);
 			}
@@ -542,7 +546,11 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 		});
 
 		this.client.on("maintenance", (args, opArgs) => {
-			this.emit("maintenance", new SequenceMaintenanceEvent(opArgs, args, this.client), this);
+			this.emit(
+				"maintenance",
+				new SequenceMaintenanceEventClass(opArgs, args, this.client),
+				this,
+			);
 		});
 
 		this.intervalCollections = new IntervalCollectionMap(

--- a/packages/dds/sequence/src/test/overlappingSequenceIntervalsIndex.spec.ts
+++ b/packages/dds/sequence/src/test/overlappingSequenceIntervalsIndex.spec.ts
@@ -18,7 +18,8 @@ import {
 	createOverlappingIntervalsIndex,
 	createOverlappingSequenceIntervalsIndex,
 } from "../intervalIndex/index.js";
-import { SequenceInterval } from "../intervals/index.js";
+import type { SequenceInterval } from "../intervals/index.js";
+import { SequenceIntervalClass } from "../intervals/index.js";
 import { SharedStringFactory, type SharedString } from "../sequenceFactory.js";
 import { SharedStringClass } from "../sharedString.js";
 
@@ -38,7 +39,7 @@ function assertSequenceIntervalsEqual(
 		let expectedStart;
 		let expectedEnd;
 
-		if (expected[i] instanceof SequenceInterval) {
+		if (expected[i] instanceof SequenceIntervalClass) {
 			expectedStart = string.localReferencePositionToPosition(
 				expected[i].start as LocalReferencePosition,
 			);

--- a/packages/dds/sequence/src/test/sequenceDeltaEvent.spec.ts
+++ b/packages/dds/sequence/src/test/sequenceDeltaEvent.spec.ts
@@ -16,7 +16,8 @@ import {
 } from "@fluidframework/merge-tree/internal";
 import { TestClient } from "@fluidframework/merge-tree/internal/test";
 
-import { SequenceDeltaEvent } from "../sequenceDeltaEvent.js";
+import type { SequenceDeltaEvent } from "../sequenceDeltaEvent.js";
+import { SequenceDeltaEventClass } from "../sequenceDeltaEvent.js";
 
 interface IExpectedSegmentInfo {
 	offset: number;
@@ -68,7 +69,7 @@ describe("non-collab", () => {
 			assert.equal(deltaArgs.deltaSegments.length, 1);
 
 			assert(op);
-			const event = new SequenceDeltaEvent({ op }, deltaArgs, client);
+			const event = new SequenceDeltaEventClass({ op }, deltaArgs, client);
 
 			assert(event.isLocal);
 			assert.equal(event.ranges.length, 1);
@@ -117,7 +118,7 @@ describe("non-collab", () => {
 			assert.equal(deltaArgs.deltaSegments.length, 1);
 
 			assert(op);
-			const event = new SequenceDeltaEvent({ op }, deltaArgs, client);
+			const event = new SequenceDeltaEventClass({ op }, deltaArgs, client);
 
 			assert(event.isLocal);
 			assert.equal(event.ranges.length, 1);
@@ -237,7 +238,7 @@ describe("non-collab", () => {
 			assert.equal(deltaArgs.deltaSegments.length, expected.length);
 
 			assert(op);
-			const event = new SequenceDeltaEvent({ op }, deltaArgs, client);
+			const event = new SequenceDeltaEventClass({ op }, deltaArgs, client);
 
 			assert(event.isLocal);
 			assert.equal(event.first.position, start);
@@ -293,7 +294,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -343,7 +344,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -393,7 +394,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -444,7 +445,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -496,7 +497,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -546,7 +547,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -602,7 +603,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -676,7 +677,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage1 = client.makeOpMessage(
@@ -751,7 +752,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -808,7 +809,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -863,9 +864,9 @@ describe("collab", () => {
 
 			const currentSeqNumber = client.mergeTree.collabWindow.currentSeq;
 
-			const events: SequenceDeltaEvent[] = [];
+			const events: SequenceDeltaEventClass[] = [];
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				events.push(new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client));
+				events.push(new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client));
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -907,9 +908,9 @@ describe("collab", () => {
 
 			const currentSeqNumber = client.mergeTree.collabWindow.currentSeq;
 
-			const events: SequenceDeltaEvent[] = [];
+			const events: SequenceDeltaEventClass[] = [];
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				events.push(new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client));
+				events.push(new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client));
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -951,9 +952,9 @@ describe("collab", () => {
 
 			const currentSeqNumber = client.mergeTree.collabWindow.currentSeq;
 
-			const events: SequenceDeltaEvent[] = [];
+			const events: SequenceDeltaEventClass[] = [];
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				events.push(new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client));
+				events.push(new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client));
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -995,9 +996,9 @@ describe("collab", () => {
 
 			const currentSeqNumber = client.mergeTree.collabWindow.currentSeq;
 
-			const events: SequenceDeltaEvent[] = [];
+			const events: SequenceDeltaEventClass[] = [];
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				events.push(new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client));
+				events.push(new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client));
 			});
 			const localRemoveMessage = client.makeOpMessage(
 				client.removeRangeLocal(localRemovePosStart, localRemovePosEnd),
@@ -1041,7 +1042,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -1096,7 +1097,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -1151,7 +1152,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -1206,7 +1207,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -1260,7 +1261,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -1313,7 +1314,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -1374,7 +1375,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localMessage = client.makeOpMessage(
@@ -1426,7 +1427,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localMessage = client.makeOpMessage(
@@ -1477,7 +1478,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localMessage = client.makeOpMessage(
@@ -1529,7 +1530,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localMessage = client.makeOpMessage(
@@ -1580,7 +1581,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localMessage = client.makeOpMessage(
@@ -1632,7 +1633,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localMessage = client.makeOpMessage(
@@ -1723,7 +1724,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localMessage1 = client.makeOpMessage(
@@ -1786,7 +1787,7 @@ describe("collab", () => {
 		function step1(seqnum: number, refseqnum: number) {
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const remoteMessage = client.makeOpMessage(
@@ -1848,7 +1849,7 @@ describe("collab", () => {
 		function step2(seqnum: number, refseqnum: number) {
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localMessage = client.makeOpMessage(
@@ -1881,7 +1882,7 @@ describe("collab", () => {
 		function step3(seqnum: number, refseqnum: number) {
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const remoteMessage = client.makeOpMessage(
@@ -1922,7 +1923,7 @@ describe("collab", () => {
 		function step4(seqnum: number, refseqnum: number) {
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localMessage = client.makeOpMessage(
@@ -2034,7 +2035,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -2091,7 +2092,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -2148,7 +2149,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -2202,7 +2203,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -2256,7 +2257,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -2310,7 +2311,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -2364,7 +2365,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -2418,7 +2419,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -2472,7 +2473,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -2528,7 +2529,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -2585,7 +2586,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -2639,7 +2640,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -2693,7 +2694,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -2747,7 +2748,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -2801,7 +2802,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -2855,7 +2856,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -2909,7 +2910,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -2975,7 +2976,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localInsertMessage = client.makeOpMessage(
@@ -3042,7 +3043,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -3096,7 +3097,7 @@ describe("collab", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 
 			const localRemoveMessage = client.makeOpMessage(
@@ -3141,7 +3142,7 @@ describe("collab", () => {
 	});
 });
 
-describe("SequenceDeltaEvent", () => {
+describe("SequenceDeltaEventClass", () => {
 	const localUserLongId = "localUser";
 	let client: TestClient;
 
@@ -3163,7 +3164,7 @@ describe("SequenceDeltaEvent", () => {
 			assert.equal(deltaArgs.deltaSegments.length, 1);
 
 			assert(op);
-			const event = new SequenceDeltaEvent({ op }, deltaArgs, client);
+			const event = new SequenceDeltaEventClass({ op }, deltaArgs, client);
 
 			assert(event.isLocal);
 			assert.equal(event.ranges.length, 1);
@@ -3195,7 +3196,7 @@ describe("SequenceDeltaEvent", () => {
 			assert.equal(deltaArgs.deltaSegments.length, segmentCount);
 
 			assert(op);
-			const event = new SequenceDeltaEvent({ op }, deltaArgs, client);
+			const event = new SequenceDeltaEventClass({ op }, deltaArgs, client);
 
 			assert(event.isLocal);
 			assert.equal(event.ranges.length, segmentCount);
@@ -3234,7 +3235,7 @@ describe("SequenceDeltaEvent", () => {
 
 			let event: SequenceDeltaEvent | undefined;
 			client.on("delta", (clientArgs, mergeTreeArgs) => {
-				event = new SequenceDeltaEvent(clientArgs, mergeTreeArgs, client);
+				event = new SequenceDeltaEventClass(clientArgs, mergeTreeArgs, client);
 			});
 			client.applyMsg(remoteRemoveMessage);
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -670,7 +670,7 @@ export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationT
 export interface ISerializableInterval extends IInterval {
     // @deprecated (undocumented)
     addProperties(props: PropertySet, collaborating?: boolean, seq?: number): PropertySet | undefined;
-    getIntervalId(): string | undefined;
+    getIntervalId(): string;
     properties: PropertySet;
     // @deprecated (undocumented)
     propertyManager: PropertiesManager;
@@ -1051,13 +1051,18 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
 
 // @alpha
-export class SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
-    // @deprecated
-    constructor(opArgs: IMergeTreeDeltaOpArgs, deltaArgs: IMergeTreeDeltaCallbackArgs, mergeTreeClient: Client);
+export interface SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
+    // (undocumented)
     readonly isLocal: boolean;
     // (undocumented)
     readonly opArgs: IMergeTreeDeltaOpArgs;
 }
+
+// @alpha (undocumented)
+export const SequenceDeltaEvent: {
+    new (opArgs: IMergeTreeDeltaOpArgs, deltaArgs: IMergeTreeDeltaCallbackArgs, mergeTreeClient: Client): SequenceDeltaEvent;
+    prototype: SequenceDeltaEvent;
+};
 
 // @alpha
 export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
@@ -1074,14 +1079,8 @@ export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTy
 }
 
 // @alpha
-export class SequenceInterval implements ISerializableInterval {
-    // @deprecated
-    constructor(client: Client,
-    start: LocalReferencePosition,
-    end: LocalReferencePosition, intervalType: IntervalType, props?: PropertySet, startSide?: Side, endSide?: Side);
+export interface SequenceInterval extends ISerializableInterval {
     addPositionChangeListeners(beforePositionChange: () => void, afterPositionChange: () => void): void;
-    // (undocumented)
-    addProperties(newProps: PropertySet, collab?: boolean, seq?: number): PropertySet | undefined;
     // (undocumented)
     clone(): SequenceInterval;
     compare(b: SequenceInterval): number;
@@ -1090,7 +1089,6 @@ export class SequenceInterval implements ISerializableInterval {
     end: LocalReferencePosition;
     // (undocumented)
     readonly endSide: Side;
-    getIntervalId(): string;
     // (undocumented)
     intervalType: IntervalType;
     modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedDocumentMessage, localSeq?: number, useNewSlidingBehavior?: boolean): SequenceInterval;
@@ -1098,12 +1096,7 @@ export class SequenceInterval implements ISerializableInterval {
     overlaps(b: SequenceInterval): boolean;
     // (undocumented)
     overlapsPos(bstart: number, bend: number): boolean;
-    properties: PropertySet;
-    // (undocumented)
-    propertyManager: PropertiesManager;
     removePositionChangeListeners(): void;
-    // (undocumented)
-    serialize(): ISerializedInterval;
     start: LocalReferencePosition;
     // (undocumented)
     readonly startSide: Side;
@@ -1112,13 +1105,23 @@ export class SequenceInterval implements ISerializableInterval {
     union(b: SequenceInterval): SequenceInterval;
 }
 
+// @alpha (undocumented)
+export const SequenceInterval: {
+    new (client: Client, start: LocalReferencePosition, end: LocalReferencePosition, intervalType: IntervalType, props?: PropertySet, startSide?: Side, endSide?: Side): SequenceInterval;
+    prototype: SequenceInterval;
+};
+
 // @alpha
-export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenanceType> {
-    // @deprecated
-    constructor(
-    opArgs: IMergeTreeDeltaOpArgs | undefined, deltaArgs: IMergeTreeMaintenanceCallbackArgs, mergeTreeClient: Client);
+export interface SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenanceType> {
+    // (undocumented)
     readonly opArgs: IMergeTreeDeltaOpArgs | undefined;
 }
+
+// @alpha (undocumented)
+export const SequenceMaintenanceEvent: {
+    new (opArgs: IMergeTreeDeltaOpArgs | undefined, deltaArgs: IMergeTreeMaintenanceCallbackArgs, mergeTreeClient: Client): SequenceMaintenanceEvent;
+    prototype: SequenceMaintenanceEvent;
+};
 
 export { SequencePlace }
 


### PR DESCRIPTION
For `merge-tree` and `sequence` packages, setup as many internal only types/values without compromising continued support for deprecated API use by customers.