### PR TITLE
fix(docs): Fix site title and description

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import React from "react";
 
@@ -13,12 +12,8 @@ import { Homepage } from "@site/src/components/home";
  * The website homepage root (including the header and footer injected by Docusaurus).
  */
 export default function Home(): React.ReactElement {
-	const { siteConfig } = useDocusaurusContext();
 	return (
-		<Layout
-			title={`Hello from ${siteConfig.title}`}
-			description="Description will go into a meta tag in <head />"
-		>
+		<Layout>
 			<Homepage />
 		</Layout>
 	);

--- a/docs/test/site-tests/Homepage.spec.ts
+++ b/docs/test/site-tests/Homepage.spec.ts
@@ -8,6 +8,6 @@ import { test, expect } from "@playwright/test";
 test.describe("Homepage", () => {
 	test("Load the homepage (smoke test)", async ({ page }) => {
 		await page.goto("/", { waitUntil: "domcontentloaded" });
-		expect(await page.title()).toBe("Hello from Fluid Framework | Fluid Framework");
+		expect(await page.title()).toBe("Fluid Framework");
 	});
 });


### PR DESCRIPTION
Current contents were copied from example boilerplate and were missed in the initial Docusaurus PR.

This PR fixes the generated site title to be `Fluid Framework` instead of `Fluid Framework | Hello from Fluid Framework!`.
Also removes the template page description.