### PR TITLE
fix(client-presence): Remove connectionId for self attendee disconnect

### DIFF
--- a/packages/framework/presence/src/presenceManager.ts
+++ b/packages/framework/presence/src/presenceManager.ts
@@ -85,6 +85,12 @@ class PresenceManager
 
 		runtime.on("connected", this.onConnect.bind(this));
 
+		runtime.on("disconnected", () => {
+			if (runtime.clientId !== undefined) {
+				this.removeClientConnectionId(runtime.clientId);
+			}
+		});
+
 		// Check if already connected at the time of construction.
 		// If constructed during data store load, the runtime may already be connected
 		// and the "connected" event will be raised during completion. With construction

--- a/packages/framework/presence/src/test/mockEphemeralRuntime.ts
+++ b/packages/framework/presence/src/test/mockEphemeralRuntime.ts
@@ -51,8 +51,10 @@ export class MockEphemeralRuntime implements IEphemeralRuntime {
 
 	public readonly listeners: {
 		connected: ((clientId: ClientConnectionId) => void)[];
+		disconnected: (() => void)[];
 	} = {
 		connected: [],
+		disconnected: [],
 	};
 	private isSupportedEvent(event: string): event is keyof typeof this.listeners {
 		return event in this.listeners;


### PR DESCRIPTION
## Description
We currently use Audience to listen for when remote clients disconnect from the session before removing their connection Id and setting their status to disconnected. 

This works perfectly fine for remote clients, but for the local client this is not possible since "removeMember" event is not sent to the local client that disconnected. 

To fix this we can listen to "disconnected" event on the ephemeral runtime (same way we listen to "connected") to know when the local client disconnects. 