### PR TITLE
fix(docs): Use no-cookies youtube link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -189,6 +189,23 @@ E.g., <https://storage.fluidframework.com/static/images/website/brainstorm-examp
 Images may only be uploaded by Microsoft Fluid team members.
 If you do not have the appropriate permissions, but would like to contribute to our documentation, please reach out to us [here](https://github.com/microsoft/FluidFramework/issues/new/choose).
 
+##### YouTube Videos
+
+To meet our privacy requirements, it is important that we avoid embedding content that will collect cookies.
+To ensure this, please never embed YouTube videos using their standard embed format.
+Instead, be sure to leverage `https://www.youtube-nocookie.com/`.
+
+To make this easy, we have a `YoutubeVideo` component under `@site/src/components/youtubeVideo` that can be used to embed a specified video ID using the correct settings.
+Example:
+
+```mdx
+import { YoutubeVideo } from "@site/src/components/youtubeVideo";
+
+...
+
+<YoutubeVideo videoId="foo" className="my-styling" />
+```
+
 ## Scripts
 
 The following npm scripts are supported in this directory:

--- a/docs/src/components/home/banner.tsx
+++ b/docs/src/components/home/banner.tsx
@@ -19,7 +19,7 @@ export function Banner(): React.ReactElement {
 		<div className="ffcom-banner">
 			<div className="ffcom-banner-inner">
 				<TitleBox />
-				<YoutubeVideo videoId={videoEmbedId} className="ffcom-video-container"/>
+				<YoutubeVideo videoId={videoEmbedId} className="ffcom-video-container" />
 			</div>
 		</div>
 	);

--- a/docs/src/components/home/banner.tsx
+++ b/docs/src/components/home/banner.tsx
@@ -5,9 +5,11 @@
 
 import React from "react";
 
+import { YoutubeVideo } from "@site/src/components/youtubeVideo";
+
 import "@site/src/css/home/banner.css";
 
-const videoSourceUrl = "https://www.youtube.com/embed/fjRfTdIYzWg";
+const videoEmbedId = "fjRfTdIYzWg";
 
 /**
  * Homepage banner component.
@@ -17,7 +19,7 @@ export function Banner(): React.ReactElement {
 		<div className="ffcom-banner">
 			<div className="ffcom-banner-inner">
 				<TitleBox />
-				<Video />
+				<YoutubeVideo videoId={videoEmbedId} className="ffcom-video-container"/>
 			</div>
 		</div>
 	);
@@ -31,22 +33,6 @@ function TitleBox(): React.ReactElement {
 		<div className="ffcom-title-box">
 			<h1 className="ffcom-title">Fluid Framework</h1>
 			<span className="ffcom-description">{titleBoxDescriptionText}</span>
-		</div>
-	);
-}
-
-function Video(): React.ReactElement {
-	return (
-		<div className="ffcom-video-container">
-			<iframe
-				width="100%"
-				height="100%"
-				src={videoSourceUrl}
-				title="Fluid Framework - Build collaborative apps fast!"
-				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-				referrerPolicy="strict-origin-when-cross-origin"
-				allowFullScreen
-			></iframe>
 		</div>
 	);
 }

--- a/docs/src/components/youtubeVideo.tsx
+++ b/docs/src/components/youtubeVideo.tsx
@@ -23,7 +23,7 @@ export interface YoutubeVideoProps {
 /**
  * Renders a YouTube video, utilizing `youtube-nocookie.com` to ensure our privacy requirements are being met (i.e., no cookies).
  */
-export function YoutubeVideo({className, videoId}: YoutubeVideoProps): React.Element {
+export function YoutubeVideo({ className, videoId }: YoutubeVideoProps): React.Element {
 	const videoSourceUrl = `https://www.youtube-nocookie.com/embed/${videoId}`;
 	return (
 		<div className={className}>

--- a/docs/src/components/youtubeVideo.tsx
+++ b/docs/src/components/youtubeVideo.tsx
@@ -1,0 +1,41 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React from "react";
+
+/**
+ * {@link YoutubeVideo} component props.
+ */
+export interface YoutubeVideoProps {
+	/**
+	 * Embed ID of the YouTube video.
+	 */
+	videoId: string;
+
+	/**
+	 * Optional class name to apply to the video container.
+	 */
+	className?: string;
+}
+
+/**
+ * Renders a YouTube video, utilizing `youtube-nocookie.com` to ensure our privacy requirements are being met (i.e., no cookies).
+ */
+export function YoutubeVideo({className, videoId}: YoutubeVideoProps): React.Element {
+	const videoSourceUrl = `https://www.youtube-nocookie.com/embed/${videoId}`;
+	return (
+		<div className={className}>
+			<iframe
+				width="100%"
+				height="100%"
+				src={videoSourceUrl}
+				title="Fluid Framework - Build collaborative apps fast!"
+				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+				referrerPolicy="strict-origin-when-cross-origin"
+				allowFullScreen
+			></iframe>
+		</div>
+	);
+}


### PR DESCRIPTION
The new website was flagged by our privacy team for embedding a youtube video without ensuring no cookies were collected. This updates the only currently embedded youtube video on the site to ensure this is not the case, adds a re-usable React component to avoid introducing such issues in the future, and adds best practices documentation to the docs README.