### PR TITLE
improvement(ai-collab): Display task id and fix duplicate console

### DIFF
--- a/examples/apps/ai-collab/src/actions/task.ts
+++ b/examples/apps/ai-collab/src/actions/task.ts
@@ -63,7 +63,7 @@ export async function editTaskGroup(
 		replaceTaskGroupIdsWithSimpleId(taskGroup);
 	console.log("newToOldTaskGroupId:", newToOldTaskGroupId);
 	console.log("newToOldTaskIds:", newToOldTaskIds);
-	console.log("taskGroupCopy:", newToOldEngineerIds);
+	console.log("newToOldEngineerIds:", newToOldEngineerIds);
 	console.log("taskGroupCopy:", taskGroupCopy);
 
 	const prompt = `You are a manager that is helping out with a project management tool. You have been asked to edit a group of tasks. \n\n

--- a/examples/apps/ai-collab/src/components/TaskGroup.tsx
+++ b/examples/apps/ai-collab/src/components/TaskGroup.tsx
@@ -137,7 +137,7 @@ export function TaskGroup(props: {
 					color="success"
 					onClick={() => {
 						props.sharedTreeTaskGroup.tasks.insertAtStart({
-							title: "New Task",
+							title: `New Task #${props.sharedTreeTaskGroup.tasks.length + 1}`,
 							description: "This is the new task. ",
 							priority: "low",
 							complexity: 1,


### PR DESCRIPTION
#### Description

Adds an id to a newly created task in the `ai-collab/example` app and replaces duplicate console id. 