### PR TITLE
Share LocalDeltaConnectionServer between documents

### DIFF
--- a/examples/service-clients/azure-client/external-controller/tests/index.ts
+++ b/examples/service-clients/azure-client/external-controller/tests/index.ts
@@ -17,10 +17,7 @@ import {
 	LocalResolver,
 	LocalSessionStorageDbFactory,
 } from "@fluidframework/local-driver/internal";
-import {
-	ILocalDeltaConnectionServer,
-	LocalDeltaConnectionServer,
-} from "@fluidframework/server-local-server";
+import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import type { IFluidContainer, ContainerSchema } from "fluid-framework";
 import { SharedMap } from "fluid-framework/legacy";
 
@@ -28,7 +25,7 @@ import { DiceRollerController } from "../src/controller.js";
 import { makeAppView } from "../src/view.js";
 
 // The local server needs to be shared across the Loader instances for collaboration to happen
-const localServerMap = new Map<string, ILocalDeltaConnectionServer>();
+const localServer = LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory());
 
 const urlResolver = new LocalResolver();
 
@@ -43,12 +40,6 @@ export async function getSessionStorageContainer(
 	containerRuntimeFactory: IRuntimeFactory,
 	createNew: boolean,
 ): Promise<{ container: IContainer; attach: (() => Promise<void>) | undefined }> {
-	let localServer = localServerMap.get(containerId);
-	if (localServer === undefined) {
-		localServer = LocalDeltaConnectionServer.create(new LocalSessionStorageDbFactory());
-		localServerMap.set(containerId, localServer);
-	}
-
 	const documentServiceFactory = new LocalDocumentServiceFactory(localServer);
 	const url = `${window.location.origin}/${containerId}`;
 


### PR DESCRIPTION
In #12127 I changed getSessionStorageContainer and webpack-fluid-loader to share their LocalDeltaConnectionServer across documents (made possible by an earlier bug fix).  However, at almost the same time I introduced the model loading pattern in #11859 but did not include that shift to a single LocalDeltaConnectionServer for the SessionStorageModelLoader (just forgot, I think).  This PR makes SessionStorageModelLoader do the same thing.

I omit the migration-tool model loader here, as I'll address it in #23119 instead to avoid merge conflicts.

[AB#25146](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/25146)