### PR TITLE
fix(gc): fullGC flag for Autorecovery shouldn't be cleared before GC runs

### DIFF
--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -461,8 +461,7 @@ export class GarbageCollector implements IGarbageCollector {
 	): Promise<IGCStats | undefined> {
 		const fullGC =
 			options.fullGC ??
-			(this.configs.runFullGC === true ||
-				this.summaryStateTracker.autoRecovery.fullGCRequested());
+			(this.configs.runFullGC === true || this.summaryStateTracker.autoRecovery.useFullGC());
 
 		// Add the options that are used to run GC to the telemetry context.
 		telemetryContext?.setMultiple("fluid_GC", "Options", {

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -857,6 +857,8 @@ export class GarbageCollector implements IGarbageCollector {
 	 * Called to refresh the latest summary state. This happens when either a pending summary is acked.
 	 */
 	public async refreshLatestSummary(result: IRefreshSummaryResult): Promise<void> {
+		//* TODO: Move autoRecovery API out of SST
+		this.summaryStateTracker.autoRecovery.onSummaryAck();
 		return this.summaryStateTracker.refreshLatestSummary(result);
 	}
 

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -338,6 +338,45 @@ export class GarbageCollector implements IGarbageCollector {
 		});
 	}
 
+	/** API for ensuring the correct auto-recovery mitigations */
+	private readonly autoRecovery = (() => {
+		/**
+		 * This uses a hidden state machine for forcing fullGC as part of autorecovery,
+		 * to regenerate the GC data for each node.
+		 *
+		 * Once fullGC has been requested, we need to wait until GC has run and the summary has been acked before clearing the state.
+		 *
+		 * States:
+		 * - undefined: No need to run fullGC now.
+		 * - "requested": FullGC requested, but GC has not yet run. Keep using fullGC until back to undefined.
+		 * - "ran": FullGC ran, but the following summary has not yet been acked. Keep using fullGC until back to undefined.
+		 *
+		 * Transitions:
+		 * - autoRecovery.requestFullGCOnNextRun :: anything TO "requested"
+		 * - autoRecovery.fullGCCompleted :: "requested" TO "ran"
+		 * - autoRecovery.onSummaryAck :: "ran" TO undefined
+		 */
+		let state: "requested" | "ran" | undefined;
+		return {
+			requestFullGCOnNextRun: () => {
+				state = "requested";
+			},
+			onFullGCCompleted: () => {
+				if (state === "requested") {
+					state = "ran";
+				}
+			},
+			onSummaryAck: () => {
+				if (state === "ran") {
+					state = undefined;
+				}
+			},
+			useFullGC: () => {
+				return state !== undefined;
+			},
+		};
+	})();
+
 	/**
 	 * Called during container initialization. Initializes the tombstone and deleted nodes state from the base snapshot.
 	 * Also, initializes the GC state including unreferenced nodes tracking if a current reference timestamp exists.
@@ -460,8 +499,7 @@ export class GarbageCollector implements IGarbageCollector {
 		telemetryContext?: ITelemetryContext,
 	): Promise<IGCStats | undefined> {
 		const fullGC =
-			options.fullGC ??
-			(this.configs.runFullGC === true || this.summaryStateTracker.autoRecovery.useFullGC());
+			options.fullGC ?? (this.configs.runFullGC === true || this.autoRecovery.useFullGC());
 
 		// Add the options that are used to run GC to the telemetry context.
 		telemetryContext?.setMultiple("fluid_GC", "Options", {
@@ -520,7 +558,7 @@ export class GarbageCollector implements IGarbageCollector {
 				await this.telemetryTracker.logPendingEvents(logger);
 				// Update the state of summary state tracker from this run's stats.
 				this.summaryStateTracker.updateStateFromGCRunStats(gcStats);
-				this.summaryStateTracker.autoRecovery.fullGCCompleted();
+				this.autoRecovery.onFullGCCompleted();
 				this.newReferencesSinceLastRun.clear();
 				this.completedRuns++;
 
@@ -857,8 +895,7 @@ export class GarbageCollector implements IGarbageCollector {
 	 * Called to refresh the latest summary state. This happens when either a pending summary is acked.
 	 */
 	public async refreshLatestSummary(result: IRefreshSummaryResult): Promise<void> {
-		//* TODO: Move autoRecovery API out of SST
-		this.summaryStateTracker.autoRecovery.onSummaryAck();
+		this.autoRecovery.onSummaryAck();
 		return this.summaryStateTracker.refreshLatestSummary(result);
 	}
 
@@ -893,7 +930,7 @@ export class GarbageCollector implements IGarbageCollector {
 
 					// In case the cause of the TombstoneLoaded event is incorrect GC Data (i.e. the object is actually reachable),
 					// do fullGC on the next run to get a chance to repair (in the likely case the bug is not deterministic)
-					this.summaryStateTracker.autoRecovery.requestFullGCOnNextRun();
+					this.autoRecovery.requestFullGCOnNextRun();
 					break;
 				}
 				default:

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -352,14 +352,14 @@ export class GarbageCollector implements IGarbageCollector {
 		//
 		// Transitions:
 		// - autoRecovery.requestFullGCOnNextRun :: [anything] --> "requested"
-		// - autoRecovery.onFullGCCompleted      :: "requested" --> "ran"
+		// - autoRecovery.onCompletedGCRun       :: "requested" --> "ran"
 		// - autoRecovery.onSummaryAck           :: "ran" --> undefined
 		let state: "requested" | "ran" | undefined;
 		return {
 			requestFullGCOnNextRun: () => {
 				state = "requested";
 			},
-			onFullGCCompleted: () => {
+			onCompletedGCRun: () => {
 				if (state === "requested") {
 					state = "ran";
 				}
@@ -556,7 +556,7 @@ export class GarbageCollector implements IGarbageCollector {
 				await this.telemetryTracker.logPendingEvents(logger);
 				// Update the state of summary state tracker from this run's stats.
 				this.summaryStateTracker.updateStateFromGCRunStats(gcStats);
-				this.autoRecovery.onFullGCCompleted();
+				this.autoRecovery.onCompletedGCRun();
 				this.newReferencesSinceLastRun.clear();
 				this.completedRuns++;
 

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -340,22 +340,20 @@ export class GarbageCollector implements IGarbageCollector {
 
 	/** API for ensuring the correct auto-recovery mitigations */
 	private readonly autoRecovery = (() => {
-		/**
-		 * This uses a hidden state machine for forcing fullGC as part of autorecovery,
-		 * to regenerate the GC data for each node.
-		 *
-		 * Once fullGC has been requested, we need to wait until GC has run and the summary has been acked before clearing the state.
-		 *
-		 * States:
-		 * - undefined: No need to run fullGC now.
-		 * - "requested": FullGC requested, but GC has not yet run. Keep using fullGC until back to undefined.
-		 * - "ran": FullGC ran, but the following summary has not yet been acked. Keep using fullGC until back to undefined.
-		 *
-		 * Transitions:
-		 * - autoRecovery.requestFullGCOnNextRun :: anything TO "requested"
-		 * - autoRecovery.fullGCCompleted :: "requested" TO "ran"
-		 * - autoRecovery.onSummaryAck :: "ran" TO undefined
-		 */
+		// This uses a hidden state machine for forcing fullGC as part of autorecovery,
+		// to regenerate the GC data for each node.
+		//
+		// Once fullGC has been requested, we need to wait until GC has run and the summary has been acked before clearing the state.
+		//
+		// States:
+		// - undefined: No need to run fullGC now.
+		// - "requested": FullGC requested, but GC has not yet run. Keep using fullGC until back to undefined.
+		// - "ran": FullGC ran, but the following summary has not yet been acked. Keep using fullGC until back to undefined.
+		//
+		// Transitions:
+		// - autoRecovery.requestFullGCOnNextRun :: [anything] --> "requested"
+		// - autoRecovery.onFullGCCompleted      :: "requested" --> "ran"
+		// - autoRecovery.onSummaryAck           :: "ran" --> undefined
 		let state: "requested" | "ran" | undefined;
 		return {
 			requestFullGCOnNextRun: () => {

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -520,6 +520,7 @@ export class GarbageCollector implements IGarbageCollector {
 				await this.telemetryTracker.logPendingEvents(logger);
 				// Update the state of summary state tracker from this run's stats.
 				this.summaryStateTracker.updateStateFromGCRunStats(gcStats);
+				this.summaryStateTracker.autoRecovery.fullGCCompleted();
 				this.newReferencesSinceLastRun.clear();
 				this.completedRuns++;
 

--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -51,16 +51,43 @@ export class GCSummaryStateTracker {
 	public updatedDSCountSinceLastSummary: number = 0;
 
 	/** API for ensuring the correct auto-recovery mitigations */
-	public autoRecovery = {
-		requestFullGCOnNextRun: () => {
-			this.fullGCModeForAutoRecovery = true;
-		},
-		fullGCRequested: () => {
-			return this.fullGCModeForAutoRecovery;
-		},
-	};
-	/** If true, the next GC run will do fullGC mode to regenerate the GC data for each node */
-	private fullGCModeForAutoRecovery: boolean = false;
+	public autoRecovery = (() => {
+		/**
+		 * This uses a hidden state machine for forcing fullGC as part of autorecovery,
+		 * to regenerate the GC data for each node.
+		 *
+		 * Once fullGC has been requested, we need to wait until GC has run and the summary has been acked before clearing the state.
+		 *
+		 * States:
+		 * - undefined: No need to run fullGC now.
+		 * - "requested": FullGC requested, but GC has not yet run. Keep using fullGC until back to undefined.
+		 * - "ran": FullGC ran, but the following summary has not yet been acked. Keep using fullGC until back to undefined.
+		 *
+		 * Transitions:
+		 * - autoRecovery.requestFullGCOnNextRun :: anything TO "requested"
+		 * - autoRecovery.fullGCCompleted :: "requested" TO "ran"
+		 * - autoRecovery.onSummaryAck :: "ran" TO undefined
+		 */
+		let state: "requested" | "ran" | undefined;
+		return {
+			requestFullGCOnNextRun: () => {
+				state = "requested";
+			},
+			fullGCCompleted: () => {
+				if (state === "requested") {
+					state = "ran";
+				}
+			},
+			onSummaryAck: () => {
+				if (state === "ran") {
+					state = undefined;
+				}
+			},
+			useFullGC: () => {
+				return state !== undefined;
+			},
+		};
+	})();
 
 	constructor(
 		// Tells whether GC should run or not.
@@ -235,7 +262,7 @@ export class GCSummaryStateTracker {
 		this.latestSummaryData = this.pendingSummaryData;
 		this.pendingSummaryData = undefined;
 		this.updatedDSCountSinceLastSummary = 0;
-		this.fullGCModeForAutoRecovery = false;
+		this.autoRecovery.onSummaryAck();
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -262,7 +262,6 @@ export class GCSummaryStateTracker {
 		this.latestSummaryData = this.pendingSummaryData;
 		this.pendingSummaryData = undefined;
 		this.updatedDSCountSinceLastSummary = 0;
-		this.autoRecovery.onSummaryAck();
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -78,7 +78,6 @@ type GcWithPrivates = IGarbageCollector & {
 		{
 			latestSummaryGCVersion: GCVersion;
 			latestSummaryData: IGCSummaryTrackingData | undefined;
-			fullGCModeForAutoRecovery: boolean;
 		}
 	>;
 	readonly telemetryTracker: GCTelemetryTracker;
@@ -441,13 +440,14 @@ describe("Garbage Collection Tests", () => {
 			);
 			corruptedGCData.gcNodes["/"] = [nodes[1]];
 
-			// getGCData set up to sometimes return the corrupted data
+			// getGCData set up to return the corrupted data unless fullGC is true
 			gc = createGarbageCollector({
 				createParams: { gcOptions: { enableGCSweep: true } }, // Required to run AutoRecovery
 				getGCData: async (fullGC?: boolean) => {
 					return fullGC ? defaultGCData : corruptedGCData;
 				},
 			});
+
 			// These spies will let us monitor how each of these functions are called (or not) during runSweepPhase.
 			// The original behavior of the function is preserved, but we can check how it was called.
 			const spies = {
@@ -527,22 +527,32 @@ describe("Garbage Collection Tests", () => {
 			// Simulate a successful GC/Summary.
 			// GC Data corruption should be fixed (nodes[0] should be referenced again) and autorecovery fullGC state should be reset
 			spies.gc.runGC.resetHistory();
+			// BUG FIX: Start with a spurious summary ack arriving before GC runs. It should not yet reset the autoRecovery state.
+			await gc.refreshLatestSummary({
+				isSummaryTracked: true,
+				isSummaryNewer: false,
+			});
+			assert(
+				gc.summaryStateTracker.autoRecovery.useFullGC(),
+				"autoRecovery.useFullGC should still be true after spurious summary ack (haven't run GC yet)",
+			);
 			await gc.collectGarbage({});
 			assert(
 				spies.gc.runGC.calledWith(/* fullGC: */ true),
 				"runGC should be called with fullGC true",
 			);
+			// This matters in case GC runs but the summary fails. We'll need to run with fullGC again next time.
 			assert(
-				gc.summaryStateTracker.fullGCModeForAutoRecovery,
-				"fullGCModeForAutoRecovery should NOT have been reset to false yet",
+				gc.summaryStateTracker.autoRecovery.useFullGC(),
+				"autoRecovery.useFullGC should still be true after GC run but before summary ack",
 			);
-			await gc.summaryStateTracker.refreshLatestSummary({
+			await gc.refreshLatestSummary({
 				isSummaryTracked: true,
 				isSummaryNewer: false,
 			});
 			assert(
-				!gc.summaryStateTracker.fullGCModeForAutoRecovery,
-				"fullGCModeForAutoRecovery should have been reset to false now",
+				!gc.summaryStateTracker.autoRecovery.useFullGC(),
+				"autoRecovery.useFullGC should have been reset to false now",
 			);
 
 			// Lastly, confirm that the node was successfully restored

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -336,7 +336,7 @@ describe("Garbage Collection Tests", () => {
 		const autoRecovery: {
 			useFullGC: () => boolean;
 			requestFullGCOnNextRun: () => void;
-			onFullGCCompleted: () => void;
+			onCompletedGCRun: () => void;
 			onSummaryAck: () => void;
 		} = createGarbageCollector().autoRecovery as any;
 
@@ -348,7 +348,7 @@ describe("Garbage Collection Tests", () => {
 		autoRecovery.onSummaryAck();
 		assert.equal(autoRecovery.useFullGC(), true, "Expect true still after early Summary Ack");
 
-		autoRecovery.onFullGCCompleted();
+		autoRecovery.onCompletedGCRun();
 		assert.equal(autoRecovery.useFullGC(), true, "Expect true still after full GC alone");
 
 		autoRecovery.onSummaryAck();

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -34,12 +34,12 @@ describe("GCSummaryStateTracker tests", () => {
 			gcVersionInBaseSnapshot: 1,
 			gcVersionInEffect: 1,
 		}) as any;
-		assert.equal(tracker.autoRecovery.fullGCRequested(), false, "Should be false by default");
+		assert.equal(tracker.autoRecovery.useFullGC(), false, "Should be false by default");
 
 		tracker.autoRecovery.requestFullGCOnNextRun();
 
 		assert.equal(
-			tracker.autoRecovery.fullGCRequested(),
+			tracker.autoRecovery.useFullGC(),
 			true,
 			"Should be true after requesting full GC",
 		);
@@ -47,11 +47,7 @@ describe("GCSummaryStateTracker tests", () => {
 		// After the first summary succeeds (refreshLatestSummary called), the state should be reset.
 		await tracker.refreshLatestSummary({ isSummaryTracked: true, isSummaryNewer: true });
 
-		assert.equal(
-			tracker.autoRecovery.fullGCRequested(),
-			false,
-			"Should be false after Summary Ack",
-		);
+		assert.equal(tracker.autoRecovery.useFullGC(), false, "Should be false after Summary Ack");
 	});
 
 	/**

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -13,43 +13,13 @@ import {
 
 import {
 	GCSummaryStateTracker,
-	GCVersion,
 	IGCStats,
 	IGarbageCollectionState,
 	gcStateBlobKey,
 	nextGCVersion,
 } from "../../gc/index.js";
 
-type GCSummaryStateTrackerWithPrivates = Omit<
-	GCSummaryStateTracker,
-	"latestSummaryGCVersion"
-> & {
-	latestSummaryGCVersion: GCVersion;
-};
-
 describe("GCSummaryStateTracker tests", () => {
-	it("Autorecovery: requesting Full GC", async () => {
-		const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker({
-			gcAllowed: true,
-			gcVersionInBaseSnapshot: 1,
-			gcVersionInEffect: 1,
-		}) as any;
-		assert.equal(tracker.autoRecovery.useFullGC(), false, "Should be false by default");
-
-		tracker.autoRecovery.requestFullGCOnNextRun();
-
-		assert.equal(
-			tracker.autoRecovery.useFullGC(),
-			true,
-			"Should be true after requesting full GC",
-		);
-
-		// After the first summary succeeds (refreshLatestSummary called), the state should be reset.
-		await tracker.refreshLatestSummary({ isSummaryTracked: true, isSummaryNewer: true });
-
-		assert.equal(tracker.autoRecovery.useFullGC(), false, "Should be false after Summary Ack");
-	});
-
 	/**
 	 * These tests validate that the GC data is written in summary incrementally. Basically, only parts of the GC
 	 * data that has changed since the last successful summary is re-written, rest is written as SummaryHandle.


### PR DESCRIPTION
## Description

Fixes [AB#14668](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/14668).

When reviewing the telemetry for autorecovery, I found that a large number of documents see Autorecovery but not fullGC.  This was unexpected since Autorecovery includes setting a flag that causes the next GC run to use fullGC.

Upon closer inspection of a few sample sessions, I found that the flag was getting cleared before the next GC run.  Likely due to unexpected case where summary triggers the load of the Tombstoned object, so the GC op and the summary Ack are racing.  If the GC op wins, then the summary Ack clears the flag.

This PR updates the logic to only clear the flag if GC actually ran with fullGC.
