### PR TITLE
ai-collab array schema requirement bugfix & 'Real' Prompt Snapshot unit tests

### DIFF
--- a/packages/framework/ai-collab/src/explicit-strategy/promptGeneration.ts
+++ b/packages/framework/ai-collab/src/explicit-strategy/promptGeneration.ts
@@ -82,9 +82,7 @@ export function getPlanningSystemPrompt(
 			The other agent follows this guidance: ${systemRoleContext}`
 	}`;
 
-	const editOptions = doesNodeContainArraySchema(treeNode)
-		? "inserting, modifying, removing, or moving elements in the tree"
-		: "modifying elements in the tree";
+	const editOptions = `modifying ${doesNodeContainArraySchema(treeNode) ? "as well as inserting, removing, or moving" : ""} elements in the tree`;
 
 	const systemPrompt = `
 	${role}
@@ -142,13 +140,13 @@ export function getEditingSystemPrompt(
 	).getSchemaText();
 
 	const topLevelEditWrapperDescription = doesNodeContainArraySchema(treeNode)
-		? `contains one of the following interfaces: "Insert", "Modify", "Remove", "Move", or null`
+		? `contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move".`
 		: `contains the interface "Modify" or null`;
 
 	// TODO: security: user prompt in system prompt
 	const systemPrompt = `
-	${role}\nEdits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which ${topLevelEditWrapperDescription}:
-	\n${treeSchemaString}
+	${role}\nEdits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which ${topLevelEditWrapperDescription}.
+	\nHere are the schema definitions for an edit:\n${treeSchemaString}\n
 	The tree is a JSON object with the following schema: ${promptFriendlySchema}
 	${plan === undefined ? "" : `You have made a plan to accomplish the user's goal. The plan is: "${plan}". You will perform one or more edits that correspond to that plan to accomplish the goal.`}
 	${

--- a/packages/framework/ai-collab/src/explicit-strategy/promptGeneration.ts
+++ b/packages/framework/ai-collab/src/explicit-strategy/promptGeneration.ts
@@ -140,7 +140,7 @@ export function getEditingSystemPrompt(
 	).getSchemaText();
 
 	const topLevelEditWrapperDescription = doesNodeContainArraySchema(treeNode)
-		? `contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move".`
+		? `contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move"`
 		: `contains the interface "Modify" or null`;
 
 	// TODO: security: user prompt in system prompt

--- a/packages/framework/ai-collab/src/explicit-strategy/typeGeneration.ts
+++ b/packages/framework/ai-collab/src/explicit-strategy/typeGeneration.ts
@@ -34,7 +34,9 @@ const objectTarget = z
 				`The id of the object (as specified by the object's ${objectIdKey} property) that is being referenced`,
 			),
 	})
-	.describe("A pointer to a specific object in the tree.");
+	.describe(
+		"A pointer to a specific object node in the tree, identified by the target object's Id.",
+	);
 /**
  * Zod Object type used to represent & validate the ObjectPlace type within a {@link TreeEdit}.
  * @remarks this is used as a component with {@link generateGenericEditTypes} to produce the final zod validation objects.
@@ -187,14 +189,7 @@ export function generateGenericEditTypes(
 
 		const typeRecord: Record<string, Zod.ZodTypeAny> = {
 			ObjectTarget: objectTarget,
-			// ObjectPlace: objectPlace,
-			// ArrayPlace: arrayPlace,
-			// Range: range,
-			// Insert: insert,
-			// Remove: remove,
-			// Move: move,
 			Modify: modify,
-			// EditWrapper: editWrapper,
 		};
 
 		typeRecord.Modify = modify;
@@ -217,46 +212,8 @@ export function generateGenericEditTypes(
 				.union(editTypes)
 				.describe("The next edit to apply to the tree, or null if the task is complete."),
 		});
-
 		typeRecord.EditWrapper = editWrapper;
 
-		// const insert = z
-		// 	.object({
-		// 		type: z.literal("insert"),
-		// 		explanation: z.string().describe(editDescription),
-		// 		content: generateDomainTypes
-		// 			? getType(insertSet)
-		// 			: z.any().describe("Domain-specific content here"),
-		// 		destination: z.union([arrayPlace, objectPlace]),
-		// 	})
-		// 	.describe("Inserts a new object at a specific Place or ArrayPlace.");
-
-		// const move = z
-		// 	.object({
-		// 		type: z.literal("move"),
-		// 		explanation: z.string().describe(editDescription),
-		// 		source: z.union([objectTarget, range]),
-		// 		destination: z.union([arrayPlace, objectPlace]),
-		// 	})
-		// 	.describe("Moves an object or Range of objects to a new Place or ArrayPlace.");
-
-		// const editTypes = [insert, remove, move, modify, z.null()] as const;
-		// const editWrapper = z.object({
-		// 	edit: z
-		// 		.union(editTypes)
-		// 		.describe("The next edit to apply to the tree, or null if the task is complete."),
-		// });
-		// const typeRecord: Record<string, Zod.ZodTypeAny> = {
-		// 	ObjectTarget: objectTarget,
-		// 	ObjectPlace: objectPlace,
-		// 	ArrayPlace: arrayPlace,
-		// 	Range: range,
-		// 	Insert: insert,
-		// 	Remove: remove,
-		// 	Move: move,
-		// 	Modify: modify,
-		// 	EditWrapper: editWrapper,
-		// };
 		return [typeRecord, "EditWrapper"];
 	});
 }

--- a/packages/framework/ai-collab/src/explicit-strategy/typeGeneration.ts
+++ b/packages/framework/ai-collab/src/explicit-strategy/typeGeneration.ts
@@ -4,11 +4,18 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { FieldKind, NodeKind, ValueSchema } from "@fluidframework/tree/internal";
+import {
+	FieldKind,
+	getSimpleSchema,
+	NodeKind,
+	Tree,
+	ValueSchema,
+} from "@fluidframework/tree/internal";
 import type {
 	SimpleFieldSchema,
 	SimpleNodeSchema,
 	SimpleTreeSchema,
+	TreeNode,
 } from "@fluidframework/tree/internal";
 import { z } from "zod";
 
@@ -19,13 +26,15 @@ import { fail, getOrCreate, mapIterable } from "./utils.js";
  * Zod Object type used to represent & validate the ObjectTarget type within a {@link TreeEdit}.
  * @remarks this is used as a component with {@link generateGenericEditTypes} to produce the final zod validation objects.
  */
-const objectTarget = z.object({
-	target: z
-		.string()
-		.describe(
-			`The id of the object (as specified by the object's ${objectIdKey} property) that is being referenced`,
-		),
-});
+const objectTarget = z
+	.object({
+		target: z
+			.string()
+			.describe(
+				`The id of the object (as specified by the object's ${objectIdKey} property) that is being referenced`,
+			),
+	})
+	.describe("A pointer to a specific object in the tree.");
 /**
  * Zod Object type used to represent & validate the ObjectPlace type within a {@link TreeEdit}.
  * @remarks this is used as a component with {@link generateGenericEditTypes} to produce the final zod validation objects.
@@ -101,6 +110,7 @@ export function generateGenericEditTypes(
 		const modifyFieldSet = new Set<string>();
 		const modifyTypeSet = new Set<string>();
 		const typeMap = new Map<string, Zod.ZodTypeAny>();
+
 		for (const name of schema.definitions.keys()) {
 			getOrCreateType(
 				schema.definitions,
@@ -132,31 +142,9 @@ export function generateGenericEditTypes(
 				}
 			}
 		}
-		const insert = z
-			.object({
-				type: z.literal("insert"),
-				explanation: z.string().describe(editDescription),
-				content: generateDomainTypes
-					? getType(insertSet)
-					: z.any().describe("Domain-specific content here"),
-				destination: z.union([arrayPlace, objectPlace]),
-			})
-			.describe("Inserts a new object at a specific Place or ArrayPlace.");
-		const remove = z
-			.object({
-				type: z.literal("remove"),
-				explanation: z.string().describe(editDescription),
-				source: z.union([objectTarget, range]),
-			})
-			.describe("Deletes an object or Range of objects from the tree.");
-		const move = z
-			.object({
-				type: z.literal("move"),
-				explanation: z.string().describe(editDescription),
-				source: z.union([objectTarget, range]),
-				destination: z.union([arrayPlace, objectPlace]),
-			})
-			.describe("Moves an object or Range of objects to a new Place or ArrayPlace.");
+
+		const doesSchemaHaveArray = insertSet.size > 0;
+
 		const modify = z
 			.object({
 				type: z.enum(["modify"]),
@@ -168,23 +156,107 @@ export function generateGenericEditTypes(
 					: z.any().describe("Domain-specific content here"),
 			})
 			.describe("Sets a field on a specific ObjectTarget.");
-		const editTypes = [insert, remove, move, modify, z.null()] as const;
+
+		const remove = z
+			.object({
+				type: z.literal("remove"),
+				explanation: z.string().describe(editDescription),
+				source: z.union([objectTarget, range]),
+			})
+			.describe("Deletes an object or Range of objects from the tree.");
+
+		const insert = z
+			.object({
+				type: z.literal("insert"),
+				explanation: z.string().describe(editDescription),
+				content: generateDomainTypes
+					? getType(insertSet)
+					: z.any().describe("Domain-specific content here"),
+				destination: z.union([arrayPlace, objectPlace]),
+			})
+			.describe("Inserts a new object at a specific Place or ArrayPlace.");
+
+		const move = z
+			.object({
+				type: z.literal("move"),
+				explanation: z.string().describe(editDescription),
+				source: z.union([objectTarget, range]),
+				destination: z.union([arrayPlace, objectPlace]),
+			})
+			.describe("Moves an object or Range of objects to a new Place or ArrayPlace.");
+
+		const typeRecord: Record<string, Zod.ZodTypeAny> = {
+			ObjectTarget: objectTarget,
+			// ObjectPlace: objectPlace,
+			// ArrayPlace: arrayPlace,
+			// Range: range,
+			// Insert: insert,
+			// Remove: remove,
+			// Move: move,
+			Modify: modify,
+			// EditWrapper: editWrapper,
+		};
+
+		typeRecord.Modify = modify;
+
+		if (doesSchemaHaveArray) {
+			typeRecord.ObjectPlace = objectPlace;
+			typeRecord.ArrayPlace = arrayPlace;
+			typeRecord.Range = range;
+			typeRecord.Insert = insert;
+			typeRecord.Remove = remove;
+			typeRecord.Move = move;
+		}
+
+		const editTypes = doesSchemaHaveArray
+			? ([insert, remove, move, modify, z.null()] as const)
+			: ([modify, z.null()] as const);
+
 		const editWrapper = z.object({
 			edit: z
 				.union(editTypes)
 				.describe("The next edit to apply to the tree, or null if the task is complete."),
 		});
-		const typeRecord: Record<string, Zod.ZodTypeAny> = {
-			ObjectTarget: objectTarget,
-			ObjectPlace: objectPlace,
-			ArrayPlace: arrayPlace,
-			Range: range,
-			Insert: insert,
-			Remove: remove,
-			Move: move,
-			Modify: modify,
-			EditWrapper: editWrapper,
-		};
+
+		typeRecord.EditWrapper = editWrapper;
+
+		// const insert = z
+		// 	.object({
+		// 		type: z.literal("insert"),
+		// 		explanation: z.string().describe(editDescription),
+		// 		content: generateDomainTypes
+		// 			? getType(insertSet)
+		// 			: z.any().describe("Domain-specific content here"),
+		// 		destination: z.union([arrayPlace, objectPlace]),
+		// 	})
+		// 	.describe("Inserts a new object at a specific Place or ArrayPlace.");
+
+		// const move = z
+		// 	.object({
+		// 		type: z.literal("move"),
+		// 		explanation: z.string().describe(editDescription),
+		// 		source: z.union([objectTarget, range]),
+		// 		destination: z.union([arrayPlace, objectPlace]),
+		// 	})
+		// 	.describe("Moves an object or Range of objects to a new Place or ArrayPlace.");
+
+		// const editTypes = [insert, remove, move, modify, z.null()] as const;
+		// const editWrapper = z.object({
+		// 	edit: z
+		// 		.union(editTypes)
+		// 		.describe("The next edit to apply to the tree, or null if the task is complete."),
+		// });
+		// const typeRecord: Record<string, Zod.ZodTypeAny> = {
+		// 	ObjectTarget: objectTarget,
+		// 	ObjectPlace: objectPlace,
+		// 	ArrayPlace: arrayPlace,
+		// 	Range: range,
+		// 	Insert: insert,
+		// 	Remove: remove,
+		// 	Move: move,
+		// 	Modify: modify,
+		// 	EditWrapper: editWrapper,
+		// };
 		return [typeRecord, "EditWrapper"];
 	});
 }
@@ -327,6 +399,7 @@ function getOrCreateTypeForField(
 		}
 	}
 }
+
 function getTypeForAllowedTypes(
 	definitionMap: ReadonlyMap<string, SimpleNodeSchema>,
 	typeMap: Map<string, Zod.ZodTypeAny>,
@@ -362,6 +435,7 @@ function getTypeForAllowedTypes(
 		);
 	}
 }
+
 function tryGetSingleton<T>(set: ReadonlySet<T>): T | undefined {
 	if (set.size === 1) {
 		for (const item of set) {
@@ -369,6 +443,26 @@ function tryGetSingleton<T>(set: ReadonlySet<T>): T | undefined {
 		}
 	}
 }
+
 function hasAtLeastTwo<T>(array: T[]): array is [T, T, ...T[]] {
 	return array.length >= 2;
+}
+
+/**
+ * Determines if the provided {@link TreeNode} contains an array schema.
+ */
+export function doesNodeContainArraySchema(node: TreeNode): boolean {
+	const schema = Tree.schema(node);
+	const simpleSchema = getSimpleSchema(schema);
+
+	const definitionMap = simpleSchema.definitions;
+
+	for (const name of simpleSchema.definitions.keys()) {
+		const nodeSchema = definitionMap.get(name) ?? fail("Unexpected definition");
+		if (nodeSchema.kind === NodeKind.Array) {
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/packages/framework/ai-collab/src/explicit-strategy/typeGeneration.ts
+++ b/packages/framework/ai-collab/src/explicit-strategy/typeGeneration.ts
@@ -411,11 +411,7 @@ function hasAtLeastTwo<T>(array: T[]): array is [T, T, ...T[]] {
 export function doesNodeContainArraySchema(node: TreeNode): boolean {
 	const schema = Tree.schema(node);
 	const simpleSchema = getSimpleSchema(schema);
-
-	const definitionMap = simpleSchema.definitions;
-
-	for (const name of simpleSchema.definitions.keys()) {
-		const nodeSchema = definitionMap.get(name) ?? fail("Unexpected definition");
+	for (const [, nodeSchema] of simpleSchema.definitions) {
 		if (nodeSchema.kind === NodeKind.Array) {
 			return true;
 		}

--- a/packages/framework/ai-collab/src/test/ai-collab/taskPlanner.spec.ts
+++ b/packages/framework/ai-collab/src/test/ai-collab/taskPlanner.spec.ts
@@ -169,8 +169,8 @@ const factory = SharedTree.getFactory();
 
 const OPENAI_API_KEY = "";
 
-describe("Ai Planner App", () => {
-	it.skip("should be able to change the priority of a task", async () => {
+describe.skip("Ai Planner App", () => {
+	it("should be able to change the priority of a task", async () => {
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
@@ -198,9 +198,9 @@ describe("Ai Planner App", () => {
 		});
 
 		assert(view.root.taskGroups[0]?.tasks[0]?.priority === "high");
-	});
+	}).timeout(60000);
 
-	it.skip("Using a tree node without any array in its schema now succeeds (BUG FIX regression)", async () => {
+	it("BUG FIX REGRESSION: Using a tree node without any array in its schema now succeeds ", async () => {
 		class TestAppSchema extends sf.object("PrioritySpecification", {
 			priority: sf.string,
 		}) {}
@@ -280,7 +280,7 @@ describe("Ai Planner App", () => {
 					"400 Invalid schema for response_format 'SharedTreeAI'. Please ensure it is a valid JSON Schema.",
 			);
 		}
-	});
+	}).timeout(60000);
 
 	it.skip("BUG: OpenAI structured output fails when json schema with psuedo optional field is used in response format", async () => {
 		class TaskList extends sf.array("taskList", sf.string) {}
@@ -359,5 +359,5 @@ describe("Ai Planner App", () => {
 		});
 
 		assert.equal(view.root.nonOptionalProp, "Hello World");
-	});
+	}).timeout(60000);
 });

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_Nested_Array_Schema_But_No_Top_Level_Array.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_Nested_Array_Schema_But_No_Top_Level_Array.snap
@@ -1,8 +1,8 @@
 ---
-Generated on: 2024-12-04T17:43:56.128Z
+Generated on: 2024-12-04T17:49:05.123Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
-Test Title: Editing System Prompt with plan and populated edit log has no regression
+Test Title: Editing System Prompt with tree node with no array schema property but has child node that does should contain array types
 ---
 
 You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
@@ -19,7 +19,7 @@ interface Modify {
     type: "modify";
     explanation: string; // A description of what this edit is meant to accomplish in human readable English
     target: ObjectTarget; // A pointer to a specific object node in the tree, identified by the target object's Id.
-    field: "title" | "description" | "completed";
+    field: "childNodeProperty" | "title" | "description" | "completed";
     modification: any; // Domain-specific content here
 }
 
@@ -71,14 +71,11 @@ interface EditWrapper {
     edit: Insert | Remove | Move | Modify | null; // The next edit to apply to the tree, or null if the task is complete.
 }
 
-	The tree is a JSON object with the following schema: interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }
-	You have made a plan to accomplish the user's goal. The plan is: "Change the completed field to false for the todo at index 0 in the list of todos". You will perform one or more edits that correspond to that plan to accomplish the goal.
-	You have already performed the following edits:
-			1. {"type":"modify","explanation":"Change the completed field to false for the todo at index 0 in the list of todos","target":{"target":"Todo1"},"field":"complete","modification":false} This edit produced an error, and was discarded. The error message was: "Expected field schema"
-2. {"type":"modify","explanation":"Change the completed field to false for the todo at index 0 in the list of todos","target":{"target":"Todo1"},"field":"completed","modification":false}
-			This means that the current state of the tree reflects these changes.
-	The current state of the tree is: {"__fluid_objectId":"TestTodoAppSchema1","title":"My First Todo List","description":"This is a list of todos","todos":[{"__fluid_objectId":"Todo1","title":"Task 1","completed":false},{"__fluid_objectId":"Todo2","title":"Task 2","completed":true}]}.
-	Before you made the above edits the user requested you accomplish the following goal:
+	The tree is a JSON object with the following schema: interface TestWrapperNode { childNodeProperty: TestTodoAppSchema; } interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }
+	
+	
+	The current state of the tree is: {"__fluid_objectId":"TestWrapperNode1","childNodeProperty":{"__fluid_objectId":"TestTodoAppSchema1","title":"My First Todo List","description":"This is a list of todos","todos":[{"__fluid_objectId":"Todo1","title":"Task 1","completed":true},{"__fluid_objectId":"Todo2","title":"Task 2","completed":true}]}}.
+	The user requested you accomplish the following goal:
 	"Change the completed to false for the first task and create a new edit"
 	If the goal is now completed or is impossible, you should return null.
 	Otherwise, you should create an edit that makes progress towards the goal. It should have an English description ("explanation") of which edit to perform (specifying one of the allowed edit types).

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_Nested_Array_Schema_But_No_Top_Level_Array.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_Nested_Array_Schema_But_No_Top_Level_Array.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-12-04T17:49:05.123Z
+Generated on: 2024-12-04T19:06:02.116Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt with tree node with no array schema property but has child node that does should contain array types
@@ -7,8 +7,9 @@ Test Title: Editing System Prompt with tree node with no array schema property b
 
 You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
 The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
-Edits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which contains one of the following interfaces: "Insert", "Modify", "Remove", "Move", or null:
+Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move"..
 	
+Here are the schema definitions for an edit:
 // A pointer to a specific object node in the tree, identified by the target object's Id.
 interface ObjectTarget {
     target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced
@@ -70,6 +71,7 @@ interface Move {
 interface EditWrapper {
     edit: Insert | Remove | Move | Modify | null; // The next edit to apply to the tree, or null if the task is complete.
 }
+
 
 	The tree is a JSON object with the following schema: interface TestWrapperNode { childNodeProperty: TestTodoAppSchema; } interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }
 	

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_Nested_Array_Schema_But_No_Top_Level_Array.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_Nested_Array_Schema_But_No_Top_Level_Array.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-12-04T19:06:02.116Z
+Generated on: 2024-12-04T19:14:12.299Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt with tree node with no array schema property but has child node that does should contain array types
@@ -7,7 +7,7 @@ Test Title: Editing System Prompt with tree node with no array schema property b
 
 You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
 The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
-Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move"..
+Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move".
 	
 Here are the schema definitions for an edit:
 // A pointer to a specific object node in the tree, identified by the target object's Id.

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log.snap
@@ -1,0 +1,81 @@
+---
+Generated on: 2024-11-27T18:26:23.039Z
+description: This is a snapshot file utilized for testing purposes.
+Test Suite Title: Prompt Generation Regression Tests
+Test Title: Editing System Prompt with no plan and empty edit log has no regression
+---
+
+You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
+The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
+Edits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which contains one of the following interfaces: "Insert", "Modify", "Remove", "Move", or null:
+	
+// A pointer to a specific object in the tree.
+interface ObjectTarget {
+    target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced
+}
+
+// Sets a field on a specific ObjectTarget.
+interface Modify {
+    type: "modify";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    target: ObjectTarget; // A pointer to a specific object in the tree.
+    field: "title" | "description" | "completed";
+    modification: any; // Domain-specific content here
+}
+
+// A pointer to a location either just before or just after an object that is in an array
+interface ObjectPlace {
+    type: "objectPlace";
+    target: string; // The id (__fluid_objectId) of the object that the new/moved object should be placed relative to. This must be the id of an object that already existed in the tree content that was originally supplied.
+    place: "before" | "after"; // Where the new/moved object will be relative to the target object - either just before or just after
+}
+
+// either the "start" or "end" of an array, as specified by a "parent" ObjectTarget and a "field" name under which the array is stored (useful for prepending or appending)
+interface ArrayPlace {
+    type: "arrayPlace";
+    parentId: string; // The id (__fluid_objectId) of the parent object of the array. This must be the id of an object that already existed in the tree content that was originally supplied.
+    field: string; // The key of the array to insert into
+    location: "start" | "end"; // Where to insert into the array - either the start or the end
+}
+
+// A range of objects in the same array specified by a "from" and "to" Place. The "to" and "from" objects MUST be in the same array.
+interface Range {
+    from: ObjectPlace; // A pointer to a location either just before or just after an object that is in an array
+    to: ObjectPlace; // A pointer to a location either just before or just after an object that is in an array
+}
+
+// Inserts a new object at a specific Place or ArrayPlace.
+interface Insert {
+    type: "insert";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    content: any; // Domain-specific content here
+    destination: ArrayPlace | ObjectPlace;
+}
+
+// Deletes an object or Range of objects from the tree.
+interface Remove {
+    type: "remove";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    source: ObjectTarget | Range;
+}
+
+// Moves an object or Range of objects to a new Place or ArrayPlace.
+interface Move {
+    type: "move";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    source: ObjectTarget | Range;
+    destination: ArrayPlace | ObjectPlace;
+}
+
+interface EditWrapper {
+    edit: Insert | Remove | Move | Modify | null; // The next edit to apply to the tree, or null if the task is complete.
+}
+
+	The tree is a JSON object with the following schema: interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }
+	
+	
+	The current state of the tree is: {"__fluid_objectId":"TestTodoAppSchema1","title":"My First Todo List","description":"This is a list of todos","todos":[{"__fluid_objectId":"Todo1","title":"Task 1","completed":true},{"__fluid_objectId":"Todo2","title":"Task 2","completed":true}]}.
+	The user requested you accomplish the following goal:
+	"Change the completed to false for the first task and create a new edit"
+	If the goal is now completed or is impossible, you should return null.
+	Otherwise, you should create an edit that makes progress towards the goal. It should have an English description ("explanation") of which edit to perform (specifying one of the allowed edit types).

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-12-04T17:43:56.109Z
+Generated on: 2024-12-04T19:06:02.105Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt with no plan and empty edit log has no regression
@@ -7,8 +7,9 @@ Test Title: Editing System Prompt with no plan and empty edit log has no regress
 
 You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
 The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
-Edits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which contains one of the following interfaces: "Insert", "Modify", "Remove", "Move", or null:
+Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move"..
 	
+Here are the schema definitions for an edit:
 // A pointer to a specific object node in the tree, identified by the target object's Id.
 interface ObjectTarget {
     target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced
@@ -70,6 +71,7 @@ interface Move {
 interface EditWrapper {
     edit: Insert | Remove | Move | Modify | null; // The next edit to apply to the tree, or null if the task is complete.
 }
+
 
 	The tree is a JSON object with the following schema: interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }
 	

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-12-04T19:06:02.105Z
+Generated on: 2024-12-04T19:14:12.288Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt with no plan and empty edit log has no regression
@@ -7,7 +7,7 @@ Test Title: Editing System Prompt with no plan and empty edit log has no regress
 
 You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
 The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
-Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move"..
+Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move".
 	
 Here are the schema definitions for an edit:
 // A pointer to a specific object node in the tree, identified by the target object's Id.

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-11-27T18:26:23.039Z
+Generated on: 2024-12-04T17:43:56.109Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt with no plan and empty edit log has no regression
@@ -9,7 +9,7 @@ You are a collaborative agent who interacts with a JSON tree by performing edits
 The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
 Edits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which contains one of the following interfaces: "Insert", "Modify", "Remove", "Move", or null:
 	
-// A pointer to a specific object in the tree.
+// A pointer to a specific object node in the tree, identified by the target object's Id.
 interface ObjectTarget {
     target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced
 }
@@ -18,7 +18,7 @@ interface ObjectTarget {
 interface Modify {
     type: "modify";
     explanation: string; // A description of what this edit is meant to accomplish in human readable English
-    target: ObjectTarget; // A pointer to a specific object in the tree.
+    target: ObjectTarget; // A pointer to a specific object node in the tree, identified by the target object's Id.
     field: "title" | "description" | "completed";
     modification: any; // Domain-specific content here
 }

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log_No_Arrays.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log_No_Arrays.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-12-04T17:43:56.136Z
+Generated on: 2024-12-04T19:06:02.146Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt created with node containing no arrays has no regression
@@ -7,8 +7,9 @@ Test Title: Editing System Prompt created with node containing no arrays has no 
 
 You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
 The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
-Edits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which contains the interface "Modify" or null:
+Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains the interface "Modify" or null.
 	
+Here are the schema definitions for an edit:
 // A pointer to a specific object node in the tree, identified by the target object's Id.
 interface ObjectTarget {
     target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced
@@ -26,6 +27,7 @@ interface Modify {
 interface EditWrapper {
     edit: Modify | null; // The next edit to apply to the tree, or null if the task is complete.
 }
+
 
 	The tree is a JSON object with the following schema: interface Todo { title: string; completed: boolean; }
 	

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log_No_Arrays.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log_No_Arrays.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-11-27T18:26:23.075Z
+Generated on: 2024-12-04T17:43:56.136Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt created with node containing no arrays has no regression
@@ -9,7 +9,7 @@ You are a collaborative agent who interacts with a JSON tree by performing edits
 The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
 Edits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which contains the interface "Modify" or null:
 	
-// A pointer to a specific object in the tree.
+// A pointer to a specific object node in the tree, identified by the target object's Id.
 interface ObjectTarget {
     target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced
 }
@@ -18,7 +18,7 @@ interface ObjectTarget {
 interface Modify {
     type: "modify";
     explanation: string; // A description of what this edit is meant to accomplish in human readable English
-    target: ObjectTarget; // A pointer to a specific object in the tree.
+    target: ObjectTarget; // A pointer to a specific object node in the tree, identified by the target object's Id.
     field: "title" | "completed";
     modification: any; // Domain-specific content here
 }

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log_No_Arrays.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log_No_Arrays.snap
@@ -1,0 +1,37 @@
+---
+Generated on: 2024-11-27T18:26:23.075Z
+description: This is a snapshot file utilized for testing purposes.
+Test Suite Title: Prompt Generation Regression Tests
+Test Title: Editing System Prompt created with node containing no arrays has no regression
+---
+
+You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
+The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
+Edits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which contains the interface "Modify" or null:
+	
+// A pointer to a specific object in the tree.
+interface ObjectTarget {
+    target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced
+}
+
+// Sets a field on a specific ObjectTarget.
+interface Modify {
+    type: "modify";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    target: ObjectTarget; // A pointer to a specific object in the tree.
+    field: "title" | "completed";
+    modification: any; // Domain-specific content here
+}
+
+interface EditWrapper {
+    edit: Modify | null; // The next edit to apply to the tree, or null if the task is complete.
+}
+
+	The tree is a JSON object with the following schema: interface Todo { title: string; completed: boolean; }
+	
+	
+	The current state of the tree is: {"__fluid_objectId":"Todo1","title":"Task 1","completed":true}.
+	The user requested you accomplish the following goal:
+	"Change the completed to false for the first task and create a new edit"
+	If the goal is now completed or is impossible, you should return null.
+	Otherwise, you should create an edit that makes progress towards the goal. It should have an English description ("explanation") of which edit to perform (specifying one of the allowed edit types).

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log_No_Arrays.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_No_Plan_No_Log_No_Arrays.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-12-04T19:06:02.146Z
+Generated on: 2024-12-04T19:14:12.326Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt created with node containing no arrays has no regression

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_No_Log.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_No_Log.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-11-27T18:26:23.047Z
+Generated on: 2024-12-04T17:43:56.118Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt with plan and empty edit log has no regression
@@ -9,7 +9,7 @@ You are a collaborative agent who interacts with a JSON tree by performing edits
 The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
 Edits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which contains one of the following interfaces: "Insert", "Modify", "Remove", "Move", or null:
 	
-// A pointer to a specific object in the tree.
+// A pointer to a specific object node in the tree, identified by the target object's Id.
 interface ObjectTarget {
     target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced
 }
@@ -18,7 +18,7 @@ interface ObjectTarget {
 interface Modify {
     type: "modify";
     explanation: string; // A description of what this edit is meant to accomplish in human readable English
-    target: ObjectTarget; // A pointer to a specific object in the tree.
+    target: ObjectTarget; // A pointer to a specific object node in the tree, identified by the target object's Id.
     field: "title" | "description" | "completed";
     modification: any; // Domain-specific content here
 }

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_No_Log.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_No_Log.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-12-04T19:06:02.126Z
+Generated on: 2024-12-04T19:14:12.307Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt with plan and empty edit log has no regression
@@ -7,7 +7,7 @@ Test Title: Editing System Prompt with plan and empty edit log has no regression
 
 You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
 The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
-Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move"..
+Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move".
 	
 Here are the schema definitions for an edit:
 // A pointer to a specific object node in the tree, identified by the target object's Id.

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_No_Log.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_No_Log.snap
@@ -1,0 +1,81 @@
+---
+Generated on: 2024-11-27T18:26:23.047Z
+description: This is a snapshot file utilized for testing purposes.
+Test Suite Title: Prompt Generation Regression Tests
+Test Title: Editing System Prompt with plan and empty edit log has no regression
+---
+
+You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
+The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
+Edits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which contains one of the following interfaces: "Insert", "Modify", "Remove", "Move", or null:
+	
+// A pointer to a specific object in the tree.
+interface ObjectTarget {
+    target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced
+}
+
+// Sets a field on a specific ObjectTarget.
+interface Modify {
+    type: "modify";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    target: ObjectTarget; // A pointer to a specific object in the tree.
+    field: "title" | "description" | "completed";
+    modification: any; // Domain-specific content here
+}
+
+// A pointer to a location either just before or just after an object that is in an array
+interface ObjectPlace {
+    type: "objectPlace";
+    target: string; // The id (__fluid_objectId) of the object that the new/moved object should be placed relative to. This must be the id of an object that already existed in the tree content that was originally supplied.
+    place: "before" | "after"; // Where the new/moved object will be relative to the target object - either just before or just after
+}
+
+// either the "start" or "end" of an array, as specified by a "parent" ObjectTarget and a "field" name under which the array is stored (useful for prepending or appending)
+interface ArrayPlace {
+    type: "arrayPlace";
+    parentId: string; // The id (__fluid_objectId) of the parent object of the array. This must be the id of an object that already existed in the tree content that was originally supplied.
+    field: string; // The key of the array to insert into
+    location: "start" | "end"; // Where to insert into the array - either the start or the end
+}
+
+// A range of objects in the same array specified by a "from" and "to" Place. The "to" and "from" objects MUST be in the same array.
+interface Range {
+    from: ObjectPlace; // A pointer to a location either just before or just after an object that is in an array
+    to: ObjectPlace; // A pointer to a location either just before or just after an object that is in an array
+}
+
+// Inserts a new object at a specific Place or ArrayPlace.
+interface Insert {
+    type: "insert";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    content: any; // Domain-specific content here
+    destination: ArrayPlace | ObjectPlace;
+}
+
+// Deletes an object or Range of objects from the tree.
+interface Remove {
+    type: "remove";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    source: ObjectTarget | Range;
+}
+
+// Moves an object or Range of objects to a new Place or ArrayPlace.
+interface Move {
+    type: "move";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    source: ObjectTarget | Range;
+    destination: ArrayPlace | ObjectPlace;
+}
+
+interface EditWrapper {
+    edit: Insert | Remove | Move | Modify | null; // The next edit to apply to the tree, or null if the task is complete.
+}
+
+	The tree is a JSON object with the following schema: interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }
+	You have made a plan to accomplish the user's goal. The plan is: "Change the completed field to false for the todo at index 0 in the list of todos". You will perform one or more edits that correspond to that plan to accomplish the goal.
+	
+	The current state of the tree is: {"__fluid_objectId":"TestTodoAppSchema1","title":"My First Todo List","description":"This is a list of todos","todos":[{"__fluid_objectId":"Todo1","title":"Task 1","completed":true},{"__fluid_objectId":"Todo2","title":"Task 2","completed":true}]}.
+	The user requested you accomplish the following goal:
+	"Change the completed to false for the first task and create a new edit"
+	If the goal is now completed or is impossible, you should return null.
+	Otherwise, you should create an edit that makes progress towards the goal. It should have an English description ("explanation") of which edit to perform (specifying one of the allowed edit types).

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_No_Log.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_No_Log.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-12-04T17:43:56.118Z
+Generated on: 2024-12-04T19:06:02.126Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt with plan and empty edit log has no regression
@@ -7,8 +7,9 @@ Test Title: Editing System Prompt with plan and empty edit log has no regression
 
 You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
 The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
-Edits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which contains one of the following interfaces: "Insert", "Modify", "Remove", "Move", or null:
+Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move"..
 	
+Here are the schema definitions for an edit:
 // A pointer to a specific object node in the tree, identified by the target object's Id.
 interface ObjectTarget {
     target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced
@@ -70,6 +71,7 @@ interface Move {
 interface EditWrapper {
     edit: Insert | Remove | Move | Modify | null; // The next edit to apply to the tree, or null if the task is complete.
 }
+
 
 	The tree is a JSON object with the following schema: interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }
 	You have made a plan to accomplish the user's goal. The plan is: "Change the completed field to false for the todo at index 0 in the list of todos". You will perform one or more edits that correspond to that plan to accomplish the goal.

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_With_Log.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_With_Log.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-12-04T19:06:02.136Z
+Generated on: 2024-12-04T19:14:12.318Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt with plan and populated edit log has no regression
@@ -7,7 +7,7 @@ Test Title: Editing System Prompt with plan and populated edit log has no regres
 
 You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
 The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
-Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move"..
+Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move".
 	
 Here are the schema definitions for an edit:
 // A pointer to a specific object node in the tree, identified by the target object's Id.

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_With_Log.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_With_Log.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-12-04T17:43:56.128Z
+Generated on: 2024-12-04T19:06:02.136Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Editing System Prompt with plan and populated edit log has no regression
@@ -7,8 +7,9 @@ Test Title: Editing System Prompt with plan and populated edit log has no regres
 
 You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
 The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
-Edits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which contains one of the following interfaces: "Insert", "Modify", "Remove", "Move", or null:
+Edits are JSON objects that conform to the schema described below. The top-level object you produce for a given edit is an "EditWrapper" object which contains one of the following interfaces: "Modify", null or an array node only edit: "Insert", "Remove", "Move"..
 	
+Here are the schema definitions for an edit:
 // A pointer to a specific object node in the tree, identified by the target object's Id.
 interface ObjectTarget {
     target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced
@@ -70,6 +71,7 @@ interface Move {
 interface EditWrapper {
     edit: Insert | Remove | Move | Modify | null; // The next edit to apply to the tree, or null if the task is complete.
 }
+
 
 	The tree is a JSON object with the following schema: interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }
 	You have made a plan to accomplish the user's goal. The plan is: "Change the completed field to false for the todo at index 0 in the list of todos". You will perform one or more edits that correspond to that plan to accomplish the goal.

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_With_Log.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Editing_System_Prompt_With_Plan_With_Log.snap
@@ -1,0 +1,84 @@
+---
+Generated on: 2024-11-27T18:26:23.058Z
+description: This is a snapshot file utilized for testing purposes.
+Test Suite Title: Prompt Generation Regression Tests
+Test Title: Editing System Prompt with plan and populated edit log has no regression
+---
+
+You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
+The application that owns the JSON tree has the following guidance about your role: "You're a helpful AI assistant".
+Edits are JSON objects that conform to the following schema of which the top level object you produce is an "EditWrapper" object which contains one of the following interfaces: "Insert", "Modify", "Remove", "Move", or null:
+	
+// A pointer to a specific object in the tree.
+interface ObjectTarget {
+    target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced
+}
+
+// Sets a field on a specific ObjectTarget.
+interface Modify {
+    type: "modify";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    target: ObjectTarget; // A pointer to a specific object in the tree.
+    field: "title" | "description" | "completed";
+    modification: any; // Domain-specific content here
+}
+
+// A pointer to a location either just before or just after an object that is in an array
+interface ObjectPlace {
+    type: "objectPlace";
+    target: string; // The id (__fluid_objectId) of the object that the new/moved object should be placed relative to. This must be the id of an object that already existed in the tree content that was originally supplied.
+    place: "before" | "after"; // Where the new/moved object will be relative to the target object - either just before or just after
+}
+
+// either the "start" or "end" of an array, as specified by a "parent" ObjectTarget and a "field" name under which the array is stored (useful for prepending or appending)
+interface ArrayPlace {
+    type: "arrayPlace";
+    parentId: string; // The id (__fluid_objectId) of the parent object of the array. This must be the id of an object that already existed in the tree content that was originally supplied.
+    field: string; // The key of the array to insert into
+    location: "start" | "end"; // Where to insert into the array - either the start or the end
+}
+
+// A range of objects in the same array specified by a "from" and "to" Place. The "to" and "from" objects MUST be in the same array.
+interface Range {
+    from: ObjectPlace; // A pointer to a location either just before or just after an object that is in an array
+    to: ObjectPlace; // A pointer to a location either just before or just after an object that is in an array
+}
+
+// Inserts a new object at a specific Place or ArrayPlace.
+interface Insert {
+    type: "insert";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    content: any; // Domain-specific content here
+    destination: ArrayPlace | ObjectPlace;
+}
+
+// Deletes an object or Range of objects from the tree.
+interface Remove {
+    type: "remove";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    source: ObjectTarget | Range;
+}
+
+// Moves an object or Range of objects to a new Place or ArrayPlace.
+interface Move {
+    type: "move";
+    explanation: string; // A description of what this edit is meant to accomplish in human readable English
+    source: ObjectTarget | Range;
+    destination: ArrayPlace | ObjectPlace;
+}
+
+interface EditWrapper {
+    edit: Insert | Remove | Move | Modify | null; // The next edit to apply to the tree, or null if the task is complete.
+}
+
+	The tree is a JSON object with the following schema: interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }
+	You have made a plan to accomplish the user's goal. The plan is: "Change the completed field to false for the todo at index 0 in the list of todos". You will perform one or more edits that correspond to that plan to accomplish the goal.
+	You have already performed the following edits:
+			1. {"type":"modify","explanation":"Change the completed field to false for the todo at index 0 in the list of todos","target":{"target":"Todo1"},"field":"complete","modification":false} This edit produced an error, and was discarded. The error message was: "Expected field schema"
+2. {"type":"modify","explanation":"Change the completed field to false for the todo at index 0 in the list of todos","target":{"target":"Todo1"},"field":"completed","modification":false}
+			This means that the current state of the tree reflects these changes.
+	The current state of the tree is: {"__fluid_objectId":"TestTodoAppSchema1","title":"My First Todo List","description":"This is a list of todos","todos":[{"__fluid_objectId":"Todo1","title":"Task 1","completed":false},{"__fluid_objectId":"Todo2","title":"Task 2","completed":true}]}.
+	Before you made the above edits the user requested you accomplish the following goal:
+	"Change the completed to false for the first task and create a new edit"
+	If the goal is now completed or is impossible, you should return null.
+	Otherwise, you should create an edit that makes progress towards the goal. It should have an English description ("explanation") of which edit to perform (specifying one of the allowed edit types).

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Planning_System_Prompt.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Planning_System_Prompt.snap
@@ -1,0 +1,16 @@
+---
+Generated on: 2024-11-27T18:26:23.026Z
+description: This is a snapshot file utilized for testing purposes.
+Test Suite Title: Prompt Generation Regression Tests
+Test Title: Planning Prompt has no regression
+---
+
+I'm an agent who makes plans for another agent to achieve a user-specified goal to update the state of an application.
+			The other agent follows this guidance: You're a helpful AI assistant
+	The application state tree is a JSON object with the following schema: interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }
+	The current state is: {"title":"My First Todo List","description":"This is a list of todos","todos":[{"title":"Task 1","completed":true},{"title":"Task 2","completed":true}]}.
+	The user requested that I accomplish the following goal:
+	"Change the completed to false for the first task and create a new edit"
+	I've made a plan to accomplish this goal by doing a sequence of edits to the tree.
+	Edits can include inserting, modifying, removing, or moving elements in the tree.
+	Here is my plan:

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Planning_System_Prompt.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Planning_System_Prompt.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-11-27T18:26:23.026Z
+Generated on: 2024-12-04T17:43:56.097Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Planning Prompt has no regression

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Planning_System_Prompt.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Planning_System_Prompt.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-12-04T17:43:56.097Z
+Generated on: 2024-12-04T17:59:27.783Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Planning Prompt has no regression
@@ -12,5 +12,5 @@ I'm an agent who makes plans for another agent to achieve a user-specified goal 
 	The user requested that I accomplish the following goal:
 	"Change the completed to false for the first task and create a new edit"
 	I've made a plan to accomplish this goal by doing a sequence of edits to the tree.
-	Edits can include inserting, modifying, removing, or moving elements in the tree.
+	Edits can include modifying as well as inserting, removing, or moving elements in the tree.
 	Here is my plan:

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Review_System_Prompt.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Review_System_Prompt.snap
@@ -1,0 +1,17 @@
+---
+Generated on: 2024-11-27T18:26:23.099Z
+description: This is a snapshot file utilized for testing purposes.
+Test Suite Title: Prompt Generation Regression Tests
+Test Title: Review System Prompt has no regression
+---
+
+You are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.
+			The application that owns the JSON tree has the following guidance: You're a helpful AI assistant
+	You have performed a number of actions already to accomplish a user request.
+	You must review the resulting state to determine if the actions you performed successfully accomplished the user's goal.
+	The tree is a JSON object with the following schema: interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }
+	The state of the tree BEFORE changes was: {"__fluid_objectId":"TestTodoAppSchema1","title":"My First Todo List","description":"This is a list of todos","todos":[{"__fluid_objectId":"Todo1","title":"Task 1","completed":true},{"__fluid_objectId":"Todo2","title":"Task 2","completed":true}]}.
+	The state of the tree AFTER changes is: {"__fluid_objectId":"TestTodoAppSchema1","title":"My First Todo List","description":"This is a list of todos","todos":[{"__fluid_objectId":"Todo1","title":"Task 1","completed":false},{"__fluid_objectId":"Todo2","title":"Task 2","completed":true}]}.
+	The user requested that the following goal should be accomplished:
+	Change the completed to false for the first task and create a new edit
+	Was the goal accomplished?

--- a/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Review_System_Prompt.snap
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/__snapshots__/Prompt_Regression_Snapshot_Tests/Review_System_Prompt.snap
@@ -1,5 +1,5 @@
 ---
-Generated on: 2024-11-27T18:26:23.099Z
+Generated on: 2024-12-04T17:43:56.147Z
 description: This is a snapshot file utilized for testing purposes.
 Test Suite Title: Prompt Generation Regression Tests
 Test Title: Review System Prompt has no regression

--- a/packages/framework/ai-collab/src/test/explicit-strategy/promptGeneration.spec.ts
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/promptGeneration.spec.ts
@@ -9,22 +9,24 @@ import { strict as assert } from "node:assert";
 import { createIdCompressor } from "@fluidframework/id-compressor/internal";
 // eslint-disable-next-line import/no-internal-modules
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
+// eslint-disable-next-line import/order
 import {
 	getSimpleSchema,
 	SchemaFactory,
 	SharedTree,
 	Tree,
 	TreeViewConfiguration,
-	type TreeNode,
 	// eslint-disable-next-line import/no-internal-modules
 } from "@fluidframework/tree/internal";
+
+// eslint-disable-next-line import/no-internal-modules
+import { describe, it } from "mocha";
 
 // eslint-disable-next-line import/no-internal-modules
 import { applyAgentEdit } from "../../explicit-strategy/agentEditReducer.js";
 // eslint-disable-next-line import/no-internal-modules
 import { IdGenerator } from "../../explicit-strategy/idGenerator.js";
 import {
-	createEditListHistoryPrompt,
 	getEditingSystemPrompt,
 	getPlanningSystemPrompt,
 	getReviewSystemPrompt,
@@ -32,6 +34,8 @@ import {
 	type EditLog,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../explicit-strategy/promptGeneration.js";
+
+import { MochaSnapshotUnitTester } from "./utils.js";
 
 const factory = SharedTree.getFactory();
 const sf = new SchemaFactory("test");
@@ -77,6 +81,11 @@ const initialAppState = {
 // which are imperitive to be caught as even small changes can lead to incorrect LLM behavior.
 describe("Prompt Generation Regression Tests", () => {
 	let idGenerator: IdGenerator;
+	const snapShotTester = new MochaSnapshotUnitTester(
+		`${process.cwd()}/src/test/explicit-strategy`,
+		"Prompt_Regression_Snapshot_Tests",
+	);
+
 	beforeEach(() => {
 		idGenerator = new IdGenerator();
 	});
@@ -85,104 +94,7 @@ describe("Prompt Generation Regression Tests", () => {
 	const systemRoleContext = "You're a helpful AI assistant";
 	const plan =
 		"Change the completed field to false for the todo at index 0 in the list of todos";
-
-	const getExpectedEditingSystemPrompt = (params: {
-		plan?: string;
-		userAsk: string;
-		editLog: EditLog;
-		treeNode: TreeNode;
-	}): string[] => {
-		return [
-			"",
-			"\tYou are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.",
-			"\t\t\tThe application that owns the JSON tree has the following guidance about your role: You're a helpful AI assistant",
-			"\tEdits are JSON objects that conform to the following schema.",
-			'\tThe top level object you produce is an "EditWrapper" object which contains one of "Insert", "Modify", "Remove", "Move", or null.',
-			"\tinterface ObjectTarget {",
-			"    target: string; // The id of the object (as specified by the object's __fluid_objectId property) that is being referenced",
-			"}",
-			"",
-			"// A pointer to a location either just before or just after an object that is in an array",
-			"interface ObjectPlace {",
-			'    type: "objectPlace";',
-			"    target: string; // The id (__fluid_objectId) of the object that the new/moved object should be placed relative to. This must be the id of an object that already existed in the tree content that was originally supplied.",
-			'    place: "before" | "after"; // Where the new/moved object will be relative to the target object - either just before or just after',
-			"}",
-			"",
-			'// either the "start" or "end" of an array, as specified by a "parent" ObjectTarget and a "field" name under which the array is stored (useful for prepending or appending)',
-			"interface ArrayPlace {",
-			'    type: "arrayPlace";',
-			"    parentId: string; // The id (__fluid_objectId) of the parent object of the array. This must be the id of an object that already existed in the tree content that was originally supplied.",
-			"    field: string; // The key of the array to insert into",
-			'    location: "start" | "end"; // Where to insert into the array - either the start or the end',
-			"}",
-			"",
-			'// A range of objects in the same array specified by a "from" and "to" Place. The "to" and "from" objects MUST be in the same array.',
-			"interface Range {",
-			"    from: ObjectPlace; // A pointer to a location either just before or just after an object that is in an array",
-			"    to: ObjectPlace; // A pointer to a location either just before or just after an object that is in an array",
-			"}",
-			"",
-			"// Inserts a new object at a specific Place or ArrayPlace.",
-			"interface Insert {",
-			'    type: "insert";',
-			"    explanation: string; // A description of what this edit is meant to accomplish in human readable English",
-			"    content: any; // Domain-specific content here",
-			"    destination: ArrayPlace | ObjectPlace;",
-			"}",
-			"",
-			"// Deletes an object or Range of objects from the tree.",
-			"interface Remove {",
-			'    type: "remove";',
-			"    explanation: string; // A description of what this edit is meant to accomplish in human readable English",
-			"    source: ObjectTarget | Range;",
-			"}",
-			"",
-			"// Moves an object or Range of objects to a new Place or ArrayPlace.",
-			"interface Move {",
-			'    type: "move";',
-			"    explanation: string; // A description of what this edit is meant to accomplish in human readable English",
-			"    source: ObjectTarget | Range;",
-			"    destination: ArrayPlace | ObjectPlace;",
-			"}",
-			"",
-			"// Sets a field on a specific ObjectTarget.",
-			"interface Modify {",
-			'    type: "modify";',
-			"    explanation: string; // A description of what this edit is meant to accomplish in human readable English",
-			"    target: ObjectTarget;",
-			'    field: "title" | "description" | "completed";',
-			"    modification: any; // Domain-specific content here",
-			"}",
-			"",
-			"interface EditWrapper {",
-			"    edit: Insert | Remove | Move | Modify | null; // The next edit to apply to the tree, or null if the task is complete.",
-			"}",
-			"",
-			"\tThe tree is a JSON object with the following schema: interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }",
-			params.plan === undefined
-				? "\t"
-				: `\tYou have made a plan to accomplish the user's goal. The plan is: "${params.plan}". You will perform one or more edits that correspond to that plan to accomplish the goal.`,
-			...(params.editLog?.length === 0
-				? ["\t"]
-				: [
-						`\tYou have already performed the following edits:`,
-						`\t\t\t${createEditListHistoryPrompt(params.editLog).split("\n")[0]}`,
-						...(params.editLog.length > 1
-							? createEditListHistoryPrompt(params.editLog).split("\n").slice(1)
-							: []),
-						`\t\t\tThis means that the current state of the tree reflects these changes.`,
-					]),
-
-			`\tThe current state of the tree is: ${toDecoratedJson(idGenerator, params.treeNode)}.`,
-			`${params.editLog.length > 0 ? "\tBefore you made the above edits t" : "\tT"}he user requested you accomplish the following goal:`,
-			`\t"${params.userAsk}"`,
-			"\tIf the goal is now completed or is impossible, you should return null.",
-			'\tOtherwise, you should create an edit that makes progress towards the goal. It should have an English description ("explanation") of which edit to perform (specifying one of the allowed edit types).',
-		];
-	};
-
-	it("Planning Prompt has no regression", () => {
+	it("Planning Prompt has no regression", function (this: Mocha.Context) {
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
@@ -190,27 +102,14 @@ describe("Prompt Generation Regression Tests", () => {
 		const view = tree.viewWith(new TreeViewConfiguration({ schema: TestTodoAppSchema }));
 		view.initialize(initialAppState);
 
-		const actualPrompt = getPlanningSystemPrompt(view.root, userAsk, systemRoleContext).split(
-			"\n",
-		);
+		const actualPrompt = getPlanningSystemPrompt(view.root, userAsk, systemRoleContext);
 
-		const expectedPrompt = [
-			"",
-			"\tI'm an agent who makes plans for another agent to achieve a user-specified goal to update the state of an application.",
-			"\t\t\tThe other agent follows this guidance: You're a helpful AI assistant",
-			"\tThe application state tree is a JSON object with the following schema: interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }",
-			'\tThe current state is: {"title":"My First Todo List","description":"This is a list of todos","todos":[{"title":"Task 1","completed":true},{"title":"Task 2","completed":true}]}.',
-			"\tThe user requested that I accomplish the following goal:",
-			`\t"${userAsk}"`,
-			"\tI've made a plan to accomplish this goal by doing a sequence of edits to the tree.",
-			"\tEdits can include setting the root, inserting, modifying, removing, or moving elements in the tree.",
-			"\tHere is my plan:",
-		];
-
-		assert.deepStrictEqual(actualPrompt, expectedPrompt);
+		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
+			fileNameOverride: "Planning_System_Prompt",
+		});
 	});
 
-	it("Editing System Prompt with no plan and empty edit log has no regression", () => {
+	it("Editing System Prompt with no plan and empty edit log has no regression", function (this: Mocha.Context) {
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
@@ -220,27 +119,20 @@ describe("Prompt Generation Regression Tests", () => {
 
 		idGenerator.assignIds(view.root);
 
-		const actualPromptWithEmptyEditLogAndNoPlan = getEditingSystemPrompt(
+		const actualPrompt = getEditingSystemPrompt(
 			userAsk,
 			idGenerator,
 			view.root,
 			[],
 			systemRoleContext,
-		).split("\n");
-
-		const expectedPromptWithEmptyEditLogAndNoPlan = getExpectedEditingSystemPrompt({
-			plan: undefined,
-			userAsk,
-			editLog: [],
-			treeNode: view.root,
-		});
-		assert.deepStrictEqual(
-			actualPromptWithEmptyEditLogAndNoPlan,
-			expectedPromptWithEmptyEditLogAndNoPlan,
 		);
+
+		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
+			fileNameOverride: "Editing_System_Prompt_No_Plan_No_Log",
+		});
 	});
 
-	it("Editing System Prompt with plan and empty edit log has no regression", () => {
+	it("Editing System Prompt with plan and empty edit log has no regression", function (this: Mocha.Context) {
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
@@ -249,28 +141,22 @@ describe("Prompt Generation Regression Tests", () => {
 		view.initialize(initialAppState);
 
 		idGenerator.assignIds(view.root);
-		const actualPromptWithEmptyEditLogAndPlan = getEditingSystemPrompt(
+
+		const actualPrompt = getEditingSystemPrompt(
 			userAsk,
 			idGenerator,
 			view.root,
 			[],
 			systemRoleContext,
 			plan,
-		).split("\n");
-		const expectedPromptWithEmptyEditLogAndPlan = getExpectedEditingSystemPrompt({
-			plan,
-			userAsk,
-			editLog: [],
-			treeNode: view.root,
-		});
-
-		assert.deepStrictEqual(
-			actualPromptWithEmptyEditLogAndPlan,
-			expectedPromptWithEmptyEditLogAndPlan,
 		);
+
+		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
+			fileNameOverride: "Editing_System_Prompt_With_Plan_No_Log",
+		});
 	});
 
-	it("Editing System Prompt with plan and populated edit log has no regression", () => {
+	it("Editing System Prompt with plan and populated edit log has no regression", function (this: Mocha.Context) {
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
@@ -316,25 +202,45 @@ describe("Prompt Generation Regression Tests", () => {
 			}
 		}
 
-		const actualPromptWithPlanAndEditLog = getEditingSystemPrompt(
+		const actualPrompt = getEditingSystemPrompt(
 			userAsk,
 			idGenerator,
 			view.root,
 			editLog,
 			systemRoleContext,
 			plan,
-		).split("\n");
+		);
 
-		const expectedPromptWithPlanAndEditLog = getExpectedEditingSystemPrompt({
-			plan,
-			userAsk,
-			editLog,
-			treeNode: view.root,
+		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
+			fileNameOverride: "Editing_System_Prompt_With_Plan_With_Log",
 		});
-		assert.deepStrictEqual(actualPromptWithPlanAndEditLog, expectedPromptWithPlanAndEditLog);
 	});
 
-	it("Review System Prompt has no regression", () => {
+	it("Editing System Prompt created with node containing no arrays has no regression", function (this: Mocha.Context) {
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+		const view = tree.viewWith(new TreeViewConfiguration({ schema: TestTodoAppSchema }));
+		view.initialize(initialAppState);
+
+		idGenerator.assignIds(view.root);
+
+		const actualPrompt = getEditingSystemPrompt(
+			userAsk,
+			idGenerator,
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			view.root.todos[0]!,
+			[],
+			systemRoleContext,
+		);
+
+		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
+			fileNameOverride: "Editing_System_Prompt_No_Plan_No_Log_No_Arrays",
+		});
+	});
+
+	it("Review System Prompt has no regression", function (this: Mocha.Context) {
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
@@ -362,29 +268,16 @@ describe("Prompt Generation Regression Tests", () => {
 			simpleSchema.definitions,
 		);
 
-		const actualReviewSystemPrompt = getReviewSystemPrompt(
+		const actualPrompt = getReviewSystemPrompt(
 			userAsk,
 			idGenerator,
 			view.root,
 			originalDecoratedJson,
 			systemRoleContext,
-		).split("\n");
+		);
 
-		const modifiedDecoratedJson = toDecoratedJson(idGenerator, view.root);
-		const expectedReviewSystemPrompt = [
-			"",
-			"\tYou are a collaborative agent who interacts with a JSON tree by performing edits to achieve a user-specified goal.",
-			"\t\t\tThe application that owns the JSON tree has the following guidance: You're a helpful AI assistant",
-			"\tYou have performed a number of actions already to accomplish a user request.",
-			"\tYou must review the resulting state to determine if the actions you performed successfully accomplished the user's goal.",
-			"\tThe tree is a JSON object with the following schema: interface TestTodoAppSchema { title: string; description: string; todos: Todo[]; } interface Todo { title: string; completed: boolean; }",
-			`\tThe state of the tree BEFORE changes was: ${originalDecoratedJson}.`,
-			`\tThe state of the tree AFTER changes is: ${modifiedDecoratedJson}.`,
-			"\tThe user requested that the following goal should be accomplished:",
-			`\t${userAsk}`,
-			"\tWas the goal accomplished?",
-		];
-
-		assert.deepStrictEqual(actualReviewSystemPrompt, expectedReviewSystemPrompt);
+		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
+			fileNameOverride: "Review_System_Prompt",
+		});
 	});
 });

--- a/packages/framework/ai-collab/src/test/explicit-strategy/promptGeneration.spec.ts
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/promptGeneration.spec.ts
@@ -9,7 +9,6 @@ import { strict as assert } from "node:assert";
 import { createIdCompressor } from "@fluidframework/id-compressor/internal";
 // eslint-disable-next-line import/no-internal-modules
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
-// eslint-disable-next-line import/order
 import {
 	getSimpleSchema,
 	SchemaFactory,
@@ -18,8 +17,6 @@ import {
 	TreeViewConfiguration,
 	// eslint-disable-next-line import/no-internal-modules
 } from "@fluidframework/tree/internal";
-
-// eslint-disable-next-line import/no-internal-modules
 import { describe, it } from "mocha";
 
 // eslint-disable-next-line import/no-internal-modules
@@ -104,9 +101,7 @@ describe("Prompt Generation Regression Tests", () => {
 
 		const actualPrompt = getPlanningSystemPrompt(view.root, userAsk, systemRoleContext);
 
-		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
-			fileNameOverride: "Planning_System_Prompt",
-		});
+		snapShotTester.expectToMatchSnapshot(this, actualPrompt, "Planning_System_Prompt");
 	});
 
 	it("Editing System Prompt with no plan and empty edit log has no regression", function (this: Mocha.Context) {
@@ -127,12 +122,14 @@ describe("Prompt Generation Regression Tests", () => {
 			systemRoleContext,
 		);
 
-		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
-			fileNameOverride: "Editing_System_Prompt_No_Plan_No_Log",
-		});
+		snapShotTester.expectToMatchSnapshot(
+			this,
+			actualPrompt,
+			"Editing_System_Prompt_No_Plan_No_Log",
+		);
 	});
 
-	it("Editing System Prompt with tree node with no array schema property but has child node that does should contain array types", function (this: Mocha.Context) {
+	it("Editing System Prompt using a tree node with a nested array property but no top level array should still contain array types", function (this: Mocha.Context) {
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
@@ -156,9 +153,11 @@ describe("Prompt Generation Regression Tests", () => {
 			systemRoleContext,
 		);
 
-		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
-			fileNameOverride: "Editing_System_Prompt_Nested_Array_Schema_But_No_Top_Level_Array",
-		});
+		snapShotTester.expectToMatchSnapshot(
+			this,
+			actualPrompt,
+			"Editing_System_Prompt_Nested_Array_Schema_But_No_Top_Level_Array",
+		);
 	});
 
 	it("Editing System Prompt with plan and empty edit log has no regression", function (this: Mocha.Context) {
@@ -180,9 +179,11 @@ describe("Prompt Generation Regression Tests", () => {
 			plan,
 		);
 
-		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
-			fileNameOverride: "Editing_System_Prompt_With_Plan_No_Log",
-		});
+		snapShotTester.expectToMatchSnapshot(
+			this,
+			actualPrompt,
+			"Editing_System_Prompt_With_Plan_No_Log",
+		);
 	});
 
 	it("Editing System Prompt with plan and populated edit log has no regression", function (this: Mocha.Context) {
@@ -240,9 +241,11 @@ describe("Prompt Generation Regression Tests", () => {
 			plan,
 		);
 
-		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
-			fileNameOverride: "Editing_System_Prompt_With_Plan_With_Log",
-		});
+		snapShotTester.expectToMatchSnapshot(
+			this,
+			actualPrompt,
+			"Editing_System_Prompt_With_Plan_With_Log",
+		);
 	});
 
 	it("Editing System Prompt created with node containing no arrays has no regression", function (this: Mocha.Context) {
@@ -264,9 +267,11 @@ describe("Prompt Generation Regression Tests", () => {
 			systemRoleContext,
 		);
 
-		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
-			fileNameOverride: "Editing_System_Prompt_No_Plan_No_Log_No_Arrays",
-		});
+		snapShotTester.expectToMatchSnapshot(
+			this,
+			actualPrompt,
+			"Editing_System_Prompt_No_Plan_No_Log_No_Arrays",
+		);
 	});
 
 	it("Review System Prompt has no regression", function (this: Mocha.Context) {
@@ -305,8 +310,6 @@ describe("Prompt Generation Regression Tests", () => {
 			systemRoleContext,
 		);
 
-		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
-			fileNameOverride: "Review_System_Prompt",
-		});
+		snapShotTester.expectToMatchSnapshot(this, actualPrompt, "Review_System_Prompt");
 	});
 });

--- a/packages/framework/ai-collab/src/test/explicit-strategy/promptGeneration.spec.ts
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/promptGeneration.spec.ts
@@ -132,6 +132,35 @@ describe("Prompt Generation Regression Tests", () => {
 		});
 	});
 
+	it("Editing System Prompt with tree node with no array schema property but has child node that does should contain array types", function (this: Mocha.Context) {
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+
+		class TestWrapperNode extends sf.object("TestWrapperNode", {
+			childNodeProperty: TestTodoAppSchema,
+		}) {}
+
+		const view = tree.viewWith(new TreeViewConfiguration({ schema: TestWrapperNode }));
+
+		view.initialize({ childNodeProperty: initialAppState });
+
+		idGenerator.assignIds(view.root);
+
+		const actualPrompt = getEditingSystemPrompt(
+			userAsk,
+			idGenerator,
+			view.root,
+			[],
+			systemRoleContext,
+		);
+
+		snapShotTester.expectToMatchSnapshot(this, actualPrompt, {
+			fileNameOverride: "Editing_System_Prompt_Nested_Array_Schema_But_No_Top_Level_Array",
+		});
+	});
+
 	it("Editing System Prompt with plan and empty edit log has no regression", function (this: Mocha.Context) {
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),

--- a/packages/framework/ai-collab/src/test/explicit-strategy/typeGeneration.spec.ts
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/typeGeneration.spec.ts
@@ -50,7 +50,7 @@ const initialAppState = {
 };
 
 describe("Type Generation", () => {
-	it("doesNodeContainArraySchema should return true if the node contains an array schema", () => {
+	it("doesNodeContainArraySchema should return true if the node contains an array schema property", () => {
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
@@ -58,10 +58,10 @@ describe("Type Generation", () => {
 		const view = tree.viewWith(new TreeViewConfiguration({ schema: TestTodoAppSchema }));
 		view.initialize(initialAppState);
 
-		assert.equal(true, doesNodeContainArraySchema(view.root));
+		assert.equal(doesNodeContainArraySchema(view.root), true);
 	});
 
-	it("doesNodeContainArraySchema should return false if the node does NOT contain an array schema", () => {
+	it("doesNodeContainArraySchema should return false if the node does NOT contain an array schema property", () => {
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
@@ -70,7 +70,7 @@ describe("Type Generation", () => {
 		view.initialize(initialAppState);
 
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		assert.equal(false, doesNodeContainArraySchema(view.root.todos[0]!));
+		assert.equal(doesNodeContainArraySchema(view.root.todos[0]!), false);
 	});
 
 	it("doesNodeContainArraySchema should return true if the node is an array itself", () => {
@@ -81,6 +81,22 @@ describe("Type Generation", () => {
 		const view = tree.viewWith(new TreeViewConfiguration({ schema: TestTodoAppSchema }));
 		view.initialize(initialAppState);
 
-		assert.equal(true, doesNodeContainArraySchema(view.root.todos));
+		assert.equal(doesNodeContainArraySchema(view.root.todos), true);
+	});
+
+	it("doesNodeContainArraySchema should return true if the node schema contains no array property but its child node does", () => {
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+
+		class TestWrapperNode extends sf.object("TestWrapperNode", {
+			childNodeProperty: TestTodoAppSchema,
+		}) {}
+
+		const view = tree.viewWith(new TreeViewConfiguration({ schema: TestWrapperNode }));
+		view.initialize({ childNodeProperty: initialAppState });
+
+		assert.equal(doesNodeContainArraySchema(view.root.childNodeProperty.todos), true);
 	});
 });

--- a/packages/framework/ai-collab/src/test/explicit-strategy/typeGeneration.spec.ts
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/typeGeneration.spec.ts
@@ -97,6 +97,6 @@ describe("Type Generation", () => {
 		const view = tree.viewWith(new TreeViewConfiguration({ schema: TestWrapperNode }));
 		view.initialize({ childNodeProperty: initialAppState });
 
-		assert.equal(doesNodeContainArraySchema(view.root.childNodeProperty.todos), true);
+		assert.equal(doesNodeContainArraySchema(view.root), true);
 	});
 });

--- a/packages/framework/ai-collab/src/test/explicit-strategy/typeGeneration.spec.ts
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/typeGeneration.spec.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { strict as assert } from "node:assert";
 
 // eslint-disable-next-line import/no-internal-modules

--- a/packages/framework/ai-collab/src/test/explicit-strategy/typeGeneration.spec.ts
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/typeGeneration.spec.ts
@@ -1,0 +1,81 @@
+import { strict as assert } from "node:assert";
+
+// eslint-disable-next-line import/no-internal-modules
+import { createIdCompressor } from "@fluidframework/id-compressor/internal";
+// eslint-disable-next-line import/no-internal-modules
+import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
+// eslint-disable-next-line import/order
+import {
+	SchemaFactory,
+	SharedTree,
+	TreeViewConfiguration,
+	// eslint-disable-next-line import/no-internal-modules
+} from "@fluidframework/tree/internal";
+
+// eslint-disable-next-line import/no-internal-modules
+import { doesNodeContainArraySchema } from "../../explicit-strategy/typeGeneration.js";
+
+const factory = SharedTree.getFactory();
+const sf = new SchemaFactory("test");
+
+class Todo extends sf.object("Todo", {
+	title: sf.string,
+	completed: sf.boolean,
+}) {}
+
+class TestTodoAppSchema extends sf.object("TestTodoAppSchema", {
+	title: sf.string,
+	description: sf.string,
+	todos: sf.array(Todo),
+}) {}
+
+const initialAppState = {
+	title: "My First Todo List",
+	description: "This is a list of todos",
+	todos: [
+		{
+			title: "Task 1",
+			completed: true,
+		},
+		{
+			title: "Task 2",
+			completed: true,
+		},
+	],
+};
+
+describe("Type Generation", () => {
+	it("doesNodeContainArraySchema should return true if the node contains an array schema", () => {
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+		const view = tree.viewWith(new TreeViewConfiguration({ schema: TestTodoAppSchema }));
+		view.initialize(initialAppState);
+
+		assert.equal(true, doesNodeContainArraySchema(view.root));
+	});
+
+	it("doesNodeContainArraySchema should return false if the node does NOT contain an array schema", () => {
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+		const view = tree.viewWith(new TreeViewConfiguration({ schema: TestTodoAppSchema }));
+		view.initialize(initialAppState);
+
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		assert.equal(false, doesNodeContainArraySchema(view.root.todos[0]!));
+	});
+
+	it("doesNodeContainArraySchema should return true if the node is an array itself", () => {
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+		const view = tree.viewWith(new TreeViewConfiguration({ schema: TestTodoAppSchema }));
+		view.initialize(initialAppState);
+
+		assert.equal(true, doesNodeContainArraySchema(view.root.todos));
+	});
+});

--- a/packages/framework/ai-collab/src/test/explicit-strategy/utils.ts
+++ b/packages/framework/ai-collab/src/test/explicit-strategy/utils.ts
@@ -82,60 +82,6 @@ export function initializeOpenAIClient(service: "openai" | "azure"): OpenAI {
 /**
  * A utility class for snapshot testing.
  */
-// export class MochaSnapshotUnitTester {
-// 	public constructor(
-// 		public readonly snapshotDirectory: string,
-// 		public readonly suiteName: string,
-// 	) {}
-
-// 	public expectToMatchSnapshot(
-// 		mochaContext: Mocha.Context,
-// 		output: string,
-// 		options?: { fileNameOverride?: string },
-// 	): void {
-// 		const snapshotBaseFolderDir = path.join(this.snapshotDirectory, "__snapshots__");
-
-// 		// Create the __snapshots__ directory if it does not exist
-// 		if (!fs.existsSync(snapshotBaseFolderDir)) {
-// 			fs.mkdirSync(snapshotBaseFolderDir);
-// 		}
-
-// 		// Directory to store snapshots
-// 		const snapshotDir: string = path.join(
-// 			this.snapshotDirectory,
-// 			"__snapshots__",
-// 			this.suiteName,
-// 		);
-
-// 		if (!fs.existsSync(snapshotDir)) {
-// 			fs.mkdirSync(snapshotDir);
-// 		}
-
-// 		const testName: string =
-// 			options?.fileNameOverride ??
-// 			mochaContext.test?.title.replace(/\s+/g, "_") ??
-// 			"unknown_test";
-// 		const snapshotFile: string = path.join(snapshotDir, `${testName}.snap.json`);
-
-// 		const shouldUpdateSnapshot: boolean = process.env.UPDATE_SNAPSHOTS === "true";
-
-// 		if (fs.existsSync(snapshotFile) && !shouldUpdateSnapshot) {
-// 			// Snapshot exists, compare outputs
-// 			const expectedOutput: string = fs.readFileSync(snapshotFile, "utf8");
-// 			assert.strictEqual(output, expectedOutput);
-// 		} else {
-// 			// Snapshot does not exist or updating snapshot
-// 			fs.writeFileSync(snapshotFile, output, "utf8");
-// 			console.log(
-// 				`Snapshot ${fs.existsSync(snapshotFile) ? "updated" : "created"} for test: ${testName}`,
-// 			);
-// 		}
-// 	}
-// }
-
-/**
- * A utility class for snapshot testing.
- */
 export class MochaSnapshotUnitTester {
 	public constructor(
 		public readonly snapshotDirectory: string,


### PR DESCRIPTION
## Description
The AiCollab package has a bug that forces you to have an array in the schema of the node you pass to the `aiCollab` function.
This is because when we generate the structured output schema for OpenAI, we include the array edit types even if the tree node doesn't have any arrays. When this happens, the end result is you'll have a structured output schema where the array edit types are an `anyOf` nothing which in turn results in a 400 from OpenAI.

This PR adds new logic to analyze the schema of the given SharedTree node and selectively include array related types in the structured output schema only when the tree node contains an array. Furthermore, the generated prompts now change to remove references to any array operations or types as well when the given tree node has no arrays.

This PR also adds a simple, bespoke snapshot testing utility library that can be used with mocha without the need for any setup. It can create a local snapshot directory, save string outputs to a `.snap` file and include file headers in each snapshot to provide metadata / context such as the date of the snapshot generation and an optional description.


## Breaking Changes

> None

## Reviewer Guidance


