### PR TITLE
(docs): remove enum from upload-json-steps param

### DIFF
--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -18,9 +18,6 @@ parameters:
 - name: uploadAsLatestRelease
   type: string
   default: false
-  values:
-    - true
-    - false
 
 # Major version to upload as latest-v*.tar.gz
 - name: majorVersion


### PR DESCRIPTION
parameter has issues processing runtime variable inputs with enum. 
It seems that during compilation time, it takes the variable input as the literal string, which causes it to fail the enum true/false check.