### PR TITLE
feat: Allow recursive maps from objects

### DIFF
--- a/.changeset/moody-flies-fly.md
+++ b/.changeset/moody-flies-fly.md
@@ -1,0 +1,26 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+---
+---
+"section": tree
+---
+
+Allow constructing recursive maps from objects
+
+Previously only non-recursive maps could be constructed from objects.
+Now all maps nodes can constructed from objects:
+
+```typescript
+class MapRecursive extends sf.mapRecursive("Map", [() => MapRecursive]) {}
+{
+	type _check = ValidateRecursiveSchema<typeof MapRecursive>;
+}
+// New:
+const fromObject = new MapRecursive({ x: new MapRecursive() });
+// Existing:
+const fromIterator = new MapRecursive([["x", new MapRecursive()]]);
+const fromMap = new MapRecursive(new Map([["x", new MapRecursive()]]));
+const fromNothing = new MapRecursive();
+const fromUndefined = new MapRecursive(undefined);
+```

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -595,6 +595,8 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
         string,
         InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>
         ]>;
+    } | {
+        readonly [x: string]: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
     }, false, T, undefined>;
     readonly null: TreeNodeSchemaNonClass<"com.fluidframework.leaf.null", NodeKind.Leaf, null, null, true, unknown, never>;
     readonly number: TreeNodeSchemaNonClass<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number, true, unknown, never>;

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -383,6 +383,8 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
         string,
         InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>
         ]>;
+    } | {
+        readonly [x: string]: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
     }, false, T, undefined>;
     readonly null: TreeNodeSchemaNonClass<"com.fluidframework.leaf.null", NodeKind.Leaf, null, null, true, unknown, never>;
     readonly number: TreeNodeSchemaNonClass<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number, true, unknown, never>;

--- a/packages/dds/tree/api-report/tree.legacy.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.alpha.api.md
@@ -378,6 +378,8 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
         string,
         InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>
         ]>;
+    } | {
+        readonly [x: string]: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
     }, false, T, undefined>;
     readonly null: TreeNodeSchemaNonClass<"com.fluidframework.leaf.null", NodeKind.Leaf, null, null, true, unknown, never>;
     readonly number: TreeNodeSchemaNonClass<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number, true, unknown, never>;

--- a/packages/dds/tree/api-report/tree.legacy.public.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.public.api.md
@@ -378,6 +378,8 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
         string,
         InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>
         ]>;
+    } | {
+        readonly [x: string]: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
     }, false, T, undefined>;
     readonly null: TreeNodeSchemaNonClass<"com.fluidframework.leaf.null", NodeKind.Leaf, null, null, true, unknown, never>;
     readonly number: TreeNodeSchemaNonClass<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number, true, unknown, never>;

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -378,6 +378,8 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
         string,
         InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>
         ]>;
+    } | {
+        readonly [x: string]: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
     }, false, T, undefined>;
     readonly null: TreeNodeSchemaNonClass<"com.fluidframework.leaf.null", NodeKind.Leaf, null, null, true, unknown, never>;
     readonly number: TreeNodeSchemaNonClass<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number, true, unknown, never>;

--- a/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
@@ -805,7 +805,7 @@ export class SchemaFactory<
 			allowedTypes as T & ImplicitAllowedTypes,
 			true,
 			// Setting this (implicitlyConstructable) to true seems to work ok currently, but not for other node kinds.
-			// Supporting this could be fragile and might break other future changes, so its being kept as false for now.
+			// Supporting this could be fragile and might break other future changes, so it's being kept as false for now.
 			false,
 		);
 

--- a/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
@@ -804,6 +804,8 @@ export class SchemaFactory<
 			name,
 			allowedTypes as T & ImplicitAllowedTypes,
 			true,
+			// Setting this (implicitlyConstructable) to true seems to work ok currently, but not for other node kinds.
+			// Supporting this could be fragile and might break other future changes, so its being kept as false for now.
 			false,
 		);
 
@@ -811,24 +813,29 @@ export class SchemaFactory<
 			ScopedSchemaName<TScope, Name>,
 			NodeKind.Map,
 			TreeMapNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>, NodeKind.Map>,
-			{
-				/**
-				 * Iterator for the iterable of content for this node.
-				 * @privateRemarks
-				 * Wrapping the constructor parameter for recursive arrays and maps in an inlined object type avoids (for unknown reasons)
-				 * the following compile error when declaring the recursive schema:
-				 * `Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.`
-				 * To benefit from this without impacting the API, the definition of `Iterable` has been inlined as such an object.
-				 *
-				 * If this workaround is kept, ideally this comment would be deduplicated with the other instance of it.
-				 * Unfortunately attempts to do this failed to avoid the compile error this was introduced to solve.
-				 */
-				[Symbol.iterator](): Iterator<
-					[string, InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>]
-				>;
-			},
-			// Ideally this would be included, but doing so breaks recursive types.
-			// | RestrictiveStringRecord<InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>>,
+			| {
+					/**
+					 * Iterator for the iterable of content for this node.
+					 * @privateRemarks
+					 * Wrapping the constructor parameter for recursive arrays and maps in an inlined object type avoids (for unknown reasons)
+					 * the following compile error when declaring the recursive schema:
+					 * `Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.`
+					 * To benefit from this without impacting the API, the definition of `Iterable` has been inlined as such an object.
+					 *
+					 * If this workaround is kept, ideally this comment would be deduplicated with the other instance of it.
+					 * Unfortunately attempts to do this failed to avoid the compile error this was introduced to solve.
+					 */
+					[Symbol.iterator](): Iterator<
+						[string, InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>]
+					>;
+			  }
+			// Ideally this would be
+			// RestrictiveStringRecord<InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>>,
+			// but doing so breaks recursive types.
+			// Instead we do a less nice version:
+			| {
+					readonly [P in string]: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
+			  },
 			false,
 			T,
 			undefined

--- a/packages/dds/tree/src/simple-tree/api/schemaFactoryRecursive.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactoryRecursive.ts
@@ -140,7 +140,7 @@ export type ValidateRecursiveSchema<
 				? Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T["info"]>]>
 				: unknown;
 		}[T["kind"]],
-		// ImplicitlyConstructable: recursive types are not implicitly constructable.
+		// ImplicitlyConstructable: recursive types are currently not implicitly constructable.
 		false,
 		// Info: What's passed to the method to create the schema. Constraining these here should be about as effective as if the actual constraints existed on the actual method itself.
 		{

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
@@ -21,6 +21,7 @@ import {
 	type InternalTreeNode,
 	type FlexListToUnion,
 	type ApplyKindInput,
+	type NodeBuilderData,
 } from "../../../simple-tree/index.js";
 import type {
 	ValidateRecursiveSchema,
@@ -579,26 +580,49 @@ describe("SchemaFactory Recursive methods", () => {
 	});
 
 	describe("mapRecursive", () => {
-		it("simple", () => {
-			class MapRecursive extends sf.mapRecursive("Map", [() => MapRecursive]) {}
-			{
-				type _check = ValidateRecursiveSchema<typeof MapRecursive>;
-			}
+		class MapRecursive extends sf.mapRecursive("Map", [() => MapRecursive]) {}
+		{
+			type _check = ValidateRecursiveSchema<typeof MapRecursive>;
+		}
+
+		it("basic use", () => {
 			const node = hydrate(MapRecursive, new MapRecursive([]));
 			const data = [...node];
 			assert.deepEqual(data, []);
 
 			// Nested
 			{
-				type T = InsertableTreeNodeFromImplicitAllowedTypes<typeof MapRecursive>;
-				const _check: T = new MapRecursive([]);
+				type TInsert = InsertableTreeNodeFromImplicitAllowedTypes<typeof MapRecursive>;
+				const _check: TInsert = new MapRecursive([]);
+
 				// Only explicitly constructed recursive maps are currently allowed:
-				type _check = requireTrue<areSafelyAssignable<T, MapRecursive>>;
+				type _check1 = requireTrue<areSafelyAssignable<TInsert, MapRecursive>>;
+
+				// Check constructor
+				type TBuild = NodeBuilderData<typeof MapRecursive>;
+				type _check2 = requireAssignableTo<MapRecursive, TBuild>;
+				type _check3 = requireAssignableTo<[], TBuild>;
+				type _check4 = requireAssignableTo<[[string, TInsert]], TBuild>;
 			}
 
 			node.set("x", new MapRecursive([]));
 
 			node.get("x")?.set("x", new MapRecursive(new Map()));
+		});
+
+		it("constructors", () => {
+			const fromIterator = new MapRecursive([["x", new MapRecursive()]]);
+			const fromMap = new MapRecursive(new Map([["x", new MapRecursive()]]));
+			const fromObject = new MapRecursive({ x: new MapRecursive() });
+
+			const fromNothing = new MapRecursive();
+			const fromUndefined = new MapRecursive(undefined);
+
+			// If supporting implicit construction, these would work:
+			// @ts-expect-error Implicit construction disabled
+			const fromNestedNeverArray = new MapRecursive({ x: [] });
+			// @ts-expect-error Implicit construction disabled
+			const fromNestedObject = new MapRecursive({ x: { x: [] } });
 		});
 	});
 

--- a/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
@@ -333,19 +333,20 @@ export function generateTestTrees(options: SharedTreeOptions) {
 			name: "nested-sequence-change",
 			runScenario: async (takeSnapshot) => {
 				const sf = new SchemaFactory("test trees");
-				class SequenceMap extends sf.mapRecursive("Recursive Map", [
-					() => sf.array(SequenceMap),
+				class Array extends sf.arrayRecursive('Array<["test trees.Recursive Map"]>', [
+					() => SequenceMap,
 				]) {}
+				class SequenceMap extends sf.mapRecursive("Recursive Map", [() => Array]) {}
 
 				const provider = new TestTreeProviderLite(1, factory, true);
 				const tree = provider.trees[0];
 				const view = tree.viewWith(
 					new TreeViewConfiguration({
-						schema: [sf.array(SequenceMap)],
+						schema: Array,
 						enableSchemaValidation,
 					}),
 				);
-				view.initialize([]);
+				view.initialize(new Array([]));
 				provider.processMessages();
 
 				// We must make this shallow change to the sequence field as part of the same transaction as the
@@ -354,7 +355,8 @@ export function generateTestTrees(options: SharedTreeOptions) {
 					view.root.insertAtStart(new SequenceMap([]));
 					const map = view.root[0];
 					const innerArray: SequenceMap[] = [];
-					map.set("foo", [new SequenceMap([["bar", innerArray]])]);
+					map.set("foo", new Array([new SequenceMap([["bar", new Array(innerArray)]])]));
+					// Since innerArray is an array, not an actual node, this does nothing (other than ensure innerArray was copied and thus the tree was not modified by this change)
 					innerArray.push(new SequenceMap([]));
 				});
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -948,6 +948,8 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
         string,
         InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>
         ]>;
+    } | {
+        readonly [x: string]: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
     }, false, T, undefined>;
     readonly null: TreeNodeSchemaNonClass<"com.fluidframework.leaf.null", NodeKind.Leaf, null, null, true, unknown, never>;
     readonly number: TreeNodeSchemaNonClass<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number, true, unknown, never>;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -733,6 +733,8 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
         string,
         InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>
         ]>;
+    } | {
+        readonly [x: string]: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
     }, false, T, undefined>;
     readonly null: TreeNodeSchemaNonClass<"com.fluidframework.leaf.null", NodeKind.Leaf, null, null, true, unknown, never>;
     readonly number: TreeNodeSchemaNonClass<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number, true, unknown, never>;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -1030,6 +1030,8 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
         string,
         InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>
         ]>;
+    } | {
+        readonly [x: string]: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
     }, false, T, undefined>;
     readonly null: TreeNodeSchemaNonClass<"com.fluidframework.leaf.null", NodeKind.Leaf, null, null, true, unknown, never>;
     readonly number: TreeNodeSchemaNonClass<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number, true, unknown, never>;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -764,6 +764,8 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
         string,
         InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>
         ]>;
+    } | {
+        readonly [x: string]: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
     }, false, T, undefined>;
     readonly null: TreeNodeSchemaNonClass<"com.fluidframework.leaf.null", NodeKind.Leaf, null, null, true, unknown, never>;
     readonly number: TreeNodeSchemaNonClass<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number, true, unknown, never>;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -728,6 +728,8 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
         string,
         InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>
         ]>;
+    } | {
+        readonly [x: string]: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T>;
     }, false, T, undefined>;
     readonly null: TreeNodeSchemaNonClass<"com.fluidframework.leaf.null", NodeKind.Leaf, null, null, true, unknown, never>;
     readonly number: TreeNodeSchemaNonClass<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number, true, unknown, never>;


### PR DESCRIPTION
## Description

It turns out the reason I couldn't allow constructing recursive maps from objects previously could be overcome my inlining the types. I don't have a complete understanding of how inlineing type sometimes allows recursive types to work better, but in this case it worked.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

