### PR TITLE
(docs): update pipeline trigger and add ado-feeds var group

### DIFF
--- a/tools/pipelines/publish-api-model-artifact.yml
+++ b/tools/pipelines/publish-api-model-artifact.yml
@@ -44,6 +44,7 @@ parameters:
 variables:
   - group: doc-versions
   - group: storage-vars
+  - group: ado-feeds
   - name: repoToTrigger
     value: microsoft/FluidFramework
   - name: latestPipeline
@@ -82,7 +83,7 @@ variables:
 trigger:
   branches:
     include:
-    - release/**
+    - release/client/*
 pr: none
 
 stages:


### PR DESCRIPTION
updating trigger condition to ensure pipeline only triggers on client release branches.

Also applied follow up to #23259
