### PR TITLE
ci(docs): Fix build location

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -194,7 +194,7 @@ stages:
         - task: PublishPipelineArtifact@1
           displayName: 'Publish site build artifact'
           inputs:
-            targetPath: '$(Build.SourcesDirectory)/docs/public'
+            targetPath: '$(Build.SourcesDirectory)/docs/build'
             artifactName: 'fluidframework-docs'
             publishLocation: 'pipeline'
 
@@ -359,11 +359,11 @@ stages:
           clean: true
 
         - task: DownloadPipelineArtifact@2
-          displayName: 'Copy fluidframework-docs to public folder'
+          displayName: 'Copy fluidframework-docs to "build" folder'
           inputs:
             source: current
             artifact: fluidframework-docs
-            path: '$(Build.SourcesDirectory)/docs/public'
+            path: '$(Build.SourcesDirectory)/docs/build'
 
         - task: AzureStaticWebApp@0
           displayName: 'Deploy website to ASWA'
@@ -371,7 +371,7 @@ stages:
             skip_app_build: true # site was built in previous stage
             skip_api_build: true # api is written in js, no build needed
             cwd: $(Build.SourcesDirectory)
-            app_location: 'docs/public'
+            app_location: 'docs/build'
             api_location: 'docs/api'
             output_location: ''
             azure_static_web_apps_api_token: '${{ variables.deploymentToken }}'


### PR DESCRIPTION
Pipeline still had a couple lingering references to the "public" directory, but the new Docusaurus site outputs to "build".