### PR TITLE
Fix areOnlyKeys handling of optional fields

### DIFF
--- a/packages/dds/tree/src/util/typeCheck.ts
+++ b/packages/dds/tree/src/util/typeCheck.ts
@@ -193,6 +193,11 @@ export type requireAssignableTo<_A extends B, B> = true;
 
 /**
  * Returns a type parameter that is true iff the `Keys` union includes all the keys of `T`.
+ *
+ * @remarks
+ * This does not handle when the T has an index signature permitting keys like `string` which
+ * TypeScript cannot omit members from.
+ *
  * @example
  * ```ts
  * type _check = requireTrue<areOnlyKeys<{a: number, b: number}, 'a' | 'b'>> // true`
@@ -201,5 +206,5 @@ export type requireAssignableTo<_A extends B, B> = true;
  */
 export type areOnlyKeys<T, Keys extends keyof T> = isAssignableTo<
 	Record<string, never>,
-	Omit<T, Keys>
+	Omit<Required<T>, Keys>
 >;

--- a/packages/dds/tree/src/util/typeCheckTests.ts
+++ b/packages/dds/tree/src/util/typeCheckTests.ts
@@ -15,6 +15,7 @@ import type {
 	Covariant,
 	Invariant,
 	MakeNominal,
+	areOnlyKeys,
 	areSafelyAssignable,
 	eitherIsAny,
 	isAny,
@@ -221,10 +222,19 @@ export type EnforceTypeCheckTests =
 	| requireTrue<isStrictSubset<[1, true], [1 | 2, true | false]>>
 	| requireTrue<isStrictSubset<[1, true], [1, true | false]>>
 	| requireTrue<isStrictSubset<[1, true], [1, true] | [1 | false]>>
+	| requireTrue<isStrictSubset<1, number>>
 	| requireFalse<isStrictSubset<1, 1>>
 	| requireFalse<isStrictSubset<1, 2>>
 	| requireFalse<isStrictSubset<[1, true], [1, true]>>
-	| requireFalse<isStrictSubset<1 | 2, 1>>;
+	| requireFalse<isStrictSubset<1 | 2, 1>>
+
+	// areOnlyKeys
+	| requireTrue<areOnlyKeys<{ a: number; b: number }, "a" | "b">>
+	| requireTrue<areOnlyKeys<{ a?: number; b: number }, "a" | "b">>
+	| requireFalse<areOnlyKeys<{ a?: number; b: number }, "b">>
+	| requireFalse<areOnlyKeys<{ a: number; b: number }, "a">>;
+// This case is explicitly documented as unsupported.
+// | requireFalse<areOnlyKeys<Record<string, unknown>, "a">>;
 
 // negative tests (should not build)
 // @ts-expect-error negative test


### PR DESCRIPTION
## Description

Fix areOnlyKeys handling of optional fields, add tests for it, and document issue with index signatures.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
