### PR TITLE
Skip summarize e2e test for r11s

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementallySubDds.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementallySubDds.spec.ts
@@ -589,7 +589,12 @@ describeCompat(
 			assert(ddsTree.tree["3"].type === SummaryType.Blob, "Blob 3 should be a blob");
 		});
 
-		it("can create summary handles for trees in DDSes that do not change", async () => {
+		it("can create summary handles for trees in DDSes that do not change", async function () {
+			// Skip this test for standard r11s as its summarization timing is flaky.
+			// This test is covering client logic and the coverage from other drivers/endpoints is sufficient.
+			if (provider.driver.type === "r11s" && provider.driver.endpointName !== "frs") {
+				this.skip();
+			}
 			const container = await createContainer();
 			const datastore = (await container.getEntryPoint()) as ITestFluidObject;
 			const dds = await datastore.getSharedObject<TestIncrementalSummaryTreeDDS>(

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithOutOfOrderDataStoreRealization.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeWithOutOfOrderDataStoreRealization.spec.ts
@@ -150,7 +150,13 @@ describeCompat(
 			await waitForContainerConnection(mainContainer);
 		});
 
-		it("No Summary Upload Error when DS gets realized between summarize and completeSummary", async () => {
+		it("No Summary Upload Error when DS gets realized between summarize and completeSummary", async function () {
+			// Skip this test for standard r11s as its summarization timing is flaky and non-reproducible.
+			// This test is covering client logic and the coverage from other drivers/endpoints is sufficient.
+			if (provider.driver.type === "r11s" && provider.driver.endpointName !== "frs") {
+				this.skip();
+			}
+
 			const summarizerClient = await createSummarizerWithVersion();
 			await provider.ensureSynchronized();
 			mainDataStore._root.set("1", "2");


### PR DESCRIPTION
I wasn't able to reproduce the flakiness locally (ran 2000 times), but I'm still seeing recent timeout failures in the build pipelines. These tests aren't testing anything that's driver specific, so it's safe to skip them for standard r11s.

Fixes [AB#11213](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/11213)
Fixes [AB#11060](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/11060)