### PR TITLE
move chunk.ts file to core/tree

### DIFF
--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -98,6 +98,11 @@ export {
 	type DeltaFieldChanges,
 	type ExclusiveMapTree,
 	deepCopyMapTree,
+	type TreeChunk,
+	dummyRoot,
+	cursorChunk,
+	tryGetChunk,
+	type ChunkedCursor,
 } from "./tree/index.js";
 
 export {

--- a/packages/dds/tree/src/core/tree/chunk.ts
+++ b/packages/dds/tree/src/core/tree/chunk.ts
@@ -11,7 +11,7 @@ import {
 	type ITreeCursor,
 	type ITreeCursorSynchronous,
 	rootFieldKey,
-} from "../../core/index.js";
+} from "../index.js";
 import type { ReferenceCounted } from "../../util/index.js";
 
 /**

--- a/packages/dds/tree/src/core/tree/chunk.ts
+++ b/packages/dds/tree/src/core/tree/chunk.ts
@@ -5,14 +5,14 @@
 
 import { assert } from "@fluidframework/core-utils/internal";
 
+import type { ReferenceCounted } from "../../util/index.js";
+import type { FieldKey } from "../schema-stored/index.js";
+import { rootFieldKey } from "./types.js";
 import {
 	CursorLocationType,
-	type FieldKey,
 	type ITreeCursor,
 	type ITreeCursorSynchronous,
-	rootFieldKey,
-} from "../index.js";
-import type { ReferenceCounted } from "../../util/index.js";
+} from "./cursor.js";
 
 /**
  * Contiguous part of the tree which get stored together in some data format.

--- a/packages/dds/tree/src/core/tree/index.ts
+++ b/packages/dds/tree/src/core/tree/index.ts
@@ -110,5 +110,13 @@ export {
 	emptyDelta,
 } from "./deltaUtil.js";
 
+export {
+	type TreeChunk,
+	dummyRoot,
+	cursorChunk,
+	tryGetChunk,
+	type ChunkedCursor,
+} from "./chunk.js";
+
 export { DetachedFieldIndex } from "./detachedFieldIndex.js";
 export { type ForestRootId } from "./detachedFieldIndexTypes.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
@@ -15,11 +15,13 @@ import {
 	type TreeValue,
 	type UpPath,
 	type Value,
+	type ChunkedCursor,
+	type TreeChunk,
+	cursorChunk,
+	dummyRoot,
 } from "../../core/index.js";
 import { ReferenceCountedBase, fail } from "../../util/index.js";
 import { SynchronousCursor, prefixPath } from "../treeCursorUtils.js";
-
-import { type ChunkedCursor, type TreeChunk, cursorChunk, dummyRoot } from "./chunk.js";
 
 /**
  * General purpose one node chunk.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -21,12 +21,13 @@ import {
 	mapCursorFields,
 	Multiplicity,
 	ValueSchema,
+	type TreeChunk,
+	tryGetChunk,
 } from "../../core/index.js";
 import { fail, getOrCreate } from "../../util/index.js";
 import type { FullSchemaPolicy } from "../modular-schema/index.js";
 
 import { BasicChunk } from "./basicChunk.js";
-import { type TreeChunk, tryGetChunk } from "./chunk.js";
 import { SequenceChunk } from "./sequenceChunk.js";
 import { type FieldShape, TreeShape, UniformChunk } from "./uniformChunk.js";
 import { isStableNodeKey } from "../node-key/index.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -27,12 +27,13 @@ import {
 	detachedFieldAsKey,
 	mapCursorField,
 	rootFieldKey,
+	type ChunkedCursor,
+	type TreeChunk,
 } from "../../core/index.js";
 import { createEmitter, type Listenable } from "../../events/index.js";
 import { assertValidRange, brand, fail, getOrAddEmptyToMap } from "../../util/index.js";
 
 import { BasicChunk, BasicChunkCursor, type SiblingsOrKey } from "./basicChunk.js";
-import type { ChunkedCursor, TreeChunk } from "./chunk.js";
 import { type IChunker, basicChunkTree, chunkTree } from "./chunkTree.js";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkCodecUtilities.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkCodecUtilities.ts
@@ -5,10 +5,9 @@
 
 import { assert, oob } from "@fluidframework/core-utils/internal";
 
-import type { TreeValue } from "../../../core/index.js";
+import type { TreeValue, TreeChunk } from "../../../core/index.js";
 import { assertValidIndex } from "../../../util/index.js";
 import { type FluidSerializableReadOnly, assertAllowedValue } from "../../valueUtilities.js";
-import type { TreeChunk } from "../chunk.js";
 
 /**
  * Utilities related to chunk encoding and decoding that do not depend on specific chunk types or formats.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
@@ -6,10 +6,14 @@
 import { assert, unreachableCase, oob } from "@fluidframework/core-utils/internal";
 
 import { DiscriminatedUnionDispatcher } from "../../../codec/index.js";
-import type { FieldKey, TreeNodeSchemaIdentifier, Value } from "../../../core/index.js";
+import type {
+	FieldKey,
+	TreeNodeSchemaIdentifier,
+	Value,
+	TreeChunk,
+} from "../../../core/index.js";
 import { assertValidIndex } from "../../../util/index.js";
 import { BasicChunk } from "../basicChunk.js";
-import type { TreeChunk } from "../chunk.js";
 import { emptyChunk } from "../emptyChunk.js";
 import { SequenceChunk } from "../sequenceChunk.js";
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.ts
@@ -7,7 +7,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 
 import type { DiscriminatedUnionDispatcher } from "../../../codec/index.js";
 import type { BrandedType } from "../../../util/index.js";
-import type { TreeChunk } from "../chunk.js";
+import type { TreeChunk } from "../../../core/index.js";
 
 import {
 	type ChunkDecoder,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/emptyChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/emptyChunk.ts
@@ -10,11 +10,13 @@ import {
 	type FieldUpPath,
 	type PathRootPrefix,
 	type UpPath,
+	type ChunkedCursor,
+	type TreeChunk,
+	cursorChunk,
+	dummyRoot,
 } from "../../core/index.js";
 import { fail } from "../../util/index.js";
 import { prefixFieldPath } from "../treeCursorUtils.js";
-
-import { type ChunkedCursor, type TreeChunk, cursorChunk, dummyRoot } from "./chunk.js";
 
 /**
  * Chunk that is empty.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/index.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/index.ts
@@ -4,7 +4,7 @@
  */
 
 export { uniformChunk, ChunkShape } from "./uniformChunk.js";
-export { type TreeChunk, dummyRoot } from "./chunk.js";
+export { type TreeChunk, dummyRoot } from "../../core/index.js";
 export {
 	chunkTree,
 	defaultChunkPolicy,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/sequenceChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/sequenceChunk.ts
@@ -6,7 +6,7 @@
 import { ReferenceCountedBase } from "../../util/index.js";
 
 import { BasicChunkCursor } from "./basicChunk.js";
-import { type ChunkedCursor, type TreeChunk, dummyRoot } from "./chunk.js";
+import { type ChunkedCursor, type TreeChunk, dummyRoot } from "../../core/index.js";
 
 /**
  * General purpose multi-node sequence chunk.

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
@@ -14,11 +14,14 @@ import {
 	type TreeValue,
 	type UpPath,
 	type Value,
+	type ChunkedCursor,
+	type TreeChunk,
+	cursorChunk,
+	dummyRoot,
 } from "../../core/index.js";
 import { ReferenceCountedBase, fail } from "../../util/index.js";
 import { SynchronousCursor, prefixFieldPath, prefixPath } from "../treeCursorUtils.js";
 
-import { type ChunkedCursor, type TreeChunk, cursorChunk, dummyRoot } from "./chunk.js";
 import type { SessionSpaceCompressedId, IIdCompressor } from "@fluidframework/id-compressor";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
@@ -10,13 +10,10 @@ import {
 	type ITreeCursor,
 	type ITreeCursorSynchronous,
 	type JsonableTree,
+	type ChunkedCursor,
 } from "../../../core/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { BasicChunk } from "../../../feature-libraries/chunked-forest/basicChunk.js";
-import type {
-	ChunkedCursor,
-	// eslint-disable-next-line import/no-internal-modules
-} from "../../../feature-libraries/chunked-forest/chunk.js";
 import {
 	basicChunkTree,
 	basicOnlyChunkPolicy,

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkTree.spec.ts
@@ -11,11 +11,10 @@ import {
 	type FieldKey,
 	type Value,
 	mapCursorField,
+	tryGetChunk,
 } from "../../../core/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { BasicChunk } from "../../../feature-libraries/chunked-forest/basicChunk.js";
-// eslint-disable-next-line import/no-internal-modules
-import { tryGetChunk } from "../../../feature-libraries/chunked-forest/chunk.js";
 import {
 	type ChunkPolicy,
 	type ShapeInfo,

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
@@ -9,7 +9,7 @@ import { type Static, Type } from "@sinclair/typebox";
 
 import { DiscriminatedUnionDispatcher, unionOptions } from "../../../../codec/index.js";
 // eslint-disable-next-line import/no-internal-modules
-import type { ChunkedCursor } from "../../../../feature-libraries/chunked-forest/chunk.js";
+import type { ChunkedCursor } from "../../../../core/index.js";
 import {
 	type ChunkDecoder,
 	type StreamCursor,


### PR DESCRIPTION
## Description

Moves the `chunk.ts` to `core/tree` to separate some chunk interfaces and types from the `ChunkedForest`.