### PR TITLE
Check if code coverage analysis cares about comments when calculating line coverage

### DIFF
--- a/packages/common/client-utils/src/events/emitter.ts
+++ b/packages/common/client-utils/src/events/emitter.ts
@@ -20,6 +20,950 @@ import type {
  * @param defaultValue - a function which returns a default value. This is called and used to set an initial value for the given key in the map if none exists
  * @returns either the existing value for the given key, or the newly-created value (the result of `defaultValue`)
  * @internal
+ *
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ * Adding a ton of comment lines
+ *
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
+ * @example
+ * ```typescript
+ * function functionInComment(arg1: string) {
+ *   return 1;
+ * }
+ * ```
  */
 function getOrCreate<K, V>(map: MapGetSet<K, V>, key: K, defaultValue: (key: K) => V): V {
 	let value = map.get(key);


### PR DESCRIPTION
## Description

Adding a bunch of comments to a file, to see if the reported line coverage decreases due to longer comment blocks. Hopefully not :).

Also checking if functions in comments cause the stats (% of functions covered) for the file to change incorrectly.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).