### PR TITLE
Test Remove back-compat code

### DIFF
--- a/.changeset/icy-webs-help.md
+++ b/.changeset/icy-webs-help.md
@@ -1,0 +1,14 @@
+---
+"@fluidframework/container-runtime": minor
+"@fluidframework/runtime-definitions": minor
+"@fluidframework/test-runtime-utils": minor
+---
+---
+"section": legacy
+---
+
+"Remove `IFluidParentContext.ensureNoDataModelChanges` and its implementations
+
+- `IFluidParentContext.ensureNoDataModelChanges` has been removed. [prior deprecation commit](https://github.com/microsoft/FluidFramework/commit/c9d156264bdfa211a3075bdf29cde442ecea234c)
+
+- `MockFluidDataStoreContext.ensureNoDataModelChanges` has also been removed.

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -171,10 +171,6 @@ export function wrapContext(context: IFluidParentContext): IFluidParentContext {
 		getAudience: (...args) => {
 			return context.getAudience(...args);
 		},
-		// back-compat, to be removed in 2.0
-		ensureNoDataModelChanges: (...args) => {
-			return context.ensureNoDataModelChanges(...args);
-		},
 		submitMessage: (...args) => {
 			return context.submitMessage(...args);
 		},

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -225,11 +225,6 @@ export abstract class FluidDataStoreContext
 		return this._containerRuntime;
 	}
 
-	// back-compat, to be removed in 2.0
-	public ensureNoDataModelChanges<T>(callback: () => T): T {
-		return this.parentContext.ensureNoDataModelChanges(callback);
-	}
-
 	public get isLoaded(): boolean {
 		return this.loaded;
 	}

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -201,8 +201,6 @@ export interface IFluidParentContext extends IProvideFluidHandleContext, Partial
     deleteChildSummarizerNode(id: string): void;
     // (undocumented)
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-    // @deprecated
-    ensureNoDataModelChanges<T>(callback: () => T): T;
     // @deprecated (undocumented)
     readonly gcThrowOnTombstoneUsage: boolean;
     // @deprecated (undocumented)

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -490,19 +490,6 @@ export interface IFluidParentContext
 	getAudience(): IAudience;
 
 	/**
-	 * Invokes the given callback and expects that no ops are submitted
-	 * until execution finishes. If an op is submitted, an error will be raised.
-	 *
-	 * Can be disabled by feature gate `Fluid.ContainerRuntime.DisableOpReentryCheck`
-	 *
-	 * @param callback - the callback to be invoked
-	 *
-	 * @deprecated
-	 * // back-compat: to be removed in 2.0
-	 */
-	ensureNoDataModelChanges<T>(callback: () => T): T;
-
-	/**
 	 * Submits the message to be sent to other clients.
 	 * @param type - Type of the message.
 	 * @param content - Content of the message.

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -303,8 +303,6 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     // (undocumented)
     deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     // (undocumented)
-    ensureNoDataModelChanges<T>(callback: () => T): T;
-    // (undocumented)
     readonly existing: boolean;
     // (undocumented)
     readonly gcThrowOnTombstoneUsage = false;

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -96,11 +96,6 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 		throw new Error("Method not implemented.");
 	}
 
-	// back-compat: to be removed in 2.0
-	public ensureNoDataModelChanges<T>(callback: () => T): T {
-		return callback();
-	}
-
 	public getQuorum(): IQuorumClients {
 		return undefined as any as IQuorumClients;
 	}


### PR DESCRIPTION
Tests: [This PR](https://github.com/microsoft/FluidFramework/pull/22842)
## Description

In light of [Remove ability to reject reentrant ops (#20621) · microsoft/FluidFramework@c9d1562 (github.com)](https://github.com/microsoft/FluidFramework/commit/c9d156264bdfa211a3075bdf29cde442ecea234c), updating this to be about finishing the removal of ensureNoDataModelChanges.

The following uses of ensureNoDataModelChanges will be removed:

packages\runtime\container-runtime\src\channelCollection.ts:

ensureNoDataModelChanges: (...args) => {
packages\runtime\container-runtime\src\dataStoreContext.ts:

public ensureNoDataModelChanges(callback: () => T): T {
packages\runtime\runtime-definitions\src\dataStoreContext.ts:

ensureNoDataModelChanges(callback: () => T): T;
packages\runtime\test-runtime-utils\src\mocksDataStoreContext.ts:

public ensureNoDataModelChanges(callback: () => T): T {
