### PR TITLE
Adding pause/resume functionality for document lambdas

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -73,11 +73,10 @@ export class DocumentContextManager extends EventEmitter {
 					lowestOffset = docContext.head.offset;
 				}
 			}
-			console.log(`TEST!! Emitting pause from contextManager, lowestOffset: ${lowestOffset}, offset: ${offset}, reason: ${reason}`);
+			Lumberjack.info("Emitting pause from contextManager", {lowestOffset, offset, reason});
 			this.emit("pause", lowestOffset, offset, reason);
 		});
 		context.addListener("resume", () => {
-			console.log(`TEST!! Emitting resume from contextManager`);
 			this.emit("resume");
 		});
 		return context;
@@ -98,9 +97,9 @@ export class DocumentContextManager extends EventEmitter {
 	 * @returns True if the head was updated, false if it was not.
 	 */
 	public setHead(head: IQueuedMessage, allowBackToOffset?: number | undefined) {
-		// if allowBackToOffset is set and is lower than lastCheckpoint, then dont reprocess
+		// if allowBackToOffset is set and is lower than lastCheckpoint, then dont reprocess and return early
 		if (allowBackToOffset !== undefined && allowBackToOffset <= this.lastCheckpoint.offset) {
-			console.log(`TEST!! DocumentContextManager setHead not updating head as allowBackToOffset ${allowBackToOffset} is already processed successfully and checkpointed. Last checkpoint offset: ${this.lastCheckpoint.offset}`);
+			Lumberjack.info("Not updating contextManager head and returning early", { allowBackToOffset, lastCheckpointOffset: this.lastCheckpoint.offset });
 			return false;
 		}
 		if (head.offset > this.head.offset || head.offset === allowBackToOffset) {
@@ -160,7 +159,6 @@ export class DocumentContextManager extends EventEmitter {
 
 		// Checkpoint once the offset has changed
 		if (queuedMessage.offset !== this.lastCheckpoint.offset) {
-			console.log("TEST!! Checkpointing offset in kafka: ", queuedMessage.offset);
 			this.partitionContext.checkpoint(queuedMessage, restartOnCheckpointFailure);
 			this.lastCheckpoint = queuedMessage;
 		}

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -123,7 +123,7 @@ export class DocumentContextManager extends EventEmitter {
 		assert(
 			(tail.offset > this.tail.offset || tail.offset === allowBackToOffset) &&
 				tail.offset <= this.head.offset,
-			`(${tail.offset} > ${this.tail.offset} || ${tail.offset} === ${allowBackToOffset}) && ${tail.offset} <= ${this.head.offset}`,
+			`Tail offset ${tail.offset} must be greater than the current tail offset ${this.tail.offset} or equal to the resume offset ${allowBackToOffset}, and less than or equal to the head offset ${this.head.offset}.`,
 		);
 
 		if (tail.offset <= this.tail.offset) {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -65,6 +65,14 @@ export class DocumentContextManager extends EventEmitter {
 			Lumberjack.verbose("Emitting error from contextManager, context error event.");
 			this.emit("error", error, errorData);
 		});
+		context.addListener("pause", (offset: number, reason?: any) => {
+			console.log(`TEST!! Emitting pause from contextManager, offset: ${offset}, reason: ${reason}`);
+			this.emit("pause", offset, reason);
+		});
+		context.addListener("resume", () => {
+			console.log(`TEST!! Emitting resume from contextManager`);
+			this.emit("resume");
+		});
 		return context;
 	}
 

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -132,6 +132,7 @@ export class DocumentContextManager extends EventEmitter {
 
 		// Checkpoint once the offset has changed
 		if (queuedMessage.offset !== this.lastCheckpoint.offset) {
+			console.log("TEST!! Checkpointing offset in kafka: ", queuedMessage.offset);
 			this.partitionContext.checkpoint(queuedMessage, restartOnCheckpointFailure);
 			this.lastCheckpoint = queuedMessage;
 		}

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -73,7 +73,7 @@ export class DocumentContextManager extends EventEmitter {
 					lowestOffset = docContext.head.offset;
 				}
 			}
-			Lumberjack.info("Emitting pause from contextManager", {lowestOffset, offset, reason});
+			Lumberjack.info("Emitting pause from contextManager", { lowestOffset, offset, reason });
 			this.emit("pause", lowestOffset, offset, reason);
 		});
 		context.addListener("resume", () => {
@@ -99,12 +99,18 @@ export class DocumentContextManager extends EventEmitter {
 	public setHead(head: IQueuedMessage, allowBackToOffset?: number | undefined) {
 		// if allowBackToOffset is set and is lower than lastCheckpoint, then dont reprocess and return early
 		if (allowBackToOffset !== undefined && allowBackToOffset <= this.lastCheckpoint.offset) {
-			Lumberjack.info("Not updating contextManager head and returning early", { allowBackToOffset, lastCheckpointOffset: this.lastCheckpoint.offset });
+			Lumberjack.info("Not updating contextManager head and returning early", {
+				allowBackToOffset,
+				lastCheckpointOffset: this.lastCheckpoint.offset,
+			});
 			return false;
 		}
 		if (head.offset > this.head.offset || head.offset === allowBackToOffset) {
 			if (head.offset <= this.head.offset) {
-				Lumberjack.info("Allowing the contextManager head to move to the specified offset", { allowBackToOffset, currentHeadOffset: this.head.offset });
+				Lumberjack.info(
+					"Allowing the contextManager head to move to the specified offset",
+					{ allowBackToOffset, currentHeadOffset: this.head.offset },
+				);
 			}
 			this.head = head;
 			return true;
@@ -115,12 +121,16 @@ export class DocumentContextManager extends EventEmitter {
 
 	public setTail(tail: IQueuedMessage, allowBackToOffset?: number | undefined) {
 		assert(
-			(tail.offset > this.tail.offset || tail.offset === allowBackToOffset) && tail.offset <= this.head.offset,
+			(tail.offset > this.tail.offset || tail.offset === allowBackToOffset) &&
+				tail.offset <= this.head.offset,
 			`(${tail.offset} > ${this.tail.offset} || ${tail.offset} === ${allowBackToOffset}) && ${tail.offset} <= ${this.head.offset}`,
 		);
 
 		if (tail.offset <= this.tail.offset) {
-			Lumberjack.info("Allowing the contextManager tail to move to the specified offset.", { allowBackToOffset, currentTailOffset: this.tail.offset });
+			Lumberjack.info("Allowing the contextManager tail to move to the specified offset.", {
+				allowBackToOffset,
+				currentTailOffset: this.tail.offset,
+			});
 		}
 
 		this.tail = tail;

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -98,6 +98,11 @@ export class DocumentContextManager extends EventEmitter {
 	 * @returns True if the head was updated, false if it was not.
 	 */
 	public setHead(head: IQueuedMessage, allowBackToOffset?: number | undefined) {
+		// if allowBackToOffset is set and is lower than lastCheckpoint, then dont reprocess
+		if (allowBackToOffset !== undefined && allowBackToOffset <= this.lastCheckpoint.offset) {
+			console.log(`TEST!! DocumentContextManager setHead not updating head as allowBackToOffset ${allowBackToOffset} is already processed successfully and checkpointed. Last checkpoint offset: ${this.lastCheckpoint.offset}`);
+			return false;
+		}
 		if (head.offset > this.head.offset || head.offset === allowBackToOffset) {
 			if (head.offset <= this.head.offset) {
 				Lumberjack.info("Allowing the contextManager head to move to the specified offset", { allowBackToOffset, currentHeadOffset: this.head.offset });

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -60,9 +60,9 @@ export class DocumentContext extends EventEmitter implements IContext {
 	 * Updates the head offset for the context.
 	 */
 	public setHead(head: IQueuedMessage, allowBackToOffset?: number | undefined) {
-		// if allowBackToOffset is set and is lower than this.tailInternal, then dont reprocess
+		// if allowBackToOffset is set and is lower than this.tailInternal, then dont reprocess and return early
 		if (allowBackToOffset !== undefined && allowBackToOffset <= this.tailInternal.offset) {
-			console.log(`TEST!! DocumentContext setHead not updating head as allowBackToOffset ${allowBackToOffset} is already processes successfully. Last tailInternal offset: ${this.tailInternal.offset}`);
+			Lumberjack.info("Not updating documentContext head and returning early", { allowBackToOffset, tailInternalOffset: this.tailInternal.offset, documentId: this.routingKey.documentId });
 			return false;
 		}
 		assert(
@@ -99,7 +99,6 @@ export class DocumentContext extends EventEmitter implements IContext {
 				`(${message.topic}, ${message.partition}, ${this.routingKey.tenantId}/${this.routingKey.documentId})`,
 		);
 
-		console.log("TEST!! DocumentContext checkpointing document queue message offset:", message.offset);
 		// Update the tail and broadcast the checkpoint
 		this.tailInternal = message;
 		this.emit("checkpoint", restartOnCheckpointFailure);

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -89,6 +89,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 				`(${message.topic}, ${message.partition}, ${this.routingKey.tenantId}/${this.routingKey.documentId})`,
 		);
 
+		console.log("TEST!! DocumentContext checkpointing document queue message offset:", message.offset);
 		// Update the tail and broadcast the checkpoint
 		this.tailInternal = message;
 		this.emit("checkpoint", restartOnCheckpointFailure);

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -60,7 +60,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 	 * Updates the head offset for the context.
 	 */
 	public setHead(head: IQueuedMessage, allowBackToOffset?: number | undefined) {
-		// if allowBackToOffset is set and is lower than this.tailInternal, then dont reprocess and return early
+		// if allowBackToOffset is set and is lower than this.tailInternal, then don't reprocess and return early
 		if (allowBackToOffset !== undefined && allowBackToOffset <= this.tailInternal.offset) {
 			Lumberjack.info("Not updating documentContext head and returning early", {
 				allowBackToOffset,
@@ -71,8 +71,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 		}
 		assert(
 			head.offset > this.head.offset || head.offset === allowBackToOffset,
-			`${head.offset} > ${this.head.offset} || ${head.offset} === ${allowBackToOffset}` +
-				`(${head.topic}, ${head.partition}, ${this.routingKey.tenantId}/${this.routingKey.documentId})`,
+			`Head offset ${head.offset} must be greater than the current head offset ${this.head.offset} or equal to the resume offset ${allowBackToOffset}. Topic ${head.topic}, partition ${head.partition}, tenantId ${this.routingKey.tenantId}, documentId ${this.routingKey.documentId}.`,
 		);
 
 		if (head.offset <= this.head.offset) {
@@ -103,8 +102,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 
 		assert(
 			offset > this.tail.offset && offset <= this.head.offset,
-			`${offset} > ${this.tail.offset} && ${offset} <= ${this.head.offset} ` +
-				`(${message.topic}, ${message.partition}, ${this.routingKey.tenantId}/${this.routingKey.documentId})`,
+			`Checkpoint offset ${offset} must be greater than the current tail offset ${this.tail.offset} and less than or equal to the head offset ${this.head.offset}. Topic ${message.topic}, partition ${message.partition}, tenantId ${this.routingKey.tenantId}, documentId ${this.routingKey.documentId}.`,
 		);
 
 		// Update the tail and broadcast the checkpoint

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -59,12 +59,16 @@ export class DocumentContext extends EventEmitter implements IContext {
 	/**
 	 * Updates the head offset for the context.
 	 */
-	public setHead(head: IQueuedMessage) {
+	public setHead(head: IQueuedMessage, allowBackToOffset?: number | undefined) {
 		assert(
-			head.offset > this.head.offset,
-			`${head.offset} > ${this.head.offset} ` +
+			head.offset > this.head.offset || head.offset === allowBackToOffset,
+			`${head.offset} > ${this.head.offset} || ${head.offset} === ${allowBackToOffset}` +
 				`(${head.topic}, ${head.partition}, ${this.routingKey.tenantId}/${this.routingKey.documentId})`,
 		);
+
+		if (head.offset <= this.head.offset) {
+			Lumberjack.info("Allowing the document context head to move to the specified offset", { allowBackToOffset, currentHeadOffset: this.head.offset, documentId: this.routingKey.documentId });
+		}
 
 		// When moving back to a state where head and tail differ we set the tail to be the old head, as in the
 		// constructor, to make tail represent the inclusive top end of the checkpoint range.

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -60,6 +60,11 @@ export class DocumentContext extends EventEmitter implements IContext {
 	 * Updates the head offset for the context.
 	 */
 	public setHead(head: IQueuedMessage, allowBackToOffset?: number | undefined) {
+		// if allowBackToOffset is set and is lower than this.tailInternal, then dont reprocess
+		if (allowBackToOffset !== undefined && allowBackToOffset <= this.tailInternal.offset) {
+			console.log(`TEST!! DocumentContext setHead not updating head as allowBackToOffset ${allowBackToOffset} is already processes successfully. Last tailInternal offset: ${this.tailInternal.offset}`);
+			return false;
+		}
 		assert(
 			head.offset > this.head.offset || head.offset === allowBackToOffset,
 			`${head.offset} > ${this.head.offset} || ${head.offset} === ${allowBackToOffset}` +
@@ -77,6 +82,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 		}
 
 		this.headInternal = head;
+		return true;
 	}
 
 	public checkpoint(message: IQueuedMessage, restartOnCheckpointFailure?: boolean) {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -62,7 +62,11 @@ export class DocumentContext extends EventEmitter implements IContext {
 	public setHead(head: IQueuedMessage, allowBackToOffset?: number | undefined) {
 		// if allowBackToOffset is set and is lower than this.tailInternal, then dont reprocess and return early
 		if (allowBackToOffset !== undefined && allowBackToOffset <= this.tailInternal.offset) {
-			Lumberjack.info("Not updating documentContext head and returning early", { allowBackToOffset, tailInternalOffset: this.tailInternal.offset, documentId: this.routingKey.documentId });
+			Lumberjack.info("Not updating documentContext head and returning early", {
+				allowBackToOffset,
+				tailInternalOffset: this.tailInternal.offset,
+				documentId: this.routingKey.documentId,
+			});
 			return false;
 		}
 		assert(
@@ -72,7 +76,11 @@ export class DocumentContext extends EventEmitter implements IContext {
 		);
 
 		if (head.offset <= this.head.offset) {
-			Lumberjack.info("Allowing the document context head to move to the specified offset", { allowBackToOffset, currentHeadOffset: this.head.offset, documentId: this.routingKey.documentId });
+			Lumberjack.info("Allowing the document context head to move to the specified offset", {
+				allowBackToOffset,
+				currentHeadOffset: this.head.offset,
+				documentId: this.routingKey.documentId,
+			});
 		}
 
 		// When moving back to a state where head and tail differ we set the tail to be the old head, as in the

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
@@ -56,7 +56,8 @@ export class DocumentLambda implements IPartitionLambda {
 			(lowestOffset: number, pausedAtOffset: number, reason?: any) => {
 				// Emit pause at the lowest offset out of all document partitions
 				// This is important for ensuring that we don't miss any messages
-				// And maintain a range for offsets allowed to be reprocessed on resume, otherwise the contextManager expects offsets only in sequence
+				// And store the reprocessRange so that we can allow contextManager to move back to it when it resumes
+				// It will move back to the first offset which was not checkpointed from this range
 				this.storeReprocessRange(lowestOffset, pausedAtOffset);
 				context.pause(lowestOffset, reason);
 			},

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
@@ -85,7 +85,7 @@ export class DocumentLambda implements IPartitionLambda {
 					}`,
 			);
 			// update reprocessRange to avoid reprocessing the same message again
-			if (this.reprocessingOffset) {
+			if (this.reprocessingOffset !== undefined) {
 				this.updateReprocessRange(this.reprocessingOffset);
 			}
 			return undefined;
@@ -95,7 +95,7 @@ export class DocumentLambda implements IPartitionLambda {
 		this.contextManager.setTail(message, this.reprocessingOffset);
 
 		// update reprocessRange to avoid reprocessing the same message again
-		if (this.reprocessingOffset) {
+		if (this.reprocessingOffset !== undefined) {
 			this.updateReprocessRange(this.reprocessingOffset);
 		}
 
@@ -137,9 +137,6 @@ export class DocumentLambda implements IPartitionLambda {
 	}
 
 	private isOffsetWithinReprocessRange(offset: number) {
-		if (this.reprocessRange === undefined) {
-			return false;
-		}
 		return (
 			this.reprocessRange.startOffset !== undefined &&
 			this.reprocessRange.endOffset !== undefined &&

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
@@ -49,19 +49,13 @@ export class DocumentLambda implements IPartitionLambda {
 			context.error(error, errorData);
 		});
 		this.contextManager.on("pause", (lowestOffset: number, pausedAtOffset: number, reason?: any) => {
-			console.log(
-				`TEST!! Listening for pause in documentLambda, lowestOffset ${lowestOffset}, pausedAtOffset ${pausedAtOffset}, reason: ${reason}`,
-			);
 			// Emit pause at the lowest offset out of all document partitions
 			// This is important for ensuring that we don't miss any messages
-			// And maintain a range for offsets allowed to be reprocessed on resume, otherwise the contextManager expected offsets only in sequence
+			// And maintain a range for offsets allowed to be reprocessed on resume, otherwise the contextManager expects offsets only in sequence
 			this.storeReprocessRange(lowestOffset, pausedAtOffset);
 			context.pause(lowestOffset, reason);
 		});
 		this.contextManager.on("resume", () => {
-			console.log(
-				`TEST!! Listening for resume in documentLambda`,
-			);
 			context.resume();
 		});
 		this.activityCheckTimer = setInterval(
@@ -262,7 +256,7 @@ export class DocumentLambda implements IPartitionLambda {
 	/**
 	 * Closes inactive documents
 	 */
-	private inactivityCheck() { // should not close the documents in paused state - TODO test.
+	private inactivityCheck() {
 		const now = Date.now();
 
 		const documentPartitions = Array.from(this.documents);

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
@@ -77,8 +77,8 @@ export class DocumentLambda implements IPartitionLambda {
 					}`,
 			);
 			// update reprocessRange to avoid reprocessing the same message again
-			if (this.isOffsetWithinReprocessRange(message.offset)) {
-				this.updateReprocessRange(message.offset);
+			if (this.reprocessingOffset) {
+				this.updateReprocessRange(this.reprocessingOffset);
 			}
 			return undefined;
 		}
@@ -87,8 +87,8 @@ export class DocumentLambda implements IPartitionLambda {
 		this.contextManager.setTail(message, this.reprocessingOffset);
 
 		// update reprocessRange to avoid reprocessing the same message again
-		if (this.isOffsetWithinReprocessRange(message.offset)) {
-			this.updateReprocessRange(message.offset);
+		if (this.reprocessingOffset) {
+			this.updateReprocessRange(this.reprocessingOffset);
 		}
 
 		return undefined;
@@ -136,8 +136,8 @@ export class DocumentLambda implements IPartitionLambda {
 			offset >= this.reprocessRange.startOffset && offset <= this.reprocessRange.endOffset;
 	}
 
-	private updateReprocessRange(processedOffset: number) {
-		this.reprocessRange.startOffset = processedOffset + 1;
+	private updateReprocessRange(reprocessedOffset: number) {
+		this.reprocessRange.startOffset = reprocessedOffset + 1;
 		if (this.reprocessRange.endOffset && this.reprocessRange.endOffset < this.reprocessRange.startOffset) {
 			// reset since all messages in the reprocess range have been processed
 			this.reprocessRange = { startOffset: undefined, endOffset: undefined };

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -82,16 +82,6 @@ export class DocumentPartition {
 			}
 		});
 
-		// this.context.on("pause", (offset: number, reason?: any) => {
-		// 	console.log("TEST!! DocumentPartition pause event", offset, reason);
-		// 	this.pause(reason);
-		// });
-
-		// this.context.on("resume", () => {
-		// 	console.log("TEST!! DocumentPartition resume event");
-		// 	this.resume();
-		// });
-
 		// Create the lambda to handle the document messages
 		this.lambdaP = factory
 			.create(documentConfig, context, this.updateActivityTime.bind(this))
@@ -118,10 +108,6 @@ export class DocumentPartition {
 				}
 			});
 	}
-
-	// private createLambda() {
-
-	// }
 
 	public process(message: IQueuedMessage) {
 		if (this.closed) {
@@ -218,7 +204,7 @@ export class DocumentPartition {
 			activityTime !== undefined ? activityTime : cacluatedActivityTimeout;
 	}
 
-	public pause() {
+	public pause(offset: number) {
 		if (this.paused) {
 			Lumberjack.info(`TEST!! Doc partition already paused, returning early.`, { documentId: this.documentId, tenantId: this.tenantId });
 			return;
@@ -229,7 +215,7 @@ export class DocumentPartition {
 		this.q.remove(() => true); // flush all the messages in the queue since kafka consumer will resume from last successful offset
 
 		if (this.lambda?.pause) {
-			this.lambda.pause();
+			this.lambda.pause(offset);
 		}
 		Lumberjack.info(`TEST!! Doc partition paused`, { documentId: this.documentId, tenantId: this.tenantId });
 	}

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -206,7 +206,10 @@ export class DocumentPartition {
 
 	public pause(offset: number) {
 		if (this.paused) {
-			Lumberjack.info("Doc partition already paused, returning early.", { documentId: this.documentId, tenantId: this.tenantId });
+			Lumberjack.info("Doc partition already paused, returning early.", {
+				documentId: this.documentId,
+				tenantId: this.tenantId,
+			});
 			return;
 		}
 		this.paused = true;
@@ -217,17 +220,26 @@ export class DocumentPartition {
 		if (this.lambda?.pause) {
 			this.lambda.pause(offset);
 		}
-		Lumberjack.info("Doc partition paused", { documentId: this.documentId, tenantId: this.tenantId });
+		Lumberjack.info("Doc partition paused", {
+			documentId: this.documentId,
+			tenantId: this.tenantId,
+		});
 	}
 
 	public resume() {
 		if (!this.paused) {
-			Lumberjack.info("Doc partition already resumed, returning early.", { documentId: this.documentId, tenantId: this.tenantId });
+			Lumberjack.info("Doc partition already resumed, returning early.", {
+				documentId: this.documentId,
+				tenantId: this.tenantId,
+			});
 			return;
 		}
 		this.paused = false;
 
 		this.q.resume();
-		Lumberjack.info("Doc partition resumed", { documentId: this.documentId, tenantId: this.tenantId });
+		Lumberjack.info("Doc partition resumed", {
+			documentId: this.documentId,
+			tenantId: this.tenantId,
+		});
 	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -206,9 +206,9 @@ export class DocumentPartition {
 
 	public pause(offset: number) {
 		if (this.paused) {
-			Lumberjack.info("Doc partition already paused, returning early.", {
-				documentId: this.documentId,
-				tenantId: this.tenantId,
+			Lumberjack.warning("Doc partition already paused, returning early.", {
+				...getLumberBaseProperties(this.documentId, this.tenantId),
+				offset,
 			});
 			return;
 		}
@@ -221,25 +221,27 @@ export class DocumentPartition {
 			this.lambda.pause(offset);
 		}
 		Lumberjack.info("Doc partition paused", {
-			documentId: this.documentId,
-			tenantId: this.tenantId,
+			...getLumberBaseProperties(this.documentId, this.tenantId),
+			offset,
 		});
 	}
 
 	public resume() {
 		if (!this.paused) {
-			Lumberjack.info("Doc partition already resumed, returning early.", {
-				documentId: this.documentId,
-				tenantId: this.tenantId,
+			Lumberjack.warning("Doc partition already resumed, returning early.", {
+				...getLumberBaseProperties(this.documentId, this.tenantId),
 			});
 			return;
 		}
 		this.paused = false;
 
 		this.q.resume();
+
+		if (this.lambda?.resume) {
+			this.lambda.resume();
+		}
 		Lumberjack.info("Doc partition resumed", {
-			documentId: this.documentId,
-			tenantId: this.tenantId,
+			...getLumberBaseProperties(this.documentId, this.tenantId),
 		});
 	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -206,7 +206,7 @@ export class DocumentPartition {
 
 	public pause(offset: number) {
 		if (this.paused) {
-			Lumberjack.info(`TEST!! Doc partition already paused, returning early.`, { documentId: this.documentId, tenantId: this.tenantId });
+			Lumberjack.info("Doc partition already paused, returning early.", { documentId: this.documentId, tenantId: this.tenantId });
 			return;
 		}
 		this.paused = true;
@@ -217,17 +217,17 @@ export class DocumentPartition {
 		if (this.lambda?.pause) {
 			this.lambda.pause(offset);
 		}
-		Lumberjack.info(`TEST!! Doc partition paused`, { documentId: this.documentId, tenantId: this.tenantId });
+		Lumberjack.info("Doc partition paused", { documentId: this.documentId, tenantId: this.tenantId });
 	}
 
 	public resume() {
 		if (!this.paused) {
-			Lumberjack.info(`TEST!! Doc partition already resumed, returning early.`, { documentId: this.documentId, tenantId: this.tenantId });
+			Lumberjack.info("Doc partition already resumed, returning early.", { documentId: this.documentId, tenantId: this.tenantId });
 			return;
 		}
 		this.paused = false;
 
-		this.q.resume(); // Should resume from the failed offset
-		Lumberjack.info(`TEST!! Doc partition resumed`, { documentId: this.documentId, tenantId: this.tenantId });
+		this.q.resume();
+		Lumberjack.info("Doc partition resumed", { documentId: this.documentId, tenantId: this.tenantId });
 	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -108,7 +108,7 @@ export class Partition extends EventEmitter {
 		}
 
 		if (this.paused) {
-			Lumberjack.info(`Partition ${this.id} is paused, skipping pushing to queue for message offset ${rawMessage.offset}`);
+			Lumberjack.info("Partition is paused, skipping pushing message to queue", { partitionId: this.id, messageOffset: rawMessage.offset });
 			return;
 		}
 		this.q.push(rawMessage).catch((error) => {
@@ -175,7 +175,7 @@ export class Partition extends EventEmitter {
 
 		this.q.resume();
 
-		if (this.lambda?.resume) { // for documentLambdas, this would be needed
+		if (this.lambda?.resume) { // needed for documentLambdas
 			this.lambda.resume();
 		}
 		Lumberjack.info(`Partition resumed`, { partitionId: this.id });

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -108,7 +108,10 @@ export class Partition extends EventEmitter {
 		}
 
 		if (this.paused) {
-			Lumberjack.info("Partition is paused, skipping pushing message to queue", { partitionId: this.id, messageOffset: rawMessage.offset });
+			Lumberjack.info("Partition is paused, skipping pushing message to queue", {
+				partitionId: this.id,
+				messageOffset: rawMessage.offset,
+			});
 			return;
 		}
 		this.q.push(rawMessage).catch((error) => {
@@ -175,7 +178,8 @@ export class Partition extends EventEmitter {
 
 		this.q.resume();
 
-		if (this.lambda?.resume) { // needed for documentLambdas
+		if (this.lambda?.resume) {
+			// needed for documentLambdas
 			this.lambda.resume();
 		}
 		Lumberjack.info(`Partition resumed`, { partitionId: this.id });

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -107,6 +107,10 @@ export class Partition extends EventEmitter {
 			return;
 		}
 
+		if (this.paused) {
+			Lumberjack.info(`Partition ${this.id} is paused, skipping pushing to queue for message offset ${rawMessage.offset}`);
+			return;
+		}
 		this.q.push(rawMessage).catch((error) => {
 			Lumberjack.error("Error pushing raw message to queue in partition", undefined, error);
 		});
@@ -144,7 +148,7 @@ export class Partition extends EventEmitter {
 		this.removeAllListeners();
 	}
 
-	public pause(): void {
+	public pause(offset: number): void {
 		if (this.paused) {
 			Lumberjack.info(`Partition already paused, returning early.`, { partitionId: this.id });
 			return;
@@ -155,7 +159,7 @@ export class Partition extends EventEmitter {
 		this.q.remove(() => true); // flush all the messages in the queue since kafka consumer will resume from last successful offset
 
 		if (this.lambda?.pause) {
-			this.lambda.pause();
+			this.lambda.pause(offset);
 		}
 		Lumberjack.info(`Partition paused`, { partitionId: this.id });
 	}

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -170,6 +170,10 @@ export class Partition extends EventEmitter {
 		this.paused = false;
 
 		this.q.resume();
+
+		if (this.lambda?.resume) { // for documentLambdas, this would be needed
+			this.lambda.resume();
+		}
 		Lumberjack.info(`Partition resumed`, { partitionId: this.id });
 	}
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -153,7 +153,10 @@ export class Partition extends EventEmitter {
 
 	public pause(offset: number): void {
 		if (this.paused) {
-			Lumberjack.info(`Partition already paused, returning early.`, { partitionId: this.id });
+			Lumberjack.warning(`Partition already paused, returning early.`, {
+				partitionId: this.id,
+				offset,
+			});
 			return;
 		}
 		this.paused = true;
@@ -164,12 +167,12 @@ export class Partition extends EventEmitter {
 		if (this.lambda?.pause) {
 			this.lambda.pause(offset);
 		}
-		Lumberjack.info(`Partition paused`, { partitionId: this.id });
+		Lumberjack.info(`Partition paused`, { partitionId: this.id, offset });
 	}
 
 	public resume(): void {
 		if (!this.paused) {
-			Lumberjack.info(`Partition already resumed, returning early.`, {
+			Lumberjack.warning(`Partition already resumed, returning early.`, {
 				partitionId: this.id,
 			});
 			return;

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -122,10 +122,10 @@ export class PartitionManager extends EventEmitter {
 		this.removeAllListeners();
 	}
 
-	public pause(partitionId: number): void {
+	public pause(partitionId: number, offset: number): void {
 		const partition = this.partitions.get(partitionId);
 		if (partition) {
-			partition.pause();
+			partition.pause(offset);
 		} else {
 			throw new Error(`PartitionId ${partitionId} not found for pause`);
 		}

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/runner.ts
@@ -151,7 +151,7 @@ export class KafkaRunner implements IRunner {
 			const seekTimeout = this.config?.get("kafka:seekTimeoutAfterPause") ?? 1000;
 			await this.consumer.pauseFetching(partitionId, seekTimeout, offset);
 		}
-		this.partitionManager?.pause(partitionId);
+		this.partitionManager?.pause(partitionId, offset);
 	}
 
 	public async resume(partitionId: number): Promise<void> {

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -502,7 +502,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 				setTimeout(() => {
 					this.context.resume();
 				}, 60000); // resume after 1 minute
-				this.context.pause(0, "error:testing circuit breaker");
+				this.context.pause(rawMessage.offset - 1, "error:testing circuit breaker"); // lastSuccessfulOffset needs to be more reliable
 				return;
 			}
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -286,8 +286,6 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 	// Session level properties
 	private serviceSummaryGenerated: boolean = false;
 
-	private readonly testingCircuitBreaker: boolean = false;
-
 	constructor(
 		private readonly context: IContext,
 		private readonly tenantId: string,
@@ -495,16 +493,6 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 			}
 
 			this.lastInstruction = ticketedMessage.instruction;
-
-			// testing circuit breaker
-			console.log(`TEST!! processing message offset ${rawMessage.offset}, partition ${rawMessage.partition}`);
-			if (this.testingCircuitBreaker) {
-				setTimeout(() => {
-					this.context.resume();
-				}, 60000); // resume after 1 minute
-				this.context.pause(rawMessage.offset - 1, "error:testing circuit breaker"); // lastSuccessfulOffset needs to be more reliable
-				return;
-			}
 
 			switch (ticketedMessage.ticketType) {
 				case TicketType.Sequenced: {

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -286,6 +286,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 	// Session level properties
 	private serviceSummaryGenerated: boolean = false;
 
+	private readonly testingCircuitBreaker: boolean = false;
+
 	constructor(
 		private readonly context: IContext,
 		private readonly tenantId: string,
@@ -493,6 +495,15 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 			}
 
 			this.lastInstruction = ticketedMessage.instruction;
+
+			// testing circuit breaker
+			console.log(`TEST!! processing message offset ${rawMessage.offset}, partition ${rawMessage.partition}`);
+			if (this.testingCircuitBreaker) {
+				setTimeout(() => {
+					this.context.resume();
+				}, 60000); // resume after 1 minute
+				this.context.pause(0, "error:testing circuit breaker");
+			}
 
 			switch (ticketedMessage.ticketType) {
 				case TicketType.Sequenced: {

--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -503,6 +503,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 					this.context.resume();
 				}, 60000); // resume after 1 minute
 				this.context.pause(0, "error:testing circuit breaker");
+				return;
 			}
 
 			switch (ticketedMessage.ticketType) {

--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -187,7 +187,7 @@ export class ScriptoriumLambda implements IPartitionLambda {
 		this.dbCircuitBreaker?.shutdown();
 	}
 
-	public pause(): void {
+	public pause(offset: number): void {
 		this.current.clear();
 		this.pending.clear();
 		this.pendingMetric = undefined;

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -133,7 +133,7 @@ export interface IPartitionLambda {
 	/**
 	 * Pauses the lambda. It should clear any pending work.
 	 */
-	pause?(): void;
+	pause?(offset: number): void;
 
 	/**
 	 * Resumes the lambda. This is relevant for documentLambda to resume the documentPartition queueus.

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -134,6 +134,11 @@ export interface IPartitionLambda {
 	 * Pauses the lambda. It should clear any pending work.
 	 */
 	pause?(): void;
+
+	/**
+	 * Resumes the lambda. This is relevant for documentLambda to resume the documentPartition queueus.
+	 */
+	resume?(): void;
 }
 
 /**


### PR DESCRIPTION
## Description

Recently we added circuit breaker and pause/resume for scriptorium, i.e. partition lambdas. With this PR, I am adding the pause/resume functionality for document lambdas. It will be triggered by a document lambda during various circuit breaker states (pause during open, and resume during close). Currently no doc lambda is using circuit breaker, so this is just to add functionality which will not be triggered until we implement circuit breaker in any doc lambda.

Important changes:
- Added pause/resume listeners for the event emitted by documentContext.
- Since there can be multiple docContexts, we pause the kafka partition at the lowest offset out of them, so that no messages are missed during resume.
- On resume, we start from the lowest offset and send to the contextManager and respective docContext. The offsets which were already processed successfully (if any) are skipped during this resume.
- Remaining offsets are then processed as usual by the respective lambdas. (Lambdas should make sure to reset any state needed on pause, such that it can reprocess the failed messages on resume)

## Reviewer Guidance

- Tested it locally by hardcoding context.pause() and resume() from deli lambda and making sure that ops are not lost on resume. Tested it with a single and multiple docPartitions.
- This feature shouldnt have any impact until we implement circuit breaker in any doc lambda and trigger pause/resume from there.