### PR TITLE
Use ADO feeds to install packages in CI builds

### DIFF
--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -20,6 +20,7 @@ variables:
   value: true
 - name: pnpmStorePath
   value: $(Pipeline.Workspace)/.pnpm-store
+- group: ado-feeds
 
 # The `resources` specify the location and version of the 1ES PT.
 resources:

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -6,19 +6,19 @@
 # This template can be included in pipelines to install pnpm with store caching enabled.
 
 parameters:
-  # The path containing the project(s) to build.
-  - name: buildDirectory
-    type: string
+# The path containing the project(s) to build.
+- name: buildDirectory
+  type: string
 
-  # If set to false, the pnpm store will not be cached or restored from cache.
-  - name: enableCache
-    type: boolean
-    default: true
+# If set to false, the pnpm store will not be cached or restored from cache.
+- name: enableCache
+  type: boolean
+  default: true
 
-  # The path to the pnpm store. The contents here will be cached and restored when using pnpm in a pipeline.
-  - name: pnpmStorePath
-    type: string
-    default: $(Pipeline.Workspace)/.pnpm-store
+# The path to the pnpm store. The contents here will be cached and restored when using pnpm in a pipeline.
+- name: pnpmStorePath
+  type: string
+  default: $(Pipeline.Workspace)/.pnpm-store
 
 steps:
 - ${{ if eq(parameters.enableCache, true) }}:

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -20,57 +20,57 @@ parameters:
     type: string
     default: $(Pipeline.Workspace)/.pnpm-store
 
-  steps:
-  - ${{ if eq(parameters.enableCache, true) }}:
-    - task: Cache@2
-      displayName: Cache pnpm store
-      timeoutInMinutes: 3
-      continueOnError: true
-      inputs:
-        # Caches are already scoped to individual pipelines, so no need to include the release group name or tag
-        # in the cache key
-        key: 'pnpm-store | "$(Agent.OS)" | ${{ parameters.buildDirectory }}/pnpm-lock.yaml'
-        path: ${{ parameters.pnpmStorePath }}
-        restoreKeys: |
-          pnpm-store | "$(Agent.OS)"
-
-  - task: Bash@3
-    displayName: Install and configure pnpm
-    # The previous task (cache restoration) can timeout, which is classified as canceled, but since it's just cache
-    # restoration, we want to continue even if it timed out.
-    condition: or(succeeded(), canceled())
+steps:
+- ${{ if eq(parameters.enableCache, true) }}:
+  - task: Cache@2
+    displayName: Cache pnpm store
+    timeoutInMinutes: 3
+    continueOnError: true
     inputs:
-      targetType: 'inline'
-      workingDirectory: ${{ parameters.buildDirectory }}
-      # workspace-concurrency 0 means use use the CPU core count. This is better than the default (4) for larger agents.
-      script: |
-        set -eu -o pipefail
-        echo "Using node $(node --version)"
-        sudo corepack enable
-        echo "Using pnpm $(pnpm -v)"
-        pnpm config set store-dir ${{ parameters.pnpmStorePath }}
-        echo "Pnpm store: ${{ parameters.pnpmStorePath }}"
-        echo "Primary registry: ${NPM_REGISTRY}"
-        pnpm config set -g workspace-concurrency 0
-        pnpm config set registry "${NPM_REGISTRY}"
-        if [ ${NPM_REGISTRY} == "https://registry.npmjs.org/" ]
-          echo "##vso[task.setvariable variable=registryType]public"
-        else
-          echo "##vso[task.setvariable variable=registryType]private"
-        fi
-    env:
-      NPM_REGISTRY: $(ado-feeds-primary-registry)
-      # We should leverage the primary npm registry to install pnpm as well. However, ADO artifacts feeds do not implement
-      # the full npm registry API including a route that corepack uses to get package metadata--the version route here:
-      # https://github.com/nodejs/corepack/blob/bc13d40037d0b1bfd386e260ae741f55505b5c7c/sources/npmRegistryUtils.ts#L32
-      # Thus installing pnpm from an ADO feed using corepack is not possible at time of writing.
-      # COREPACK_NPM_REGISTRY: $(ado-feeds-primary-registry)
+      # Caches are already scoped to individual pipelines, so no need to include the release group name or tag
+      # in the cache key
+      key: 'pnpm-store | "$(Agent.OS)" | ${{ parameters.buildDirectory }}/pnpm-lock.yaml'
+      path: ${{ parameters.pnpmStorePath }}
+      restoreKeys: |
+        pnpm-store | "$(Agent.OS)"
 
-  # Authenticate to npm feed if required
-  - task: npmAuthenticate@0
-    displayName: 'npm authenticate (internal feed)'
-    condition: eq(variables['registryType'], 'private')
-    retryCountOnTaskFailure: 1
-    inputs:
-      # All pnpm configuration above applies to the user-level .npmrc, located at $HOME/.npmrc.
-      workingFile: $(Agent.HomeDirectory)/.npmrc
+- task: Bash@3
+  displayName: Install and configure pnpm
+  # The previous task (cache restoration) can timeout, which is classified as canceled, but since it's just cache
+  # restoration, we want to continue even if it timed out.
+  condition: or(succeeded(), canceled())
+  inputs:
+    targetType: 'inline'
+    workingDirectory: ${{ parameters.buildDirectory }}
+    # workspace-concurrency 0 means use use the CPU core count. This is better than the default (4) for larger agents.
+    script: |
+      set -eu -o pipefail
+      echo "Using node $(node --version)"
+      sudo corepack enable
+      echo "Using pnpm $(pnpm -v)"
+      pnpm config set store-dir ${{ parameters.pnpmStorePath }}
+      echo "Pnpm store: ${{ parameters.pnpmStorePath }}"
+      echo "Primary registry: ${NPM_REGISTRY}"
+      pnpm config set -g workspace-concurrency 0
+      pnpm config set registry "${NPM_REGISTRY}"
+      if [ ${NPM_REGISTRY} == "https://registry.npmjs.org/" ]
+        echo "##vso[task.setvariable variable=registryType]public"
+      else
+        echo "##vso[task.setvariable variable=registryType]private"
+      fi
+  env:
+    NPM_REGISTRY: $(ado-feeds-primary-registry)
+    # We should leverage the primary npm registry to install pnpm as well. However, ADO artifacts feeds do not implement
+    # the full npm registry API including a route that corepack uses to get package metadata--the version route here:
+    # https://github.com/nodejs/corepack/blob/bc13d40037d0b1bfd386e260ae741f55505b5c7c/sources/npmRegistryUtils.ts#L32
+    # Thus installing pnpm from an ADO feed using corepack is not possible at time of writing.
+    # COREPACK_NPM_REGISTRY: $(ado-feeds-primary-registry)
+
+# Authenticate to npm feed if required
+- task: npmAuthenticate@0
+  displayName: 'npm authenticate (internal feed)'
+  condition: eq(variables['registryType'], 'private')
+  retryCountOnTaskFailure: 1
+  inputs:
+    # All pnpm configuration above applies to the user-level .npmrc, located at $HOME/.npmrc.
+    workingFile: $(Agent.HomeDirectory)/.npmrc

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -48,6 +48,9 @@ steps:
       echo "Using node $(node --version)"
       sudo corepack enable
       echo "Using pnpm $(pnpm -v)"
+      # All below settings are user-level. We set the user-level .npmrc to be located in a well-known temp location
+      # that will persist for the duration of this job.
+      echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Agent.TempDirectory)/.npmrc"
       pnpm config set store-dir ${{ parameters.pnpmStorePath }}
       echo "Pnpm store: ${{ parameters.pnpmStorePath }}"
       echo "Primary registry: ${NPM_REGISTRY}"
@@ -69,8 +72,8 @@ steps:
 # Authenticate to npm feed if required
 - task: npmAuthenticate@0
   displayName: 'npm authenticate (internal feed)'
-  condition: eq(variables['registryType'], 'private')
+  condition: and(succeeded(), eq(variables['registryType'], 'private'))
   retryCountOnTaskFailure: 1
   inputs:
-    # All pnpm configuration above applies to the user-level .npmrc, located at $HOME/.npmrc.
-    workingFile: $(Agent.HomeDirectory)/.npmrc
+    # All pnpm configuration above applies to the user-level .npmrc, which is explicitly positioned via NPM_CONFIG_USERCONFIG above.
+    workingFile: $(Agent.TempDirectory)/.npmrc

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -20,6 +20,13 @@ parameters:
   type: string
   default: $(Pipeline.Workspace)/.pnpm-store
 
+# Where to place the user-level .npmrc file. Pnpm will be configured to reference this file for the duration of the job.
+# Rather than rely on the default $HOME/.npmrc, we specify a known-reasonable location here.
+# Users of the template probably don't need to change this.
+- name: userNpmrcPath
+  type: string
+  default: $(Agent.TempDirectory)/.npmrc
+
 steps:
 - ${{ if eq(parameters.enableCache, true) }}:
   - task: Cache@2
@@ -48,9 +55,8 @@ steps:
       echo "Using node $(node --version)"
       sudo corepack enable
       echo "Using pnpm $(pnpm -v)"
-      # All below settings are user-level. We set the user-level .npmrc to be located in a well-known temp location
-      # that will persist for the duration of this job.
-      echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Agent.TempDirectory)/.npmrc"
+      # This ensures all subsequent tasks in this job will use the pnpm configuration set here.
+      echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$NPM_CONFIG_USERCONFIG"
       echo "Pnpm user config location: $(pnpm config get userconfig)"
       pnpm config set store-dir ${{ parameters.pnpmStorePath }}
       echo "Pnpm store: ${{ parameters.pnpmStorePath }}"
@@ -64,9 +70,7 @@ steps:
       fi
   env:
     NPM_REGISTRY: $(ado-feeds-primary-registry)
-    # The setvariable task in this script only sets the environment variable for subsequent tasks in this job.
-    # We use the same value here to ensure that all configuration applies throughout pnpm usage in this job.
-    NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/.npmrc
+    NPM_CONFIG_USERCONFIG: ${{ parameters.userNpmrcPath}}
     # We should leverage the primary npm registry to install pnpm as well. However, ADO artifacts feeds do not implement
     # the full npm registry API including a route that corepack uses to get package metadata--the version route here:
     # https://github.com/nodejs/corepack/blob/bc13d40037d0b1bfd386e260ae741f55505b5c7c/sources/npmRegistryUtils.ts#L32
@@ -79,5 +83,4 @@ steps:
   condition: and(succeeded(), eq(variables['registryType'], 'private'))
   retryCountOnTaskFailure: 1
   inputs:
-    # All pnpm configuration above applies to the user-level .npmrc, which is explicitly positioned via NPM_CONFIG_USERCONFIG above.
-    workingFile: $(Agent.TempDirectory)/.npmrc
+    workingFile: ${{ parameters.userNpmrcPath }}

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -71,7 +71,7 @@ steps:
 
 # Authenticate to npm feed if required
 - task: npmAuthenticate@0
-  displayName: 'npm authenticate (internal feed)'
+  displayName: 'Npm authenticate'
   condition: and(succeeded(), eq(variables['registryType'], 'private'))
   retryCountOnTaskFailure: 1
   inputs:

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -53,7 +53,7 @@ steps:
       echo "Primary registry: ${NPM_REGISTRY}"
       pnpm config set -g workspace-concurrency 0
       pnpm config set registry "${NPM_REGISTRY}"
-      if [ ${NPM_REGISTRY} == "https://registry.npmjs.org/" ]
+      if [ ${NPM_REGISTRY} == "https://registry.npmjs.org/" ]; then
         echo "##vso[task.setvariable variable=registryType]public"
       else
         echo "##vso[task.setvariable variable=registryType]private"

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -51,6 +51,7 @@ steps:
       # All below settings are user-level. We set the user-level .npmrc to be located in a well-known temp location
       # that will persist for the duration of this job.
       echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Agent.TempDirectory)/.npmrc"
+      echo "Pnpm user config location: $(pnpm config get userconfig)"
       pnpm config set store-dir ${{ parameters.pnpmStorePath }}
       echo "Pnpm store: ${{ parameters.pnpmStorePath }}"
       echo "Primary registry: ${NPM_REGISTRY}"

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -6,47 +6,71 @@
 # This template can be included in pipelines to install pnpm with store caching enabled.
 
 parameters:
-# The path containing the project(s) to build.
-- name: buildDirectory
-  type: string
+  # The path containing the project(s) to build.
+  - name: buildDirectory
+    type: string
 
-# If set to false, the pnpm store will not be cached or restored from cache.
-- name: enableCache
-  type: boolean
-  default: true
+  # If set to false, the pnpm store will not be cached or restored from cache.
+  - name: enableCache
+    type: boolean
+    default: true
 
-# The path to the pnpm store. The contents here will be cached and restored when using pnpm in a pipeline.
-- name: pnpmStorePath
-  type: string
-  default: $(Pipeline.Workspace)/.pnpm-store
+  # The path to the pnpm store. The contents here will be cached and restored when using pnpm in a pipeline.
+  - name: pnpmStorePath
+    type: string
+    default: $(Pipeline.Workspace)/.pnpm-store
 
-steps:
-- ${{ if eq(parameters.enableCache, true) }}:
-  - task: Cache@2
-    displayName: Cache pnpm store
-    timeoutInMinutes: 3
-    continueOnError: true
+  steps:
+  - ${{ if eq(parameters.enableCache, true) }}:
+    - task: Cache@2
+      displayName: Cache pnpm store
+      timeoutInMinutes: 3
+      continueOnError: true
+      inputs:
+        # Caches are already scoped to individual pipelines, so no need to include the release group name or tag
+        # in the cache key
+        key: 'pnpm-store | "$(Agent.OS)" | ${{ parameters.buildDirectory }}/pnpm-lock.yaml'
+        path: ${{ parameters.pnpmStorePath }}
+        restoreKeys: |
+          pnpm-store | "$(Agent.OS)"
+
+  - task: Bash@3
+    displayName: Install and configure pnpm
+    # The previous task (cache restoration) can timeout, which is classified as canceled, but since it's just cache
+    # restoration, we want to continue even if it timed out.
+    condition: or(succeeded(), canceled())
     inputs:
-      # Caches are already scoped to individual pipelines, so no need to include the release group name or tag
-      # in the cache key
-      key: 'pnpm-store | "$(Agent.OS)" | ${{ parameters.buildDirectory }}/pnpm-lock.yaml'
-      path: ${{ parameters.pnpmStorePath }}
-      restoreKeys: |
-        pnpm-store | "$(Agent.OS)"
+      targetType: 'inline'
+      workingDirectory: ${{ parameters.buildDirectory }}
+      # workspace-concurrency 0 means use use the CPU core count. This is better than the default (4) for larger agents.
+      script: |
+        set -eu -o pipefail
+        echo "Using node $(node --version)"
+        sudo corepack enable
+        echo "Using pnpm $(pnpm -v)"
+        pnpm config set store-dir ${{ parameters.pnpmStorePath }}
+        echo "Pnpm store: ${{ parameters.pnpmStorePath }}"
+        echo "Primary registry: ${NPM_REGISTRY}"
+        pnpm config set -g workspace-concurrency 0
+        pnpm config set registry "${NPM_REGISTRY}"
+        if [ ${NPM_REGISTRY} == "https://registry.npmjs.org/" ]
+          echo "##vso[task.setvariable variable=registryType]public"
+        else
+          echo "##vso[task.setvariable variable=registryType]private"
+        fi
+    env:
+      NPM_REGISTRY: $(ado-feeds-primary-registry)
+      # We should leverage the primary npm registry to install pnpm as well. However, ADO artifacts feeds do not implement
+      # the full npm registry API including a route that corepack uses to get package metadata--the version route here:
+      # https://github.com/nodejs/corepack/blob/bc13d40037d0b1bfd386e260ae741f55505b5c7c/sources/npmRegistryUtils.ts#L32
+      # Thus installing pnpm from an ADO feed using corepack is not possible at time of writing.
+      # COREPACK_NPM_REGISTRY: $(ado-feeds-primary-registry)
 
-- task: Bash@3
-  displayName: Install and configure pnpm
-  # The previous task (cache restoration) can timeout, which is classified as canceled, but since it's just cache
-  # restoration, we want to continue even if it timed out.
-  condition: or(succeeded(), canceled())
-  inputs:
-    targetType: 'inline'
-    workingDirectory: ${{ parameters.buildDirectory }}
-    # workspace-concurrency 0 means use use the CPU core count. This is better than the default (4) for larger agents.
-    script: |
-      set -eu -o pipefail
-      echo "Using node $(node --version)"
-      sudo corepack enable
-      echo "Using pnpm $(pnpm -v)"
-      pnpm config set store-dir ${{ parameters.pnpmStorePath }}
-      pnpm config set -g workspace-concurrency 0
+  # Authenticate to npm feed if required
+  - task: npmAuthenticate@0
+    displayName: 'npm authenticate (internal feed)'
+    condition: eq(variables['registryType'], 'private')
+    retryCountOnTaskFailure: 1
+    inputs:
+      # All pnpm configuration above applies to the user-level .npmrc, located at $HOME/.npmrc.
+      workingFile: $(Agent.HomeDirectory)/.npmrc

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -64,6 +64,9 @@ steps:
       fi
   env:
     NPM_REGISTRY: $(ado-feeds-primary-registry)
+    # The setvariable task in this script only sets the environment variable for subsequent tasks in this job.
+    # We use the same value here to ensure that all configuration applies throughout pnpm usage in this job.
+    NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/.npmrc
     # We should leverage the primary npm registry to install pnpm as well. However, ADO artifacts feeds do not implement
     # the full npm registry API including a route that corepack uses to get package metadata--the version route here:
     # https://github.com/nodejs/corepack/blob/bc13d40037d0b1bfd386e260ae741f55505b5c7c/sources/npmRegistryUtils.ts#L32

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -18,7 +18,6 @@ steps:
     - template: include-install-pnpm.yml
       parameters:
         buildDirectory: ${{ parameters.buildDirectory }}
-        enableCache: false
 
   - task: Bash@3
     displayName: Install dependencies

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -18,6 +18,7 @@ steps:
     - template: include-install-pnpm.yml
       parameters:
         buildDirectory: ${{ parameters.buildDirectory }}
+        enableCache: false
 
   - task: Bash@3
     displayName: Install dependencies

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -21,6 +21,7 @@ parameters:
 
 variables:
 - group: prague-key-vault
+- group: ado-feeds
 - name: skipComponentGovernanceDetection
   value: true
 - name: testBuild


### PR DESCRIPTION
## Description

Updates our pipeline's install-pnpm template to use the npm feed configured by `ado-feeds-primary-registry`. For the public project (PR builds), this is still npmjs. For internal project (CI builds), this points to an ADO feed that upstreams npmjs. This puts us closer to Microsoft OSS guidance [here](https://docs.opensource.microsoft.com/security/cfs/), specifically:

> Microsoft teams building production-grade software need to use [Central Feed Services](https://aka.ms/cfs) to pull their components from an Azure Artifacts feed that upstreams and protects Microsoft, instead of using publicly-available package managers.

with [this section](https://docs.opensource.microsoft.com/security/cfs/#public-project) being the applicable one for microsoft/FluidFramework.
