### PR TITLE
feat(odsp-driver): Add logging property if doc is in dogfood or MSIT server environments

### DIFF
--- a/packages/drivers/odsp-driver/src/createFile/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile/createFile.ts
@@ -26,7 +26,7 @@ import { createOdspUrl } from "./../createOdspUrl.js";
 import { EpochTracker } from "./../epochTracker.js";
 import { getHeadersWithAuth } from "./../getUrlAndHeadersWithAuth.js";
 import { OdspDriverUrlResolver } from "./../odspDriverUrlResolver.js";
-import { checkForInternalFarmType, getApiRoot } from "./../odspUrlHelper.js";
+import { checkForKnownServerFarmType, getApiRoot } from "./../odspUrlHelper.js";
 import {
 	INewFileInfo,
 	buildOdspShareLinkReqParams,
@@ -193,7 +193,7 @@ export async function createNewEmptyFluidFile(
 			{ ...options, request: { url, method } },
 			"CreateNewFile",
 		);
-		const internalFarmType = checkForInternalFarmType(newFileInfo.siteUrl);
+		const internalFarmType = checkForKnownServerFarmType(newFileInfo.siteUrl);
 
 		return PerformanceEvent.timedExecAsync(
 			logger,

--- a/packages/drivers/odsp-driver/src/createFile/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile/createFile.ts
@@ -26,7 +26,7 @@ import { createOdspUrl } from "./../createOdspUrl.js";
 import { EpochTracker } from "./../epochTracker.js";
 import { getHeadersWithAuth } from "./../getUrlAndHeadersWithAuth.js";
 import { OdspDriverUrlResolver } from "./../odspDriverUrlResolver.js";
-import { getApiRoot } from "./../odspUrlHelper.js";
+import { checkForInternalFarmType, getApiRoot } from "./../odspUrlHelper.js";
 import {
 	INewFileInfo,
 	buildOdspShareLinkReqParams,
@@ -193,10 +193,16 @@ export async function createNewEmptyFluidFile(
 			{ ...options, request: { url, method } },
 			"CreateNewFile",
 		);
+		const internalFarmType = checkForInternalFarmType(newFileInfo.siteUrl);
 
 		return PerformanceEvent.timedExecAsync(
 			logger,
-			{ eventName: "createNewEmptyFile" },
+			{
+				eventName: "createNewEmptyFile",
+				details: {
+					...(internalFarmType && { internalFarmType }),
+				},
+			},
 			async (event) => {
 				const headers = getHeadersWithAuth(authHeader);
 				headers["Content-Type"] = "application/json";

--- a/packages/drivers/odsp-driver/src/createFile/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile/createFile.ts
@@ -200,7 +200,7 @@ export async function createNewEmptyFluidFile(
 			{
 				eventName: "createNewEmptyFile",
 				details: {
-					...(internalFarmType && { internalFarmType }),
+					internalFarmType,
 				},
 			},
 			async (event) => {

--- a/packages/drivers/odsp-driver/src/createFile/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createFile/createNewUtils.ts
@@ -32,7 +32,7 @@ import {
 } from "./../contracts.js";
 import { EpochTracker, FetchType } from "./../epochTracker.js";
 import { getHeadersWithAuth } from "./../getUrlAndHeadersWithAuth.js";
-import { checkForInternalFarmType } from "./../odspUrlHelper.js";
+import { checkForKnownServerFarmType } from "./../odspUrlHelper.js";
 import { getWithRetryForTokenRefresh, maxUmpPostBodySize } from "./../odspUtils.js";
 import { runWithRetry } from "./../retryUtils.js";
 
@@ -223,7 +223,7 @@ export async function createNewFluidContainerCore<T>(args: {
 		fetchType,
 		validateResponseCallback,
 	} = args;
-	const internalFarmType = checkForInternalFarmType(initialUrl);
+	const internalFarmType = checkForKnownServerFarmType(initialUrl);
 
 	return getWithRetryForTokenRefresh(async (options) => {
 		return PerformanceEvent.timedExecAsync(

--- a/packages/drivers/odsp-driver/src/createFile/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createFile/createNewUtils.ts
@@ -32,6 +32,7 @@ import {
 } from "./../contracts.js";
 import { EpochTracker, FetchType } from "./../epochTracker.js";
 import { getHeadersWithAuth } from "./../getUrlAndHeadersWithAuth.js";
+import { checkForInternalFarmType } from "./../odspUrlHelper.js";
 import { getWithRetryForTokenRefresh, maxUmpPostBodySize } from "./../odspUtils.js";
 import { runWithRetry } from "./../retryUtils.js";
 
@@ -222,11 +223,12 @@ export async function createNewFluidContainerCore<T>(args: {
 		fetchType,
 		validateResponseCallback,
 	} = args;
+	const internalFarmType = checkForInternalFarmType(initialUrl);
 
 	return getWithRetryForTokenRefresh(async (options) => {
 		return PerformanceEvent.timedExecAsync(
 			logger,
-			{ eventName: telemetryName },
+			{ eventName: telemetryName, details: { internalFarmType } },
 			async (event) => {
 				const snapshotBody = JSON.stringify(containerSnapshot);
 				let url: string;

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -47,6 +47,7 @@ import { EpochTracker } from "./epochTracker.js";
 import { getQueryString } from "./getQueryString.js";
 import { getHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
 import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "./odspSnapshotParser.js";
+import { checkForInternalFarmType } from "./odspUrlHelper.js";
 import {
 	IOdspResponse,
 	fetchAndParseAsJSONHelper,
@@ -297,6 +298,7 @@ async function fetchLatestSnapshotCore(
 	return getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
 		const fetchSnapshotForLoadingGroup = isSnapshotFetchForLoadingGroup(loadingGroupIds);
 		const eventName = fetchSnapshotForLoadingGroup ? "TreesLatestForGroup" : "TreesLatest";
+		const internalFarmType = checkForInternalFarmType(odspResolvedUrl.siteUrl);
 
 		const perfEvent = {
 			eventName,
@@ -304,6 +306,9 @@ async function fetchLatestSnapshotCore(
 			shareLinkPresent: odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem !== undefined,
 			isSummarizer: odspResolvedUrl.summarizer,
 			redeemFallbackEnabled: enableRedeemFallback,
+			details: {
+				...(internalFarmType && { internalFarmType }),
+			},
 		};
 		if (snapshotOptions !== undefined) {
 			for (const [key, value] of Object.entries(snapshotOptions)) {

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -47,7 +47,7 @@ import { EpochTracker } from "./epochTracker.js";
 import { getQueryString } from "./getQueryString.js";
 import { getHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
 import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "./odspSnapshotParser.js";
-import { checkForInternalFarmType } from "./odspUrlHelper.js";
+import { checkForKnownServerFarmType } from "./odspUrlHelper.js";
 import {
 	IOdspResponse,
 	fetchAndParseAsJSONHelper,
@@ -298,7 +298,7 @@ async function fetchLatestSnapshotCore(
 	return getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
 		const fetchSnapshotForLoadingGroup = isSnapshotFetchForLoadingGroup(loadingGroupIds);
 		const eventName = fetchSnapshotForLoadingGroup ? "TreesLatestForGroup" : "TreesLatest";
-		const internalFarmType = checkForInternalFarmType(odspResolvedUrl.siteUrl);
+		const internalFarmType = checkForKnownServerFarmType(odspResolvedUrl.siteUrl);
 
 		const perfEvent = {
 			eventName,

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -307,7 +307,7 @@ async function fetchLatestSnapshotCore(
 			isSummarizer: odspResolvedUrl.summarizer,
 			redeemFallbackEnabled: enableRedeemFallback,
 			details: {
-				...(internalFarmType && { internalFarmType }),
+				internalFarmType,
 			},
 		};
 		if (snapshotOptions !== undefined) {

--- a/packages/drivers/odsp-driver/src/odspUrlHelper.ts
+++ b/packages/drivers/odsp-driver/src/odspUrlHelper.ts
@@ -129,10 +129,11 @@ export async function getOdspUrlParts(url: URL): Promise<IOdspUrlParts | undefin
 
 /**
  * Inspect the ODSP siteUrl to guess if this document is in SPDF or MSIT, to aid livesite investigations
+ * @param urlOnSite - The URL of the site or a resource on the site
  * @returns undefined if the URL doesn't match known SPDF/MSIT patterns, "SPDF" if it's SPDF, "MSIT" if it's MSIT
  */
-export function checkForInternalFarmType(siteUrl: string): "SPDF" | "MSIT" | undefined {
-	const domain = new URL(siteUrl).hostname.toLowerCase();
+export function checkForInternalFarmType(urlOnSite: string): "SPDF" | "MSIT" | undefined {
+	const domain = new URL(urlOnSite).hostname.toLowerCase();
 	if (domain.endsWith(".sharepoint-df.com")) {
 		return "SPDF";
 	} else if (

--- a/packages/drivers/odsp-driver/src/odspUrlHelper.ts
+++ b/packages/drivers/odsp-driver/src/odspUrlHelper.ts
@@ -126,3 +126,20 @@ export async function getOdspUrlParts(url: URL): Promise<IOdspUrlParts | undefin
 		return { siteUrl: `${url.origin}${url.pathname}`, driveId, itemId };
 	}
 }
+
+/**
+ * Inspect the ODSP siteUrl to guess if this document is in SPDF or MSIT, to aid livesite investigations
+ * @returns undefined if the URL doesn't match known SPDF/MSIT patterns, "SPDF" if it's SPDF, "MSIT" if it's MSIT
+ */
+export function checkForInternalFarmType(siteUrl: string): "SPDF" | "MSIT" | undefined {
+	const domain = new URL(siteUrl).hostname.toLowerCase();
+	if (domain.endsWith(".sharepoint-df.com")) {
+		return "SPDF";
+	} else if (
+		domain === "microsoft.sharepoint.com" ||
+		domain === "microsoft-my.sharepoint.com"
+	) {
+		return "MSIT";
+	}
+	return undefined;
+}

--- a/packages/drivers/odsp-driver/src/odspUrlHelper.ts
+++ b/packages/drivers/odsp-driver/src/odspUrlHelper.ts
@@ -132,7 +132,7 @@ export async function getOdspUrlParts(url: URL): Promise<IOdspUrlParts | undefin
  * @param urlOnSite - The URL of the site or a resource on the site
  * @returns undefined if the URL doesn't match known SPDF/MSIT patterns, "SPDF" if it's SPDF, "MSIT" if it's MSIT
  */
-export function checkForInternalFarmType(urlOnSite: string): "SPDF" | "MSIT" | undefined {
+export function checkForKnownServerFarmType(urlOnSite: string): "SPDF" | "MSIT" | undefined {
 	const domain = new URL(urlOnSite).hostname.toLowerCase();
 	if (domain.endsWith(".sharepoint-df.com")) {
 		return "SPDF";

--- a/packages/drivers/odsp-driver/src/test/odspUrlHelper.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspUrlHelper.spec.ts
@@ -188,13 +188,27 @@ describe("odspUrlHelper", () => {
 				checkForInternalFarmType("https://microsoft.sharepoint-df.com/path?query=string"),
 				"SPDF",
 			);
+			// Actual create-new-file URL (with IDs scrubbed)
+			assert.equal(
+				checkForInternalFarmType(
+					"https://microsoft.sharepoint-df.com/_api/v2.1/drives/b!ci..bo/items/root:%2FLoopAppData/Untitled.loop:/opStream/snapshots/snapshot?ump=1",
+				),
+				"SPDF",
+			);
+			// Actual trees-latest URL (with IDs scrubbed)
+			assert.equal(
+				checkForInternalFarmType(
+					"https://microsoft-my.sharepoint-df.com/_api/v2.1/drives/b!AG..wb/items/01..NV/opStream/snapshots/trees/latest?ump=1",
+				),
+				"SPDF",
+			);
 			assert.equal(
 				checkForInternalFarmType("https://foo.sharepoint-df.com/path?query=string"),
 				"SPDF",
 			);
 			assert.equal(
 				checkForInternalFarmType("https://sharepoint-df.com/path?query=string"),
-				"SPDF",
+				undefined,
 			);
 			assert.equal(
 				checkForInternalFarmType("https://foo.not-sharepoint-df.com/path?query=string"),

--- a/packages/drivers/odsp-driver/src/test/odspUrlHelper.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspUrlHelper.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import {
-	checkForInternalFarmType,
+	checkForKnownServerFarmType,
 	hasOdcOrigin,
 	isOdcUrl,
 	isSpoUrl,
@@ -182,61 +182,66 @@ describe("odspUrlHelper", () => {
 		});
 	});
 
-	describe("checkForInternalFarmType", () => {
+	describe("checkForKnownServerFarmType", () => {
 		it("SPDF", () => {
 			assert.equal(
-				checkForInternalFarmType("https://microsoft.sharepoint-df.com/path?query=string"),
+				checkForKnownServerFarmType("https://microsoft.sharepoint-df.com/path?query=string"),
 				"SPDF",
 			);
 			// Actual create-new-file URL (with IDs scrubbed)
 			assert.equal(
-				checkForInternalFarmType(
+				checkForKnownServerFarmType(
 					"https://microsoft.sharepoint-df.com/_api/v2.1/drives/b!ci..bo/items/root:%2FLoopAppData/Untitled.loop:/opStream/snapshots/snapshot?ump=1",
 				),
 				"SPDF",
 			);
 			// Actual trees-latest URL (with IDs scrubbed)
 			assert.equal(
-				checkForInternalFarmType(
+				checkForKnownServerFarmType(
 					"https://microsoft-my.sharepoint-df.com/_api/v2.1/drives/b!AG..wb/items/01..NV/opStream/snapshots/trees/latest?ump=1",
 				),
 				"SPDF",
 			);
 			assert.equal(
-				checkForInternalFarmType("https://foo.sharepoint-df.com/path?query=string"),
+				checkForKnownServerFarmType("https://foo.sharepoint-df.com/path?query=string"),
 				"SPDF",
 			);
 			assert.equal(
-				checkForInternalFarmType("https://sharepoint-df.com/path?query=string"),
+				checkForKnownServerFarmType("https://sharepoint-df.com/path?query=string"),
 				undefined,
 			);
 			assert.equal(
-				checkForInternalFarmType("https://foo.not-sharepoint-df.com/path?query=string"),
+				checkForKnownServerFarmType("https://foo.not-sharepoint-df.com/path?query=string"),
 				undefined,
 			);
 		});
 		it("MSIT", () => {
 			assert.equal(
-				checkForInternalFarmType("https://microsoft.sharepoint.com/path?query=string"),
+				checkForKnownServerFarmType("https://microsoft.sharepoint.com/path?query=string"),
 				"MSIT",
 			);
 			assert.equal(
-				checkForInternalFarmType("https://microsoft-my.sharepoint.com/path?query=string"),
+				checkForKnownServerFarmType("https://microsoft-my.sharepoint.com/path?query=string"),
 				"MSIT",
 			);
 			assert.equal(
-				checkForInternalFarmType("https://microsoft-my.not.sharepoint.com/path?query=string"),
+				checkForKnownServerFarmType(
+					"https://microsoft-my.not.sharepoint.com/path?query=string",
+				),
 				undefined,
 			);
 			assert.equal(
-				checkForInternalFarmType("https://microsoft.foo.com/path?query=string"),
+				checkForKnownServerFarmType("https://microsoft.foo.com/path?query=string"),
 				undefined,
 			);
 		});
 		it("other", () => {
-			assert.equal(checkForInternalFarmType("https://foo.com/path?query=string"), undefined);
+			assert.equal(
+				checkForKnownServerFarmType("https://foo.com/path?query=string"),
+				undefined,
+			);
 			assert.throws(
-				() => checkForInternalFarmType("NOT A URL"),
+				() => checkForKnownServerFarmType("NOT A URL"),
 				"expected it to throw with invalid input",
 			);
 		});

--- a/packages/drivers/odsp-driver/src/test/odspUrlHelper.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspUrlHelper.spec.ts
@@ -5,7 +5,12 @@
 
 import { strict as assert } from "node:assert";
 
-import { hasOdcOrigin, isOdcUrl, isSpoUrl } from "../odspUrlHelper.js";
+import {
+	checkForInternalFarmType,
+	hasOdcOrigin,
+	isOdcUrl,
+	isSpoUrl,
+} from "../odspUrlHelper.js";
 
 describe("odspUrlHelper", () => {
 	describe("hasOdcOrigin", () => {
@@ -173,6 +178,52 @@ describe("odspUrlHelper", () => {
 					new URL("https://foo.onedrive.com/v2x1/drives('ABC123')/items('ABC123!123')"),
 				),
 				false,
+			);
+		});
+	});
+
+	describe("checkForInternalFarmType", () => {
+		it("SPDF", () => {
+			assert.equal(
+				checkForInternalFarmType("https://microsoft.sharepoint-df.com/path?query=string"),
+				"SPDF",
+			);
+			assert.equal(
+				checkForInternalFarmType("https://foo.sharepoint-df.com/path?query=string"),
+				"SPDF",
+			);
+			assert.equal(
+				checkForInternalFarmType("https://sharepoint-df.com/path?query=string"),
+				"SPDF",
+			);
+			assert.equal(
+				checkForInternalFarmType("https://foo.not-sharepoint-df.com/path?query=string"),
+				undefined,
+			);
+		});
+		it("MSIT", () => {
+			assert.equal(
+				checkForInternalFarmType("https://microsoft.sharepoint.com/path?query=string"),
+				"MSIT",
+			);
+			assert.equal(
+				checkForInternalFarmType("https://microsoft-my.sharepoint.com/path?query=string"),
+				"MSIT",
+			);
+			assert.equal(
+				checkForInternalFarmType("https://microsoft-my.not.sharepoint.com/path?query=string"),
+				undefined,
+			);
+			assert.equal(
+				checkForInternalFarmType("https://microsoft.foo.com/path?query=string"),
+				undefined,
+			);
+		});
+		it("other", () => {
+			assert.equal(checkForInternalFarmType("https://foo.com/path?query=string"), undefined);
+			assert.throws(
+				() => checkForInternalFarmType("NOT A URL"),
+				"expected it to throw with invalid input",
 			);
 		});
 	});


### PR DESCRIPTION
## Description

Fixes [AB#16011](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/16011)

Sometimes we are investigating a live site incident with our 1P customers, and it would be helpful to know which service environment (SharePoint "Farm") the document belongs to, since different settings or code can be deployed to these independently.  We can get a reasonable proxy of this by inspecting the domain of the URL against some known patterns.

We are computing/logging this for trees-latest and create-New events - should typically be once per session.