### PR TITLE
Fix race condition while establishing connection due to multiplexing in ODSP Driver

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -641,7 +641,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 		// we dispose connection object and stop listening to further events on the socket. Due to this we get stuck as the connection
 		// is not yet established and so we don't return any connection object to the client(connection manager). So, we remain stuck.
 		// In order to handle this, listen for the "disconnect" event and reject the promise with the error so that the caller can
-		// know anf handle the error.
+		// know and handle the error.
 		this.on("disconnect", (reason: IAnyDriverError) => {
 			if (!p.isCompleted) {
 				p.reject(reason);

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -634,7 +634,26 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 			}
 		});
 
-		await super.initialize(connectMessage, timeout).finally(() => {
+		const p = new Deferred<void>();
+		// Due to socket reuse(multiplexing), we can get "disconnect" event from other clients in the socket reference.
+		// So, a race condition could happen, where this client is establishing connection and listening for "connect_document_success"
+		// on the socket among other events, but we get "disconnect" event on the socket reference from other clients, in which case,
+		// we dispose connection object and stop listening to further events on the socket. Due to this we get stuck as the connection
+		// is not yet established and so we don't return any connection object to the client(connection manager). So, we remain stuck.
+		// In order to handle this, listen for the "disconnect" event and reject the promise with the error so that the caller can
+		// know anf handle the error.
+		this.on("disconnect", (reason: IAnyDriverError) => {
+			if (!p.isCompleted) {
+				p.reject(reason);
+			}
+		});
+
+		super
+			.initialize(connectMessage, timeout)
+			.then(() => p.resolve())
+			.catch((error) => p.reject(error));
+
+		await p.promise.finally(() => {
 			this.logger.sendTelemetryEvent({
 				eventName: "ConnectionAttemptInfo",
 				...this.getConnectionDetailsProps(),
@@ -642,7 +661,6 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 		});
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	protected addTrackedListener(event: string, listener: (...args: any[]) => void): void {
 		// override some event listeners in order to support multiple documents/clients over the same websocket
 		switch (event) {

--- a/packages/drivers/odsp-driver/src/test/socketTests/socketMock.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/socketMock.ts
@@ -42,6 +42,9 @@ export interface IMockSocketConnectResponse {
 		  }
 		| {
 				eventToEmit: "connect_timeout";
+		  }
+		| {
+				eventToEmit: undefined;
 		  };
 }
 
@@ -52,7 +55,7 @@ export interface IMockSocketConnectResponse {
 export class ClientSocketMock extends TypedEventEmitter<SocketMockEvents> {
 	public disconnected = false;
 	constructor(
-		private readonly mockSocketConnectResponse: IMockSocketConnectResponse = {
+		private mockSocketConnectResponse: IMockSocketConnectResponse = {
 			connect_document: { eventToEmit: "connect_document_success" },
 		},
 	) {
@@ -102,6 +105,16 @@ export class ClientSocketMock extends TypedEventEmitter<SocketMockEvents> {
 			this.disconnect();
 		}
 		this.emit("server_disconnect", socketError, clientId);
+	}
+
+	/**
+	 * Use this to set connect response when the socket is reused.
+	 * @param connectResponse - response to be send on connect event.
+	 */
+	public setMockSocketConnectResponseForReuse(
+		connectResponse: IMockSocketConnectResponse,
+	): void {
+		this.mockSocketConnectResponse = connectResponse;
 	}
 
 	public emit(eventName: string, ...args: unknown[]): boolean {

--- a/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
@@ -490,4 +490,61 @@ describe("OdspDocumentDeltaConnection tests", () => {
 			"1 get_ops_response listener should exiist",
 		);
 	});
+
+	it("Multiple connection objects should handle server_disconnect event when the second client is still waiting for connection to complete", async () => {
+		socket = new ClientSocketMock();
+		const connection1 = await mockSocket(socket as unknown as Socket, async () =>
+			OdspDocumentDeltaConnection.create(
+				tenantId,
+				documentId,
+				token,
+				client,
+				webSocketUrl,
+				logger,
+				60000,
+				epochTracker,
+				socketReferenceKeyPrefix,
+			),
+		);
+
+		socket.setMockSocketConnectResponseForReuse({
+			connect_document: { eventToEmit: undefined },
+		});
+		let connection2Fails = false;
+		let errorReceived: IAnyDriverError | undefined;
+		const connection2 = mockSocket(socket as unknown as Socket, async () =>
+			OdspDocumentDeltaConnection.create(
+				tenantId,
+				documentId,
+				token,
+				client,
+				webSocketUrl,
+				logger,
+				60000,
+				epochTracker,
+				socketReferenceKeyPrefix,
+			),
+		).catch((error: IAnyDriverError) => {
+			connection2Fails = true;
+			errorReceived = error;
+		});
+		let disconnectedEvent1 = false;
+
+		const errorToThrow = { message: "OdspSocketError", code: 400 };
+		connection1.on("disconnect", (reason: IAnyDriverError) => {
+			disconnectedEvent1 = true;
+		});
+
+		socket.sendServerDisconnectEvent(errorToThrow);
+
+		assert(disconnectedEvent1, "disconnect event should happen on first object");
+
+		assert(socket !== undefined && !socket.connected, "socket should be disconnected");
+		checkListenerCount(socket);
+		await connection2;
+		assert(connection2Fails, "connection2 should fail");
+		assert(errorReceived?.message.includes("server_disconnect"), "message should be correct");
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+		assert((errorReceived as any).statusCode === 400, "status code should be correct");
+	});
 });


### PR DESCRIPTION
## Description

[AB#22192](https://dev.azure.com/fluidframework/internal/_workitems/edit/22192)

This fixes a bug reported by Loop where the reconnecting banner did not go away after user returned after being dormant for some time.

Reason for the bug:
Due to socket reuse(multiplexing), we can get "disconnect" event from other clients in the socket reference. So, a race condition could happen, where this client is establishing connection and listening for "connect_document_success" on the socket among other events, but we get "disconnect" event on the socket reference from other clients, in which case, we dispose connection object and stop listening to further events on the socket. Due to this we get stuck as the connection is not yet established and so we don't return any connection object to the client (connection manager). So, we remain stuck.
In order to handle this, listen for the "disconnect" event and reject the promise with the error so that the caller can know and handle the error.