### PR TITLE
refactor(devtools): Mark interfaces as `@sealed` and `@system` as appropriate

### DIFF
--- a/.changeset/long-hats-smile.md
+++ b/.changeset/long-hats-smile.md
@@ -6,7 +6,7 @@
 "section": other
 ---
 
-Mark APIs as `@sealed` and `@system` as appropriate
+Mark APIs as `@sealed` and `@system` as appropriate, and make interface properties `readonly`
 
 APIs that were never intended for direct consumer use have been marked as `@system`.
 These are:
@@ -20,3 +20,5 @@ These are:
 - DevtoolsProps
 - HasContainerKey
 - IDevtools
+
+Additionally, interface properties have been marked as `readonly`.

--- a/.changeset/long-hats-smile.md
+++ b/.changeset/long-hats-smile.md
@@ -13,7 +13,7 @@ These are:
 
 - HasContainerKey
 
-And APIs that were not intended to be extended by consumers have been marked as `@sealed`.
+APIs that were not intended to be extended by consumers have been marked as `@sealed`.
 These are:
 
 - ContainerDevtoolsProps

--- a/.changeset/long-hats-smile.md
+++ b/.changeset/long-hats-smile.md
@@ -1,0 +1,22 @@
+---
+"@fluidframework/devtools": minor
+"@fluidframework/devtools-core": minor
+---
+---
+"section": other
+---
+
+Mark APIs as `@sealed` and `@system` as appropriate
+
+APIs that were never intended for direct consumer use have been marked as `@system`.
+These are:
+
+- HasContainerKey
+
+And APIs that were not intended to be extended by consumers have been marked as `@sealed`.
+These are:
+
+- ContainerDevtoolsProps
+- DevtoolsProps
+- HasContainerKey
+- IDevtools

--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.alpha.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.alpha.api.md
@@ -24,7 +24,7 @@ export interface FluidDevtoolsProps {
 
 // @beta @sealed
 export interface HasContainerKey {
-    containerKey: ContainerKey;
+    readonly containerKey: ContainerKey;
 }
 
 // @beta @sealed

--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.alpha.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.alpha.api.md
@@ -22,7 +22,7 @@ export interface FluidDevtoolsProps {
     logger?: IDevtoolsLogger;
 }
 
-// @beta
+// @beta @sealed
 export interface HasContainerKey {
     containerKey: ContainerKey;
 }

--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.beta.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.beta.api.md
@@ -12,7 +12,7 @@ export function createDevtoolsLogger(baseLogger?: ITelemetryBaseLogger): IDevtoo
 
 // @beta @sealed
 export interface HasContainerKey {
-    containerKey: ContainerKey;
+    readonly containerKey: ContainerKey;
 }
 
 // @beta @sealed

--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.beta.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.beta.api.md
@@ -10,7 +10,7 @@ export type ContainerKey = string;
 // @beta
 export function createDevtoolsLogger(baseLogger?: ITelemetryBaseLogger): IDevtoolsLogger;
 
-// @beta
+// @beta @sealed
 export interface HasContainerKey {
     containerKey: ContainerKey;
 }

--- a/packages/tools/devtools/devtools-core/src/CommonInterfaces.ts
+++ b/packages/tools/devtools/devtools-core/src/CommonInterfaces.ts
@@ -25,7 +25,7 @@ export interface HasContainerKey {
 	/**
 	 * {@inheritDoc ContainerKey}
 	 */
-	containerKey: ContainerKey;
+	readonly containerKey: ContainerKey;
 }
 
 /**
@@ -45,7 +45,7 @@ export interface HasFluidObjectId {
 	/**
 	 * The ID of the Fluid object (DDS) associated with data or a request.
 	 */
-	fluidObjectId: FluidObjectId;
+	readonly fluidObjectId: FluidObjectId;
 }
 
 /**

--- a/packages/tools/devtools/devtools-core/src/CommonInterfaces.ts
+++ b/packages/tools/devtools/devtools-core/src/CommonInterfaces.ts
@@ -8,15 +8,17 @@
  *
  * @remarks Each Container registered with the Devtools must be assigned a unique `containerKey`.
  *
- * @example
+ * @example "Canvas Container"
  *
- * "Canvas Container"
  * @beta
  */
 export type ContainerKey = string;
 
 /**
  * Common interface for data associated with a particular Container registered with the Devtools.
+ *
+ * @sealed
+ * @system
  * @beta
  */
 export interface HasContainerKey {

--- a/packages/tools/devtools/devtools/api-report/devtools.alpha.api.md
+++ b/packages/tools/devtools/devtools/api-report/devtools.alpha.api.md
@@ -6,7 +6,7 @@
 
 // @beta @sealed
 export interface ContainerDevtoolsProps extends HasContainerKey {
-    container: IFluidContainer;
+    readonly container: IFluidContainer;
 }
 
 // @beta
@@ -17,13 +17,13 @@ export function createDevtoolsLogger(baseLogger?: ITelemetryBaseLogger): IDevtoo
 
 // @beta @sealed
 export interface DevtoolsProps {
-    initialContainers?: ContainerDevtoolsProps[];
-    logger?: IDevtoolsLogger;
+    readonly initialContainers?: ContainerDevtoolsProps[];
+    readonly logger?: IDevtoolsLogger;
 }
 
 // @beta @sealed
 export interface HasContainerKey {
-    containerKey: ContainerKey;
+    readonly containerKey: ContainerKey;
 }
 
 // @beta @sealed

--- a/packages/tools/devtools/devtools/api-report/devtools.alpha.api.md
+++ b/packages/tools/devtools/devtools/api-report/devtools.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @beta
+// @beta @sealed
 export interface ContainerDevtoolsProps extends HasContainerKey {
     container: IFluidContainer;
 }
@@ -15,18 +15,18 @@ export type ContainerKey = string;
 // @beta
 export function createDevtoolsLogger(baseLogger?: ITelemetryBaseLogger): IDevtoolsLogger;
 
-// @beta
+// @beta @sealed
 export interface DevtoolsProps {
     initialContainers?: ContainerDevtoolsProps[];
     logger?: IDevtoolsLogger;
 }
 
-// @beta
+// @beta @sealed
 export interface HasContainerKey {
     containerKey: ContainerKey;
 }
 
-// @beta
+// @beta @sealed
 export interface IDevtools extends IDisposable {
     closeContainerDevtools(id: string): void;
     registerContainerDevtools(props: ContainerDevtoolsProps): void;

--- a/packages/tools/devtools/devtools/api-report/devtools.beta.api.md
+++ b/packages/tools/devtools/devtools/api-report/devtools.beta.api.md
@@ -6,7 +6,7 @@
 
 // @beta @sealed
 export interface ContainerDevtoolsProps extends HasContainerKey {
-    container: IFluidContainer;
+    readonly container: IFluidContainer;
 }
 
 // @beta
@@ -17,13 +17,13 @@ export function createDevtoolsLogger(baseLogger?: ITelemetryBaseLogger): IDevtoo
 
 // @beta @sealed
 export interface DevtoolsProps {
-    initialContainers?: ContainerDevtoolsProps[];
-    logger?: IDevtoolsLogger;
+    readonly initialContainers?: ContainerDevtoolsProps[];
+    readonly logger?: IDevtoolsLogger;
 }
 
 // @beta @sealed
 export interface HasContainerKey {
-    containerKey: ContainerKey;
+    readonly containerKey: ContainerKey;
 }
 
 // @beta @sealed

--- a/packages/tools/devtools/devtools/api-report/devtools.beta.api.md
+++ b/packages/tools/devtools/devtools/api-report/devtools.beta.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @beta
+// @beta @sealed
 export interface ContainerDevtoolsProps extends HasContainerKey {
     container: IFluidContainer;
 }
@@ -15,18 +15,18 @@ export type ContainerKey = string;
 // @beta
 export function createDevtoolsLogger(baseLogger?: ITelemetryBaseLogger): IDevtoolsLogger;
 
-// @beta
+// @beta @sealed
 export interface DevtoolsProps {
     initialContainers?: ContainerDevtoolsProps[];
     logger?: IDevtoolsLogger;
 }
 
-// @beta
+// @beta @sealed
 export interface HasContainerKey {
     containerKey: ContainerKey;
 }
 
-// @beta
+// @beta @sealed
 export interface IDevtools extends IDisposable {
     closeContainerDevtools(id: string): void;
     registerContainerDevtools(props: ContainerDevtoolsProps): void;

--- a/packages/tools/devtools/devtools/src/index.ts
+++ b/packages/tools/devtools/devtools/src/index.ts
@@ -49,14 +49,14 @@ export interface DevtoolsProps {
 	 * This is provided to the Devtools instance strictly to enable communicating supported / desired functionality with
 	 * external listeners.
 	 */
-	logger?: IDevtoolsLogger;
+	readonly logger?: IDevtoolsLogger;
 
 	/**
 	 * (optional) List of Containers to initialize the devtools with.
 	 *
 	 * @remarks Additional Containers can be registered with the Devtools via {@link IDevtools.registerContainerDevtools}.
 	 */
-	initialContainers?: ContainerDevtoolsProps[];
+	readonly initialContainers?: ContainerDevtoolsProps[];
 
 	// TODO: Add ability for customers to specify custom data visualizer overrides
 }
@@ -71,7 +71,7 @@ export interface ContainerDevtoolsProps extends HasContainerKey {
 	/**
 	 * The Container to register with the Devtools.
 	 */
-	container: IFluidContainer;
+	readonly container: IFluidContainer;
 
 	// TODO: Add ability for customers to specify custom data visualizer overrides
 }

--- a/packages/tools/devtools/devtools/src/index.ts
+++ b/packages/tools/devtools/devtools/src/index.ts
@@ -34,6 +34,8 @@ import { isInternalFluidContainer } from "@fluidframework/fluid-static/internal"
 
 /**
  * Properties for configuring {@link IDevtools}.
+ *
+ * @sealed
  * @beta
  */
 export interface DevtoolsProps {
@@ -61,6 +63,8 @@ export interface DevtoolsProps {
 
 /**
  * Properties for configuring Devtools for an individual {@link @fluidframework/fluid-static#IFluidContainer}.
+ *
+ * @sealed
  * @beta
  */
 export interface ContainerDevtoolsProps extends HasContainerKey {
@@ -84,6 +88,8 @@ export interface ContainerDevtoolsProps extends HasContainerKey {
  * The lifetime of the associated singleton is bound by that of the Window (globalThis), and it will be automatically
  * disposed of on Window unload.
  * If you wish to dispose of it earlier, you may call its {@link @fluidframework/core-interfaces#IDisposable.dispose} method.
+ *
+ * @sealed
  * @beta
  */
 export interface IDevtools extends IDisposable {
@@ -145,6 +151,7 @@ class Devtools implements IDevtools {
  * Initializes the Devtools singleton and returns a handle to it.
  *
  * @see {@link @fluidframework/devtools-core#initializeDevtoolsBase}
+ *
  * @beta
  */
 export function initializeDevtools(props: DevtoolsProps): IDevtools {


### PR DESCRIPTION
APIs that were never intended for direct consumer use have been marked as `@system`.
These are:

- HasContainerKey

And APIs that were not intended to be extended by consumers have been marked as `@sealed`.
These are:

- ContainerDevtoolsProps
- DevtoolsProps
- HasContainerKey
- IDevtools

Additionally, interface properties have been marked as `readonly`.

Note that all of the affected APIs are `@beta`, so this change is not in violation of our breaking changes policy.
And in practice, it is unlikely to affect any users of our APIs.