### PR TITLE
feat: Make flub release request bump type lazily

### DIFF
--- a/build-tools/packages/build-cli/src/handlers/askFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/askFunctions.ts
@@ -3,11 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { type VersionBumpType, bumpVersionScheme } from "@fluid-tools/version-tools";
-import { rawlist } from "@inquirer/prompts";
 import { Machine } from "jssm";
 
-import { getDefaultBumpTypeForBranch } from "../library/index.js";
 import { CommandLogger } from "../logging.js";
 import { MachineState } from "../machines/index.js";
 import { FluidReleaseStateHandlerData } from "./fluidReleaseStateHandler.js";
@@ -32,34 +29,8 @@ export const askForReleaseType: StateHandlerFunction = async (
 ): Promise<boolean> => {
 	if (testMode) return true;
 
-	const { bumpType: inputBumpType, context, releaseVersion } = data;
-
-	const currentBranch = await context.gitRepo.getCurrentBranchName();
-	const currentVersion = releaseVersion;
-	const bumpedMajor = bumpVersionScheme(currentVersion, "major");
-	const bumpedMinor = bumpVersionScheme(currentVersion, "minor");
-	const bumpedPatch = bumpVersionScheme(currentVersion, "patch");
-
-	// If an bumpType was set in the handler data, use it. Otherwise set it as the default for the branch. If there's
-	// no default for the branch, ask the user.
-	let bumpType = inputBumpType ?? getDefaultBumpTypeForBranch(currentBranch);
-	if (inputBumpType === undefined) {
-		const selectedBumpType: VersionBumpType = await rawlist({
-			choices: [
-				{ value: "major", name: `major (${currentVersion} => ${bumpedMajor.version})` },
-				{ value: "minor", name: `minor (${currentVersion} => ${bumpedMinor.version})` },
-				{ value: "patch", name: `patch  (${currentVersion} => ${bumpedPatch.version})` },
-			],
-			message: `The current branch is '${currentBranch}'. The default bump type for that branch is '${bumpType}', but you can change it now if needed.`,
-		});
-		bumpType = selectedBumpType;
-		// eslint-disable-next-line require-atomic-updates
-		data.bumpType = selectedBumpType;
-	}
-
-	if (bumpType === undefined) {
-		throw new Error(`bumpType is undefined.`);
-	}
+	const { bumpType: bumpTypeLazy } = data;
+	const bumpType = await bumpTypeLazy.value;
 
 	// This state is unique; it uses major/minor/patch as the actions
 	const result = machine.action(bumpType);

--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -55,7 +55,8 @@ export const checkBranchName: StateHandlerFunction = async (
 ): Promise<boolean> => {
 	if (testMode) return true;
 
-	const { context, bumpType, shouldCheckBranch } = data;
+	const { context, bumpType: bumpTypeLazy, shouldCheckBranch } = data;
+	const bumpType = await bumpTypeLazy.value;
 
 	if (shouldCheckBranch === true) {
 		switch (bumpType) {
@@ -276,7 +277,7 @@ export const checkMainNextIntegrated: StateHandlerFunction = async (
 
 	const { bumpType, context, shouldCheckMainNextIntegrated } = data;
 
-	if (bumpType === "major") {
+	if ((await bumpType.value) === "major") {
 		if (shouldCheckMainNextIntegrated === true) {
 			const [main, next] = await Promise.all([
 				context.gitRepo.getShaForBranch("main"),
@@ -508,7 +509,8 @@ export const checkReleaseNotes: StateHandlerFunction = async (
 ): Promise<boolean> => {
 	if (testMode) return true;
 
-	const { bumpType, releaseGroup, releaseVersion } = data;
+	const { bumpType: bumpTypeLazy, releaseGroup, releaseVersion } = data;
+	const bumpType = await bumpTypeLazy.value;
 
 	if (
 		// Only some release groups use changeset-based change-tracking.
@@ -563,7 +565,8 @@ export const checkChangelogs: StateHandlerFunction = async (
 ): Promise<boolean> => {
 	if (testMode) return true;
 
-	const { releaseGroup, bumpType } = data;
+	const { releaseGroup, bumpType: bumpTypeLazy } = data;
+	const bumpType = await bumpTypeLazy.value;
 
 	if (
 		// Only some release groups use changeset-based change-tracking.
@@ -641,10 +644,12 @@ export const checkReleaseGroupIsBumped: StateHandlerFunction = async (
 ): Promise<boolean> => {
 	if (testMode) return true;
 
-	const { context, releaseGroup, releaseVersion, bumpType } = data;
+	const { context, releaseGroup, releaseVersion, bumpType: bumpTypeLazy } = data;
 
 	context.repo.reload();
 	const repoVersion = context.getVersion(releaseGroup);
+
+	const bumpType = await bumpTypeLazy.value;
 	const targetVersion = bumpVersionScheme(releaseVersion, bumpType).version;
 
 	if (repoVersion !== targetVersion) {
@@ -707,13 +712,14 @@ export const checkShouldCommit: StateHandlerFunction = async (
 ): Promise<boolean> => {
 	if (testMode) return true;
 
-	const { bumpType, context, shouldCommit, releaseGroup, releaseVersion } = data;
+	const { bumpType: bumpTypeLazy, context, shouldCommit, releaseGroup, releaseVersion } = data;
 
 	if (shouldCommit !== true) {
 		BaseStateHandler.signalFailure(machine, state);
 		return true;
 	}
 
+	const bumpType = await bumpTypeLazy.value;
 	const branchName = generateBumpVersionBranchName(releaseGroup, bumpType, releaseVersion);
 	const commitMsg = generateBumpVersionCommitMessage(releaseGroup, bumpType, releaseVersion);
 

--- a/build-tools/packages/build-cli/src/handlers/doFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/doFunctions.ts
@@ -156,7 +156,13 @@ export const doReleaseGroupBump: StateHandlerFunction = async (
 ): Promise<boolean> => {
 	if (testMode) return true;
 
-	const { bumpType, context, releaseGroup, releaseVersion, shouldInstall } = data;
+	const {
+		bumpType: bumpTypeLazy,
+		context,
+		releaseGroup,
+		releaseVersion,
+		shouldInstall,
+	} = data;
 
 	const rgRepo = isReleaseGroup(releaseGroup)
 		? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -165,6 +171,9 @@ export const doReleaseGroupBump: StateHandlerFunction = async (
 			context.fullPackageMap.get(releaseGroup)!;
 
 	const scheme = detectVersionScheme(releaseVersion);
+
+	const bumpType = await bumpTypeLazy.value;
+
 	const newVersion = bumpVersionScheme(releaseVersion, bumpType, scheme);
 	const packages = rgRepo instanceof MonoRepo ? rgRepo.packages : [rgRepo];
 

--- a/build-tools/packages/build-cli/src/handlers/fluidReleaseStateHandler.ts
+++ b/build-tools/packages/build-cli/src/handlers/fluidReleaseStateHandler.ts
@@ -12,6 +12,7 @@ import { Context } from "../library/index.js";
 import { ReleaseVersion, VersionBumpType, VersionScheme } from "@fluid-tools/version-tools";
 
 import { InstructionalPromptWriter } from "../instructionalPromptWriter.js";
+import type { Lazy } from "../lazy.js";
 import { CommandLogger } from "../logging.js";
 import { MachineState } from "../machines/index.js";
 import { ReleaseGroup, ReleasePackage } from "../releaseGroups.js";
@@ -79,7 +80,7 @@ export interface FluidReleaseStateHandlerData {
 	/**
 	 * The bump type used for this release.
 	 */
-	bumpType: VersionBumpType;
+	bumpType: Lazy<Promise<VersionBumpType>>;
 
 	/**
 	 * An {@link InstructionalPromptWriter} that the command can use to display instructional prompts.

--- a/build-tools/packages/build-cli/src/handlers/fluidReleaseStateHandler.ts
+++ b/build-tools/packages/build-cli/src/handlers/fluidReleaseStateHandler.ts
@@ -80,7 +80,7 @@ export interface FluidReleaseStateHandlerData {
 	/**
 	 * The bump type used for this release.
 	 */
-	bumpType: Lazy<Promise<VersionBumpType>>;
+	readonly bumpType: Lazy<Promise<VersionBumpType>>;
 
 	/**
 	 * An {@link InstructionalPromptWriter} that the command can use to display instructional prompts.

--- a/build-tools/packages/build-cli/src/handlers/promptFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/promptFunctions.ts
@@ -10,7 +10,6 @@ import { type InstructionalPrompt, mapADOLinks } from "../instructionalPromptWri
 import {
 	difference,
 	generateReleaseBranchName,
-	getDefaultBumpTypeForBranch,
 	getPreReleaseDependencies,
 } from "../library/index.js";
 import { CommandLogger } from "../logging.js";
@@ -486,16 +485,13 @@ export const promptToGenerateReleaseNotes: StateHandlerFunction = async (
 
 	const {
 		command,
-		context,
 		promptWriter,
 		releaseGroup,
 		releaseVersion,
 		bumpType: inputBumpType,
 	} = data;
-	const currentBranch = await context.gitRepo.getCurrentBranchName();
 
-	// If an bumpType was set in the handler data, use it. Otherwise set it as the default for the branch.
-	const bumpType = inputBumpType ?? getDefaultBumpTypeForBranch(currentBranch);
+	const bumpType = await inputBumpType.value;
 
 	const prompt: InstructionalPrompt = {
 		title: "NEED TO GENERATE RELEASE NOTES",

--- a/build-tools/packages/build-cli/src/lazy.ts
+++ b/build-tools/packages/build-cli/src/lazy.ts
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Helper class for lazy initialized values.
+ * Ensures the value is only generated once.
+ */
+export class Lazy<T> {
+	/**
+	 * Sentinel value that valueGenerator could not return (unlike undefined) for the unset case.
+	 */
+	private static readonly unset: unique symbol = Symbol("unset");
+
+	/**
+	 * The value, if computed, otherwise `unset`.
+	 */
+	private lazyValue: T | typeof Lazy.unset = Lazy.unset;
+
+	/**
+	 * Instantiates an instance of Lazy<T>.
+	 * @param valueGenerator - The function that will generate the value when value is accessed the first time.
+	 */
+	public constructor(private readonly valueGenerator: () => T) {}
+
+	/**
+	 * Get the value. If this is the first call the value will be generated.
+	 */
+	public get value(): T {
+		if (this.lazyValue === Lazy.unset) {
+			this.lazyValue = this.valueGenerator();
+		}
+		return this.lazyValue;
+	}
+}


### PR DESCRIPTION
## Description

Make flub release request bump type lazily.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I don't know a great way to test this locally easily, since running it on my branch doesn't hit very many of the cases since it objects to the branch it's on. I can confirm it prompts if I disable checks, but I'm not sure if it would skip prompting run on a release that's not released where the bump type should not be needed.
