### PR TITLE
refactor(shared-object-base): Move to recommended eslint base config

### DIFF
--- a/packages/dds/shared-object-base/.eslintrc.cjs
+++ b/packages/dds/shared-object-base/.eslintrc.cjs
@@ -4,10 +4,7 @@
  */
 
 module.exports = {
-	extends: [
-		require.resolve("@fluidframework/eslint-config-fluid/minimal-deprecated"),
-		"prettier",
-	],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid/recommended"), "prettier"],
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},

--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
@@ -33,10 +33,10 @@ export interface ISharedObjectKind<TSharedObject> {
 }
 
 // @alpha
-export function makeHandlesSerializable(value: any, serializer: IFluidSerializer, bind: IFluidHandle): any;
+export function makeHandlesSerializable(value: unknown, serializer: IFluidSerializer, bind: IFluidHandle): any;
 
 // @alpha
-export function parseHandles(value: any, serializer: IFluidSerializer): any;
+export function parseHandles(value: unknown, serializer: IFluidSerializer): any;
 
 // @alpha
 export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends SharedObjectCore<TEvent> {
@@ -79,7 +79,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     protected newAckBasedPromise<T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
     protected onConnect(): void;
     protected abstract onDisconnect(): any;
-    protected abstract processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): any;
+    protected abstract processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     protected reSubmitCore(content: any, localOpMetadata: unknown): void;
     protected rollback(content: any, localOpMetadata: unknown): void;
     // (undocumented)

--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
@@ -6,10 +6,10 @@
 
 // @alpha (undocumented)
 export interface IFluidSerializer {
-    decode(input: unknown): any;
-    encode(value: unknown, bind: IFluidHandle): any;
+    decode(input: any): any;
+    encode(value: any, bind: IFluidHandle): any;
     parse(value: string): any;
-    stringify(value: unknown, bind: IFluidHandle): string;
+    stringify(value: any, bind: IFluidHandle): string;
 }
 
 // @alpha

--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
@@ -53,7 +53,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
 // @alpha
 export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends EventEmitterWithErrorHandling<TEvent> implements ISharedObject<TEvent> {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
-    protected abstract applyStashedOp(content: unknown): void;
+    protected abstract applyStashedOp(content: any): void;
     // (undocumented)
     readonly attributes: IChannelAttributes;
     bindToContext(): void;
@@ -62,7 +62,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     protected get deltaManager(): IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     protected didAttach(): void;
     protected dirty(): void;
-    emit(event: EventEmitterEventType, ...args: unknown[]): boolean;
+    emit(event: EventEmitterEventType, ...args: any[]): boolean;
     abstract getAttachSummary(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     abstract getGCData(fullGC?: boolean): IGarbageCollectionData;
     readonly handle: IFluidHandleInternal;
@@ -79,7 +79,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     protected newAckBasedPromise<T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
     protected onConnect(): void;
     protected abstract onDisconnect(): any;
-    protected abstract processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
+    protected abstract processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): any;
     protected reSubmitCore(content: any, localOpMetadata: unknown): void;
     protected rollback(content: any, localOpMetadata: unknown): void;
     // (undocumented)

--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
@@ -53,7 +53,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
 // @alpha
 export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends EventEmitterWithErrorHandling<TEvent> implements ISharedObject<TEvent> {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
-    protected abstract applyStashedOp(content: any): void;
+    protected abstract applyStashedOp(content: unknown): void;
     // (undocumented)
     readonly attributes: IChannelAttributes;
     bindToContext(): void;
@@ -62,7 +62,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     protected get deltaManager(): IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     protected didAttach(): void;
     protected dirty(): void;
-    emit(event: EventEmitterEventType, ...args: any[]): boolean;
+    emit(event: EventEmitterEventType, ...args: unknown[]): boolean;
     abstract getAttachSummary(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     abstract getGCData(fullGC?: boolean): IGarbageCollectionData;
     readonly handle: IFluidHandleInternal;

--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
@@ -6,10 +6,10 @@
 
 // @alpha (undocumented)
 export interface IFluidSerializer {
-    decode(input: any): any;
-    encode(value: any, bind: IFluidHandle): any;
+    decode(input: unknown): any;
+    encode(value: unknown, bind: IFluidHandle): any;
     parse(value: string): any;
-    stringify(value: any, bind: IFluidHandle): string;
+    stringify(value: unknown, bind: IFluidHandle): string;
 }
 
 // @alpha

--- a/packages/dds/shared-object-base/src/remoteObjectHandle.ts
+++ b/packages/dds/shared-object-base/src/remoteObjectHandle.ts
@@ -20,10 +20,6 @@ import { FluidHandleBase, responseToException } from "@fluidframework/runtime-ut
  * IFluidHandle can be retrieved by calling `get` on it.
  */
 export class RemoteFluidObjectHandle extends FluidHandleBase<FluidObject> {
-	public get IFluidHandleContext() {
-		return this;
-	}
-
 	public readonly isAttached = true;
 	private objectP: Promise<FluidObject> | undefined;
 

--- a/packages/dds/shared-object-base/src/remoteObjectHandle.ts
+++ b/packages/dds/shared-object-base/src/remoteObjectHandle.ts
@@ -48,7 +48,7 @@ export class RemoteFluidObjectHandle extends FluidHandleBase<FluidObject> {
 			};
 			this.objectP = this.routeContext.resolveHandle(request).then<FluidObject>((response) => {
 				if (response.mimeType === "fluid/object") {
-					const fluidObject: FluidObject = response.value;
+					const fluidObject: FluidObject = response.value as FluidObject;
 					return fluidObject;
 				}
 				throw responseToException(response, request);

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -89,12 +89,14 @@ export class FluidSerializer implements IFluidSerializer {
 	 *
 	 * Any unbound handles encountered are bound to the provided IFluidHandle.
 	 */
-	public encode(input: unknown, bind: IFluidHandleInternal): unknown {
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: ddsFuzzHarness breaks
+	public encode(input: any, bind: IFluidHandleInternal): any {
 		// If the given 'input' cannot contain handles, return it immediately.  Otherwise,
 		// return the result of 'recursivelyReplace()'.
 		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 		return !!input && typeof input === "object"
-			? this.recursivelyReplace(input, this.encodeValue, bind)
+			? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- TODO: ddsFuzzHarness breaks
+				this.recursivelyReplace(input, this.encodeValue, bind)
 			: input;
 	}
 
@@ -107,7 +109,8 @@ export class FluidSerializer implements IFluidSerializer {
 	 *
 	 * The decoded handles are implicitly bound to the handle context of this serializer.
 	 */
-	public decode(input: unknown): unknown {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: ddsFuzzHarness breaks
+	public decode(input: unknown): any {
 		// If the given 'input' cannot contain handles, return it immediately.  Otherwise,
 		// return the result of 'recursivelyReplace()'.
 		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -87,13 +87,13 @@ export class FluidSerializer implements IFluidSerializer {
 	 *
 	 * Any unbound handles encountered are bound to the provided IFluidHandle.
 	 */
-	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: ddsFuzzHarness breaks
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: AB#26129 ddsFuzzHarness breaks when we update any->unknown
 	public encode(input: any, bind: IFluidHandleInternal): any {
 		// If the given 'input' cannot contain handles, return it immediately.  Otherwise,
 		// return the result of 'recursivelyReplace()'.
 		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 		return !!input && typeof input === "object"
-			? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- TODO: ddsFuzzHarness breaks
+			? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- TODO: AB#26129 ddsFuzzHarness breaks when we update any->unknown
 				this.recursivelyReplace(input, this.encodeValue, bind)
 			: input;
 	}
@@ -107,7 +107,7 @@ export class FluidSerializer implements IFluidSerializer {
 	 *
 	 * The decoded handles are implicitly bound to the handle context of this serializer.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: ddsFuzzHarness breaks
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: AB#26129 ddsFuzzHarness breaks when we update any->unknown
 	public decode(input: unknown): any {
 		// If the given 'input' cannot contain handles, return it immediately.  Otherwise,
 		// return the result of 'recursivelyReplace()'.

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import {
 	IFluidHandleContext,
@@ -33,7 +32,7 @@ export interface IFluidSerializer {
 	 * the root to any replaced handles.  (If no handles are found, returns the original object.)
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
-	encode(value: unknown, bind: IFluidHandle): any;
+	encode(value: any, bind: IFluidHandle): any;
 
 	/**
 	 * Given a fully-jsonable object tree that may have encoded handle objects embedded within, will return an
@@ -45,12 +44,13 @@ export interface IFluidSerializer {
 	 * The decoded handles are implicitly bound to the handle context of this serializer.
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
-	decode(input: unknown): any;
+	decode(input: any): any;
 
 	/**
 	 * Stringifies a given value. Converts any IFluidHandle to its stringified equivalent.
 	 */
-	stringify(value: unknown, bind: IFluidHandle): string;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
+	stringify(value: any, bind: IFluidHandle): string;
 
 	/**
 	 * Parses the given JSON input string and returns the JavaScript object defined by it. Any Fluid

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -4,7 +4,6 @@
  */
 
 // RATIONALE: Many methods consume and return 'any' by necessity.
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import {

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -32,7 +32,7 @@ export interface IFluidSerializer {
 	 * The original `input` object is not mutated.  This method will shallowly clones all objects in the path from
 	 * the root to any replaced handles.  (If no handles are found, returns the original object.)
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: use unknown (breaking change)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
 	encode(value: unknown, bind: IFluidHandle): any;
 
 	/**
@@ -44,7 +44,7 @@ export interface IFluidSerializer {
 	 *
 	 * The decoded handles are implicitly bound to the handle context of this serializer.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: use unknown (breaking change)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
 	decode(input: unknown): any;
 
 	/**
@@ -56,7 +56,7 @@ export interface IFluidSerializer {
 	 * Parses the given JSON input string and returns the JavaScript object defined by it. Any Fluid
 	 * handles will be realized as part of the parse
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: use unknown (breaking change)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
 	parse(value: string): any;
 }
 

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -158,10 +158,10 @@ export class FluidSerializer implements IFluidSerializer {
 	// Invoked for non-null objects to recursively replace references to IFluidHandles.
 	// Clones as-needed to avoid mutating the `input` object.  If no IFluidHandes are present,
 	// returns the original `input`.
-	private recursivelyReplace<T = unknown>(
+	private recursivelyReplace<TContext = unknown>(
 		input: object,
-		replacer: (input: unknown, context?: T) => unknown,
-		context?: T,
+		replacer: (input: unknown, context?: TContext) => unknown,
+		context?: TContext,
 	): unknown {
 		// Note: Caller is responsible for ensuring that `input` is defined / non-null.
 		//       (Required for Object.keys() below.)

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// RATIONALE: Many methods consume and return 'any' by necessity.
 
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import {

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -48,6 +48,7 @@ import {
 	loggerToMonitoringContext,
 	tagCodeArtifacts,
 	type ICustomData,
+	type IFluidErrorBase,
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 
@@ -77,7 +78,7 @@ export abstract class SharedObjectCore<
 	extends EventEmitterWithErrorHandling<TEvent>
 	implements ISharedObject<TEvent>
 {
-	public get IFluidLoadable() {
+	public get IFluidLoadable(): this {
 		return this;
 	}
 
@@ -136,7 +137,9 @@ export abstract class SharedObjectCore<
 		protected runtime: IFluidDataStoreRuntime,
 		public readonly attributes: IChannelAttributes,
 	) {
-		super((event: EventEmitterEventType, e: any) => this.eventListenerErrorHandler(event, e));
+		super((event: EventEmitterEventType, e: unknown) =>
+			this.eventListenerErrorHandler(event, e),
+		);
 
 		assert(!id.includes("/"), 0x304 /* Id cannot contain slashes */);
 
@@ -217,7 +220,7 @@ export abstract class SharedObjectCore<
 	 * would result in same error thrown. If called multiple times, only first error is remembered.
 	 * @param error - error object that is thrown whenever an attempt is made to modify this object
 	 */
-	private closeWithError(error: any): void {
+	private closeWithError(error: IFluidErrorBase | undefined): void {
 		if (this.closeError === undefined) {
 			this.closeError = error;
 		}
@@ -259,7 +262,8 @@ export abstract class SharedObjectCore<
 		// always propagate connection state
 		this.setBoundAndHandleAttach = () => this.setConnectionState(this.runtime.connected);
 		this._isBoundToContext = true;
-		const runDidAttach = () => {
+		// eslint-disable-next-line unicorn/consistent-function-scoping
+		const runDidAttach: () => void = () => {
 			// Allows objects to do any custom processing if it is attached.
 			this.didAttach();
 			this.setConnectionState(this.runtime.connected);
@@ -390,7 +394,9 @@ export abstract class SharedObjectCore<
 	/**
 	 * Called when the object has disconnected from the delta stream.
 	 */
-	protected abstract onDisconnect();
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: change return type to void (legacy breaking)
+	protected abstract onDisconnect(): any;
 
 	/**
 	 * The serializer to serialize / parse handles.
@@ -405,6 +411,7 @@ export abstract class SharedObjectCore<
 	 * and not sent to the server. This will be sent back when this message is received back from the server. This is
 	 * also sent if we are asked to resubmit the message.
 	 */
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: use unknown instead of any (legacy breaking)
 	protected submitLocalMessage(content: any, localOpMetadata: unknown = undefined): void {
 		this.verifyNotClosed();
 		if (this.isAttached()) {
@@ -443,6 +450,7 @@ export abstract class SharedObjectCore<
 	 * @param content - The content of the original message.
 	 * @param localOpMetadata - The local metadata associated with the original message.
 	 */
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: use unknown instead of any (legacy breaking)
 	protected reSubmitCore(content: any, localOpMetadata: unknown): void {
 		this.submitLocalMessage(content, localOpMetadata);
 	}
@@ -456,6 +464,7 @@ export abstract class SharedObjectCore<
 	protected async newAckBasedPromise<T>(
 		executor: (
 			resolve: (value: T | PromiseLike<T>) => void,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: use unknown instead of any (legacy breaking)
 			reject: (reason?: any) => void,
 		) => void,
 	): Promise<T> {
@@ -609,6 +618,7 @@ export abstract class SharedObjectCore<
 	/**
 	 * Revert an op
 	 */
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: use unknown instead of any (legacy breaking)
 	protected rollback(content: any, localOpMetadata: unknown): void {
 		throw new Error("rollback not supported");
 	}

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -504,13 +504,13 @@ export abstract class SharedObjectCore<
 			setConnectionState: (connected: boolean) => {
 				this.setConnectionState(connected);
 			},
-			reSubmit: (content: any, localOpMetadata: unknown) => {
+			reSubmit: (content: unknown, localOpMetadata: unknown) => {
 				this.reSubmit(content, localOpMetadata);
 			},
-			applyStashedOp: (content: any): void => {
+			applyStashedOp: (content: unknown): void => {
 				this.applyStashedOp(parseHandles(content, this.serializer));
 			},
-			rollback: (content: any, localOpMetadata: unknown) => {
+			rollback: (content: unknown, localOpMetadata: unknown) => {
 				this.rollback(content, localOpMetadata);
 			},
 		} satisfies IDeltaHandler);
@@ -630,7 +630,7 @@ export abstract class SharedObjectCore<
 	 *
 	 * @param content - Contents of a stashed op.
 	 */
-	protected abstract applyStashedOp(content: any): void;
+	protected abstract applyStashedOp(content: unknown): void;
 
 	/**
 	 * Emit an event. This function is only intended for use by DDS classes that extend SharedObject/SharedObjectCore,
@@ -642,7 +642,7 @@ export abstract class SharedObjectCore<
 	 * @param args - Arguments to pass to the event listeners.
 	 * @returns `true` if the event had listeners, `false` otherwise.
 	 */
-	public emit(event: EventEmitterEventType, ...args: any[]): boolean {
+	public emit(event: EventEmitterEventType, ...args: unknown[]): boolean {
 		return this.callbacksHelper.measure(() => {
 			return super.emit(event, ...args);
 		});
@@ -655,7 +655,7 @@ export abstract class SharedObjectCore<
 	 * @param args - Arguments for the event
 	 * @returns Whatever `super.emit()` returns.
 	 */
-	private emitInternal(event: EventEmitterEventType, ...args: any[]): boolean {
+	private emitInternal(event: EventEmitterEventType, ...args: unknown[]): boolean {
 		return super.emit(event, ...args);
 	}
 }
@@ -793,7 +793,7 @@ export abstract class SharedObject<
 	 * Calls the serializer over all data in this object that reference other GC nodes.
 	 * Derived classes must override this to provide custom list of references to other GC nodes.
 	 */
-	protected processGCDataCore(serializer: IFluidSerializer) {
+	protected processGCDataCore(serializer: IFluidSerializer): void {
 		// We run the full summarize logic to get the list of outbound routes from this object. This is a little
 		// expensive but its okay for now. It will be updated to not use full summarize and make it more efficient.
 		// See: https://github.com/microsoft/FluidFramework/issues/4547
@@ -814,7 +814,7 @@ export abstract class SharedObject<
 		propertyName: string,
 		incrementBy: number,
 		telemetryContext?: ITelemetryContext,
-	) {
+	): void {
 		if (telemetryContext !== undefined) {
 			// TelemetryContext needs to implment a get function
 			assert(

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -396,7 +396,7 @@ export abstract class SharedObjectCore<
 	 * Called when the object has disconnected from the delta stream.
 	 */
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: change return type to void (legacy breaking)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: AB#26129 change return type to void (legacy breaking)
 	protected abstract onDisconnect(): any;
 
 	/**

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -532,17 +532,17 @@ export abstract class SharedObjectCore<
 		// Should I change the state at the end? So that we *can't* send new stuff before we send old?
 		this._connected = connected;
 
-		if (!connected) {
+		if (connected) {
+			// Call this for now so that DDSes like ConsensusOrderedCollection that maintain their own pending
+			// messages will work.
+			this.onConnect();
+		} else {
 			// Things that are true now...
 			// - if we had a connection we can no longer send messages over it
 			// - if we had outbound messages some may or may not be ACK'd. Won't know until next message
 			//
 			// - nack could get a new msn - but might as well do it in the join?
 			this.onDisconnect();
-		} else {
-			// Call this for now so that DDSes like ConsensusOrderedCollection that maintain their own pending
-			// messages will work.
-			this.onConnect();
 		}
 	}
 

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -217,7 +217,7 @@ export abstract class SharedObjectCore<
 	 * would result in same error thrown. If called multiple times, only first error is remembered.
 	 * @param error - error object that is thrown whenever an attempt is made to modify this object
 	 */
-	private closeWithError(error: any) {
+	private closeWithError(error: any): void {
 		if (this.closeError === undefined) {
 			this.closeError = error;
 		}
@@ -226,7 +226,7 @@ export abstract class SharedObjectCore<
 	/**
 	 * Verifies that this object is not closed via closeWithError(). If it is, throws an error used to close it.
 	 */
-	private verifyNotClosed() {
+	private verifyNotClosed(): void {
 		if (this.closeError !== undefined) {
 			throw this.closeError;
 		}
@@ -242,7 +242,7 @@ export abstract class SharedObjectCore<
 	 * DDS state does not match what user sees. Because of it DDS moves to "corrupted state" and does not
 	 * allow processing of ops or local changes, which very quickly results in container closure.
 	 */
-	private eventListenerErrorHandler(event: EventEmitterEventType, e: any) {
+	private eventListenerErrorHandler(event: EventEmitterEventType, e: unknown): void {
 		const error = DataProcessingError.wrapIfUnrecognized(
 			e,
 			"SharedObjectEventListenerException",
@@ -253,7 +253,7 @@ export abstract class SharedObjectCore<
 		throw error;
 	}
 
-	private setBoundAndHandleAttach() {
+	private setBoundAndHandleAttach(): void {
 		// Ensure didAttach is only called once, and we only register a single event
 		// but we still call setConnectionState as our existing mocks don't
 		// always propagate connection state
@@ -312,7 +312,7 @@ export abstract class SharedObjectCore<
 	/**
 	 * {@inheritDoc @fluidframework/datastore-definitions#(IChannel:interface).connect}
 	 */
-	public connect(services: IChannelServices) {
+	public connect(services: IChannelServices): void {
 		// handle the case where load is called
 		// before connect; loading detached data stores
 		if (this.services === undefined) {
@@ -362,7 +362,7 @@ export abstract class SharedObjectCore<
 	/**
 	 * Allows the distributed data type to perform custom local loading.
 	 */
-	protected initializeLocalCore() {
+	protected initializeLocalCore(): void {
 		return;
 	}
 
@@ -370,7 +370,7 @@ export abstract class SharedObjectCore<
 	 * Allows the distributive data type the ability to perform custom processing once an attach has happened.
 	 * Also called after non-local data type get loaded.
 	 */
-	protected didAttach() {
+	protected didAttach(): void {
 		return;
 	}
 
@@ -385,7 +385,7 @@ export abstract class SharedObjectCore<
 		message: ISequencedDocumentMessage,
 		local: boolean,
 		localOpMetadata: unknown,
-	);
+	): void;
 
 	/**
 	 * Called when the object has disconnected from the delta stream.
@@ -433,7 +433,7 @@ export abstract class SharedObjectCore<
 	 * Called when the object has fully connected to the delta stream
 	 * Default implementation for DDS, override if different behavior is required.
 	 */
-	protected onConnect() {}
+	protected onConnect(): void {}
 
 	/**
 	 * Called when a message has to be resubmitted. This typically happens after a reconnection for unacked messages.
@@ -443,7 +443,7 @@ export abstract class SharedObjectCore<
 	 * @param content - The content of the original message.
 	 * @param localOpMetadata - The local metadata associated with the original message.
 	 */
-	protected reSubmitCore(content: any, localOpMetadata: unknown) {
+	protected reSubmitCore(content: any, localOpMetadata: unknown): void {
 		this.submitLocalMessage(content, localOpMetadata);
 	}
 
@@ -479,7 +479,7 @@ export abstract class SharedObjectCore<
 		});
 	}
 
-	private attachDeltaHandler() {
+	private attachDeltaHandler(): void {
 		// Services should already be there in case we are attaching delta handler.
 		assert(
 			this.services !== undefined,
@@ -520,7 +520,7 @@ export abstract class SharedObjectCore<
 	 * Set the state of connection to services.
 	 * @param connected - true if connected, false otherwise.
 	 */
-	private setConnectionState(connected: boolean) {
+	private setConnectionState(connected: boolean): void {
 		// only an attached shared object can transition its
 		// connected state. This is defensive, as some
 		// of our test harnesses don't handle this correctly
@@ -557,7 +557,7 @@ export abstract class SharedObjectCore<
 		message: ISequencedDocumentMessage,
 		local: boolean,
 		localOpMetadata: unknown,
-	) {
+	): void {
 		this.verifyNotClosed(); // This will result in container closure.
 		this.emitInternal("pre-op", message, local, this);
 
@@ -581,7 +581,7 @@ export abstract class SharedObjectCore<
 	 * Process messages for this shared object. The messages here are contiguous messages for this object in a batch.
 	 * @param messageCollection - The collection of messages to process.
 	 */
-	private processMessages(messagesCollection: IRuntimeMessageCollection) {
+	private processMessages(messagesCollection: IRuntimeMessageCollection): void {
 		const { envelope, messagesContent, local } = messagesCollection;
 		for (const { contents, localOpMetadata, clientSequenceNumber } of messagesContent) {
 			this.process(
@@ -602,14 +602,14 @@ export abstract class SharedObjectCore<
 	 * @param content - The content of the original message.
 	 * @param localOpMetadata - The local metadata associated with the original message.
 	 */
-	private reSubmit(content: any, localOpMetadata: unknown) {
+	private reSubmit(content: unknown, localOpMetadata: unknown): void {
 		this.reSubmitCore(content, localOpMetadata);
 	}
 
 	/**
 	 * Revert an op
 	 */
-	protected rollback(content: any, localOpMetadata: unknown) {
+	protected rollback(content: any, localOpMetadata: unknown): void {
 		throw new Error("rollback not supported");
 	}
 

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -389,7 +389,8 @@ export abstract class SharedObjectCore<
 		message: ISequencedDocumentMessage,
 		local: boolean,
 		localOpMetadata: unknown,
-	): void;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: AB#26129 use void instead of any (legacy breaking)
+	): any;
 
 	/**
 	 * Called when the object has disconnected from the delta stream.
@@ -640,7 +641,8 @@ export abstract class SharedObjectCore<
 	 *
 	 * @param content - Contents of a stashed op.
 	 */
-	protected abstract applyStashedOp(content: unknown): void;
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
+	protected abstract applyStashedOp(content: any): void;
 
 	/**
 	 * Emit an event. This function is only intended for use by DDS classes that extend SharedObject/SharedObjectCore,
@@ -652,8 +654,9 @@ export abstract class SharedObjectCore<
 	 * @param args - Arguments to pass to the event listeners.
 	 * @returns `true` if the event had listeners, `false` otherwise.
 	 */
-	public emit(event: EventEmitterEventType, ...args: unknown[]): boolean {
+	public emit(event: EventEmitterEventType, ...args: any[]): boolean {
 		return this.callbacksHelper.measure(() => {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 			return super.emit(event, ...args);
 		});
 	}

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -411,7 +411,7 @@ export abstract class SharedObjectCore<
 	 * and not sent to the server. This will be sent back when this message is received back from the server. This is
 	 * also sent if we are asked to resubmit the message.
 	 */
-	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: use unknown instead of any (legacy breaking)
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
 	protected submitLocalMessage(content: any, localOpMetadata: unknown = undefined): void {
 		this.verifyNotClosed();
 		if (this.isAttached()) {
@@ -450,7 +450,7 @@ export abstract class SharedObjectCore<
 	 * @param content - The content of the original message.
 	 * @param localOpMetadata - The local metadata associated with the original message.
 	 */
-	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: use unknown instead of any (legacy breaking)
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
 	protected reSubmitCore(content: any, localOpMetadata: unknown): void {
 		this.submitLocalMessage(content, localOpMetadata);
 	}
@@ -464,7 +464,7 @@ export abstract class SharedObjectCore<
 	protected async newAckBasedPromise<T>(
 		executor: (
 			resolve: (value: T | PromiseLike<T>) => void,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: use unknown instead of any (legacy breaking)
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
 			reject: (reason?: any) => void,
 		) => void,
 	): Promise<T> {
@@ -618,7 +618,7 @@ export abstract class SharedObjectCore<
 	/**
 	 * Revert an op
 	 */
-	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: use unknown instead of any (legacy breaking)
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
 	protected rollback(content: any, localOpMetadata: unknown): void {
 		throw new Error("rollback not supported");
 	}

--- a/packages/dds/shared-object-base/src/summarySerializer.ts
+++ b/packages/dds/shared-object-base/src/summarySerializer.ts
@@ -4,6 +4,7 @@
  */
 
 import { type IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
+import type { ISerializedHandle } from "@fluidframework/runtime-utils/internal";
 
 import { FluidSerializer } from "./serializer.js";
 
@@ -17,7 +18,10 @@ export class SummarySerializer extends FluidSerializer {
 		return [...this.serializedRoutes];
 	}
 
-	protected serializeHandle(handle: IFluidHandleInternal, bind: IFluidHandleInternal) {
+	protected serializeHandle(
+		handle: IFluidHandleInternal,
+		bind: IFluidHandleInternal,
+	): ISerializedHandle {
 		this.serializedRoutes.add(handle.absolutePath);
 		return super.serializeHandle(handle, bind);
 	}

--- a/packages/dds/shared-object-base/src/summarySerializer.ts
+++ b/packages/dds/shared-object-base/src/summarySerializer.ts
@@ -14,7 +14,7 @@ import { FluidSerializer } from "./serializer.js";
 export class SummarySerializer extends FluidSerializer {
 	private readonly serializedRoutes: Set<string> = new Set();
 	public getSerializedRoutes(): string[] {
-		return Array.from(this.serializedRoutes);
+		return [...this.serializedRoutes];
 	}
 
 	protected serializeHandle(handle: IFluidHandleInternal, bind: IFluidHandleInternal) {

--- a/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
+++ b/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
@@ -465,7 +465,7 @@ describe("SharedObject attaching binding and connecting", () => {
 			let attachCalled = false;
 			const { overrides, sharedObject } = createTestSharedObject({
 				runtime: {
-					// ...runtimeEvents,
+					...(runtimeEvents as unknown as Overridable<IFluidDataStoreRuntime>),
 					attachState: AttachState.Detached,
 					connected: false,
 					bindChannel: (channel) => {

--- a/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
+++ b/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { generatePairwiseOptions } from "@fluid-private/test-pairwise-generator";
@@ -137,7 +137,7 @@ describe("SharedObject attaching binding and connecting", () => {
 	});
 
 	describe("shared object after creation", () => {
-		runtimeAttachStateAndConnectedMatrix.forEach(({ connected, attachState }) =>
+		for (const { connected, attachState } of runtimeAttachStateAndConnectedMatrix) {
 			it(`!isAttached and !connected with runtime ${JSON.stringify({
 				connected,
 				attachState,
@@ -151,8 +151,8 @@ describe("SharedObject attaching binding and connecting", () => {
 
 				assert.strictEqual(sharedObject.isAttached(), false, "!isAttached");
 				assert.strictEqual(sharedObject.connected, false, "!connected");
-			}),
-		);
+			});
+		}
 
 		it("!isAttached with detached transition to attach runtime", () => {
 			const runtimeEvents = new TypedEventEmitter<IFluidDataStoreRuntimeEvents>();
@@ -180,7 +180,7 @@ describe("SharedObject attaching binding and connecting", () => {
 	});
 
 	describe("shared object after load", () => {
-		runtimeAttachStateAndConnectedMatrix.forEach(({ connected, attachState }) =>
+		for (const { connected, attachState } of runtimeAttachStateAndConnectedMatrix) {
 			it(`With runtime ${JSON.stringify({
 				connected,
 				attachState,
@@ -225,8 +225,8 @@ describe("SharedObject attaching binding and connecting", () => {
 					connected && sharedObject.isAttached(),
 					"connected",
 				);
-			}),
-		);
+			});
+		}
 
 		it("isAttached with detached transition to attach runtime", async () => {
 			const runtimeEvents = new TypedEventEmitter<IFluidDataStoreRuntimeEvents>();
@@ -270,7 +270,7 @@ describe("SharedObject attaching binding and connecting", () => {
 	});
 
 	describe("shared object after connect", () => {
-		runtimeAttachStateAndConnectedMatrix.forEach(({ connected, attachState }) =>
+		for (const { connected, attachState } of runtimeAttachStateAndConnectedMatrix) {
 			it(`With runtime ${JSON.stringify({
 				connected,
 				attachState,
@@ -310,8 +310,8 @@ describe("SharedObject attaching binding and connecting", () => {
 					connected && sharedObject.isAttached(),
 					"connected",
 				);
-			}),
-		);
+			});
+		}
 
 		it("isAttached with detached transition to attach runtime", async () => {
 			const runtimeEvents = new TypedEventEmitter<IFluidDataStoreRuntimeEvents>();
@@ -351,7 +351,7 @@ describe("SharedObject attaching binding and connecting", () => {
 	});
 
 	describe("shared object after load and connect", () => {
-		runtimeAttachStateAndConnectedMatrix.forEach(({ connected, attachState }) =>
+		for (const { connected, attachState } of runtimeAttachStateAndConnectedMatrix) {
 			it(`With runtime ${JSON.stringify({
 				connected,
 				attachState,
@@ -398,12 +398,12 @@ describe("SharedObject attaching binding and connecting", () => {
 					connected && sharedObject.isAttached(),
 					"connected",
 				);
-			}),
-		);
+			});
+		}
 	});
 
 	describe("shared object after bindToContext", () => {
-		runtimeAttachStateAndConnectedMatrix.forEach(({ connected, attachState }) =>
+		for (const { connected, attachState } of runtimeAttachStateAndConnectedMatrix) {
 			it(`With runtime ${JSON.stringify({
 				connected,
 				attachState,
@@ -450,8 +450,8 @@ describe("SharedObject attaching binding and connecting", () => {
 					connected && sharedObject.isAttached(),
 					"connected",
 				);
-			}),
-		);
+			});
+		}
 
 		it("isAttached with detached transition to attach runtime", async () => {
 			const runtimeEvents = new TypedEventEmitter<IFluidDataStoreRuntimeEvents>();

--- a/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
+++ b/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
@@ -81,12 +81,10 @@ function createTestSharedObject(overrides: OverridableType): {
 } {
 	class TestSharedObject extends SharedObject {
 		protected summarizeCore = overrides?.summarizeCore?.bind(this);
-		/* eslint-disable @typescript-eslint/no-non-null-assertion */
-		protected loadCore = overrides?.loadCore!.bind(this);
-		protected processCore = overrides?.processCore!.bind(this);
-		protected onDisconnect = overrides?.onDisconnect!.bind(this);
-		protected applyStashedOp = overrides?.applyStashedOp!.bind(this);
-		/* eslint-enable @typescript-eslint/no-non-null-assertion */
+		protected loadCore = overrides?.loadCore?.bind(this);
+		protected processCore = overrides?.processCore?.bind(this);
+		protected onDisconnect = overrides?.onDisconnect?.bind(this);
+		protected applyStashedOp = overrides?.applyStashedOp?.bind(this);
 		protected didAttach =
 			overrides.didAttach?.bind(this) ?? (() => assert.fail("didAttach not set"));
 	}
@@ -116,7 +114,7 @@ function createTestSharedObject(overrides: OverridableType): {
 			createOverridableProxy<IFluidDataStoreRuntime>(
 				"runtime",
 				runtime,
-				new TypedEventEmitter<IFluidDataStoreRuntimeEvents>() as any as Overridable<IFluidDataStoreRuntime>,
+				new TypedEventEmitter<IFluidDataStoreRuntimeEvents>() as unknown as Overridable<IFluidDataStoreRuntime>,
 			),
 			createOverridableProxy<IChannelAttributes>("attributes", attributes),
 			overrides?.telemetryConfigPrefix ?? "testSharedObject",
@@ -167,7 +165,7 @@ describe("SharedObject attaching binding and connecting", () => {
 			let didAttach = 0;
 			const { overrides, sharedObject } = createTestSharedObject({
 				runtime: {
-					...(runtimeEvents as any as Overridable<IFluidDataStoreRuntime>),
+					...(runtimeEvents as unknown as Overridable<IFluidDataStoreRuntime>),
 					attachState: AttachState.Detached,
 				},
 				didAttach: () => didAttach++,
@@ -242,7 +240,7 @@ describe("SharedObject attaching binding and connecting", () => {
 			let loaded = false;
 			const { overrides, sharedObject } = createTestSharedObject({
 				runtime: {
-					...(runtimeEvents as any as Overridable<IFluidDataStoreRuntime>),
+					...(runtimeEvents as unknown as Overridable<IFluidDataStoreRuntime>),
 					attachState: AttachState.Detached,
 					connected: true,
 				},
@@ -326,7 +324,7 @@ describe("SharedObject attaching binding and connecting", () => {
 			let didAttach = 0;
 			const { overrides, sharedObject } = createTestSharedObject({
 				runtime: {
-					...(runtimeEvents as any as Overridable<IFluidDataStoreRuntime>),
+					...(runtimeEvents as unknown as Overridable<IFluidDataStoreRuntime>),
 					attachState: AttachState.Detached,
 					connected: true,
 				},
@@ -462,11 +460,12 @@ describe("SharedObject attaching binding and connecting", () => {
 
 		it("isAttached with detached transition to attach runtime", async () => {
 			const runtimeEvents = new TypedEventEmitter<IFluidDataStoreRuntimeEvents>();
+
 			let didAttach = 0;
 			let attachCalled = false;
 			const { overrides, sharedObject } = createTestSharedObject({
 				runtime: {
-					...(runtimeEvents as any),
+					// ...runtimeEvents,
 					attachState: AttachState.Detached,
 					connected: false,
 					bindChannel: (channel) => {

--- a/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
+++ b/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
@@ -460,7 +460,6 @@ describe("SharedObject attaching binding and connecting", () => {
 
 		it("isAttached with detached transition to attach runtime", async () => {
 			const runtimeEvents = new TypedEventEmitter<IFluidDataStoreRuntimeEvents>();
-
 			let didAttach = 0;
 			let attachCalled = false;
 			const { overrides, sharedObject } = createTestSharedObject({

--- a/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
+++ b/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
@@ -28,7 +28,7 @@ import { IFluidSerializer } from "../serializer.js";
 import { SharedObject } from "../sharedObject.js";
 
 /* eslint-disable-next-line @typescript-eslint/ban-types --
-	Trying to use sepcfic function signatures here instead of Function makes it so some of the properties of
+	Trying to use specific function signatures here instead of Function makes it so some of the properties of
 	OverridableType below (summarizeCore, loadCore, processCore) end up not typed correctly */
 type Overridable<T> = T extends Function | string | number | undefined | []
 	? T

--- a/packages/dds/shared-object-base/src/test/createSharedObjectKind.spec.ts
+++ b/packages/dds/shared-object-base/src/test/createSharedObjectKind.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 
 import type { IFluidLoadable } from "@fluidframework/core-interfaces";
 import type {

--- a/packages/dds/shared-object-base/src/test/createSharedObjectKind.spec.ts
+++ b/packages/dds/shared-object-base/src/test/createSharedObjectKind.spec.ts
@@ -54,7 +54,7 @@ describe("createSharedObjectKind's return type", () => {
 		const runtime = new MockFluidDataStoreRuntime();
 		runtime.createChannel = (id: string | undefined, type: string) => {
 			createChannelCalls.push([id, type]);
-			return null as unknown as IChannel;
+			return undefined as unknown as IChannel;
 		};
 		SharedFoo.create(runtime);
 		assert.deepEqual(createChannelCalls, [[undefined, SharedFooFactory.Type]]);

--- a/packages/dds/shared-object-base/src/test/serializer.spec.ts
+++ b/packages/dds/shared-object-base/src/test/serializer.spec.ts
@@ -28,7 +28,7 @@ describe("FluidSerializer", () => {
 				return o;
 			}, {}),
 			// Add an array that contains each of our constructed test cases.
-			[...testCases]
+			[...testCases],
 		);
 
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -52,7 +52,7 @@ describe("FluidSerializer", () => {
 				return o;
 			}, {}),
 			// Add an array that contains each of our constructed test cases.
-			[...simple]
+			[...simple],
 		);
 
 		// Verify that `encode` is a no-op for these simple cases.
@@ -102,7 +102,12 @@ describe("FluidSerializer", () => {
 		}
 
 		// Non-finite numbers are coerced to null.  Date is coerced to string.
-		const tricky = createNestedCases([Number.NEGATIVE_INFINITY, Number.NaN, +Number.POSITIVE_INFINITY, new Date()]);
+		const tricky = createNestedCases([
+			Number.NEGATIVE_INFINITY,
+			Number.NaN,
+			+Number.POSITIVE_INFINITY,
+			new Date(),
+		]);
 
 		// Undefined is extra special in that it can't appear at the root, but can appear
 		// embedded in the tree, in which case the key is elided (if an object) or it is

--- a/packages/dds/shared-object-base/src/test/serializer.spec.ts
+++ b/packages/dds/shared-object-base/src/test/serializer.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 
 import { RemoteFluidObjectHandle } from "../remoteObjectHandle.js";
 import { FluidSerializer } from "../serializer.js";
@@ -15,22 +15,21 @@ describe("FluidSerializer", () => {
 	function printHandle(target: any) {
 		return JSON.stringify(target, (key, value) => {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-			return value?.IFluidHandle !== undefined ? "#HANDLE" : value;
+			return value?.IFluidHandle === undefined ? value : "#HANDLE";
 		});
 	}
 
 	function createNestedCases(testCases: any[]) {
-		// Add an object where each field references one of the JSON serializable types.
 		testCases.push(
+			// Add an object where each field references one of the JSON serializable types.
 			testCases.reduce<any>((o, value, index) => {
 				o[`f${index}`] = value;
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 				return o;
 			}, {}),
+			// Add an array that contains each of our constructed test cases.
+			[...testCases]
 		);
-
-		// Add an array that contains each of our constructed test cases.
-		testCases.push([...testCases]);
 
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return testCases;
@@ -45,17 +44,16 @@ describe("FluidSerializer", () => {
 		// are of particular interest.
 		const simple = createNestedCases([false, true, 0, 1, "", "x", null, [], {}]);
 
-		// Add an object where each field references one of the JSON serializable types.
 		simple.push(
+			// Add an object where each field references one of the JSON serializable types.
 			simple.reduce<any>((o, value, index) => {
 				o[`f${index}`] = value;
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 				return o;
 			}, {}),
+			// Add an array that contains each of our constructed test cases.
+			[...simple]
 		);
-
-		// Add an array that contains each of our constructed test cases.
-		simple.push([...simple]);
 
 		// Verify that `encode` is a no-op for these simple cases.
 		for (const input of simple) {
@@ -104,7 +102,7 @@ describe("FluidSerializer", () => {
 		}
 
 		// Non-finite numbers are coerced to null.  Date is coerced to string.
-		const tricky = createNestedCases([-Infinity, NaN, +Infinity, new Date()]);
+		const tricky = createNestedCases([Number.NEGATIVE_INFINITY, Number.NaN, +Number.POSITIVE_INFINITY, new Date()]);
 
 		// Undefined is extra special in that it can't appear at the root, but can appear
 		// embedded in the tree, in which case the key is elided (if an object) or it is

--- a/packages/dds/shared-object-base/src/test/serializer.spec.ts
+++ b/packages/dds/shared-object-base/src/test/serializer.spec.ts
@@ -282,7 +282,9 @@ describe("FluidSerializer", () => {
 			});
 
 			// Parse a handle whose url is absolute path.
-			const parsedHandle: RemoteFluidObjectHandle = serializer.parse(serializedHandle);
+			const parsedHandle: RemoteFluidObjectHandle = serializer.parse(
+				serializedHandle,
+			) as RemoteFluidObjectHandle;
 			assert.strictEqual(
 				parsedHandle.absolutePath,
 				"/default/sharedDDS",
@@ -303,7 +305,9 @@ describe("FluidSerializer", () => {
 
 			// Parse a handle whose url is a path relative to its route context. The serializer will generate absolute
 			// path for the handle and create a handle with it.
-			const parsedHandle: RemoteFluidObjectHandle = serializer.parse(serializedHandle);
+			const parsedHandle: RemoteFluidObjectHandle = serializer.parse(
+				serializedHandle,
+			) as RemoteFluidObjectHandle;
 			assert.strictEqual(
 				parsedHandle.absolutePath,
 				"/default/sharedDDS",

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 
 import {
 	IChannelAttributes,

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -40,13 +40,13 @@ class MySharedObject extends SharedObject {
 		message: ISequencedDocumentMessage,
 		local: boolean,
 		localOpMetadata: unknown,
-	) {
+	): void {
 		throw new Error("Method not implemented.");
 	}
-	protected onDisconnect() {
+	protected onDisconnect(): void {
 		throw new Error("Method not implemented.");
 	}
-	protected applyStashedOp(content: any): unknown {
+	protected applyStashedOp(content: unknown): void {
 		throw new Error("Method not implemented.");
 	}
 }
@@ -60,7 +60,7 @@ class MySharedObjectCore extends SharedObjectCore {
 		);
 	}
 
-	protected readonly serializer = {} as any as IFluidSerializer;
+	protected readonly serializer = {} as unknown as IFluidSerializer;
 
 	protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats {
 		throw new Error("Method not implemented.");
@@ -72,13 +72,13 @@ class MySharedObjectCore extends SharedObjectCore {
 		message: ISequencedDocumentMessage,
 		local: boolean,
 		localOpMetadata: unknown,
-	) {
+	): void {
 		throw new Error("Method not implemented.");
 	}
-	protected onDisconnect() {
+	protected onDisconnect(): void {
 		throw new Error("Method not implemented.");
 	}
-	protected applyStashedOp(content: any): unknown {
+	protected applyStashedOp(content: unknown): void {
 		throw new Error("Method not implemented.");
 	}
 	public getAttachSummary(fullTree?: boolean, trackState?: boolean): ISummaryTreeWithStats {
@@ -98,7 +98,7 @@ class MySharedObjectCore extends SharedObjectCore {
 describe("SharedObject", () => {
 	it("rejects slashes in id", () => {
 		const invalidId = "beforeSlash/afterSlash";
-		const codeBlock = () => new MySharedObject(invalidId);
+		const codeBlock = (): SharedObject => new MySharedObject(invalidId);
 		assert.throws(codeBlock, (e: Error) =>
 			validateAssertionError(e, "Id cannot contain slashes"),
 		);
@@ -108,7 +108,7 @@ describe("SharedObject", () => {
 describe("SharedObjectCore", () => {
 	it("rejects slashes in id", () => {
 		const invalidId = "beforeSlash/afterSlash";
-		const codeBlock = () => new MySharedObjectCore(invalidId);
+		const codeBlock = (): SharedObjectCore => new MySharedObjectCore(invalidId);
 		assert.throws(codeBlock, (e: Error) =>
 			validateAssertionError(e, "Id cannot contain slashes"),
 		);

--- a/packages/dds/shared-object-base/src/test/utils.ts
+++ b/packages/dds/shared-object-base/src/test/utils.ts
@@ -4,13 +4,13 @@
  */
 
 import { IRequest } from "@fluidframework/core-interfaces";
-import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
+import { IFluidHandleContext, type IResponse } from "@fluidframework/core-interfaces/internal";
 import { Serializable } from "@fluidframework/datastore-definitions/internal";
 import { create404Response } from "@fluidframework/runtime-utils/internal";
 
 export class MockHandleContext implements IFluidHandleContext {
 	public isAttached = false;
-	public get IFluidHandleContext() {
+	public get IFluidHandleContext(): IFluidHandleContext {
 		return this;
 	}
 
@@ -23,11 +23,11 @@ export class MockHandleContext implements IFluidHandleContext {
 		public readonly routeContext?: IFluidHandleContext,
 	) {}
 
-	public attachGraph() {
+	public attachGraph(): void {
 		throw new Error("Method not implemented.");
 	}
 
-	public async resolveHandle(request: IRequest) {
+	public async resolveHandle(request: IRequest): Promise<IResponse> {
 		return create404Response(request);
 	}
 }
@@ -40,7 +40,7 @@ export function makeJson<T>(
 	breadth: number,
 	depth: number,
 	createLeaf: () => Serializable<T>,
-) {
+): unknown {
 	let depthInternal = depth;
 	if (--depthInternal === 0) {
 		return createLeaf();

--- a/packages/dds/shared-object-base/src/utils.ts
+++ b/packages/dds/shared-object-base/src/utils.ts
@@ -45,7 +45,7 @@ export function makeHandlesSerializable(
 	value: unknown,
 	serializer: IFluidSerializer,
 	bind: IFluidHandle,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: use unknown (breaking change)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
 ): any {
 	return serializer.encode(value, bind);
 }
@@ -61,7 +61,7 @@ export function makeHandlesSerializable(
  * @legacy
  * @alpha
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: use unknown (breaking change)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: AB#26129 use unknown instead of any (legacy breaking)
 export function parseHandles(value: unknown, serializer: IFluidSerializer): any {
 	return serializer.decode(value);
 }

--- a/packages/dds/shared-object-base/src/utils.ts
+++ b/packages/dds/shared-object-base/src/utils.ts
@@ -20,11 +20,10 @@ import { IFluidSerializer } from "./serializer.js";
  * @internal
  */
 export function serializeHandles(
-	value: any,
+	value: unknown,
 	serializer: IFluidSerializer,
 	bind: IFluidHandle,
 ): string | undefined {
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 	return value === undefined ? value : serializer.stringify(value, bind);
 }
 
@@ -43,11 +42,11 @@ export function serializeHandles(
  * @alpha
  */
 export function makeHandlesSerializable(
-	value: any,
+	value: unknown,
 	serializer: IFluidSerializer,
 	bind: IFluidHandle,
-) {
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: use unknown (breaking change)
+): any {
 	return serializer.encode(value, bind);
 }
 
@@ -62,8 +61,8 @@ export function makeHandlesSerializable(
  * @legacy
  * @alpha
  */
-export function parseHandles(value: any, serializer: IFluidSerializer) {
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: use unknown (breaking change)
+export function parseHandles(value: unknown, serializer: IFluidSerializer): any {
 	return serializer.decode(value);
 }
 
@@ -89,7 +88,7 @@ export function createSingleBlobSummary(
  * @internal
  */
 export function bindHandles(
-	value: any,
+	value: unknown,
 	serializer: IFluidSerializer,
 	bind: IFluidHandle,
 ): void {

--- a/packages/dds/shared-object-base/src/utils.ts
+++ b/packages/dds/shared-object-base/src/utils.ts
@@ -25,7 +25,7 @@ export function serializeHandles(
 	bind: IFluidHandle,
 ): string | undefined {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-	return value !== undefined ? serializer.stringify(value, bind) : value;
+	return value === undefined ? value : serializer.stringify(value, bind);
 }
 
 /**


### PR DESCRIPTION
## Description

Moves from the minimal-deprecated eslint config to the recommended one in the shared-object-base package.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#3018](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3018)