### PR TITLE
build(devtools): Bundle `devtools-core` in API-Extractor

### DIFF
--- a/packages/tools/devtools/devtools-core/src/CommonInterfaces.ts
+++ b/packages/tools/devtools/devtools-core/src/CommonInterfaces.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * A key used to identify and differentiate Containers registered with the {@link IFluidDevtools}.
+ * A key used to identify and differentiate Containers registered with the {@link @fluidframework/devtools-core#IFluidDevtools}.
  *
  * @remarks Each Container registered with the Devtools must be assigned a unique `containerKey`.
  *

--- a/packages/tools/devtools/devtools/api-extractor.json
+++ b/packages/tools/devtools/devtools/api-extractor.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../../common/build/build-common/api-extractor-base.esm.no-legacy.json"
+	"extends": "../../../../common/build/build-common/api-extractor-base.esm.no-legacy.json",
+	"bundledPackages": ["@fluidframework/devtools-core"]
 }

--- a/packages/tools/devtools/devtools/api-report/devtools.alpha.api.md
+++ b/packages/tools/devtools/devtools/api-report/devtools.alpha.api.md
@@ -9,9 +9,11 @@ export interface ContainerDevtoolsProps extends HasContainerKey {
     container: IFluidContainer;
 }
 
-export { ContainerKey }
+// @beta
+export type ContainerKey = string;
 
-export { createDevtoolsLogger }
+// @beta
+export function createDevtoolsLogger(baseLogger?: ITelemetryBaseLogger): IDevtoolsLogger;
 
 // @beta
 export interface DevtoolsProps {
@@ -19,7 +21,10 @@ export interface DevtoolsProps {
     logger?: IDevtoolsLogger;
 }
 
-export { HasContainerKey }
+// @beta
+export interface HasContainerKey {
+    containerKey: ContainerKey;
+}
 
 // @beta
 export interface IDevtools extends IDisposable {
@@ -27,7 +32,9 @@ export interface IDevtools extends IDisposable {
     registerContainerDevtools(props: ContainerDevtoolsProps): void;
 }
 
-export { IDevtoolsLogger }
+// @beta @sealed
+export interface IDevtoolsLogger extends ITelemetryBaseLogger {
+}
 
 // @beta
 export function initializeDevtools(props: DevtoolsProps): IDevtools;

--- a/packages/tools/devtools/devtools/api-report/devtools.beta.api.md
+++ b/packages/tools/devtools/devtools/api-report/devtools.beta.api.md
@@ -9,9 +9,11 @@ export interface ContainerDevtoolsProps extends HasContainerKey {
     container: IFluidContainer;
 }
 
-export { ContainerKey }
+// @beta
+export type ContainerKey = string;
 
-export { createDevtoolsLogger }
+// @beta
+export function createDevtoolsLogger(baseLogger?: ITelemetryBaseLogger): IDevtoolsLogger;
 
 // @beta
 export interface DevtoolsProps {
@@ -19,7 +21,10 @@ export interface DevtoolsProps {
     logger?: IDevtoolsLogger;
 }
 
-export { HasContainerKey }
+// @beta
+export interface HasContainerKey {
+    containerKey: ContainerKey;
+}
 
 // @beta
 export interface IDevtools extends IDisposable {
@@ -27,7 +32,9 @@ export interface IDevtools extends IDisposable {
     registerContainerDevtools(props: ContainerDevtoolsProps): void;
 }
 
-export { IDevtoolsLogger }
+// @beta @sealed
+export interface IDevtoolsLogger extends ITelemetryBaseLogger {
+}
 
 // @beta
 export function initializeDevtools(props: DevtoolsProps): IDevtools;

--- a/packages/tools/devtools/devtools/api-report/devtools.public.api.md
+++ b/packages/tools/devtools/devtools/api-report/devtools.public.api.md
@@ -4,12 +4,4 @@
 
 ```ts
 
-export { ContainerKey }
-
-export { createDevtoolsLogger }
-
-export { HasContainerKey }
-
-export { IDevtoolsLogger }
-
 ```

--- a/packages/tools/devtools/devtools/src/index.ts
+++ b/packages/tools/devtools/devtools/src/index.ts
@@ -4,7 +4,8 @@
  */
 
 /**
- * Primary entry-point to the Fluid Devtools.
+ * Used in conjunction with the Fluid Framework Developer Tools browser extension to allow visualization of
+ * and interaction with Fluid data.
  *
  * To initialize the Devtools alongside your application's {@link @fluidframework/fluid-static#IFluidContainer}, call
  * {@link initializeDevtools}.
@@ -12,8 +13,10 @@
  * The Devtools will automatically dispose of themselves upon Window unload, but if you would like to close them
  * earlier, call {@link IDevtools.dispose}.
  *
- * To enable visualization of Telemetry data, you may create a {@link @fluidframework/devtools-core#DevtoolsLogger} and
+ * To enable visualization of Telemetry data, you may create a {@link DevtoolsLogger} and
  * provide it during Devtools initialization.
+ *
+ * For more details and examples, see the {@link https://github.com/microsoft/FluidFramework/tree/main/packages/tools/devtools/devtools | package README}.
  *
  * @packageDocumentation
  */


### PR DESCRIPTION
Will ensure that core API members appear directly in website API docs and will help detect transitive breaking changes from `devtools-core`.

Also updates `@packageDocumentation` comment with more details.