### PR TITLE
Sequence zero length obliterate fix

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2105,11 +2105,7 @@ export class MergeTree {
 
 		this.slideAckedRemovedSegmentReferences(localOverlapWithRefs);
 		// opArgs == undefined => test code
-		if (
-			(clientId === this.collabWindow.clientId &&
-				(start.pos !== end.pos || start.side !== end.side)) ||
-			movedSegments.length > 0
-		) {
+		if (start.pos !== end.pos || start.side !== end.side) {
 			this.mergeTreeDeltaCallback?.(opArgs, {
 				operation: MergeTreeDeltaType.OBLITERATE,
 				deltaSegments: movedSegments,

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1250,12 +1250,9 @@ export class MergeTree {
 				});
 			});
 
-			if (
-				opArgs.op.type === MergeTreeDeltaType.OBLITERATE ||
-				opArgs.op.type === MergeTreeDeltaType.OBLITERATE_SIDED
-			) {
-				pendingSegmentGroup.obliterateInfo!.seq = seq;
-				this.obliterates.addOrUpdate(pendingSegmentGroup.obliterateInfo!);
+			if (pendingSegmentGroup.obliterateInfo !== undefined) {
+				pendingSegmentGroup.obliterateInfo.seq = seq;
+				this.obliterates.addOrUpdate(pendingSegmentGroup.obliterateInfo);
 			}
 
 			// Perform slides after all segments have been acked, so that

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2105,7 +2105,11 @@ export class MergeTree {
 
 		this.slideAckedRemovedSegmentReferences(localOverlapWithRefs);
 		// opArgs == undefined => test code
-		if (start.pos !== end.pos || start.side !== end.side) {
+		if (
+			(clientId === this.collabWindow.clientId &&
+				(start.pos !== end.pos || start.side !== end.side)) ||
+			movedSegments.length > 0
+		) {
 			this.mergeTreeDeltaCallback?.(opArgs, {
 				operation: MergeTreeDeltaType.OBLITERATE,
 				deltaSegments: movedSegments,

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1254,6 +1254,7 @@ export class MergeTree {
 				opArgs.op.type === MergeTreeDeltaType.OBLITERATE ||
 				opArgs.op.type === MergeTreeDeltaType.OBLITERATE_SIDED
 			) {
+				pendingSegmentGroup.obliterateInfo!.seq = seq;
 				this.obliterates.addOrUpdate(pendingSegmentGroup.obliterateInfo!);
 			}
 
@@ -2107,7 +2108,7 @@ export class MergeTree {
 
 		this.slideAckedRemovedSegmentReferences(localOverlapWithRefs);
 		// opArgs == undefined => test code
-		if (movedSegments.length > 0) {
+		if (start.pos !== end.pos || start.side !== end.side) {
 			this.mergeTreeDeltaCallback?.(opArgs, {
 				operation: MergeTreeDeltaType.OBLITERATE,
 				deltaSegments: movedSegments,

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -703,8 +703,7 @@ export abstract class BaseSegment implements ISegment {
 				this.localMovedSeq = obliterateInfo.localSeq = undefined;
 				const seqIdx = moveInfo.movedSeqs.indexOf(UnassignedSequenceNumber);
 				assert(seqIdx !== -1, 0x86f /* expected movedSeqs to contain unacked seq */);
-				moveInfo.movedSeqs[seqIdx] = obliterateInfo.seq =
-					opArgs.sequencedMessage!.sequenceNumber;
+				moveInfo.movedSeqs[seqIdx] = opArgs.sequencedMessage!.sequenceNumber;
 
 				if (moveInfo.movedSeq === UnassignedSequenceNumber) {
 					moveInfo.movedSeq = opArgs.sequencedMessage!.sequenceNumber;

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -538,7 +538,9 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 			if (event.isLocal) {
 				this.submitSequenceMessage(opArgs.op);
 			}
-			this.emit("sequenceDelta", event, this);
+			if (deltaArgs.deltaSegments.length > 0) {
+				this.emit("sequenceDelta", event, this);
+			}
 		});
 
 		this.client.on("maintenance", (args, opArgs) => {

--- a/packages/dds/sequence/src/sequenceDeltaEvent.ts
+++ b/packages/dds/sequence/src/sequenceDeltaEvent.ts
@@ -13,6 +13,7 @@ import {
 	ISegment,
 	MergeTreeDeltaOperationType,
 	MergeTreeDeltaOperationTypes,
+	MergeTreeDeltaType,
 	MergeTreeMaintenanceType,
 	PropertySet, // eslint-disable-next-line import/no-deprecated
 	SortedSegmentSet,
@@ -47,10 +48,15 @@ export abstract class SequenceEvent<
 		// eslint-disable-next-line import/no-deprecated
 		private readonly mergeTreeClient: Client,
 	) {
-		assert(
-			deltaArgs.deltaSegments.length > 0,
-			0x2d8 /* "Empty change event should not be emitted." */,
-		);
+		if (
+			deltaArgs.operation !== MergeTreeDeltaType.OBLITERATE &&
+			deltaArgs.operation !== MergeTreeMaintenanceType.ACKNOWLEDGED
+		) {
+			assert(
+				deltaArgs.deltaSegments.length > 0,
+				0x2d8 /* "Empty change event should not be emitted." */,
+			);
+		}
 		this.deltaOperation = deltaArgs.operation;
 
 		// eslint-disable-next-line import/no-deprecated

--- a/packages/dds/sequence/src/test/sharedString.spec.ts
+++ b/packages/dds/sequence/src/test/sharedString.spec.ts
@@ -887,9 +887,7 @@ describe("Shared String Obliterate", () => {
 		sharedString2.connect(services2);
 	});
 
-	// TODO: this test currently fails with 0x2d8
-	// AB#19722
-	it.skip("zero length obliterate in the middle of the string", () => {
+	it("zero length obliterate in the middle of the string", () => {
 		sharedString.insertText(0, "0123456789");
 		containerRuntimeFactory.processAllMessages();
 		assert.equal(
@@ -909,6 +907,6 @@ describe("Shared String Obliterate", () => {
 			sharedString2.getText(),
 			"end state should be equal after obliterate",
 		);
-		assert.equal(sharedString2.getText(), "01234AAA56789", "obliterate failed");
+		assert.equal(sharedString2.getText(), "01234BBB56789", "obliterate failed");
 	});
 });


### PR DESCRIPTION
Guard assert on `deltaArgs.deltaSegments.length` in `SequenceEvent` to allow zero length obliterates. An obliterate can still have an effect on concurrent inserts even if it affects zero segments when it is sequenced.