### PR TITLE
Fix stashed upload blob issue when processing reuploaded blob

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -185,6 +185,9 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 	private readonly pendingStashedBlobs: Map<string, Promise<ICreateBlobResponse | void>> =
 		new Map();
 	private stashedBlobsUploadP: Promise<(void | ICreateBlobResponse)[]> | undefined = undefined;
+	// Blobs that were already processed and deleted. This can happen if the blob was reuploaded by the stashing process
+	// This set is used to avoid processing the same blob twice.
+	private readonly tombstoneBlobs: Set<string> = new Set();
 
 	constructor(props: {
 		readonly routeContext: IFluidHandleContext;
@@ -548,10 +551,21 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		if (this.pendingBlobs.delete(id) && !this.hasPendingBlobs) {
 			this.emit("noPendingBlobs");
 		}
+		this.tombstoneBlobs.add(id);
 	}
 
 	private onUploadResolve(localId: string, response: ICreateBlobResponseWithTTL) {
 		const entry = this.pendingBlobs.get(localId);
+		if (entry === undefined && this.tombstoneBlobs.has(localId)) {
+			// The blob was already processed and deleted. This can happen if the blob was reuploaded by
+			// the stashing process and the original upload was processed before the stashed upload.
+			this.mc.logger.sendTelemetryEvent({
+				eventName: "BlobAlreadyProcessedOnUploadResolve",
+				localId,
+			});
+			return;
+		}
+
 		assert(entry !== undefined, 0x6c8 /* pending blob entry not found for uploaded blob */);
 		if ((entry.abortSignal?.aborted === true && !entry.opsent) || this.stopAttaching) {
 			this.mc.logger.sendTelemetryEvent({

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1116,7 +1116,7 @@ export class ContainerRuntime
 			undefined, // summaryConfiguration
 		);
 
-		runtime.blobManager.trackPendingStashedUploads().then(
+		runtime.blobManager.waitForStashedBlobs().then(
 			() => {
 				// make sure we didn't reconnect before the promise resolved
 				if (runtime.delayConnectClientId !== undefined && !runtime.disposed) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1116,7 +1116,7 @@ export class ContainerRuntime
 			undefined, // summaryConfiguration
 		);
 
-		runtime.blobManager.waitForStashedBlobs().then(
+		runtime.blobManager.stashedBlobsUploadP.then(
 			() => {
 				// make sure we didn't reconnect before the promise resolved
 				if (runtime.delayConnectClientId !== undefined && !runtime.disposed) {

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -243,7 +243,7 @@ export class MockRuntime
 	}
 
 	public async processStashed(processStashedWithRetry?: boolean) {
-		const uploadP = this.blobManager.trackPendingStashedUploads();
+		const uploadP = this.blobManager.waitForStashedBlobs();
 		this.processing = true;
 		if (processStashedWithRetry) {
 			await this.processBlobs(false, false, 0);

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -243,7 +243,7 @@ export class MockRuntime
 	}
 
 	public async processStashed(processStashedWithRetry?: boolean) {
-		const uploadP = this.blobManager.waitForStashedBlobs();
+		const uploadP = this.blobManager.stashedBlobsUploadP;
 		this.processing = true;
 		if (processStashedWithRetry) {
 			await this.processBlobs(false, false, 0);

--- a/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
@@ -81,7 +81,7 @@ describe("BlobManager.stashed", () => {
 	it("No Pending Stashed Uploads", async () => {
 		const blobManager = createBlobManager();
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
-		await blobManager.trackPendingStashedUploads();
+		await blobManager.waitForStashedBlobs();
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 	});
 
@@ -167,7 +167,7 @@ describe("BlobManager.stashed", () => {
 		);
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager2.trackPendingStashedUploads(),
+			blobManager2.waitForStashedBlobs(),
 		]);
 		createResponse2.resolve({
 			id: "new-storage-id",
@@ -193,7 +193,7 @@ describe("BlobManager.stashed", () => {
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.trackPendingStashedUploads(),
+			blobManager.waitForStashedBlobs(),
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		createResponse.resolve({
@@ -201,7 +201,7 @@ describe("BlobManager.stashed", () => {
 		});
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.trackPendingStashedUploads(),
+			blobManager.waitForStashedBlobs(),
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 		assert.strictEqual(blobManager.allBlobsAttached, true);
@@ -223,7 +223,7 @@ describe("BlobManager.stashed", () => {
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.trackPendingStashedUploads(),
+			blobManager.waitForStashedBlobs(),
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		createResponse.resolve({
@@ -231,7 +231,7 @@ describe("BlobManager.stashed", () => {
 		});
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.trackPendingStashedUploads(),
+			blobManager.waitForStashedBlobs(),
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 		assert.strictEqual(blobManager.allBlobsAttached, true);
@@ -244,7 +244,7 @@ describe("BlobManager.stashed", () => {
 			},
 		});
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
-		await blobManager.trackPendingStashedUploads();
+		await blobManager.waitForStashedBlobs();
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 	});
 
@@ -264,7 +264,7 @@ describe("BlobManager.stashed", () => {
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.trackPendingStashedUploads(),
+			blobManager.waitForStashedBlobs(),
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		createResponse.resolve({
@@ -272,7 +272,7 @@ describe("BlobManager.stashed", () => {
 		});
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.trackPendingStashedUploads(),
+			blobManager.waitForStashedBlobs(),
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 		assert.strictEqual(blobManager.allBlobsAttached, true);
@@ -309,14 +309,14 @@ describe("BlobManager.stashed", () => {
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.trackPendingStashedUploads(),
+			blobManager.waitForStashedBlobs(),
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		letUploadsComplete.resolve();
 
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.trackPendingStashedUploads(),
+			blobManager.waitForStashedBlobs(),
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 

--- a/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
@@ -81,7 +81,7 @@ describe("BlobManager.stashed", () => {
 	it("No Pending Stashed Uploads", async () => {
 		const blobManager = createBlobManager();
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
-		await blobManager.waitForStashedBlobs();
+		await blobManager.stashedBlobsUploadP;
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 	});
 
@@ -167,12 +167,12 @@ describe("BlobManager.stashed", () => {
 		);
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager2.waitForStashedBlobs(),
+			blobManager2.stashedBlobsUploadP,
 		]);
 		createResponse2.resolve({
 			id: "new-storage-id",
 		});
-		await blobManager2.waitForStashedBlobs();
+		await blobManager2.stashedBlobsUploadP;
 	});
 
 	it("Already stashed blob", async () => {
@@ -193,7 +193,7 @@ describe("BlobManager.stashed", () => {
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.waitForStashedBlobs(),
+			blobManager.stashedBlobsUploadP,
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		createResponse.resolve({
@@ -201,7 +201,7 @@ describe("BlobManager.stashed", () => {
 		});
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.waitForStashedBlobs(),
+			blobManager.stashedBlobsUploadP,
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 		assert.strictEqual(blobManager.allBlobsAttached, true);
@@ -223,7 +223,7 @@ describe("BlobManager.stashed", () => {
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.waitForStashedBlobs(),
+			blobManager.stashedBlobsUploadP,
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		createResponse.resolve({
@@ -231,7 +231,7 @@ describe("BlobManager.stashed", () => {
 		});
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.waitForStashedBlobs(),
+			blobManager.stashedBlobsUploadP,
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 		assert.strictEqual(blobManager.allBlobsAttached, true);
@@ -244,7 +244,7 @@ describe("BlobManager.stashed", () => {
 			},
 		});
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
-		await blobManager.waitForStashedBlobs();
+		await blobManager.stashedBlobsUploadP;
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 	});
 
@@ -264,7 +264,7 @@ describe("BlobManager.stashed", () => {
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.waitForStashedBlobs(),
+			blobManager.stashedBlobsUploadP,
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		createResponse.resolve({
@@ -272,7 +272,7 @@ describe("BlobManager.stashed", () => {
 		});
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.waitForStashedBlobs(),
+			blobManager.stashedBlobsUploadP,
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 		assert.strictEqual(blobManager.allBlobsAttached, true);
@@ -309,14 +309,14 @@ describe("BlobManager.stashed", () => {
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.waitForStashedBlobs(),
+			blobManager.stashedBlobsUploadP,
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		letUploadsComplete.resolve();
 
 		await Promise.race([
 			new Promise<void>((resolve) => setTimeout(() => resolve(), 10)),
-			blobManager.waitForStashedBlobs(),
+			blobManager.stashedBlobsUploadP,
 		]);
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 


### PR DESCRIPTION
This change fixes issue covered in PR https://github.com/microsoft/FluidFramework/pull/22981
After several simplifications, I realized we could reuse pendingStashedBlobs map to identify the bug scenario, which is reuploading a stashed blob that was already processed. If while onUploadResolve we don't see the blob in the pending list but it's on the stashed one, then just ignore the new upload.
trackPendingStashedUploads is replaced with waitForStashedBlobs which also implies there are further simplifications to the blob manager logic, mainly we could also remove the stashedUpload property on the PendingBlob type since now we keep track of stashed blobs separately . 