### PR TITLE
refactor(api-markdown-documenter): Update dependency on `@fluidframework/eslint-config-fluid` and fix violations

### DIFF
--- a/tools/api-markdown-documenter/.eslintrc.cjs
+++ b/tools/api-markdown-documenter/.eslintrc.cjs
@@ -9,6 +9,9 @@ module.exports = {
 		project: ["./tsconfig.json"],
 	},
 	rules: {
+		// Too many false positives with array access
+		"@fluid-internal/fluid/no-unchecked-record-access": "off",
+
 		// Rule is reported in a lot of places where it would be invalid to follow the suggested pattern
 		"@typescript-eslint/class-literal-property-style": "off",
 

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -5,15 +5,15 @@
 ```ts
 
 import { ApiCallSignature } from '@microsoft/api-extractor-model';
-import { ApiClass } from '@microsoft/api-extractor-model';
+import type { ApiClass } from '@microsoft/api-extractor-model';
 import { ApiConstructor } from '@microsoft/api-extractor-model';
 import { ApiConstructSignature } from '@microsoft/api-extractor-model';
 import { ApiEntryPoint } from '@microsoft/api-extractor-model';
-import { ApiEnum } from '@microsoft/api-extractor-model';
-import { ApiEnumMember } from '@microsoft/api-extractor-model';
+import type { ApiEnum } from '@microsoft/api-extractor-model';
+import type { ApiEnumMember } from '@microsoft/api-extractor-model';
 import { ApiFunction } from '@microsoft/api-extractor-model';
 import { ApiIndexSignature } from '@microsoft/api-extractor-model';
-import { ApiInterface } from '@microsoft/api-extractor-model';
+import type { ApiInterface } from '@microsoft/api-extractor-model';
 import { ApiItem } from '@microsoft/api-extractor-model';
 import { ApiItemKind } from '@microsoft/api-extractor-model';
 import { ApiMethod } from '@microsoft/api-extractor-model';
@@ -21,9 +21,9 @@ import { ApiMethodSignature } from '@microsoft/api-extractor-model';
 import { ApiModel } from '@microsoft/api-extractor-model';
 import { ApiNamespace } from '@microsoft/api-extractor-model';
 import { ApiPackage } from '@microsoft/api-extractor-model';
-import { ApiPropertyItem } from '@microsoft/api-extractor-model';
-import { ApiTypeAlias } from '@microsoft/api-extractor-model';
-import { ApiVariable } from '@microsoft/api-extractor-model';
+import type { ApiPropertyItem } from '@microsoft/api-extractor-model';
+import type { ApiTypeAlias } from '@microsoft/api-extractor-model';
+import type { ApiVariable } from '@microsoft/api-extractor-model';
 import type { Data } from 'unist';
 import { DocNode } from '@microsoft/tsdoc';
 import { DocSection } from '@microsoft/tsdoc';

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -5,15 +5,15 @@
 ```ts
 
 import { ApiCallSignature } from '@microsoft/api-extractor-model';
-import { ApiClass } from '@microsoft/api-extractor-model';
+import type { ApiClass } from '@microsoft/api-extractor-model';
 import { ApiConstructor } from '@microsoft/api-extractor-model';
 import { ApiConstructSignature } from '@microsoft/api-extractor-model';
 import { ApiEntryPoint } from '@microsoft/api-extractor-model';
-import { ApiEnum } from '@microsoft/api-extractor-model';
-import { ApiEnumMember } from '@microsoft/api-extractor-model';
+import type { ApiEnum } from '@microsoft/api-extractor-model';
+import type { ApiEnumMember } from '@microsoft/api-extractor-model';
 import { ApiFunction } from '@microsoft/api-extractor-model';
 import { ApiIndexSignature } from '@microsoft/api-extractor-model';
-import { ApiInterface } from '@microsoft/api-extractor-model';
+import type { ApiInterface } from '@microsoft/api-extractor-model';
 import { ApiItem } from '@microsoft/api-extractor-model';
 import { ApiItemKind } from '@microsoft/api-extractor-model';
 import { ApiMethod } from '@microsoft/api-extractor-model';
@@ -21,9 +21,9 @@ import { ApiMethodSignature } from '@microsoft/api-extractor-model';
 import { ApiModel } from '@microsoft/api-extractor-model';
 import { ApiNamespace } from '@microsoft/api-extractor-model';
 import { ApiPackage } from '@microsoft/api-extractor-model';
-import { ApiPropertyItem } from '@microsoft/api-extractor-model';
-import { ApiTypeAlias } from '@microsoft/api-extractor-model';
-import { ApiVariable } from '@microsoft/api-extractor-model';
+import type { ApiPropertyItem } from '@microsoft/api-extractor-model';
+import type { ApiTypeAlias } from '@microsoft/api-extractor-model';
+import type { ApiVariable } from '@microsoft/api-extractor-model';
 import type { Data } from 'unist';
 import { DocNode } from '@microsoft/tsdoc';
 import { DocSection } from '@microsoft/tsdoc';

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -5,15 +5,15 @@
 ```ts
 
 import { ApiCallSignature } from '@microsoft/api-extractor-model';
-import { ApiClass } from '@microsoft/api-extractor-model';
+import type { ApiClass } from '@microsoft/api-extractor-model';
 import { ApiConstructor } from '@microsoft/api-extractor-model';
 import { ApiConstructSignature } from '@microsoft/api-extractor-model';
 import { ApiEntryPoint } from '@microsoft/api-extractor-model';
-import { ApiEnum } from '@microsoft/api-extractor-model';
-import { ApiEnumMember } from '@microsoft/api-extractor-model';
+import type { ApiEnum } from '@microsoft/api-extractor-model';
+import type { ApiEnumMember } from '@microsoft/api-extractor-model';
 import { ApiFunction } from '@microsoft/api-extractor-model';
 import { ApiIndexSignature } from '@microsoft/api-extractor-model';
-import { ApiInterface } from '@microsoft/api-extractor-model';
+import type { ApiInterface } from '@microsoft/api-extractor-model';
 import { ApiItem } from '@microsoft/api-extractor-model';
 import { ApiItemKind } from '@microsoft/api-extractor-model';
 import { ApiMethod } from '@microsoft/api-extractor-model';
@@ -21,9 +21,9 @@ import { ApiMethodSignature } from '@microsoft/api-extractor-model';
 import { ApiModel } from '@microsoft/api-extractor-model';
 import { ApiNamespace } from '@microsoft/api-extractor-model';
 import { ApiPackage } from '@microsoft/api-extractor-model';
-import { ApiPropertyItem } from '@microsoft/api-extractor-model';
-import { ApiTypeAlias } from '@microsoft/api-extractor-model';
-import { ApiVariable } from '@microsoft/api-extractor-model';
+import type { ApiPropertyItem } from '@microsoft/api-extractor-model';
+import type { ApiTypeAlias } from '@microsoft/api-extractor-model';
+import type { ApiVariable } from '@microsoft/api-extractor-model';
 import type { Data } from 'unist';
 import { DocNode } from '@microsoft/tsdoc';
 import { DocSection } from '@microsoft/tsdoc';

--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -88,7 +88,7 @@
 		"@fluid-tools/markdown-magic": "file:../markdown-magic",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.44.0",
-		"@fluidframework/eslint-config-fluid": "^5.1.0",
+		"@fluidframework/eslint-config-fluid": "^5.5.1",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/chai": "^4.3.4",
 		"@types/hast": "^3.0.4",

--- a/tools/api-markdown-documenter/pnpm-lock.yaml
+++ b/tools/api-markdown-documenter/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^0.44.0
         version: 0.44.0
       '@fluidframework/eslint-config-fluid':
-        specifier: ^5.1.0
-        version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
+        specifier: ^5.5.1
+        version: 5.5.1(eslint@8.55.0)(typescript@5.1.6)
       '@microsoft/api-extractor':
         specifier: ^7.45.1
         version: 7.45.1(@types/node@18.15.11)
@@ -218,12 +218,12 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@fluid-internal/eslint-plugin-fluid@0.1.1(eslint@8.55.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-7CNeAjn81BPvq/BKc1nQo/6HUZXg4KUAglFuCX6HFCnpGPrDLdm7cdkrGyA1tExB1EGnCAPFzVNbSqSYcwJnag==}
+  /@fluid-internal/eslint-plugin-fluid@0.1.3(eslint@8.55.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-l3MPEQ34lYP9QOIQ9vx9ncyvkYqR7ci7ZixxD4RdOmGBnAFOqipBjn5Je9AJfztQ3jWgcT3jiV+AVT3rBjc2Yw==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
-      '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.1.6)
-      ts-morph: 20.0.0
+      '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.1.6)
+      ts-morph: 22.0.0
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -315,10 +315,10 @@ packages:
       '@fluidframework/protocol-definitions': 3.2.0
     dev: true
 
-  /@fluidframework/eslint-config-fluid@5.2.0(eslint@8.55.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-FGAt7QIm//36j+ZiiIAj1+LZ6NYP2UJLwE5NT70ztgjl90jaCEWZUgoGUgPUWB9CpTmVZYo1+dGWOSsMLHidJA==}
+  /@fluidframework/eslint-config-fluid@5.5.1(eslint@8.55.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-rbHvimalOIyLd6nsK5uWJQylxwkztJc0yWKOrop8rrxgMR9dSuGnjJXcjhijZ0p1+zHbZ325+udoDFWw2HJZRQ==}
     dependencies:
-      '@fluid-internal/eslint-plugin-fluid': 0.1.1(eslint@8.55.0)(typescript@5.1.6)
+      '@fluid-internal/eslint-plugin-fluid': 0.1.3(eslint@8.55.0)(typescript@5.1.6)
       '@microsoft/tsdoc': 0.14.2
       '@rushstack/eslint-patch': 1.4.0
       '@rushstack/eslint-plugin': 0.13.1(eslint@8.55.0)(typescript@5.1.6)
@@ -326,13 +326,13 @@ packages:
       '@typescript-eslint/eslint-plugin': 6.7.5(@typescript-eslint/parser@6.7.5)(eslint@8.55.0)(typescript@5.1.6)
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.1.6)
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.7.5)(eslint-plugin-i@2.29.0)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5)(eslint-plugin-i@2.29.1)(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: /eslint-plugin-i@2.29.0(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
+      eslint-plugin-import: /eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.55.0)
+      eslint-plugin-react-hooks: 4.6.2(eslint@8.55.0)
       eslint-plugin-tsdoc: 0.2.17
       eslint-plugin-unicorn: 48.0.1(eslint@8.55.0)
       eslint-plugin-unused-imports: 3.0.0(@typescript-eslint/eslint-plugin@6.7.5)(eslint@8.55.0)
@@ -340,6 +340,7 @@ packages:
       - eslint
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
       - supports-color
       - typescript
     dev: true
@@ -542,6 +543,11 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
+    dev: true
+
+  /@nolyfill/is-core-module@1.0.39:
+    resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
+    engines: {node: '>=12.4.0'}
     dev: true
 
   /@oclif/core@4.0.20:
@@ -819,15 +825,6 @@ packages:
       - supports-color
     dev: true
 
-  /@ts-morph/common@0.21.0:
-    resolution: {integrity: sha512-ES110Mmne5Vi4ypUKrtVQfXFDtCsDXiUiGxF6ILVlE90dDD4fdpC1LSjydl/ml7xJWKSDZwUYD2zkOePMSrPBA==}
-    dependencies:
-      fast-glob: 3.3.2
-      minimatch: 7.4.6
-      mkdirp: 2.1.6
-      path-browserify: 1.0.1
-    dev: true
-
   /@ts-morph/common@0.23.0:
     resolution: {integrity: sha512-m7Lllj9n/S6sOkCkRftpM7L24uvmfXQFedlW/4hENcuJH1HHm9u5EgxZb9uVjQSCGrbBWBkOGgcTxNg36r6ywA==}
     dependencies:
@@ -988,7 +985,7 @@ packages:
       '@typescript-eslint/type-utils': 6.7.5(eslint@8.55.0)(typescript@5.1.6)
       '@typescript-eslint/utils': 6.7.5(eslint@8.55.0)(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.7.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       eslint: 8.55.0
       graphemer: 1.4.0
       ignore: 5.2.4
@@ -1013,6 +1010,27 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.1.6)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.6(supports-color@8.1.1)
+      eslint: 8.55.0
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6):
     resolution: {integrity: sha512-bIZVSGx2UME/lmhLcjdVc7ePBwn7CLqKarUBL4me1C5feOd663liTGjMBGVcGr+BhnSLeP4SgwdvNnnkbIdkCw==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -1027,7 +1045,7 @@ packages:
       '@typescript-eslint/types': 6.7.5
       '@typescript-eslint/typescript-estree': 6.7.5(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.7.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       eslint: 8.55.0
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -1040,6 +1058,14 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.11
       '@typescript-eslint/visitor-keys': 5.59.11
+    dev: true
+
+  /@typescript-eslint/scope-manager@6.21.0:
+    resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
     dev: true
 
   /@typescript-eslint/scope-manager@6.7.5:
@@ -1075,6 +1101,11 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@typescript-eslint/types@6.21.0:
+    resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
   /@typescript-eslint/types@6.7.5:
     resolution: {integrity: sha512-WboQBlOXtdj1tDFPyIthpKrUb+kZf2VroLZhxKa/VlwLlLyqv/PwUNgL30BlTVZV1Wu4Asu2mMYPqarSO4L5ZQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -1096,6 +1127,28 @@ packages:
       is-glob: 4.0.3
       semver: 7.6.0
       tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree@6.21.0(typescript@5.1.6):
+    resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.6(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.6.0
+      ts-api-utils: 1.0.3(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
@@ -1166,6 +1219,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.59.11
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@typescript-eslint/visitor-keys@6.21.0:
+    resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -1649,10 +1710,6 @@ packages:
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
-    dev: true
-
-  /code-block-writer@12.0.0:
-    resolution: {integrity: sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==}
     dev: true
 
   /code-block-writer@13.0.1:
@@ -2194,21 +2251,28 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.7.5)(eslint-plugin-i@2.29.0)(eslint@8.55.0):
-    resolution: {integrity: sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==}
+  /eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5)(eslint-plugin-i@2.29.1)(eslint@8.55.0):
+    resolution: {integrity: sha512-ud9aw4szY9cCT1EWWdGv1L1XR6hh2PaRWif0j2QjQ0pgTY/69iw+W0Z4qZv5wHahOl8isEr+k/JnyAqNQkLkIA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
       eslint-plugin-import: '*'
+      eslint-plugin-import-x: '*'
+    peerDependenciesMeta:
+      eslint-plugin-import:
+        optional: true
+      eslint-plugin-import-x:
+        optional: true
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.3.6(supports-color@8.1.1)
       enhanced-resolve: 5.15.0
       eslint: 8.55.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
-      eslint-plugin-import: /eslint-plugin-i@2.29.0(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: /eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       fast-glob: 3.3.2
-      get-tsconfig: 4.7.2
-      is-core-module: 2.13.1
+      get-tsconfig: 4.8.1
+      is-bun-module: 1.2.1
       is-glob: 4.0.3
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -2217,7 +2281,36 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0):
+  /eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+    resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.1.6)
+      debug: 3.2.7
+      eslint: 8.55.0
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5)(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2242,7 +2335,7 @@ packages:
       debug: 3.2.7
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.7.5)(eslint-plugin-i@2.29.0)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5)(eslint-plugin-i@2.29.1)(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2276,21 +2369,20 @@ packages:
       ignore: 5.2.4
     dev: true
 
-  /eslint-plugin-i@2.29.0(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0):
-    resolution: {integrity: sha512-slGeTS3GQzx9267wLJnNYNO8X9EHGsc75AKIAFvnvMYEcTJKotPKL1Ru5PIGVHIVet+2DsugePWp8Oxpx8G22w==}
+  /eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+    resolution: {integrity: sha512-ORizX37MelIWLbMyqI7hi8VJMf7A0CskMmYkB+lkCX3aF4pkGV7kwx5bSEb4qx7Yce2rAf9s34HqDRPjGRZPNQ==}
     engines: {node: '>=12'}
     peerDependencies:
       eslint: ^7.2.0 || ^8
     dependencies:
-      debug: 3.2.7
-      doctrine: 2.1.0
+      debug: 4.3.6(supports-color@8.1.1)
+      doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.5)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       get-tsconfig: 4.7.2
       is-glob: 4.0.3
       minimatch: 3.1.2
-      resolve: 1.22.8
       semver: 7.6.0
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -2308,7 +2400,7 @@ packages:
       '@es-joy/jsdoccomment': 0.40.1
       are-docs-informative: 0.0.2
       comment-parser: 1.4.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint: 8.55.0
       esquery: 1.5.0
@@ -2328,8 +2420,8 @@ packages:
       eslint: 8.55.0
     dev: true
 
-  /eslint-plugin-react-hooks@4.6.0(eslint@8.55.0):
-    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
+  /eslint-plugin-react-hooks@4.6.2(eslint@8.55.0):
+    resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
@@ -2784,6 +2876,12 @@ packages:
 
   /get-tsconfig@4.7.2:
     resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: true
+
+  /get-tsconfig@4.8.1:
+    resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
     dependencies:
       resolve-pkg-maps: 1.0.0
     dev: true
@@ -3319,6 +3417,12 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       builtin-modules: 3.3.0
+    dev: true
+
+  /is-bun-module@1.2.1:
+    resolution: {integrity: sha512-AmidtEM6D6NmUiLOvvU7+IePxjEjOzra2h0pSrsfSAcXwl/83zLLXDByafUJy9k/rKK0pvXMLdwKwGHlX2Ke6Q==}
+    dependencies:
+      semver: 7.6.3
     dev: true
 
   /is-callable@1.2.7:
@@ -4060,15 +4164,15 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
-  /minimatch@7.4.6:
-    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
-    engines: {node: '>=10'}
+  /minimatch@8.0.4:
+    resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
+    engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
     dev: true
 
-  /minimatch@8.0.4:
-    resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
@@ -4107,12 +4211,6 @@ packages:
 
   /mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: true
-
-  /mkdirp@2.1.6:
-    resolution: {integrity: sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==}
     engines: {node: '>=10'}
     hasBin: true
     dev: true
@@ -4810,6 +4908,12 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
+  /semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
   /serialize-javascript@6.0.0:
     resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
     dependencies:
@@ -5208,13 +5312,6 @@ packages:
   /ts-deepmerge@7.0.1:
     resolution: {integrity: sha512-JBFCmNenZdUCc+TRNCtXVM6N8y/nDQHAcpj5BlwXG/gnogjam1NunulB9ia68mnqYI446giMfpqeBFFkOleh+g==}
     engines: {node: '>=14.13.1'}
-    dev: true
-
-  /ts-morph@20.0.0:
-    resolution: {integrity: sha512-JVmEJy2Wow5n/84I3igthL9sudQ8qzjh/6i4tmYCm6IqYyKFlNbJZi7oBdjyqcWSWYRu3CtL0xbT6fS03ESZIg==}
-    dependencies:
-      '@ts-morph/common': 0.21.0
-      code-block-writer: 12.0.0
     dev: true
 
   /ts-morph@22.0.0:

--- a/tools/api-markdown-documenter/src/ConfigurationBase.ts
+++ b/tools/api-markdown-documenter/src/ConfigurationBase.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type Logger } from "./Logging.js";
+import type { Logger } from "./Logging.js";
 
 /**
  * Common base interface for configuration interfaces.

--- a/tools/api-markdown-documenter/src/FileSystemConfiguration.ts
+++ b/tools/api-markdown-documenter/src/FileSystemConfiguration.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type NewlineKind } from "@rushstack/node-core-library";
+import type { NewlineKind } from "@rushstack/node-core-library";
 
 /**
  * Configuration for interacting with the file-system.

--- a/tools/api-markdown-documenter/src/LintApiModel.ts
+++ b/tools/api-markdown-documenter/src/LintApiModel.ts
@@ -4,6 +4,7 @@
  */
 
 import { fail, strict as assert } from "node:assert";
+
 import {
 	ApiDocumentedItem,
 	type ApiItem,
@@ -20,9 +21,10 @@ import {
 	DocNodeContainer,
 	DocNodeKind,
 } from "@microsoft/tsdoc";
+
+import type { ConfigurationBase } from "./ConfigurationBase.js";
 import { defaultConsoleLogger } from "./Logging.js";
 import { resolveSymbolicReference } from "./utilities/index.js";
-import type { ConfigurationBase } from "./ConfigurationBase.js";
 
 /**
  * {@link lintApiModel} configuration.

--- a/tools/api-markdown-documenter/src/LoadModel.ts
+++ b/tools/api-markdown-documenter/src/LoadModel.ts
@@ -12,11 +12,11 @@ import {
 	ApiModel,
 	type IResolveDeclarationReferenceResult,
 } from "@microsoft/api-extractor-model";
-import { type DocComment, type DocInheritDocTag } from "@microsoft/tsdoc";
+import type { DocComment, DocInheritDocTag } from "@microsoft/tsdoc";
 import { FileSystem } from "@rushstack/node-core-library";
 
-import { defaultConsoleLogger, type Logger } from "./Logging.js";
 import type { ConfigurationBase } from "./ConfigurationBase.js";
+import { defaultConsoleLogger, type Logger } from "./Logging.js";
 
 /**
  * {@link loadModel} options.

--- a/tools/api-markdown-documenter/src/RenderHtml.ts
+++ b/tools/api-markdown-documenter/src/RenderHtml.ts
@@ -7,14 +7,14 @@ import * as Path from "node:path";
 
 import { FileSystem, NewlineKind } from "@rushstack/node-core-library";
 
+import type { FileSystemConfiguration } from "./FileSystemConfiguration.js";
+import type { Logger } from "./Logging.js";
 import {
 	type ApiItemTransformationConfiguration,
 	transformApiModel,
 } from "./api-item-transforms/index.js";
-import { type DocumentNode } from "./documentation-domain/index.js";
-import { type Logger } from "./Logging.js";
+import type { DocumentNode } from "./documentation-domain/index.js";
 import { type RenderDocumentAsHtmlConfig, renderDocumentAsHtml } from "./renderers/index.js";
-import { type FileSystemConfiguration } from "./FileSystemConfiguration.js";
 
 /**
  * Renders the provided model and its contents, and writes each document to a file on disk.

--- a/tools/api-markdown-documenter/src/RenderMarkdown.ts
+++ b/tools/api-markdown-documenter/src/RenderMarkdown.ts
@@ -7,14 +7,14 @@ import * as Path from "node:path";
 
 import { FileSystem, NewlineKind } from "@rushstack/node-core-library";
 
+import type { FileSystemConfiguration } from "./FileSystemConfiguration.js";
+import type { Logger } from "./Logging.js";
 import {
 	type ApiItemTransformationConfiguration,
 	transformApiModel,
 } from "./api-item-transforms/index.js";
-import { type DocumentNode } from "./documentation-domain/index.js";
-import { type Logger } from "./Logging.js";
+import type { DocumentNode } from "./documentation-domain/index.js";
 import { type MarkdownRenderConfiguration, renderDocumentAsMarkdown } from "./renderers/index.js";
-import { type FileSystemConfiguration } from "./FileSystemConfiguration.js";
 
 /**
  * Renders the provided model and its contents, and writes each document to a file on disk.

--- a/tools/api-markdown-documenter/src/api-item-transforms/ApiItemTransformUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/ApiItemTransformUtilities.ts
@@ -7,13 +7,14 @@ import * as Path from "node:path";
 
 import { type ApiItem, ApiItemKind, ReleaseTag } from "@microsoft/api-extractor-model";
 
-import { type Heading } from "../Heading.js";
-import { type Link } from "../Link.js";
+import type { Heading } from "../Heading.js";
+import type { Link } from "../Link.js";
 import { getQualifiedApiItemName, getReleaseTag } from "../utilities/index.js";
-import {
-	type ApiItemTransformationConfiguration,
-	type DocumentBoundaries,
-	type HierarchyBoundaries,
+
+import type {
+	ApiItemTransformationConfiguration,
+	DocumentBoundaries,
+	HierarchyBoundaries,
 } from "./configuration/index.js";
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiItem.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiItem.ts
@@ -23,10 +23,11 @@ import {
 	type ApiVariable,
 } from "@microsoft/api-extractor-model";
 
-import { type DocumentNode, type SectionNode } from "../documentation-domain/index.js";
+import type { DocumentNode, SectionNode } from "../documentation-domain/index.js";
+
 import { doesItemRequireOwnDocument, shouldItemBeIncluded } from "./ApiItemTransformUtilities.js";
 import { createDocument } from "./Utilities.js";
-import { type ApiItemTransformationConfiguration } from "./configuration/index.js";
+import type { ApiItemTransformationConfiguration } from "./configuration/index.js";
 import { createBreadcrumbParagraph, wrapInSection } from "./helpers/index.js";
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
@@ -3,22 +3,18 @@
  * Licensed under the MIT License.
  */
 
-import {
-	type ApiEntryPoint,
-	type ApiItem,
-	type ApiModel,
-	type ApiPackage,
-} from "@microsoft/api-extractor-model";
+import type { ApiEntryPoint, ApiItem, ApiModel, ApiPackage } from "@microsoft/api-extractor-model";
 
-import { type DocumentNode, type SectionNode } from "../documentation-domain/index.js";
+import type { DocumentNode, SectionNode } from "../documentation-domain/index.js";
+
+import { doesItemRequireOwnDocument, shouldItemBeIncluded } from "./ApiItemTransformUtilities.js";
+import { apiItemToDocument, apiItemToSections } from "./TransformApiItem.js";
 import { createDocument } from "./Utilities.js";
 import {
 	type ApiItemTransformationConfiguration,
 	getApiItemTransformationConfigurationWithDefaults,
 } from "./configuration/index.js";
-import { doesItemRequireOwnDocument, shouldItemBeIncluded } from "./ApiItemTransformUtilities.js";
 import { createBreadcrumbParagraph, createEntryPointList, wrapInSection } from "./helpers/index.js";
-import { apiItemToDocument, apiItemToSections } from "./TransformApiItem.js";
 
 /**
  * Renders the provided model and its contents to a series of {@link DocumentNode}s.

--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type ApiItem } from "@microsoft/api-extractor-model";
+import type { ApiItem } from "@microsoft/api-extractor-model";
 import {
 	type DocCodeSpan,
 	type DocDeclarationReference,
@@ -20,7 +20,8 @@ import {
 	type DocHtmlStartTag,
 } from "@microsoft/tsdoc";
 
-import { type Link } from "../Link.js";
+import type { ConfigurationBase } from "../ConfigurationBase.js";
+import type { Link } from "../Link.js";
 import {
 	CodeSpanNode,
 	type DocumentationNode,
@@ -34,9 +35,9 @@ import {
 	SingleLineSpanNode,
 	SpanNode,
 } from "../documentation-domain/index.js";
-import { type ConfigurationBase } from "../ConfigurationBase.js";
+
 import { getTsdocNodeTransformationOptions } from "./Utilities.js";
-import { type ApiItemTransformationConfiguration } from "./configuration/index.js";
+import type { ApiItemTransformationConfiguration } from "./configuration/index.js";
 
 /**
  * Library of transformations from {@link https://github.com/microsoft/tsdoc/blob/main/tsdoc/src/nodes/DocNode.ts| DocNode}s

--- a/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
@@ -4,19 +4,20 @@
  */
 
 import type { ApiItem } from "@microsoft/api-extractor-model";
-import { type DocDeclarationReference } from "@microsoft/tsdoc";
+import type { DocDeclarationReference } from "@microsoft/tsdoc";
 
+import type { Link } from "../Link.js";
 import { DocumentNode, type SectionNode } from "../documentation-domain/index.js";
-import { type Link } from "../Link.js";
+import { resolveSymbolicReference } from "../utilities/index.js";
+
 import {
 	getDocumentPathForApiItem,
 	getLinkForApiItem,
 	shouldItemBeIncluded,
 } from "./ApiItemTransformUtilities.js";
-import { type TsdocNodeTransformOptions } from "./TsdocNodeTransforms.js";
-import { type ApiItemTransformationConfiguration } from "./configuration/index.js";
+import type { TsdocNodeTransformOptions } from "./TsdocNodeTransforms.js";
+import type { ApiItemTransformationConfiguration } from "./configuration/index.js";
 import { wrapInSection } from "./helpers/index.js";
-import { resolveSymbolicReference } from "../utilities/index.js";
 
 /**
  * Creates a {@link DocumentNode} representing the provided API item.

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/Configuration.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/Configuration.ts
@@ -3,10 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { type ApiModel } from "@microsoft/api-extractor-model";
+import type { ApiModel } from "@microsoft/api-extractor-model";
 
-import { type ConfigurationBase } from "../../ConfigurationBase.js";
+import type { ConfigurationBase } from "../../ConfigurationBase.js";
 import { defaultConsoleLogger } from "../../Logging.js";
+
 import {
 	type DocumentationSuiteOptions,
 	getDocumentationSuiteOptionsWithDefaults,

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/TransformationOptions.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/TransformationOptions.ts
@@ -3,30 +3,31 @@
  * Licensed under the MIT License.
  */
 
-import {
-	type ApiCallSignature,
-	type ApiClass,
-	type ApiConstructSignature,
-	type ApiConstructor,
-	type ApiEntryPoint,
-	type ApiEnum,
-	type ApiEnumMember,
-	type ApiFunction,
-	type ApiIndexSignature,
-	type ApiInterface,
-	type ApiItem,
-	type ApiMethod,
-	type ApiMethodSignature,
-	type ApiModel,
-	type ApiNamespace,
-	type ApiPropertyItem,
-	type ApiTypeAlias,
-	type ApiVariable,
+import type {
+	ApiCallSignature,
+	ApiClass,
+	ApiConstructSignature,
+	ApiConstructor,
+	ApiEntryPoint,
+	ApiEnum,
+	ApiEnumMember,
+	ApiFunction,
+	ApiIndexSignature,
+	ApiInterface,
+	ApiItem,
+	ApiMethod,
+	ApiMethodSignature,
+	ApiModel,
+	ApiNamespace,
+	ApiPropertyItem,
+	ApiTypeAlias,
+	ApiVariable,
 } from "@microsoft/api-extractor-model";
 
-import { type SectionNode } from "../../documentation-domain/index.js";
+import type { SectionNode } from "../../documentation-domain/index.js";
 import * as DefaultTransformationImplementations from "../default-implementations/index.js";
-import { type ApiItemTransformationConfiguration } from "./Configuration.js";
+
+import type { ApiItemTransformationConfiguration } from "./Configuration.js";
 
 /**
  * Signature for a function which generates one or more {@link SectionNode}s describing an

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/CreateDefaultLayout.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/CreateDefaultLayout.ts
@@ -5,9 +5,10 @@
 
 import { type ApiItem, ReleaseTag } from "@microsoft/api-extractor-model";
 
-import { type SectionNode } from "../../documentation-domain/index.js";
+import type { SectionNode } from "../../documentation-domain/index.js";
+import { getReleaseTag } from "../../utilities/index.js";
 import { doesItemRequireOwnDocument, getHeadingForApiItem } from "../ApiItemTransformUtilities.js";
-import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import {
 	alphaWarningSpan,
 	betaWarningSpan,
@@ -20,7 +21,6 @@ import {
 	createThrowsSection,
 	wrapInSection,
 } from "../helpers/index.js";
-import { getReleaseTag } from "../../utilities/index.js";
 
 /**
  * Default content layout for all API items.

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
@@ -16,9 +16,9 @@ import {
 
 import type { SectionNode } from "../../documentation-domain/index.js";
 import { ApiModifier, getScopedMemberNameForDiagnostics, isStatic } from "../../utilities/index.js";
+import { filterChildMembers } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
-import { filterChildMembers } from "../ApiItemTransformUtilities.js";
 
 /**
  * Default documentation transform for `Class` items.

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEntryPoint.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEntryPoint.ts
@@ -3,10 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { type ApiEntryPoint, type ApiItem } from "@microsoft/api-extractor-model";
+import type { ApiEntryPoint, ApiItem } from "@microsoft/api-extractor-model";
 
-import { type SectionNode } from "../../documentation-domain/index.js";
-import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
+import type { SectionNode } from "../../documentation-domain/index.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
+
 import { transformApiModuleLike } from "./TransformApiModuleLike.js";
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
@@ -11,10 +11,10 @@ import {
 } from "@microsoft/api-extractor-model";
 
 import type { DocumentationNode, SectionNode } from "../../documentation-domain/index.js";
+import { getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
+import { filterChildMembers } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createMemberTables, wrapInSection } from "../helpers/index.js";
-import { filterChildMembers } from "../ApiItemTransformUtilities.js";
-import { getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
 
 /**
  * Default documentation transform for `Enum` items.

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiFunctionLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiFunctionLike.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { type SectionNode } from "../../documentation-domain/index.js";
-import { type ApiFunctionLike } from "../../utilities/index.js";
-import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
+import type { SectionNode } from "../../documentation-domain/index.js";
+import type { ApiFunctionLike } from "../../utilities/index.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createParametersSection, createReturnsSection } from "../helpers/index.js";
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
@@ -15,10 +15,10 @@ import {
 } from "@microsoft/api-extractor-model";
 
 import type { SectionNode } from "../../documentation-domain/index.js";
+import { getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
+import { filterChildMembers } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
-import { filterChildMembers } from "../ApiItemTransformUtilities.js";
-import { getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
 
 /**
  * Default documentation transform for `Interface` items.

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiItemWithoutChildren.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiItemWithoutChildren.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { type ApiItem } from "@microsoft/api-extractor-model";
+import type { ApiItem } from "@microsoft/api-extractor-model";
 
-import { type SectionNode } from "../../documentation-domain/index.js";
-import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
+import type { SectionNode } from "../../documentation-domain/index.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 
 /**
  * Default transformation helper for rendering item kinds that do not have children.

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModel.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModel.ts
@@ -6,7 +6,7 @@
 import { ApiItemKind, type ApiModel } from "@microsoft/api-extractor-model";
 
 import { ParagraphNode, SectionNode, SpanNode } from "../../documentation-domain/index.js";
-import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createTableWithHeading } from "../helpers/index.js";
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
@@ -17,10 +17,10 @@ import {
 
 import type { SectionNode } from "../../documentation-domain/index.js";
 import type { ApiModuleLike } from "../../utilities/index.js";
+import { getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
+import { filterItems } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
-import { filterItems } from "../ApiItemTransformUtilities.js";
-import { getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
 
 /**
  * Default documentation transform for module-like API items (packages, namespaces).

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiNamespace.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiNamespace.ts
@@ -7,6 +7,7 @@ import type { ApiItem, ApiNamespace } from "@microsoft/api-extractor-model";
 
 import type { SectionNode } from "../../documentation-domain/index.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
+
 import { transformApiModuleLike } from "./TransformApiModuleLike.js";
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -29,7 +29,8 @@ import {
 	type DocSection,
 } from "@microsoft/tsdoc";
 
-import { type Heading } from "../../Heading.js";
+import type { Heading } from "../../Heading.js";
+import type { Logger } from "../../Logging.js";
 import {
 	type DocumentationNode,
 	DocumentationNodeType,
@@ -46,7 +47,6 @@ import {
 	SpanNode,
 	UnorderedListNode,
 } from "../../documentation-domain/index.js";
-import { type Logger } from "../../Logging.js";
 import {
 	type ApiFunctionLike,
 	injectSeparator,
@@ -65,7 +65,8 @@ import {
 } from "../ApiItemTransformUtilities.js";
 import { transformTsdocSection } from "../TsdocNodeTransforms.js";
 import { getTsdocNodeTransformationOptions } from "../Utilities.js";
-import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
+
 import { createParametersSummaryTable, createTypeParametersSummaryTable } from "./TableHelpers.js";
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
@@ -39,7 +39,8 @@ import {
 import { getLinkForApiItem } from "../ApiItemTransformUtilities.js";
 import { transformTsdocSection } from "../TsdocNodeTransforms.js";
 import { getTsdocNodeTransformationOptions } from "../Utilities.js";
-import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
+
 import { createExcerptSpanWithHyperlinks } from "./Helpers.js";
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
@@ -38,12 +38,12 @@ import {
 } from "../../documentation-domain/index.js";
 import { getHeadingForApiItem } from "../ApiItemTransformUtilities.js";
 import { apiItemToSections } from "../TransformApiItem.js";
+import { transformApiModel } from "../TransformApiModel.js";
 import {
 	type ApiItemTransformationConfiguration,
 	getApiItemTransformationConfigurationWithDefaults,
 } from "../configuration/index.js";
 import { betaWarningSpan, wrapInSection } from "../helpers/index.js";
-import { transformApiModel } from "../TransformApiModel.js";
 
 /**
  * Sample "default" configuration.

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/ToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/ToHtml.ts
@@ -5,12 +5,14 @@
 
 import type { Root as HastRoot, Nodes as HastTree } from "hast";
 import { h } from "hastscript";
+
 import type { DocumentNode, DocumentationNode } from "../documentation-domain/index.js";
-import type { TransformationConfig } from "./configuration/index.js";
+
 import {
 	createTransformationContext,
 	type TransformationContext,
 } from "./TransformationContext.js";
+import type { TransformationConfig } from "./configuration/index.js";
 
 /**
  * Generates an HTML AST from the provided {@link DocumentNode}.

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/TransformationContext.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/TransformationContext.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import type { TextFormatting } from "../documentation-domain/index.js";
 import { defaultConsoleLogger, type Logger } from "../Logging.js";
+import type { TextFormatting } from "../documentation-domain/index.js";
+
 import {
 	defaultTransformations,
 	type TransformationConfig,

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/Utilities.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/Utilities.ts
@@ -9,9 +9,11 @@
  */
 import type { Element as HastElement } from "hast";
 import { h } from "hastscript";
+
 import type { DocumentationNode } from "../index.js";
-import type { TransformationContext } from "./TransformationContext.js";
+
 import { documentationNodesToHtml } from "./ToHtml.js";
+import type { TransformationContext } from "./TransformationContext.js";
 
 /**
  * An HTML tag and its (optional) attributes.

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/Configuration.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/Configuration.ts
@@ -4,9 +4,10 @@
  */
 
 import type { ConfigurationBase } from "../../ConfigurationBase.js";
-import type { TextFormatting } from "../../documentation-domain/index.js";
 import { defaultConsoleLogger } from "../../Logging.js";
-import { type Transformations } from "./Transformation.js";
+import type { TextFormatting } from "../../documentation-domain/index.js";
+
+import type { Transformations } from "./Transformation.js";
 
 /**
  * Configuration for transforming {@link DocumentationNode}s to HTML.

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/Transformation.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/Transformation.ts
@@ -5,6 +5,7 @@
 
 import type { Nodes as HastNodes } from "hast";
 import { h } from "hastscript";
+
 import {
 	DocumentationNodeType,
 	type DocumentationNode,
@@ -23,6 +24,7 @@ import {
 	type TableRowNode,
 	type UnorderedListNode,
 } from "../../documentation-domain/index.js";
+import type { TransformationContext } from "../TransformationContext.js";
 import {
 	blockQuoteToHtml,
 	codeSpanToHtml,
@@ -39,7 +41,6 @@ import {
 	tableRowToHtml,
 	unorderedListToHtml,
 } from "../default-transformations/index.js";
-import type { TransformationContext } from "../TransformationContext.js";
 
 /**
  * Configuration for transforming {@link DocumentationNode}s to {@link https://github.com/syntax-tree/hast | hast},

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/BlockQuoteToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/BlockQuoteToHtml.ts
@@ -8,6 +8,7 @@
  * Licensed under the MIT License.
  */
 import type { Element as HastElement } from "hast";
+
 import type { BlockQuoteNode } from "../../index.js";
 import type { TransformationContext } from "../TransformationContext.js";
 import { transformChildrenUnderTag } from "../Utilities.js";

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/CodeSpanToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/CodeSpanToHtml.ts
@@ -8,6 +8,7 @@ import type { Nodes as HastTree } from "hast";
 import type { CodeSpanNode } from "../../index.js";
 import type { TransformationContext } from "../TransformationContext.js";
 import { transformChildrenUnderTag } from "../Utilities.js";
+
 import { applyFormatting } from "./Utilities.js";
 
 /**

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/FencedCodeBlockToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/FencedCodeBlockToHtml.ts
@@ -8,6 +8,7 @@
  * Licensed under the MIT License.
  */
 import type { Element as HastElement } from "hast";
+
 import type { FencedCodeBlockNode } from "../../documentation-domain/index.js";
 import type { TransformationContext } from "../TransformationContext.js";
 import { transformChildrenUnderTag } from "../Utilities.js";

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/HeadingToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/HeadingToHtml.ts
@@ -9,6 +9,7 @@
  */
 import type { Element as HastElement, Nodes as HastNodes } from "hast";
 import { h } from "hastscript";
+
 import type { HeadingNode } from "../../documentation-domain/index.js";
 import type { TransformationContext } from "../TransformationContext.js";
 import { transformChildrenUnderTag } from "../Utilities.js";

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/LinkToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/LinkToHtml.ts
@@ -8,6 +8,7 @@
  * Licensed under the MIT License.
  */
 import type { Element as HastElement } from "hast";
+
 import type { LinkNode } from "../../documentation-domain/index.js";
 import type { TransformationContext } from "../TransformationContext.js";
 import { transformChildrenUnderTag } from "../Utilities.js";

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/OrderedListToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/OrderedListToHtml.ts
@@ -9,6 +9,7 @@
  */
 import type { Element as HastElement } from "hast";
 import { h } from "hastscript";
+
 import type { OrderedListNode } from "../../documentation-domain/index.js";
 import type { TransformationContext } from "../TransformationContext.js";
 import { transformListChildren } from "../Utilities.js";

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/ParagraphToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/ParagraphToHtml.ts
@@ -8,6 +8,7 @@
  * Licensed under the MIT License.
  */
 import type { Element as HastElement } from "hast";
+
 import type { ParagraphNode } from "../../documentation-domain/index.js";
 import type { TransformationContext } from "../TransformationContext.js";
 import { transformChildrenUnderTag } from "../Utilities.js";

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/PlainTextToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/PlainTextToHtml.ts
@@ -8,8 +8,10 @@
 import "hast-util-raw";
 
 import type { Nodes as HastTree } from "hast";
+
 import type { PlainTextNode } from "../../documentation-domain/index.js";
 import type { TransformationContext } from "../TransformationContext.js";
+
 import { applyFormatting } from "./Utilities.js";
 
 /**

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/SectionToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/SectionToHtml.ts
@@ -9,9 +9,10 @@
  */
 import type { Element as HastElement, Nodes as HastNodes } from "hast";
 import { h } from "hastscript";
+
 import type { SectionNode } from "../../documentation-domain/index.js";
-import type { TransformationContext } from "../TransformationContext.js";
 import { documentationNodeToHtml, documentationNodesToHtml } from "../ToHtml.js";
+import type { TransformationContext } from "../TransformationContext.js";
 
 /**
  * Transform a {@link SectionNode} to HTML.

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/SpanToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/SpanToHtml.ts
@@ -7,8 +7,8 @@ import type { Element as HastElement } from "hast";
 import { h } from "hastscript";
 
 import type { SpanNode } from "../../documentation-domain/index.js";
-import type { TransformationContext } from "../TransformationContext.js";
 import { documentationNodesToHtml } from "../ToHtml.js";
+import type { TransformationContext } from "../TransformationContext.js";
 
 /**
  * Transform a {@link SpanNode} to HTML.

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/TableCellToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/TableCellToHtml.ts
@@ -8,9 +8,10 @@
  * Licensed under the MIT License.
  */
 import type { Element as HastElement } from "hast";
+
 import { TableCellKind, type TableCellNode } from "../../documentation-domain/index.js";
-import { transformChildrenUnderTag } from "../Utilities.js";
 import type { TransformationContext } from "../TransformationContext.js";
+import { transformChildrenUnderTag } from "../Utilities.js";
 
 /**
  * Transform a {@link TableCellNode} to HTML.

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/TableRowToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/TableRowToHtml.ts
@@ -8,6 +8,7 @@
  * Licensed under the MIT License.
  */
 import type { Element as HastElement } from "hast";
+
 import type { TableRowNode } from "../../documentation-domain/index.js";
 import type { TransformationContext } from "../TransformationContext.js";
 import { transformChildrenUnderTag, type HtmlTag } from "../Utilities.js";

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/TableToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/TableToHtml.ts
@@ -9,9 +9,10 @@
  */
 import type { Element as HastElement } from "hast";
 import { h } from "hastscript";
+
 import type { TableNode } from "../../documentation-domain/index.js";
-import { transformChildrenUnderTag } from "../Utilities.js";
 import type { TransformationContext } from "../TransformationContext.js";
+import { transformChildrenUnderTag } from "../Utilities.js";
 
 /**
  * Transform a {@link TableNode} to HTML.

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/UnorderedListToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/UnorderedListToHtml.ts
@@ -9,6 +9,7 @@
  */
 import type { Element as HastElement } from "hast";
 import { h } from "hastscript";
+
 import type { UnorderedListNode } from "../../documentation-domain/index.js";
 import type { TransformationContext } from "../TransformationContext.js";
 import { transformListChildren } from "../Utilities.js";

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/BlockQuoteToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/BlockQuoteToHtml.test.ts
@@ -4,7 +4,9 @@
  */
 
 import { h } from "hastscript";
+
 import { BlockQuoteNode, LineBreakNode, PlainTextNode } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 describe("BlockQuote HTML rendering tests", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/CodeSpanToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/CodeSpanToHtml.test.ts
@@ -8,7 +8,9 @@
  * Licensed under the MIT License.
  */
 import { h } from "hastscript";
+
 import { CodeSpanNode, PlainTextNode } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 describe("CodeSpan HTML rendering tests", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/CustomNodeTypeToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/CustomNodeTypeToHtml.test.ts
@@ -9,8 +9,10 @@
  */
 import { expect } from "chai";
 import type { Nodes as HastNodes } from "hast";
+
 import { DocumentationLiteralNodeBase } from "../../documentation-domain/index.js";
 import type { TransformationContext } from "../TransformationContext.js";
+
 import { testTransformation } from "./Utilities.js";
 
 /**

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/DocumentToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/DocumentToHtml.test.ts
@@ -5,6 +5,7 @@
 
 import { expect } from "chai";
 import { h } from "hastscript";
+
 import {
 	DocumentNode,
 	HeadingNode,

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/FencedCodeBlockToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/FencedCodeBlockToHtml.test.ts
@@ -4,11 +4,13 @@
  */
 
 import { h } from "hastscript";
+
 import {
 	FencedCodeBlockNode,
 	LineBreakNode,
 	PlainTextNode,
 } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 const brElement = h("br");

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/HeadingToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/HeadingToHtml.test.ts
@@ -10,6 +10,7 @@
 import { h } from "hastscript";
 
 import { HeadingNode } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 describe("HeadingNode -> Html", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/HierarchicalSectionToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/HierarchicalSectionToHtml.test.ts
@@ -15,6 +15,7 @@ import {
 	ParagraphNode,
 	SectionNode,
 } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 describe("HierarchicalSection HTML rendering tests", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/HorizontalRuleToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/HorizontalRuleToHtml.test.ts
@@ -10,6 +10,7 @@
 import { h } from "hastscript";
 
 import { HorizontalRuleNode } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 it("HorizontalRule HTML rendering test", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/LineBreakToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/LineBreakToHtml.test.ts
@@ -10,6 +10,7 @@
 import { h } from "hastscript";
 
 import { LineBreakNode } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 it("LineBreak HTML rendering test", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/LinkToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/LinkToHtml.test.ts
@@ -10,6 +10,7 @@
 import { h } from "hastscript";
 
 import { LinkNode, PlainTextNode } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 describe("Link HTML rendering tests", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/OrderedListToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/OrderedListToHtml.test.ts
@@ -10,6 +10,7 @@
 import { h } from "hastscript";
 
 import { OrderedListNode } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 describe("OrderedListNode HTML rendering tests", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/ParagraphToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/ParagraphToHtml.test.ts
@@ -8,7 +8,9 @@
  * Licensed under the MIT License.
  */
 import { h } from "hastscript";
+
 import { ParagraphNode, PlainTextNode } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 describe("ParagraphNode HTML rendering tests", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/PlainTextToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/PlainTextToHtml.test.ts
@@ -4,7 +4,9 @@
  */
 
 import type { Nodes as HastTree } from "hast";
+
 import { PlainTextNode } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 describe("PlainText to HTML transformation tests", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/SpanToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/SpanToHtml.test.ts
@@ -4,12 +4,14 @@
  */
 
 import { h } from "hastscript";
+
 import {
 	LineBreakNode,
 	PlainTextNode,
 	SpanNode,
 	type TextFormatting,
 } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 describe("Span to HTML transformation tests", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/TableToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/TableToHtml.test.ts
@@ -8,6 +8,7 @@
  * Licensed under the MIT License.
  */
 import { h } from "hastscript";
+
 import {
 	TableBodyCellNode,
 	TableBodyRowNode,
@@ -15,6 +16,7 @@ import {
 	TableHeaderRowNode,
 	TableNode,
 } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 describe("Table HTML rendering tests", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/UnorderedListToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/UnorderedListToHtml.test.ts
@@ -4,7 +4,9 @@
  */
 
 import { h } from "hastscript";
+
 import { UnorderedListNode } from "../../documentation-domain/index.js";
+
 import { assertTransformation } from "./Utilities.js";
 
 describe("UnorderedListNode HTML rendering tests", () => {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/Utilities.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/Utilities.ts
@@ -5,10 +5,11 @@
 
 import { expect } from "chai";
 import type { Nodes as HastNodes } from "hast";
+
 import type { DocumentationNode } from "../../documentation-domain/index.js";
-import { createTransformationContext } from "../TransformationContext.js";
-import { type TransformationConfig } from "../configuration/index.js";
 import { documentationNodeToHtml } from "../ToHtml.js";
+import { createTransformationContext } from "../TransformationContext.js";
+import type { TransformationConfig } from "../configuration/index.js";
 
 /**
  * Tests transforming an individual {@link DocumentationNode} to HTML.

--- a/tools/api-markdown-documenter/src/documentation-domain/DocumentNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/DocumentNode.ts
@@ -5,9 +5,10 @@
 
 import type { Parent as UnistParent } from "unist";
 
-import { type ApiItem } from "../index.js";
+import type { ApiItem } from "../index.js";
+
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
-import { type SectionNode } from "./SectionNode.js";
+import type { SectionNode } from "./SectionNode.js";
 
 /**
  * {@link DocumentNode} construction properties.

--- a/tools/api-markdown-documenter/src/documentation-domain/HeadingNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/HeadingNode.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { type Heading } from "../Heading.js";
+import type { Heading } from "../Heading.js";
+
 import {
 	DocumentationParentNodeBase,
 	type MultiLineDocumentationNode,

--- a/tools/api-markdown-documenter/src/documentation-domain/HorizontalRuleNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/HorizontalRuleNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type MultiLineDocumentationNode } from "./DocumentationNode.js";
+import type { MultiLineDocumentationNode } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 
 /**

--- a/tools/api-markdown-documenter/src/documentation-domain/LineBreakNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/LineBreakNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type MultiLineDocumentationNode } from "./DocumentationNode.js";
+import type { MultiLineDocumentationNode } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 
 /**

--- a/tools/api-markdown-documenter/src/documentation-domain/LinkNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/LinkNode.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { type Link, type UrlTarget } from "../Link.js";
+import type { Link, UrlTarget } from "../Link.js";
+
 import {
 	DocumentationParentNodeBase,
 	type SingleLineDocumentationNode,

--- a/tools/api-markdown-documenter/src/documentation-domain/SectionNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/SectionNode.ts
@@ -9,7 +9,7 @@ import {
 	type MultiLineDocumentationNode,
 } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
-import { type HeadingNode } from "./HeadingNode.js";
+import type { HeadingNode } from "./HeadingNode.js";
 
 /**
  * Represents a hierarchically nested section.

--- a/tools/api-markdown-documenter/src/documentation-domain/SpanNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/SpanNode.ts
@@ -10,7 +10,7 @@ import {
 } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 import { PlainTextNode } from "./PlainTextNode.js";
-import { type TextFormatting } from "./TextFormatting.js";
+import type { TextFormatting } from "./TextFormatting.js";
 import { createNodesFromPlainText } from "./Utilities.js";
 
 // TODO: Rename to "FormattedSpan" - this doesn't really correspond to a "span" in a traditional sense.

--- a/tools/api-markdown-documenter/src/documentation-domain/TableNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/TableNode.ts
@@ -8,7 +8,7 @@ import {
 	type MultiLineDocumentationNode,
 } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
-import { type TableBodyRowNode, type TableHeaderRowNode } from "./TableRowNode.js";
+import type { TableBodyRowNode, TableHeaderRowNode } from "./TableRowNode.js";
 
 // TODOs:
 // - Support alignment properties in Table, TableRow and TableCell (inherit pattern for resolution)

--- a/tools/api-markdown-documenter/src/documentation-domain/TableRowNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/TableRowNode.ts
@@ -5,7 +5,7 @@
 
 import { DocumentationParentNodeBase } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
-import { type TableCellNode, type TableHeaderCellNode } from "./TableCellNode.js";
+import type { TableCellNode, TableHeaderCellNode } from "./TableCellNode.js";
 
 /**
  * Kind of Table Row.

--- a/tools/api-markdown-documenter/src/documentation-domain/Utilities.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/Utilities.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type DocumentationNode, type SingleLineDocumentationNode } from "./DocumentationNode.js";
+import type { DocumentationNode, SingleLineDocumentationNode } from "./DocumentationNode.js";
 import { LineBreakNode } from "./LineBreakNode.js";
 import { PlainTextNode } from "./PlainTextNode.js";
 

--- a/tools/api-markdown-documenter/src/index.ts
+++ b/tools/api-markdown-documenter/src/index.ts
@@ -77,7 +77,7 @@ export {
 // #region Scoped exports
 
 // This pattern is required to scope the utilities in a way that API-Extractor supports.
-/* eslint-disable unicorn/prefer-export-from */
+/* eslint-disable import/order, unicorn/prefer-export-from */
 
 // Export `ApiItem`-related utilities
 import * as ApiItemUtilities from "./ApiItemUtilitiesModule.js";
@@ -124,7 +124,7 @@ export {
 	MarkdownRenderer,
 };
 
-/* eslint-enable unicorn/prefer-export-from */
+/* eslint-enable import/order, unicorn/prefer-export-from */
 
 // #endregion
 

--- a/tools/api-markdown-documenter/src/renderers/html-renderer/Render.ts
+++ b/tools/api-markdown-documenter/src/renderers/html-renderer/Render.ts
@@ -7,11 +7,11 @@ import type { Root as HastRoot, Nodes as HastTree } from "hast";
 import { format } from "hast-util-format";
 import { toHtml as toHtmlString } from "hast-util-to-html";
 
+import type { DocumentNode } from "../../documentation-domain/index.js";
 import {
 	documentToHtml,
 	type TransformationConfig,
 } from "../../documentation-domain-to-html/index.js";
-import type { DocumentNode } from "../../documentation-domain/index.js";
 
 /**
  * Configuration for rendering HTML.

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/Render.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/Render.ts
@@ -5,8 +5,9 @@
 
 import type { DocumentNode, DocumentationNode } from "../../documentation-domain/index.js";
 import { DocumentWriter } from "../DocumentWriter.js";
-import { type RenderConfiguration, defaultRenderers } from "./configuration/index.js";
+
 import { type RenderContext, getContextWithDefaults } from "./RenderContext.js";
+import { type RenderConfiguration, defaultRenderers } from "./configuration/index.js";
 
 /**
  * Renders a {@link DocumentNode} as Markdown, and returns the resulting file contents as a `string`.

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/RenderContext.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/RenderContext.ts
@@ -4,6 +4,7 @@
  */
 
 import type { TextFormatting } from "../../documentation-domain/index.js";
+
 import type { Renderers } from "./configuration/index.js";
 
 /**

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/Utilities.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/Utilities.ts
@@ -3,11 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { type DocumentationNode } from "../../documentation-domain/index.js";
-import { type DocumentWriter } from "../DocumentWriter.js";
-import { renderHtml } from "../html-renderer/index.js";
-import { type RenderContext as MarkdownRenderContext } from "./RenderContext.js";
+import type { DocumentationNode } from "../../documentation-domain/index.js";
 import { documentationNodeToHtml } from "../../documentation-domain-to-html/index.js";
+import type { DocumentWriter } from "../DocumentWriter.js";
+import { renderHtml } from "../html-renderer/index.js";
+
+import type { RenderContext as MarkdownRenderContext } from "./RenderContext.js";
 
 /**
  * Renders the provided {@link DocumentationNode} using HTML syntax.

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/configuration/Configuration.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/configuration/Configuration.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { type ConfigurationBase } from "../../../ConfigurationBase.js";
+import type { ConfigurationBase } from "../../../ConfigurationBase.js";
 import { defaultConsoleLogger } from "../../../Logging.js";
-import { type Renderers } from "./RenderOptions.js";
+
+import type { Renderers } from "./RenderOptions.js";
 
 /**
  * Configuration for Markdown rendering of generated documentation contents.

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderHeading.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderHeading.ts
@@ -3,11 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { type HeadingNode } from "../../../documentation-domain/index.js";
+import type { HeadingNode } from "../../../documentation-domain/index.js";
 import type { DocumentWriter } from "../../DocumentWriter.js";
 import { renderNodes } from "../Render.js";
 import type { RenderContext } from "../RenderContext.js";
 import { renderNodeWithHtmlSyntax } from "../Utilities.js";
+
 import { escapeTextForMarkdown } from "./RenderPlainText.js";
 
 /**

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderBlockQuote.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderBlockQuote.test.ts
@@ -10,6 +10,7 @@ import {
 	LineBreakNode,
 	PlainTextNode,
 } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("BlockQuote Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderCodeSpan.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderCodeSpan.test.ts
@@ -6,6 +6,7 @@
 import { expect } from "chai";
 
 import { CodeSpanNode, PlainTextNode } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("CodeSpan Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderCustomNodeType.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderCustomNodeType.test.ts
@@ -6,8 +6,9 @@
 import { expect } from "chai";
 
 import { DocumentationLiteralNodeBase } from "../../../documentation-domain/index.js";
-import { type DocumentWriter } from "../../DocumentWriter.js";
-import { type RenderContext } from "../RenderContext.js";
+import type { DocumentWriter } from "../../DocumentWriter.js";
+import type { RenderContext } from "../RenderContext.js";
+
 import { testRender } from "./Utilities.js";
 
 /**

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderFencedCodeBlock.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderFencedCodeBlock.test.ts
@@ -10,6 +10,7 @@ import {
 	LineBreakNode,
 	PlainTextNode,
 } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("FencedCodeBlock Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHeading.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHeading.test.ts
@@ -6,6 +6,7 @@
 import { expect } from "chai";
 
 import { HeadingNode } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("Heading Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHierarchicalSection.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHierarchicalSection.test.ts
@@ -11,6 +11,7 @@ import {
 	ParagraphNode,
 	SectionNode,
 } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("HierarchicalSection Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHorizontalRule.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderHorizontalRule.test.ts
@@ -6,6 +6,7 @@
 import { expect } from "chai";
 
 import { HorizontalRuleNode } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("HorizontalRule Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderLineBreak.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderLineBreak.test.ts
@@ -6,6 +6,7 @@
 import { expect } from "chai";
 
 import { LineBreakNode } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("LineBreak Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderLink.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderLink.test.ts
@@ -6,6 +6,7 @@
 import { expect } from "chai";
 
 import { LinkNode, PlainTextNode } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("Link Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderOrderedList.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderOrderedList.test.ts
@@ -6,6 +6,7 @@
 import { expect } from "chai";
 
 import { OrderedListNode } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("OrderedListNode Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderParagraph.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderParagraph.test.ts
@@ -6,6 +6,7 @@
 import { expect } from "chai";
 
 import { ParagraphNode, PlainTextNode } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("ParagraphNode Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderPlainText.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderPlainText.test.ts
@@ -6,7 +6,8 @@
 import { expect } from "chai";
 
 import { PlainTextNode } from "../../../documentation-domain/index.js";
-import { type RenderContext } from "../RenderContext.js";
+import type { RenderContext } from "../RenderContext.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("PlainText Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderSpan.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderSpan.test.ts
@@ -11,6 +11,7 @@ import {
 	SpanNode,
 	type TextFormatting,
 } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("Span Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderTable.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderTable.test.ts
@@ -12,6 +12,7 @@ import {
 	TableHeaderRowNode,
 	TableNode,
 } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("Table Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderTableCell.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderTableCell.test.ts
@@ -13,6 +13,7 @@ import {
 	TableBodyCellNode,
 	TableHeaderCellNode,
 } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("Table Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderUnorderedList.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderUnorderedList.test.ts
@@ -6,6 +6,7 @@
 import { expect } from "chai";
 
 import { UnorderedListNode } from "../../../documentation-domain/index.js";
+
 import { testRender } from "./Utilities.js";
 
 describe("UnorderedListNode Markdown rendering tests", () => {

--- a/tools/api-markdown-documenter/src/test/EndToEndTests.ts
+++ b/tools/api-markdown-documenter/src/test/EndToEndTests.ts
@@ -9,13 +9,13 @@ import type { ApiModel } from "@microsoft/api-extractor-model";
 import { FileSystem } from "@rushstack/node-core-library";
 import { expect } from "chai";
 import { compare } from "dir-compare";
+import type { Suite } from "mocha";
 
+import { loadModel } from "../LoadModel.js";
 import {
 	transformApiModel,
 	type ApiItemTransformationConfiguration,
 } from "../api-item-transforms/index.js";
-import type { Suite } from "mocha";
-import { loadModel } from "../LoadModel.js";
 import type { DocumentNode } from "../documentation-domain/index.js";
 
 /**

--- a/tools/api-markdown-documenter/src/test/HtmlEndToEnd.test.ts
+++ b/tools/api-markdown-documenter/src/test/HtmlEndToEnd.test.ts
@@ -9,13 +9,14 @@ import { fileURLToPath } from "node:url";
 import { ApiItemKind, ReleaseTag } from "@microsoft/api-extractor-model";
 import { FileSystem, NewlineKind } from "@rushstack/node-core-library";
 
+import type { DocumentNode } from "../documentation-domain/index.js";
 import { type RenderDocumentAsHtmlConfig, renderDocumentAsHtml } from "../renderers/index.js";
+
 import {
 	endToEndTests,
 	type ApiModelTestOptions,
 	type EndToEndTestConfig,
 } from "./EndToEndTests.js";
-import type { DocumentNode } from "../documentation-domain/index.js";
 
 const dirname = Path.dirname(fileURLToPath(import.meta.url));
 

--- a/tools/api-markdown-documenter/src/test/MarkdownEndToEnd.test.ts
+++ b/tools/api-markdown-documenter/src/test/MarkdownEndToEnd.test.ts
@@ -9,13 +9,14 @@ import { fileURLToPath } from "node:url";
 import { ApiItemKind, ReleaseTag } from "@microsoft/api-extractor-model";
 import { FileSystem, NewlineKind } from "@rushstack/node-core-library";
 
+import type { DocumentNode } from "../documentation-domain/index.js";
 import { type MarkdownRenderConfiguration, renderDocumentAsMarkdown } from "../renderers/index.js";
+
 import {
 	endToEndTests,
 	type ApiModelTestOptions,
 	type EndToEndTestConfig,
 } from "./EndToEndTests.js";
-import type { DocumentNode } from "../documentation-domain/index.js";
 
 const dirname = Path.dirname(fileURLToPath(import.meta.url));
 

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -34,7 +34,8 @@ import {
 	TSDocTagDefinition,
 } from "@microsoft/tsdoc";
 import { PackageName } from "@rushstack/node-core-library";
-import { type Logger } from "../Logging.js";
+
+import type { Logger } from "../Logging.js";
 
 /**
  * This module contains general `ApiItem`-related types and utilities.


### PR DESCRIPTION
Most of the changes are import style changes auto-fixed via `eslint --fix`.