### PR TITLE
Use ADO feeds to install packages in CI builds

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -170,18 +170,11 @@ stages:
 
         - template: templates/include-use-node-version.yml
 
-        - template: templates/include-install-pnpm.yml
+        - template: /tools/pipelines/templates/include-install.yml@self
           parameters:
+            packageManager: pnpm
             buildDirectory: $(Build.SourcesDirectory)/docs
-
-        - task: Bash@3
-          displayName: Install dependencies
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(Build.SourcesDirectory)/docs
-            script: |
-              set -eu -o pipefail
-              pnpm i --frozen-lockfile
+            packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
 
         - task: Npm@1
           displayName: npm run build
@@ -293,18 +286,11 @@ stages:
 
         - template: templates/include-use-node-version.yml
 
-        - template: templates/include-install-pnpm.yml
+        - template: /tools/pipelines/templates/include-install.yml@self
           parameters:
+            packageManager: pnpm
             buildDirectory: $(Build.SourcesDirectory)/docs
-
-        - task: Bash@3
-          displayName: Install dependencies
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(Build.SourcesDirectory)/docs
-            script: |
-              set -eu -o pipefail
-              pnpm i --frozen-lockfile
+            packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
 
         - task: Npm@1
           displayName: Build

--- a/tools/pipelines/deploy-website.yml
+++ b/tools/pipelines/deploy-website.yml
@@ -110,18 +110,11 @@ stages:
 
         - template: templates/include-use-node-version.yml
 
-        - template: templates/include-install-pnpm.yml
+        - template: /tools/pipelines/templates/include-install.yml@self
           parameters:
+            packageManager: pnpm
             buildDirectory: $(Build.SourcesDirectory)/docs
-
-        - task: Bash@3
-          displayName: Install dependencies
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(Build.SourcesDirectory)/docs
-            script: |
-              set -eu -o pipefail
-              pnpm i --frozen-lockfile
+            packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
 
         - task: Npm@1
           displayName: npm run build
@@ -233,18 +226,11 @@ stages:
 
         - template: templates/include-use-node-version.yml
 
-        - template: templates/include-install-pnpm.yml
+        - template: /tools/pipelines/templates/include-install.yml@self
           parameters:
+            packageManager: pnpm
             buildDirectory: $(Build.SourcesDirectory)/docs
-
-        - task: Bash@3
-          displayName: Install dependencies
-          inputs:
-            targetType: 'inline'
-            workingDirectory: $(Build.SourcesDirectory)/docs
-            script: |
-              set -eu -o pipefail
-              pnpm i --frozen-lockfile
+            packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
 
         - task: Npm@1
           displayName: Build

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -64,19 +64,12 @@ extends:
       - job: run_policy_check
         steps:
         - template: /tools/pipelines/templates/include-use-node-version.yml@self
-        - template: /tools/pipelines/templates/include-install-pnpm.yml@self
+        - template: /tools/pipelines/templates/include-install.yml@self
           parameters:
+            packageManager: pnpm
             buildDirectory: .
-
-        - task: Bash@3
-          displayName: Install root dependencies
-          inputs:
-            targetType: 'inline'
-            workingDirectory: .
-            script: |
-              set -eu -o pipefail
-              # We only need to install the root dependencies
-              pnpm install --workspace-root --frozen-lockfile
+            # We only need to install the root dependencies
+            packageManagerInstallCommand: 'pnpm install --workspace-root --frozen-lockfile'
 
         - task: Npm@1
           displayName: Policy Check

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -51,7 +51,8 @@ steps:
       pnpm config set store-dir ${{ parameters.pnpmStorePath }}
       pnpm config set -g workspace-concurrency 0
   # We should leverage the primary npm registry to install pnpm. However, ADO artifacts feeds do not implement
-  # the full npm registry API including a route that corepack uses to get package metadata, including the version
+  # the full npm registry API including a route that corepack uses to get package metadata--the version
   # route here: https://github.com/nodejs/corepack/blob/bc13d40037d0b1bfd386e260ae741f55505b5c7c/sources/npmRegistryUtils.ts#L32
+  # Thus installing pnpm from an ADO feed using corepack is not currently possible.
   # env:
   #   COREPACK_NPM_REGISTRY: $(ado-feeds-primary-registry)

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -50,5 +50,8 @@ steps:
       echo "Using pnpm $(pnpm -v)"
       pnpm config set store-dir ${{ parameters.pnpmStorePath }}
       pnpm config set -g workspace-concurrency 0
-  env:
-    COREPACK_NPM_REGISTRY: $(ado-feeds-primary-registry)
+  # We should leverage the primary npm registry to install pnpm. However, ADO artifacts feeds do not implement
+  # the full npm registry API including a route that corepack uses to get package metadata, including the version
+  # route here: https://github.com/nodejs/corepack/blob/bc13d40037d0b1bfd386e260ae741f55505b5c7c/sources/npmRegistryUtils.ts#L32
+  # env:
+  #   COREPACK_NPM_REGISTRY: $(ado-feeds-primary-registry)

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -50,3 +50,5 @@ steps:
       echo "Using pnpm $(pnpm -v)"
       pnpm config set store-dir ${{ parameters.pnpmStorePath }}
       pnpm config set -g workspace-concurrency 0
+  env:
+    COREPACK_NPM_REGISTRY: $(ado-feeds-primary-registry)

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -27,3 +27,5 @@ steps:
       script: |
         set -eu -o pipefail
         ${{ parameters.packageManagerInstallCommand }}
+    env:
+      NPM_CONFIG_REGISTRY: $(ado-feeds-primary-registry)

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-# include-install template for the install step in client build and test stability pipeline
+# Installs dependencies in the specified directory. If using pnpm, also ensures pnpm is installed
+# and configured in ${{ parameters.pnpmInstallDirectory }}
 
 parameters:
 - name: packageManager
@@ -13,12 +14,15 @@ parameters:
 - name: packageManagerInstallCommand
   type: string
 
+- name: pnpmInstallDirectory
+  type: string
+  default: $(Build.SourcesDirectory)
+
 steps:
   - ${{ if eq(parameters.packageManager, 'pnpm') }}:
     - template: include-install-pnpm.yml
       parameters:
-        buildDirectory: ${{ parameters.buildDirectory }}
-        enableCache: false
+        buildDirectory: ${{ parameters.pnpmInstallDirectory }}
 
   - task: Bash@3
     displayName: Install dependencies
@@ -27,10 +31,6 @@ steps:
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
         set -eu -o pipefail
-        echo "registry: $(pnpm config get registry)"
-        echo "Removing node_modules"
-        rm -rf node_modules
-        echo "Running install"
         registry="$(pnpm config get registry)"
         token=$(echo -n "${SYSTEM_ACCESSTOKEN}" | base64 --wrap 0)
         if [ $registry != "https://registry.npmjs.org/" ]; then
@@ -42,6 +42,7 @@ steps:
         else
           echo "No authentication needed for registry: ${registry}"
         fi
+        echo "Installing dependencies."
         ${{ parameters.packageManagerInstallCommand }}
     env:
       NPM_CONFIG_REGISTRY: $(ado-feeds-primary-registry)

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -26,6 +26,7 @@ steps:
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
         set -eu -o pipefail
-        ${{ parameters.packageManagerInstallCommand }}
+        echo $(pnpm config get registry)
+        ${{ parameters.packageManagerInstallCommand }} --force
     env:
       NPM_CONFIG_REGISTRY: $(ado-feeds-primary-registry)

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -31,6 +31,15 @@ steps:
         echo "Removing node_modules"
         rm -rf node_modules
         echo "Running install"
-        ${{ parameters.packageManagerInstallCommand }} --force
+        registry = "$(pnpm config get registry)"
+        token = echo -n "Bearer ${SYSTEM_ACCESSTOKEN}" | base64
+        if [ $registry != "https://registry.npmjs.org/" ]; then
+          echo "Authenticating to registry: ${registry}"
+          npm config set //${registry}:_authToken=${token}
+        else
+          echo "No authentication needed for registry: ${registry}"
+        fi
+        ${{ parameters.packageManagerInstallCommand }}
     env:
       NPM_CONFIG_REGISTRY: $(ado-feeds-primary-registry)
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -35,7 +35,8 @@ steps:
         token=$(echo -n "Bearer ${SYSTEM_ACCESSTOKEN}" | base64)
         if [ $registry != "https://registry.npmjs.org/" ]; then
           echo "Authenticating to registry: ${registry}"
-          npm config set //${registry}:_authToken=${token}
+          # Remove leading `https://` from registry URL
+          pnpm config set "//${registry##https://}:_authToken=${token}"
         else
           echo "No authentication needed for registry: ${registry}"
         fi

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -32,7 +32,7 @@ steps:
         rm -rf node_modules
         echo "Running install"
         registry="$(pnpm config get registry)"
-        token=$(echo -n "Bearer ${SYSTEM_ACCESSTOKEN}" | base64)
+        token=$(echo -n "Bearer ${SYSTEM_ACCESSTOKEN}" | base64 --wrap 0)
         if [ $registry != "https://registry.npmjs.org/" ]; then
           echo "Authenticating to registry: ${registry}"
           # Remove leading `https://` from registry URL

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -32,11 +32,13 @@ steps:
         rm -rf node_modules
         echo "Running install"
         registry="$(pnpm config get registry)"
-        token=$(echo -n "Bearer ${SYSTEM_ACCESSTOKEN}" | base64 --wrap 0)
+        token=$(echo -n "${SYSTEM_ACCESSTOKEN}" | base64 --wrap 0)
         if [ $registry != "https://registry.npmjs.org/" ]; then
           echo "Authenticating to registry: ${registry}"
           # Remove leading `https://` from registry URL
-          pnpm config set "//${registry##https://}:_authToken=${token}"
+          registryNoProtocol=${registry#https://}
+          pnpm config set "//${registryNoProtocol}:username=ci"
+          pnpm config set "//${registryNoProtocol}:_password=\"${token}\""
         else
           echo "No authentication needed for registry: ${registry}"
         fi

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -31,8 +31,8 @@ steps:
         echo "Removing node_modules"
         rm -rf node_modules
         echo "Running install"
-        registry = "$(pnpm config get registry)"
-        token = echo -n "Bearer ${SYSTEM_ACCESSTOKEN}" | base64
+        registry="$(pnpm config get registry)"
+        token=echo -n "Bearer ${SYSTEM_ACCESSTOKEN}" | base64
         if [ $registry != "https://registry.npmjs.org/" ]; then
           echo "Authenticating to registry: ${registry}"
           npm config set //${registry}:_authToken=${token}

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -18,6 +18,7 @@ steps:
     - template: include-install-pnpm.yml
       parameters:
         buildDirectory: ${{ parameters.buildDirectory }}
+        enableCache: false
 
   - task: Bash@3
     displayName: Install dependencies

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -26,7 +26,10 @@ steps:
       workingDirectory: ${{ parameters.buildDirectory }}
       script: |
         set -eu -o pipefail
-        echo $(pnpm config get registry)
+        echo "registry: $(pnpm config get registry)"
+        echo "Removing node_modules"
+        rm -rf node_modules
+        echo "Running install"
         ${{ parameters.packageManagerInstallCommand }} --force
     env:
       NPM_CONFIG_REGISTRY: $(ado-feeds-primary-registry)

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -32,7 +32,7 @@ steps:
         rm -rf node_modules
         echo "Running install"
         registry="$(pnpm config get registry)"
-        token=echo -n "Bearer ${SYSTEM_ACCESSTOKEN}" | base64
+        token=$(echo -n "Bearer ${SYSTEM_ACCESSTOKEN}" | base64)
         if [ $registry != "https://registry.npmjs.org/" ]; then
           echo "Authenticating to registry: ${registry}"
           npm config set //${registry}:_authToken=${token}

--- a/tools/pipelines/templates/include-policy-check.yml
+++ b/tools/pipelines/templates/include-policy-check.yml
@@ -35,18 +35,11 @@ stages:
     steps:
     - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
-    - template: /tools/pipelines/templates/include-install-pnpm.yml@self
+    - template: /tools/pipelines/templates/include-install.yml@self
       parameters:
-        buildDirectory: $(Build.SourcesDirectory)
-
-    - task: Bash@3
-      displayName: Install dependencies
-      inputs:
-        targetType: 'inline'
-        workingDirectory: ${{ parameters.buildDirectory }}
-        script: |
-          set -eu -o pipefail
-          ${{ parameters.dependencyInstallCommand }}
+        packageManager: pnpm
+        buildDirectory: ${{ parameters.buildDirectory }}
+        packageManagerInstallCommand: ${{ parameters.dependencyInstallCommand }}
 
     - ${{ if ne(convertToJson(parameters.checks), '[]') }}:
       - ${{ each check in parameters.checks }}:


### PR DESCRIPTION
## Description

Updates our pipeline's install template to use the feed configured by `ado-feeds-primary-registry`. For the public project (PR builds), this is still npmjs. For internal project (CI builds), this points to an ADO feed that upstreams npmjs. This puts us closer to Microsoft OSS guidance [here](https://docs.opensource.microsoft.com/security/cfs/), specifically:

> Microsoft teams building production-grade software need to use [Central Feed Services](https://aka.ms/cfs) to pull their components from an Azure Artifacts feed that upstreams and protects Microsoft, instead of using publicly-available package managers.

with [this section](https://docs.opensource.microsoft.com/security/cfs/#public-project) being the applicable one for microsoft/FluidFramework.

This PR also updates a number of inlined "install dependencies" commands to use this template instead.