### PR TITLE
bump(eslint-config-fluid): bump eslint-config-fluid to version 5.4.0 across repo

### DIFF
--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -81,7 +81,7 @@
 	},
 	"devDependencies": {
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@types/async": "^3.2.9",
 		"@types/cors": "^2.8.4",
 		"@types/debug": "^4.1.5",

--- a/server/gitrest/packages/gitrest/package.json
+++ b/server/gitrest/packages/gitrest/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@types/async": "^3.2.9",
 		"@types/cors": "^2.8.4",
 		"@types/debug": "^4.1.5",

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -78,7 +78,7 @@
 	},
 	"devDependencies": {
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/eslint-config-fluid": "^5.1.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-test-utils": "6.0.0-301718",
 		"@types/compression": "0.0.36",
 		"@types/cors": "^2.8.4",

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -43,7 +43,7 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluidframework/eslint-config-fluid": "^5.1.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@types/compression": "0.0.36",
 		"@types/cors": "^2.8.4",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -32,7 +32,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"concurrently": "^8.2.1",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -35,7 +35,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@5.0.0",
 		"@types/node": "^18.19.39",
 		"concurrently": "^8.2.1",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -67,7 +67,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/async": "^3.2.9",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -80,7 +80,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/async": "^3.2.9",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -74,7 +74,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/jsrsasign": "^10.5.12",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -81,7 +81,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@5.0.0",
 		"@types/mocha": "^10.0.1",
 		"@types/uuid": "^9.0.2",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -68,7 +68,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/assert": "^1.5.1",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -89,7 +89,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-local-server": "workspace:~",
 		"@fluidframework/server-routerlicious-base-previous": "npm:@fluidframework/server-routerlicious-base@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -62,7 +62,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-local-server": "workspace:~",
 		"@fluidframework/server-routerlicious-previous": "npm:@fluidframework/server-routerlicious@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -76,7 +76,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -44,7 +44,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@5.0.0",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -42,7 +42,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -41,7 +41,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -35,7 +35,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -82,7 +82,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/body-parser": "^1.19.2",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -62,7 +62,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@5.0.0",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.19.39",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -75,7 +75,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -80,7 +80,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/amqplib": "^0.5.17",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -72,7 +72,7 @@
 		"@fluid-tools/build-cli": "^0.38.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@5.0.0",
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/tinylicious/package.json
+++ b/server/routerlicious/packages/tinylicious/package.json
@@ -73,7 +73,7 @@
 	"devDependencies": {
 		"@fluid-internal/mocha-test-setup": "~2.0.5",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/compression": "^1.7.2",
 		"@types/cookie-parser": "^1.4.1",

--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -88,7 +88,7 @@
 		"@fluid-tools/markdown-magic": "file:../markdown-magic",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.44.0",
-		"@fluidframework/eslint-config-fluid": "^5.1.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/chai": "^4.3.4",
 		"@types/hast": "^3.0.4",

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -46,7 +46,7 @@
 	"devDependencies": {
 		"@fluid-internal/mocha-test-setup": "~2.0.0-rc.3.0.3",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/benchmark": "^2.1.0",
 		"@types/chai": "^4.3.4",

--- a/tools/getkeys/package.json
+++ b/tools/getkeys/package.json
@@ -29,7 +29,7 @@
 		"@fluidframework/tool-utils": "^0.35.0"
 	},
 	"devDependencies": {
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"eslint": "~8.55.0",
 		"prettier": "~3.0.3",
 		"typescript": "~4.5.5"

--- a/tools/telemetry-generator/package-lock.json
+++ b/tools/telemetry-generator/package-lock.json
@@ -17,7 +17,7 @@
 			"devDependencies": {
 				"@fluid-internal/mocha-test-setup": "^2.3.1",
 				"@fluidframework/build-common": "^2.0.1",
-				"@fluidframework/eslint-config-fluid": "^5.2.0",
+				"@fluidframework/eslint-config-fluid": "^5.4.0",
 				"@types/mocha": "^10.0.9",
 				"@types/node": "^14.18.0",
 				"@types/sinon": "^17.0.3",

--- a/tools/telemetry-generator/package.json
+++ b/tools/telemetry-generator/package.json
@@ -37,7 +37,7 @@
 	"devDependencies": {
 		"@fluid-internal/mocha-test-setup": "^2.3.1",
 		"@fluidframework/build-common": "^2.0.1",
-		"@fluidframework/eslint-config-fluid": "^5.2.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@types/mocha": "^10.0.9",
 		"@types/node": "^14.18.0",
 		"@types/sinon": "^17.0.3",

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.44.0",
-		"@fluidframework/eslint-config-fluid": "^5.1.0",
+		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@types/mocha": "^10.0.0",
 		"@types/node": "^18.19.0",
 		"eslint": "~8.55.0",


### PR DESCRIPTION
#### Description

This PR makes every packages in the repo to consume `eslint-config-fluid` at `5.4.0`. 