### PR TITLE
build(client-presence): split most types for coverage accuracy

### DIFF
--- a/packages/framework/presence/.eslintrc.cjs
+++ b/packages/framework/presence/.eslintrc.cjs
@@ -7,7 +7,9 @@ module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
 	parserOptions: {
 		project: [
-			"./tsconfig.json",
+			"./tsconfig.externals.json",
+			"./tsconfig.runtime.json",
+			"./tsconfig.types.json",
 			"./src/test/tsconfig.json",
 			"./src/test/core-interfaces/tsconfig.no-exactOptionalPropertyTypes.json",
 		],

--- a/packages/framework/presence/api-extractor.json
+++ b/packages/framework/presence/api-extractor.json
@@ -1,6 +1,10 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.esm.no-legacy.json",
+	"projectFolder": "./",
+	"compiler": {
+		"tsconfigFilePath": "./tsconfig.runtime.json"
+	},
 	"messages": {
 		"extractorMessageReporting": {
 			// api-extractor does not appear able to resolve self references such as

--- a/packages/framework/presence/api-extractor/api-extractor-lint-alpha.cjs.json
+++ b/packages/framework/presence/api-extractor/api-extractor-lint-alpha.cjs.json
@@ -1,5 +1,11 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
-	"mainEntryPointFilePath": "<projectFolder>/dist/alpha.d.ts"
+	"mainEntryPointFilePath": "<projectFolder>/dist/alpha.d.ts",
+	"projectFolder": "../",
+	"compiler": {
+		// Use the ESM tsconfig. Otherwise, there are many complaints like:
+		//  (TS1479) The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("@fluidframework/presence/internal/exposedInternalTypes")' call instead.
+		"tsconfigFilePath": "../tsconfig.runtime.json"
+	}
 }

--- a/packages/framework/presence/api-extractor/api-extractor-lint-alpha.esm.json
+++ b/packages/framework/presence/api-extractor/api-extractor-lint-alpha.esm.json
@@ -2,6 +2,10 @@
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
 	"mainEntryPointFilePath": "<projectFolder>/lib/alpha.d.ts",
+	"projectFolder": "../",
+	"compiler": {
+		"tsconfigFilePath": "../tsconfig.runtime.json"
+	},
 	"messages": {
 		"extractorMessageReporting": {
 			"ae-wrong-input-file-type": {

--- a/packages/framework/presence/api-extractor/api-extractor-lint-bundle.json
+++ b/packages/framework/presence/api-extractor/api-extractor-lint-bundle.json
@@ -2,6 +2,10 @@
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.json",
 	"mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
+	"projectFolder": "../",
+	"compiler": {
+		"tsconfigFilePath": "../tsconfig.runtime.json"
+	},
 	"messages": {
 		"extractorMessageReporting": {
 			// api-extractor does not appear able to resolve self references such as

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -222,13 +222,13 @@ export type PresenceWorkspaceAddress = `${string}:${string}`;
 export type PresenceWorkspaceEntry<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<unknown>, TManager = unknown> = InternalTypes.ManagerFactory<TKey, TValue, TManager>;
 
 // @alpha
-export const SessionClientStatus: {
+export type SessionClientStatus = "Connected" | "Disconnected";
+
+// @alpha
+export const SessionClientStatusEnum: {
     readonly Connected: "Connected";
     readonly Disconnected: "Disconnected";
 };
-
-// @alpha
-export type SessionClientStatus = (typeof SessionClientStatus)[keyof typeof SessionClientStatus];
 
 // @alpha @sealed
 export interface ValueMap<K extends string | number, V> {

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -80,7 +80,7 @@
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm run test:mocha:esm",
-		"test:mocha": "npm run test:mocha:esm && npm run test:mocha:cjs",
+		"test:mocha": "npm run test:mocha:esm && echo skip per CI coverage run pattern npm run test:mocha:cjs",
 		"test:mocha:cjs": "mocha --recursive \"dist/test/**/*.spec.*js\" --exit",
 		"test:mocha:esm": "mocha --recursive \"lib/test/**/*.spec.*js\" --exit",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -54,7 +54,10 @@
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",
-		"build:esnext": "tsc --project ./tsconfig.json",
+		"build:esm:externals": "tsc --project ./tsconfig.externals.json",
+		"build:esm:runtime": "tsc --project ./tsconfig.runtime.json",
+		"build:esm:types": "tsc --project ./tsconfig.types.json",
+		"build:esnext": "npm run build:esm:externals && npm run build:esm:types && npm run build:esm:runtime",
 		"build:test": "npm run build:test:esm && npm run build:test:cjs && npm run build:test:esm:core-interfaces-no-exactOptionalPropertyTypes",
 		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
 		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
@@ -76,7 +79,7 @@
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"test": "npm run test:mocha",
-		"test:coverage": "c8 npm test",
+		"test:coverage": "c8 npm run test:mocha:esm",
 		"test:mocha": "npm run test:mocha:esm && npm run test:mocha:cjs",
 		"test:mocha:cjs": "mocha --recursive \"dist/test/**/*.spec.*js\" --exit",
 		"test:mocha:esm": "mocha --recursive \"lib/test/**/*.spec.*js\" --exit",
@@ -89,14 +92,11 @@
 		"all": true,
 		"cache-dir": "nyc/.cache",
 		"exclude": [
-			"src/test/**/*.*ts",
 			"dist/test/**/*.*js",
 			"lib/test/**/*.*js"
 		],
 		"exclude-after-remap": false,
 		"include": [
-			"src/**/*.*ts",
-			"dist/**/*.*js",
 			"lib/**/*.*js"
 		],
 		"report-dir": "nyc/report",
@@ -151,8 +151,14 @@
 	},
 	"fluidBuild": {
 		"tasks": {
+			"build:esm:types": [
+				"build:esm:externals"
+			],
+			"build:esm:runtime": [
+				"build:esm:types"
+			],
 			"build:test:esm:core-interfaces-no-exactOptionalPropertyTypes": [
-				"build:esnext"
+				"build:esm:externals"
 			],
 			"check:exports:bundle-release-tags": [
 				"build:esnext"

--- a/packages/framework/presence/src/broadcastControls.ts
+++ b/packages/framework/presence/src/broadcastControls.ts
@@ -3,61 +3,7 @@
  * Licensed under the MIT License.
  */
 
-/**
- * Common controls for Value Managers.
- *
- * @sealed
- * @alpha
- */
-export interface BroadcastControls {
-	/**
-	 * Maximum time in milliseconds that a local value update is allowed
-	 * to remain pending before it must be broadcast.
-	 *
-	 * @remarks
-	 * There is no guarantee of broadcast within time allowed
-	 * as other conditions such as disconnect or service throttling may
-	 * cause a delay.
-	 *
-	 * Setting to `undefined` will restore to a system default.
-	 */
-	allowableUpdateLatencyMs: number | undefined;
-
-	/**
-	 * Target time in milliseconds between oldest changed local state
-	 * has been broadcast and forced rebroadcast of all local values.
-	 * A value of less than 10 disables forced refresh.
-	 *
-	 * @privateRemarks
-	 * Any time less than 10 milliseconds is likely to generate too
-	 * many signals. Ideally this feature becomes obsolete as
-	 * we understand the system better and account for holes.
-	 */
-	// forcedRefreshIntervalMs is removed until it is supported.
-	// forcedRefreshIntervalMs: number | undefined;
-}
-
-/**
- * Value set to configure {@link BroadcastControls}.
- *
- * @alpha
- */
-export interface BroadcastControlSettings {
-	/**
-	 * {@inheritdoc BroadcastControls.allowableUpdateLatencyMs}
-	 *
-	 * @defaultValue 60 [milliseconds]
-	 */
-	readonly allowableUpdateLatencyMs?: number;
-
-	/**
-	 * {@inheritdoc BroadcastControls.forcedRefreshIntervalMs}
-	 *
-	 * @defaultValue 0 (disabled)
-	 */
-	// forcedRefreshIntervalMs is removed until it is supported.
-	// readonly forcedRefreshIntervalMs?: number;
-}
+import type { BroadcastControls, BroadcastControlSettings } from "./broadcastControlsTypes.js";
 
 class ForcedRefreshControl
 	implements

--- a/packages/framework/presence/src/broadcastControlsTypes.ts
+++ b/packages/framework/presence/src/broadcastControlsTypes.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Common controls for Value Managers.
+ *
+ * @sealed
+ * @alpha
+ */
+export interface BroadcastControls {
+	/**
+	 * Maximum time in milliseconds that a local value update is allowed
+	 * to remain pending before it must be broadcast.
+	 *
+	 * @remarks
+	 * There is no guarantee of broadcast within time allowed
+	 * as other conditions such as disconnect or service throttling may
+	 * cause a delay.
+	 *
+	 * Setting to `undefined` will restore to a system default.
+	 */
+	allowableUpdateLatencyMs: number | undefined;
+
+	/**
+	 * Target time in milliseconds between oldest changed local state
+	 * has been broadcast and forced rebroadcast of all local values.
+	 * A value of less than 10 disables forced refresh.
+	 *
+	 * @privateRemarks
+	 * Any time less than 10 milliseconds is likely to generate too
+	 * many signals. Ideally this feature becomes obsolete as
+	 * we understand the system better and account for holes.
+	 */
+	// forcedRefreshIntervalMs is removed until it is supported.
+	// forcedRefreshIntervalMs: number | undefined;
+}
+
+/**
+ * Value set to configure {@link BroadcastControls}.
+ *
+ * @alpha
+ */
+export interface BroadcastControlSettings {
+	/**
+	 * {@inheritdoc BroadcastControls.allowableUpdateLatencyMs}
+	 *
+	 * @defaultValue 60 [milliseconds]
+	 */
+	readonly allowableUpdateLatencyMs?: number;
+
+	/**
+	 * {@inheritdoc BroadcastControls.forcedRefreshIntervalMs}
+	 *
+	 * @defaultValue 0 (disabled)
+	 */
+	// forcedRefreshIntervalMs is removed until it is supported.
+	// readonly forcedRefreshIntervalMs?: number;
+}

--- a/packages/framework/presence/src/datastorePresenceManagerFactory.ts
+++ b/packages/framework/presence/src/datastorePresenceManagerFactory.ts
@@ -9,14 +9,13 @@
 
 import type { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
+import type { IExtensionMessage } from "@fluidframework/presence/internal/container-definitions/internal";
 import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 import type { SharedObjectKind } from "@fluidframework/shared-object-base";
 
 import { BasicDataStoreFactory, LoadableFluidObject } from "./datastoreSupport.js";
 import type { IPresence } from "./presence.js";
 import { createPresenceManager } from "./presenceManager.js";
-
-import type { IExtensionMessage } from "@fluidframework/presence/internal/container-definitions/internal";
 
 function assertSignalMessageIsValid(
 	message: IInboundSignalMessage | IExtensionMessage,

--- a/packages/framework/presence/src/experimentalAccess.ts
+++ b/packages/framework/presence/src/experimentalAccess.ts
@@ -7,19 +7,18 @@ import type { IContainerExperimental } from "@fluidframework/container-loader/in
 import { assert } from "@fluidframework/core-utils/internal";
 import type { IFluidContainer } from "@fluidframework/fluid-static";
 import { isInternalFluidContainer } from "@fluidframework/fluid-static/internal";
-import type { IContainerRuntimeBase } from "@fluidframework/runtime-definitions/internal";
-
-import type { IEphemeralRuntime } from "./internalTypes.js";
-import type { IPresence } from "./presence.js";
-import type { PresenceExtensionInterface } from "./presenceManager.js";
-import { createPresenceManager } from "./presenceManager.js";
-
 import type {
 	ContainerExtensionStore,
 	IContainerExtension,
 	IExtensionMessage,
 	IExtensionRuntime,
 } from "@fluidframework/presence/internal/container-definitions/internal";
+import type { IContainerRuntimeBase } from "@fluidframework/runtime-definitions/internal";
+
+import type { IEphemeralRuntime } from "./internalTypes.js";
+import type { IPresence } from "./presence.js";
+import type { PresenceExtensionInterface } from "./presenceManager.js";
+import { createPresenceManager } from "./presenceManager.js";
 
 function isContainerExtensionStore(
 	manager: ContainerExtensionStore | IContainerRuntimeBase | IContainerExperimental,

--- a/packages/framework/presence/src/index.ts
+++ b/packages/framework/presence/src/index.ts
@@ -30,18 +30,10 @@ export type {
 	PresenceWorkspaceEntry,
 } from "./types.js";
 
-export {
-	type ClientSessionId,
-	type IPresence,
-	type ISessionClient,
-	type PresenceEvents,
-	SessionClientStatus,
-} from "./presence.js";
-
 export type {
 	BroadcastControls,
 	BroadcastControlSettings,
-} from "./broadcastControls.js";
+} from "./broadcastControlsTypes.js";
 
 export { acquirePresence } from "./experimentalAccess.js";
 
@@ -71,11 +63,25 @@ export type {
 	LatestValueMetadata,
 } from "./latestValueTypes.js";
 
-export {
-	type NotificationEmitter,
-	type NotificationListenable,
-	type NotificationSubscriptions,
-	Notifications,
-	type NotificationsManager,
-	type NotificationsManagerEvents,
-} from "./notificationsManager.js";
+export type {
+	NotificationEmitter,
+	NotificationListenable,
+	NotificationSubscriptions,
+	NotificationsManager,
+	NotificationsManagerEvents,
+} from "./notificationsManagerTypes.js";
+
+export { Notifications } from "./notificationsManager.js";
+
+export type {
+	IPresence,
+	PresenceEvents,
+} from "./presence.js";
+
+export type {
+	ClientSessionId,
+	ISessionClient,
+	SessionClientStatus,
+} from "./sessionClientTypes.js";
+
+export { SessionClientStatusEnum } from "./sessionClient.js";

--- a/packages/framework/presence/src/internalTypes.ts
+++ b/packages/framework/presence/src/internalTypes.ts
@@ -5,11 +5,10 @@
 
 import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
+import type { IRuntimeInternal } from "@fluidframework/presence/internal/container-definitions/internal";
 
 import type { InternalTypes } from "./exposedInternalTypes.js";
-import type { ClientSessionId, ISessionClient } from "./presence.js";
-
-import type { IRuntimeInternal } from "@fluidframework/presence/internal/container-definitions/internal";
+import type { ClientSessionId, ISessionClient } from "./sessionClientTypes.js";
 
 /**
  * @internal
@@ -20,15 +19,6 @@ export interface ClientRecord<TValue extends InternalTypes.ValueDirectoryOrState
 	// See https://github.com/microsoft/TypeScript/issues/42810.
 	[ClientSessionId: ClientSessionId]: TValue;
 }
-
-/**
- * Object.entries retyped to support branded string-based keys.
- *
- * @internal
- */
-export const brandedObjectEntries = Object.entries as <K extends string, T>(
-	o: Record<K, T>,
-) => [K, T][];
 
 /**
  * This interface is a subset of (IContainerRuntime & IRuntimeInternal) and

--- a/packages/framework/presence/src/internalUtils.ts
+++ b/packages/framework/presence/src/internalUtils.ts
@@ -1,0 +1,13 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Object.entries retyped to support branded string-based keys.
+ *
+ * @internal
+ */
+export const brandedObjectEntries = Object.entries as <K extends string, T>(
+	o: Record<K, T>,
+) => [K, T][];

--- a/packages/framework/presence/src/latestMapValueManager.ts
+++ b/packages/framework/presence/src/latestMapValueManager.ts
@@ -5,25 +5,28 @@
 
 import { createEmitter } from "@fluid-internal/client-utils";
 import type { Listenable } from "@fluidframework/core-interfaces";
-
-import type { BroadcastControls, BroadcastControlSettings } from "./broadcastControls.js";
-import { OptionalBroadcastControl } from "./broadcastControls.js";
-import type { ValueManager } from "./internalTypes.js";
-import type {
-	LatestValueClientData,
-	LatestValueData,
-	LatestValueMetadata,
-} from "./latestValueTypes.js";
-import type { ClientSessionId, ISessionClient, SpecificSessionClient } from "./presence.js";
-import { datastoreFromHandle, type StateDatastore } from "./stateDatastore.js";
-import { brandIVM } from "./valueManager.js";
-
 import type {
 	JsonDeserialized,
 	JsonSerializable,
 } from "@fluidframework/presence/internal/core-interfaces";
 import type { InternalTypes } from "@fluidframework/presence/internal/exposedInternalTypes";
 import type { InternalUtilityTypes } from "@fluidframework/presence/internal/exposedUtilityTypes";
+
+import { OptionalBroadcastControl } from "./broadcastControls.js";
+import type { BroadcastControls, BroadcastControlSettings } from "./broadcastControlsTypes.js";
+import type { ValueManager } from "./internalTypes.js";
+import type {
+	LatestValueClientData,
+	LatestValueData,
+	LatestValueMetadata,
+} from "./latestValueTypes.js";
+import type {
+	ClientSessionId,
+	ISessionClient,
+	SpecificSessionClient,
+} from "./sessionClientTypes.js";
+import { datastoreFromHandle, type StateDatastore } from "./stateDatastore.js";
+import { brandIVM } from "./valueManager.js";
 
 /**
  * Collection of latest known values for a specific client.

--- a/packages/framework/presence/src/latestValueManager.ts
+++ b/packages/framework/presence/src/latestValueManager.ts
@@ -5,22 +5,21 @@
 
 import { createEmitter } from "@fluid-internal/client-utils";
 import type { Listenable } from "@fluidframework/core-interfaces";
-
-import type { BroadcastControls, BroadcastControlSettings } from "./broadcastControls.js";
-import { OptionalBroadcastControl } from "./broadcastControls.js";
-import type { ValueManager } from "./internalTypes.js";
-import { brandedObjectEntries } from "./internalTypes.js";
-import type { LatestValueClientData, LatestValueData } from "./latestValueTypes.js";
-import type { ISessionClient } from "./presence.js";
-import { datastoreFromHandle, type StateDatastore } from "./stateDatastore.js";
-import { brandIVM } from "./valueManager.js";
-
 import type {
 	JsonDeserialized,
 	JsonSerializable,
 } from "@fluidframework/presence/internal/core-interfaces";
 import type { InternalTypes } from "@fluidframework/presence/internal/exposedInternalTypes";
 import type { InternalUtilityTypes } from "@fluidframework/presence/internal/exposedUtilityTypes";
+
+import { OptionalBroadcastControl } from "./broadcastControls.js";
+import type { BroadcastControls, BroadcastControlSettings } from "./broadcastControlsTypes.js";
+import type { ValueManager } from "./internalTypes.js";
+import { brandedObjectEntries } from "./internalUtils.js";
+import type { LatestValueClientData, LatestValueData } from "./latestValueTypes.js";
+import type { ISessionClient } from "./sessionClientTypes.js";
+import { datastoreFromHandle, type StateDatastore } from "./stateDatastore.js";
+import { brandIVM } from "./valueManager.js";
 
 /**
  * @sealed

--- a/packages/framework/presence/src/latestValueTypes.ts
+++ b/packages/framework/presence/src/latestValueTypes.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import type { ISessionClient } from "./presence.js";
-
 import type { JsonDeserialized } from "@fluidframework/presence/internal/core-interfaces";
 import type { InternalUtilityTypes } from "@fluidframework/presence/internal/exposedUtilityTypes";
+
+import type { ISessionClient } from "./sessionClientTypes.js";
 
 /**
  * Metadata for the value state.

--- a/packages/framework/presence/src/notificationsManager.ts
+++ b/packages/framework/presence/src/notificationsManager.ts
@@ -4,152 +4,21 @@
  */
 
 import { createEmitter } from "@fluid-internal/client-utils";
-import type { Listeners, Listenable, Off } from "@fluidframework/core-interfaces";
-
-import type { ValueManager } from "./internalTypes.js";
-import type { ISessionClient } from "./presence.js";
-import { datastoreFromHandle, type StateDatastore } from "./stateDatastore.js";
-import { brandIVM } from "./valueManager.js";
-
+import type { Listeners } from "@fluidframework/core-interfaces";
 import type { JsonTypeWith } from "@fluidframework/presence/internal/core-interfaces";
 import type { InternalTypes } from "@fluidframework/presence/internal/exposedInternalTypes";
 import type { InternalUtilityTypes } from "@fluidframework/presence/internal/exposedUtilityTypes";
 
-/**
- * @sealed
- * @alpha
- */
-export interface NotificationsManagerEvents {
-	/**
-	 * Raised when notification is received, but no subscribers were found.
-	 *
-	 * @eventProperty
-	 */
-	unattendedNotification: (
-		name: string,
-		sender: ISessionClient,
-		...content: unknown[]
-	) => void;
-}
-
-/**
- * An object which allows the registration of listeners so that subscribers can be
- * notified when a notification happens.
- *
- * @sealed
- * @alpha
- */
-export interface NotificationListenable<
-	TListeners extends InternalUtilityTypes.NotificationListeners<TListeners>,
-> {
-	/**
-	 * Register a notification listener.
-	 * @param notificationName - the name of the notification
-	 * @param listener - The listener function to run when the notification is fired.
-	 * @returns A {@link @fluidframework/core-interfaces#Off | function} which will deregister the listener when called.
-	 * Calling the deregistration function more than once will have no effect.
-	 *
-	 * Listeners may also be deregistered by passing the listener to {@link NotificationListenable.off | off()}.
-	 * @remarks Registering the exact same `listener` object for the same notification more than once will throw an error.
-	 * If registering the same listener for the same notification multiple times is desired, consider using a wrapper function for the second subscription.
-	 */
-	on<K extends keyof InternalUtilityTypes.NotificationListeners<TListeners>>(
-		notificationName: K,
-		listener: (
-			sender: ISessionClient,
-			...args: InternalUtilityTypes.JsonDeserializedParameters<TListeners[K]>
-		) => void,
-	): Off;
-
-	/**
-	 * Deregister notification listener.
-	 * @param notificationName - The name of the notification.
-	 * @param listener - The listener function to remove from the current set of notification listeners.
-	 * @remarks If `listener` is not currently registered, this method will have no effect.
-	 *
-	 * Listeners may also be deregistered by calling the {@link @fluidframework/core-interfaces#Off | deregistration function} returned when they are {@link NotificationListenable.on | registered}.
-	 */
-	off<K extends keyof InternalUtilityTypes.NotificationListeners<TListeners>>(
-		notificationName: K,
-		listener: (
-			sender: ISessionClient,
-			...args: InternalUtilityTypes.JsonDeserializedParameters<TListeners[K]>
-		) => void,
-	): void;
-}
-
-/**
- * Record of notification subscriptions.
- *
- * @sealed
- * @alpha
- */
-export type NotificationSubscriptions<
-	E extends InternalUtilityTypes.NotificationListeners<E>,
-> = {
-	[K in string & keyof InternalUtilityTypes.NotificationListeners<E>]: (
-		sender: ISessionClient,
-		...args: InternalUtilityTypes.JsonDeserializedParameters<E[K]>
-	) => void;
-};
-
-/**
- * Interface for a notification emitter that can send typed notification to other clients.
- *
- * @sealed
- * @alpha
- */
-export interface NotificationEmitter<E extends InternalUtilityTypes.NotificationListeners<E>> {
-	/**
-	 * Emits a notification with the specified name and arguments, notifying all clients.
-	 * @param notificationName - the name of the notification to fire
-	 * @param args - the arguments sent with the notification
-	 */
-	broadcast<K extends string & keyof InternalUtilityTypes.NotificationListeners<E>>(
-		notificationName: K,
-		...args: Parameters<E[K]>
-	): void;
-
-	/**
-	 * Emits a notification with the specified name and arguments, notifying a single client.
-	 * @param notificationName - the name of the notification to fire
-	 * @param targetClient - the single client to notify
-	 * @param args - the arguments sent with the notification
-	 */
-	unicast<K extends string & keyof InternalUtilityTypes.NotificationListeners<E>>(
-		notificationName: K,
-		targetClient: ISessionClient,
-		...args: Parameters<E[K]>
-	): void;
-}
-
-/**
- * Value manager that provides notifications from this client to others and subscription
- * to their notifications.
- *
- * @remarks Create using {@link Notifications} registered to {@link PresenceStates}.
- *
- * @sealed
- * @alpha
- */
-export interface NotificationsManager<
-	T extends InternalUtilityTypes.NotificationListeners<T>,
-> {
-	/**
-	 * Events for Notifications manager.
-	 */
-	readonly events: Listenable<NotificationsManagerEvents>;
-
-	/**
-	 * Send notifications to other clients.
-	 */
-	readonly emit: NotificationEmitter<T>;
-
-	/**
-	 * Provides subscription to notifications from other clients.
-	 */
-	readonly notifications: NotificationListenable<T>;
-}
+import type { ValueManager } from "./internalTypes.js";
+import type {
+	NotificationEmitter,
+	NotificationsManager,
+	NotificationsManagerEvents,
+	NotificationSubscriptions,
+} from "./notificationsManagerTypes.js";
+import type { ISessionClient } from "./sessionClientTypes.js";
+import { datastoreFromHandle, type StateDatastore } from "./stateDatastore.js";
+import { brandIVM } from "./valueManager.js";
 
 /**
  * Object.keys retyped to support specific records keys and

--- a/packages/framework/presence/src/notificationsManagerTypes.ts
+++ b/packages/framework/presence/src/notificationsManagerTypes.ts
@@ -1,0 +1,145 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { Listenable, Off } from "@fluidframework/core-interfaces";
+import type { InternalUtilityTypes } from "@fluidframework/presence/internal/exposedUtilityTypes";
+
+import type { ISessionClient } from "./sessionClientTypes.js";
+
+/**
+ * @sealed
+ * @alpha
+ */
+export interface NotificationsManagerEvents {
+	/**
+	 * Raised when notification is received, but no subscribers were found.
+	 *
+	 * @eventProperty
+	 */
+	unattendedNotification: (
+		name: string,
+		sender: ISessionClient,
+		...content: unknown[]
+	) => void;
+}
+
+/**
+ * An object which allows the registration of listeners so that subscribers can be
+ * notified when a notification happens.
+ *
+ * @sealed
+ * @alpha
+ */
+export interface NotificationListenable<
+	TListeners extends InternalUtilityTypes.NotificationListeners<TListeners>,
+> {
+	/**
+	 * Register a notification listener.
+	 * @param notificationName - the name of the notification
+	 * @param listener - The listener function to run when the notification is fired.
+	 * @returns A {@link @fluidframework/core-interfaces#Off | function} which will deregister the listener when called.
+	 * Calling the deregistration function more than once will have no effect.
+	 *
+	 * Listeners may also be deregistered by passing the listener to {@link NotificationListenable.off | off()}.
+	 * @remarks Registering the exact same `listener` object for the same notification more than once will throw an error.
+	 * If registering the same listener for the same notification multiple times is desired, consider using a wrapper function for the second subscription.
+	 */
+	on<K extends keyof InternalUtilityTypes.NotificationListeners<TListeners>>(
+		notificationName: K,
+		listener: (
+			sender: ISessionClient,
+			...args: InternalUtilityTypes.JsonDeserializedParameters<TListeners[K]>
+		) => void,
+	): Off;
+
+	/**
+	 * Deregister notification listener.
+	 * @param notificationName - The name of the notification.
+	 * @param listener - The listener function to remove from the current set of notification listeners.
+	 * @remarks If `listener` is not currently registered, this method will have no effect.
+	 *
+	 * Listeners may also be deregistered by calling the {@link @fluidframework/core-interfaces#Off | deregistration function} returned when they are {@link NotificationListenable.on | registered}.
+	 */
+	off<K extends keyof InternalUtilityTypes.NotificationListeners<TListeners>>(
+		notificationName: K,
+		listener: (
+			sender: ISessionClient,
+			...args: InternalUtilityTypes.JsonDeserializedParameters<TListeners[K]>
+		) => void,
+	): void;
+}
+
+/**
+ * Record of notification subscriptions.
+ *
+ * @sealed
+ * @alpha
+ */
+export type NotificationSubscriptions<
+	E extends InternalUtilityTypes.NotificationListeners<E>,
+> = {
+	[K in string & keyof InternalUtilityTypes.NotificationListeners<E>]: (
+		sender: ISessionClient,
+		...args: InternalUtilityTypes.JsonDeserializedParameters<E[K]>
+	) => void;
+};
+
+/**
+ * Interface for a notification emitter that can send typed notification to other clients.
+ *
+ * @sealed
+ * @alpha
+ */
+export interface NotificationEmitter<E extends InternalUtilityTypes.NotificationListeners<E>> {
+	/**
+	 * Emits a notification with the specified name and arguments, notifying all clients.
+	 * @param notificationName - the name of the notification to fire
+	 * @param args - the arguments sent with the notification
+	 */
+	broadcast<K extends string & keyof InternalUtilityTypes.NotificationListeners<E>>(
+		notificationName: K,
+		...args: Parameters<E[K]>
+	): void;
+
+	/**
+	 * Emits a notification with the specified name and arguments, notifying a single client.
+	 * @param notificationName - the name of the notification to fire
+	 * @param targetClient - the single client to notify
+	 * @param args - the arguments sent with the notification
+	 */
+	unicast<K extends string & keyof InternalUtilityTypes.NotificationListeners<E>>(
+		notificationName: K,
+		targetClient: ISessionClient,
+		...args: Parameters<E[K]>
+	): void;
+}
+
+/**
+ * Value manager that provides notifications from this client to others and subscription
+ * to their notifications.
+ *
+ * @remarks Create using {@link Notifications} registered to {@link PresenceStates}.
+ *
+ * @sealed
+ * @alpha
+ */
+export interface NotificationsManager<
+	T extends InternalUtilityTypes.NotificationListeners<T>,
+> {
+	/**
+	 * Events for Notifications manager.
+	 */
+	readonly events: Listenable<NotificationsManagerEvents>;
+
+	/**
+	 * Send notifications to other clients.
+	 */
+	readonly emit: NotificationEmitter<T>;
+
+	/**
+	 * Provides subscription to notifications from other clients.
+	 */
+	readonly notifications: NotificationListenable<T>;
+}

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -4,10 +4,10 @@
  */
 
 import type { Listenable } from "@fluidframework/core-interfaces";
-import type { SessionId } from "@fluidframework/id-compressor";
 
 import type { ClientConnectionId } from "./baseTypes.js";
-import type { BroadcastControlSettings } from "./broadcastControls.js";
+import type { BroadcastControlSettings } from "./broadcastControlsTypes.js";
+import type { ClientSessionId, ISessionClient } from "./sessionClientTypes.js";
 import type {
 	PresenceNotifications,
 	PresenceNotificationsSchema,
@@ -15,108 +15,6 @@ import type {
 	PresenceStatesSchema,
 	PresenceWorkspaceAddress,
 } from "./types.js";
-
-/**
- * A Fluid client session identifier.
- *
- * @remarks
- * Each client once connected to a session is given a unique identifier for the
- * duration of the session. If a client disconnects and reconnects, it will
- * retain its identifier. Prefer use of {@link ISessionClient} as a way to
- * identify clients in a session. {@link ISessionClient.sessionId} will provide
- * the session ID.
- *
- * @alpha
- */
-export type ClientSessionId = SessionId & { readonly ClientSessionId: "ClientSessionId" };
-
-/**
- * The connection status of the {@link ISessionClient}.
- *
- * @alpha
- */
-export const SessionClientStatus = {
-	/**
-	 * The session client is connected to the Fluid service.
-	 */
-	Connected: "Connected",
-
-	/**
-	 * The session client is not connected to the Fluid service.
-	 */
-	Disconnected: "Disconnected",
-} as const;
-
-/**
- * Represents the connection status of an {@link ISessionClient}.
- *
- * This type can be either `'Connected'` or `'Disconnected'`, indicating whether
- * the session client is currently connected to the Fluid service.
- *
- * When `'Disconnected'`:
- * - State changes are kept locally and communicated to others upon reconnect.
- * - Notification requests are discarded (silently).
- *
- * @alpha
- */
-export type SessionClientStatus =
-	(typeof SessionClientStatus)[keyof typeof SessionClientStatus];
-
-/**
- * A client within a Fluid session (period of container connectivity to service).
- *
- * @remarks
- * Note: This is very preliminary session client representation.
- *
- * `ISessionClient` should be used as key to distinguish between different
- * clients as they join, rejoin, and disconnect from a session. While a
- * client's {@link ClientConnectionId} from {@link ISessionClient.getConnectionStatus}
- * may change over time, `ISessionClient` will be fixed.
- *
- * @privateRemarks
- * As this is evolved, pay attention to how this relates to Audience, Service
- * Audience, and Quorum representations of clients and users.
- *
- * @sealed
- * @alpha
- */
-export interface ISessionClient<
-	SpecificSessionClientId extends ClientSessionId = ClientSessionId,
-> {
-	/**
-	 * The session ID of the client that is stable over all connections.
-	 */
-	readonly sessionId: SpecificSessionClientId;
-
-	/**
-	 * Get current client connection ID.
-	 *
-	 * @returns Current client connection ID.
-	 *
-	 * @remarks
-	 * Connection ID will change on reconnect.
-	 *
-	 * If {@link ISessionClient.getConnectionStatus} is {@link (SessionClientStatus:variable).Disconnected}, this will represent the last known connection ID.
-	 */
-	getConnectionId(): ClientConnectionId;
-
-	/**
-	 * Get connection status of session client.
-	 *
-	 * @returns Connection status of session client.
-	 *
-	 */
-	getConnectionStatus(): SessionClientStatus;
-}
-
-/**
- * Utility type limiting to a specific session client. (A session client with
- * a specific session ID - not just any session ID.)
- *
- * @internal
- */
-export type SpecificSessionClient<SpecificSessionClientId extends ClientSessionId> =
-	string extends SpecificSessionClientId ? never : ISessionClient<SpecificSessionClientId>;
 
 /**
  * @sealed

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -4,14 +4,14 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
+import type { IExtensionMessage } from "@fluidframework/presence/internal/container-definitions/internal";
 import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import type { ClientConnectionId } from "./baseTypes.js";
-import type { BroadcastControlSettings } from "./broadcastControls.js";
-import { brandedObjectEntries } from "./internalTypes.js";
+import type { BroadcastControlSettings } from "./broadcastControlsTypes.js";
 import type { IEphemeralRuntime } from "./internalTypes.js";
-import type { ClientSessionId, ISessionClient } from "./presence.js";
+import { brandedObjectEntries } from "./internalUtils.js";
 import type {
 	ClientUpdateEntry,
 	RuntimeLocalUpdateOptions,
@@ -23,6 +23,7 @@ import {
 	mergeUntrackedDatastore,
 	mergeValueDirectory,
 } from "./presenceStates.js";
+import type { ClientSessionId, ISessionClient } from "./sessionClientTypes.js";
 import type { SystemWorkspaceDatastore } from "./systemWorkspace.js";
 import { TimerManager } from "./timerManager.js";
 import type {
@@ -30,8 +31,6 @@ import type {
 	PresenceStatesSchema,
 	PresenceWorkspaceAddress,
 } from "./types.js";
-
-import type { IExtensionMessage } from "@fluidframework/presence/internal/container-definitions/internal";
 
 interface PresenceWorkspaceEntry<TSchema extends PresenceStatesSchema> {
 	public: PresenceStates<TSchema>;

--- a/packages/framework/presence/src/presenceManager.ts
+++ b/packages/framework/presence/src/presenceManager.ts
@@ -7,22 +7,22 @@ import { createEmitter } from "@fluid-internal/client-utils";
 import type { IEmitter } from "@fluidframework/core-interfaces/internal";
 import { createSessionId } from "@fluidframework/id-compressor/internal";
 import type {
+	IContainerExtension,
+	IExtensionMessage,
+} from "@fluidframework/presence/internal/container-definitions/internal";
+import type {
 	ITelemetryLoggerExt,
 	MonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 import { createChildMonitoringContext } from "@fluidframework/telemetry-utils/internal";
 
 import type { ClientConnectionId } from "./baseTypes.js";
-import type { BroadcastControlSettings } from "./broadcastControls.js";
+import type { BroadcastControlSettings } from "./broadcastControlsTypes.js";
 import type { IEphemeralRuntime } from "./internalTypes.js";
-import type {
-	ClientSessionId,
-	IPresence,
-	ISessionClient,
-	PresenceEvents,
-} from "./presence.js";
+import type { IPresence, PresenceEvents } from "./presence.js";
 import type { PresenceDatastoreManager } from "./presenceDatastoreManager.js";
 import { PresenceDatastoreManagerImpl } from "./presenceDatastoreManager.js";
+import type { ClientSessionId, ISessionClient } from "./sessionClientTypes.js";
 import type { SystemWorkspace, SystemWorkspaceDatastore } from "./systemWorkspace.js";
 import { createSystemWorkspace } from "./systemWorkspace.js";
 import type {
@@ -30,11 +30,6 @@ import type {
 	PresenceWorkspaceAddress,
 	PresenceStatesSchema,
 } from "./types.js";
-
-import type {
-	IContainerExtension,
-	IExtensionMessage,
-} from "@fluidframework/presence/internal/container-definitions/internal";
 
 /**
  * Portion of the container extension requirements ({@link IContainerExtension}) that are delegated to presence manager.

--- a/packages/framework/presence/src/presenceStates.ts
+++ b/packages/framework/presence/src/presenceStates.ts
@@ -6,12 +6,12 @@
 import { assert } from "@fluidframework/core-utils/internal";
 
 import type { ClientConnectionId } from "./baseTypes.js";
-import type { BroadcastControlSettings } from "./broadcastControls.js";
 import { RequiredBroadcastControl } from "./broadcastControls.js";
+import type { BroadcastControlSettings } from "./broadcastControlsTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { ClientRecord } from "./internalTypes.js";
-import { brandedObjectEntries } from "./internalTypes.js";
-import type { ClientSessionId, ISessionClient } from "./presence.js";
+import { brandedObjectEntries } from "./internalUtils.js";
+import type { ClientSessionId, ISessionClient } from "./sessionClientTypes.js";
 import type { LocalStateUpdateOptions, StateDatastore } from "./stateDatastore.js";
 import { handleFromDatastore } from "./stateDatastore.js";
 import type { PresenceStates, PresenceStatesSchema } from "./types.js";

--- a/packages/framework/presence/src/sessionClient.ts
+++ b/packages/framework/presence/src/sessionClient.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * The connection status of the {@link ISessionClient}.
+ *
+ * @alpha
+ */
+export const SessionClientStatusEnum = {
+	/**
+	 * The session client is connected to the Fluid service.
+	 */
+	Connected: "Connected",
+
+	/**
+	 * The session client is not connected to the Fluid service.
+	 */
+	Disconnected: "Disconnected",
+} as const;

--- a/packages/framework/presence/src/sessionClientTypes.ts
+++ b/packages/framework/presence/src/sessionClientTypes.ts
@@ -1,0 +1,92 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { SessionId } from "@fluidframework/id-compressor";
+
+import type { ClientConnectionId } from "./baseTypes.js";
+
+/**
+ * A Fluid client session identifier.
+ *
+ * @remarks
+ * Each client once connected to a session is given a unique identifier for the
+ * duration of the session. If a client disconnects and reconnects, it will
+ * retain its identifier. Prefer use of {@link ISessionClient} as a way to
+ * identify clients in a session. {@link ISessionClient.sessionId} will provide
+ * the session ID.
+ *
+ * @alpha
+ */
+export type ClientSessionId = SessionId & { readonly ClientSessionId: "ClientSessionId" };
+
+/**
+ * Represents the connection status of an {@link ISessionClient}.
+ *
+ * This type can be either `'Connected'` or `'Disconnected'`, indicating whether
+ * the session client is currently connected to the Fluid service.
+ *
+ * When `'Disconnected'`:
+ * - State changes are kept locally and communicated to others upon reconnect.
+ * - Notification requests are discarded (silently).
+ *
+ * @alpha
+ */
+export type SessionClientStatus = "Connected" | "Disconnected";
+
+/**
+ * A client within a Fluid session (period of container connectivity to service).
+ *
+ * @remarks
+ * Note: This is very preliminary session client representation.
+ *
+ * `ISessionClient` should be used as key to distinguish between different
+ * clients as they join, rejoin, and disconnect from a session. While a
+ * client's {@link ClientConnectionId} from {@link ISessionClient.getConnectionStatus}
+ * may change over time, `ISessionClient` will be fixed.
+ *
+ * @privateRemarks
+ * As this is evolved, pay attention to how this relates to Audience, Service
+ * Audience, and Quorum representations of clients and users.
+ *
+ * @sealed
+ * @alpha
+ */
+export interface ISessionClient<
+	SpecificSessionClientId extends ClientSessionId = ClientSessionId,
+> {
+	/**
+	 * The session ID of the client that is stable over all connections.
+	 */
+	readonly sessionId: SpecificSessionClientId;
+
+	/**
+	 * Get current client connection ID.
+	 *
+	 * @returns Current client connection ID.
+	 *
+	 * @remarks
+	 * Connection ID will change on reconnect.
+	 *
+	 * If {@link ISessionClient.getConnectionStatus} is {@link (SessionClientStatusEnum:variable).Disconnected}, this will represent the last known connection ID.
+	 */
+	getConnectionId(): ClientConnectionId;
+
+	/**
+	 * Get connection status of session client.
+	 *
+	 * @returns Connection status of session client.
+	 *
+	 */
+	getConnectionStatus(): SessionClientStatus;
+}
+
+/**
+ * Utility type limiting to a specific session client. (A session client with
+ * a specific session ID - not just any session ID.)
+ *
+ * @internal
+ */
+export type SpecificSessionClient<SpecificSessionClientId extends ClientSessionId> =
+	string extends SpecificSessionClientId ? never : ISessionClient<SpecificSessionClientId>;

--- a/packages/framework/presence/src/stateDatastore.ts
+++ b/packages/framework/presence/src/stateDatastore.ts
@@ -6,7 +6,7 @@
 import type { ClientConnectionId } from "./baseTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { ClientRecord } from "./internalTypes.js";
-import type { ClientSessionId, ISessionClient } from "./presence.js";
+import type { ClientSessionId, ISessionClient } from "./sessionClientTypes.js";
 
 // type StateDatastoreSchemaNode<
 // 	TValue extends InternalTypes.ValueDirectoryOrState<any> = InternalTypes.ValueDirectoryOrState<unknown>,

--- a/packages/framework/presence/src/systemWorkspace.ts
+++ b/packages/framework/presence/src/systemWorkspace.ts
@@ -9,14 +9,14 @@ import { assert } from "@fluidframework/core-utils/internal";
 
 import type { ClientConnectionId } from "./baseTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
+import type { IPresence, PresenceEvents } from "./presence.js";
+import type { PresenceStatesInternal } from "./presenceStates.js";
+import { SessionClientStatusEnum } from "./sessionClient.js";
 import type {
 	ClientSessionId,
-	IPresence,
 	ISessionClient,
-	PresenceEvents,
-} from "./presence.js";
-import { SessionClientStatus } from "./presence.js";
-import type { PresenceStatesInternal } from "./presenceStates.js";
+	SessionClientStatus,
+} from "./sessionClientTypes.js";
 import type { PresenceStates, PresenceStatesSchema } from "./types.js";
 
 /**
@@ -45,8 +45,8 @@ class SessionClient implements ISessionClient {
 	) {
 		this.connectionStatus =
 			connectionId === undefined
-				? SessionClientStatus.Disconnected
-				: SessionClientStatus.Connected;
+				? SessionClientStatusEnum.Disconnected
+				: SessionClientStatusEnum.Connected;
 	}
 
 	public getConnectionId(): ClientConnectionId {
@@ -62,11 +62,11 @@ class SessionClient implements ISessionClient {
 
 	public setConnectionId(connectionId: ClientConnectionId): void {
 		this.connectionId = connectionId;
-		this.connectionStatus = SessionClientStatus.Connected;
+		this.connectionStatus = SessionClientStatusEnum.Connected;
 	}
 
 	public setDisconnected(): void {
-		this.connectionStatus = SessionClientStatus.Disconnected;
+		this.connectionStatus = SessionClientStatusEnum.Disconnected;
 	}
 }
 
@@ -153,7 +153,7 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 
 			if (isAttendeeConnected) {
 				connectedAttendees.add(attendee);
-				if (attendee.getConnectionStatus() === SessionClientStatus.Disconnected) {
+				if (attendee.getConnectionStatus() === SessionClientStatusEnum.Disconnected) {
 					attendee.setConnectionId(clientConnectionId);
 				}
 				if (isNew) {
@@ -202,7 +202,7 @@ class SystemWorkspaceImpl implements PresenceStatesInternal, SystemWorkspace {
 		// If the last known connectionID is different from the connection ID being removed, the attendee has reconnected,
 		// therefore we should not change the attendee connection status or emit a disconnect event.
 		const attendeeReconnected = attendee.getConnectionId() !== clientConnectionId;
-		const connected = attendee.getConnectionStatus() === SessionClientStatus.Connected;
+		const connected = attendee.getConnectionStatus() === SessionClientStatusEnum.Connected;
 		if (!attendeeReconnected && connected) {
 			attendee.setDisconnected();
 			this.events.emit("attendeeDisconnected", attendee);

--- a/packages/framework/presence/src/test/broadcastControlsTests.ts
+++ b/packages/framework/presence/src/test/broadcastControlsTests.ts
@@ -5,7 +5,10 @@
 
 import assert from "node:assert";
 
-import type { BroadcastControls, BroadcastControlSettings } from "../broadcastControls.js";
+import type {
+	BroadcastControls,
+	BroadcastControlSettings,
+} from "../broadcastControlsTypes.js";
 import type { IPresence } from "../presence.js";
 import { createPresenceManager } from "../presenceManager.js";
 

--- a/packages/framework/presence/src/test/core-interfaces/tsconfig.no-exactOptionalPropertyTypes.json
+++ b/packages/framework/presence/src/test/core-interfaces/tsconfig.no-exactOptionalPropertyTypes.json
@@ -12,7 +12,7 @@
 	},
 	"references": [
 		{
-			"path": "../../..",
+			"path": "../../../tsconfig.externals.json",
 		},
 	],
 }

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -9,16 +9,23 @@ import { EventAndErrorTrackingLogger } from "@fluidframework/test-utils/internal
 import type { SinonFakeTimers } from "sinon";
 import { useFakeTimers } from "sinon";
 
-import type { ClientConnectionId } from "../baseTypes.js";
-import { SessionClientStatus, type ISessionClient } from "../presence.js";
 import { createPresenceManager } from "../presenceManager.js";
 
 import { MockEphemeralRuntime } from "./mockEphemeralRuntime.js";
 import {
 	assertFinalExpectations,
+	assertIdenticalTypes,
+	createInstanceOf,
 	generateBasicClientJoin,
 	prepareConnectedPresence,
 } from "./testUtils.js";
+
+import type {
+	ClientConnectionId,
+	ISessionClient,
+	SessionClientStatus,
+} from "@fluidframework/presence/alpha";
+import { SessionClientStatusEnum } from "@fluidframework/presence/alpha";
 
 describe("Presence", () => {
 	describe("PresenceManager", () => {
@@ -76,6 +83,14 @@ describe("Presence", () => {
 		});
 
 		describe("when connected", () => {
+			// Make sure the enum and the common type are in sync
+			assertIdenticalTypes(
+				createInstanceOf<
+					(typeof SessionClientStatusEnum)[keyof typeof SessionClientStatusEnum]
+				>(),
+				createInstanceOf<SessionClientStatus>(),
+			);
+
 			let presence: ReturnType<typeof createPresenceManager>;
 			const afterCleanUp: (() => void)[] = [];
 
@@ -161,7 +176,7 @@ describe("Presence", () => {
 						);
 						assert.equal(
 							newAttendee.getConnectionStatus(),
-							SessionClientStatus.Connected,
+							SessionClientStatusEnum.Connected,
 							"Attendee connection status is not Connected",
 						);
 					}
@@ -289,9 +304,9 @@ describe("Presence", () => {
 					});
 
 					for (const [status, setup] of [
-						[SessionClientStatus.Connected, () => {}] as const,
+						[SessionClientStatusEnum.Connected, () => {}] as const,
 						[
-							SessionClientStatus.Disconnected,
+							SessionClientStatusEnum.Disconnected,
 							() => runtime.removeMember(initialAttendeeConnectionId),
 						] as const,
 					]) {
@@ -370,7 +385,7 @@ describe("Presence", () => {
 							);
 							assert.equal(
 								disconnectedAttendee.getConnectionStatus(),
-								SessionClientStatus.Disconnected,
+								SessionClientStatusEnum.Disconnected,
 								"Disconnected attendee has wrong status",
 							);
 						});

--- a/packages/framework/presence/src/test/presenceStates.spec.ts
+++ b/packages/framework/presence/src/test/presenceStates.spec.ts
@@ -3,15 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import type { IPresence } from "../presence.js";
-
-import { addControlsTests } from "./broadcastControlsTests.js";
-
 import type {
 	JsonDeserialized,
 	JsonSerializable,
 } from "@fluidframework/presence/internal/core-interfaces";
 import type { InternalTypes } from "@fluidframework/presence/internal/exposedInternalTypes";
+
+import type { IPresence } from "../presence.js";
+
+import { addControlsTests } from "./broadcastControlsTests.js";
 
 describe("Presence", () => {
 	describe("PresenceStates", () => {

--- a/packages/framework/presence/src/test/testUtils.ts
+++ b/packages/framework/presence/src/test/testUtils.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import type { IExtensionMessage } from "@fluidframework/presence/internal/container-definitions/internal";
+import type { InternalUtilityTypes } from "@fluidframework/presence/internal/core-interfaces";
 import type { EventAndErrorTrackingLogger } from "@fluidframework/test-utils/internal";
 import { getUnexpectedLogErrorException } from "@fluidframework/test-utils/internal";
 import type { SinonFakeTimers } from "sinon";
@@ -12,8 +14,6 @@ import { createPresenceManager } from "../presenceManager.js";
 import type { MockEphemeralRuntime } from "./mockEphemeralRuntime.js";
 
 import type { ClientConnectionId, ClientSessionId } from "@fluidframework/presence/alpha";
-import type { IExtensionMessage } from "@fluidframework/presence/internal/container-definitions/internal";
-import type { InternalUtilityTypes } from "@fluidframework/presence/internal/core-interfaces";
 
 /**
  * Use to compile-time assert types of two variables are identical.

--- a/packages/framework/presence/src/test/tsconfig.json
+++ b/packages/framework/presence/src/test/tsconfig.json
@@ -13,7 +13,7 @@
 	},
 	"references": [
 		{
-			"path": "../..",
+			"path": "../../tsconfig.runtime.json",
 		},
 	],
 }

--- a/packages/framework/presence/src/types.ts
+++ b/packages/framework/presence/src/types.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import type { BroadcastControls } from "./broadcastControls.js";
-import type { NotificationsManager } from "./notificationsManager.js";
-
 import type { InternalTypes } from "@fluidframework/presence/internal/exposedInternalTypes";
+
+import type { BroadcastControls } from "./broadcastControlsTypes.js";
+import type { NotificationsManager } from "./notificationsManagerTypes.js";
 
 /**
  * Unique address within a session.

--- a/packages/framework/presence/tsconfig.base.json
+++ b/packages/framework/presence/tsconfig.base.json
@@ -1,7 +1,5 @@
 {
 	"extends": "../../../common/build/build-common/tsconfig.node16.json",
-	"include": ["src/**/*"],
-	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/packages/framework/presence/tsconfig.cjs.json
+++ b/packages/framework/presence/tsconfig.cjs.json
@@ -1,6 +1,8 @@
 {
 	// This config must be used in a "type": "commonjs" environment. (Use fluid-tsc commonjs.)
-	"extends": "./tsconfig.json",
+	"extends": "./tsconfig.base.json",
+	"include": ["src/**/*"],
+	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"outDir": "./dist",
 	},

--- a/packages/framework/presence/tsconfig.externals.json
+++ b/packages/framework/presence/tsconfig.externals.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.base.json",
+	"include": ["src/container-definitions/**/*", "src/core-interfaces/**/*"],
+	"exclude": ["src/test/**/*"],
+	"compilerOptions": {
+		"emitDeclarationOnly": true,
+	},
+}

--- a/packages/framework/presence/tsconfig.runtime.json
+++ b/packages/framework/presence/tsconfig.runtime.json
@@ -1,0 +1,17 @@
+{
+	"extends": "./tsconfig.base.json",
+	"include": ["src/**/*"],
+	"exclude": [
+		"src/**/types.ts",
+		"src/**/*Types.*ts",
+		"src/presence.ts",
+		"src/container-definitions/**/*",
+		"src/core-interfaces/**/*",
+		"src/test/**/*",
+	],
+	"references": [
+		{
+			"path": "./tsconfig.types.json",
+		},
+	],
+}

--- a/packages/framework/presence/tsconfig.types.json
+++ b/packages/framework/presence/tsconfig.types.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig.base.json",
+	"include": ["src/**/types.ts", "src/**/*Types.*ts", "src/presence.ts"],
+	"exclude": ["src/container-definitions/**/*", "src/core-interfaces/**/*", "src/test/**/*"],
+	"compilerOptions": {
+		"emitDeclarationOnly": true,
+	},
+	"references": [
+		{
+			"path": "./tsconfig.externals.json",
+		},
+	],
+}


### PR DESCRIPTION
- breaking change: `SessionClientStatus` constant (enum) renamed to `SessionClientStatusEnum`

Note that CJS build is left as single compile for simplicity and it is not used for code coverage.

As all externals are currently declarations there is no need for separation from the types compile. It does appear that this separation leads to eslint import/order rule making more sensible choice for import orderings.