### PR TITLE
feat(tree): normalize the NeverField/NeverTree before validating repo su…

### DIFF
--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -77,6 +77,7 @@ export {
 	getAllowedContentDiscrepancies,
 	isRepoSuperset,
 	isNeverTree,
+	normalizeStoredSchema,
 } from "./modular-schema/index.js";
 
 export { mapRootChanges } from "./deltaUtils.js";

--- a/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
@@ -544,7 +544,7 @@ function throwUnsupportedNodeType(type: string): never {
  * - All never trees dropped from the schema
  * - All never fields converted to explicit Forbidden fields
  */
-function normalizeStoredSchema(
+export function normalizeStoredSchema(
 	schema: TreeStoredSchema,
 	policy: FullSchemaPolicy,
 ): TreeStoredSchema {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
@@ -77,4 +77,5 @@ export type {
 export {
 	getAllowedContentDiscrepancies,
 	isRepoSuperset,
+	normalizeStoredSchema,
 } from "./discrepancies.js";

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -194,7 +194,7 @@ describe("Schema Comparison", () => {
 			isSuperset: boolean,
 		): void => {
 			assert.equal(allowsRepoSuperset(defaultSchemaPolicy, stored, view), isSuperset);
-			assert.equal(isRepoSuperset(view, stored), isSuperset);
+			assert.equal(isRepoSuperset(defaultSchemaPolicy, view, stored), isSuperset);
 		};
 
 		it("Same rootFieldSchema with different TreeNodeStoredSchemas", () => {
@@ -300,7 +300,7 @@ describe("Schema Comparison", () => {
 			});
 
 			testOrder(compareTwoRepo, repos);
-			assert.equal(isRepoSuperset(repos[1], repos[0]), true);
+			assert.equal(isRepoSuperset(defaultSchemaPolicy, repos[1], repos[0]), true);
 		});
 
 		it("Validate the ordering when the identifiers are different", () => {


### PR DESCRIPTION
…perset

## Description

Add a function to normalize the store schema by cleaning up the `NeverField`/`NeverTree`. This will help ensure that the logic for `isRepoSuperset` aligns with the handling in `allowsRepoSuperset`.

[AB#11525](https://dev.azure.com/fluidframework/internal/_workitems/edit/11525)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

> List any specific things you want to get reviewer opinions on, and anything a reviewer would need to know to review this PR effectively.
> Things you might want to include:
>
> -   Questions about how to properly make automated tests for your changes.
> -   Questions about design choices you made.
> -   Descriptions of how to manually test the changes (and how much of that you have done).
> -   etc.
>
> If you have any questions in this section, consider making the PR a draft until all questions have been resolved.
