### PR TITLE
fix(migration-tools): Fix id for create new request in SessionStorageSimpleLoader

### DIFF
--- a/examples/utils/migration-tools/src/simpleLoader/sessionStorageSimpleLoader.ts
+++ b/examples/utils/migration-tools/src/simpleLoader/sessionStorageSimpleLoader.ts
@@ -40,24 +40,22 @@ export class SessionStorageSimpleLoader implements ISimpleLoader {
 	public async createDetached(
 		version: string,
 	): Promise<{ container: IContainer; attach: () => Promise<string> }> {
-		const documentId = uuid();
 		const loader = new SimpleLoader({
 			urlResolver,
 			documentServiceFactory: new LocalDocumentServiceFactory(localServer),
 			codeLoader: this.codeLoader,
 			logger: this.logger,
-			generateCreateNewRequest: () => createLocalResolverCreateNewRequest(documentId),
+			generateCreateNewRequest: () => createLocalResolverCreateNewRequest(uuid()),
 		});
 		return loader.createDetached(version);
 	}
 	public async loadExisting(id: string): Promise<IContainer> {
-		const documentId = id;
 		const loader = new SimpleLoader({
 			urlResolver,
 			documentServiceFactory: new LocalDocumentServiceFactory(localServer),
 			codeLoader: this.codeLoader,
 			logger: this.logger,
-			generateCreateNewRequest: () => createLocalResolverCreateNewRequest(documentId),
+			generateCreateNewRequest: () => createLocalResolverCreateNewRequest(uuid()),
 		});
 		return loader.loadExisting(`${window.location.origin}/${id}`);
 	}


### PR DESCRIPTION
For local driver, a create new request should always be using a new uuid.  It didn't matter because the loader would never get reused to create a new container, but was incorrect nonetheless.