### PR TITLE
Fix type test generation issues

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -536,10 +536,13 @@ export function generateCompatibilityTestCases(
  * Returns the name of the type preprocessing type meta-function to use, or undefined if no type test should be generated.
  */
 function selectTypePreprocessor(typeData: TypeData): string | undefined {
-	if (typeData.tags.has("type-test-minimal")) {
+	if (typeData.tags.has("system")) {
+		return undefined;
+	}
+	if (typeData.tags.has("typeTestMinimal")) {
 		return "MinimalType";
 	}
-	if (typeData.tags.has("type-test-full")) {
+	if (typeData.tags.has("typeTestFull")) {
 		return "FullType";
 	}
 	return "TypeOnly";

--- a/build-tools/packages/build-cli/src/typeValidator/typeData.ts
+++ b/build-tools/packages/build-cli/src/typeValidator/typeData.ts
@@ -44,16 +44,19 @@ export function toTypeString(
 		// does the type take generics that don't have defaults?
 		// eslint-disable-next-line unicorn/no-lonely-if -- logic is clearer when grouped this way.
 		if (
-			node.getTypeParameters().length > 0 &&
-			node.getTypeParameters().some((tp) => tp.getDefault() === undefined)
+			node
+				.getTypeParameters()
+				.some((typeParameter) => typeParameter.getDefault() === undefined)
 		) {
-			// it's really hard to build the right type for a generic,
-			// so for now we'll just pass any, as it will always work
-			// even though it may defeat the utility of a type or related test.
+			// In general there is no single correct value to test for the type parameters,
+			// so for now we'll just pass `never`, as it will always be valid.
+			// This may result in a type test with very little utility since most APIs aren't intended to be used with "never",
+			// and doing so is unlikely to test most of the actual use-cases of the generic type.
+			// `Never` is used instead of `any` since some contravariant generics constrain the input to `never`, and `any` is not assignable to `never`.
 			typeParams = `<${node
 				.getTypeParameters()
-				.filter((tp) => tp.getDefault() === undefined)
-				.map(() => "any")
+				.filter((typeParameter) => typeParameter.getDefault() === undefined)
+				.map(() => "never")
 				.join(",")}>`;
 		}
 	}

--- a/build-tools/packages/build-tools/src/common/typeCompatibility.ts
+++ b/build-tools/packages/build-tools/src/common/typeCompatibility.ts
@@ -77,7 +77,7 @@ export type TypeOnly<T> = T extends number
 				};
 
 /**
- * Type preprocessing function selected with the `@type-test-minimal` tag.
+ * Type preprocessing function selected with the `@typeTestMinimal` tag.
  *
  * This throws away even more type information that the default {@link TypeOnly} option, resulting in only the most minimal of type compatibility testing.
  * Currently this minimal level of compatibility resting only includes existence of the type and does not preserve any details.
@@ -90,7 +90,7 @@ export type TypeOnly<T> = T extends number
 export type MinimalType<T> = 0;
 
 /**
- * Type preprocessing function selected with the `@type-test-full` tag.
+ * Type preprocessing function selected with the `@typeTestFull` tag.
  *
  * This allows opting into full type compatibility: two types will only be considered compatible if they are assignable unmodified.
  *
@@ -303,4 +303,15 @@ namespace Test_TypeOnly_Symbols {
 
 	type _check3 = requireAssignableTo<TypeOnly<B>, object>;
 	type _check4 = requireAssignableTo<object, TypeOnly<B>>;
+}
+
+namespace TestNeverParameter {
+	type FooNever<T extends never> = T;
+	type AnyNever<T extends never> = T;
+
+	// @ts-expect-error any not assignable to never
+	type _check1 = FooNever<any>;
+
+	// never is assignable to any
+	type _check2 = AnyNever<never>;
 }


### PR DESCRIPTION
## Description

generic types with an extends clause of `never` currently generate type tests which do not compile due to any not extending never. This is fixed by using `never` instead of `any`.

`@system` types which do not promise user facing stability are now omitted from type testing.

The currently unused tags to opt into alternative type testing for a given type have been converted from `-` separated to camel case since it seems `-` does not work well in tags.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
