### PR TITLE
Add re-entrancy errors for TreeCheckout

### DIFF
--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -383,7 +383,7 @@ export class SchematizingSimpleTreeView<
 
 	// #region Branching
 
-	public fork(): ReturnType<TreeBranch["fork"]> & TreeViewAlpha<TRootSchema> {
+	public fork(): ReturnType<TreeBranch["fork"]> & SchematizingSimpleTreeView<TRootSchema> {
 		return this.checkout.branch().viewWith(this.config);
 	}
 

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -51,6 +51,7 @@ import {
 	getOrCreateInnerNode,
 	toStoredSchema,
 	type InsertableField,
+	type TreeBranch,
 } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { stringSchema } from "../../simple-tree/leafNodeSchema.js";
@@ -1267,6 +1268,78 @@ describe("sharedTreeView", () => {
 				unsubscribe();
 			});
 		}
+	});
+
+	describe("throws an error if it is in the middle of an edit when a user attempts to", () => {
+		const sf = new SchemaFactory("Checkout and view test schema");
+		class NumberNode extends sf.object("Number", { number: sf.number }) {}
+
+		/** Tests that an error is thrown when a given action is taken during the execution of a nodeChanged/treeChanged listener */
+		function expectErrorDuringEdit(args: {
+			/**
+			 * Runs after the main view has been created but before the edit occurs
+			 * @returns (optionally) a view (e.g. a fork of the main view) that will be passed to `duringEdit`
+			 */
+			setup?: (
+				view: SchematizingSimpleTreeView<typeof NumberNode>,
+			) => void | SchematizingSimpleTreeView<typeof NumberNode>;
+			/** The code to run during the edit that should throw an error */
+			duringEdit: (view: SchematizingSimpleTreeView<typeof NumberNode>) => void;
+			/** The expected error message */
+			error: string;
+		}): void {
+			let view = getView(
+				new TreeViewConfiguration({ enableSchemaValidation, schema: NumberNode }),
+			);
+
+			view.initialize({ number: 3 });
+			view = args.setup?.(view) ?? view;
+
+			Tree.on(view.root, "nodeChanged", () => {
+				args.duringEdit(view);
+			});
+
+			assert.throws(() => (view.root.number = 0), new RegExp(args.error));
+		}
+
+		it("edit the tree", () => {
+			expectErrorDuringEdit({
+				duringEdit: (view) => {
+					view.root.number = 4;
+				},
+				error: "Editing the tree is forbidden during a nodeChanged or treeChanged event",
+			});
+		});
+
+		it("create a branch", () => {
+			expectErrorDuringEdit({
+				duringEdit: (view) => view.fork(),
+				error: ".*Branching is forbidden during a nodeChanged or treeChanged event.*",
+			});
+		});
+
+		it("rebase a branch", () => {
+			expectErrorDuringEdit({
+				duringEdit: (view) => view.rebaseOnto(view),
+				error: "Rebasing is forbidden during a nodeChanged or treeChanged event",
+			});
+		});
+
+		it("merge a branch", () => {
+			expectErrorDuringEdit({
+				duringEdit: (view) => view.merge(view),
+				error: "Merging is forbidden during a nodeChanged or treeChanged event",
+			});
+		});
+
+		it("dispose", () => {
+			let branch: TreeBranch | undefined;
+			expectErrorDuringEdit({
+				setup: (view) => (branch = view.fork()), // Create a fork of the view because the main view can't be disposed
+				duringEdit: (view) => view.dispose(),
+				error: "Disposing a view is forbidden during a nodeChanged or treeChanged event",
+			});
+		});
 	});
 });
 


### PR DESCRIPTION
## Description

This prevents the user from doing various actions to a SharedTree view while in the middle of an ongoing tree edit. The current behavior for these scenarios is undefined and currently tends to give unpredictable internal error messages to users.
