### PR TITLE
docs(client-presence): remove 'experimental package' usage in Presence docs 

### DIFF
--- a/packages/framework/presence/README.md
+++ b/packages/framework/presence/README.md
@@ -80,7 +80,7 @@ Notifications value managers are special case where no data is retained during a
 
 ## Onboarding
 
-While this package is developing as experimental and other Fluid Framework internals are being updated to accommodate it, a temporary Shared Object must be added within container to gain access.
+While this package is developing and other Fluid Framework internals are being updated to accommodate it, a temporary Shared Object must be added within container to gain access.
 
 ```typescript
 import { acquirePresenceViaDataObject, ExperimentalPresenceManager } from "@fluidframework/presence/alpha";

--- a/packages/framework/presence/src/index.ts
+++ b/packages/framework/presence/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * Experimental package for client presence within a connected session.
+ * Package for client presence within a connected session.
  *
  * See {@link https://github.com/microsoft/FluidFramework/tree/main/packages/framework/presence#readme | README.md } for an overview of the package.
  *


### PR DESCRIPTION
## Description
Presence has been promoted to alpha and is not experimental package anymore. This PR removes the 'experimental package' usage in Presence docs