### PR TITLE
fix(gitrest): Handle FileSystem Errors in HTTP Responses

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/utils/fileSystemBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/fileSystemBase.ts
@@ -9,7 +9,7 @@ import type { Stream } from "node:stream";
 import type { Abortable } from "node:events";
 import sizeof from "object-sizeof";
 import { type IFileSystemPromises } from "./definitions";
-import { FilesystemError, SystemErrors } from "./fileSystemHelper";
+import { filepathToString, FilesystemError, SystemErrors } from "./fileSystemHelper";
 
 export abstract class FsPromisesBase implements IFileSystemPromises {
 	public readonly promises: IFileSystemPromises;
@@ -88,8 +88,14 @@ export abstract class FsPromisesBase implements IFileSystemPromises {
 			this.maxFileSizeBytes > 0 &&
 			sizeof(data) > this.maxFileSizeBytes
 		) {
-			// eslint-disable-next-line @typescript-eslint/no-base-to-string
-			throw new FilesystemError(SystemErrors.EFBIG, filepath.toString());
+			throw new FilesystemError(
+				SystemErrors.EFBIG,
+				`Attempted write size (${sizeof(
+					data,
+				)} bytes) to ${filepathToString(filepath)} exceeds limit (${
+					this.maxFileSizeBytes
+				} bytes).`,
+			);
 		}
 		return this.writeFileCore(filepath, data, options);
 	}

--- a/server/gitrest/packages/gitrest-base/src/utils/fileSystemBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/fileSystemBase.ts
@@ -90,11 +90,9 @@ export abstract class FsPromisesBase implements IFileSystemPromises {
 		) {
 			throw new FilesystemError(
 				SystemErrors.EFBIG,
-				`Attempted write size (${sizeof(
-					data,
-				)} bytes) to ${filepathToString(filepath)} exceeds limit (${
-					this.maxFileSizeBytes
-				} bytes).`,
+				`Attempted write size (${sizeof(data)} bytes) to ${filepathToString(
+					filepath,
+				)} exceeds limit (${this.maxFileSizeBytes} bytes).`,
 			);
 		}
 		return this.writeFileCore(filepath, data, options);

--- a/server/gitrest/packages/gitrest-base/src/utils/fileSystemHelper.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/fileSystemHelper.ts
@@ -131,7 +131,6 @@ export function filepathToString(filepath: PathLike | FileHandle): string {
 		return "Unknown file handle path";
 	}
 	return filepath.toString();
-
 }
 
 /**

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -145,9 +145,7 @@ export async function persistLatestFullSummaryInStorage(
 			"Failed to persist latest full summary in storage",
 			error,
 		);
-		if (
-			isFilesystemError(error)
-		) {
+		if (isFilesystemError(error)) {
 			throwFileSystemErrorAsNetworkError(error);
 		}
 		throw error;

--- a/server/gitrest/packages/gitrest-base/src/utils/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/index.ts
@@ -19,7 +19,12 @@ export {
 	IStorageRoutingId,
 } from "./definitions";
 export { FsPromisesBase } from "./fileSystemBase";
-export { SystemErrors } from "./fileSystemHelper";
+export {
+	SystemErrors,
+	isFilesystemError,
+	throwFileSystemErrorAsNetworkError,
+	filepathToString,
+} from "./fileSystemHelper";
 export { MemFsManagerFactory, NodeFsManagerFactory, RedisFsManagerFactory } from "./filesystems";
 export {
 	BaseGitRestTelemetryProperties,


### PR DESCRIPTION
## Description

Currently, there are some filesystem operations in Gitrest that result in a generic 400 HTTP error code, rather than a helpful HTTP status and message based on the error that occurred.

This PR adds some wrapper functions that help determine if an error is a FileSystemError (or RedisFSError, which is similar) and bubble that up as a NetworkError that can be parsed for the HTTP response.
