### PR TITLE
Update path-to-regexp to address CVE

### DIFF
--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -8889,8 +8889,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /express@4.21.1:
-    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
+  /express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       accepts: 1.3.8
@@ -8912,7 +8912,7 @@ packages:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
       qs: 6.13.0
       range-parser: 1.2.1
@@ -13029,8 +13029,8 @@ packages:
       minipass: 7.1.2
     dev: true
 
-  /path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+  /path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
     dev: true
 
   /path-to-regexp@1.9.0:
@@ -16624,7 +16624,7 @@ packages:
       compression: 1.7.5
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.21.1
+      express: 4.21.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
       http-proxy-middleware: 2.0.7(@types/express@4.17.21)(debug@4.3.7)

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
@@ -43,7 +43,7 @@
 		"@fluidframework/odsp-urlresolver": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@fluidframework/tool-utils": "workspace:~",
-		"express": "^4.21.1",
+		"express": "^4.21.2",
 		"webpack-dev-server": "~4.15.2"
 	},
 	"devDependencies": {

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -72,7 +72,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"cors": "^2.8.4",
 		"css-loader": "^7.1.2",
-		"express": "^4.21.1",
+		"express": "^4.21.2",
 		"lodash.isequal": "^4.5.0",
 		"node-fetch": "^2.6.9",
 		"react": "^18.3.1",

--- a/examples/utils/webpack-fluid-loader/package.json
+++ b/examples/utils/webpack-fluid-loader/package.json
@@ -105,7 +105,7 @@
 		"@fluidframework/tool-utils": "workspace:~",
 		"axios": "^1.7.7",
 		"buffer": "^6.0.3",
-		"express": "^4.21.1",
+		"express": "^4.21.2",
 		"isomorphic-fetch": "^3.0.0",
 		"nconf": "^0.12.0",
 		"sillyname": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2000,8 +2000,8 @@ importers:
         specifier: workspace:~
         version: link:../../../packages/utils/tool-utils
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       webpack-dev-server:
         specifier: ~4.15.2
         version: 4.15.2(webpack-cli@5.1.4)(webpack@5.95.0)
@@ -4097,8 +4097,8 @@ importers:
         specifier: ^7.1.2
         version: 7.1.2(webpack@5.95.0)
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       lodash.isequal:
         specifier: ^4.5.0
         version: 4.5.0
@@ -4871,8 +4871,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       isomorphic-fetch:
         specifier: ^3.0.0
         version: 3.0.0
@@ -20901,7 +20901,7 @@ packages:
       '@fluidframework/server-services-core': 5.0.0
       '@fluidframework/server-services-telemetry': 5.0.0
       debug: 4.3.7(supports-color@8.1.1)
-      express: 4.21.1
+      express: 4.21.2
       ioredis: 5.4.1
       json-stringify-safe: 5.0.1
       jsonwebtoken: 9.0.2
@@ -23375,7 +23375,7 @@ packages:
       '@previewjs/iframe': 11.0.1
       '@previewjs/properties': 3.0.3
       '@previewjs/vfs': 2.1.2
-      express: 4.21.1
+      express: 4.21.2
       pino: 8.21.0
       pino-pretty: 10.3.1
       playwright: 1.47.2
@@ -23413,7 +23413,7 @@ packages:
       assert-never: 1.3.0
       axios: 1.7.7(debug@4.3.7)
       exclusive-promises: 1.0.3
-      express: 4.21.1
+      express: 4.21.2
       fs-extra: 11.2.0
       globby: 13.2.2
       html-escaper: 3.0.3
@@ -29121,8 +29121,8 @@ packages:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
     dev: true
 
-  /express@4.21.1:
-    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
+  /express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       accepts: 1.3.8
@@ -29144,7 +29144,7 @@ packages:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
       qs: 6.13.0
       range-parser: 1.2.1
@@ -34975,8 +34975,8 @@ packages:
       minipass: 7.1.2
     dev: true
 
-  /path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+  /path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   /path-to-regexp@1.9.0:
     resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
@@ -38248,7 +38248,7 @@ packages:
       cookie-parser: 1.4.7
       cors: 2.8.5
       detect-port: 1.6.1
-      express: 4.21.1
+      express: 4.21.2
       isomorphic-git: 1.27.1
       json-stringify-safe: 5.0.1
       level: 8.0.1
@@ -39605,7 +39605,7 @@ packages:
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.21.1
+      express: 4.21.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)(debug@4.3.7)
@@ -39657,7 +39657,7 @@ packages:
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.21.1
+      express: 4.21.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)(debug@4.3.7)

--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -67,7 +67,7 @@
 		"compression": "^1.7.3",
 		"cors": "^2.8.5",
 		"debug": "^4.3.4",
-		"express": "^4.21.1",
+		"express": "^4.21.2",
 		"ioredis": "^5.2.3",
 		"isomorphic-git": "^1.25.10",
 		"json-stringify-safe": "^5.0.1",

--- a/server/gitrest/packages/gitrest/package.json
+++ b/server/gitrest/packages/gitrest/package.json
@@ -34,7 +34,7 @@
 		"compression": "^1.7.3",
 		"cors": "^2.8.5",
 		"debug": "^4.3.4",
-		"express": "^4.21.1",
+		"express": "^4.21.2",
 		"isomorphic-git": "^1.25.10",
 		"json-stringify-safe": "^5.0.1",
 		"nconf": "^0.11.4",

--- a/server/gitrest/pnpm-lock.yaml
+++ b/server/gitrest/pnpm-lock.yaml
@@ -116,8 +116,8 @@ importers:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@8.1.1)
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       isomorphic-git:
         specifier: ^1.25.10
         version: 1.25.10
@@ -243,8 +243,8 @@ importers:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@8.1.1)
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       ioredis:
         specifier: ^5.2.3
         version: 5.3.2
@@ -1437,9 +1437,9 @@ packages:
       '@fluidframework/gitresources': 6.0.0-287165
       '@fluidframework/protocol-base': 6.0.0-287165
       '@fluidframework/protocol-definitions': 3.2.0
-      axios: 1.7.7(debug@4.3.4)
+      axios: 1.7.7(debug@4.3.6)
       crc-32: 1.2.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
       jsrsasign: 11.1.0
       jwt-decode: 4.0.0
@@ -1478,7 +1478,7 @@ packages:
       '@fluidframework/server-services-telemetry': 6.0.0-287165
       '@types/nconf': 0.10.3
       '@types/node': 18.17.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       events: 3.3.0
       nconf: 0.12.0
     transitivePeerDependencies:
@@ -1551,7 +1551,7 @@ packages:
       body-parser: 1.20.3
       debug: 4.3.6(supports-color@8.1.1)
       events: 3.3.0
-      express: 4.21.1
+      express: 4.21.2
       fast-redact: 3.3.0
       ioredis: 5.3.2
       lodash: 4.17.21
@@ -1597,7 +1597,7 @@ packages:
       '@fluidframework/server-services-core': 6.0.0-287165
       '@fluidframework/server-services-telemetry': 6.0.0-287165
       debug: 4.3.4(supports-color@8.1.1)
-      express: 4.21.1
+      express: 4.21.2
       ioredis: 5.3.2
       json-stringify-safe: 5.0.1
       jsonwebtoken: 9.0.2
@@ -1621,7 +1621,7 @@ packages:
       '@fluidframework/server-services-core': 6.0.0-310414
       '@fluidframework/server-services-telemetry': 6.0.0-310414
       debug: 4.3.6(supports-color@8.1.1)
-      express: 4.21.1
+      express: 4.21.2
       ioredis: 5.3.2
       json-stringify-safe: 5.0.1
       jsonwebtoken: 9.0.2
@@ -5918,8 +5918,8 @@ packages:
       homedir-polyfill: 1.0.3
     dev: true
 
-  /express@4.21.1:
-    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
+  /express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       accepts: 1.3.8
@@ -5941,7 +5941,7 @@ packages:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
       qs: 6.11.2
       range-parser: 1.2.1
@@ -7003,7 +7003,7 @@ packages:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -9415,8 +9415,8 @@ packages:
       minipass: 7.1.2
     dev: true
 
-  /path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+  /path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
     dev: false
 
   /path-to-regexp@8.2.0:
@@ -10395,7 +10395,7 @@ packages:
   /socket.io-adapter@2.5.5:
     resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
       ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
@@ -10408,7 +10408,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       '@socket.io/component-emitter': 3.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false

--- a/server/historian/packages/historian-base/package.json
+++ b/server/historian/packages/historian-base/package.json
@@ -67,7 +67,7 @@
 		"compression": "^1.7.3",
 		"cors": "^2.8.5",
 		"debug": "^4.3.4",
-		"express": "^4.21.1",
+		"express": "^4.21.2",
 		"ioredis": "^5.2.3",
 		"ioredis-mock": "^8.9.0",
 		"json-stringify-safe": "5.0.1",

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -35,7 +35,7 @@
 		"compression": "^1.7.3",
 		"cors": "^2.8.5",
 		"debug": "^4.3.4",
-		"express": "^4.21.1",
+		"express": "^4.21.2",
 		"ioredis": "^5.2.3",
 		"lodash": "^4.17.19",
 		"nconf": "^0.11.4",

--- a/server/historian/pnpm-lock.yaml
+++ b/server/historian/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@8.1.1)
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       ioredis:
         specifier: ^5.2.3
         version: 5.2.3
@@ -220,8 +220,8 @@ importers:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@8.1.1)
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       ioredis:
         specifier: ^5.2.3
         version: 5.2.3
@@ -2120,7 +2120,7 @@ packages:
       body-parser: 1.20.3
       debug: 4.3.6(supports-color@8.1.1)
       events: 3.3.0
-      express: 4.21.1
+      express: 4.21.2
       fast-redact: 3.3.0
       ioredis: 5.2.3
       lodash: 4.17.21
@@ -2165,7 +2165,7 @@ packages:
       '@fluidframework/server-services-core': 6.0.0-287165
       '@fluidframework/server-services-telemetry': 6.0.0-287165
       debug: 4.3.4(supports-color@8.1.1)
-      express: 4.21.1
+      express: 4.21.2
       ioredis: 5.2.3
       json-stringify-safe: 5.0.1
       jsonwebtoken: 9.0.2
@@ -2189,7 +2189,7 @@ packages:
       '@fluidframework/server-services-core': 6.0.0-310414
       '@fluidframework/server-services-telemetry': 6.0.0-310414
       debug: 4.3.6(supports-color@8.1.1)
-      express: 4.21.1
+      express: 4.21.2
       ioredis: 5.2.3
       json-stringify-safe: 5.0.1
       jsonwebtoken: 9.0.2
@@ -7131,8 +7131,8 @@ packages:
       homedir-polyfill: 1.0.3
     dev: true
 
-  /express@4.21.1:
-    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
+  /express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       accepts: 1.3.8
@@ -7154,7 +7154,7 @@ packages:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
       qs: 6.11.2
       range-parser: 1.2.1
@@ -10870,8 +10870,8 @@ packages:
       minipass: 7.1.2
     dev: true
 
-  /path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+  /path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
     dev: false
 
   /path-to-regexp@8.2.0:

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -72,7 +72,7 @@
 		"compression": "^1.7.2",
 		"cookie-parser": "^1.4.7",
 		"cors": "^2.8.4",
-		"express": "^4.21.1",
+		"express": "^4.21.2",
 		"ioredis": "^5.2.3",
 		"json-stringify-safe": "^5.0.1",
 		"jsonwebtoken": "^9.0.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -53,7 +53,7 @@
 		"@fluidframework/server-services-telemetry": "workspace:~",
 		"@fluidframework/server-services-utils": "workspace:~",
 		"commander": "^2.17.1",
-		"express": "^4.21.1",
+		"express": "^4.21.2",
 		"ioredis": "^5.2.3",
 		"nconf": "^0.12.0",
 		"winston": "^3.6.0"

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -65,7 +65,7 @@
 		"body-parser": "^1.20.3",
 		"debug": "^4.3.4",
 		"events": "^3.1.0",
-		"express": "^4.21.1",
+		"express": "^4.21.2",
 		"fast-redact": "^3.3.0",
 		"ioredis": "^5.2.3",
 		"lodash": "^4.17.21",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -58,7 +58,7 @@
 		"@fluidframework/server-services-core": "workspace:~",
 		"@fluidframework/server-services-telemetry": "workspace:~",
 		"debug": "^4.3.4",
-		"express": "^4.21.1",
+		"express": "^4.21.2",
 		"ioredis": "^5.2.3",
 		"json-stringify-safe": "^5.0.1",
 		"jsonwebtoken": "^9.0.0",

--- a/server/routerlicious/packages/tinylicious/package.json
+++ b/server/routerlicious/packages/tinylicious/package.json
@@ -57,7 +57,7 @@
 		"cookie-parser": "^1.4.7",
 		"cors": "^2.8.4",
 		"detect-port": "^1.3.0",
-		"express": "^4.21.1",
+		"express": "^4.21.2",
 		"isomorphic-git": "^1.25.7",
 		"json-stringify-safe": "^5.0.1",
 		"level": "^8.0.0",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -721,8 +721,8 @@ importers:
         specifier: ^2.17.1
         version: 2.20.3
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       ioredis:
         specifier: ^5.2.3
         version: 5.3.2
@@ -842,8 +842,8 @@ importers:
         specifier: ^2.8.4
         version: 2.8.5
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       ioredis:
         specifier: ^5.2.3
         version: 5.3.2
@@ -1557,8 +1557,8 @@ importers:
         specifier: ^3.1.0
         version: 3.3.0
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       fast-redact:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1751,8 +1751,8 @@ importers:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@8.1.1)
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       ioredis:
         specifier: ^5.2.3
         version: 5.3.2
@@ -2038,8 +2038,8 @@ importers:
         specifier: ^1.3.0
         version: 1.5.1
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       isomorphic-git:
         specifier: ^1.25.7
         version: 1.25.7
@@ -4088,7 +4088,7 @@ packages:
       compression: 1.7.4
       cookie-parser: 1.4.7
       cors: 2.8.5
-      express: 4.21.1
+      express: 4.21.2
       ioredis: 5.3.2
       json-stringify-safe: 5.0.1
       jsonwebtoken: 9.0.2
@@ -4126,7 +4126,7 @@ packages:
       '@fluidframework/server-services-telemetry': 5.0.0
       '@fluidframework/server-services-utils': 5.0.0
       commander: 2.20.3
-      express: 4.21.1
+      express: 4.21.2
       ioredis: 5.3.2
       nconf: 0.12.1
       winston: 3.9.0
@@ -4264,7 +4264,7 @@ packages:
       '@fluidframework/server-services-core': 5.0.0
       '@fluidframework/server-services-telemetry': 5.0.0
       debug: 4.3.4(supports-color@8.1.1)
-      express: 4.21.1
+      express: 4.21.2
       ioredis: 5.3.2
       json-stringify-safe: 5.0.1
       jsonwebtoken: 9.0.2
@@ -9330,8 +9330,8 @@ packages:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
     dev: true
 
-  /express@4.21.1:
-    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
+  /express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       accepts: 1.3.8
@@ -9353,7 +9353,7 @@ packages:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
       qs: 6.11.2
       range-parser: 1.2.1
@@ -12863,8 +12863,8 @@ packages:
       minipass: 6.0.2
     dev: true
 
-  /path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+  /path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   /path-to-regexp@8.2.0:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}


### PR DESCRIPTION
## Description

Updates dependencies on `path-to-regexp` to address https://nvd.nist.gov/vuln/detail/CVE-2024-52798. `express` had to be updated it uses pinned versions for its dependencies, and it is the one that brings in `path-to-regexp` as a transitive dependency for us.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#26328](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26328)
[AB#26329](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26329)