### PR TITLE
ci: Update upload/download artifact actions to v4 latest

### DIFF
--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -71,7 +71,8 @@ jobs:
           echo $(jq -c '. += {required: false}' changeset-metadata.json) > changeset-metadata.json
 
       - name: Upload changeset metadata
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # ratchet:actions/upload-artifact@v3
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
         with:
           name: changeset-metadata
           path: ./changeset-metadata.json
@@ -96,7 +97,8 @@ jobs:
           echo $(jq -c '. += { pr: "${{ github.event.number }}" }' changeset-metadata.json) > changeset-metadata.json
 
       - name: Upload changeset metadata
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # ratchet:actions/upload-artifact@v3
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
         with:
           name: changeset-metadata
           path: ./changeset-metadata.json

--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -71,8 +71,8 @@ jobs:
           echo $(jq -c '. += {required: false}' changeset-metadata.json) > changeset-metadata.json
 
       - name: Upload changeset metadata
-        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # ratchet:actions/upload-artifact@v4
         with:
           name: changeset-metadata
           path: ./changeset-metadata.json
@@ -97,8 +97,8 @@ jobs:
           echo $(jq -c '. += { pr: "${{ github.event.number }}" }' changeset-metadata.json) > changeset-metadata.json
 
       - name: Upload changeset metadata
-        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # ratchet:actions/upload-artifact@v4
         with:
           name: changeset-metadata
           path: ./changeset-metadata.json

--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -69,8 +69,8 @@ jobs:
         run: |
           flub release fromTag $TAG_NAME --json | jq -c > release-metadata.json
       - name: Upload release metadata JSON
-        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # ratchet:actions/upload-artifact@v4
         with:
           name: release-metadata
           path: release-metadata.json
@@ -99,8 +99,8 @@ jobs:
           mkdir reports
           flub release report -g ${{ fromJson(env.RELEASE_JSON).packageOrReleaseGroup }} -o reports
       - name: Upload release reports
-        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # ratchet:actions/upload-artifact@v4
         with:
           name: release-reports
           path: reports

--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -69,7 +69,8 @@ jobs:
         run: |
           flub release fromTag $TAG_NAME --json | jq -c > release-metadata.json
       - name: Upload release metadata JSON
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # ratchet:actions/upload-artifact@v3
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
         with:
           name: release-metadata
           path: release-metadata.json
@@ -98,7 +99,8 @@ jobs:
           mkdir reports
           flub release report -g ${{ fromJson(env.RELEASE_JSON).packageOrReleaseGroup }} -o reports
       - name: Upload release reports
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # ratchet:actions/upload-artifact@v3
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
         with:
           name: release-reports
           path: reports

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -79,8 +79,8 @@ jobs:
         run: echo ${{ github.event.pull_request.head.sha }} > ./artifacts/commit_sha
 
       - name: Upload artifact
-        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # ratchet:actions/upload-artifact@v4
         with:
           name: release-branch-pr-metadata
           path: ./artifacts

--- a/.github/workflows/website-validation.yml
+++ b/.github/workflows/website-validation.yml
@@ -38,8 +38,8 @@ jobs:
           pnpm i --frozen-lockfile
           npm run ci:build
       - name: Upload site artifact
-        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # ratchet:actions/upload-artifact@v4
         with:
           name: fluidframework-site
           path: docs/public
@@ -104,8 +104,8 @@ jobs:
           cat ./results/linkcheck-output.txt | tee -a ./results/linkcheck
           echo -e "\n\`\`\`" | tee -a ./results/linkcheck
       - name: Upload results artifact
-        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # ratchet:actions/upload-artifact@v4
         with:
           name: website-validation-results
           path: ./docs/results

--- a/.github/workflows/website-validation.yml
+++ b/.github/workflows/website-validation.yml
@@ -38,7 +38,8 @@ jobs:
           pnpm i --frozen-lockfile
           npm run ci:build
       - name: Upload site artifact
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # ratchet:actions/upload-artifact@v3
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
         with:
           name: fluidframework-site
           path: docs/public
@@ -80,7 +81,8 @@ jobs:
         run: mkdir -p ./results
 
       - name: Download site artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # ratchet:actions/download-artifact@v3
+         # release notes: https://github.com/actions/download-artifact/releases/tag/v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # ratchet:actions/download-artifact@v4
         with:
           name: fluidframework-site
           path: docs/public
@@ -102,7 +104,8 @@ jobs:
           cat ./results/linkcheck-output.txt | tee -a ./results/linkcheck
           echo -e "\n\`\`\`" | tee -a ./results/linkcheck
       - name: Upload results artifact
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # ratchet:actions/upload-artifact@v3
+        # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.0
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # ratchet:actions/upload-artifact@v4.4.0
         with:
           name: website-validation-results
           path: ./docs/results


### PR DESCRIPTION
This change updates the upload and download artifacts action to the latest v4 versions.

The v3 versions of the GitHub actions artifact actions are being deprecated: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

None of the breaking changes should affect us: https://github.com/actions/upload-artifact#breaking-changes