### PR TITLE
Reenable skipped migration test

### DIFF
--- a/examples/version-migration/separate-container/tests/separateContainer.test.ts
+++ b/examples/version-migration/separate-container/tests/separateContainer.test.ts
@@ -3,8 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { IMigrator } from "@fluid-example/migration-tools/internal";
-import { IContainer } from "@fluidframework/container-definitions/internal";
+import type { IMigrator } from "@fluid-example/migration-tools/internal";
+import type { IContainer } from "@fluidframework/container-definitions/internal";
+import type { ISequencedClient } from "@fluidframework/driver-definitions/internal";
+
 import { globals } from "../jest.config.cjs";
 
 describe("separate-container migration", () => {
@@ -38,7 +40,7 @@ describe("separate-container migration", () => {
 				const migrationStatusElement = document.querySelector(".migration-status");
 				return migrationStatusElement?.textContent?.includes("one") === true;
 			});
-			await expect(containsOne).toEqual(true);
+			expect(containsOne).toEqual(true);
 		});
 
 		it("migrates and shows the correct code version after migration", async () => {
@@ -55,17 +57,17 @@ describe("separate-container migration", () => {
 				const migrationStatusElements = document.querySelectorAll(".migration-status");
 				return migrationStatusElements[1]?.textContent?.includes("one") === true;
 			});
-			await expect(leftContainsOne).toEqual(true);
-			await expect(rightContainsOne).toEqual(true);
+			expect(leftContainsOne).toEqual(true);
+			expect(rightContainsOne).toEqual(true);
 
 			const migratorsLength = await page.evaluate(() => {
-				return window["migrators"].length;
+				return (window["migrators"] as IMigrator[]).length;
 			});
-			await expect(migratorsLength).toEqual(2);
+			expect(migratorsLength).toEqual(2);
 
 			// Get a promise that will resolve when both sides have finished migration
-			const migrationP = page.evaluate(() => {
-				const migrationPs = (window["migrators"] as IMigrator[]).map((migrator) => {
+			const migrationP = page.evaluate(async () => {
+				const migrationPs = (window["migrators"] as IMigrator[]).map(async (migrator) => {
 					return new Promise<void>((resolve) => {
 						migrator.events.once("migrated", resolve);
 					});
@@ -86,8 +88,8 @@ describe("separate-container migration", () => {
 				const migrationStatusElements = document.querySelectorAll(".migration-status");
 				return migrationStatusElements[1]?.textContent?.includes("two") === true;
 			});
-			await expect(leftContainsTwo).toEqual(true);
-			await expect(rightContainsTwo).toEqual(true);
+			expect(leftContainsTwo).toEqual(true);
+			expect(rightContainsTwo).toEqual(true);
 		});
 	});
 
@@ -120,27 +122,28 @@ describe("separate-container migration", () => {
 				const migrationStatusElements = document.querySelectorAll(".migration-status");
 				return migrationStatusElements[1]?.textContent?.includes("one") === true;
 			});
-			await expect(leftContainsOne).toEqual(true);
-			await expect(rightContainsOne).toEqual(true);
+			expect(leftContainsOne).toEqual(true);
+			expect(rightContainsOne).toEqual(true);
 
 			// Wait until we see the summarizer join
-			await page.evaluate(() => {
+			await page.evaluate(async () => {
 				// This is reaching a bit, but we just need to watch it for test purposes.
 				const leftQuorum = (
-					window["migrators"][0]._currentMigratable.model.container as IContainer
-				).getQuorum();
-				const alreadyHasSummarizer =
-					[...leftQuorum.getMembers().values()].find(
-						(client) => client.client.details.type === "summarizer",
-					) !== undefined;
+					(window["migrators"] as IMigrator[])[0].currentModel as unknown as {
+						container: IContainer;
+					}
+				).container.getQuorum();
+				const alreadyHasSummarizer = [...leftQuorum.getMembers().values()].some(
+					(sequencedClient) => sequencedClient.client.details.type === "summarizer",
+				);
 				if (alreadyHasSummarizer) {
 					// This should be the path taken since demo mode should spawn the summarizer instantly.
 					return;
 				}
 				// In case the summarizer isn't quite connected yet, return a Promise so we can await for it to join.
 				return new Promise<void>((resolve) => {
-					const watchForSummarizer = (clientId, details) => {
-						if (details.type === "summarizer") {
+					const watchForSummarizer = (clientId, sequencedClient: ISequencedClient): void => {
+						if (sequencedClient.client.details.type === "summarizer") {
 							resolve();
 							leftQuorum.off("addMember", watchForSummarizer);
 						}
@@ -150,28 +153,23 @@ describe("separate-container migration", () => {
 			});
 
 			const migratorsLength = await page.evaluate(() => {
-				return window["migrators"].length;
+				return (window["migrators"] as IMigrator[]).length;
 			});
-			await expect(migratorsLength).toEqual(2);
-
-			await expect(page).toClick("button", { text: '"two"' });
+			expect(migratorsLength).toEqual(2);
 
 			// Get a promise that will resolve when both sides have finished migration
-			await page.evaluate(() => {
-				const migrationPs = (window["migrators"] as IMigrator[]).map((migrator) => {
+			const migrationP = page.evaluate(async () => {
+				const migrationPs = (window["migrators"] as IMigrator[]).map(async (migrator) => {
 					return new Promise<void>((resolve) => {
-						// Catch both cases:
-						// 1. Migration has already happened after clicking the button but before this
-						//    page.evaluate and so the version is "two"
-						// 2. Migration has not happened yet, so we need to wait for the "migrated" event
-						if (migrator.currentModel.version === "two") {
-							resolve();
-						}
 						migrator.events.once("migrated", resolve);
 					});
 				});
 				return Promise.all(migrationPs);
 			});
+
+			await expect(page).toClick("button", { text: '"two"' });
+
+			await migrationP;
 
 			// Validate the migration status shows "two" after the migration
 			const leftContainsTwo = await page.evaluate(() => {
@@ -182,8 +180,8 @@ describe("separate-container migration", () => {
 				const migrationStatusElements = document.querySelectorAll(".migration-status");
 				return migrationStatusElements[1]?.textContent?.includes("two") === true;
 			});
-			await expect(leftContainsTwo).toEqual(true);
-			await expect(rightContainsTwo).toEqual(true);
+			expect(leftContainsTwo).toEqual(true);
+			expect(rightContainsTwo).toEqual(true);
 		});
 	});
 });

--- a/examples/version-migration/separate-container/tests/separateContainer.test.ts
+++ b/examples/version-migration/separate-container/tests/separateContainer.test.ts
@@ -160,6 +160,13 @@ describe("separate-container migration", () => {
 			// Get a promise that will resolve when both sides have finished migration
 			const migrationP = page.evaluate(async () => {
 				const migrationPs = (window["migrators"] as IMigrator[]).map(async (migrator) => {
+					// Since we expect this to run before the button click below, nothing should have migrated.
+					// However, we are getting flaky errors and want to rule out the possibility that the puppeteer interaction
+					// is somehow permitting these to occur out of order.  Throwing here will cause the returned migrationP
+					// promise to immediately reject (since Promise.all rejects as soon as the first rejection occurs).
+					if (migrator.currentModel.version === "two") {
+						throw new Error("Unexpected early migration!");
+					}
 					return new Promise<void>((resolve) => {
 						migrator.events.once("migrated", resolve);
 					});

--- a/examples/version-migration/separate-container/tests/separateContainer.test.ts
+++ b/examples/version-migration/separate-container/tests/separateContainer.test.ts
@@ -164,7 +164,7 @@ describe("separate-container migration", () => {
 					// However, we are getting flaky errors and want to rule out the possibility that the puppeteer interaction
 					// is somehow permitting these to occur out of order.  Throwing here will cause the returned migrationP
 					// promise to immediately reject (since Promise.all rejects as soon as the first rejection occurs).
-					if (migrator.currentModel.version === "two") {
+					if (migrator.currentModel.version !== "one") {
 						throw new Error("Unexpected early migration!");
 					}
 					return new Promise<void>((resolve) => {


### PR DESCRIPTION
[AB#14341](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/14341)

I'm not able to repro any flakiness locally, but the reported error would ostensibly come from a floated promise beyond the end of the test I believe.  I don't see how this could happen given the current state of the test, but here I change the test flow to ensure we immediately await every promise just to be extra sure.

If we still have some flakiness show up, I can take another look.