### PR TITLE
improvement(client-presence): move `PresenceStates` entries under `props`

### DIFF
--- a/.changeset/twenty-cameras-take.md
+++ b/.changeset/twenty-cameras-take.md
@@ -1,0 +1,10 @@
+---
+"@fluid-experimental/presence": minor
+---
+---
+"section": other
+---
+
+Untangle `PresenceStates` methods and properties
+
+`PresenceStatesEntries` which represent each of the states in `PresenceStates` schema have been relocated from directly within `PresenceStates` to under property names `prop`. Only the `add` method remains. (Type `PresenceStatesMethods` has been removed.)

--- a/examples/service-clients/azure-client/external-controller/src/app.ts
+++ b/examples/service-clients/azure-client/external-controller/src/app.ts
@@ -183,7 +183,7 @@ async function start(): Promise<void> {
 	// eslint-disable-next-line @typescript-eslint/member-delimiter-style
 	const lastRoll: { die1?: DieValue; die2?: DieValue } = {};
 	const presence = acquirePresenceViaDataObject(container.initialObjects.presence);
-	const states = buildDicePresence(presence);
+	const states = buildDicePresence(presence).props;
 
 	// Initialize Devtools
 	initializeDevtools({

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -187,23 +187,21 @@ export interface PresenceNotificationsSchema {
 }
 
 // @alpha @sealed
-export type PresenceStates<TSchema extends PresenceStatesSchema, TManagerRestrictions = unknown> = PresenceStatesEntries<TSchema, TManagerRestrictions> & PresenceStatesMethods<TSchema, TManagerRestrictions>;
+export interface PresenceStates<TSchema extends PresenceStatesSchema, TManagerConstraints = unknown> {
+    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<any>, TManager extends TManagerConstraints>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is PresenceStates<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
+    readonly props: PresenceStatesEntries<TSchema>;
+}
 
 // @alpha @sealed
-export type PresenceStatesEntries<TSchema extends PresenceStatesSchema, TManagerRestrictions> = {
+export type PresenceStatesEntries<TSchema extends PresenceStatesSchema> = {
     /**
     * Registered `Value Manager`s
     */
-    readonly [Key in Exclude<keyof TSchema, keyof PresenceStatesMethods<TSchema, TManagerRestrictions>>]: ReturnType<TSchema[Key]>["manager"] extends InternalTypes.StateValue<infer TManager> ? TManager : never;
+    readonly [Key in keyof TSchema]: ReturnType<TSchema[Key]>["manager"] extends InternalTypes.StateValue<infer TManager> ? TManager : never;
 };
 
 // @alpha
 export type PresenceStatesEntry<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalTypes.ManagerFactory<TKey, TValue, TManager>;
-
-// @alpha @sealed
-export interface PresenceStatesMethods<TSchema extends PresenceStatesSchema, TManagerRestrictions> {
-    add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<any>, TManager extends TManagerRestrictions>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is PresenceStates<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>>;
-}
 
 // @alpha
 export interface PresenceStatesSchema {

--- a/packages/framework/presence/src/index.ts
+++ b/packages/framework/presence/src/index.ts
@@ -33,7 +33,6 @@ export type {
 	PresenceStates,
 	PresenceStatesEntries,
 	PresenceStatesEntry,
-	PresenceStatesMethods,
 	PresenceStatesSchema,
 	PresenceWorkspaceAddress,
 } from "./types.js";

--- a/packages/framework/presence/src/test/latestMapValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestMapValueManager.spec.ts
@@ -28,23 +28,24 @@ export function checkCompiles(): void {
 		fixedMap: LatestMap({ key1: { x: 0, y: 0 }, key2: { ref: "default", someId: 0 } }),
 	});
 	// Workaround ts(2775): Assertions require every name in the call target to be declared with an explicit type annotation.
-	const map: typeof statesWorkspace = statesWorkspace;
+	const workspace: typeof statesWorkspace = statesWorkspace;
+	const props = workspace.props;
 
-	map.fixedMap.local.get("key1");
+	props.fixedMap.local.get("key1");
 	// @ts-expect-error with inferred keys only those named it init are accessible
-	map.fixedMap.local.get("key3");
+	props.fixedMap.local.get("key3");
 
-	map.fixedMap.local.set("key2", { x: 0, y: 2 });
-	map.fixedMap.local.set("key2", { ref: "string", someId: -1 });
+	props.fixedMap.local.set("key2", { x: 0, y: 2 });
+	props.fixedMap.local.set("key2", { ref: "string", someId: -1 });
 	// @ts-expect-error with inferred type `undefined` optional values are errors
-	map.fixedMap.local.set("key2", { x: undefined, y: undefined, ref: "string", someId: -1 });
+	props.fixedMap.local.set("key2", { x: undefined, y: undefined, ref: "string", someId: -1 });
 	// @ts-expect-error with inferred type partial values are errors
-	map.fixedMap.local.set("key2", { x: 0 });
+	props.fixedMap.local.set("key2", { x: 0 });
 	// @ts-expect-error with inferred heterogenous type mixed type values are errors
-	map.fixedMap.local.set("key2", { x: 0, y: 2, ref: "a", someId: 3 });
+	props.fixedMap.local.set("key2", { x: 0, y: 2, ref: "a", someId: 3 });
 
-	for (const key of map.fixedMap.local.keys()) {
-		const value = map.fixedMap.local.get(key);
+	for (const key of props.fixedMap.local.keys()) {
+		const value = props.fixedMap.local.get(key);
 		console.log(key, value);
 	}
 
@@ -55,9 +56,9 @@ export function checkCompiles(): void {
 		tilt?: number;
 	}
 
-	map.add("pointers", LatestMap<PointerData>({}));
+	workspace.add("pointers", LatestMap<PointerData>({}));
 
-	const pointers = map.pointers;
+	const pointers = workspace.props.pointers;
 	const localPointers = pointers.local;
 
 	function logClientValue<T>({

--- a/packages/framework/presence/src/test/latestValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestValueManager.spec.ts
@@ -29,15 +29,17 @@ export function checkCompiles(): void {
 		camera: Latest({ x: 0, y: 0, z: 0 }),
 	});
 	// Workaround ts(2775): Assertions require every name in the call target to be declared with an explicit type annotation.
-	const map: typeof statesWorkspace = statesWorkspace;
+	const workspace: typeof statesWorkspace = statesWorkspace;
+	const props = workspace.props;
 
-	map.add("caret", Latest({ id: "", pos: 0 }));
+	workspace.add("caret", Latest({ id: "", pos: 0 }));
 
-	const fakeAdd = map.caret.local.pos + map.camera.local.z + map.cursor.local.x;
+	const fakeAdd =
+		workspace.props.caret.local.pos + props.camera.local.z + props.cursor.local.x;
 	console.log(fakeAdd);
 
 	// @ts-expect-error local may be set wholly, but partially it is readonly
-	map.caret.local.pos = 0;
+	workspace.props.caret.local.pos = 0;
 
 	function logClientValue<
 		T /* following extends should not be required: */ extends Record<string, unknown>,
@@ -46,7 +48,7 @@ export function checkCompiles(): void {
 	}
 
 	// Create new cursor state
-	const cursor = map.cursor;
+	const cursor = props.cursor;
 
 	// Update our cursor position
 	cursor.local = { x: 1, y: 2 };

--- a/packages/framework/presence/src/test/notificationsManager.spec.ts
+++ b/packages/framework/presence/src/test/notificationsManager.spec.ts
@@ -69,7 +69,7 @@ export function checkCompiles(): void {
 		);
 	}
 
-	const chat = notifications.chat;
+	const chat = notifications.props.chat;
 
 	chat.emit.broadcast("msg", "howdy");
 

--- a/packages/framework/presence/src/test/presenceStates.spec.ts
+++ b/packages/framework/presence/src/test/presenceStates.spec.ts
@@ -55,8 +55,9 @@ export function checkCompiles(): void {
 
 	const initialCaret = { id: "", pos: 0 };
 	states.add("caret", createValueManager(initialCaret));
+	const statesProps = states.props;
 
-	const fakeAdd = states.camera.z + states.cursor.x + states.caret.pos;
+	const fakeAdd = statesProps.camera.z + statesProps.cursor.x + statesProps.caret.pos;
 	console.log(fakeAdd);
 
 	// @ts-expect-error should error on typo detection

--- a/packages/framework/presence/src/types.ts
+++ b/packages/framework/presence/src/types.ts
@@ -55,47 +55,16 @@ export interface PresenceStatesSchema {
  * @sealed
  * @alpha
  */
-export type PresenceStatesEntries<
-	TSchema extends PresenceStatesSchema,
-	TManagerRestrictions,
-> = {
+export type PresenceStatesEntries<TSchema extends PresenceStatesSchema> = {
 	/**
 	 * Registered `Value Manager`s
 	 */
-	readonly [Key in Exclude<
-		keyof TSchema,
-		keyof PresenceStatesMethods<TSchema, TManagerRestrictions>
-	>]: ReturnType<TSchema[Key]>["manager"] extends InternalTypes.StateValue<infer TManager>
+	readonly [Key in keyof TSchema]: ReturnType<
+		TSchema[Key]
+	>["manager"] extends InternalTypes.StateValue<infer TManager>
 		? TManager
 		: never;
 };
-
-/**
- * Provides methods for managing `Value Manager`s in {@link PresenceStates}.
- *
- * @sealed
- * @alpha
- */
-export interface PresenceStatesMethods<
-	TSchema extends PresenceStatesSchema,
-	TManagerRestrictions,
-> {
-	/**
-	 * Registers a new `Value Manager` with the {@link PresenceStates}.
-	 * @param key - new unique key for the `Value Manager`
-	 * @param manager - factory for creating a `Value Manager`
-	 */
-	add<
-		TKey extends string,
-		TValue extends InternalTypes.ValueDirectoryOrState<any>,
-		TManager extends TManagerRestrictions,
-	>(
-		key: TKey,
-		manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>,
-	): asserts this is PresenceStates<
-		TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>
-	>;
-}
 
 /**
  * `PresenceStates` maintains a registry of `Value Manager`s that all share and provide access to
@@ -107,11 +76,32 @@ export interface PresenceStatesMethods<
  * @sealed
  * @alpha
  */
-export type PresenceStates<
+export interface PresenceStates<
 	TSchema extends PresenceStatesSchema,
-	TManagerRestrictions = unknown,
-> = PresenceStatesEntries<TSchema, TManagerRestrictions> &
-	PresenceStatesMethods<TSchema, TManagerRestrictions>;
+	TManagerConstraints = unknown,
+> {
+	/**
+	 * Registers a new `Value Manager` with the {@link PresenceStates}.
+	 * @param key - new unique key for the `Value Manager`
+	 * @param manager - factory for creating a `Value Manager`
+	 */
+	add<
+		TKey extends string,
+		TValue extends InternalTypes.ValueDirectoryOrState<any>,
+		TManager extends TManagerConstraints,
+	>(
+		key: TKey,
+		manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>,
+	): asserts this is PresenceStates<
+		TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>,
+		TManagerConstraints
+	>;
+
+	/**
+	 * Registry of `Value Manager`s.
+	 */
+	readonly props: PresenceStatesEntries<TSchema>;
+}
 
 // #endregion PresenceStates
 


### PR DESCRIPTION
to allow arbitrary entry names and future PresenceStates methods