### PR TITLE
fix(api-markdown-documenter): Escape heading ID text in Markdown

### DIFF
--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/HeadingToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/HeadingToHtml.ts
@@ -50,7 +50,7 @@ export function headingToHtml(headingNode: HeadingNode, context: TransformationC
 	} else {
 		const transformedChildren: HastElement[] = [];
 		if (headingNode.id !== undefined) {
-			transformedChildren.push(h("a", { name: headingNode.id }));
+			transformedChildren.push(h("a", { id: headingNode.id }));
 		}
 		transformedChildren.push(
 			transformChildrenUnderTag({ name: "b" }, headingNode.children, context),

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/HeadingToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/HeadingToHtml.test.ts
@@ -38,7 +38,7 @@ describe("HeadingNode -> Html", () => {
 		// As a policy, if we have a heading nested deeper than that, we transform the content to bold text with an
 		// anchor tag above it.
 		const input = HeadingNode.createFromPlainText("Foo", "foo-id");
-		const expected = h(undefined, [h("a", { name: "foo-id" }), h("b", "Foo")]);
+		const expected = h(undefined, [h("a", { id: "foo-id" }), h("b", "Foo")]);
 		assertTransformation(input, expected, { startingHeadingLevel: 7 });
 	});
 });

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderHeading.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderHeading.ts
@@ -84,6 +84,6 @@ function renderHeadingWithMarkdownSyntax(
  */
 function renderAnchor(anchorId: string, writer: DocumentWriter): void {
 	writer.ensureNewLine(); // Ensure line break before tag
-	writer.write(`<a name="${anchorId}" />`);
+	writer.write(`<a id="${anchorId}"></a>`);
 	writer.ensureNewLine(); // Ensure line break after tag
 }

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderHeading.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderHeading.ts
@@ -3,11 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import type { HeadingNode } from "../../../documentation-domain/index.js";
+import { type HeadingNode } from "../../../documentation-domain/index.js";
 import type { DocumentWriter } from "../../DocumentWriter.js";
 import { renderNodes } from "../Render.js";
 import type { RenderContext } from "../RenderContext.js";
 import { renderNodeWithHtmlSyntax } from "../Utilities.js";
+import { escapeTextForMarkdown } from "./RenderPlainText.js";
 
 /**
  * Maximum heading level supported by most systems.
@@ -59,8 +60,10 @@ function renderHeadingWithMarkdownSyntax(
 		const headingPreamble = "#".repeat(headingLevel);
 		writer.write(`${headingPreamble} `);
 		renderNodes(headingNode.children, writer, context);
+
 		if (headingNode.id !== undefined) {
-			writer.write(` {#${headingNode.id}}`);
+			const escapedId = escapeTextForMarkdown(headingNode.id);
+			writer.write(` {#${escapedId}}`);
 		}
 	} else {
 		if (headingNode.id !== undefined) {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderPlainText.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderPlainText.ts
@@ -69,7 +69,7 @@ export function renderPlainText(
 
 	// Don't escape text within a code block in Markdown, or if it has already been escaped
 	const text =
-		context.insideCodeBlock === true || node.escaped ? body : getMarkdownEscapedText(body);
+		context.insideCodeBlock === true || node.escaped ? body : escapeTextForMarkdown(body);
 	writer.write(text);
 
 	if (context.strikethrough === true) {
@@ -104,12 +104,12 @@ function splitLeadingAndTrailingWhitespace(text: string): SplitTextResult {
 }
 
 /**
- * Converts text into an escaped, html-nesting-friendly form
+ * Escapes the provided text for use in Markdown.
  *
- * @param text - Text to escape
- * @returns Escaped text
+ * @param text - The text to escape.
+ * @returns The escaped text.
  */
-function getMarkdownEscapedText(text: string): string {
+export function escapeTextForMarkdown(text: string): string {
 	return text
 		.replace(/\\/g, "\\\\") // first replace the escape character
 		.replace(/[#*[\]_`|~]/g, (x) => `\\${x}`) // then escape any special characters

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHeading.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHeading.test.ts
@@ -10,62 +10,126 @@ import { testRender } from "./Utilities.js";
 
 describe("Heading Markdown rendering tests", () => {
 	describe("Standard context", () => {
-		it("Without ID", () => {
-			const input = HeadingNode.createFromPlainText("Hello World");
-			const result = testRender(input);
-			const expected = ["", "# Hello World", "", ""].join("\n");
-			expect(result).to.equal(expected);
+		describe("Within max heading level", () => {
+			it("Without ID", () => {
+				const input = HeadingNode.createFromPlainText("Hello World");
+				const result = testRender(input);
+				const expected = ["", "# Hello World", "", ""].join("\n");
+				expect(result).to.equal(expected);
+			});
+
+			it("With ID", () => {
+				const input = HeadingNode.createFromPlainText(
+					"Hello World",
+					/* id: */ "heading-id",
+				);
+				const result = testRender(input);
+				const expected = ["", "# Hello World {#heading-id}", "", ""].join("\n");
+				expect(result).to.equal(expected);
+			});
+
+			it("With ID - includes content that must be escaped for Markdown", () => {
+				const input = HeadingNode.createFromPlainText(
+					"Hello World",
+					/* id: */ "_heading-id_",
+				);
+				const result = testRender(input);
+				const expected = ["", "# Hello World {#\\_heading-id\\_}", "", ""].join("\n");
+				expect(result).to.equal(expected);
+			});
 		});
 
-		it("With ID", () => {
-			const input = HeadingNode.createFromPlainText("Hello World", /* id: */ "heading-id");
-			const result = testRender(input);
-			const expected = ["", "# Hello World {#heading-id}", "", ""].join("\n");
-			expect(result).to.equal(expected);
-		});
+		describe("Beyond max heading level", () => {
+			it("Without ID", () => {
+				const input = HeadingNode.createFromPlainText("Hello World");
+				const result = testRender(input, { headingLevel: 7 });
+				const expected = ["", "**Hello World**", "", ""].join("\n");
+				expect(result).to.equal(expected);
+			});
 
-		it("With ID - includes content that must be escaped for Markdown", () => {
-			const input = HeadingNode.createFromPlainText("Hello World", /* id: */ "_heading-id_");
-			const result = testRender(input);
-			const expected = ["", "# Hello World {#\\_heading-id\\_}", "", ""].join("\n");
-			expect(result).to.equal(expected);
-		});
+			it("With ID", () => {
+				const input = HeadingNode.createFromPlainText(
+					"Hello World",
+					/* id: */ "heading-id",
+				);
+				const result = testRender(input, { headingLevel: 7 });
+				const expected = ["", '<a id="heading-id"></a>', "**Hello World**", "", ""].join(
+					"\n",
+				);
+				expect(result).to.equal(expected);
+			});
 
-		it("Without ID (beyond max heading level)", () => {
-			const input = HeadingNode.createFromPlainText("Hello World");
-			const result = testRender(input, { headingLevel: 7 });
-			const expected = ["", "**Hello World**", "", ""].join("\n");
-			expect(result).to.equal(expected);
-		});
-
-		it("With ID (beyond max heading level)", () => {
-			const input = HeadingNode.createFromPlainText("Hello World", /* id: */ "heading-id");
-			const result = testRender(input, { headingLevel: 7 });
-			const expected = ["", '<a id="heading-id"></a>', "**Hello World**", "", ""].join("\n");
-			expect(result).to.equal(expected);
+			it("With ID - includes content that must be escaped for Markdown", () => {
+				const input = HeadingNode.createFromPlainText(
+					"Hello World",
+					/* id: */ "_heading-id_",
+				);
+				const result = testRender(input);
+				const expected = ["", '<a id="_heading-id_"></a>', "**Hello World**", "", ""].join(
+					"\n",
+				);
+				expect(result).to.equal(expected);
+			});
 		});
 	});
 
 	describe("Table context", () => {
-		it("Without ID", () => {
-			const input = HeadingNode.createFromPlainText("Hello World");
-			const result = testRender(input, { insideTable: true });
-			const expected = ["<h1>Hello World</h1>"].join("\n");
-			expect(result).to.equal(expected);
+		describe("Within max heading level", () => {
+			it("Without ID", () => {
+				const input = HeadingNode.createFromPlainText("Hello World");
+				const result = testRender(input, { insideTable: true });
+				const expected = ["<h1>Hello World</h1>"].join("\n");
+				expect(result).to.equal(expected);
+			});
+
+			it("With ID", () => {
+				const input = HeadingNode.createFromPlainText(
+					"Hello World",
+					/* id: */ "heading-id",
+				);
+				const result = testRender(input, { insideTable: true });
+				const expected = ['<h1 id="heading-id">Hello World</h1>'].join("\n");
+				expect(result).to.equal(expected);
+			});
+
+			it("With ID - includes content that would be escaped in Markdown", () => {
+				const input = HeadingNode.createFromPlainText(
+					"Hello World",
+					/* id: */ "_heading-id_",
+				);
+				const result = testRender(input, { insideTable: true });
+				const expected = ['<h1 id="_heading-id_">Hello World</h1>'].join("\n");
+				expect(result).to.equal(expected);
+			});
 		});
 
-		it("With ID", () => {
-			const input = HeadingNode.createFromPlainText("Hello World", /* id: */ "heading-id");
-			const result = testRender(input, { insideTable: true });
-			const expected = ['<h1 id="heading-id">Hello World</h1>'].join("\n");
-			expect(result).to.equal(expected);
-		});
+		describe("Beyond max heading level", () => {
+			it("Without ID", () => {
+				const input = HeadingNode.createFromPlainText("Hello World");
+				const result = testRender(input, { insideTable: true, headingLevel: 7 });
+				const expected = ["<b>Hello World</b>"].join("\n");
+				expect(result).to.equal(expected);
+			});
 
-		it("With ID - includes content that would be escaped in Markdown", () => {
-			const input = HeadingNode.createFromPlainText("Hello World", /* id: */ "_heading-id_");
-			const result = testRender(input, { insideTable: true });
-			const expected = ['<h1 id="_heading-id_">Hello World</h1>'].join("\n");
-			expect(result).to.equal(expected);
+			it("With ID", () => {
+				const input = HeadingNode.createFromPlainText(
+					"Hello World",
+					/* id: */ "heading-id",
+				);
+				const result = testRender(input, { insideTable: true, headingLevel: 7 });
+				const expected = ['<a id="heading-id"></a><b>Hello World</b>'].join("\n");
+				expect(result).to.equal(expected);
+			});
+
+			it("With ID - includes content that would be escaped in Markdown", () => {
+				const input = HeadingNode.createFromPlainText(
+					"Hello World",
+					/* id: */ "_heading-id_",
+				);
+				const result = testRender(input, { insideTable: true, headingLevel: 7 });
+				const expected = ['<a id="_heading-id_"></a><b>Hello World</b>'].join("\n");
+				expect(result).to.equal(expected);
+			});
 		});
 	});
 });

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHeading.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHeading.test.ts
@@ -1,0 +1,50 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { expect } from "chai";
+
+import { HeadingNode } from "../../../documentation-domain/index.js";
+import { testRender } from "./Utilities.js";
+
+describe("Heading Markdown rendering tests", () => {
+	describe("Standard context", () => {
+		it("Without ID", () => {
+			const input = HeadingNode.createFromPlainText("Hello World");
+			const result = testRender(input);
+			const expected = ["", "# Hello World", "", ""].join("\n");
+			expect(result).to.equal(expected);
+		});
+
+		it("With ID", () => {
+			const input = HeadingNode.createFromPlainText("Hello World", /* id: */ "heading-id");
+			const result = testRender(input);
+			const expected = ["", "# Hello World {#heading-id}", "", ""].join("\n");
+			expect(result).to.equal(expected);
+		});
+
+		it("With ID - includes content that must be escaped for Markdown", () => {
+			const input = HeadingNode.createFromPlainText("Hello World", /* id: */ "_heading-id_");
+			const result = testRender(input);
+			const expected = ["", "# Hello World {#\\_heading-id\\_}", "", ""].join("\n");
+			expect(result).to.equal(expected);
+		});
+	});
+
+	describe("Table context", () => {
+		it("Without ID", () => {
+			const input = HeadingNode.createFromPlainText("Hello World");
+			const result = testRender(input);
+			const expected = ["", "# Hello World", "", ""].join("\n");
+			expect(result).to.equal(expected);
+		});
+
+		it("With ID", () => {
+			const input = HeadingNode.createFromPlainText("Hello World", /* id: */ "heading-id");
+			const result = testRender(input);
+			const expected = ["", "# Hello World {#heading-id}", "", ""].join("\n");
+			expect(result).to.equal(expected);
+		});
+	});
+});

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHeading.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHeading.test.ts
@@ -30,20 +30,41 @@ describe("Heading Markdown rendering tests", () => {
 			const expected = ["", "# Hello World {#\\_heading-id\\_}", "", ""].join("\n");
 			expect(result).to.equal(expected);
 		});
+
+		it("Without ID (beyond max heading level)", () => {
+			const input = HeadingNode.createFromPlainText("Hello World");
+			const result = testRender(input, { headingLevel: 7 });
+			const expected = ["", "**Hello World**", "", ""].join("\n");
+			expect(result).to.equal(expected);
+		});
+
+		it("With ID (beyond max heading level)", () => {
+			const input = HeadingNode.createFromPlainText("Hello World", /* id: */ "heading-id");
+			const result = testRender(input, { headingLevel: 7 });
+			const expected = ["", '<a id="heading-id"></a>', "**Hello World**", "", ""].join("\n");
+			expect(result).to.equal(expected);
+		});
 	});
 
 	describe("Table context", () => {
 		it("Without ID", () => {
 			const input = HeadingNode.createFromPlainText("Hello World");
-			const result = testRender(input);
-			const expected = ["", "# Hello World", "", ""].join("\n");
+			const result = testRender(input, { insideTable: true });
+			const expected = ["<h1>Hello World</h1>"].join("\n");
 			expect(result).to.equal(expected);
 		});
 
 		it("With ID", () => {
 			const input = HeadingNode.createFromPlainText("Hello World", /* id: */ "heading-id");
-			const result = testRender(input);
-			const expected = ["", "# Hello World {#heading-id}", "", ""].join("\n");
+			const result = testRender(input, { insideTable: true });
+			const expected = ['<h1 id="heading-id">Hello World</h1>'].join("\n");
+			expect(result).to.equal(expected);
+		});
+
+		it("With ID - includes content that would be escaped in Markdown", () => {
+			const input = HeadingNode.createFromPlainText("Hello World", /* id: */ "_heading-id_");
+			const result = testRender(input, { insideTable: true });
+			const expected = ['<h1 id="_heading-id_">Hello World</h1>'].join("\n");
 			expect(result).to.equal(expected);
 		});
 	});

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHeading.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHeading.test.ts
@@ -64,7 +64,7 @@ describe("Heading Markdown rendering tests", () => {
 					"Hello World",
 					/* id: */ "_heading-id_",
 				);
-				const result = testRender(input);
+				const result = testRender(input, { headingLevel: 7 });
 				const expected = ["", '<a id="_heading-id_"></a>', "**Hello World**", "", ""].join(
 					"\n",
 				);

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
@@ -1740,8 +1740,8 @@
                 <section>
                   <p>Test class constructor</p>
                 </section>
-                <section><a name="_constructor_-signature"></a><b>Signature</b><code>constructor(testClassProperty: string);</code></section>
-                <section><a name="_constructor_-parameters"></a><b>Parameters</b>
+                <section><a id="_constructor_-signature"></a><b>Signature</b><code>constructor(testClassProperty: string);</code></section>
+                <section><a id="_constructor_-parameters"></a><b>Parameters</b>
                   <table>
                     <thead>
                       <tr>
@@ -1768,7 +1768,7 @@
                 <section>
                   <p>Test interface property</p>
                 </section>
-                <section><a name="testclassproperty-signature"></a><b>Signature</b><code>readonly testClassProperty: string;</code>
+                <section><a id="testclassproperty-signature"></a><b>Signature</b><code>readonly testClassProperty: string;</code>
                   <p><span><span><b>Type: </b></span><span>string</span></span></p>
                 </section>
               </section>
@@ -1780,8 +1780,8 @@
                 <section>
                   <p>Test class method</p>
                 </section>
-                <section><a name="testclassmethod-signature"></a><b>Signature</b><code>testClassMethod(testParameter: string): Promise&#x3C;string>;</code></section>
-                <section><a name="testclassmethod-parameters"></a><b>Parameters</b>
+                <section><a id="testclassmethod-signature"></a><b>Signature</b><code>testClassMethod(testParameter: string): Promise&#x3C;string>;</code></section>
+                <section><a id="testclassmethod-parameters"></a><b>Parameters</b>
                   <table>
                     <thead>
                       <tr>
@@ -1799,11 +1799,11 @@
                     </tbody>
                   </table>
                 </section>
-                <section><a name="testclassmethod-returns"></a><b>Returns</b>
+                <section><a id="testclassmethod-returns"></a><b>Returns</b>
                   <p>A Promise</p>
                   <p><span><b>Return type: </b></span><span>Promise&#x3C;string></span></p>
                 </section>
-                <section><a name="testclassmethod-throws"></a><b>Throws</b>
+                <section><a id="testclassmethod-throws"></a><b>Throws</b>
                   <p>An Error when something happens for which an error should be thrown. Except in the cases where another kind of error is thrown. We don't throw this error in those cases.</p>
                   <p>
                     <p>A different kind of error when a thing happens, but not when the first kind of error is thrown instead.</p>
@@ -1851,14 +1851,14 @@
                 <section>
                   <p>Test enum value 1</p>
                 </section>
-                <section><a name="testenumvalue1-signature"></a><b>Signature</b><code>TestEnumValue1 = 0</code></section>
+                <section><a id="testenumvalue1-signature"></a><b>Signature</b><code>TestEnumValue1 = 0</code></section>
               </section>
               <section>
                 <h6 id="testnamespace-testenum-testenumvalue2-enummember">TestEnumValue2</h6>
                 <section>
                   <p>Test enum value 2</p>
                 </section>
-                <section><a name="testenumvalue2-signature"></a><b>Signature</b><code>TestEnumValue2 = 1</code></section>
+                <section><a id="testenumvalue2-signature"></a><b>Signature</b><code>TestEnumValue2 = 1</code></section>
               </section>
             </section>
           </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testabstractclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testabstractclass-class.md
@@ -33,17 +33,17 @@ export declare abstract class TestAbstractClass
 
 ## Constructor Details
 
-### (constructor) {#_constructor_-constructor}
+### (constructor) {#\_constructor\_-constructor}
 
 This is a _{@customTag constructor}_.
 
-#### Signature {#_constructor_-signature}
+#### Signature {#\_constructor\_-signature}
 
 ```typescript
 protected constructor(privateProperty: number, protectedProperty: TestEnum);
 ```
 
-#### Parameters {#_constructor_-parameters}
+#### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
 | --- | --- | --- |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
@@ -65,21 +65,21 @@ Here are some remarks about the class
 
 ## Constructor Details
 
-### (constructor) {#_constructor_-constructor}
+### (constructor) {#\_constructor\_-constructor}
 
 Test class constructor
 
-#### Signature {#_constructor_-signature}
+#### Signature {#\_constructor\_-signature}
 
 ```typescript
 constructor(privateProperty: number, protectedProperty: TestEnum, testClassProperty: TTypeParameterB, testClassEventProperty: () => void);
 ```
 
-#### Remarks {#_constructor_-remarks}
+#### Remarks {#\_constructor\_-remarks}
 
 Here are some remarks about the constructor
 
-#### Parameters {#_constructor_-parameters}
+#### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
 | --- | --- | --- |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
@@ -51,17 +51,17 @@ Here are some remarks about the interface
 
 ## Construct Signature Details
 
-### new (): TestInterface {#_new_-constructsignature}
+### new (): TestInterface {#\_new\_-constructsignature}
 
 Test construct signature.
 
-#### Signature {#_new_-signature}
+#### Signature {#\_new\_-signature}
 
 ```typescript
 new (): TestInterface;
 ```
 
-#### Returns {#_new_-returns}
+#### Returns {#\_new\_-returns}
 
 **Return type:** [TestInterface](./test-suite-a/testinterface-interface)
 
@@ -166,31 +166,31 @@ Here are some remarks about the method
 
 ## Call Signature Details
 
-### (event: 'testCallSignature', listener: (input: unknown) =&gt; void): any {#_call_-callsignature}
+### (event: 'testCallSignature', listener: (input: unknown) =&gt; void): any {#\_call\_-callsignature}
 
 Test interface event call signature
 
-#### Signature {#_call_-signature}
+#### Signature {#\_call\_-signature}
 
 ```typescript
 (event: 'testCallSignature', listener: (input: unknown) => void): any;
 ```
 
-#### Remarks {#_call_-remarks}
+#### Remarks {#\_call\_-remarks}
 
 Here are some remarks about the event call signature
 
-### (event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number {#_call__1-callsignature}
+### (event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number {#\_call\_\_1-callsignature}
 
 Another example call signature
 
-#### Signature {#_call__1-signature}
+#### Signature {#\_call\_\_1-signature}
 
 ```typescript
 (event: 'anotherTestCallSignature', listener: (input: number) => string): number;
 ```
 
-#### Remarks {#_call__1-remarks}
+#### Remarks {#\_call\_\_1-remarks}
 
 Here are some remarks about the event call signature
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithindexsignature-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithindexsignature-interface.md
@@ -18,11 +18,11 @@ export interface TestInterfaceWithIndexSignature
 
 ## Index Signature Details
 
-### \[foo: number\]: { bar: string; } {#_indexer_-indexsignature}
+### \[foo: number\]: { bar: string; } {#\_indexer\_-indexsignature}
 
 Test index signature.
 
-#### Signature {#_indexer_-signature}
+#### Signature {#\_indexer\_-signature}
 
 ```typescript
 [foo: number]: {

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace/testclass-class.md
@@ -30,17 +30,17 @@ class TestClass
 
 ## Constructor Details
 
-### (constructor) {#_constructor_-constructor}
+### (constructor) {#\_constructor\_-constructor}
 
 Test class constructor
 
-#### Signature {#_constructor_-signature}
+#### Signature {#\_constructor\_-signature}
 
 ```typescript
 constructor(testClassProperty: string);
 ```
 
-#### Parameters {#_constructor_-parameters}
+#### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
 | --- | --- | --- |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
@@ -151,17 +151,17 @@ Here are some remarks about the interface
 
 ### Construct Signature Details
 
-#### new (): TestInterface {#testinterface-_new_-constructsignature}
+#### new (): TestInterface {#testinterface-\_new\_-constructsignature}
 
 Test construct signature.
 
-##### Signature {#_new_-signature}
+##### Signature {#\_new\_-signature}
 
 ```typescript
 new (): TestInterface;
 ```
 
-##### Returns {#_new_-returns}
+##### Returns {#\_new\_-returns}
 
 **Return type:** [TestInterface](docs/test-suite-a#testinterface-interface)
 
@@ -266,31 +266,31 @@ Here are some remarks about the method
 
 ### Call Signature Details
 
-#### (event: 'testCallSignature', listener: (input: unknown) =&gt; void): any {#testinterface-_call_-callsignature}
+#### (event: 'testCallSignature', listener: (input: unknown) =&gt; void): any {#testinterface-\_call\_-callsignature}
 
 Test interface event call signature
 
-##### Signature {#_call_-signature}
+##### Signature {#\_call\_-signature}
 
 ```typescript
 (event: 'testCallSignature', listener: (input: unknown) => void): any;
 ```
 
-##### Remarks {#_call_-remarks}
+##### Remarks {#\_call\_-remarks}
 
 Here are some remarks about the event call signature
 
-#### (event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number {#testinterface-_call__1-callsignature}
+#### (event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number {#testinterface-\_call\_\_1-callsignature}
 
 Another example call signature
 
-##### Signature {#_call__1-signature}
+##### Signature {#\_call\_\_1-signature}
 
 ```typescript
 (event: 'anotherTestCallSignature', listener: (input: number) => string): number;
 ```
 
-##### Remarks {#_call__1-remarks}
+##### Remarks {#\_call\_\_1-remarks}
 
 Here are some remarks about the event call signature
 
@@ -380,11 +380,11 @@ export interface TestInterfaceWithIndexSignature
 
 ### Index Signature Details
 
-#### \[foo: number\]: { bar: string; } {#testinterfacewithindexsignature-_indexer_-indexsignature}
+#### \[foo: number\]: { bar: string; } {#testinterfacewithindexsignature-\_indexer\_-indexsignature}
 
 Test index signature.
 
-##### Signature {#_indexer_-signature}
+##### Signature {#\_indexer\_-signature}
 
 ```typescript
 [foo: number]: {
@@ -471,17 +471,17 @@ export declare abstract class TestAbstractClass
 
 ### Constructor Details
 
-#### (constructor) {#testabstractclass-_constructor_-constructor}
+#### (constructor) {#testabstractclass-\_constructor\_-constructor}
 
 This is a _{@customTag constructor}_.
 
-##### Signature {#_constructor_-signature}
+##### Signature {#\_constructor\_-signature}
 
 ```typescript
 protected constructor(privateProperty: number, protectedProperty: TestEnum);
 ```
 
-##### Parameters {#_constructor_-parameters}
+##### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
 | --- | --- | --- |
@@ -625,21 +625,21 @@ Here are some remarks about the class
 
 ### Constructor Details
 
-#### (constructor) {#testclass-_constructor_-constructor}
+#### (constructor) {#testclass-\_constructor\_-constructor}
 
 Test class constructor
 
-##### Signature {#_constructor_-signature}
+##### Signature {#\_constructor\_-signature}
 
 ```typescript
 constructor(privateProperty: number, protectedProperty: TestEnum, testClassProperty: TTypeParameterB, testClassEventProperty: () => void);
 ```
 
-##### Remarks {#_constructor_-remarks}
+##### Remarks {#\_constructor\_-remarks}
 
 Here are some remarks about the constructor
 
-##### Parameters {#_constructor_-parameters}
+##### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
 | --- | --- | --- |
@@ -1139,7 +1139,7 @@ class TestClass
 
 ##### Constructor Details
 
-###### (constructor) {#testnamespace-testclass-_constructor_-constructor}
+###### (constructor) {#testnamespace-testclass-\_constructor\_-constructor}
 
 Test class constructor
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
@@ -1143,14 +1143,14 @@ class TestClass
 
 Test class constructor
 
-<a name="_constructor_-signature" />
+<a id="_constructor_-signature"></a>
 **Signature**
 
 ```typescript
 constructor(testClassProperty: string);
 ```
 
-<a name="_constructor_-parameters" />
+<a id="_constructor_-parameters"></a>
 **Parameters**
 
 | Parameter | Type | Description |
@@ -1163,7 +1163,7 @@ constructor(testClassProperty: string);
 
 Test interface property
 
-<a name="testclassproperty-signature" />
+<a id="testclassproperty-signature"></a>
 **Signature**
 
 ```typescript
@@ -1178,28 +1178,28 @@ readonly testClassProperty: string;
 
 Test class method
 
-<a name="testclassmethod-signature" />
+<a id="testclassmethod-signature"></a>
 **Signature**
 
 ```typescript
 testClassMethod(testParameter: string): Promise<string>;
 ```
 
-<a name="testclassmethod-parameters" />
+<a id="testclassmethod-parameters"></a>
 **Parameters**
 
 | Parameter | Type | Description |
 | --- | --- | --- |
 | testParameter | string | A string |
 
-<a name="testclassmethod-returns" />
+<a id="testclassmethod-returns"></a>
 **Returns**
 
 A Promise
 
 **Return type:** Promise&lt;string&gt;
 
-<a name="testclassmethod-throws" />
+<a id="testclassmethod-throws"></a>
 **Throws**
 
 An Error when something happens for which an error should be thrown. Except in the cases where another kind of error is thrown. We don't throw this error in those cases.
@@ -1231,7 +1231,7 @@ enum TestEnum
 
 Test enum value 1
 
-<a name="testenumvalue1-signature" />
+<a id="testenumvalue1-signature"></a>
 **Signature**
 
 ```typescript
@@ -1242,7 +1242,7 @@ TestEnumValue1 = 0
 
 Test enum value 2
 
-<a name="testenumvalue2-signature" />
+<a id="testenumvalue2-signature"></a>
 **Signature**
 
 ```typescript

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-_constructor_-constructor.md
@@ -2,13 +2,13 @@
 
 This is a _{@customTag constructor}_.
 
-### Signature {#_constructor_-signature}
+### Signature {#\_constructor\_-signature}
 
 ```typescript
 protected constructor(privateProperty: number, protectedProperty: TestEnum);
 ```
 
-### Parameters {#_constructor_-parameters}
+### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
 | --- | --- | --- |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-_constructor_-constructor.md
@@ -2,17 +2,17 @@
 
 Test class constructor
 
-### Signature {#_constructor_-signature}
+### Signature {#\_constructor\_-signature}
 
 ```typescript
 constructor(privateProperty: number, protectedProperty: TestEnum, testClassProperty: TTypeParameterB, testClassEventProperty: () => void);
 ```
 
-### Remarks {#_constructor_-remarks}
+### Remarks {#\_constructor\_-remarks}
 
 Here are some remarks about the constructor
 
-### Parameters {#_constructor_-parameters}
+### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
 | --- | --- | --- |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-_call_-callsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-_call_-callsignature.md
@@ -2,12 +2,12 @@
 
 Test interface event call signature
 
-### Signature {#_call_-signature}
+### Signature {#\_call\_-signature}
 
 ```typescript
 (event: 'testCallSignature', listener: (input: unknown) => void): any;
 ```
 
-### Remarks {#_call_-remarks}
+### Remarks {#\_call\_-remarks}
 
 Here are some remarks about the event call signature

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-_call__1-callsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-_call__1-callsignature.md
@@ -2,12 +2,12 @@
 
 Another example call signature
 
-### Signature {#_call__1-signature}
+### Signature {#\_call\_\_1-signature}
 
 ```typescript
 (event: 'anotherTestCallSignature', listener: (input: number) => string): number;
 ```
 
-### Remarks {#_call__1-remarks}
+### Remarks {#\_call\_\_1-remarks}
 
 Here are some remarks about the event call signature

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-_new_-constructsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-_new_-constructsignature.md
@@ -2,12 +2,12 @@
 
 Test construct signature.
 
-### Signature {#_new_-signature}
+### Signature {#\_new\_-signature}
 
 ```typescript
 new (): TestInterface;
 ```
 
-### Returns {#_new_-returns}
+### Returns {#\_new\_-returns}
 
 **Return type:** [TestInterface](docs/test-suite-a/testinterface-interface)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfacewithindexsignature-_indexer_-indexsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfacewithindexsignature-_indexer_-indexsignature.md
@@ -2,7 +2,7 @@
 
 Test index signature.
 
-### Signature {#_indexer_-signature}
+### Signature {#\_indexer\_-signature}
 
 ```typescript
 [foo: number]: {

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-_constructor_-constructor.md
@@ -2,13 +2,13 @@
 
 Test class constructor
 
-### Signature {#_constructor_-signature}
+### Signature {#\_constructor\_-signature}
 
 ```typescript
 constructor(testClassProperty: string);
 ```
 
-### Parameters {#_constructor_-parameters}
+### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
 | --- | --- | --- |


### PR DESCRIPTION
For various call signature API items, we frequently IDs like `_call_-call`. There are a number of reasons for this, but mostly it boils down to trying to avoid creating artificial name conflicts while also ensuring generated files don't contain invalid characters. When we generate heading IDs from these, we previously weren't escaping the contents, which was invalid. Hugo previously handled this in most cases, but Docusaurus (the tooling we're working to adopt in place of Hugo for generating our website) does not.

This PR updates heading rendering to ensure ID contents are escaped for Markdown.

[AB#23444](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/23444)