### PR TITLE
refactor: Make all pipelines use new agent pools in eastus2

### DIFF
--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -114,7 +114,7 @@ extends:
     - test:copyresults
     taskLint: true
     taskLintName: ci:eslint
-    poolBuild: Large-centralus
+    poolBuild: Large-eastus2
     checkoutSubmodules: true
     taskBundleAnalysis: false
     checks:

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -114,7 +114,7 @@ extends:
     - test:copyresults
     taskLint: true
     taskLintName: ci:eslint
-    poolBuild: NewLarge-linux-1ES
+    poolBuild: Large-centralus
     checkoutSubmodules: true
     taskBundleAnalysis: false
     checks:

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -39,7 +39,7 @@ extends:
     tagName: bundle-and-code-coverage-artifacts
     # This pipeline doesn't generate production artifacts but the build-npm-package template is too intertwined with
     # that scenario, which requires that the pipeline runs in the 1ES pool.
-    poolBuild: NewLarge-linux-1ES
+    poolBuild: Large-centralus
     checkoutSubmodules: true
     releaseBuildOverride: none
     publishOverride: default

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -39,7 +39,7 @@ extends:
     tagName: bundle-and-code-coverage-artifacts
     # This pipeline doesn't generate production artifacts but the build-npm-package template is too intertwined with
     # that scenario, which requires that the pipeline runs in the 1ES pool.
-    poolBuild: Large-centralus
+    poolBuild: Large-eastus2
     checkoutSubmodules: true
     releaseBuildOverride: none
     publishOverride: default

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -193,7 +193,7 @@ extends:
     buildDirectory: .
     tagName: client
     isReleaseGroup: true
-    poolBuild: NewLarge-linux-1ES
+    poolBuild: Large-centralus
     checkoutSubmodules: true
     taskBundleAnalysis: true
     taskLint: false # Linting is captured by `ci:build` via fluid-build

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -193,7 +193,7 @@ extends:
     buildDirectory: .
     tagName: client
     isReleaseGroup: true
-    poolBuild: Large-centralus
+    poolBuild: Large-eastus2
     checkoutSubmodules: true
     taskBundleAnalysis: true
     taskLint: false # Linting is captured by `ci:build` via fluid-build

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -100,7 +100,7 @@ stages:
     - job: debug_variables
       displayName: Show Variables
       dependsOn: [] # run in parallel
-      pool: Small-centralus
+      pool: Small-eastus2
       steps:
         - checkout: none
         - script: |
@@ -121,7 +121,7 @@ stages:
     - job: component_detection
       displayName: Component Detection
       dependsOn: [] # run in parallel
-      pool: Small-centralus
+      pool: Small-eastus2
       steps:
         - task: ComponentGovernanceComponentDetection@0
           displayName: Component Detection
@@ -135,7 +135,7 @@ stages:
       displayName: 'Combine api-extractor JSON'
       dependsOn: [] # run in parallel
       environment: 'fluid-docs-env'
-      pool: Large-centralus
+      pool: Large-eastus2
       strategy:
         runOnce:
           deploy:
@@ -148,7 +148,7 @@ stages:
     - job: build_site
       displayName: 'Build website'
       dependsOn: upload_json
-      pool: Large-centralus
+      pool: Large-eastus2
       steps:
         - checkout: self
           submodules: false
@@ -194,7 +194,7 @@ stages:
 - stage: guardian
   displayName: Guardian
   dependsOn: [] # run in parallel
-  pool: Large-centralus
+  pool: Large-eastus2
   jobs:
     - job: guardian_tasks
       displayName: Guardian tasks
@@ -256,7 +256,7 @@ stages:
 - stage: link_check
   displayName: 'Website Link Check'
   dependsOn: [] # run in parallel
-  pool: Large-centralus
+  pool: Large-eastus2
   jobs:
     - job: link_check
       displayName: 'Website Link Check'
@@ -297,7 +297,7 @@ stages:
 
 - stage: check_branch_version
   displayName: 'Check Version Deployment Condition'
-  pool: Small-centralus
+  pool: Small-eastus2
   jobs:
     - job: check_branch_version
       displayName: 'Check Version Deployment Condition'
@@ -329,7 +329,7 @@ stages:
 
 - stage: deploy
   displayName: 'Deploy website'
-  pool: Small-centralus
+  pool: Small-eastus2
   dependsOn: ['build', 'guardian', 'check_branch_version']
   variables:
     deployOverrideVar: ${{ parameters.deployOverride }}

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -100,7 +100,7 @@ stages:
     - job: debug_variables
       displayName: Show Variables
       dependsOn: [] # run in parallel
-      pool: Small
+      pool: Small-centralus
       steps:
         - checkout: none
         - script: |
@@ -121,7 +121,7 @@ stages:
     - job: component_detection
       displayName: Component Detection
       dependsOn: [] # run in parallel
-      pool: Small
+      pool: Small-centralus
       steps:
         - task: ComponentGovernanceComponentDetection@0
           displayName: Component Detection
@@ -135,7 +135,7 @@ stages:
       displayName: 'Combine api-extractor JSON'
       dependsOn: [] # run in parallel
       environment: 'fluid-docs-env'
-      pool: Large
+      pool: Large-centralus
       strategy:
         runOnce:
           deploy:
@@ -148,7 +148,7 @@ stages:
     - job: build_site
       displayName: 'Build website'
       dependsOn: upload_json
-      pool: Large
+      pool: Large-centralus
       steps:
         - checkout: self
           submodules: false
@@ -194,7 +194,7 @@ stages:
 - stage: guardian
   displayName: Guardian
   dependsOn: [] # run in parallel
-  pool: Large
+  pool: Large-centralus
   jobs:
     - job: guardian_tasks
       displayName: Guardian tasks
@@ -256,7 +256,7 @@ stages:
 - stage: link_check
   displayName: 'Website Link Check'
   dependsOn: [] # run in parallel
-  pool: Large
+  pool: Large-centralus
   jobs:
     - job: link_check
       displayName: 'Website Link Check'
@@ -297,7 +297,7 @@ stages:
 
 - stage: check_branch_version
   displayName: 'Check Version Deployment Condition'
-  pool: Small
+  pool: Small-centralus
   jobs:
     - job: check_branch_version
       displayName: 'Check Version Deployment Condition'
@@ -329,7 +329,7 @@ stages:
 
 - stage: deploy
   displayName: 'Deploy website'
-  pool: Small
+  pool: Small-centralus
   dependsOn: ['build', 'guardian', 'check_branch_version']
   variables:
     deployOverrideVar: ${{ parameters.deployOverride }}

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -39,7 +39,7 @@ extends:
     template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:
-      name: Small-centralus
+      name: Small-eastus2
       os: linux
     sdl:
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -39,7 +39,7 @@ extends:
     template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:
-      name: Small-1ES # This is one of the Fluid Orgs new 1ES hosted pools.
+      name: Small-centralus
       os: linux
     sdl:
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -130,7 +130,7 @@ extends:
     packageManager: pnpm
     tagName: server
     isReleaseGroup: true
-    pool: Large-centralus
+    pool: Large-eastus2
     pack: true
     lint: true
     test: ci:test

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -130,7 +130,7 @@ extends:
     packageManager: pnpm
     tagName: server
     isReleaseGroup: true
-    pool: NewLarge-linux-1ES
+    pool: Large-centralus
     pack: true
     lint: true
     test: ci:test

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -52,7 +52,7 @@ parameters:
 
   - name: pool
     type: string
-    default: Small-centralus
+    default: Small-eastus2
 
   - name: buildToolsVersionToInstall
     type: string

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -52,7 +52,7 @@ parameters:
 
   - name: pool
     type: string
-    default: Small-1ES
+    default: Small-centralus
 
   - name: buildToolsVersionToInstall
     type: string

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -53,7 +53,7 @@ parameters:
 
 - name: poolBuild
   type: object
-  default: Small-1ES
+  default: Small-centralus
 
 - name: preCG
   type: stepList
@@ -679,7 +679,7 @@ extends:
           jobs:
             - job: upload_run_telemetry
               displayName: Upload pipeline run telemetry to Kusto
-              pool: Small-1ES
+              pool: Small-centralus
               variables:
               - group: ado-feeds
               - name: pipelineTelemetryWorkdir

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -53,7 +53,7 @@ parameters:
 
 - name: poolBuild
   type: object
-  default: Small-centralus
+  default: Small-eastus2
 
 - name: preCG
   type: stepList
@@ -679,7 +679,7 @@ extends:
           jobs:
             - job: upload_run_telemetry
               displayName: Upload pipeline run telemetry to Kusto
-              pool: Small-centralus
+              pool: Small-eastus2
               variables:
               - group: ado-feeds
               - name: pipelineTelemetryWorkdir

--- a/tools/pipelines/templates/include-conditionally-run-stress-tests.yml
+++ b/tools/pipelines/templates/include-conditionally-run-stress-tests.yml
@@ -20,7 +20,7 @@ parameters:
 
 - name: pool
   type: object
-  default: Small
+  default: Small-centralus
 
 # The supported values are: short, normal, long
 - name: stressMode
@@ -36,7 +36,7 @@ parameters:
 stages:
   - stage: CheckAffectedPaths
     displayName: Determine changed packages
-    pool: Small
+    pool: Small-centralus
     jobs:
     - job: Job
       displayName: Check for DDS package changes

--- a/tools/pipelines/templates/include-conditionally-run-stress-tests.yml
+++ b/tools/pipelines/templates/include-conditionally-run-stress-tests.yml
@@ -20,7 +20,7 @@ parameters:
 
 - name: pool
   type: object
-  default: Small-centralus
+  default: Small-eastus2
 
 # The supported values are: short, normal, long
 - name: stressMode
@@ -36,7 +36,7 @@ parameters:
 stages:
   - stage: CheckAffectedPaths
     displayName: Determine changed packages
-    pool: Small-centralus
+    pool: Small-eastus2
     jobs:
     - job: Job
       displayName: Check for DDS package changes

--- a/tools/pipelines/templates/include-policy-check.yml
+++ b/tools/pipelines/templates/include-policy-check.yml
@@ -28,7 +28,7 @@ stages:
 - stage: run_checks
   dependsOn: [] # Has no prereqs
   displayName: Policy checks
-  pool: Small-centralus
+  pool: Small-eastus2
   jobs:
   - job:
     displayName: Run checks

--- a/tools/pipelines/templates/include-policy-check.yml
+++ b/tools/pipelines/templates/include-policy-check.yml
@@ -28,7 +28,7 @@ stages:
 - stage: run_checks
   dependsOn: [] # Has no prereqs
   displayName: Policy checks
-  pool: Small-1ES
+  pool: Small-centralus
   jobs:
   - job:
     displayName: Run checks

--- a/tools/pipelines/templates/include-publish-docker-service-steps.yml
+++ b/tools/pipelines/templates/include-publish-docker-service-steps.yml
@@ -9,7 +9,7 @@ parameters:
 
 - name: pool
   type: object
-  default: Small-1ES
+  default: Small-centralus
 
 - name: containerRegistry
   type: string

--- a/tools/pipelines/templates/include-publish-docker-service-steps.yml
+++ b/tools/pipelines/templates/include-publish-docker-service-steps.yml
@@ -9,7 +9,7 @@ parameters:
 
 - name: pool
   type: object
-  default: Small-centralus
+  default: Small-eastus2
 
 - name: containerRegistry
   type: string

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -15,7 +15,7 @@ parameters:
 
 - name: pool
   type: object
-  default: Small-centralus
+  default: Small-eastus2
 
 - name: publishFlags
   type: string

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -15,7 +15,7 @@ parameters:
 
 - name: pool
   type: object
-  default: Small-1ES
+  default: Small-centralus
 
 - name: publishFlags
   type: string

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -9,7 +9,7 @@ parameters:
 
 - name: pool
   type: object
-  default: Small-1ES
+  default: Small-centralus
 
 - name: isReleaseGroup
   type: boolean

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -9,7 +9,7 @@ parameters:
 
 - name: pool
   type: object
-  default: Small-centralus
+  default: Small-eastus2
 
 - name: isReleaseGroup
   type: boolean

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -34,7 +34,7 @@ parameters:
 
 - name: poolBuild
   type: object
-  default: Small-centralus
+  default: Small-eastus2
 
 - name: testPackage
   type: string

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -34,7 +34,7 @@ parameters:
 
 - name: poolBuild
   type: object
-  default: Small
+  default: Small-centralus
 
 - name: testPackage
   type: string

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -26,7 +26,7 @@ parameters:
 
 - name: poolBuild
   type: object
-  default: Large-centralus
+  default: Large-eastus2
 
 - name: checkoutSubmodules
   type: boolean

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -26,7 +26,7 @@ parameters:
 
 - name: poolBuild
   type: object
-  default: Large
+  default: Large-centralus
 
 - name: checkoutSubmodules
   type: boolean

--- a/tools/pipelines/templates/include-upload-stage-telemetry.yml
+++ b/tools/pipelines/templates/include-upload-stage-telemetry.yml
@@ -40,7 +40,7 @@ stages:
   jobs:
   - job: upload_run_telemetry
     displayName: Upload stage telemetry to Kusto
-    pool: Small-centralus
+    pool: Small-eastus2
     variables:
     - group: ado-feeds
 

--- a/tools/pipelines/templates/include-upload-stage-telemetry.yml
+++ b/tools/pipelines/templates/include-upload-stage-telemetry.yml
@@ -40,7 +40,7 @@ stages:
   jobs:
   - job: upload_run_telemetry
     displayName: Upload stage telemetry to Kusto
-    pool: Small
+    pool: Small-centralus
     variables:
     - group: ado-feeds
 

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -22,7 +22,7 @@ parameters:
 
 - name: poolBuild
   type: object
-  default: Large
+  default: Large-centralus
 
 - name: memoryTestPackages
   type: object

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -22,7 +22,7 @@ parameters:
 
 - name: poolBuild
   type: object
-  default: Large-centralus
+  default: Large-eastus2
 
 - name: memoryTestPackages
   type: object

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -44,7 +44,7 @@ stages:
     parameters:
       stageId: stress_tests_odsp
       stageDisplayName: Stress tests - Odsp
-      poolBuild: Large
+      poolBuild: Large-centralus
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -65,7 +65,7 @@ stages:
     parameters:
       stageId: stress_tests_odspdf
       stageDisplayName: Stress tests - Odspdf
-      poolBuild: Large
+      poolBuild: Large-centralus
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -86,7 +86,7 @@ stages:
     parameters:
       stageId: stress_tests_tinylicious
       stageDisplayName: Stress tests - tinylicious
-      poolBuild: Large
+      poolBuild: Large-centralus
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -106,7 +106,7 @@ stages:
     parameters:
       stageId: stress_tests_frs
       stageDisplayName: Stress tests - frs
-      poolBuild: Large
+      poolBuild: Large-centralus
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -126,7 +126,7 @@ stages:
     parameters:
       stageId: stress_tests_frs_canary
       stageDisplayName: Stress tests - frs canary
-      poolBuild: Large
+      poolBuild: Large-centralus
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -44,7 +44,7 @@ stages:
     parameters:
       stageId: stress_tests_odsp
       stageDisplayName: Stress tests - Odsp
-      poolBuild: Large-centralus
+      poolBuild: Large-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -65,7 +65,7 @@ stages:
     parameters:
       stageId: stress_tests_odspdf
       stageDisplayName: Stress tests - Odspdf
-      poolBuild: Large-centralus
+      poolBuild: Large-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -86,7 +86,7 @@ stages:
     parameters:
       stageId: stress_tests_tinylicious
       stageDisplayName: Stress tests - tinylicious
-      poolBuild: Large-centralus
+      poolBuild: Large-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -106,7 +106,7 @@ stages:
     parameters:
       stageId: stress_tests_frs
       stageDisplayName: Stress tests - frs
-      poolBuild: Large-centralus
+      poolBuild: Large-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -126,7 +126,7 @@ stages:
     parameters:
       stageId: stress_tests_frs_canary
       stageDisplayName: Stress tests - frs canary
-      poolBuild: Large-centralus
+      poolBuild: Large-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -44,7 +44,7 @@ stages:
     parameters:
       stageId: e2e_local_server
       stageDisplayName: e2e - local server
-      poolBuild: Large-centralus # Need Large pool for full-compat matrix
+      poolBuild: Large-eastus2 # Need Large pool for full-compat matrix
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -61,7 +61,7 @@ stages:
     parameters:
       stageId: e2e_tinylicious
       stageDisplayName: e2e - tinylicious
-      poolBuild: Large-centralus # Need Large pool for full-compat matrix
+      poolBuild: Large-eastus2 # Need Large pool for full-compat matrix
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -83,7 +83,7 @@ stages:
     parameters:
       stageId: e2e_routerlicious
       stageDisplayName: e2e - routerlicious
-      poolBuild: Small-centralus
+      poolBuild: Small-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -114,7 +114,7 @@ stages:
     parameters:
       stageId: e2e_frs
       stageDisplayName: e2e - frs
-      poolBuild: Small-centralus
+      poolBuild: Small-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -146,7 +146,7 @@ stages:
     parameters:
       stageId: e2e_odsp
       stageDisplayName: e2e - odsp
-      poolBuild: Small-centralus
+      poolBuild: Small-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -44,7 +44,7 @@ stages:
     parameters:
       stageId: e2e_local_server
       stageDisplayName: e2e - local server
-      poolBuild: NewLarge-linux-1ES # Need Large pool for full-compat matrix
+      poolBuild: Large-centralus # Need Large pool for full-compat matrix
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -61,7 +61,7 @@ stages:
     parameters:
       stageId: e2e_tinylicious
       stageDisplayName: e2e - tinylicious
-      poolBuild: Large # Need Large pool for full-compat matrix
+      poolBuild: Large-centralus # Need Large pool for full-compat matrix
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -83,7 +83,7 @@ stages:
     parameters:
       stageId: e2e_routerlicious
       stageDisplayName: e2e - routerlicious
-      poolBuild: Small
+      poolBuild: Small-centralus
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -114,7 +114,7 @@ stages:
     parameters:
       stageId: e2e_frs
       stageDisplayName: e2e - frs
-      poolBuild: Small
+      poolBuild: Small-centralus
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)
@@ -146,7 +146,7 @@ stages:
     parameters:
       stageId: e2e_odsp
       stageDisplayName: e2e - odsp
-      poolBuild: Small
+      poolBuild: Small-centralus
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       artifactBuildId: $(resources.pipeline.client.runID)

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -43,7 +43,7 @@ stages:
     parameters:
       stageId: e2e_azure_client_frs
       stageDisplayName: e2e - azure client with frs
-      poolBuild: Small-centralus
+      poolBuild: Small-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       testCommand: test:realsvc:azure
@@ -60,7 +60,7 @@ stages:
     parameters:
       stageId: e2e_azure_client_local_server
       stageDisplayName: e2e - azure client with azure local service
-      poolBuild: Small-centralus
+      poolBuild: Small-eastus2
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       testCommand: test:realsvc:tinylicious
@@ -77,7 +77,7 @@ stages:
     parameters:
       stageId: e2e_odsp_client_odsp_server
       stageDisplayName: e2e - odsp client with odsp service
-      poolBuild: Small-centralus
+      poolBuild: Small-eastus2
       testPackage: ${{ variables.testOdspPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       testCommand: test:realsvc:odsp:run

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -43,7 +43,7 @@ stages:
     parameters:
       stageId: e2e_azure_client_frs
       stageDisplayName: e2e - azure client with frs
-      poolBuild: Small
+      poolBuild: Small-centralus
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       testCommand: test:realsvc:azure
@@ -60,7 +60,7 @@ stages:
     parameters:
       stageId: e2e_azure_client_local_server
       stageDisplayName: e2e - azure client with azure local service
-      poolBuild: Small
+      poolBuild: Small-centralus
       testPackage: ${{ variables.testPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       testCommand: test:realsvc:tinylicious
@@ -77,7 +77,7 @@ stages:
     parameters:
       stageId: e2e_odsp_client_odsp_server
       stageDisplayName: e2e - odsp client with odsp service
-      poolBuild: Small
+      poolBuild: Small-centralus
       testPackage: ${{ variables.testOdspPackage }}
       testWorkspace: ${{ variables.testWorkspace }}
       testCommand: test:realsvc:odsp:run

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -11,7 +11,7 @@ pr: none
 parameters:
 - name: poolBuild
   type: object
-  default: Large-centralus
+  default: Large-eastus2
 
 - name: stageNames
   type: object

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -11,7 +11,7 @@ pr: none
 parameters:
 - name: poolBuild
   type: object
-  default: Large
+  default: Large-centralus
 
 - name: stageNames
   type: object


### PR DESCRIPTION
## Description

We're moving our agent pools to the eastus2 region as part of a capacity management initiative. This PR updates all pipelines to use the new pools.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I did manual runs of all pipelines with these changes applied, and they all run fine. Failures in test pipelines are unrelated to this change, just the usual flaky tests & similar. And `build-docs` is not designed to run from test/ branches so its failure is also expected.

[AB#23299](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/23299)