### PR TITLE
Skip flaky SharedString e2e test for ODSP and r11s

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
@@ -188,7 +188,11 @@ describeCompat("SharedString grouped batching", "NoCompat", (getTestObjectProvid
 		await provider.ensureSynchronized();
 	});
 
-	it("can load summarized grouped batch", async () => {
+	it("can load summarized grouped batch", async function () {
+		// We've seen flakiness in ODSP and r11s. This test is verifying SharedString logic regardless of what service handles the ops/summary.
+		if (!["local", "tinylicious", "t9s"].includes(provider.driver.type)) {
+			this.skip();
+		}
 		const container1 = await provider.makeTestContainer(groupedBatchingContainerConfig);
 		const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
 		const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);


### PR DESCRIPTION
This test is observed to be somewhat flaky in the e2e pipeline. There isn't much to be done for this test as it's testing simple behavior, and the flakiness is most likely due to server performance at the time of the pipeline run. Since the test is simply verifying end-to-end flow (loader -> runtime -> DDS) for a specific feature, we can skip it for the specifically flaky drivers.

[AB#12905](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/12905)
[AB#13656](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/13656)

Data point side note when running the test 1000 times for specific drivers:
- ODSP 0/1000 failed
- FRS 2/1000 failed