### PR TITLE
refactor(telemetry-utlis): Make MockLogger internal

### DIFF
--- a/.changeset/green-readers-burn.md
+++ b/.changeset/green-readers-burn.md
@@ -1,0 +1,13 @@
+---
+"@fluidframework/telemetry-utils": minor
+---
+---
+"section": legacy
+---
+
+`MockLogger` has been removed from the alpha+legacy API surface
+
+The `MockLogger` class previously exposed in the alpha+legacy API surface of `@fluidframework/telemetry-utils` has
+been removed.
+No replacement is provided, as this class was only intended for use in testing scenarios, and should be trivial to
+re-implement in any codebase that still uses it.

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.legacy.alpha.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.legacy.alpha.api.md
@@ -55,24 +55,6 @@ export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt
 // @alpha
 export type ITelemetryPropertiesExt = Record<string, TelemetryEventPropertyTypeExt | Tagged<TelemetryEventPropertyTypeExt>>;
 
-// @alpha @deprecated
-export class MockLogger implements ITelemetryBaseLogger {
-    constructor(minLogLevel?: LogLevel);
-    assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): void;
-    assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): void;
-    assertMatchNone(disallowedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): void;
-    assertMatchStrict(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): void;
-    clear(): void;
-    get events(): readonly ITelemetryBaseEvent[];
-    matchAnyEvent(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): boolean;
-    matchEvents(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): boolean;
-    matchEventStrict(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): boolean;
-    readonly minLogLevel: LogLevel;
-    send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
-    // (undocumented)
-    toTelemetryLogger(): ITelemetryLoggerExt;
-}
-
 // @alpha
 export type TelemetryEventCategory = "generic" | "error" | "performance";
 

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -23,28 +23,7 @@ import type {
  * Records events sent to it, and then can walk back over those events, searching for a set of expected events to
  * match against the logged events.
  *
- * @deprecated
- *
- * This class is not intended for use outside of the `fluid-framework` repo, and will be removed from
- * package exports in the near future.
- *
- * Please migrate usages by either creating your own mock {@link @fluidframework/core-interfaces#ITelemetryBaseLogger}
- * implementation, or by copying this code as-is into your own repo.
- *
- * @privateRemarks TODO: When we are ready, this type should be made `internal`, and the deprecation notice should be removed.
- *
- * @deprecated
- *
- * This class is not intended for use outside of the `fluid-framework` repo, and will be removed from
- * package exports in the near future.
- *
- * Please migrate usages by either creating your own mock {@link @fluidframework/core-interfaces#ITelemetryBaseLogger}
- * implementation, or by copying this code as-is into your own repo.
- *
- * @privateRemarks TODO: When we are ready, this type should be made `internal`, and the deprecation notice should be removed.
- *
- * @legacy
- * @alpha
+ * @internal
  */
 export class MockLogger implements ITelemetryBaseLogger {
 	/**


### PR DESCRIPTION
## Description

Removes the `MockLogger` class from the `@alpha+@legacy` API surface. It has been deprecated for external use since 2024-06-18. 

## Breaking Changes

- `MockLogger` is now removed from the `@alpha+@legacy` API surface, becoming only `@internal`.
 
## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#22886](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/22886)