### PR TITLE
refactor(client-presence): Rename ExperimentalPresenceManager to PresenceManager + remove all experimental naming from package

### DIFF
--- a/.changeset/common-cars-swim.md
+++ b/.changeset/common-cars-swim.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/presence": minor
+---
+---
+"section": other
+---
+
+Rename ExperimentalPresenceManager to PresenceManger
+
+Now that Presence package has been promoted from experimental to alpha, we have renamed ExperimentalPresenceManager to PresenceManager.

--- a/.changeset/common-cars-swim.md
+++ b/.changeset/common-cars-swim.md
@@ -7,4 +7,4 @@
 
 Rename ExperimentalPresenceManager to PresenceManger
 
-Now that Presence package has been promoted from experimental to alpha, we have renamed ExperimentalPresenceManager to PresenceManager.
+Now that Presence package has been promoted from experimental to alpha, we have renamed `ExperimentalPresenceManager` to `PresenceManager` and `ExperimentalPresenceDO` to `PresenceDO`.

--- a/examples/service-clients/azure-client/external-controller/src/app.ts
+++ b/examples/service-clients/azure-client/external-controller/src/app.ts
@@ -13,10 +13,7 @@ import {
 import { createDevtoolsLogger, initializeDevtools } from "@fluidframework/devtools/internal";
 // eslint-disable-next-line import/no-internal-modules
 import { ISharedMap, IValueChanged, SharedMap } from "@fluidframework/map/internal";
-import {
-	acquirePresenceViaDataObject,
-	ExperimentalPresenceManager,
-} from "@fluidframework/presence/alpha";
+import { acquirePresenceViaDataObject, PresenceManager } from "@fluidframework/presence/alpha";
 // eslint-disable-next-line import/no-internal-modules
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 // eslint-disable-next-line import/no-internal-modules
@@ -81,7 +78,7 @@ const containerSchema = {
 		map2: SharedMap,
 		// A Presence Manager object temporarily needs to be placed within container schema
 		// https://github.com/microsoft/FluidFramework/blob/main/packages/framework/presence/README.md#onboarding
-		presence: ExperimentalPresenceManager,
+		presence: PresenceManager,
 	},
 } satisfies ContainerSchema;
 type DiceRollerContainerSchema = typeof containerSchema;

--- a/packages/framework/presence/CHANGELOG.md
+++ b/packages/framework/presence/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @fluid-experimental/presence
+# @fluidframework/presence
 
 ## 2.5.0
 
@@ -18,11 +18,11 @@ Dependency updates only.
 
 ### Major Changes
 
--   Experimental Presence package added ([#22499](https://github.com/microsoft/FluidFramework/pull/22499)) [42b323cdbf1](https://github.com/microsoft/FluidFramework/commit/42b323cdbf129c897cf9bb51c1f1b9de5642ef8a)
+-   Presence package added ([#22499](https://github.com/microsoft/FluidFramework/pull/22499)) [42b323cdbf1](https://github.com/microsoft/FluidFramework/commit/42b323cdbf129c897cf9bb51c1f1b9de5642ef8a)
 
-    **[@fluid-experimental/presence](https://github.com/microsoft/FluidFramework/tree/main/packages/framework/presence#readme)** is now available for investigation. The new package is meant to support presence of collaborators connected to the same container. Use this library to quickly share simple, non-persisted data among all clients or send/receive fire and forget notifications.
+    **[@fluidframework/presence](https://github.com/microsoft/FluidFramework/tree/main/packages/framework/presence#readme)** is now available for investigation. The new package is meant to support presence of collaborators connected to the same container. Use this library to quickly share simple, non-persisted data among all clients or send/receive fire and forget notifications.
 
-    API documentation for **@fluid-experimental/presence** is available at <https://fluidframework.com/docs/apis/presence>.
+    API documentation for **@fluidframework/presence** is available at <https://fluidframework.com/docs/apis/presence>.
 
     There are some limitations; see the README.md of installed package for most relevant notes.
 

--- a/packages/framework/presence/README.md
+++ b/packages/framework/presence/README.md
@@ -80,7 +80,7 @@ Notifications value managers are special case where no data is retained during a
 
 ## Onboarding
 
-While this package is developing as experimental and other Fluid Framework internals are being updated to accommodate it, a temporary Shared Object must be added within container to gain access.
+While this package is developing and other Fluid Framework internals are being updated to accommodate it, a temporary Shared Object must be added within container to gain access.
 
 ```typescript
 import { acquirePresenceViaDataObject, PresenceManager } from "@fluidframework/presence/alpha";

--- a/packages/framework/presence/README.md
+++ b/packages/framework/presence/README.md
@@ -83,11 +83,11 @@ Notifications value managers are special case where no data is retained during a
 While this package is developing as experimental and other Fluid Framework internals are being updated to accommodate it, a temporary Shared Object must be added within container to gain access.
 
 ```typescript
-import { acquirePresenceViaDataObject, ExperimentalPresenceManager } from "@fluidframework/presence/alpha";
+import { acquirePresenceViaDataObject, PresenceManager } from "@fluidframework/presence/alpha";
 
 const containerSchema = {
 	initialObjects: {
-        presence: ExperimentalPresenceManager
+        presence: PresenceManager
     }
 } satisfies ContainerSchema;
 

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -22,9 +22,6 @@ export type ClientSessionId = SessionId & {
 export class ExperimentalPresenceDO {
 }
 
-// @alpha
-export const ExperimentalPresenceManager: SharedObjectKind<IFluidLoadable & ExperimentalPresenceDO>;
-
 // @alpha @sealed
 export interface IPresence {
     readonly events: ISubscribable<PresenceEvents>;
@@ -176,6 +173,9 @@ export interface PresenceEvents {
     attendeeJoined: (attendee: ISessionClient) => void;
     workspaceActivated: (workspaceAddress: PresenceWorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
 }
+
+// @alpha
+export const PresenceManager: SharedObjectKind<IFluidLoadable & ExperimentalPresenceDO>;
 
 // @alpha @sealed
 export type PresenceNotifications<TSchema extends PresenceNotificationsSchema> = PresenceStates<TSchema, NotificationsManager<any>>;

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -8,7 +8,7 @@
 export function acquirePresence(fluidContainer: IFluidContainer): IPresence;
 
 // @alpha
-export function acquirePresenceViaDataObject(fluidLoadable: ExperimentalPresenceDO): IPresence;
+export function acquirePresenceViaDataObject(fluidLoadable: PresenceDO): IPresence;
 
 // @alpha
 export type ClientConnectionId = string;
@@ -17,10 +17,6 @@ export type ClientConnectionId = string;
 export type ClientSessionId = SessionId & {
     readonly ClientSessionId: "ClientSessionId";
 };
-
-// @alpha @sealed
-export class ExperimentalPresenceDO {
-}
 
 // @alpha @sealed
 export interface IPresence {
@@ -165,6 +161,10 @@ export type NotificationSubscriptions<E extends InternalUtilityTypes.Notificatio
     [K in string & keyof InternalUtilityTypes.NotificationEvents<E>]: (sender: ISessionClient, ...args: InternalUtilityTypes.JsonDeserializedParameters<E[K]>) => void;
 };
 
+// @alpha @sealed
+export class PresenceDO {
+}
+
 // @alpha @sealed (undocumented)
 export interface PresenceEvents {
     // @eventProperty
@@ -175,7 +175,7 @@ export interface PresenceEvents {
 }
 
 // @alpha
-export const PresenceManager: SharedObjectKind<IFluidLoadable & ExperimentalPresenceDO>;
+export const PresenceManager: SharedObjectKind<IFluidLoadable & PresenceDO>;
 
 // @alpha @sealed
 export type PresenceNotifications<TSchema extends PresenceNotificationsSchema> = PresenceStates<TSchema, NotificationsManager<any>>;

--- a/packages/framework/presence/src/datastorePresenceManagerFactory.ts
+++ b/packages/framework/presence/src/datastorePresenceManagerFactory.ts
@@ -106,9 +106,7 @@ export const PresenceManager = new PresenceManagerFactory() as unknown as Shared
  *
  * @alpha
  */
-export function acquirePresenceViaDataObject(
-	fluidLoadable: PresenceDO,
-): IPresence {
+export function acquirePresenceViaDataObject(fluidLoadable: PresenceDO): IPresence {
 	if (fluidLoadable instanceof PresenceManagerDataObject) {
 		return fluidLoadable.presenceManager();
 	}

--- a/packages/framework/presence/src/datastorePresenceManagerFactory.ts
+++ b/packages/framework/presence/src/datastorePresenceManagerFactory.ts
@@ -53,7 +53,7 @@ class PresenceManagerDataObject extends LoadableFluidObject {
  * Factory class to create {@link IPresence} in own data store.
  */
 class PresenceManagerFactory {
-	public is(value: IFluidLoadable | ExperimentalPresenceDO): value is ExperimentalPresenceDO {
+	public is(value: IFluidLoadable | PresenceDO): value is PresenceDO {
 		return value instanceof PresenceManagerDataObject;
 	}
 
@@ -64,7 +64,7 @@ class PresenceManagerFactory {
 }
 
 /**
- * Brand for Experimental Presence Data Object.
+ * Brand for Presence Data Object.
  *
  * @remarks
  * See {@link acquirePresenceViaDataObject} for example usage.
@@ -72,8 +72,8 @@ class PresenceManagerFactory {
  * @sealed
  * @alpha
  */
-export declare class ExperimentalPresenceDO {
-	private readonly _self: ExperimentalPresenceDO;
+export declare class PresenceDO {
+	private readonly _self: PresenceDO;
 }
 
 /**
@@ -83,7 +83,7 @@ export declare class ExperimentalPresenceDO {
  * @alpha
  */
 export const PresenceManager = new PresenceManagerFactory() as unknown as SharedObjectKind<
-	IFluidLoadable & ExperimentalPresenceDO
+	IFluidLoadable & PresenceDO
 >;
 
 /**
@@ -93,21 +93,21 @@ export const PresenceManager = new PresenceManagerFactory() as unknown as Shared
  * ```typescript
  * const containerSchema = {
  * 	initialObjects: {
- * 		experimentalPresence: ExperimentalPresenceDO,
+ * 		presence: PresenceDO,
  * 	},
  * } satisfies ContainerSchema;
  * ```
  * then
  * ```typescript
  * const presence = acquirePresenceViaDataObject(
- * 	container.initialObjects.experimentalPresence,
+ * 	container.initialObjects.presence,
  * 	);
  * ```
  *
  * @alpha
  */
 export function acquirePresenceViaDataObject(
-	fluidLoadable: ExperimentalPresenceDO,
+	fluidLoadable: PresenceDO,
 ): IPresence {
 	if (fluidLoadable instanceof PresenceManagerDataObject) {
 		return fluidLoadable.presenceManager();

--- a/packages/framework/presence/src/datastorePresenceManagerFactory.ts
+++ b/packages/framework/presence/src/datastorePresenceManagerFactory.ts
@@ -82,10 +82,9 @@ export declare class ExperimentalPresenceDO {
  *
  * @alpha
  */
-export const ExperimentalPresenceManager =
-	new PresenceManagerFactory() as unknown as SharedObjectKind<
-		IFluidLoadable & ExperimentalPresenceDO
-	>;
+export const PresenceManager = new PresenceManagerFactory() as unknown as SharedObjectKind<
+	IFluidLoadable & ExperimentalPresenceDO
+>;
 
 /**
  * Acquire IPresence from a DataStore based Presence Manager
@@ -114,5 +113,5 @@ export function acquirePresenceViaDataObject(
 		return fluidLoadable.presenceManager();
 	}
 
-	throw new Error("Incompatible loadable; make sure to use ExperimentalPresenceManager");
+	throw new Error("Incompatible loadable; make sure to use PresenceManager");
 }

--- a/packages/framework/presence/src/index.ts
+++ b/packages/framework/presence/src/index.ts
@@ -50,7 +50,7 @@ export { acquirePresence } from "./experimentalAccess.js";
 export {
 	acquirePresenceViaDataObject,
 	type ExperimentalPresenceDO,
-	ExperimentalPresenceManager,
+	PresenceManager,
 } from "./datastorePresenceManagerFactory.js";
 
 export type { LatestValueControls } from "./latestValueControls.js";

--- a/packages/framework/presence/src/index.ts
+++ b/packages/framework/presence/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * Experimental package for client presence within a connected session.
+ * Package for client presence within a connected session.
  *
  * See {@link https://github.com/microsoft/FluidFramework/tree/main/packages/framework/presence#readme | README.md } for an overview of the package.
  *
@@ -49,7 +49,7 @@ export { acquirePresence } from "./experimentalAccess.js";
 
 export {
 	acquirePresenceViaDataObject,
-	type ExperimentalPresenceDO,
+	type PresenceDO,
 	PresenceManager,
 } from "./datastorePresenceManagerFactory.js";
 


### PR DESCRIPTION
## Description
Now that Presence package has been promoted from experimental to alpha, we should rename ExperimentalPresenceManager to just PresenceManager. 

This PR completeley removes all 'experimental' naming from the Presence package.