### PR TITLE
test(tree): add tests for re-indexing up a spine

### DIFF
--- a/packages/dds/tree/src/feature-libraries/indexing/anchorTreeIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/indexing/anchorTreeIndex.ts
@@ -151,7 +151,7 @@ export class AnchorTreeIndex<TKey extends TreeIndexKey, TValue>
 				assert(cursor.mode === CursorLocationType.Nodes, "replace should happen in a node");
 				cursor.exitNode();
 				this.indexField(cursor);
-				if (this.isShallowIndex) {
+				if (!this.isShallowIndex) {
 					// we must also re-index the spine if the key finders allow for any value under a subtree to be the key
 					// this means that a replace can cause the key for any node up its spine to be changed
 					this.indexSpine(cursor);
@@ -313,7 +313,6 @@ export class AnchorTreeIndex<TKey extends TreeIndexKey, TValue>
 	 */
 	private reIndexSpine(path: UpPath): void {
 		if (!this.isShallowIndex) {
-			assert(parent !== undefined, "must have a parent");
 			const cursor = this.forest.allocateCursor();
 			this.forest.moveCursorToPath(path, cursor);
 			assert(cursor.mode === CursorLocationType.Nodes, "attach should happen in a node");

--- a/packages/dds/tree/src/simple-tree/api/simpleTreeIndex.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleTreeIndex.ts
@@ -200,9 +200,8 @@ export function createSimpleTreeIndex<
 				return treeNodeApi.status(simpleTree);
 			}
 		},
-		// simple tree indexes do not need to re-index their spines because the api only allows nodes to be keyed on fields directly under them
-		// rather than anywhere in their subtree
-		false,
+		// simple tree indexes are shallow indexes, indicating so allows for a performance optimization
+		true,
 	);
 
 	// all the type checking guarantees that we put nodes of the correct type in the index

--- a/packages/dds/tree/src/simple-tree/api/simpleTreeIndex.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleTreeIndex.ts
@@ -200,6 +200,9 @@ export function createSimpleTreeIndex<
 				return treeNodeApi.status(simpleTree);
 			}
 		},
+		// simple tree indexes do not need to re-index their spines because the api only allows nodes to be keyed on fields directly under them
+		// rather than anywhere in their subtree
+		false,
 	);
 
 	// all the type checking guarantees that we put nodes of the correct type in the index


### PR DESCRIPTION
- tests that indexes can be re-indexed up the spine when values/nodes change
- adds a performance optimization so that we do not re-index spines when it's not necessary