### PR TITLE
fix(client-presence): export SessionClientStatus type and constant

### DIFF
--- a/packages/framework/presence/src/index.ts
+++ b/packages/framework/presence/src/index.ts
@@ -37,11 +37,11 @@ export type {
 	PresenceWorkspaceAddress,
 } from "./types.js";
 
-export type {
-	ClientSessionId,
-	IPresence,
-	ISessionClient,
-	PresenceEvents,
+export {
+	type ClientSessionId,
+	type IPresence,
+	type ISessionClient,
+	type PresenceEvents,
 	SessionClientStatus,
 } from "./presence.js";
 


### PR DESCRIPTION
## Description

Currently only exporting SessionClientStatus, this change exports both the type and the constant values