### PR TITLE
docs(odsp-driver): comment added to explain ternary for batched signals back compat

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -699,6 +699,10 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 						);
 
 						if (filteredMsgs.length > 0) {
+							// This ternary is needed for signal-based layer compat tests to pass,
+							// specifically the layer version combination where you have an old loader and the most recent driver layer.
+							// Old loader doesn't send or receive batched signals (ISignalMessage[]),
+							// so only individual ISignalMessage's should be passed when there's one element for backcompat.
 							listener(filteredMsgs.length === 1 ? filteredMsgs[0] : filteredMsgs, documentId);
 						}
 					},


### PR DESCRIPTION
## Description

In #22749, we added `targetClientId` check to make sure only the specified client receives the targeted signal. 

We added a conditional check to make sure individual ISignalMessage's should be passed when there's one element. This done for signal-based layer combination compat testing to pass, as old loaders don't handle batched signals. 