### PR TITLE
fix(gitrest): ensure there are size limit checks before compression

### DIFF
--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -73,7 +73,8 @@ data:
             "redisApiMetricsSamplingPeriod": {{ .Values.gitrest.git.redisApiMetricsSamplingPeriod }},
             "enforceStrictPersistedFullSummaryReads": {{ .Values.gitrest.git.enforceStrictPersistedFullSummaryReads }},
             "enableRedisFsOptimizedStat": {{ .Values.gitrest.git.enableRedisFsOptimizedStat }},
-            "redisApiMetricsSamplingPeriod": {{ .Values.gitrest.git.redisApiMetricsSamplingPeriod }}
+            "redisApiMetricsSamplingPeriod": {{ .Values.gitrest.git.redisApiMetricsSamplingPeriod }},
+            "maxBlobSizeBytes": {{ .Values.gitrest.git.maxBlobSizeBytes }}
         },
         "redis": {
             "host": "{{ .Values.gitrest.redis.url }}",

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -78,6 +78,7 @@ gitrest:
     enableRedisFsOptimizedStat: false
     redisApiMetricsSamplingPeriod: 0
     enforceStrictPersistedFullSummaryReads: false
+    maxBlobSizeBytes: 0
   redis:
     url: redis_url
     port: 6379

--- a/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
+++ b/server/gitrest/packages/gitrest-base/src/runnerFactory.ts
@@ -157,6 +157,7 @@ export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestRe
 			"git:apiMetricsSamplingPeriod",
 		);
 		const enableSlimGitInit: boolean = config.get("git:enableSlimGitInit") ?? false;
+		const maxBlobSizeBytes: number | undefined = config.get("git:maxBlobSizeBytes");
 
 		if (gitLibrary === "isomorphic-git") {
 			return new IsomorphicGitManagerFactory(
@@ -167,6 +168,7 @@ export class GitrestResourcesFactory implements core.IResourcesFactory<GitrestRe
 				enableRepositoryManagerMetrics,
 				enableSlimGitInit,
 				apiMetricsSamplingPeriod,
+				maxBlobSizeBytes,
 			);
 		}
 		throw new Error("Invalid git library name.");

--- a/server/gitrest/packages/gitrest-base/src/test/gitManager.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/gitManager.spec.ts
@@ -1,0 +1,141 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+import {
+	IRepoManagerParams,
+	IsomorphicGitManagerFactory,
+	MemFsManagerFactory,
+	SystemErrors,
+} from "../utils";
+import { NullExternalStorageManager } from "../externalStorageManager";
+
+/**
+ * Get a string that cannot be compressed by zlib.
+ * http://blog.chenshuo.com/2014/05/incompressible-zlibdeflate-data.html
+ * @param length - The length of the string to generate (substring of the incompressible string).
+ */
+function getIncompressibleString(length: number): string {
+	const incompressible = [];
+	for (let step = 1; step <= 128; ++step) {
+		for (let inc = 0; inc < step; ++inc) {
+			for (let i = inc; i < 256; i += step) {
+				incompressible.push(String.fromCharCode(i));
+			}
+		}
+	}
+	if (length > incompressible.length) {
+		throw new Error(
+			`Requested incompressible string length ${length} is greater than the maximum possible length ${incompressible.length}`,
+		);
+	}
+	return incompressible.join("").substring(0, length);
+}
+
+describe("isomorphic-git manager", () => {
+	/**
+	 * The maximum file size that can be created in the filesystem.
+	 * This will be applied _after_ compression.
+	 */
+	const fsMaxFileSizeBytes = 5 * 1024;
+	/**
+	 * The maximum file size that can be created in the git repository.
+	 * This will be applied _before_ compression.
+	 *
+	 * This is 3x larger than fsMaxFileSizeBytes to ensure that we can accurately
+	 * test the size limits of the filesystem distinctly from the git repository.
+	 */
+	const gitMaxFileSizeBytes = 3 * fsMaxFileSizeBytes;
+	const fsFactory = new MemFsManagerFactory(fsMaxFileSizeBytes);
+	const repoManagerFactory = new IsomorphicGitManagerFactory(
+		{ useRepoOwner: false },
+		{ defaultFileSystemManagerFactory: fsFactory },
+		new NullExternalStorageManager(),
+		true /* repoPerDocEnabled */,
+		false /* enableRepositoryManagerMetrics */,
+		true /* enableSlimGitInit */,
+	);
+	const repoManagerParams: Required<IRepoManagerParams> = {
+		repoOwner: "fluid",
+		repoName: "test",
+		storageRoutingId: {
+			tenantId: "fluid",
+			documentId: "test",
+		},
+		fileSystemManagerParams: {
+			rootDir: "/",
+		},
+		optimizeForInitialSummary: true,
+		isEphemeralContainer: false,
+	};
+
+	it("should create/read a blob", async () => {
+		const repoManager = await repoManagerFactory.create(repoManagerParams);
+		const base64BlobContents = Buffer.from("Hello, World!", "utf-8").toString("base64");
+		const createBlobResponse = await repoManager.createBlob({
+			content: base64BlobContents,
+			encoding: "base64",
+		});
+		const readBlobResponse = await repoManager.getBlob(createBlobResponse.sha);
+		assert.strictEqual(readBlobResponse.content, base64BlobContents);
+		assert.strictEqual(readBlobResponse.encoding, "base64");
+		assert.strictEqual(readBlobResponse.sha, createBlobResponse.sha);
+		assert.strictEqual(readBlobResponse.size, base64BlobContents.length);
+	});
+
+	it("should not create a too large blob (uncompressible)", async () => {
+		const repoManager = await repoManagerFactory.create(repoManagerParams);
+		/**
+		 * A blob of all "a"s that is one byte larger than the maximum allowed size
+		 * This blob is highly compressible, so it will go around any filesystem level size limits
+		 * after isomorphic-git uses Pako deflate (zlib) to compress it.
+		 */
+		const base64BlobContents = Buffer.from(
+			getIncompressibleString(fsMaxFileSizeBytes + 1),
+		).toString("base64");
+		assert(
+			base64BlobContents.length > fsMaxFileSizeBytes,
+			`Blob size: ${base64BlobContents.length} should be greater than ${fsMaxFileSizeBytes}`,
+		);
+		await assert.rejects(
+			async () =>
+				await repoManager.createBlob({
+					content: base64BlobContents,
+					encoding: "base64",
+				}),
+			{
+				name: "FilesystemError",
+				code: SystemErrors.EFBIG.code,
+			},
+		);
+	});
+
+	it("should not create a too large blob (compressible)", async () => {
+		const repoManager = await repoManagerFactory.create(repoManagerParams);
+		/**
+		 * A blob of all "a"s that is one byte larger than the maximum allowed size
+		 * This blob is highly compressible, so it will go around any filesystem level size limits
+		 * after isomorphic-git uses Pako deflate (zlib) to compress it.
+		 */
+		const base64BlobContents = Buffer.from("a".repeat(gitMaxFileSizeBytes + 1)).toString(
+			"base64",
+		);
+		assert(
+			base64BlobContents.length > gitMaxFileSizeBytes,
+			`Blob size: ${base64BlobContents.length} should be greater than ${fsMaxFileSizeBytes}`,
+		);
+		await assert.rejects(
+			async () =>
+				await repoManager.createBlob({
+					content: base64BlobContents,
+					encoding: "base64",
+				}),
+			{
+				name: "FilesystemError",
+				code: SystemErrors.EFBIG,
+			},
+		);
+	});
+});

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -18,7 +18,7 @@ import {
 import { BaseGitRestTelemetryProperties } from "./gitrestTelemetryDefinitions";
 import * as helpers from "./helpers";
 import * as conversions from "./isomorphicgitConversions";
-import { RepositoryManagerBase } from "./repositoryManagerBase";
+import { IRepositoryManagerBaseOptions, RepositoryManagerBase } from "./repositoryManagerBase";
 import { RepositoryManagerFactoryBase } from "./repositoryManagerFactoryBase";
 
 export class IsomorphicGitRepositoryManager extends RepositoryManagerBase {
@@ -28,15 +28,9 @@ export class IsomorphicGitRepositoryManager extends RepositoryManagerBase {
 		private readonly repoName: string,
 		directory: string,
 		lumberjackBaseProperties: Record<string, any>,
-		enableRepositoryManagerMetrics: boolean = false,
-		apiMetricsSamplingPeriod?: number,
+		options: Partial<IRepositoryManagerBaseOptions>,
 	) {
-		super(
-			directory,
-			lumberjackBaseProperties,
-			enableRepositoryManagerMetrics,
-			apiMetricsSamplingPeriod,
-		);
+		super(directory, lumberjackBaseProperties, options);
 	}
 
 	protected async getCommitCore(sha: string): Promise<resources.ICommit> {
@@ -389,6 +383,7 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
 		enableRepositoryManagerMetrics: boolean = false,
 		private readonly enableSlimGitInit: boolean = false,
 		apiMetricsSamplingPeriod?: number,
+		maxBlobSizeBytes?: number,
 	) {
 		super(
 			storageDirectoryConfig,
@@ -398,6 +393,7 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
 			enableRepositoryManagerMetrics,
 			false /* enforceSynchronous */,
 			apiMetricsSamplingPeriod,
+			maxBlobSizeBytes,
 		);
 	}
 
@@ -426,6 +422,7 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
 		enableRepositoryManagerMetrics: boolean,
 		apiMetricsSamplingPeriod?: number,
 		isEphemeralContainer?: boolean,
+		maxBlobSizeBytes?: number,
 	): IRepositoryManager {
 		return new IsomorphicGitRepositoryManager(
 			fileSystemManager,
@@ -433,8 +430,7 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
 			repoName,
 			gitdir,
 			lumberjackBaseProperties,
-			enableRepositoryManagerMetrics,
-			apiMetricsSamplingPeriod,
+			{ enableRepositoryManagerMetrics, apiMetricsSamplingPeriod, maxBlobSizeBytes },
 		);
 	}
 

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerBase.ts
@@ -11,14 +11,43 @@ import {
 	GitRestLumberEventName,
 	GitRestRepositoryApiCategory,
 } from "./gitrestTelemetryDefinitions";
+import sizeof from "object-sizeof";
+import { NetworkError } from "@fluidframework/server-services-client";
+
+export interface IRepositoryManagerBaseOptions {
+	/**
+	 * Maximum allowed size of a blob in bytes.
+	 * If not provided or limit is less than 1, no size limit is enforced.
+	 */
+	maxBlobSizeBytes: number;
+	/**
+	 * Flag to enable repository manager metrics.
+	 * When enabled, metrics are generated for each repository manager API call.
+	 * If not provided, defaults to false.
+	 */
+	enableRepositoryManagerMetrics: boolean;
+	/**
+	 * Sampling period for repository manager metrics when enabled.
+	 * If not provided, no sampling is performed and all metrics are emitted.
+	 * If provided, metrics are sampled at the specified period (e.g. 1/N calls where N is the sampling period).
+	 */
+	apiMetricsSamplingPeriod: number;
+}
 
 export abstract class RepositoryManagerBase implements IRepositoryManager {
+	protected readonly apiMetricsSamplingPeriod: number | undefined;
+	protected readonly enableRepositoryManagerMetrics: boolean;
+	protected readonly maxBlobSizeBytes: number | undefined;
+
 	constructor(
 		protected readonly directory: string,
 		protected readonly lumberjackBaseProperties: Record<string, any>,
-		private readonly enableRepositoryManagerMetrics: boolean = false,
-		private readonly apiMetricsSamplingPeriod?: number,
-	) {}
+		options: Partial<IRepositoryManagerBaseOptions>,
+	) {
+		this.apiMetricsSamplingPeriod = options.apiMetricsSamplingPeriod;
+		this.enableRepositoryManagerMetrics = options.enableRepositoryManagerMetrics ?? false;
+		this.maxBlobSizeBytes = options.maxBlobSizeBytes;
+	}
 
 	protected abstract getCommitCore(sha: string): Promise<git.ICommit>;
 	protected abstract getCommitsCore(
@@ -160,6 +189,13 @@ export abstract class RepositoryManagerBase implements IRepositoryManager {
 	public async createBlob(
 		createBlobParams: git.ICreateBlobParams,
 	): Promise<git.ICreateBlobResponse> {
+		if (
+			this.maxBlobSizeBytes !== undefined &&
+			this.maxBlobSizeBytes > 0 &&
+			sizeof(createBlobParams.content) > this.maxBlobSizeBytes
+		) {
+			throw new NetworkError(413, "Blob size exceeds the limit.");
+		}
 		return executeApiWithMetric(
 			async () => this.createBlobCore(createBlobParams),
 			GitRestLumberEventName.RepositoryManager,

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
@@ -55,6 +55,7 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
 		enableRepositoryManagerMetrics: boolean,
 		apiMetricsSamplingPeriod?: number,
 		isEphemeralContainer?: boolean,
+		maxBlobSizeBytes?: number,
 	): IRepositoryManager;
 
 	constructor(
@@ -65,6 +66,7 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
 		private readonly enableRepositoryManagerMetrics: boolean = false,
 		private readonly enforceSynchronous: boolean = true,
 		private readonly apiMetricsSamplingPeriod?: number,
+		private readonly maxBlobSizeBytes?: number,
 	) {
 		this.internalHandler = repoPerDocEnabled
 			? this.repoPerDocInternalHandler.bind(this)
@@ -271,6 +273,7 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
 				this.enableRepositoryManagerMetrics,
 				this.apiMetricsSamplingPeriod,
 				params.isEphemeralContainer,
+				this.maxBlobSizeBytes,
 			);
 		};
 

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -58,7 +58,8 @@
 		"enableHashmapRedisFs": false,
 		"enableRedisFsOptimizedStat": false,
 		"redisApiMetricsSamplingPeriod": 0,
-		"enforceStrictPersistedFullSummaryReads": false
+		"enforceStrictPersistedFullSummaryReads": false,
+		"maxBlobSizeBytes": 0
 	},
 	"redis": {
 		"host": "redis",


### PR DESCRIPTION
## Description

Currently, when Gitrest checks file size within Isomorphic-git, the file is already compressed. That means when Gitrest can write a file above specified limits if it compresses below the limit. This makes limiting file sizes for the purpose of service memory use inconsistent and unreliable.

This PR adds an extra config, `git:maxBlobSizeBytes`. This new config is distinct from the existing `git:filesystem:maxFileSizeBytes` and `git:ephemeralFilesystem:maxFileSizeBytes` because this pre-compression limit is about _service memory_, not storage size. The filesystem limits will still apply to their respective filesystems.

For example, an 300kb Ephemeral summary that does not compress is less than the maxBlobSize but greater than the maxFileSize for Redis, so it will still throw an EFBig error. However, a 300kb Ephemeral summary that compresses to 100Kb will not throw, and this is OK because Redis will only know about the 100Kb, which is in spec.

## Breaking Changes

The internally used RepoManagerFactoryBase and RepoManagerBase constructor params has a partial change to an `options` object. This will help avoid the param list getting overly long and confusing. However, the publicly used IsomorphicGitManagerFactory simply had an additional optional param added, so public APIs should be unchanged.
