### PR TITLE
improvement(eslint-config-fluid): Update `@typescript-eslint/consistent-type-exports` auto-fix behavior

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @fluidframework/eslint-config-fluid Changelog
 
+## [5.5.2](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.5.2)
+
+Update auto-fix policy for `@typescript-eslint/consistent-type-exports` to prefer inline `type` annotations, rather than splitting exports into type-only and non-type-only groups.
+This makes it easier to tell at a glance how the auto-fix changes affect individual exports when a list of exports is large.
+It also makes it easier to detect issues in edge-cases where the the rule is applied incorrectly.
+
+E.g.:
+
+```typescript
+export { type Foo, Bar } from "./baz.js";
+```
+
+instead of:
+
+```typescript
+export type { Foo } from "./baz.js";
+export { Bar } from "./baz.js";
+```
+
 ## [5.5.1](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.5.1)
 
 ### Disabled rules

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "5.5.1",
+	"version": "5.5.2",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -106,7 +106,7 @@
         "@typescript-eslint/consistent-type-exports": [
             "error",
             {
-                "fixMixedExportsWithInlineTypeSpecifier": false
+                "fixMixedExportsWithInlineTypeSpecifier": true
             }
         ],
         "@typescript-eslint/consistent-type-imports": [

--- a/common/build/eslint-config-fluid/strict.js
+++ b/common/build/eslint-config-fluid/strict.js
@@ -78,7 +78,10 @@ module.exports = {
 				 */
 				"@typescript-eslint/consistent-type-exports": [
 					"error",
-					{ fixMixedExportsWithInlineTypeSpecifier: false },
+					{
+						// Makes it easier to tell, at a glance, the impact of a change to individual exports.
+						fixMixedExportsWithInlineTypeSpecifier: true,
+					},
 				],
 
 				/**


### PR DESCRIPTION
Updates auto-fix policy for `@typescript-eslint/consistent-type-exports` to prefer inline `type` annotations, rather than splitting exports into type-only and non-type-only groups.
This makes it easier to tell at a glance how the auto-fix changes affect individual exports when a list of exports is large.
It also makes it easier to detect issues in edge-cases where the the rule is applied incorrectly.

E.g.:

```typescript
export { type Foo, Bar } from "./baz.js";
```

instead of:

```typescript
export type { Foo } from "./baz.js";
export { Bar } from "./baz.js";
```

[AB#22618](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/22618)