### PR TITLE
fix(tree): do not fire changed event for rebases on branches

### DIFF
--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -54,7 +54,11 @@ import {
 	jsonableTreeFromCursor,
 	makeFieldBatchCodec,
 } from "../feature-libraries/index.js";
-import { SharedTreeBranch, getChangeReplaceType } from "../shared-tree-core/index.js";
+import {
+	SharedTreeBranch,
+	getChangeReplaceType,
+	type SharedTreeBranchChange,
+} from "../shared-tree-core/index.js";
 import { Breakable, TransactionResult, disposeSymbol, fail } from "../util/index.js";
 
 import { SharedTreeChangeFamily, hasSchemaChange } from "./sharedTreeChangeFamily.js";
@@ -581,7 +585,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 						this.events.emit("changed", { isLocal: true, kind }, getRevertible);
 						withinEventContext = false;
 					}
-				} else if (event.type === "replace") {
+				} else if (this.isRemoteChangeEvent(event)) {
 					// TODO: figure out how to plumb through commit kind info for remote changes
 					this.events.emit("changed", { isLocal: false, kind: CommitKind.Default });
 				}
@@ -869,6 +873,21 @@ export class TreeCheckout implements ITreeCheckoutFork {
 
 			rootFields.delete(field);
 		} while (cursor.nextField());
+	}
+
+	/**
+	 * `true` iff the given branch change event is due to a remote change
+	 */
+	private isRemoteChangeEvent(event: SharedTreeBranchChange<SharedTreeChange>): boolean {
+		return (
+			// remote changes are only ever applied to the main branch
+			!this.isBranch &&
+			// remote changes are applied to the main branch by rebasing it onto the trunk,
+			// no other rebases are allowed on the main branch so this means any replaces that are not
+			// transaction commits are remote changes
+			event.type === "replace" &&
+			getChangeReplaceType(event) !== "transactionCommit"
+		);
 	}
 }
 

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -315,24 +315,20 @@ describe("SchematizingSimpleTreeView", () => {
 				new MockNodeKeyManager(),
 			);
 			const branch = main.fork();
-
-			let changes = 0;
-
-			const unsubscribe = branch.events.on("changed", (data) => {
-				changes++;
-			});
-
 			const mainRoot = main.root;
 			const branchRoot = branch.root;
 
-			branchRoot.removeAt(1);
-			assert.deepEqual([...branchRoot], ["a", "c"]);
 			mainRoot.insertAt(0, "a");
 			assert.deepEqual([...mainRoot], ["a", "a", "b", "c"]);
+
+			let changes = 0;
+			branch.events.on("changed", (data) => {
+				changes++;
+			});
+
 			branch.rebaseOnto(main);
-			assert.deepEqual([...branchRoot], ["a", "a", "c"]);
-			assert.equal(changes, 1);
-			unsubscribe();
+			assert.deepEqual([...branchRoot], ["a", "a", "b", "c"]);
+			assert.equal(changes, 0);
 		});
 	});
 });

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -309,7 +309,11 @@ describe("SchematizingSimpleTreeView", () => {
 				initialTree: cursorFromInsertable(stringArraySchema, ["a", "b", "c"]),
 			};
 			const checkout = checkoutWithContent(stringArrayContent);
-			const main = new SchematizingSimpleTreeView(checkout, new TreeViewConfiguration({ schema: stringArraySchema }), new MockNodeKeyManager());
+			const main = new SchematizingSimpleTreeView(
+				checkout,
+				new TreeViewConfiguration({ schema: stringArraySchema }),
+				new MockNodeKeyManager(),
+			);
 			const branch = main.fork();
 
 			let changes = 0;


### PR DESCRIPTION
This makes it so that changed events are not fired when rebases happen on branches that are not the main branch and also adds a regression test for this scenario. Rebases that happen on the main branch are remote changes and therefore correct.