### PR TITLE
refactor: Use assert.equal() to see values when test fails

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -889,12 +889,14 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 
 		const { summaryTree } = await summarizeNow(summarizer);
 		const summaryStats = getCompressorSummaryStats(summaryTree);
-		assert(
-			summaryStats.sessionCount === 1,
+		assert.equal(
+			summaryStats.sessionCount,
+			1,
 			"Should have a local session as all ids are ack'd",
 		);
-		assert(
-			summaryStats.clusterCount === 1,
+		assert.equal(
+			summaryStats.clusterCount,
+			1,
 			"Should have a local cluster as all ids are ack'd",
 		);
 	});
@@ -921,12 +923,14 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 
 		const { summaryTree } = await summarizeNow(summarizer1);
 		const summaryStats = getCompressorSummaryStats(summaryTree);
-		assert(
-			summaryStats.sessionCount === 1,
+		assert.equal(
+			summaryStats.sessionCount,
+			1,
 			"Should have a local session as all ids are ack'd",
 		);
-		assert(
-			summaryStats.clusterCount === 1,
+		assert.equal(
+			summaryStats.clusterCount,
+			1,
 			"Should have a local cluster as all ids are ack'd",
 		);
 
@@ -1011,8 +1015,9 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 		);
 
 		// Test assumption
-		assert(
-			entryPoint2._runtime.attachState === AttachState.Detached,
+		assert.equal(
+			entryPoint2._runtime.attachState,
+			AttachState.Detached,
 			"data store is detached",
 		);
 
@@ -1028,12 +1033,9 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 		// attached data store.
 		await ds2.trySetAlias("foo");
 
-		assert(
-			// For some reason TSC gets it wrong - it assumes that attachState is constant and that assert above
-			// established it's AttachState.Detached, so this comparison is useless.
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			entryPoint2._runtime.attachState === AttachState.Attached,
+		assert.equal(
+			entryPoint2._runtime.attachState,
+			AttachState.Attached,
 			"data store is detached",
 		);
 


### PR DESCRIPTION
## Description

The `Includes ack'd ids in summary` test sometimes fails against routerlicious but the error output only says `false !== true` so we can't tell the actual value of the number that is being compared to 1. This PR updates a few asserts in that file so they'll give us the actual value instead of just `expected true, got false` in the output when the test fails.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).