### PR TITLE
improvement(eslint-config-fluid): Better support our existing test patterns

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @fluidframework/eslint-config-fluid Changelog
 
+## 5.5.1
+
+Update rule overrides for test code to better support patterns in the repo.
+Namely, adds the allowance to "**/tests" directories.
+
 ## [5.5.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.5.0)
 
 ### Disabled rules

--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 5.5.1
 
 Update rule overrides for test code to better support patterns in the repo.
-Namely, adds the allowance to "**/tests" directories.
+Namely, adds the allowance to "\*\*/tests" directories.
 
 ## [5.5.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.5.0)
 

--- a/common/build/eslint-config-fluid/base.js
+++ b/common/build/eslint-config-fluid/base.js
@@ -135,15 +135,11 @@ module.exports = {
 			},
 		],
 
-		// eslint-plugin-import
+		// #region eslint-plugin-import
+
 		"import/no-default-export": "error",
 		"import/no-deprecated": "off",
-		"import/no-extraneous-dependencies": [
-			"error",
-			{
-				devDependencies: ["**/*.spec.ts", "src/test/**"],
-			},
-		],
+		"import/no-extraneous-dependencies": "error",
 		"import/no-internal-modules": "error",
 		"import/no-unassigned-import": "error",
 		"import/no-unresolved": [
@@ -167,6 +163,8 @@ module.exports = {
 				},
 			},
 		],
+
+		// #region
 
 		// eslint-plugin-unicorn
 		"unicorn/better-regex": "error",

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -426,7 +426,13 @@ module.exports = {
 		},
 		{
 			// Rules only for test files
-			files: ["*.spec.ts", "*.test.ts", "**/test/**"],
+			files: [
+				"*.spec.ts",
+				"*.test.ts",
+				"**/test/**",
+				// TODO: consider unifying code across the repo to use "test" and not "tests", then we can remove this.
+				"**/tests/**",
+			],
 			rules: {
 				"@typescript-eslint/no-invalid-this": "off",
 				"@typescript-eslint/unbound-method": "off", // This rule has false positives in many of our test projects.
@@ -446,6 +452,9 @@ module.exports = {
 						),
 					},
 				],
+
+				// Test code may leverage dev dependencies
+				"import/no-extraneous-dependencies": ["error", { devDependencies: true }],
 			},
 		},
 	],

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "5.5.0",
+	"version": "5.5.1",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -579,13 +579,7 @@
             1
         ],
         "import/no-extraneous-dependencies": [
-            "error",
-            {
-                "devDependencies": [
-                    "**/*.spec.ts",
-                    "src/test/**"
-                ]
-            }
+            "error"
         ],
         "import/no-internal-modules": [
             "error",

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -569,13 +569,7 @@
             1
         ],
         "import/no-extraneous-dependencies": [
-            "error",
-            {
-                "devDependencies": [
-                    "**/*.spec.ts",
-                    "src/test/**"
-                ]
-            }
+            "error"
         ],
         "import/no-internal-modules": [
             "error",

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -581,13 +581,7 @@
             1
         ],
         "import/no-extraneous-dependencies": [
-            "error",
-            {
-                "devDependencies": [
-                    "**/*.spec.ts",
-                    "src/test/**"
-                ]
-            }
+            "error"
         ],
         "import/no-internal-modules": [
             "error",

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -579,13 +579,7 @@
             1
         ],
         "import/no-extraneous-dependencies": [
-            "error",
-            {
-                "devDependencies": [
-                    "**/*.spec.ts",
-                    "src/test/**"
-                ]
-            }
+            "error"
         ],
         "import/no-internal-modules": [
             "error",

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -598,13 +598,7 @@
             1
         ],
         "import/no-extraneous-dependencies": [
-            "error",
-            {
-                "devDependencies": [
-                    "**/*.spec.ts",
-                    "src/test/**"
-                ]
-            }
+            "error"
         ],
         "import/no-internal-modules": [
             "error",

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -581,10 +581,7 @@
         "import/no-extraneous-dependencies": [
             "error",
             {
-                "devDependencies": [
-                    "**/*.spec.ts",
-                    "src/test/**"
-                ]
+                "devDependencies": true
             }
         ],
         "import/no-internal-modules": [

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -196,10 +196,17 @@ module.exports = {
 		},
 		{
 			// Rules for test code
-			files: ["*.spec.ts", "*.test.ts", "**/test/**"],
+			files: [
+				"*.spec.ts",
+				"*.test.ts",
+				"**/test/**",
+				// TODO: consider unifying code across the repo to use "test" and not "tests", then we can remove this.
+				"**/tests/**",
+			],
 			rules: {
 				// Does not work well with describe/it block scoping
 				"unicorn/consistent-function-scoping": "off",
+
 				// We run most of our tests in a Node.js environment, so this rule is not important and makes
 				// file-system logic more cumbersome.
 				"unicorn/prefer-module": "off",


### PR DESCRIPTION
A number of our "example" packages are structured such that their tests live under "/tests". Our eslint config previously assumed that tests would live under "**/test". This PR updates our test pattern lists to allow "**/tests".

I am personally of the opinion that we should clean up usages of "tests" and be consistent with our test directory naming across the repo. But until such a time as that has been done, the eslint configs will now better support the _current_ state of the repo.
 
This PR also updates the pattern used for allowing dev dependency use in tests to be a bit simpler (see updated reports for reference).

[AB#23035](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/23035)