### PR TITLE
refactor(build-tools): Add path to error message

### DIFF
--- a/build-tools/packages/build-cli/src/config.ts
+++ b/build-tools/packages/build-cli/src/config.ts
@@ -364,7 +364,7 @@ export function getFlubConfig(configPath: string, noCache = false): FlubConfig {
 	const config = configResult?.config as FlubConfig | undefined;
 
 	if (config === undefined) {
-		throw new Error("No flub configuration found.");
+		throw new Error(`No flub configuration found (configPath='${configPath}').`);
 	}
 
 	// Only version 1 of the config is supported. If any other value is provided, throw an error.


### PR DESCRIPTION
## Description

Add details to error message so we get better info to troubleshoot if the error happens. Motivated by the fact that we're hitting this error when some build pipelines run in the LTS branch.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).