### PR TITLE
Replace use of contentSnapshot in dev tools visualizer with newer APIs

### DIFF
--- a/packages/dds/tree/src/core/schema-stored/format.ts
+++ b/packages/dds/tree/src/core/schema-stored/format.ts
@@ -14,7 +14,6 @@ export const version = 1 as const;
  * Key (aka Name or Label) for a field which is scoped to a specific TreeNodeStoredSchema.
  *
  * Stable identifier, used when persisting data.
- * @internal
  */
 export type FieldKey = Brand<string, "tree.FieldKey">;
 
@@ -28,7 +27,6 @@ export const FieldKeySchema = brandedStringType<FieldKey>();
  * Also known as "Definition"
  *
  * Stable identifier, used when persisting data.
- * @internal
  */
 export type TreeNodeSchemaIdentifier<TName extends string = string> = Brand<
 	TName,
@@ -40,7 +38,6 @@ export type TreeNodeSchemaIdentifier<TName extends string = string> = Brand<
  * Refers to an exact stable policy (ex: specific version of a policy),
  * for how to handle (ex: edit and merge edits to) fields marked with this kind.
  * Persisted in documents as part of stored schema.
- * @internal
  */
 export type FieldKindIdentifier = Brand<string, "tree.FieldKindIdentifier">;
 export const FieldKindIdentifierSchema = brandedStringType<FieldKindIdentifier>();

--- a/packages/dds/tree/src/core/schema-stored/schema.ts
+++ b/packages/dds/tree/src/core/schema-stored/schema.ts
@@ -17,7 +17,9 @@ import {
 import type { Multiplicity } from "./multiplicity.js";
 
 /**
- * Schema for what {@link TreeValue} is allowed on a Leaf node.
+ * Schema for what {@link TreeLeafValue} is allowed on a Leaf node.
+ * @privateRemarks
+ * See also {@link TreeValue}.
  * @internal
  */
 export enum ValueSchema {
@@ -51,7 +53,6 @@ export enum ValueSchema {
  * - Constrain the types allowed based on which types guarantee their data will always meet the constraints.
  *
  * Care would need to be taken to make sure this is sound for the schema updating mechanisms.
- * @internal
  */
 export type TreeTypeSet = ReadonlySet<TreeNodeSchemaIdentifier>;
 
@@ -96,7 +97,6 @@ export interface SchemaPolicy {
 /**
  * Schema for a field.
  * Object implementing this interface should never be modified.
- * @internal
  */
 export interface TreeFieldStoredSchema {
 	readonly kind: FieldKindIdentifier;
@@ -136,7 +136,6 @@ export const identifierFieldKindIdentifier = "Identifier";
 
 /**
  * Opaque type erased handle to the encoded representation of the contents of a stored schema.
- * @internal
  */
 export interface ErasedTreeNodeSchemaDataFormat
 	extends ErasedType<"TreeNodeSchemaDataFormat"> {}
@@ -154,7 +153,6 @@ export function toTreeNodeSchemaDataFormat(
 }
 
 /**
- * @internal
  */
 export abstract class TreeNodeStoredSchema {
 	protected _typeCheck!: MakeNominal;
@@ -174,7 +172,6 @@ export abstract class TreeNodeStoredSchema {
 }
 
 /**
- * @internal
  */
 export class ObjectNodeStoredSchema extends TreeNodeStoredSchema {
 	/**
@@ -214,7 +211,6 @@ export class ObjectNodeStoredSchema extends TreeNodeStoredSchema {
 }
 
 /**
- * @internal
  */
 export class MapNodeStoredSchema extends TreeNodeStoredSchema {
 	/**
@@ -241,7 +237,6 @@ export class MapNodeStoredSchema extends TreeNodeStoredSchema {
 }
 
 /**
- * @internal
  */
 export class LeafNodeStoredSchema extends TreeNodeStoredSchema {
 	/**
@@ -330,7 +325,6 @@ export function decodeFieldSchema(schema: FieldSchemaFormat): TreeFieldStoredSch
  * @remarks
  * Note: the owner of this may modify it over time:
  * thus if needing to hand onto a specific version, make a copy.
- * @internal
  */
 export interface TreeStoredSchema extends StoredSchemaCollection {
 	/**
@@ -345,7 +339,6 @@ export interface TreeStoredSchema extends StoredSchemaCollection {
  * @remarks
  * Note: the owner of this may modify it over time:
  * thus if needing to hang onto a specific version, make a copy.
- * @internal
  */
 export interface StoredSchemaCollection {
 	/**

--- a/packages/dds/tree/src/core/tree/treeTextFormat.ts
+++ b/packages/dds/tree/src/core/tree/treeTextFormat.ts
@@ -49,8 +49,6 @@ import type { NodeData } from "./types.js";
  * Only use this type when needed for json compatible maps,
  * but even in those cases consider lists of key value pairs for serialization and using `Map`
  * for runtime.
- *
- * @internal
  */
 export interface FieldMapObject<TChild> {
 	[key: string]: TChild[];
@@ -59,14 +57,12 @@ export interface FieldMapObject<TChild> {
 /**
  * Json comparable tree node, generic over child type.
  * Json compatibility assumes `TChild` is also json compatible.
- * @internal
  */
 export interface GenericTreeNode<TChild> extends GenericFieldsNode<TChild>, NodeData {}
 
 /**
  * Json comparable field collection, generic over child type.
  * Json compatibility assumes `TChild` is also json compatible.
- * @internal
  */
 export interface GenericFieldsNode<TChild> {
 	fields?: FieldMapObject<TChild>;
@@ -79,7 +75,6 @@ export interface GenericFieldsNode<TChild> {
  * {@link @fluidframework/shared-object-base#IFluidSerializer.stringify} must be used instead of `JSON.stringify`.
  *
  * JsonableTrees should not store empty fields.
- * @internal
  */
 export interface JsonableTree extends GenericTreeNode<JsonableTree> {}
 

--- a/packages/dds/tree/src/core/tree/types.ts
+++ b/packages/dds/tree/src/core/tree/types.ts
@@ -33,7 +33,6 @@ export type TreeType = TreeNodeSchemaIdentifier;
  * This has to be a FieldKey since different nodes will have different TreeFieldStoredSchema for it.
  * This makes it prone to collisions and suggests
  * that this intention may be better conveyed by metadata on the ITreeSchema.
- * @internal
  */
 export const EmptyKey: FieldKey = brand("");
 
@@ -116,7 +115,6 @@ export interface FieldKind {
 
 /**
  * Value that may be stored on a leaf node.
- * @internal
  */
 export type TreeValue<TSchema extends ValueSchema = ValueSchema> = [
 	{
@@ -131,7 +129,6 @@ export type TreeValue<TSchema extends ValueSchema = ValueSchema> = [
 
 /**
  * Value stored on a node.
- * @internal
  */
 export type Value = undefined | TreeValue;
 
@@ -141,8 +138,6 @@ export type Value = undefined | TreeValue;
  * @privateRemarks A forked version of this type is used in `persistedTreeTextFormat.ts`.
  * Changes to this type might necessitate changes to `EncodedNodeData` or codecs.
  * See persistedTreeTextFormat's module documentation for more details.
- *
- * @internal
  */
 export interface NodeData {
 	/**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/isNeverTree.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/isNeverTree.ts
@@ -19,9 +19,7 @@ import { fail } from "../../util/index.js";
 import type { FullSchemaPolicy } from "./fieldKind.js";
 
 /**
- * @internal
  */
-
 export function isNeverField(
 	policy: FullSchemaPolicy,
 	originalData: TreeStoredSchema,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/types.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/types.ts
@@ -25,7 +25,6 @@ export interface HasMoveId {
 }
 
 /**
- * @internal
  */
 export interface CellId extends ChangeAtomId {}
 

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -13,7 +13,6 @@ export {
 	type RevertibleAlphaFactory,
 	type RevertibleAlpha,
 } from "./core/index.js";
-export { type Brand } from "./util/index.js";
 
 export type {
 	Listeners,
@@ -170,11 +169,6 @@ export {
 	type SimpleObjectNodeSchema,
 	normalizeAllowedTypes,
 	getSimpleSchema,
-	numberSchema,
-	stringSchema,
-	booleanSchema,
-	handleSchema,
-	nullSchema,
 	type ReadonlyArrayNode,
 	type InsertableTreeNodeFromAllowedTypes,
 	type Input,
@@ -197,8 +191,6 @@ export { noopValidator } from "./codec/index.js";
 export { typeboxValidator } from "./external-utilities/index.js";
 
 export {
-	type Covariant,
-	BrandedType,
 	type RestrictiveReadonlyRecord,
 	type RestrictiveStringRecord,
 	type MakeNominal,

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -4,30 +4,11 @@
  */
 
 export {
-	EmptyKey,
-	type FieldKey,
-	type TreeValue,
-	type FieldMapObject,
-	type NodeData,
-	type GenericTreeNode,
-	type JsonableTree,
-	type GenericFieldsNode,
-	type TreeNodeSchemaIdentifier,
-	type TreeFieldStoredSchema,
 	ValueSchema,
-	TreeNodeStoredSchema,
-	type FieldKindIdentifier,
-	type TreeTypeSet,
-	type TreeStoredSchema,
 	type Revertible,
 	CommitKind,
 	RevertibleStatus,
 	type CommitMetadata,
-	type StoredSchemaCollection,
-	type ErasedTreeNodeSchemaDataFormat,
-	ObjectNodeStoredSchema,
-	MapNodeStoredSchema,
-	LeafNodeStoredSchema,
 	type RevertibleFactory,
 	type RevertibleAlphaFactory,
 	type RevertibleAlpha,
@@ -50,10 +31,9 @@ export {
 } from "./feature-libraries/index.js";
 
 export {
-	type ISharedTree,
+	type ITreeInternal,
 	type SharedTreeOptions,
 	ForestType,
-	type SharedTreeContentSnapshot,
 	type SharedTreeFormatOptions,
 	SharedTreeFormatVersion,
 	Tree,

--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -16,6 +16,7 @@ export {
 	buildConfiguredForest,
 	defaultSharedTreeOptions,
 	type ForestOptions,
+	type ITreeInternal,
 } from "./sharedTree.js";
 
 export {

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -98,7 +98,6 @@ import type { IIdCompressor } from "@fluidframework/id-compressor";
  * Copy of data from an {@link ISharedTree} at some point in time.
  * @remarks
  * This is unrelated to Fluids concept of "snapshots".
- * @internal
  */
 export interface SharedTreeContentSnapshot {
 	/**
@@ -123,16 +122,7 @@ export interface SharedTreeContentSnapshot {
  * {@link ITree} extended with some non-public APIs.
  * @internal
  */
-export interface ISharedTree extends ISharedObject, ITree {
-	/**
-	 * Provides a copy of the current content of the tree.
-	 * This can be useful for inspecting the tree when no suitable view schema is available.
-	 * This is only intended for use in testing and exceptional code paths: it is not performant.
-	 *
-	 * This does not include everything that is included in a tree summary, since information about how to merge future edits is omitted.
-	 */
-	contentSnapshot(): SharedTreeContentSnapshot;
-
+export interface ITreeInternal extends ISharedObject, ITree {
 	/**
 	 * Exports root in the same format as {@link TreeAlpha.(exportVerbose:1)} using stored keys.
 	 * @privateRemarks
@@ -147,6 +137,20 @@ export interface ISharedTree extends ISharedObject, ITree {
 	 * To get the schema using property keys, use {@link getSimpleSchema} on the view schema.
 	 */
 	exportSimpleSchema(): SimpleTreeSchema;
+}
+
+/**
+ * {@link ITreeInternal} extended with some non-exported APIs.
+ */
+export interface ISharedTree extends ISharedObject, ITree {
+	/**
+	 * Provides a copy of the current content of the tree.
+	 * This can be useful for inspecting the tree when no suitable view schema is available.
+	 * This is only intended for use in testing and exceptional code paths: it is not performant.
+	 *
+	 * This does not include everything that is included in a tree summary, since information about how to merge future edits is omitted.
+	 */
+	contentSnapshot(): SharedTreeContentSnapshot;
 }
 
 /**

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -142,7 +142,7 @@ export interface ITreeInternal extends ISharedObject, ITree {
 /**
  * {@link ITreeInternal} extended with some non-exported APIs.
  */
-export interface ISharedTree extends ISharedObject, ITree {
+export interface ISharedTree extends ISharedObject, ITreeInternal {
 	/**
 	 * Provides a copy of the current content of the tree.
 	 * This can be useful for inspecting the tree when no suitable view schema is available.

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -674,6 +674,10 @@ function exportSimpleFieldSchemaStored(schema: TreeFieldStoredSchema): SimpleFie
 		case FieldKinds.required.identifier:
 			kind = FieldKind.Required;
 			break;
+		case FieldKinds.forbidden.identifier:
+			kind = FieldKind.Optional;
+			assert(schema.types.size === 0, "invalid forbidden field");
+			break;
 		default:
 			fail("invalid field kind");
 	}

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -127,7 +127,7 @@ export interface ITreeInternal extends ISharedObject, ITree {
 	 * Exports root in the same format as {@link TreeAlpha.(exportVerbose:1)} using stored keys.
 	 * @privateRemarks
 	 * TODO:
-	 * THis should probably get promoted to a public API on ITree eventually.
+	 * This should probably get promoted to a public API on ITree eventually.
 	 */
 	exportVerbose(): VerboseTree | undefined;
 

--- a/packages/dds/tree/src/simple-tree/api/conciseTree.ts
+++ b/packages/dds/tree/src/simple-tree/api/conciseTree.ts
@@ -8,7 +8,7 @@ import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { ITreeCursor } from "../../core/index.js";
 import type { TreeLeafValue, ImplicitAllowedTypes } from "../schemaTypes.js";
 import type { TreeNodeSchema } from "../core/index.js";
-import { customFromCursorInner, type EncodeOptions } from "./customTree.js";
+import { customFromCursor, type EncodeOptions } from "./customTree.js";
 import { getUnhydratedContext } from "../createContext.js";
 
 /**
@@ -55,5 +55,5 @@ function conciseFromCursorInner<TCustom>(
 	options: Required<EncodeOptions<TCustom>>,
 	schema: ReadonlyMap<string, TreeNodeSchema>,
 ): ConciseTree<TCustom> {
-	return customFromCursorInner(reader, options, schema, conciseFromCursorInner);
+	return customFromCursor(reader, options, schema, conciseFromCursorInner);
 }

--- a/packages/dds/tree/src/simple-tree/api/customTree.ts
+++ b/packages/dds/tree/src/simple-tree/api/customTree.ts
@@ -11,8 +11,12 @@ import {
 	EmptyKey,
 	forEachField,
 	inCursorField,
+	LeafNodeStoredSchema,
 	mapCursorField,
+	ObjectNodeStoredSchema,
 	type ITreeCursor,
+	type TreeNodeSchemaIdentifier,
+	type TreeNodeStoredSchema,
 } from "../../core/index.js";
 import { fail } from "../../util/index.js";
 import type { TreeLeafValue } from "../schemaTypes.js";
@@ -25,6 +29,7 @@ import {
 	stringSchema,
 } from "../leafNodeSchema.js";
 import { isObjectNodeSchema } from "../objectNodeTypes.js";
+import { FieldKinds, valueSchemaAllows } from "../../feature-libraries/index.js";
 
 /**
  * Options for how to encode a tree.
@@ -63,7 +68,7 @@ export type CustomTreeNode<TChild> = TChild[] | { [key: string]: TChild };
 /**
  * Builds an {@link CustomTree} from a cursor in Nodes mode.
  */
-export function customFromCursorInner<TChild, THandle>(
+export function customFromCursor<TChild, THandle>(
 	reader: ITreeCursor,
 	options: Required<EncodeOptions<THandle>>,
 	schema: ReadonlyMap<string, TreeNodeSchema>,
@@ -115,6 +120,64 @@ export function customFromCursorInner<TChild, THandle>(
 				});
 				return fields;
 			}
+		}
+	}
+}
+
+/**
+ * Builds an {@link CustomTree} from a cursor in Nodes mode.
+ * @remarks
+ * Uses stored keys and stored schema.
+ */
+export function customFromCursorStored<TChild>(
+	reader: ITreeCursor,
+	schema: ReadonlyMap<TreeNodeSchemaIdentifier, TreeNodeStoredSchema>,
+	childHandler: (
+		reader: ITreeCursor,
+		schema: ReadonlyMap<TreeNodeSchemaIdentifier, TreeNodeStoredSchema>,
+	) => TChild,
+): CustomTree<TChild, IFluidHandle> {
+	const type = reader.type;
+	const nodeSchema = schema.get(type) ?? fail("missing schema for type in cursor");
+
+	if (nodeSchema instanceof LeafNodeStoredSchema) {
+		assert(valueSchemaAllows(nodeSchema.leafValue, reader.value), "invalid value");
+		return reader.value;
+	}
+
+	assert(reader.value === undefined, "out of schema: unexpected value");
+
+	const arrayTypes = tryStoredSchemaAsArray(nodeSchema);
+	if (arrayTypes !== undefined) {
+		const field = inCursorField(reader, EmptyKey, () =>
+			mapCursorField(reader, () => childHandler(reader, schema)),
+		);
+		return field;
+	}
+
+	const fields: Record<string, TChild> = {};
+	forEachField(reader, () => {
+		const children = mapCursorField(reader, () => childHandler(reader, schema));
+		if (children.length === 1) {
+			const storedKey = reader.getFieldKey();
+			// Length is checked above.
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			fields[storedKey] = children[0]!;
+		} else {
+			assert(children.length === 0, "invalid children number");
+		}
+	});
+	return fields;
+}
+
+export function tryStoredSchemaAsArray(
+	schema: TreeNodeStoredSchema,
+): ReadonlySet<string> | undefined {
+	if (schema instanceof ObjectNodeStoredSchema) {
+		const empty = schema.getFieldSchema(EmptyKey);
+		if (empty.kind === FieldKinds.sequence.identifier) {
+			assert(schema.objectNodeFields.size === 1, "invalid schema");
+			return empty.types;
 		}
 	}
 }

--- a/packages/dds/tree/src/simple-tree/api/customTree.ts
+++ b/packages/dds/tree/src/simple-tree/api/customTree.ts
@@ -170,6 +170,11 @@ export function customFromCursorStored<TChild>(
 	return fields;
 }
 
+/**
+ * Assumes `schema` corresponds to a simple-tree schema.
+ * If it is an array schema, returns the allowed types for the array field.
+ * Otherwise returns `undefined`.
+ */
 export function tryStoredSchemaAsArray(
 	schema: TreeNodeStoredSchema,
 ): ReadonlySet<string> | undefined {

--- a/packages/dds/tree/src/simple-tree/api/index.ts
+++ b/packages/dds/tree/src/simple-tree/api/index.ts
@@ -90,7 +90,13 @@ export {
 	verboseFromCursor,
 } from "./verboseTree.js";
 
-export type { EncodeOptions } from "./customTree.js";
+export {
+	type EncodeOptions,
+	customFromCursorStored,
+	type CustomTreeNode,
+	type CustomTreeValue,
+	tryStoredSchemaAsArray,
+} from "./customTree.js";
 
 export { type ConciseTree, conciseFromCursor } from "./conciseTree.js";
 

--- a/packages/dds/tree/src/simple-tree/api/simpleSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleSchema.ts
@@ -30,7 +30,9 @@ export interface SimpleNodeSchemaBase<TNodeKind extends NodeKind> {
  */
 export interface SimpleObjectNodeSchema extends SimpleNodeSchemaBase<NodeKind.Object> {
 	/**
-	 * Schemas for each of the object's fields, keyed off of schema's property keys.
+	 * Schemas for each of the object's fields, keyed off of schema's keys.
+	 * @remarks
+	 * Depending on how this schema was exported, the string keys may be either the property keys or the stored keys.
 	 */
 	readonly fields: Record<string, SimpleFieldSchema>;
 }

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -41,6 +41,7 @@ import { walkFieldSchema } from "../walkFieldSchema.js";
  * Maybe rename "exportJsonSchema" to align on "concise" terminology.
  * Ensure schema exporting APIs here align and reference APIs for exporting view schema to the same formats (which should include stored vs property key choice).
  * Make sure users of independentView can use these export APIs (maybe provide a reference back to the ViewableTree from the TreeView to accomplish that).
+ * Some of these APIs are on ISharedTree and can get moved here.
  * @system @sealed @public
  */
 export interface ViewableTree {

--- a/packages/dds/tree/src/simple-tree/api/verboseTree.ts
+++ b/packages/dds/tree/src/simple-tree/api/verboseTree.ts
@@ -38,7 +38,7 @@ import {
 } from "../leafNodeSchema.js";
 import { isObjectNodeSchema } from "../objectNodeTypes.js";
 import {
-	customFromCursorInner,
+	customFromCursor,
 	type CustomTreeNode,
 	type CustomTreeValue,
 	type EncodeOptions,
@@ -344,7 +344,7 @@ function verboseFromCursorInner<TCustom>(
 	options: Required<EncodeOptions<TCustom>>,
 	schema: ReadonlyMap<string, TreeNodeSchema>,
 ): VerboseTree<TCustom> {
-	const fields = customFromCursorInner(reader, options, schema, verboseFromCursorInner);
+	const fields = customFromCursor(reader, options, schema, verboseFromCursorInner);
 	const nodeSchema = schema.get(reader.type) ?? fail("missing schema for type in cursor");
 	if (nodeSchema.kind === NodeKind.Leaf) {
 		return fields as CustomTreeValue<TCustom>;

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -118,6 +118,10 @@ export {
 	conciseFromCursor,
 	createFromCursor,
 	asTreeViewAlpha,
+	customFromCursorStored,
+	type CustomTreeNode,
+	type CustomTreeValue,
+	tryStoredSchemaAsArray,
 } from "./api/index.js";
 export {
 	type NodeFromSchema,

--- a/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
@@ -68,27 +68,8 @@ function makeLeaf<Name extends string, const T extends ValueSchema>(
 }
 
 // Leaf schema shared between all SchemaFactory instances.
-/**
- * @internal
- */
 export const stringSchema = makeLeaf("string", ValueSchema.String);
-
-/**
- * @internal
- */
 export const numberSchema = makeLeaf("number", ValueSchema.Number);
-
-/**
- * @internal
- */
 export const booleanSchema = makeLeaf("boolean", ValueSchema.Boolean);
-
-/**
- * @internal
- */
 export const nullSchema = makeLeaf("null", ValueSchema.Null);
-
-/**
- * @internal
- */
 export const handleSchema = makeLeaf("handle", ValueSchema.FluidHandle);

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -62,6 +62,7 @@ import {
 import type { EditManager } from "../../shared-tree-core/index.js";
 import {
 	cursorFromInsertable,
+	getSimpleSchema,
 	SchemaFactory,
 	toStoredSchema,
 	type TreeFieldFromImplicitField,
@@ -2147,5 +2148,21 @@ describe("SharedTree", () => {
 			() => tree.getAttachSummary(),
 			validateUsageError(/invalid state by another error/),
 		);
+	});
+
+	it("exportVerbose & exportSimpleSchema", () => {
+		const tree = treeTestFactory();
+		assert.deepEqual(tree.exportVerbose(), undefined);
+		const sf = new SchemaFactory(undefined);
+		assert.deepEqual(tree.exportSimpleSchema(), getSimpleSchema(sf.optional([])));
+
+		const config = new TreeViewConfiguration({
+			schema: numberSchema,
+		});
+		const view = tree.viewWith(config);
+		view.initialize(10);
+
+		assert.deepEqual(tree.exportVerbose(), 10);
+		assert.deepEqual(tree.exportSimpleSchema(), getSimpleSchema(numberSchema));
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/api/customTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/customTree.spec.ts
@@ -96,7 +96,7 @@ describe("simple-tree customTree", () => {
 	it("tryStoredSchemaAsArray", () => {
 		const arraySchema = schemaFactory.array(schemaFactory.number);
 		const arrayCase = tryStoredSchemaAsArray(getStoredSchema(arraySchema));
-		assert.deepEqual(arrayCase, new Set([schemaFactory.number]));
+		assert.deepEqual(arrayCase, new Set([schemaFactory.number.identifier]));
 
 		const objectSchema = schemaFactory.object("x", {});
 		const objectCase = tryStoredSchemaAsArray(getStoredSchema(objectSchema));

--- a/packages/dds/tree/src/test/simple-tree/api/customTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/customTree.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert, fail } from "node:assert";
 import { cursorFromInsertable, SchemaFactory } from "../../../simple-tree/index.js";
 
 // eslint-disable-next-line import/no-internal-modules
-import { customFromCursorInner } from "../../../simple-tree/api/customTree.js";
+import { customFromCursor } from "../../../simple-tree/api/customTree.js";
 // eslint-disable-next-line import/no-internal-modules
 import { getUnhydratedContext } from "../../../simple-tree/createContext.js";
 import { JsonUnion, singleJsonCursor } from "../../json/index.js";
@@ -18,21 +18,21 @@ const schemaFactory = new SchemaFactory("Test");
 
 describe("simple-tree customTree", () => {
 	const handle = new MockHandle(1);
-	describe("customFromCursorInner", () => {
+	describe("customFromCursor", () => {
 		it("leaf", () => {
 			const schema = getUnhydratedContext(JsonUnion).schema;
 			const leaf_options = { useStoredKeys: true, valueConverter: () => fail("unused") };
 			assert.equal(
-				customFromCursorInner(singleJsonCursor(null), leaf_options, schema, () => fail()),
+				customFromCursor(singleJsonCursor(null), leaf_options, schema, () => fail()),
 				null,
 			);
 			assert.equal(
-				customFromCursorInner(singleJsonCursor(5), leaf_options, schema, () => fail()),
+				customFromCursor(singleJsonCursor(5), leaf_options, schema, () => fail()),
 				5,
 			);
 			const log: unknown[] = [];
 			assert.equal(
-				customFromCursorInner(
+				customFromCursor(
 					cursorFromInsertable(schemaFactory.handle, handle),
 					{
 						useStoredKeys: true,
@@ -57,7 +57,7 @@ describe("simple-tree customTree", () => {
 
 			const schema = getUnhydratedContext(A).schema;
 			assert.deepEqual(
-				customFromCursorInner(
+				customFromCursor(
 					cursorFromInsertable(A, { a: 1, b: 2 }),
 					{
 						useStoredKeys: true,
@@ -70,7 +70,7 @@ describe("simple-tree customTree", () => {
 			);
 
 			assert.deepEqual(
-				customFromCursorInner(
+				customFromCursor(
 					cursorFromInsertable(A, { a: 1, b: 2 }),
 					{
 						useStoredKeys: false,

--- a/packages/dds/tree/src/util/brand.ts
+++ b/packages/dds/tree/src/util/brand.ts
@@ -18,7 +18,6 @@ import type { Covariant } from "./typeCheck.js";
  * `Type 'Name1' is not assignable to type 'Name2'.`
  *
  * These branded types are not opaque: A `Brand<A, B>` can still be used as a `B`.
- * @internal
  */
 export type Brand<ValueType, Name> = ValueType & BrandedType<ValueType, Name>;
 
@@ -42,7 +41,6 @@ export type Brand<ValueType, Name> = ValueType & BrandedType<ValueType, Name>;
  * - get nominal typing (so types produced without using this class can never be assignable to it).
  *
  * @sealed
- * @internal
  */
 export abstract class BrandedType<out ValueType, Name> {
 	protected _typeCheck?: Covariant<ValueType>;

--- a/packages/dds/tree/src/util/typeCheck.ts
+++ b/packages/dds/tree/src/util/typeCheck.ts
@@ -107,8 +107,6 @@ export interface Contravariant<in T> {
  * ```typescript
  * protected _typeCheck?: Covariant<T>;
  * ```
- *
- * @internal
  */
 export interface Covariant<out T> {
 	_removeContravariance?: T;

--- a/packages/framework/ai-collab/src/explicit-strategy/agentEditReducer.ts
+++ b/packages/framework/ai-collab/src/explicit-strategy/agentEditReducer.ts
@@ -18,12 +18,8 @@ import {
 	FieldSchema,
 	normalizeAllowedTypes,
 	type ImplicitFieldSchema,
-	booleanSchema,
-	handleSchema,
-	nullSchema,
-	numberSchema,
-	stringSchema,
 	type IterableTreeArrayContent,
+	SchemaFactory,
 } from "@fluidframework/tree/internal";
 
 import {
@@ -66,25 +62,27 @@ function populateDefaults(
 }
 
 function getSchemaIdentifier(content: TreeEditValue): string | undefined {
+	const sf = new SchemaFactory(undefined);
+
 	switch (typeof content) {
 		case "boolean": {
-			return booleanSchema.identifier;
+			return sf.boolean.identifier;
 		}
 		case "number": {
-			return numberSchema.identifier;
+			return sf.number.identifier;
 		}
 		case "string": {
-			return stringSchema.identifier;
+			return sf.string.identifier;
 		}
 		case "object": {
 			if (content === null) {
-				return nullSchema.identifier;
+				return sf.null.identifier;
 			}
 			if (Array.isArray(content)) {
 				throw new UsageError("Arrays are not currently supported in this context");
 			}
 			if (isFluidHandle(content)) {
-				return handleSchema.identifier;
+				return sf.handle.identifier;
 			}
 			return content[typeField];
 		}

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
@@ -257,19 +257,21 @@ export const visualizeSharedTree: VisualizeSharedObject = async (
 	visualizeChildData: VisualizeChildData,
 ): Promise<FluidObjectNode> => {
 	const sharedTree = sharedObject as ISharedTree;
-	const contentSnapshot = sharedTree.contentSnapshot();
 
-	// Root node of the SharedTree's treeview. Assume there is only one root node.
-	const treeView = contentSnapshot.tree[0];
+	// Root node of the SharedTree's content.
+	const treeView = sharedTree.exportVerbose();
+	// TODO: this visualizer doesn't consider the root as a field, and thus does not display the allowed types or handle when it is empty.
+	if (treeView === undefined) {
+		throw new Error("Support for visualizing empty trees is not implemented");
+	}
 
 	// Schema of the tree node.
-	const treeSchema = contentSnapshot.schema.nodeSchema.get(treeView.type);
+	const treeSchema = sharedTree.exportSimpleSchema();
 
 	// Traverses the SharedTree and generates a visual representation of the tree and its schema.
 	const visualTreeRepresentation = await visualizeSharedTreeNodeBySchema(
 		treeView,
 		treeSchema,
-		contentSnapshot,
 		visualizeChildData,
 	);
 

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
@@ -21,7 +21,7 @@ import {
 import { SharedMatrix } from "@fluidframework/matrix/internal";
 import { SharedString } from "@fluidframework/sequence/internal";
 import type { ISharedObject } from "@fluidframework/shared-object-base/internal";
-import type { ISharedTree } from "@fluidframework/tree/internal";
+import type { ITreeInternal } from "@fluidframework/tree/internal";
 import { SharedTree } from "@fluidframework/tree/internal";
 
 import { EditType } from "../CommonInterfaces.js";
@@ -256,7 +256,7 @@ export const visualizeSharedTree: VisualizeSharedObject = async (
 	sharedObject: ISharedObject,
 	visualizeChildData: VisualizeChildData,
 ): Promise<FluidObjectNode> => {
-	const sharedTree = sharedObject as ISharedTree;
+	const sharedTree = sharedObject as ITreeInternal;
 
 	// Root node of the SharedTree's content.
 	const treeView = sharedTree.exportVerbose();

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
@@ -261,6 +261,7 @@ export const visualizeSharedTree: VisualizeSharedObject = async (
 	// Root node of the SharedTree's content.
 	const treeView = sharedTree.exportVerbose();
 	// TODO: this visualizer doesn't consider the root as a field, and thus does not display the allowed types or handle when it is empty.
+	// Tracked by https://dev.azure.com/fluidframework/internal/_workitems/edit/26472.
 	if (treeView === undefined) {
 		throw new Error("Support for visualizing empty trees is not implemented");
 	}

--- a/packages/tools/devtools/devtools-core/src/data-visualization/SharedTreeVisualizer.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/SharedTreeVisualizer.ts
@@ -4,25 +4,16 @@
  */
 
 import type {
-	FieldMapObject,
-	JsonableTree,
-	SharedTreeContentSnapshot,
-	TreeNodeStoredSchema,
-	TreeTypeSet,
+	SimpleMapNodeSchema,
+	SimpleObjectNodeSchema,
+	SimpleTreeSchema,
+	VerboseTree,
+	VerboseTreeNode,
 } from "@fluidframework/tree/internal";
-import {
-	EmptyKey,
-	LeafNodeStoredSchema,
-	MapNodeStoredSchema,
-	ObjectNodeStoredSchema,
-} from "@fluidframework/tree/internal";
+import { EmptyKey, NodeKind, SchemaFactory, Tree } from "@fluidframework/tree/internal";
 
 import type { VisualizeChildData } from "./DataVisualization.js";
-import type {
-	SharedTreeLeafNode,
-	VisualSharedTreeNode,
-	SharedTreeSchemaNode,
-} from "./VisualSharedTreeTypes.js";
+import type { VisualSharedTreeNode, SharedTreeSchemaNode } from "./VisualSharedTreeTypes.js";
 import { VisualSharedTreeNodeKind } from "./VisualSharedTreeTypes.js";
 import {
 	type VisualChildNode,
@@ -159,30 +150,21 @@ export function toVisualTree(tree: VisualSharedTreeNode): VisualChildNode {
 /**
  * Concatenrate allowed types for `ObjectNodeStoredSchema` and `MapNodeStoredSchema`.
  */
-function concatenateTypes(fieldKey: string, fieldTypes: TreeTypeSet | undefined): string {
-	let fieldAllowedType = fieldKey === EmptyKey ? "" : `${fieldKey} : `;
-
-	if (fieldTypes === undefined) {
-		fieldAllowedType += "any";
-	} else {
-		const allowedTypes = [...fieldTypes].join(" | ");
-		fieldAllowedType += `${allowedTypes}`;
-	}
-
-	return fieldAllowedType;
+function concatenateTypes(fieldTypes: ReadonlySet<string>): string {
+	return [...fieldTypes].join(" | ");
 }
 
 /**
  * Returns the allowed fields & types for the object fields (e.g., `foo : string | number, bar: boolean`)
  */
-function getObjectAllowedTypes(schema: ObjectNodeStoredSchema): string {
+function getObjectAllowedTypes(schema: SimpleObjectNodeSchema): string {
 	const result: string[] = [];
 
-	for (const [fieldKey, treeFieldStoredSchema] of schema.objectNodeFields) {
+	for (const [fieldKey, treeFieldSimpleSchema] of Object.entries(schema.fields)) {
 		// Set of allowed tree types `TreeTypeSet`.
-		const fieldTypes = treeFieldStoredSchema.types;
+		const fieldTypes = treeFieldSimpleSchema.allowedTypes;
 
-		result.push(concatenateTypes(fieldKey, fieldTypes));
+		result.push(`${fieldKey} : ${concatenateTypes(fieldTypes)}`);
 
 		// If the field key is `EmptyKey`, then it is an array field.
 		// Return the allowed types in string format, instead of JSON format.
@@ -195,103 +177,43 @@ function getObjectAllowedTypes(schema: ObjectNodeStoredSchema): string {
 }
 
 /**
- * Returns the allowed fields & types for the map fields.
+ * Returns the schema & fields of the node.
  */
-function getMapAllowedTypes(
-	fields: FieldMapObject<JsonableTree> | undefined,
-	schema: MapNodeStoredSchema,
-): string {
-	if (fields === undefined) {
-		throw new TypeError("Fields should not be undefined.");
-	}
-
-	const mapFieldAllowedTypes = schema.mapFields.types;
-
-	const result: string[] = [];
-
-	for (const [fieldKey] of Object.entries(fields)) {
-		result.push(concatenateTypes(fieldKey, mapFieldAllowedTypes));
-	}
-
-	return `{ ${result.join(", ")} }`;
-}
-
-/**
- * Returns the schema & leaf value of the node with type {@link LeafNodeStoredSchema}.
- */
-async function visualizeLeafNode(
-	tree: JsonableTree,
+async function visualizeVerboseNodeFields(
+	tree: VerboseTreeNode,
+	treeSchema: SimpleTreeSchema,
 	visualizeChildData: VisualizeChildData,
-): Promise<SharedTreeLeafNode> {
-	return {
-		schema: {
-			schemaName: tree.type,
-		},
-		value: await visualizeChildData(tree.value),
-		kind: VisualSharedTreeNodeKind.LeafNode,
-	};
+): Promise<Record<string, VisualSharedTreeNode>> {
+	const treeFields = tree.fields;
+
+	const fields: Record<string | number, VisualSharedTreeNode> = {};
+
+	for (const [fieldKey, childField] of Object.entries(treeFields)) {
+		fields[fieldKey] = await visualizeSharedTreeNodeBySchema(
+			childField,
+			treeSchema,
+			visualizeChildData,
+		);
+	}
+
+	return fields;
 }
 
 /**
  * Returns the schema & fields of the node with type {@link ObjectNodeStoredSchema}.
  */
 async function visualizeObjectNode(
-	tree: JsonableTree,
-	schema: ObjectNodeStoredSchema,
-	contentSnapshot: SharedTreeContentSnapshot,
+	tree: VerboseTreeNode,
+	schema: SimpleObjectNodeSchema,
+	treeSchema: SimpleTreeSchema,
 	visualizeChildData: VisualizeChildData,
 ): Promise<VisualSharedTreeNode> {
-	const treeFields = tree.fields;
-
-	if (treeFields === undefined || Object.keys(treeFields).length === 0) {
-		return {
-			schema: {
-				schemaName: tree.type,
-				allowedTypes: getObjectAllowedTypes(schema),
-			},
-			fields: {},
-			kind: VisualSharedTreeNodeKind.InternalNode,
-		};
-	}
-
-	const fields: Record<string | number, VisualSharedTreeNode> = {};
-
-	// `EmptyKey` indicates an array field (e.g., `schemabuilder.array()`).
-	// Hides level of indirection by omitting the empty key in the visual output.
-	if (
-		Object.keys(treeFields).length === 1 &&
-		Object.prototype.hasOwnProperty.call(treeFields, EmptyKey)
-	) {
-		const children = treeFields[EmptyKey];
-
-		for (let i = 0; i < children.length; i++) {
-			const childSchema = contentSnapshot.schema.nodeSchema.get(children[i].type);
-			fields[i] = await visualizeSharedTreeNodeBySchema(
-				children[i],
-				childSchema,
-				contentSnapshot,
-				visualizeChildData,
-			);
-		}
-	} else {
-		for (const [fieldKey, childField] of Object.entries(treeFields)) {
-			const childSchema = contentSnapshot.schema.nodeSchema.get(childField[0].type);
-
-			fields[fieldKey] = await visualizeSharedTreeNodeBySchema(
-				childField[0],
-				childSchema,
-				contentSnapshot,
-				visualizeChildData,
-			);
-		}
-	}
-
 	return {
 		schema: {
 			schemaName: tree.type,
 			allowedTypes: getObjectAllowedTypes(schema),
 		},
-		fields,
+		fields: await visualizeVerboseNodeFields(tree, treeSchema, visualizeChildData),
 		kind: VisualSharedTreeNodeKind.InternalNode,
 	};
 }
@@ -300,43 +222,17 @@ async function visualizeObjectNode(
  * Returns the schema & fields of the node with type {@link MapNodeStoredSchema}.
  */
 async function visualizeMapNode(
-	tree: JsonableTree,
-	schema: MapNodeStoredSchema,
-	contentSnapshot: SharedTreeContentSnapshot,
+	tree: VerboseTreeNode,
+	schema: SimpleMapNodeSchema,
+	treeSchema: SimpleTreeSchema,
 	visualizeChildData: VisualizeChildData,
 ): Promise<VisualSharedTreeNode> {
-	const treeFields = tree.fields;
-
-	if (treeFields === undefined || Object.keys(treeFields).length === 0) {
-		return {
-			schema: {
-				schemaName: tree.type,
-				allowedTypes: getMapAllowedTypes(treeFields, schema),
-			},
-			fields: {},
-			kind: VisualSharedTreeNodeKind.InternalNode,
-		};
-	}
-
-	const fields: Record<string | number, VisualSharedTreeNode> = {};
-
-	for (const [fieldKey, childField] of Object.entries(treeFields)) {
-		const fieldSchema = contentSnapshot.schema.nodeSchema.get(childField[0].type);
-
-		fields[fieldKey] = await visualizeSharedTreeNodeBySchema(
-			childField[0],
-			fieldSchema,
-			contentSnapshot,
-			visualizeChildData,
-		);
-	}
-
 	return {
 		schema: {
 			schemaName: tree.type,
-			allowedTypes: getMapAllowedTypes(treeFields, schema),
+			allowedTypes: concatenateTypes(schema.allowedTypes),
 		},
-		fields,
+		fields: await visualizeVerboseNodeFields(tree, treeSchema, visualizeChildData),
 		kind: VisualSharedTreeNodeKind.InternalNode,
 	};
 }
@@ -350,26 +246,67 @@ async function visualizeMapNode(
  * @remarks
  */
 export async function visualizeSharedTreeNodeBySchema(
-	tree: JsonableTree,
-	schema: TreeNodeStoredSchema | undefined,
-	contentSnapshot: SharedTreeContentSnapshot,
+	tree: VerboseTree,
+	treeSchema: SimpleTreeSchema,
 	visualizeChildData: VisualizeChildData,
 ): Promise<VisualSharedTreeNode> {
-	if (schema instanceof LeafNodeStoredSchema) {
-		const leafVisualized = await visualizeLeafNode(tree, visualizeChildData);
-		return leafVisualized;
-	} else if (schema instanceof ObjectNodeStoredSchema) {
-		const objectVisualized = visualizeObjectNode(
-			tree,
-			schema,
-			contentSnapshot,
-			visualizeChildData,
-		);
-		return objectVisualized;
-	} else if (schema instanceof MapNodeStoredSchema) {
-		const mapVisualized = visualizeMapNode(tree, schema, contentSnapshot, visualizeChildData);
-		return mapVisualized;
-	} else {
+	const sf = new SchemaFactory(undefined);
+	if (Tree.is(tree, [sf.boolean, sf.null, sf.number, sf.handle, sf.string])) {
+		const nodeSchema = Tree.schema(tree);
+		return {
+			schema: {
+				schemaName: nodeSchema.identifier,
+			},
+			value: await visualizeChildData(tree),
+			kind: VisualSharedTreeNodeKind.LeafNode,
+		};
+	}
+
+	const schema = treeSchema.definitions.get(tree.type);
+	if (schema === undefined) {
 		throw new TypeError("Unrecognized schema type.");
+	}
+
+	switch (schema.kind) {
+		case NodeKind.Object: {
+			const objectVisualized = visualizeObjectNode(
+				tree,
+				schema,
+				treeSchema,
+				visualizeChildData,
+			);
+			return objectVisualized;
+		}
+		case NodeKind.Map: {
+			const mapVisualized = visualizeMapNode(tree, schema, treeSchema, visualizeChildData);
+			return mapVisualized;
+		}
+		case NodeKind.Array: {
+			const fields: Record<number, VisualSharedTreeNode> = {};
+			const children = tree.fields;
+			if (!Array.isArray(children)) {
+				throw new TypeError("Invalid array");
+			}
+
+			for (let i = 0; i < children.length; i++) {
+				fields[i] = await visualizeSharedTreeNodeBySchema(
+					children[i],
+					treeSchema,
+					visualizeChildData,
+				);
+			}
+
+			return {
+				schema: {
+					schemaName: tree.type,
+					allowedTypes: concatenateTypes(schema.allowedTypes),
+				},
+				fields: await visualizeVerboseNodeFields(tree, treeSchema, visualizeChildData),
+				kind: VisualSharedTreeNodeKind.InternalNode,
+			};
+		}
+		default: {
+			throw new TypeError("Unrecognized schema type.");
+		}
 	}
 }

--- a/packages/tools/devtools/devtools-core/src/data-visualization/SharedTreeVisualizer.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/SharedTreeVisualizer.ts
@@ -10,7 +10,7 @@ import type {
 	VerboseTree,
 	VerboseTreeNode,
 } from "@fluidframework/tree/internal";
-import { EmptyKey, NodeKind, SchemaFactory, Tree } from "@fluidframework/tree/internal";
+import { NodeKind, SchemaFactory, Tree } from "@fluidframework/tree/internal";
 
 import type { VisualizeChildData } from "./DataVisualization.js";
 import type { VisualSharedTreeNode, SharedTreeSchemaNode } from "./VisualSharedTreeTypes.js";
@@ -161,16 +161,8 @@ function getObjectAllowedTypes(schema: SimpleObjectNodeSchema): string {
 	const result: string[] = [];
 
 	for (const [fieldKey, treeFieldSimpleSchema] of Object.entries(schema.fields)) {
-		// Set of allowed tree types `TreeTypeSet`.
 		const fieldTypes = treeFieldSimpleSchema.allowedTypes;
-
 		result.push(`${fieldKey} : ${concatenateTypes(fieldTypes)}`);
-
-		// If the field key is `EmptyKey`, then it is an array field.
-		// Return the allowed types in string format, instead of JSON format.
-		if (fieldKey === EmptyKey) {
-			return result.join("");
-		}
 	}
 
 	return `{ ${result.join(", ")} }`;
@@ -230,7 +222,7 @@ async function visualizeMapNode(
 	return {
 		schema: {
 			schemaName: tree.type,
-			allowedTypes: concatenateTypes(schema.allowedTypes),
+			allowedTypes: `Record<string, ${concatenateTypes(schema.allowedTypes)}>`,
 		},
 		fields: await visualizeVerboseNodeFields(tree, treeSchema, visualizeChildData),
 		kind: VisualSharedTreeNodeKind.InternalNode,

--- a/packages/tools/devtools/devtools-core/src/data-visualization/SharedTreeVisualizer.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/SharedTreeVisualizer.ts
@@ -196,14 +196,14 @@ async function visualizeVerboseNodeFields(
  */
 async function visualizeObjectNode(
 	tree: VerboseTreeNode,
-	schema: SimpleObjectNodeSchema,
+	nodeSchema: SimpleObjectNodeSchema,
 	treeSchema: SimpleTreeSchema,
 	visualizeChildData: VisualizeChildData,
 ): Promise<VisualSharedTreeNode> {
 	return {
 		schema: {
 			schemaName: tree.type,
-			allowedTypes: getObjectAllowedTypes(schema),
+			allowedTypes: getObjectAllowedTypes(nodeSchema),
 		},
 		fields: await visualizeVerboseNodeFields(tree, treeSchema, visualizeChildData),
 		kind: VisualSharedTreeNodeKind.InternalNode,
@@ -215,14 +215,14 @@ async function visualizeObjectNode(
  */
 async function visualizeMapNode(
 	tree: VerboseTreeNode,
-	schema: SimpleMapNodeSchema,
+	nodeSchema: SimpleMapNodeSchema,
 	treeSchema: SimpleTreeSchema,
 	visualizeChildData: VisualizeChildData,
 ): Promise<VisualSharedTreeNode> {
 	return {
 		schema: {
 			schemaName: tree.type,
-			allowedTypes: `Record<string, ${concatenateTypes(schema.allowedTypes)}>`,
+			allowedTypes: `Record<string, ${concatenateTypes(nodeSchema.allowedTypes)}>`,
 		},
 		fields: await visualizeVerboseNodeFields(tree, treeSchema, visualizeChildData),
 		kind: VisualSharedTreeNodeKind.InternalNode,

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
@@ -677,7 +677,7 @@ describe("DefaultVisualizers unit tests", () => {
 								},
 								allowedTypes: {
 									value:
-										"com.fluidframework.leaf.string | com.fluidframework.leaf.number | com.fluidframework.leaf.handle",
+										"Record<string, com.fluidframework.leaf.string | com.fluidframework.leaf.number | com.fluidframework.leaf.handle>",
 									nodeKind: "ValueNode",
 								},
 							},
@@ -1698,7 +1698,7 @@ describe("DefaultVisualizers unit tests", () => {
 								},
 								allowedTypes: {
 									value:
-										"com.fluidframework.leaf.string | com.fluidframework.leaf.number | com.fluidframework.leaf.handle | shared-tree-test.map-object",
+										"Record<string, com.fluidframework.leaf.string | com.fluidframework.leaf.number | com.fluidframework.leaf.handle | shared-tree-test.map-object>",
 									nodeKind: "ValueNode",
 								},
 							},

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
@@ -677,7 +677,7 @@ describe("DefaultVisualizers unit tests", () => {
 								},
 								allowedTypes: {
 									value:
-										"{ apple : com.fluidframework.leaf.string | com.fluidframework.leaf.number | com.fluidframework.leaf.handle, banana : com.fluidframework.leaf.string | com.fluidframework.leaf.number | com.fluidframework.leaf.handle, cherry : com.fluidframework.leaf.string | com.fluidframework.leaf.number | com.fluidframework.leaf.handle }",
+										"com.fluidframework.leaf.string | com.fluidframework.leaf.number | com.fluidframework.leaf.handle",
 									nodeKind: "ValueNode",
 								},
 							},
@@ -1698,7 +1698,7 @@ describe("DefaultVisualizers unit tests", () => {
 								},
 								allowedTypes: {
 									value:
-										"{ anthropology : com.fluidframework.leaf.string | com.fluidframework.leaf.number | com.fluidframework.leaf.handle | shared-tree-test.map-object, biology : com.fluidframework.leaf.string | com.fluidframework.leaf.number | com.fluidframework.leaf.handle | shared-tree-test.map-object, choreography : com.fluidframework.leaf.string | com.fluidframework.leaf.number | com.fluidframework.leaf.handle | shared-tree-test.map-object }",
+										"com.fluidframework.leaf.string | com.fluidframework.leaf.number | com.fluidframework.leaf.handle | shared-tree-test.map-object",
 									nodeKind: "ValueNode",
 								},
 							},


### PR DESCRIPTION
## Description

contentSnapshot being package exported is the only cause for many internal tree types being package exported, and its only being used due to there being no way to read data from a tree without a schema.

Now that proper types exist for reading such data, this change implements exporters in those formats that work without view schema to replace the external use of contentSnapshot.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


