### PR TITLE
refactor(historian): use strictNullChecks

### DIFF
--- a/server/historian/.vscode/settings.json
+++ b/server/historian/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"eslint.workingDirectories": [
+		{
+			"mode": "auto",
+		},
+	],
+	// server code still uses prettier for formatting
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+}

--- a/server/historian/packages/historian-base/src/app.ts
+++ b/server/historian/packages/historian-base/src/app.ts
@@ -30,7 +30,7 @@ import { Constants, getDocumentIdFromRequest, getTenantIdFromRequest } from "./u
 export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
-	storageNameRetriever: IStorageNameRetriever,
+	storageNameRetriever: IStorageNameRetriever | undefined,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
 	documentManager: IDocumentManager,
@@ -67,6 +67,7 @@ export function create(
 				"historian",
 				(tokens, req, res) => {
 					const tenantId = getTenantIdFromRequest(req.params);
+					const authHeader = req.get("Authorization");
 					const additionalProperties: Record<string, any> = {
 						[HttpProperties.driverVersion]: tokens.req(
 							req,
@@ -76,7 +77,7 @@ export function create(
 						[BaseTelemetryProperties.tenantId]: tenantId,
 						[BaseTelemetryProperties.documentId]: getDocumentIdFromRequest(
 							tenantId,
-							req.get("Authorization"),
+							authHeader,
 						),
 					};
 					if (req.get(Constants.IsEphemeralContainer) !== undefined) {

--- a/server/historian/packages/historian-base/src/routes/git/blobs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/blobs.ts
@@ -10,11 +10,7 @@ import {
 	IRevokedTokenChecker,
 	IDocumentManager,
 } from "@fluidframework/server-services-core";
-import {
-	IThrottleMiddlewareOptions,
-	throttle,
-	getParam,
-} from "@fluidframework/server-services-utils";
+import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
 import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
@@ -26,7 +22,7 @@ import { Constants } from "../../utils";
 export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
-	storageNameRetriever: IStorageNameRetriever,
+	storageNameRetriever: IStorageNameRetriever | undefined,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
 	documentManager: IDocumentManager,
@@ -38,7 +34,7 @@ export function create(
 	const router: Router = Router();
 
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
-		throttleIdPrefix: (req) => getParam(req.params, "tenantId"),
+		throttleIdPrefix: (req) => req.params.tenantId,
 		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
 	};
 	const restTenantGeneralThrottler = restTenantThrottlers.get(
@@ -47,7 +43,7 @@ export function create(
 
 	async function createBlob(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		body: git.ICreateBlobParams,
 	): Promise<git.ICreateBlobResponse> {
 		const service = await utils.createGitService({
@@ -66,7 +62,7 @@ export function create(
 
 	async function getBlob(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		sha: string,
 		useCache: boolean,
 	): Promise<git.IBlob> {

--- a/server/historian/packages/historian-base/src/routes/git/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/git/commits.ts
@@ -10,11 +10,7 @@ import {
 	IRevokedTokenChecker,
 	IDocumentManager,
 } from "@fluidframework/server-services-core";
-import {
-	IThrottleMiddlewareOptions,
-	throttle,
-	getParam,
-} from "@fluidframework/server-services-utils";
+import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
 import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
@@ -26,7 +22,7 @@ import { Constants } from "../../utils";
 export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
-	storageNameRetriever: IStorageNameRetriever,
+	storageNameRetriever: IStorageNameRetriever | undefined,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
 	documentManager: IDocumentManager,
@@ -38,7 +34,7 @@ export function create(
 	const router: Router = Router();
 
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
-		throttleIdPrefix: (req) => getParam(req.params, "tenantId"),
+		throttleIdPrefix: (req) => req.params.tenantId,
 		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
 	};
 	const restTenantGeneralThrottler = restTenantThrottlers.get(
@@ -47,7 +43,7 @@ export function create(
 
 	async function createCommit(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		params: ICreateCommitParams,
 	): Promise<ICommit> {
 		const service = await utils.createGitService({
@@ -66,7 +62,7 @@ export function create(
 
 	async function getCommit(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		sha: string,
 		useCache: boolean,
 	): Promise<ICommit> {

--- a/server/historian/packages/historian-base/src/routes/git/refs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/refs.ts
@@ -14,11 +14,7 @@ import {
 	IRevokedTokenChecker,
 	IDocumentManager,
 } from "@fluidframework/server-services-core";
-import {
-	IThrottleMiddlewareOptions,
-	throttle,
-	getParam,
-} from "@fluidframework/server-services-utils";
+import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
 import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
@@ -30,7 +26,7 @@ import { Constants } from "../../utils";
 export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
-	storageNameRetriever: IStorageNameRetriever,
+	storageNameRetriever: IStorageNameRetriever | undefined,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
 	documentManager: IDocumentManager,
@@ -42,14 +38,17 @@ export function create(
 	const router: Router = Router();
 
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
-		throttleIdPrefix: (req) => getParam(req.params, "tenantId"),
+		throttleIdPrefix: (req) => req.params.tenantId,
 		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
 	};
 	const restTenantGeneralThrottler = restTenantThrottlers.get(
 		Constants.generalRestCallThrottleIdPrefix,
 	);
 
-	async function getRefs(tenantId: string, authorization: string): Promise<git.IRef[]> {
+	async function getRefs(
+		tenantId: string,
+		authorization: string | undefined,
+	): Promise<git.IRef[]> {
 		const service = await utils.createGitService({
 			config,
 			tenantId,
@@ -64,7 +63,11 @@ export function create(
 		return service.getRefs();
 	}
 
-	async function getRef(tenantId: string, authorization: string, ref: string): Promise<git.IRef> {
+	async function getRef(
+		tenantId: string,
+		authorization: string | undefined,
+		ref: string,
+	): Promise<git.IRef> {
 		const service = await utils.createGitService({
 			config,
 			tenantId,
@@ -81,7 +84,7 @@ export function create(
 
 	async function createRef(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		params: ICreateRefParamsExternal,
 	): Promise<git.IRef> {
 		const service = await utils.createGitService({
@@ -100,7 +103,7 @@ export function create(
 
 	async function updateRef(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		ref: string,
 		params: IPatchRefParamsExternal,
 	): Promise<git.IRef> {
@@ -118,7 +121,11 @@ export function create(
 		return service.updateRef(ref, params);
 	}
 
-	async function deleteRef(tenantId: string, authorization: string, ref: string): Promise<void> {
+	async function deleteRef(
+		tenantId: string,
+		authorization: string | undefined,
+		ref: string,
+	): Promise<void> {
 		const service = await utils.createGitService({
 			config,
 			tenantId,

--- a/server/historian/packages/historian-base/src/routes/git/tags.ts
+++ b/server/historian/packages/historian-base/src/routes/git/tags.ts
@@ -10,11 +10,7 @@ import {
 	IRevokedTokenChecker,
 	IDocumentManager,
 } from "@fluidframework/server-services-core";
-import {
-	IThrottleMiddlewareOptions,
-	throttle,
-	getParam,
-} from "@fluidframework/server-services-utils";
+import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
 import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
@@ -26,7 +22,7 @@ import { Constants } from "../../utils";
 export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
-	storageNameRetriever: IStorageNameRetriever,
+	storageNameRetriever: IStorageNameRetriever | undefined,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
 	documentManager: IDocumentManager,
@@ -38,7 +34,7 @@ export function create(
 	const router: Router = Router();
 
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
-		throttleIdPrefix: (req) => getParam(req.params, "tenantId"),
+		throttleIdPrefix: (req) => req.params.tenantId,
 		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
 	};
 	const restTenantGeneralThrottler = restTenantThrottlers.get(
@@ -47,7 +43,7 @@ export function create(
 
 	async function createTag(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		params: git.ICreateTagParams,
 	): Promise<git.ITag> {
 		const service = await utils.createGitService({
@@ -64,7 +60,11 @@ export function create(
 		return service.createTag(params);
 	}
 
-	async function getTag(tenantId: string, authorization: string, tag: string): Promise<git.ITag> {
+	async function getTag(
+		tenantId: string,
+		authorization: string | undefined,
+		tag: string,
+	): Promise<git.ITag> {
 		const service = await utils.createGitService({
 			config,
 			tenantId,

--- a/server/historian/packages/historian-base/src/routes/git/trees.ts
+++ b/server/historian/packages/historian-base/src/routes/git/trees.ts
@@ -10,11 +10,7 @@ import {
 	IRevokedTokenChecker,
 	IDocumentManager,
 } from "@fluidframework/server-services-core";
-import {
-	IThrottleMiddlewareOptions,
-	throttle,
-	getParam,
-} from "@fluidframework/server-services-utils";
+import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
 import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
@@ -26,7 +22,7 @@ import { Constants } from "../../utils";
 export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
-	storageNameRetriever: IStorageNameRetriever,
+	storageNameRetriever: IStorageNameRetriever | undefined,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
 	documentManager: IDocumentManager,
@@ -38,7 +34,7 @@ export function create(
 	const router: Router = Router();
 
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
-		throttleIdPrefix: (req) => getParam(req.params, "tenantId"),
+		throttleIdPrefix: (req) => req.params.tenantId,
 		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
 	};
 	const restTenantGeneralThrottler = restTenantThrottlers.get(
@@ -47,7 +43,7 @@ export function create(
 
 	async function createTree(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		params: git.ICreateTreeParams,
 	): Promise<git.ITree> {
 		const service = await utils.createGitService({
@@ -66,7 +62,7 @@ export function create(
 
 	async function getTree(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		sha: string,
 		recursive: boolean,
 		useCache: boolean,

--- a/server/historian/packages/historian-base/src/routes/index.ts
+++ b/server/historian/packages/historian-base/src/routes/index.ts
@@ -44,7 +44,7 @@ export interface IRoutes {
 export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
-	storageNameRetriever: IStorageNameRetriever,
+	storageNameRetriever: IStorageNameRetriever | undefined,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
 	documentManager: IDocumentManager,

--- a/server/historian/packages/historian-base/src/routes/repository/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/commits.ts
@@ -10,23 +10,23 @@ import {
 	IRevokedTokenChecker,
 	IDocumentManager,
 } from "@fluidframework/server-services-core";
+import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
 import {
-	IThrottleMiddlewareOptions,
-	throttle,
-	getParam,
-} from "@fluidframework/server-services-utils";
-import { validateRequestParams } from "@fluidframework/server-services-shared";
+	containsPathTraversal,
+	validateRequestParams,
+} from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
 import { ICache, IDenyList, ITenantService } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
+import { NetworkError } from "@fluidframework/server-services-client";
 
 export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
-	storageNameRetriever: IStorageNameRetriever,
+	storageNameRetriever: IStorageNameRetriever | undefined,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
 	documentManager: IDocumentManager,
@@ -38,7 +38,7 @@ export function create(
 	const router: Router = Router();
 
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
-		throttleIdPrefix: (req) => getParam(req.params, "tenantId"),
+		throttleIdPrefix: (req) => req.params.tenantId,
 		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
 	};
 	const restTenantGeneralThrottler = restTenantThrottlers.get(
@@ -47,10 +47,13 @@ export function create(
 
 	async function getCommits(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		sha: string,
-		count: number,
+		count: number = 1,
 	): Promise<git.ICommitDetails[]> {
+		if (sha === undefined) {
+			throw new NetworkError(400, "Missing required parameter 'sha'");
+		}
 		const service = await utils.createGitService({
 			config,
 			tenantId,
@@ -67,14 +70,31 @@ export function create(
 
 	router.get(
 		"/repos/:ignored?/:tenantId/commits",
-		validateRequestParams("sha"),
+		validateRequestParams("tenantId"),
 		throttle(restTenantGeneralThrottler, winston, tenantThrottleOptions),
 		utils.verifyToken(revokedTokenChecker),
 		(request, response, next) => {
+			const sha = utils.queryParamToString(request.query.sha);
+			if (sha === undefined) {
+				utils.handleResponse(
+					Promise.reject(new NetworkError(400, "Missing required parameter 'sha'")),
+					response,
+					false,
+				);
+				return;
+			}
+			if (containsPathTraversal(sha)) {
+				utils.handleResponse(
+					Promise.reject(new NetworkError(400, "Invalid sha")),
+					response,
+					false,
+				);
+				return;
+			}
 			const commitsP = getCommits(
 				request.params.tenantId,
 				request.get("Authorization"),
-				utils.queryParamToString(request.query.sha),
+				sha,
 				utils.queryParamToNumber(request.query.count),
 			);
 

--- a/server/historian/packages/historian-base/src/routes/repository/contents.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/contents.ts
@@ -9,11 +9,7 @@ import {
 	IRevokedTokenChecker,
 	IDocumentManager,
 } from "@fluidframework/server-services-core";
-import {
-	IThrottleMiddlewareOptions,
-	throttle,
-	getParam,
-} from "@fluidframework/server-services-utils";
+import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
 import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
@@ -25,7 +21,7 @@ import { Constants } from "../../utils";
 export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
-	storageNameRetriever: IStorageNameRetriever,
+	storageNameRetriever: IStorageNameRetriever | undefined,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
 	documentManager: IDocumentManager,
@@ -37,7 +33,7 @@ export function create(
 	const router: Router = Router();
 
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
-		throttleIdPrefix: (req) => getParam(req.params, "tenantId"),
+		throttleIdPrefix: (req) => req.params.tenantId,
 		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
 	};
 	const restTenantGeneralThrottler = restTenantThrottlers.get(
@@ -46,9 +42,9 @@ export function create(
 
 	async function getContent(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		path: string,
-		ref: string,
+		ref: string | undefined,
 	): Promise<any> {
 		const service = await utils.createGitService({
 			config,

--- a/server/historian/packages/historian-base/src/routes/repository/headers.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/headers.ts
@@ -10,11 +10,7 @@ import {
 	IRevokedTokenChecker,
 	IDocumentManager,
 } from "@fluidframework/server-services-core";
-import {
-	IThrottleMiddlewareOptions,
-	throttle,
-	getParam,
-} from "@fluidframework/server-services-utils";
+import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
 import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
@@ -26,7 +22,7 @@ import { Constants } from "../../utils";
 export function create(
 	config: nconf.Provider,
 	tenantService: ITenantService,
-	storageNameRetriever: IStorageNameRetriever,
+	storageNameRetriever: IStorageNameRetriever | undefined,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
 	documentManager: IDocumentManager,
@@ -38,7 +34,7 @@ export function create(
 	const router: Router = Router();
 
 	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
-		throttleIdPrefix: (req) => getParam(req.params, "tenantId"),
+		throttleIdPrefix: (req) => req.params.tenantId,
 		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
 	};
 	const restTenantGeneralThrottler = restTenantThrottlers.get(
@@ -47,7 +43,7 @@ export function create(
 
 	async function getHeader(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		sha: string,
 		useCache: boolean,
 	): Promise<IHeader> {
@@ -67,7 +63,7 @@ export function create(
 
 	async function getTree(
 		tenantId: string,
-		authorization: string,
+		authorization: string | undefined,
 		sha: string,
 		useCache: boolean,
 	): Promise<any> {

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -20,7 +20,6 @@ import {
 	IStorageNameRetriever,
 	IRevokedTokenChecker,
 	IDocumentManager,
-	IDocumentStaticProperties,
 	IThrottler,
 } from "@fluidframework/server-services-core";
 import {
@@ -37,7 +36,7 @@ export { handleResponse } from "@fluidframework/server-services-shared";
 export type CommonRouteParams = [
 	config: nconf.Provider,
 	tenantService: ITenantService,
-	storageNameRetriever: IStorageNameRetriever,
+	storageNameRetriever: IStorageNameRetriever | undefined,
 	restTenantThrottlers: Map<string, IThrottler>,
 	restClusterThrottlers: Map<string, IThrottler>,
 	documentManager: IDocumentManager,
@@ -47,21 +46,33 @@ export type CommonRouteParams = [
 	ephemeralDocumentTTLSec?: number,
 ];
 
-export class createGitServiceArgs {
+export interface ICreateGitServiceArgs {
 	config: nconf.Provider;
 	tenantId: string;
-	authorization: string;
+	authorization: string | undefined;
 	tenantService: ITenantService;
-	storageNameRetriever: IStorageNameRetriever;
+	storageNameRetriever?: IStorageNameRetriever;
 	documentManager: IDocumentManager;
 	cache?: ICache;
-	initialUpload?: boolean = false;
+	initialUpload?: boolean;
 	storageName?: string;
-	allowDisabledTenant?: boolean = false;
-	isEphemeralContainer?: boolean = false;
-	ephemeralDocumentTTLSec?: number = 60 * 60 * 24; // 24 hours
+	allowDisabledTenant?: boolean;
+	isEphemeralContainer?: boolean;
+	ephemeralDocumentTTLSec?: number; // 24 hours
 	denyList?: IDenyList;
 }
+
+const defaultCreateGitServiceArgs: Required<
+	Pick<
+		ICreateGitServiceArgs,
+		"initialUpload" | "allowDisabledTenant" | "isEphemeralContainer" | "ephemeralDocumentTTLSec"
+	>
+> = {
+	initialUpload: false,
+	allowDisabledTenant: false,
+	isEphemeralContainer: false,
+	ephemeralDocumentTTLSec: 60 * 60 * 24, // 24 hours
+};
 
 function getEphemeralContainerCacheKey(documentId: string): string {
 	return `isEphemeralContainer:${documentId}`;
@@ -71,8 +82,15 @@ async function updateIsEphemeralCache(
 	documentId: string,
 	tenantId: string,
 	isEphemeral: boolean,
-	cache: ICache,
+	cache: ICache | undefined,
 ): Promise<void> {
+	if (!cache) {
+		Lumberjack.warning("Cache not provided. Skipping ephemeral cache update.", {
+			...getLumberBaseProperties(documentId, tenantId),
+			isEphemeral,
+		});
+		return;
+	}
 	const isEphemeralKey: string = getEphemeralContainerCacheKey(documentId);
 	Lumberjack.info(
 		`Setting cache for ${isEphemeralKey} to ${isEphemeral}.`,
@@ -94,13 +112,19 @@ async function updateIsEphemeralCache(
 }
 
 async function getDocumentCachedEphemeralProperties(
-	cache: ICache,
+	cache: ICache | undefined,
 	documentId: string,
 	tenantId: string,
 ): Promise<boolean | undefined> {
+	if (!cache) {
+		Lumberjack.warning("Cache not provided. Skipping ephemeral cache check.", {
+			...getLumberBaseProperties(documentId, tenantId),
+		});
+		return undefined;
+	}
 	const isEphemeralKey: string = getEphemeralContainerCacheKey(documentId);
 	try {
-		const cachedIsEphemeral: boolean | undefined = await runWithRetry<boolean | undefined>(
+		const cachedIsEphemeral = await runWithRetry(
 			async () => cache?.get(isEphemeralKey) /* api */,
 			"utils.createGitService.get" /* callName */,
 			3 /* maxRetries */,
@@ -133,14 +157,13 @@ async function getDocumentStaticEphemeralProperties(
 	documentId: string,
 ): Promise<{ isEphemeralContainer: boolean; createTime: number | undefined }> {
 	try {
-		const staticProps: IDocumentStaticProperties | undefined =
-			await runWithRetry<IDocumentStaticProperties>(
-				async () => documentManager.readStaticProperties(tenantId, documentId) /* api */,
-				"utils.createGitService.readStaticProperties" /* callName */,
-				3 /* maxRetries */,
-				1000 /* retryAfterMs */,
-				getLumberBaseProperties(documentId, tenantId) /* telemetryProperties */,
-			);
+		const staticProps = await runWithRetry(
+			async () => documentManager.readStaticProperties(tenantId, documentId) /* api */,
+			"utils.createGitService.readStaticProperties" /* callName */,
+			3 /* maxRetries */,
+			1000 /* retryAfterMs */,
+			getLumberBaseProperties(documentId, tenantId) /* telemetryProperties */,
+		);
 		if (!staticProps) {
 			Lumberjack.error(
 				`Static data not found when checking isEphemeral flag.`,
@@ -235,7 +258,7 @@ async function checkAndCacheIsEphemeral({
 	return staticPropsIsEphemeral;
 }
 
-export async function createGitService(createArgs: createGitServiceArgs): Promise<RestGitService> {
+export async function createGitService(createArgs: ICreateGitServiceArgs): Promise<RestGitService> {
 	const {
 		config,
 		tenantId,
@@ -250,8 +273,14 @@ export async function createGitService(createArgs: createGitServiceArgs): Promis
 		isEphemeralContainer,
 		ephemeralDocumentTTLSec,
 		denyList,
-	} = createArgs;
+	} = { ...defaultCreateGitServiceArgs, ...createArgs };
+	if (!authorization) {
+		throw new NetworkError(403, "Authorization header is missing.");
+	}
 	const token = parseToken(tenantId, authorization);
+	if (!token) {
+		throw new NetworkError(403, "Authorization token is missing.");
+	}
 	const decoded = decode(token) as ITokenClaims;
 	const documentId = decoded.documentId;
 	if (containsPathTraversal(documentId)) {
@@ -305,7 +334,7 @@ export async function createGitService(createArgs: createGitServiceArgs): Promis
  * Helper function to convert Request's query param to a number.
  * @param value - The value to be converted to number.
  */
-export function queryParamToNumber(value: any): number {
+export function queryParamToNumber(value: any): number | undefined {
 	if (typeof value !== "string") {
 		return undefined;
 	}
@@ -317,7 +346,7 @@ export function queryParamToNumber(value: any): number {
  * Helper function to convert Request's query param to a string.
  * @param value - The value to be converted to number.
  */
-export function queryParamToString(value: any): string {
+export function queryParamToString(value: any): string | undefined {
 	if (typeof value !== "string") {
 		return undefined;
 	}
@@ -330,7 +359,13 @@ export function verifyToken(revokedTokenChecker: IRevokedTokenChecker | undefine
 		try {
 			const reqTenantId = request.params.tenantId;
 			const authorization = request.get("Authorization");
+			if (!authorization) {
+				throw new NetworkError(403, "Authorization header is missing.");
+			}
 			const token = parseToken(reqTenantId, authorization);
+			if (!token) {
+				throw new NetworkError(403, "Authorization token is missing.");
+			}
 			const claims = validateTokenClaims(token, "documentId", reqTenantId, false);
 			const documentId = claims.documentId;
 			const tenantId = claims.tenantId;

--- a/server/historian/packages/historian-base/src/runner.ts
+++ b/server/historian/packages/historian-base/src/runner.ts
@@ -21,15 +21,15 @@ import { ICache, IDenyList, ITenantService } from "./services";
 import * as app from "./app";
 
 export class HistorianRunner implements IRunner {
-	private server: IWebServer;
-	private runningDeferred: Deferred<void>;
+	private server: IWebServer | undefined;
+	private runningDeferred: Deferred<void> | undefined;
 
 	constructor(
 		private readonly serverFactory: IWebServerFactory,
 		private readonly config: Provider,
 		private readonly port: string | number,
 		private readonly riddler: ITenantService,
-		private readonly storageNameRetriever: IStorageNameRetriever,
+		private readonly storageNameRetriever: IStorageNameRetriever | undefined,
 		public readonly restTenantThrottlers: Map<string, IThrottler>,
 		public readonly restClusterThrottlers: Map<string, IThrottler>,
 		private readonly documentManager: IDocumentManager,
@@ -79,15 +79,15 @@ export class HistorianRunner implements IRunner {
 	public stop(): Promise<void> {
 		// Close the underlying server and then resolve the runner once closed
 		this.server
-			.close()
+			?.close()
 			.then(() => {
-				this.runningDeferred.resolve();
+				this.runningDeferred?.resolve();
 			})
 			.catch((error) => {
-				this.runningDeferred.reject(error);
+				this.runningDeferred?.reject(error);
 			});
 
-		return this.runningDeferred.promise;
+		return this.runningDeferred?.promise ?? Promise.resolve();
 	}
 
 	/**
@@ -123,8 +123,8 @@ export class HistorianRunner implements IRunner {
 	 */
 
 	private onListening() {
-		const addr = this.server.httpServer.address();
-		const bind = typeof addr === "string" ? `pipe ${addr}` : `port ${addr.port}`;
+		const addr = this.server?.httpServer?.address();
+		const bind = typeof addr === "string" ? `pipe ${addr}` : `port ${addr?.port}`;
 		winston.info(`Listening on ${bind}`);
 		Lumberjack.info(`Listening on ${bind}`);
 	}

--- a/server/historian/packages/historian-base/src/runnerFactory.ts
+++ b/server/historian/packages/historian-base/src/runnerFactory.ts
@@ -198,7 +198,7 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 		const port = normalizePort(process.env.PORT || "3000");
 		const tenantManager: core.ITenantManager = new services.TenantManager(
 			riddlerEndpoint,
-			`http://localhost:${port}` /* internalHistorianUrl (self) */,
+			"http://invalid-api-use" /* internalHistorianUrl (explicitly invalid to avoid circular reference) */,
 		);
 		const documentManager: core.IDocumentManager = new services.DocumentManager(
 			alfredEndpoint,

--- a/server/historian/packages/historian-base/src/runnerFactory.ts
+++ b/server/historian/packages/historian-base/src/runnerFactory.ts
@@ -22,7 +22,7 @@ export class HistorianResources implements core.IResources {
 		public readonly config: Provider,
 		public readonly port: string | number,
 		public readonly riddler: historianServices.ITenantService,
-		public readonly storageNameRetriever: core.IStorageNameRetriever,
+		public readonly storageNameRetriever: core.IStorageNameRetriever | undefined,
 		public readonly restTenantThrottlers: Map<string, core.IThrottler>,
 		public readonly restClusterThrottlers: Map<string, core.IThrottler>,
 		public readonly documentManager: core.IDocumentManager,
@@ -195,17 +195,16 @@ export class HistorianResourcesFactory implements core.IResourcesFactory<Histori
 			? customizations?.storageNameRetriever ?? new services.StorageNameRetriever()
 			: undefined;
 
+		const port = normalizePort(process.env.PORT || "3000");
 		const tenantManager: core.ITenantManager = new services.TenantManager(
 			riddlerEndpoint,
-			undefined /* internalHistorianUrl */,
+			`http://localhost:${port}` /* internalHistorianUrl (self) */,
 		);
 		const documentManager: core.IDocumentManager = new services.DocumentManager(
 			alfredEndpoint,
 			tenantManager,
 			gitCache,
 		);
-
-		const port = normalizePort(process.env.PORT || "3000");
 
 		// Token revocation
 		const revokedTokenChecker: core.IRevokedTokenChecker | undefined =

--- a/server/historian/packages/historian-base/src/services/definitions.ts
+++ b/server/historian/packages/historian-base/src/services/definitions.ts
@@ -12,7 +12,7 @@ export interface ICache {
 	/**
 	 * Retrieves the cached entry for the given key. Or null if it doesn't exist.
 	 */
-	get<T>(key: string): Promise<T>;
+	get<T>(key: string): Promise<T | null>;
 
 	/**
 	 * Sets a cache value

--- a/server/historian/packages/historian-base/src/services/redisCache.ts
+++ b/server/historian/packages/historian-base/src/services/redisCache.ts
@@ -31,10 +31,13 @@ export class RedisCache implements ICache {
 		redisClientConnectionManager.addErrorHandler(undefined, "Redis Cache Error");
 	}
 
-	public async get<T>(key: string): Promise<T> {
+	public async get<T>(key: string): Promise<T | null> {
 		const stringValue = await this.redisClientConnectionManager
 			.getRedisClient()
 			.get(this.getKey(key));
+		if (stringValue === null) {
+			return null;
+		}
 		return JSON.parse(stringValue) as T;
 	}
 

--- a/server/historian/packages/historian-base/src/services/redisTenantCache.ts
+++ b/server/historian/packages/historian-base/src/services/redisTenantCache.ts
@@ -76,7 +76,7 @@ export class RedisTenantCache {
 		}
 	}
 
-	public async get(key: string): Promise<string> {
+	public async get(key: string): Promise<string | null> {
 		try {
 			return await this.redisClientConnectionManager.getRedisClient().get(this.getKey(key));
 		} catch (error) {

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -228,11 +228,7 @@ export class RestGitService {
 	public async createRef(params: ICreateRefParamsExternal): Promise<git.IRef> {
 		// We modify this param to prevent writes to external storage if tenant is not linked
 		if (!this.writeToExternalStorage) {
-			if (params.config === undefined) {
-				params.config = { enabled: false };
-			} else {
-				params.config.enabled = false;
-			}
+			params.config = { ...params.config, enabled: false };
 		}
 		return this.post(`/repos/${this.getRepoPath()}/git/refs`, params);
 	}
@@ -334,11 +330,7 @@ export class RestGitService {
 	public async updateRef(ref: string, params: IPatchRefParamsExternal): Promise<git.IRef> {
 		// We modify this param to prevent writes to external storage if tenant is not linked
 		if (!this.writeToExternalStorage) {
-			if (params.config === undefined) {
-				params.config = { enabled: false };
-			} else {
-				params.config.enabled = false;
-			}
+			params.config = { ...params.config, enabled: false };
 		}
 		return this.patch(`/repos/${this.getRepoPath()}/git/refs/${ref}`, params);
 	}

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -147,10 +147,13 @@ export class RestGitService {
 		return createResults;
 	}
 
-	public async getContent(path: string, ref: string): Promise<any> {
-		const query = new URLSearchParams({ ref }).toString();
+	public async getContent(path: string, ref: string | undefined): Promise<any> {
+		const query = new URLSearchParams();
+		if (ref !== undefined) {
+			query.set("ref", ref);
+		}
 		return this.get(
-			`/repos/${this.getRepoPath()}/contents/${encodeURIComponent(path)}?${query}`,
+			`/repos/${this.getRepoPath()}/contents/${encodeURIComponent(path)}?${query.toString()}`,
 		);
 	}
 
@@ -225,7 +228,11 @@ export class RestGitService {
 	public async createRef(params: ICreateRefParamsExternal): Promise<git.IRef> {
 		// We modify this param to prevent writes to external storage if tenant is not linked
 		if (!this.writeToExternalStorage) {
-			params.config.enabled = false;
+			if (params.config === undefined) {
+				params.config = { enabled: false };
+			} else {
+				params.config.enabled = false;
+			}
 		}
 		return this.post(`/repos/${this.getRepoPath()}/git/refs`, params);
 	}
@@ -244,7 +251,8 @@ export class RestGitService {
 		if (
 			summaryParams.type === "container" &&
 			(summaryResponse as IWholeFlatSummary).trees !== undefined &&
-			summarySize <= this.maxCacheableSummarySize
+			(this.maxCacheableSummarySize === undefined ||
+				summarySize <= this.maxCacheableSummarySize)
 		) {
 			// Cache the written summary for future retrieval. If this fails, next summary retrieval
 			// will receive an older version, but that is OK. Client will catch up with ops.
@@ -326,7 +334,11 @@ export class RestGitService {
 	public async updateRef(ref: string, params: IPatchRefParamsExternal): Promise<git.IRef> {
 		// We modify this param to prevent writes to external storage if tenant is not linked
 		if (!this.writeToExternalStorage) {
-			params.config.enabled = false;
+			if (params.config === undefined) {
+				params.config = { enabled: false };
+			} else {
+				params.config.enabled = false;
+			}
 		}
 		return this.patch(`/repos/${this.getRepoPath()}/git/refs/${ref}`, params);
 	}
@@ -405,7 +417,7 @@ export class RestGitService {
 
 				const submoduleCommits = new Array<string>();
 				const quorumValuesSha = new Array<string>();
-				let quorumValues: string;
+				let quorumValues: string | undefined;
 
 				baseTree.tree.forEach((entry) => {
 					if (entry.path.includes("quorum")) {
@@ -522,7 +534,7 @@ export class RestGitService {
 		if (this.cache) {
 			// Attempt to cache to Redis - log any errors but don't fail
 			runWithRetry(
-				async () => this.cache.set(key, value) /* api */,
+				async () => this.cache?.set(key, value) /* api */,
 				"RestGitService.setCache" /* callName */,
 				3 /* maxRetries */,
 				1000 /* retryAfterMs */,
@@ -537,8 +549,8 @@ export class RestGitService {
 	private async getCache<T>(key: string): Promise<T | undefined> {
 		if (this.cache) {
 			// Attempt to cache to Redis - log any errors but don't fail
-			const cachedValue: T | undefined = await runWithRetry(
-				async () => this.cache.get<T | undefined>(key) /* api */,
+			const cachedValue = await runWithRetry(
+				async () => this.cache?.get<T>(key) /* api */,
 				"RestGitService.getCache" /* callName */,
 				3 /* maxRetries */,
 				1000 /* retryAfterMs */,
@@ -548,7 +560,9 @@ export class RestGitService {
 				Lumberjack.error(`Error fetching ${key} from cache`, this.lumberProperties, error);
 				return undefined;
 			});
-			return cachedValue;
+			if (cachedValue !== null) {
+				return cachedValue;
+			}
 		}
 		return undefined;
 	}

--- a/server/historian/packages/historian-base/src/utils.ts
+++ b/server/historian/packages/historian-base/src/utils.ts
@@ -41,7 +41,7 @@ export const Constants = Object.freeze({
 	isInitialSummary: "isInitialSummary",
 });
 
-export function getTokenLifetimeInSec(token: string): number {
+export function getTokenLifetimeInSec(token: string): number | undefined {
 	const claims = decode(token) as ITokenClaims;
 	if (claims?.exp) {
 		return claims.exp - Math.round(new Date().getTime() / 1000);
@@ -62,7 +62,10 @@ export function getTenantIdFromRequest(params: Params) {
 	return "-";
 }
 
-export function getDocumentIdFromRequest(tenantId: string, authorization: string) {
+export function getDocumentIdFromRequest(tenantId: string, authorization: string | undefined) {
+	if (!authorization) {
+		return "-";
+	}
 	try {
 		const token = parseToken(tenantId, authorization);
 		const decoded = decode(token) as ITokenClaims;
@@ -72,8 +75,11 @@ export function getDocumentIdFromRequest(tenantId: string, authorization: string
 	}
 }
 
-export function parseToken(tenantId: string, authorization: string): string {
-	let token: string;
+export function parseToken(
+	tenantId: string,
+	authorization: string | undefined,
+): string | undefined {
+	let token: string | undefined;
 	if (authorization) {
 		const base64TokenMatch = authorization.match(/Basic (.+)/);
 		if (!base64TokenMatch) {

--- a/server/historian/packages/historian-base/tsconfig.json
+++ b/server/historian/packages/historian-base/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "@fluidframework/build-common/ts-common-config.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"strictNullChecks": false,
+		"strictNullChecks": true,
 		"rootDir": "./src",
 		"outDir": "./dist",
 		"composite": true,


### PR DESCRIPTION
## Description

Continuation of #23054 in Historian.

## Breaking Changes

Many functions now return `| undefined` or `| null` types to reflect existing functionality. However, we don't expose Historian code APIs publicly.

## Reviewer Guidance

The majority of changes shouldn't actually change functionality, with the exception of the following bugs that were fixed:

- `validateRequestParams("sha")` in `getCommits` API wasn't actually doing anything, because `sha` isn't a path param in that route. Instead, it should have been `tenantId`. Additionally, I added a manual path traversal check for the sha query param in that API to make sure this PR doesn't remove any security features.
- A few APIs now throw 400 or 403 in places where request information could be missing. Previously, this would have thrown a type error and been exposed as a 500 most likely.