### PR TITLE
test(client-presence): Presence AzureClient E2E test setup 

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -33,10 +33,10 @@
 		"test:realsvc": "npm run test:realsvc:tinylicious",
 		"test:realsvc:azure": "cross-env FLUID_CLIENT=azure npm run test:realsvc:azure:run -- --driver=r11s --r11sEndpointName=frs",
 		"test:realsvc:azure:run": "mocha --recursive \"lib/test/**/*.spec.*js\" --exit --timeout 20000 --config src/test/.mocharc.cjs",
-		"test:realsvc:run": "mocha lib/test/presence.spec.js --exit --timeout 20000 --config src/test/.mocharc.cjs",
+		"test:realsvc:run": "mocha lib/test --config src/test/.mocharc.cjs",
 		"test:realsvc:tinylicious": "start-server-and-test start:tinylicious:test 7071 test:realsvc:tinylicious:run",
 		"test:realsvc:tinylicious:report": "npm run test:realsvc:tinylicious",
-		"test:realsvc:tinylicious:run": "npm run test:realsvc:run -- --driver=t9s",
+		"test:realsvc:tinylicious:run": "npm run test:realsvc:azure:run -- --driver=t9s",
 		"test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:realsvc"
 	},
 	"c8": {

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -33,10 +33,10 @@
 		"test:realsvc": "npm run test:realsvc:tinylicious",
 		"test:realsvc:azure": "cross-env FLUID_CLIENT=azure npm run test:realsvc:azure:run -- --driver=r11s --r11sEndpointName=frs",
 		"test:realsvc:azure:run": "mocha --recursive \"lib/test/**/*.spec.*js\" --exit --timeout 20000 --config src/test/.mocharc.cjs",
-		"test:realsvc:run": "mocha lib/test --config src/test/.mocharc.cjs",
+		"test:realsvc:run": "mocha lib/test/presence.spec.js --exit --timeout 20000 --config src/test/.mocharc.cjs",
 		"test:realsvc:tinylicious": "start-server-and-test start:tinylicious:test 7071 test:realsvc:tinylicious:run",
 		"test:realsvc:tinylicious:report": "npm run test:realsvc:tinylicious",
-		"test:realsvc:tinylicious:run": "npm run test:realsvc:azure:run -- --driver=t9s",
+		"test:realsvc:tinylicious:run": "npm run test:realsvc:run -- --driver=t9s",
 		"test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:realsvc"
 	},
 	"c8": {
@@ -76,6 +76,7 @@
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/map-legacy": "npm:@fluidframework/map@^1.4.0",
 		"@fluidframework/matrix": "workspace:~",
+		"@fluidframework/presence": "workspace:~",
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/presence.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/presence.spec.ts
@@ -33,7 +33,7 @@ async function waitForAttendeeEvent(
 				(resolve) => presence.events.on(event, (attendee) => resolve(attendee)),
 				{
 					durationMs: 2000,
-					errorMsg: `Signaller[${index}] Timeout`,
+					errorMsg: `Attendee[${index}] Timeout`,
 				},
 			),
 		),

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/presence.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/presence.spec.ts
@@ -1,0 +1,155 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { AzureClient, type AzureContainerServices } from "@fluidframework/azure-client";
+import { type AzureUser, ScopeType } from "@fluidframework/azure-client/internal";
+import { AttachState } from "@fluidframework/container-definitions";
+import { ConnectionState } from "@fluidframework/container-loader";
+import { ContainerSchema, type IFluidContainer } from "@fluidframework/fluid-static";
+import {
+	acquirePresenceViaDataObject,
+	ExperimentalPresenceManager,
+	type ExperimentalPresenceDO,
+	type IPresence,
+	type ISessionClient,
+	// eslint-disable-next-line import/no-internal-modules
+} from "@fluidframework/presence/alpha";
+import { timeoutPromise } from "@fluidframework/test-utils/internal";
+
+import { createAzureClient } from "./AzureClientFactory.js";
+import { configProvider } from "./utils.js";
+
+async function waitForAttendeeEvent(
+	event: "attendeeDisconnected" | "attendeeJoined",
+	...presences: IPresence[]
+): Promise<ISessionClient[]> {
+	return Promise.all(
+		presences.map(async (presence, index) =>
+			timeoutPromise<ISessionClient>(
+				(resolve) => presence.events.on(event, (attendee) => resolve(attendee)),
+				{
+					durationMs: 2000,
+					errorMsg: `Signaller[${index}] Timeout`,
+				},
+			),
+		),
+	);
+}
+
+describe(`Presence with AzureClient`, () => {
+	const connectedContainers: IFluidContainer[] = [];
+	const connectTimeoutMs = 10_000;
+	const user1: AzureUser = {
+		id: "test-user-id-1",
+		name: "test-user-name-2",
+	};
+	const user2: AzureUser = {
+		id: "test-user-id-1",
+		name: "test-user-name-2",
+	};
+
+	afterEach(async () => {
+		for (const container of connectedContainers) {
+			container.disconnect();
+			container.dispose();
+		}
+		connectedContainers.splice(0, connectedContainers.length);
+	});
+
+	const getOrCreatePresenceContainer = async (
+		id: string | undefined,
+		user: AzureUser,
+		config?: ReturnType<typeof configProvider>,
+		scopes?: ScopeType[],
+	): Promise<{
+		container: IFluidContainer;
+		presence: IPresence;
+		services: AzureContainerServices;
+		client: AzureClient;
+		containerId: string;
+	}> => {
+		const client = createAzureClient(user.id, user.name, undefined, config, scopes);
+		const schema: ContainerSchema = {
+			initialObjects: {
+				presence: ExperimentalPresenceManager,
+			},
+		};
+		let container: IFluidContainer;
+		let services: AzureContainerServices;
+		let containerId: string;
+		if (id === undefined) {
+			({ container, services } = await client.createContainer(schema, "2"));
+			containerId = await container.attach();
+		} else {
+			containerId = id;
+			({ container, services } = await client.getContainer(containerId, schema, "2"));
+		}
+
+		if (container.connectionState !== ConnectionState.Connected) {
+			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
+				durationMs: connectTimeoutMs,
+				errorMsg: "container connect() timeout",
+			});
+		}
+		connectedContainers.push(container);
+
+		assert.strictEqual(typeof containerId, "string", "Attach did not return a string ID");
+		assert.strictEqual(
+			container.attachState,
+			AttachState.Attached,
+			"Container is not attached after attach is called",
+		);
+
+		const presence = acquirePresenceViaDataObject(
+			container.initialObjects.presence as ExperimentalPresenceDO,
+		);
+		return {
+			client,
+			container,
+			presence,
+			services,
+			containerId,
+		};
+	};
+
+	it("announces 'attendeeDisconnected' when remote client disconnects", async () => {
+		// SETUP
+		const {
+			container: container1,
+			presence: presence1,
+			containerId,
+		} = await getOrCreatePresenceContainer(undefined, user1);
+		const { presence: presence2 } = await getOrCreatePresenceContainer(containerId, user2);
+
+		// Wait for attendees to join
+		await waitForAttendeeEvent("attendeeJoined", presence1, presence2);
+
+		// Get attendee we will disconnect
+		const disconnectedAttendee = presence1.getMyself();
+
+		// ACT - Disconnect first attendee
+		container1.disconnect();
+
+		// VERIFY - Ensure the attendeeDisconnected event is emitted
+		const returnedAttendees = await waitForAttendeeEvent("attendeeDisconnected", presence2);
+		assert.strictEqual(returnedAttendees.length, 1);
+
+		for (const attendee of returnedAttendees) {
+			assert.equal(attendee.sessionId, disconnectedAttendee.sessionId, "Session ID mismatch");
+			assert.equal(
+				attendee.getConnectionId(),
+				disconnectedAttendee.getConnectionId(),
+				"Connection ID mismatch",
+			);
+			assert.equal(
+				attendee.getConnectionStatus(),
+				"Disconnected",
+				"Connection status mismatch",
+			);
+		}
+	});
+});

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/presence.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/presence.spec.ts
@@ -45,11 +45,15 @@ describe(`Presence with AzureClient`, () => {
 	const connectTimeoutMs = 10_000;
 	const user1: AzureUser = {
 		id: "test-user-id-1",
-		name: "test-user-name-2",
+		name: "test-user-name-1",
 	};
 	const user2: AzureUser = {
-		id: "test-user-id-1",
+		id: "test-user-id-2",
 		name: "test-user-name-2",
+	};
+	const user3: AzureUser = {
+		id: "test-user-id-3",
+		name: "test-user-name-3",
 	};
 
 	afterEach(async () => {
@@ -124,10 +128,11 @@ describe(`Presence with AzureClient`, () => {
 			containerId,
 		} = await getOrCreatePresenceContainer(undefined, user1);
 		const { presence: presence2 } = await getOrCreatePresenceContainer(containerId, user2);
-
 		// Wait for attendees to join
 		await waitForAttendeeEvent("attendeeJoined", presence1, presence2);
-
+		const { presence: presence3 } = await getOrCreatePresenceContainer(containerId, user3);
+		// Wait for attendees to join
+		await waitForAttendeeEvent("attendeeJoined", presence1, presence2, presence3);
 		// Get attendee we will disconnect
 		const disconnectedAttendee = presence1.getMyself();
 
@@ -135,8 +140,12 @@ describe(`Presence with AzureClient`, () => {
 		container1.disconnect();
 
 		// VERIFY - Ensure the attendeeDisconnected event is emitted
-		const returnedAttendees = await waitForAttendeeEvent("attendeeDisconnected", presence2);
-		assert.strictEqual(returnedAttendees.length, 1);
+		const returnedAttendees = await waitForAttendeeEvent(
+			"attendeeDisconnected",
+			presence2,
+			presence3,
+		);
+		assert.strictEqual(returnedAttendees.length, 2);
 
 		for (const attendee of returnedAttendees) {
 			assert.equal(attendee.sessionId, disconnectedAttendee.sessionId, "Session ID mismatch");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13040,6 +13040,9 @@ importers:
       '@fluidframework/matrix':
         specifier: workspace:~
         version: link:../../../dds/matrix
+      '@fluidframework/presence':
+        specifier: workspace:~
+        version: link:../../../framework/presence
       '@fluidframework/runtime-definitions':
         specifier: workspace:~
         version: link:../../../runtime/runtime-definitions


### PR DESCRIPTION
## Description

This PR is a preliminary setup for E2E/audience integration testing for new presence package. 

Currently the best way to test E2E capabilities of declarative model, without exposing any internal packages, is through the service clients. Here we can run real service tests against AFR, Tinylicious, and ODSP. While this PR only includes tests for AFR/Tinylicious, upon approval we can setup for odsp-client as well. There has also been talk of [merging into one service-client package](https://microsoft.sharepoint-df.com/:fl:/g/contentstorage/CSP_5fcca107-c97c-4b0a-899e-42a2578d1609/EX3Cew9vjshMmgeYPckgHHkB7O_6yukNZg00D2mrpR2kMA?e=N9b9NY&nav=cz0lMkZjb250ZW50c3RvcmFnZSUyRkNTUF81ZmNjYTEwNy1jOTdjLTRiMGEtODk5ZS00MmEyNTc4ZDE2MDkmZD1iJTIxQjZITVgzekpDa3VKbmtLaVY0MFdDY3JoRTNub2dqNURqZ01yWHlBTGQ3MWxiZ0VwY3VvYlFKXzhnb2luWjJFTyZmPTAxTUdUSktNTDVZSjVRNjM0T1pCR0pVQjRZSFhFU0FIRFomYz0lMkYlM0ZtaW5pZmllZCUzRGUyNzMzNDVhLTU3NTMtNGIyMi04YjFlLWVhNGMyOWE1MWVjMyUyNnNlcSUzRDIyNDkwJmE9TG9vcEFwcCZwPSU0MGZsdWlkeCUyRmxvb3AtcGFnZS1jb250YWluZXI%3D). Testing in service clients is also beneficial because we're truly testing the entire end to end experience that customers will have when using Presence. 

For the test setup, I followed a similar pattern for how we currently test SharedTree here https://github.com/microsoft/FluidFramework/pull/20925