### PR TITLE
fix(server): retry correct number of times on error

### DIFF
--- a/server/routerlicious/packages/services-core/.eslintrc.cjs
+++ b/server/routerlicious/packages/services-core/.eslintrc.cjs
@@ -8,6 +8,9 @@ module.exports = {
 		require.resolve("@fluidframework/eslint-config-fluid/minimal-deprecated"),
 		"prettier",
 	],
+	parserOptions: {
+		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
+	},
 	rules: {
 		"import/no-nodejs-modules": "off",
 		"promise/catch-or-return": ["error", { allowFinally: true }],

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -14,9 +14,10 @@
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "npm run build:genver && concurrently npm:build:compile npm:lint",
-		"build:compile": "npm run tsc && npm run typetests:gen",
+		"build:compile": "npm run tsc && npm run typetests:gen && npm run build:test",
 		"build:genver": "gen-version",
-		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\"",
+		"build:test": "tsc --project ./src/test/tsconfig.json",
+		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
 		"eslint": "eslint --format stylish src",
 		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
 		"format": "npm run prettier:fix",
@@ -24,6 +25,8 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
+		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
+		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
@@ -46,10 +49,15 @@
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@5.0.0",
+		"@types/mocha": "^10.0.1",
+		"@types/sinon": "^17.0.3",
+		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",
+		"mocha": "^10.2.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
+		"sinon": "^18.0.1",
 		"typescript": "~5.1.6"
 	},
 	"fluidBuild": {
@@ -87,9 +95,6 @@
 				"backCompat": false
 			},
 			"InterfaceDeclaration_IBoxcarMessage": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_IWebServer": {
 				"backCompat": false
 			}
 		}

--- a/server/routerlicious/packages/services-core/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-core/src/runWithRetry.ts
@@ -82,10 +82,6 @@ export async function runWithRetry<T>(
 					);
 					throw error;
 				}
-				// if maxRetries is -1, we retry indefinitely
-				// unless shouldRetry returns false at some point.
-				if (maxRetries !== -1 && retryCount >= maxRetries) {
-				}
 
 				const intervalMs = calculateIntervalMs(error, retryCount, retryAfterMs);
 				await delay(intervalMs);

--- a/server/routerlicious/packages/services-core/src/runWithRetry.ts
+++ b/server/routerlicious/packages/services-core/src/runWithRetry.ts
@@ -50,7 +50,7 @@ export async function runWithRetry<T>(
 		metric = Lumberjack.newLumberMetric(LumberEventName.RunWithRetry, telemetryProperties);
 	}
 	try {
-		while (retryCount < maxRetries || maxRetries === -1) {
+		while (retryCount <= maxRetries || maxRetries === -1) {
 			try {
 				const result = await api();
 				success = true;
@@ -163,7 +163,7 @@ export async function requestWithRetry<T>(
 	try {
 		// if maxRetries is -1, we retry indefinitely
 		// unless shouldRetry returns false at some point.
-		while (retryCount < maxRetries || maxRetries === -1) {
+		while (retryCount <= maxRetries || maxRetries === -1) {
 			try {
 				const result = await request();
 				success = true;

--- a/server/routerlicious/packages/services-core/src/test/runWithRetry.spec.ts
+++ b/server/routerlicious/packages/services-core/src/test/runWithRetry.spec.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from "assert";
 import sinon from "sinon";
-import { runWithRetry } from "../runWithRetry";
+import { runWithRetry, requestWithRetry } from "../runWithRetry";
+import { NetworkError } from "@fluidframework/server-services-client";
 
 describe("runWithRetry", () => {
 	let apiStub: sinon.SinonStub;
@@ -140,6 +141,150 @@ describe("runWithRetry", () => {
 			{},
 			undefined,
 			undefined,
+			(error, numRetries, retryAfterInterval) => retryAfterInterval,
+			onErrorFn,
+		).catch(() => {
+			// Expected to throw
+		});
+		await clock.runAllAsync();
+		await promise;
+
+		assert.equal(onErrorFn.callCount, maxRetries + 1);
+	});
+});
+
+describe("requestWithRetry", () => {
+	let requestStub: sinon.SinonStub;
+	let clock: sinon.SinonFakeTimers;
+
+	beforeEach(() => {
+		requestStub = sinon.stub();
+		clock = sinon.useFakeTimers();
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	it("should retry the expected number of times on failure", async () => {
+		requestStub.rejects(new NetworkError(500, "Test error", true /* canRetry */));
+
+		const maxRetries = 3;
+		const retryAfterMs = 1000;
+
+		const promise = requestWithRetry(
+			requestStub,
+			"testRequest",
+			undefined,
+			undefined,
+			maxRetries,
+			retryAfterMs,
+			(error, numRetries, retryAfterInterval) => retryAfterInterval,
+		).catch(() => {
+			// Expected to throw
+		});
+
+		await clock.runAllAsync();
+
+		await promise;
+
+		assert.equal(requestStub.callCount, maxRetries + 1);
+	});
+
+	it("should not retry on success", async () => {
+		requestStub.resolves("Success");
+
+		const maxRetries = 3;
+		const retryAfterMs = 1000;
+
+		const result = await requestWithRetry(
+			requestStub,
+			"testRequest",
+			undefined,
+			undefined,
+			maxRetries,
+			retryAfterMs,
+			(error, numRetries, retryAfterInterval) => retryAfterInterval,
+		);
+
+		assert.equal(requestStub.callCount, 1);
+		assert.equal(result, "Success");
+	});
+
+	it("should wait the correct interval between multiple retries", async () => {
+		requestStub.rejects(new NetworkError(500, "Test error", true /* canRetry */));
+		requestStub.rejects(new NetworkError(500, "Test error", true /* canRetry */));
+		requestStub.onCall(2).resolves("Success");
+
+		const maxRetries = 3;
+		const retryAfterMs = 1000;
+		const startTime = Date.now();
+		const calculateIntervalMs = (error, numRetries, retryAfterInterval) =>
+			retryAfterInterval * 2 ** numRetries;
+
+		const promise = requestWithRetry(
+			requestStub,
+			"testRequest",
+			undefined,
+			undefined,
+			maxRetries,
+			retryAfterMs,
+			calculateIntervalMs,
+		);
+
+		await clock.runAllAsync();
+
+		const result = await promise;
+
+		const endTime = Date.now();
+		// The total time should be the sum of the retry intervals defined by the calculateIntervalMs function
+		assert.equal(
+			endTime - startTime,
+			calculateIntervalMs(undefined, 0, retryAfterMs) +
+				calculateIntervalMs(undefined, 1, retryAfterMs),
+		);
+
+		assert.equal(requestStub.callCount, 3);
+		assert.equal(result, "Success");
+	});
+
+	it("should stop retrying if network error canRetry is false", async () => {
+		requestStub.rejects(new NetworkError(404, "Test error", false /* canRetry */));
+
+		const maxRetries = 3;
+		const retryAfterMs = 1000;
+
+		const promise = requestWithRetry(
+			requestStub,
+			"testRequest",
+			undefined,
+			undefined,
+			maxRetries,
+			retryAfterMs,
+			(error, numRetries, retryAfterInterval) => retryAfterInterval,
+		).catch(() => {
+			// Expected to throw
+		});
+
+		await promise;
+
+		assert.equal(requestStub.callCount, 1);
+	});
+
+	it("should call onErrorFn on error", async () => {
+		requestStub.rejects(new NetworkError(500, "Test error", true /* canRetry */));
+
+		const maxRetries = 3;
+		const retryAfterMs = 1000;
+		const onErrorFn = sinon.spy();
+
+		const promise = requestWithRetry(
+			requestStub,
+			"testRequest",
+			undefined,
+			undefined,
+			maxRetries,
+			retryAfterMs,
 			(error, numRetries, retryAfterInterval) => retryAfterInterval,
 			onErrorFn,
 		).catch(() => {

--- a/server/routerlicious/packages/services-core/src/test/runWithRetry.spec.ts
+++ b/server/routerlicious/packages/services-core/src/test/runWithRetry.spec.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { strict as assert } from "assert";
 import sinon from "sinon";
 import { runWithRetry, requestWithRetry } from "../runWithRetry";

--- a/server/routerlicious/packages/services-core/src/test/runWithRetry.spec.ts
+++ b/server/routerlicious/packages/services-core/src/test/runWithRetry.spec.ts
@@ -1,0 +1,111 @@
+import { strict as assert } from "assert";
+import sinon from "sinon";
+import { runWithRetry } from "../runWithRetry";
+
+describe("runWithRetry", () => {
+	let apiStub: sinon.SinonStub;
+	let clock: sinon.SinonFakeTimers;
+
+	beforeEach(() => {
+		apiStub = sinon.stub();
+		clock = sinon.useFakeTimers();
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	it("should retry the expected number of times on failure", async () => {
+		apiStub.rejects(new Error("Test error"));
+
+		const maxRetries = 3;
+		const retryAfterMs = 1000;
+
+		try {
+			await runWithRetry(apiStub, "testApi", maxRetries, retryAfterMs);
+		} catch (error) {
+			// Expected to throw
+		}
+
+		assert.equal(apiStub.callCount, maxRetries + 1);
+	});
+
+	it("should not retry on success", async () => {
+		apiStub.resolves("Success");
+
+		const maxRetries = 3;
+		const retryAfterMs = 1000;
+
+		const result = await runWithRetry(apiStub, "testApi", maxRetries, retryAfterMs);
+
+		assert.equal(apiStub.callCount, 1);
+		assert.equal(result, "Success");
+	});
+
+	it("should wait the correct interval between retries", async () => {
+		apiStub.onCall(0).rejects(new Error("Test error"));
+		apiStub.onCall(1).resolves("Success");
+
+		const maxRetries = 3;
+		const retryAfterMs = 1000;
+
+		const promise = runWithRetry(apiStub, "testApi", maxRetries, retryAfterMs);
+
+		await clock.tickAsync(retryAfterMs);
+
+		const result = await promise;
+
+		assert.equal(apiStub.callCount, 2);
+		assert.equal(result, "Success");
+	});
+
+	it("should stop retrying if shouldRetry returns false", async () => {
+		apiStub.rejects(new Error("Test error"));
+
+		const maxRetries = 3;
+		const retryAfterMs = 1000;
+		const shouldRetry = sinon.stub().returns(false);
+
+		try {
+			await runWithRetry(
+				apiStub,
+				"testApi",
+				maxRetries,
+				retryAfterMs,
+				{},
+				undefined,
+				shouldRetry,
+			);
+		} catch (error) {
+			// Expected to throw
+		}
+
+		assert.equal(apiStub.callCount, 1);
+	});
+
+	it("should call onErrorFn on error", async () => {
+		apiStub.rejects(new Error("Test error"));
+
+		const maxRetries = 3;
+		const retryAfterMs = 1000;
+		const onErrorFn = sinon.spy();
+
+		try {
+			await runWithRetry(
+				apiStub,
+				"testApi",
+				maxRetries,
+				retryAfterMs,
+				{},
+				undefined,
+				undefined,
+				undefined,
+				onErrorFn,
+			);
+		} catch (error) {
+			// Expected to throw
+		}
+
+		assert.equal(onErrorFn.callCount, maxRetries + 1);
+	});
+});

--- a/server/routerlicious/packages/services-core/src/test/tsconfig.json
+++ b/server/routerlicious/packages/services-core/src/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"compilerOptions": {
+		"strictNullChecks": false,
+		"rootDir": "./",
+		"outDir": "../../dist/test",
+		"types": ["node", "mocha"],
+		"declaration": false,
+		"declarationMap": false,
+	},
+	"include": ["./**/*"],
+	"references": [
+		{
+			"path": "../..",
+		},
+	],
+}

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -2835,7 +2835,6 @@ declare function get_current_InterfaceDeclaration_IWebServer():
 declare function use_old_InterfaceDeclaration_IWebServer(
     use: TypeOnly<old.IWebServer>): void;
 use_old_InterfaceDeclaration_IWebServer(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IWebServer());
 
 /*

--- a/server/routerlicious/packages/services-core/tsconfig.json
+++ b/server/routerlicious/packages/services-core/tsconfig.json
@@ -1,10 +1,11 @@
 {
 	"extends": "@fluidframework/build-common/ts-common-config.json",
-	"exclude": ["dist", "node_modules"],
+	"exclude": ["dist", "node_modules", "src/test/**/*"],
 	"compilerOptions": {
 		"strictNullChecks": true,
 		"rootDir": "./src",
 		"outDir": "./dist",
+		"composite": true,
 		"types": [
 			"node", // TODO: this package shouldn't depend on node, but current depends on node types
 		],

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -1271,18 +1271,33 @@ importers:
       '@fluidframework/server-services-core-previous':
         specifier: npm:@fluidframework/server-services-core@5.0.0
         version: /@fluidframework/server-services-core@5.0.0
+      '@types/mocha':
+        specifier: ^10.0.1
+        version: 10.0.1
+      '@types/sinon':
+        specifier: ^17.0.3
+        version: 17.0.3
+      c8:
+        specifier: ^8.0.1
+        version: 8.0.1
       concurrently:
         specifier: ^8.2.1
         version: 8.2.1
       eslint:
         specifier: ~8.55.0
         version: 8.55.0
+      mocha:
+        specifier: ^10.2.0
+        version: 10.2.0
       prettier:
         specifier: ~3.0.3
         version: 3.0.3
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
+      sinon:
+        specifier: ^18.0.1
+        version: 18.0.1
       typescript:
         specifier: ~5.1.6
         version: 5.1.6
@@ -13697,6 +13712,7 @@ packages:
 
   /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
     dependencies:
       glob: 7.2.3


### PR DESCRIPTION
## Description

#23054 inadvertently changed the number of retries while trying to clean up undefined logic in `runWithRetry`.

PR adds UTs to make sure the behavior remains as expected.
