### PR TITLE
[bump] Bump test tools to next major version

### DIFF
--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/test-tools",
-	"version": "2.1.0",
+	"version": "3.0.0",
 	"description": "Fluid test tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/test-tools",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "Fluid test tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
## Description

Bumps the (independent) test-tools package to the next major version. This is because we want to release 2.0 (with the changes from https://github.com/microsoft/FluidFramework/pull/23202) in order to fix the build of the LTS branch, and the first step towards that is bumping the package version in main to then cut the release branch from the commit before the bump is merged.

Note: after this release, I'm hoping to make test-tools a private package inside the client release group (in https://github.com/microsoft/FluidFramework/pull/23211), so 2.x would be the last version we release for it. This bump would be just to satisfy the process to release it today.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
