### PR TITLE
docs(client-presence): changelog & changeset updates

### DIFF
--- a/.changeset/twenty-cameras-take.md
+++ b/.changeset/twenty-cameras-take.md
@@ -7,6 +7,12 @@
 
 Presence package updates
 
+#### Package scope advanced from `@fluid-experimental` ([#23073](https://github.com/microsoft/FluidFramework/pull/23073))
+
+To update existing:
+- package.json: replace `@fluid-experimental/presence` with `@fluidframework/presence`
+- code imports: replace `@fluid-experimental/presence` with `@fluidframework/presence/alpha`
+
 #### The methods and properties of `PresenceStates` have been reorganized ([#23021](https://github.com/microsoft/FluidFramework/pull/23021))
 
 The `PresenceStatesEntries` object, which represents each of the states in the `PresenceStates` schema, has been moved from directly within `PresenceStates` to under property names `props`. Only the `add` method remains directly within `PresenceStates`. The type `PresenceStatesMethods` has also been removed since it is no longer used.

--- a/.changeset/twenty-cameras-take.md
+++ b/.changeset/twenty-cameras-take.md
@@ -5,6 +5,14 @@
 "section": other
 ---
 
-Untangle `PresenceStates` methods and properties
+Presence package updates
 
-`PresenceStatesEntries` which represent each of the states in `PresenceStates` schema have been relocated from directly within `PresenceStates` to under property names `prop`. Only the `add` method remains. (Type `PresenceStatesMethods` has been removed.)
+#### The methods and properties of `PresenceStates` have been reorganized ([#23021](https://github.com/microsoft/FluidFramework/pull/23021))
+
+The `PresenceStatesEntries` object, which represents each of the states in the `PresenceStates` schema, has been moved from directly within `PresenceStates` to under property names `props`. Only the `add` method remains directly within `PresenceStates`. The type `PresenceStatesMethods` has also been removed since it is no longer used.
+
+To update existing code, access your presence states from the `props` property instead of directly on the `PresenceStates` object. For example:
+```patch
+- presenceStatesWorkspace.myMap.local.get("key1");
++ presenceStatesWorkspace.props.myMap.local.get("key1");
+```

--- a/packages/framework/presence/CHANGELOG.md
+++ b/packages/framework/presence/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ### Minor Changes
 
--   ISessionClient now exposes connectivity information ([#22973](https://github.com/microsoft/FluidFramework/pull/22973)) [6096657620](https://github.com/microsoft/FluidFramework/commit/609665762050b5f3baf737d752fc87ef962b3a21)
+ISessionClient now exposes connectivity information
 
-    1. `ISessionClient` has a new method, `getConnectionStatus()`, with two possible states: `Connected` and `Disconnected`.
-    2. `ISessionClient`'s `connectionId()` member has been renamed to `getConnectionId()` for consistency.
-    3. `IPresence` event `attendeeDisconnected` is now implemented.
+    1. `ISessionClient` has a new method, `getConnectionStatus()`, with two possible states: `Connected` and `Disconnected`. ([#22833](https://github.com/microsoft/FluidFramework/pull/22833))
+    2. `ISessionClient`'s `connectionId()` member has been renamed to `getConnectionId()` for consistency. ([#22973](https://github.com/microsoft/FluidFramework/issues/22973))
+    3. `IPresence` event `attendeeDisconnected` is now implemented. ([#22833](https://github.com/microsoft/FluidFramework/pull/22833))
 
 ## 2.4.0
 
-Dependency updates only.
+Various implementation improvements.
 
 ## 2.3.0
 


### PR DESCRIPTION
1. Setup changeset to be used for all `Presence` changes
2. Add notes for rename
3. Update CHANGELOG to reflect 2.50 release notes and [vague] 2.4.0 history