### PR TITLE
Added support for custom jwtid value

### DIFF
--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -79,9 +79,9 @@ export function getCreationToken(
 	// Current time in seconds
 	const tokenClaims = decode(token) as ITokenClaims;
 
-	const { tenantId, user } = tokenClaims;
+	const { tenantId, user, jti } = tokenClaims;
 
-	return generateToken(tenantId, documentId, key, [], user, lifetime);
+	return generateToken(tenantId, documentId, key, [], user, jti /* JwtId */, lifetime);
 }
 
 /**
@@ -96,6 +96,7 @@ export function generateToken(
 	key: string,
 	scopes: ScopeType[],
 	user?: IUser,
+	jti?: string,
 	lifetime: number = 60 * 60,
 	ver: string = "1.0",
 ): string {
@@ -116,8 +117,9 @@ export function generateToken(
 		exp: now + lifetime,
 		ver,
 	};
+	const jwtid = jti ? jti : uuid();
 
-	return sign(claims, key, { jwtid: uuid() });
+	return sign(claims, key, { jwtid });
 }
 
 /**

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -79,9 +79,9 @@ export function getCreationToken(
 	// Current time in seconds
 	const tokenClaims = decode(token) as ITokenClaims;
 
-	const { tenantId, user, jti } = tokenClaims;
+	const { tenantId, user, jti, ver } = tokenClaims;
 
-	return generateToken(tenantId, documentId, key, [], user, jti /* JwtId */, lifetime);
+	return generateToken(tenantId, documentId, key, [], user, lifetime, ver, jti);
 }
 
 /**
@@ -96,9 +96,9 @@ export function generateToken(
 	key: string,
 	scopes: ScopeType[],
 	user?: IUser,
-	jti?: string,
 	lifetime: number = 60 * 60,
 	ver: string = "1.0",
+	jti: string = uuid(),
 ): string {
 	let userClaim = user ? user : generateUser();
 	if (userClaim.id === "" || userClaim.id === undefined) {
@@ -117,9 +117,8 @@ export function generateToken(
 		exp: now + lifetime,
 		ver,
 	};
-	const jwtid = jti ? jti : uuid();
 
-	return sign(claims, key, { jwtid });
+	return sign(claims, key, { jwtid: jti });
 }
 
 /**


### PR DESCRIPTION
## Description

This PR adds support for a custom JTI value being provided in the `generateToken` method. This can be used by customers to use their own provided JTI guid value. One use case would be using Entra-ID to generate tokens where customers want to provide their own JTI value.

## Breaking Changes

Adds a new optional arg - `jti` - in `generateToken`.

## Reviewer Guidance

Do I need to update this method definition in all packages to support custom JTI values?
