### PR TITLE
refactor(telemetry-utils): Remove deprecated internal type

### DIFF
--- a/packages/utils/telemetry-utils/src/index.ts
+++ b/packages/utils/telemetry-utils/src/index.ts
@@ -89,7 +89,6 @@ export type {
 	ITelemetryErrorEventExt,
 	ITelemetryPerformanceEventExt,
 	ITelemetryLoggerExt,
-	ITaggedTelemetryPropertyTypeExt,
 	ITelemetryPropertiesExt,
 	TelemetryEventCategory,
 } from "./telemetryTypes.js";

--- a/packages/utils/telemetry-utils/src/telemetryTypes.ts
+++ b/packages/utils/telemetry-utils/src/telemetryTypes.ts
@@ -36,19 +36,6 @@ export type TelemetryEventPropertyTypeExt =
 	| Record<string, string | number | boolean | undefined | (string | number | boolean)[]>;
 
 /**
- * A property to be logged to telemetry containing both the value and a tag. Tags are generic strings that can be used
- * to mark pieces of information that should be organized or handled differently by loggers in various first or third
- * party scenarios. For example, tags are used to mark personal information that should not be stored in logs.
- *
- * @deprecated Use {@link @fluidframework/core-interfaces#Tagged}\<{@link TelemetryEventPropertyTypeExt}\>
- * @internal
- */
-export interface ITaggedTelemetryPropertyTypeExt {
-	value: TelemetryEventPropertyTypeExt;
-	tag: string;
-}
-
-/**
  * JSON-serializable properties, which will be logged with telemetry.
  * @legacy
  * @alpha

--- a/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
@@ -5,7 +5,7 @@
 
 import assert from "node:assert";
 
-import type { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
+import type { ITelemetryBaseEvent, Tagged } from "@fluidframework/core-interfaces";
 
 import {
 	type ITelemetryLoggerPropertyBag,
@@ -13,10 +13,7 @@ import {
 	TelemetryLogger,
 	convertToBasePropertyType,
 } from "../logger.js";
-import type {
-	ITaggedTelemetryPropertyTypeExt,
-	TelemetryEventPropertyTypeExt,
-} from "../telemetryTypes.js";
+import type { TelemetryEventPropertyTypeExt } from "../telemetryTypes.js";
 
 class TestTelemetryLogger extends TelemetryLogger {
 	public events: ITelemetryBaseEvent[] = [];
@@ -205,48 +202,48 @@ describe("TelemetryLogger", () => {
 describe("convertToBasePropertyType", () => {
 	describe("tagged properties", () => {
 		it("tagged number", () => {
-			const taggedProperty: ITaggedTelemetryPropertyTypeExt = {
+			const taggedProperty: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: 123,
 				tag: "tag",
 			};
 			const converted = convertToBasePropertyType(taggedProperty);
-			const expected: ITaggedTelemetryPropertyTypeExt = {
+			const expected: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: 123,
 				tag: "tag",
 			};
 			assert.deepStrictEqual(converted, expected);
 		});
 		it("tagged string", () => {
-			const taggedProperty: ITaggedTelemetryPropertyTypeExt = {
+			const taggedProperty: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: "test",
 				tag: "tag",
 			};
 			const converted = convertToBasePropertyType(taggedProperty);
-			const expected: ITaggedTelemetryPropertyTypeExt = {
+			const expected: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: "test",
 				tag: "tag",
 			};
 			assert.deepStrictEqual(converted, expected);
 		});
 		it("tagged boolean", () => {
-			const taggedProperty: ITaggedTelemetryPropertyTypeExt = {
+			const taggedProperty: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: true,
 				tag: "tag",
 			};
 			const converted = convertToBasePropertyType(taggedProperty);
-			const expected: ITaggedTelemetryPropertyTypeExt = {
+			const expected: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: true,
 				tag: "tag",
 			};
 			assert.deepStrictEqual(converted, expected);
 		});
 		it("tagged array", () => {
-			const taggedProperty: ITaggedTelemetryPropertyTypeExt = {
+			const taggedProperty: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: [true, "test"],
 				tag: "tag",
 			};
 			const converted = convertToBasePropertyType(taggedProperty);
-			const expected: ITaggedTelemetryPropertyTypeExt = {
+			const expected: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: JSON.stringify([true, "test"]),
 				tag: "tag",
 			};
@@ -259,12 +256,12 @@ describe("convertToBasePropertyType", () => {
 				c: true,
 				d: [false, "okay"],
 			};
-			const taggedProperty: ITaggedTelemetryPropertyTypeExt = {
+			const taggedProperty: Tagged<TelemetryEventPropertyTypeExt> = {
 				value,
 				tag: "tag",
 			};
 			const converted = convertToBasePropertyType(taggedProperty);
-			const expected: ITaggedTelemetryPropertyTypeExt = {
+			const expected: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: JSON.stringify(value),
 				tag: "tag",
 			};
@@ -327,66 +324,66 @@ describe("convertToBasePropertyType", () => {
 	// These are unexpected, but it's good to have coverage to ensure they behave "well enough"
 	// (e.g. they shouldn't crash)
 	describe("Check various invalid (per typings) cases", () => {
-		it("nested ITaggedTelemetryPropertyTypeExt", () => {
-			const taggedProperty: ITaggedTelemetryPropertyTypeExt = {
+		it("nested Tagged<TelemetryEventPropertyTypeExt>", () => {
+			const taggedProperty: Tagged<TelemetryEventPropertyTypeExt> = {
 				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 				value: { value: true, tag: "tag" } as TelemetryEventPropertyTypeExt,
 				tag: "tag",
 			};
 			const converted = convertToBasePropertyType(taggedProperty);
-			const expected: ITaggedTelemetryPropertyTypeExt = {
+			const expected: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: '{"value":true,"tag":"tag"}',
 				tag: "tag",
 			};
 			assert.deepStrictEqual(converted, expected);
 		});
-		it("nested non ITaggedTelemetryPropertyTypeExt", () => {
-			const taggedProperty: ITaggedTelemetryPropertyTypeExt = {
+		it("nested non Tagged<TelemetryEventPropertyTypeExt>", () => {
+			const taggedProperty: Tagged<TelemetryEventPropertyTypeExt> = {
 				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 				value: { foo: 3, bar: { x: 5 } as unknown } as TelemetryEventPropertyTypeExt,
 				tag: "tag",
 			};
 			const converted = convertToBasePropertyType(taggedProperty);
-			const expected: ITaggedTelemetryPropertyTypeExt = {
+			const expected: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: '{"foo":3,"bar":{"x":5}}',
 				tag: "tag",
 			};
 			assert.deepStrictEqual(converted, expected);
 		});
 		it("tagged function", () => {
-			const taggedProperty: ITaggedTelemetryPropertyTypeExt = {
+			const taggedProperty: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: function x() {
 					return 54;
 				} as unknown as TelemetryEventPropertyTypeExt,
 				tag: "tag",
 			};
 			const converted = convertToBasePropertyType(taggedProperty);
-			const expected: ITaggedTelemetryPropertyTypeExt = {
+			const expected: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: "INVALID PROPERTY (typed as function)",
 				tag: "tag",
 			};
 			assert.deepStrictEqual(converted, expected);
 		});
 		it("tagged null value", () => {
-			const taggedProperty: ITaggedTelemetryPropertyTypeExt = {
+			const taggedProperty: Tagged<TelemetryEventPropertyTypeExt> = {
 				// eslint-disable-next-line unicorn/no-null
 				value: null as unknown as TelemetryEventPropertyTypeExt,
 				tag: "tag",
 			};
 			const converted = convertToBasePropertyType(taggedProperty);
-			const expected: ITaggedTelemetryPropertyTypeExt = {
+			const expected: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: "null",
 				tag: "tag",
 			};
 			assert.deepStrictEqual(converted, expected);
 		});
 		it("tagged symbol", () => {
-			const taggedProperty: ITaggedTelemetryPropertyTypeExt = {
+			const taggedProperty: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: Symbol("Test") as unknown as TelemetryEventPropertyTypeExt,
 				tag: "tag",
 			};
 			const converted = convertToBasePropertyType(taggedProperty);
-			const expected: ITaggedTelemetryPropertyTypeExt = {
+			const expected: Tagged<TelemetryEventPropertyTypeExt> = {
 				value: "INVALID PROPERTY (typed as symbol)",
 				tag: "tag",
 			};
@@ -400,7 +397,7 @@ describe("convertToBasePropertyType", () => {
 			const converted = convertToBasePropertyType(
 				nestedObject as unknown as
 					| TelemetryEventPropertyTypeExt
-					| ITaggedTelemetryPropertyTypeExt,
+					| Tagged<TelemetryEventPropertyTypeExt>,
 			);
 			const expected = '{"foo":{"foo":true,"test":"test"},"test":"test"}';
 			assert.deepStrictEqual(converted, expected);
@@ -408,14 +405,16 @@ describe("convertToBasePropertyType", () => {
 		it("function", () => {
 			const converted = convertToBasePropertyType(function x() {
 				return 54;
-			} as unknown as TelemetryEventPropertyTypeExt | ITaggedTelemetryPropertyTypeExt);
+			} as unknown as TelemetryEventPropertyTypeExt | Tagged<TelemetryEventPropertyTypeExt>);
 			const expected = "INVALID PROPERTY (typed as function)";
 			assert.deepStrictEqual(converted, expected);
 		});
 		it("null", () => {
 			const converted = convertToBasePropertyType(
 				// eslint-disable-next-line unicorn/no-null
-				null as unknown as TelemetryEventPropertyTypeExt | ITaggedTelemetryPropertyTypeExt,
+				null as unknown as
+					| TelemetryEventPropertyTypeExt
+					| Tagged<TelemetryEventPropertyTypeExt>,
 			);
 			const expected = "null";
 			assert.deepStrictEqual(converted, expected);
@@ -424,7 +423,7 @@ describe("convertToBasePropertyType", () => {
 			const converted = convertToBasePropertyType(
 				Symbol("Test") as unknown as
 					| TelemetryEventPropertyTypeExt
-					| ITaggedTelemetryPropertyTypeExt,
+					| Tagged<TelemetryEventPropertyTypeExt>,
 			);
 			const expected = "INVALID PROPERTY (typed as symbol)";
 			assert.deepStrictEqual(converted, expected);


### PR DESCRIPTION
## Description

Removes the deprecated `@internal` type `ITaggedTelemetryPropertyTypeExt`, replacing its uses with the recommendation from the deprecation message, `Tagged<TelemetryEventPropertyTypeExt>`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).