### PR TITLE
chunked forest memory benchmark tests

### DIFF
--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -118,7 +118,7 @@
 		"test:coverage": "c8 npm test",
 		"test:customBenchmarks": "mocha --config ./.mocharc.customBenchmarks.cjs",
 		"test:customBenchmarks:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:customBenchmarks",
-		"test:memory": "mocha --config ./src/test/memory/.mocharc.cjs",
+		"test:memory": "mocha --perfMode --config ./src/test/memory/.mocharc.cjs",
 		"test:memory-profiling:report": "mocha --config ./src/test/memory/.mocharc.cjs",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "cross-env MOCHA_SPEC=dist/test mocha",

--- a/packages/dds/tree/src/test/memory/tree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tree.spec.ts
@@ -267,6 +267,7 @@ describe("SharedTree memory usage", () => {
 	}
 
 	const numberOfNodesForTests = isInPerformanceTestingMode ? [1, 10, 100, 1000] : [10];
+	// TODO: needs .only to describe block when running in performance mode if you need to see the results. Check to see why it does not run without .only.
 	describe("Forest memory usage", () => {
 		runBenchmarkMemoryForSubTree(
 			"Array of monomorphic leaves",

--- a/packages/dds/tree/src/test/memory/tree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tree.spec.ts
@@ -78,7 +78,9 @@ class DeepMonomorphicNode extends builder.object("wrapped-item", {
 	}),
 }) {}
 
-// Array with nodes which are nested
+/**
+ * Array of Deep monomorphic nodes to emphasize chunked forest's efficiency
+ */
 class DeepMonomorphicArray extends builder.array(
 	"root-item-with-nested-nodes",
 	DeepMonomorphicNode,

--- a/packages/dds/tree/src/test/memory/tree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tree.spec.ts
@@ -216,14 +216,14 @@ describe("SharedTree memory usage", () => {
 		).timeout(40000); // Set relatively higher threshold as 100_000 iterations can take a while.
 	}
 
-	const numberOfNodesForTests = isInPerformanceTestingMode ? [10] : [10];
+	const numberOfNodesForTests = isInPerformanceTestingMode ? [1000, 10_000, 50_000] : [10];
 	describe("Chunked Forest memory usage", () => {
 		for (const numberOfNodes of numberOfNodesForTests) {
 			for (const forestType of [ForestType.Reference, ForestType.Optimized]) {
 				benchmarkMemory(
 					new (class implements IMemoryTestObject {
 						public readonly title =
-							`initialize ${numberOfNodes} nodes into tree with schema that is inefficient for chunked forest using ${forestType}`;
+							`initialize ${numberOfNodes} nodes into tree with schema that is inefficient for chunked forest using ${forestType === 0 ? "ObjectForest" : "ChunkedForest"}`;
 
 						private sharedTree: TreeView<typeof RootNodeSchemaBasicChunks> | undefined;
 
@@ -247,7 +247,7 @@ describe("SharedTree memory usage", () => {
 				benchmarkMemory(
 					new (class implements IMemoryTestObject {
 						public readonly title =
-							`initialize ${numberOfNodes} nodes into tree with schema that is efficient for chunked forest using ${forestType}`;
+							`initialize ${numberOfNodes} nodes into tree with schema that is efficient for chunked forest using ${forestType === 0 ? "ObjectForest" : "ChunkedForest"}`;
 
 						private sharedTree: TreeView<typeof RootNodeSchemaUniform> | undefined;
 
@@ -271,7 +271,7 @@ describe("SharedTree memory usage", () => {
 				benchmarkMemory(
 					new (class implements IMemoryTestObject {
 						public readonly title =
-							`initialize ${numberOfNodes} nested nodes into tree with schema that is efficient for chunked forest using ${forestType}`;
+							`initialize ${numberOfNodes} nested nodes into tree with schema that is efficient for chunked forest using ${forestType === 0 ? "ObjectForest" : "ChunkedForest"}`;
 
 						private sharedTree: TreeView<typeof RootNodeSchemaWithNestedNodes> | undefined;
 

--- a/packages/dds/tree/src/test/memory/tree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tree.spec.ts
@@ -264,7 +264,7 @@ describe("SharedTree memory usage", () => {
 	}
 
 	const numberOfNodesForTests = isInPerformanceTestingMode ? [1, 10, 100, 1000] : [10];
-	// TODO: needs .only to describe block when running in performance mode if you need to see the results. Check to see why it does not run without .only.
+	// TODO: AB#24885 needs .only to describe block when running in performance mode if you need to see the results. Check to see why it does not run without .only.
 	describe("Forest memory usage", () => {
 		describeMemoryBenchmarksForSubtrees(
 			"Array of monomorphic leaves",

--- a/packages/dds/tree/src/test/memory/tree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tree.spec.ts
@@ -234,13 +234,13 @@ describe("SharedTree memory usage", () => {
 		generateContent: (numberOfNodes: number) => InsertableTreeFieldFromImplicitField<TSchema>,
 		testNodeCounts: number[],
 	) {
-		for (const numberOfNodes of testNodeCounts) {
-			for (const forestType of [ForestType.Reference, ForestType.Optimized]) {
-				describe(title, () => {
+		describe(title, () => {
+			for (const numberOfNodes of testNodeCounts) {
+				for (const forestType of [ForestType.Reference, ForestType.Optimized]) {
 					benchmarkMemory(
 						new (class implements IMemoryTestObject {
 							public readonly title =
-								`initialize ${numberOfNodes} nodes into tree with schema that is efficient for chunked forest using ${forestType === 0 ? "ObjectForest" : "ChunkedForest"}`;
+								`initialize ${numberOfNodes} nodes into tree using ${forestType === 0 ? "ObjectForest" : "ChunkedForest"}`;
 
 							private sharedTree: TreeView<typeof schema> | undefined;
 
@@ -261,13 +261,13 @@ describe("SharedTree memory usage", () => {
 							}
 						})(),
 					).timeout(400000);
-				});
+				}
 			}
-		}
+		});
 	}
 
-	const numberOfNodesForTests = isInPerformanceTestingMode ? [1] : [10];
-	describe("Chunked Forest memory usage", () => {
+	const numberOfNodesForTests = isInPerformanceTestingMode ? [1, 10, 100, 1000] : [10];
+	describe("Forest memory usage", () => {
 		runBenchmarkMemoryForSubTree(
 			"Array of monomorphic leaves",
 			MonomorphicArray,

--- a/packages/dds/tree/src/test/memory/tree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tree.spec.ts
@@ -222,7 +222,7 @@ describe("SharedTree memory usage", () => {
 		).timeout(40000); // Set relatively higher threshold as 100_000 iterations can take a while.
 	}
 
-	const numberOfNodesForTests = isInPerformanceTestingMode ? [1000, 10_000, 50_000] : [10];
+	const numberOfNodesForTests = isInPerformanceTestingMode ? [1, 10, 100, 1000] : [10];
 	describe("Chunked Forest memory usage", () => {
 		for (const numberOfNodes of numberOfNodesForTests) {
 			for (const forestType of [ForestType.Reference, ForestType.Optimized]) {

--- a/packages/dds/tree/src/test/memory/tree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tree.spec.ts
@@ -79,7 +79,7 @@ class DeepMonomorphicNode extends builder.object("wrapped-item", {
 }) {}
 
 // Array with nodes which are nested
-class RootNodeSchemaWithNestedNodes extends builder.array(
+class DeepMonomorphicArray extends builder.array(
 	"root-item-with-nested-nodes",
 	DeepMonomorphicNode,
 ) {}
@@ -277,13 +277,13 @@ describe("SharedTree memory usage", () => {
 						public readonly title =
 							`initialize ${numberOfNodes} nested nodes into tree with schema that is efficient for chunked forest using ${forestType === 0 ? "ObjectForest" : "ChunkedForest"}`;
 
-						private sharedTree: TreeView<typeof RootNodeSchemaWithNestedNodes> | undefined;
+						private sharedTree: TreeView<typeof DeepMonomorphicArray> | undefined;
 
 						public async run(): Promise<void> {
 							this.sharedTree = createLocalSharedTree(
 								"testSharedTree",
-								RootNodeSchemaWithNestedNodes,
-								new RootNodeSchemaWithNestedNodes(
+								DeepMonomorphicArray,
+								new DeepMonomorphicArray(
 									Array.from(
 										{ length: numberOfNodes },
 										(_, index) =>

--- a/packages/dds/tree/src/test/memory/tree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tree.spec.ts
@@ -108,12 +108,6 @@ function createLocalSharedTree<TSchema extends ImplicitFieldSchema>(
 	return view;
 }
 
-enum SubtreeType {
-	Monomorphic,
-	Polymorphic,
-	DeepMonomorphic,
-}
-
 describe("SharedTree memory usage", () => {
 	// IMPORTANT: variables scoped to the test suite are a big problem for memory-profiling tests
 	// because they won't be out of scope when we garbage-collect between runs of the same test,
@@ -228,7 +222,10 @@ describe("SharedTree memory usage", () => {
 		).timeout(40000); // Set relatively higher threshold as 100_000 iterations can take a while.
 	}
 
-	function runBenchmarkMemoryForSubTree<TSchema extends ImplicitFieldSchema>(
+	/**
+	 * Define a suite of benchmarks for testing the memory use of variety of sizes of trees of the given schema in various forest implementations.
+	 */
+	function describeMemoryBenchmarksForSubtrees<TSchema extends ImplicitFieldSchema>(
 		title: string,
 		schema: TSchema,
 		generateContent: (numberOfNodes: number) => InsertableTreeFieldFromImplicitField<TSchema>,
@@ -269,7 +266,7 @@ describe("SharedTree memory usage", () => {
 	const numberOfNodesForTests = isInPerformanceTestingMode ? [1, 10, 100, 1000] : [10];
 	// TODO: needs .only to describe block when running in performance mode if you need to see the results. Check to see why it does not run without .only.
 	describe("Forest memory usage", () => {
-		runBenchmarkMemoryForSubTree(
+		describeMemoryBenchmarksForSubtrees(
 			"Array of monomorphic leaves",
 			MonomorphicArray,
 			(numberOfNodes: number) =>
@@ -277,7 +274,7 @@ describe("SharedTree memory usage", () => {
 			numberOfNodesForTests,
 		);
 
-		runBenchmarkMemoryForSubTree(
+		describeMemoryBenchmarksForSubtrees(
 			"Array of polymorphic leaves",
 			PolymorphicArray,
 			(numberOfNodes: number) =>
@@ -285,7 +282,7 @@ describe("SharedTree memory usage", () => {
 			numberOfNodesForTests,
 		);
 
-		runBenchmarkMemoryForSubTree(
+		describeMemoryBenchmarksForSubtrees(
 			"Array of deep monomorphic leaves",
 			DeepMonomorphicArray,
 			(numberOfNodes: number) =>


### PR DESCRIPTION
## Description

Adds memory benchmark tests for initializing different types of trees for chunked forest. 

Currently the `defaultChunkPolicy` is being used during initialization, which defaults to a polymorphic shape. Once this is resolved, the memory benchmarks should see much better performance for chunked forest.

### SharedTree Memory Usage - Array of Monomorphic Leaves

| Status | Name                                              | Total Time (s) | Heap Used Avg | Heap Used StdDev | Margin of Error | Relative Margin of Error | Iterations |
|--------|---------------------------------------------------|----------------|----------------|-------------------|----------------|---------------------------|------------|
| ✔      | Initialize 1 nodes into tree using ObjectForest   | 6.29           | 236,784.95     | 27,567.46         | ±5,895.40      | ±2.49%                   | 88         |
| ✔      | Initialize 1 nodes into tree using ChunkedForest  | 4.07           | 198,545.04     | 18,408.64         | ±4,909.99      | ±2.47%                   | 57         |
| ✔      | Initialize 10 nodes into tree using ObjectForest  | 3.54           | 205,398.64     | 6,858.28          | ±1,960.75      | ±0.95%                   | 50         |
| ✔      | Initialize 10 nodes into tree using ChunkedForest | 3.56           | 205,955.57     | 17,454.18         | ±4,990.07      | ±2.42%                   | 50         |
| ✔      | Initialize 100 nodes into tree using ObjectForest | 7.98           | 296,463.31     | 35,117.96         | ±6,749.45      | ±2.28%                   | 110        |
| ✔      | Initialize 100 nodes into tree using ChunkedForest| 3.63           | 332,212.26     | 24,223.60         | ±6,925.42      | ±2.08%                   | 50         |
| ✔      | Initialize 1000 nodes into tree using ObjectForest| 3.76           | 1,250,473.70   | 101,907.43        | ±29,134.86     | ±2.33%                   | 50         |
| ✔      | Initialize 1000 nodes into tree using ChunkedForest| 3.83          | 1,644,462.98   | 3,907.74          | ±1,117.20      | ±0.07%                   | 50         |

---

### SharedTree Memory Usage - Array of Polymorphic Leaves

| Status | Name                                              | Total Time (s) | Heap Used Avg | Heap Used StdDev | Margin of Error | Relative Margin of Error | Iterations |
|--------|---------------------------------------------------|----------------|----------------|-------------------|----------------|---------------------------|------------|
| ✔      | Initialize 1 nodes into tree using ObjectForest   | 3.61           | 222,729.19     | 6,744.83          | ±1,928.32      | ±0.87%                   | 50         |
| ✔      | Initialize 1 nodes into tree using ChunkedForest  | 3.56           | 198,200.85     | 5,705.92          | ±1,631.30      | ±0.82%                   | 50         |
| ✔      | Initialize 10 nodes into tree using ObjectForest  | 5.01           | 200,724.97     | 19,817.98         | ±4,781.27      | ±2.38%                   | 70         |
| ✔      | Initialize 10 nodes into tree using ChunkedForest | 5.07           | 207,667.39     | 12,572.93         | ±3,033.34      | ±1.46%                   | 70         |
| ✔      | Initialize 100 nodes into tree using ObjectForest | 3.62           | 299,202.55     | 10,332.74         | ±2,954.08      | ±0.99%                   | 50         |
| ✔      | Initialize 100 nodes into tree using ChunkedForest| 5.10           | 338,058.06     | 3,393.39          | ±818.69        | ±0.24%                   | 70         |
| ✔      | Initialize 1000 nodes into tree using ObjectForest| 3.74           | 1,270,979.74   | 17,797.32         | ±5,088.17      | ±0.40%                   | 50         |
| ✔      | Initialize 1000 nodes into tree using ChunkedForest| 3.88          | 1,639,710.13   | 43,026.98         | ±12,301.22     | ±0.75%                   | 50         |

---

### SharedTree Memory Usage - Array of Deep Monomorphic Leaves

| Status | Name                                              | Total Time (s) | Heap Used Avg | Heap Used StdDev | Margin of Error | Relative Margin of Error | Iterations |
|--------|---------------------------------------------------|----------------|----------------|-------------------|----------------|---------------------------|------------|
| ✔      | Initialize 1 nodes into tree using ObjectForest   | 3.77           | 241,242.72     | 19,135.28         | ±5,470.69      | ±2.27%                   | 50         |
| ✔      | Initialize 1 nodes into tree using ChunkedForest  | 3.56           | 216,456.17     | 11,844.90         | ±3,386.40      | ±1.56%                   | 50         |
| ✔      | Initialize 10 nodes into tree using ObjectForest  | 3.66           | 350,359.83     | 5,682.95          | ±1,624.73      | ±0.46%                   | 50         |
| ✔      | Initialize 10 nodes into tree using ChunkedForest | 3.69           | 338,993.87     | 9,305.82          | ±2,660.49      | ±0.78%                   | 50         |
| ✔      | Initialize 100 nodes into tree using ObjectForest | 5.53           | 1,700,227.76   | 155,393.86        | ±37,490.22     | ±2.21%                   | 70         |
| ✔      | Initialize 100 nodes into tree using ChunkedForest| 8.95           | 1,556,630.92   | 193,734.91        | ±37,234.65     | ±2.39%                   | 110        |
| ✔      | Initialize 1000 nodes into tree using ObjectForest| 11.03          | 15,515,518.13  | 5,076.09          | ±1,451.23      | ±0.01%                   | 50         |
| ✔      | Initialize 1000 nodes into tree using ChunkedForest| 12.95         | 13,930,719.83  | 2,269.00          | ±648.70        | ±0.00%                   | 50         |

---