### PR TITLE
fix(client): declare proper `IAudience` implementation

### DIFF
--- a/packages/framework/presence/src/test/mockEphemeralRuntime.ts
+++ b/packages/framework/presence/src/test/mockEphemeralRuntime.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "node:assert";
 
-import type { IAudience } from "@fluidframework/container-definitions";
 import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import type { IClient, ISequencedClient } from "@fluidframework/driver-definitions";
 import { MockAudience, MockQuorumClients } from "@fluidframework/test-runtime-utils/internal";
@@ -98,8 +97,7 @@ export class MockEphemeralRuntime implements IEphemeralRuntime {
 		this.quorum = makeMockQuorum(clientsData);
 		this.getQuorum = () => this.quorum;
 		this.audience = makeMockAudience(clientsData);
-		// TODO: Correct MockAudience to implement IAudience.getSelf accurately.
-		this.getAudience = () => this.audience as IAudience;
+		this.getAudience = () => this.audience;
 		this.on = (
 			event: string,
 			listener: (...args: any[]) => void,

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -40,10 +40,7 @@ export class MockAudience extends TypedEventEmitter<IAudienceEvents> implements 
     // (undocumented)
     getMembers(): Map<string, IClient>;
     // (undocumented)
-    getSelf(): {
-        clientId: string;
-        client: undefined;
-    } | undefined;
+    getSelf(): ISelf | undefined;
     // (undocumented)
     removeMember(clientId: string): boolean;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/tsconfig.json
+++ b/packages/runtime/test-runtime-utils/tsconfig.json
@@ -7,6 +7,8 @@
 		"outDir": "./lib",
 		"noImplicitOverride": true,
 		"noUncheckedIndexedAccess": false,
-		"exactOptionalPropertyTypes": false,
+		"exactOptionalPropertyTypes": true,
+		// Skip lib check to avoid exactOptionalPropertyTypes errors in dependencies (routerlicious-driver)
+		"skipLibCheck": true,
 	},
 }


### PR DESCRIPTION
by explicitly specifying `getSelf` return type. Also remove the incorrect undefined `client` property.

Enable `exactOptionalPropertyTypes` and fix errors to keep `IAudience` implementation strictly checked.