### PR TITLE
fix: Empty ObjectNode type safety

### DIFF
--- a/.changeset/free-lights-start.md
+++ b/.changeset/free-lights-start.md
@@ -1,0 +1,17 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+---
+---
+"section": tree
+---
+
+Providing unused properties in object literals for building empty ObjectNodes no longer compiles
+
+ObjectNodes with no fields will now emit a compiler error if constructed from an object literal with fields.
+This matches the behavior of non-empty ObjectNodes which already gave errors when unexpected properties were provided.
+
+```typescript
+class A extends schemaFactory.object("A", {}) {}
+const a = new A({ thisDoesNotExist: 5 }); // This now errors.
+```

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -224,7 +224,7 @@ TSchema
 ] extends [ImplicitFieldSchema] ? InsertableTreeFieldFromImplicitField<TSchema> : [TSchema] extends [UnsafeUnknownSchema] ? InsertableContent | undefined : never;
 
 // @public
-type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = FlattenKeys<{
+type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = Record<string, never> extends T ? Record<string, never> : FlattenKeys<{
     readonly [Property in keyof T]?: InsertableTreeFieldFromImplicitField<T[Property & string]>;
 } & {
     readonly [Property in keyof T as FieldHasDefault<T[Property & string]> extends false ? Property : never]: InsertableTreeFieldFromImplicitField<T[Property & string]>;

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -110,7 +110,7 @@ type _InlineTrick = 0;
 export type Input<T extends never> = T;
 
 // @public
-type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = FlattenKeys<{
+type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = Record<string, never> extends T ? Record<string, never> : FlattenKeys<{
     readonly [Property in keyof T]?: InsertableTreeFieldFromImplicitField<T[Property & string]>;
 } & {
     readonly [Property in keyof T as FieldHasDefault<T[Property & string]> extends false ? Property : never]: InsertableTreeFieldFromImplicitField<T[Property & string]>;

--- a/packages/dds/tree/api-report/tree.legacy.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.alpha.api.md
@@ -110,7 +110,7 @@ type _InlineTrick = 0;
 export type Input<T extends never> = T;
 
 // @public
-type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = FlattenKeys<{
+type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = Record<string, never> extends T ? Record<string, never> : FlattenKeys<{
     readonly [Property in keyof T]?: InsertableTreeFieldFromImplicitField<T[Property & string]>;
 } & {
     readonly [Property in keyof T as FieldHasDefault<T[Property & string]> extends false ? Property : never]: InsertableTreeFieldFromImplicitField<T[Property & string]>;

--- a/packages/dds/tree/api-report/tree.legacy.public.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.public.api.md
@@ -110,7 +110,7 @@ type _InlineTrick = 0;
 export type Input<T extends never> = T;
 
 // @public
-type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = FlattenKeys<{
+type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = Record<string, never> extends T ? Record<string, never> : FlattenKeys<{
     readonly [Property in keyof T]?: InsertableTreeFieldFromImplicitField<T[Property & string]>;
 } & {
     readonly [Property in keyof T as FieldHasDefault<T[Property & string]> extends false ? Property : never]: InsertableTreeFieldFromImplicitField<T[Property & string]>;

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -110,7 +110,7 @@ type _InlineTrick = 0;
 export type Input<T extends never> = T;
 
 // @public
-type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = FlattenKeys<{
+type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = Record<string, never> extends T ? Record<string, never> : FlattenKeys<{
     readonly [Property in keyof T]?: InsertableTreeFieldFromImplicitField<T[Property & string]>;
 } & {
     readonly [Property in keyof T as FieldHasDefault<T[Property & string]> extends false ? Property : never]: InsertableTreeFieldFromImplicitField<T[Property & string]>;

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
@@ -846,8 +846,7 @@ describe("schemaFactory", () => {
 
 		class Empty extends f.object("C", {}) {}
 
-		// TODO: should not build
-		// BUG: object schema with no fields permit construction with any object, not just empty object.
+		// @ts-expect-error Invalid extra field
 		// TODO: this should runtime error when constructed (not just when hydrated)
 		const c2 = new Empty({ x: {} });
 

--- a/packages/dds/tree/src/test/simple-tree/objectNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/objectNode.spec.ts
@@ -409,7 +409,7 @@ describeHydration(
 			const allowed = [Note] as const;
 			{
 				type X = InsertableTreeNodeFromAllowedTypes<typeof allowed>;
-				const test: X = [{}];
+				const test: X = {};
 			}
 		});
 
@@ -552,6 +552,28 @@ describeHydration(
 			assert.equal(Tree.schema(node), Customizable);
 			assert.equal(node[typeNameSymbol], Customizable.identifier);
 			assert.equal(node[typeSchemaSymbol], Customizable);
+		});
+
+		it("Build Parameter unexpected properties", () => {
+			class A extends schemaFactory.object("A", {}) {}
+			class B extends schemaFactory.object("B", { a: schemaFactory.number }) {}
+
+			const a = new A({});
+			const b = new B({ a: 1 });
+
+			// @ts-expect-error "Object literal may only specify known properties"
+			const a2 = new A({ thisDoesNotExist: 5 });
+
+			// @ts-expect-error "Object literal may only specify known properties"
+			const b3 = new B({ a: 1, thisDoesNotExist: 5 });
+
+			type BuildA = NodeBuilderData<typeof A>;
+			type BuildB = NodeBuilderData<typeof B>;
+
+			// @ts-expect-error "Object literal may only specify known properties"
+			const builderA: BuildA = { thisDoesNotExist: 5 };
+			// @ts-expect-error "Object literal may only specify known properties"
+			const builderB: BuildB = { a: 1, thisDoesNotExist: 5 };
 		});
 	},
 );

--- a/packages/dds/tree/src/test/simple-tree/schemaTypes.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaTypes.spec.ts
@@ -287,7 +287,7 @@ describe("schemaTypes", () => {
 			}
 		});
 
-		it("bad union", () => {
+		it("unsound union properties", () => {
 			const schemaFactory = new SchemaFactory("demo");
 			class A extends schema.object("A", { value: schemaFactory.number }) {}
 			class B extends schema.object("B", { value: schemaFactory.string }) {}

--- a/packages/dds/tree/src/test/simple-tree/schemaTypes.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaTypes.spec.ts
@@ -286,6 +286,24 @@ describe("schemaTypes", () => {
 			}
 		});
 
+		it("Demo", () => {
+			const schemaFactory = new SchemaFactory("demo");
+			class A extends schema.object("A", { value: schemaFactory.number }) {}
+			class B extends schema.object("B", { value: schemaFactory.string }) {}
+
+			class ParentA extends schema.object("ParentA", { child: A }) {}
+			class ParentB extends schema.object("ParentB", { child: B }) {}
+
+			function getValue(node: ParentA | ParentB): number | string {
+				return node.child.value;
+			}
+
+			function setValue(node: ParentA | ParentB, v: number | string): void {
+				// TODO: This is not safe: this should not build
+				node.child.value = v;
+			}
+		});
+
 		it("Objects", () => {
 			const A = schema.object("A", {});
 			const B = schema.object("B", { a: A });
@@ -319,6 +337,13 @@ describe("schemaTypes", () => {
 			const a = new A({});
 			const b = new B({ a });
 			const b2 = new B({ a: {} });
+
+			// TODO: this should not compile!
+			// @ts-expect-error Unrecognized fields should error.
+			const a2 = new A({ thisDoesNotExist: 5 });
+
+			// @ts-expect-error Unrecognized fields error.
+			const b3 = new B({ a: {}, thisDoesNotExist: 5 });
 		});
 
 		it("Mixed Regression test", () => {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -534,7 +534,7 @@ TSchema
 ] extends [ImplicitFieldSchema] ? InsertableTreeFieldFromImplicitField<TSchema> : [TSchema] extends [UnsafeUnknownSchema] ? InsertableContent | undefined : never;
 
 // @public
-type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = FlattenKeys<{
+type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = Record<string, never> extends T ? Record<string, never> : FlattenKeys<{
     readonly [Property in keyof T]?: InsertableTreeFieldFromImplicitField<T[Property & string]>;
 } & {
     readonly [Property in keyof T as FieldHasDefault<T[Property & string]> extends false ? Property : never]: InsertableTreeFieldFromImplicitField<T[Property & string]>;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -417,7 +417,7 @@ type _InlineTrick = 0;
 export type Input<T extends never> = T;
 
 // @public
-type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = FlattenKeys<{
+type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = Record<string, never> extends T ? Record<string, never> : FlattenKeys<{
     readonly [Property in keyof T]?: InsertableTreeFieldFromImplicitField<T[Property & string]>;
 } & {
     readonly [Property in keyof T as FieldHasDefault<T[Property & string]> extends false ? Property : never]: InsertableTreeFieldFromImplicitField<T[Property & string]>;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -517,7 +517,7 @@ type _InlineTrick = 0;
 export type Input<T extends never> = T;
 
 // @public
-type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = FlattenKeys<{
+type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = Record<string, never> extends T ? Record<string, never> : FlattenKeys<{
     readonly [Property in keyof T]?: InsertableTreeFieldFromImplicitField<T[Property & string]>;
 } & {
     readonly [Property in keyof T as FieldHasDefault<T[Property & string]> extends false ? Property : never]: InsertableTreeFieldFromImplicitField<T[Property & string]>;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -445,7 +445,7 @@ type _InlineTrick = 0;
 export type Input<T extends never> = T;
 
 // @public
-type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = FlattenKeys<{
+type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = Record<string, never> extends T ? Record<string, never> : FlattenKeys<{
     readonly [Property in keyof T]?: InsertableTreeFieldFromImplicitField<T[Property & string]>;
 } & {
     readonly [Property in keyof T as FieldHasDefault<T[Property & string]> extends false ? Property : never]: InsertableTreeFieldFromImplicitField<T[Property & string]>;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -417,7 +417,7 @@ type _InlineTrick = 0;
 export type Input<T extends never> = T;
 
 // @public
-type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = FlattenKeys<{
+type InsertableObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> = Record<string, never> extends T ? Record<string, never> : FlattenKeys<{
     readonly [Property in keyof T]?: InsertableTreeFieldFromImplicitField<T[Property & string]>;
 } & {
     readonly [Property in keyof T as FieldHasDefault<T[Property & string]> extends false ? Property : never]: InsertableTreeFieldFromImplicitField<T[Property & string]>;


### PR DESCRIPTION
## Description

ObjectNodes with no fields will now emit a compiler error if constructed from an object literal with fields.
This matches the behavior of non-empty ObjectNodes which already gave errors when unexpected properties were provided.

Also adds an "unsound union properties" test demoing a type soundness issue which impacts tree but is a limitation of TypeScript which Tree can no workaround.

## Breaking Changes

Any code which constructed object nodes with no fields from object literals with fields should have those fields removed as they have no impact at runtime.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
