### PR TITLE
Add IContainerRuntimeOptionInternal for soon-to-be-deprecated options

### DIFF
--- a/packages/framework/fluid-static/src/compatibilityConfiguration.ts
+++ b/packages/framework/fluid-static/src/compatibilityConfiguration.ts
@@ -5,7 +5,7 @@
 
 import {
 	CompressionAlgorithms,
-	type IContainerRuntimeOptions,
+	type IContainerRuntimeOptionsInternal,
 } from "@fluidframework/container-runtime/internal";
 import { FlushMode } from "@fluidframework/runtime-definitions/internal";
 
@@ -17,7 +17,7 @@ import type { CompatibilityMode } from "./types.js";
  */
 export const compatibilityModeRuntimeOptions: Record<
 	CompatibilityMode,
-	IContainerRuntimeOptions
+	IContainerRuntimeOptionsInternal
 > = {
 	"1": {
 		// 1.x clients are compatible with TurnBased flushing, but here we elect to remain on Immediate flush mode

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1117,6 +1117,21 @@ export class ContainerRuntime
 
 		const featureGatesForTelemetry: Record<string, boolean | number | undefined> = {};
 
+		// Make sure we've got all the options including internal ones (even though we have to cast back to IContainerRuntimeOptions below)
+		const internalRuntimeOptions: Readonly<Required<IContainerRuntimeOptionsInternal>> = {
+			summaryOptions,
+			gcOptions,
+			loadSequenceNumberVerification,
+			flushMode,
+			compressionOptions,
+			maxBatchSizeInBytes,
+			chunkSizeInBytes,
+			// Requires<> drops undefined from IdCompressorType
+			enableRuntimeIdCompressor: enableRuntimeIdCompressor as "on" | "delayed",
+			enableGroupedBatching,
+			explicitSchemaControl,
+		};
+
 		const runtime = new containerRuntimeCtor(
 			context,
 			registry,
@@ -1124,19 +1139,7 @@ export class ContainerRuntime
 			electedSummarizerData,
 			chunks ?? [],
 			aliases ?? [],
-			{
-				summaryOptions,
-				gcOptions,
-				loadSequenceNumberVerification,
-				flushMode,
-				compressionOptions,
-				maxBatchSizeInBytes,
-				chunkSizeInBytes,
-				// Requires<> drops undefined from IdCompressorType
-				enableRuntimeIdCompressor: enableRuntimeIdCompressor as "on" | "delayed",
-				enableGroupedBatching,
-				explicitSchemaControl,
-			} satisfies Readonly<Required<IContainerRuntimeOptionsInternal>>, // (Make sure we include all the options including internal ones)
+			internalRuntimeOptions,
 			containerScope,
 			logger,
 			existing,
@@ -1556,7 +1559,6 @@ export class ContainerRuntime
 			snapshotWithContents,
 		} = context;
 
-		// Note that this is implicitly down-casting to the internal type (so we can access internal options)
 		this.runtimeOptions = runtimeOptions;
 
 		this.logger = createChildLogger({ logger: this.baseLogger });

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1118,21 +1118,6 @@ export class ContainerRuntime
 
 		const featureGatesForTelemetry: Record<string, boolean | number | undefined> = {};
 
-		// Make sure we've got all the options including internal ones (even though we have to cast back to IContainerRuntimeOptions below)
-		const internalRuntimeOptions: Readonly<Required<IContainerRuntimeOptionsInternal>> = {
-			summaryOptions,
-			gcOptions,
-			loadSequenceNumberVerification,
-			flushMode,
-			compressionOptions,
-			maxBatchSizeInBytes,
-			chunkSizeInBytes,
-			// Requires<> drops undefined from IdCompressorType
-			enableRuntimeIdCompressor: enableRuntimeIdCompressor as "on" | "delayed",
-			enableGroupedBatching,
-			explicitSchemaControl,
-		};
-
 		const runtime = new containerRuntimeCtor(
 			context,
 			registry,
@@ -1140,7 +1125,19 @@ export class ContainerRuntime
 			electedSummarizerData,
 			chunks ?? [],
 			aliases ?? [],
-			internalRuntimeOptions as Readonly<Required<IContainerRuntimeOptions>>,
+			{
+				summaryOptions,
+				gcOptions,
+				loadSequenceNumberVerification,
+				flushMode,
+				compressionOptions,
+				maxBatchSizeInBytes,
+				chunkSizeInBytes,
+				// Requires<> drops undefined from IdCompressorType
+				enableRuntimeIdCompressor: enableRuntimeIdCompressor as "on" | "delayed",
+				enableGroupedBatching,
+				explicitSchemaControl,
+			} satisfies Readonly<Required<IContainerRuntimeOptionsInternal>>, // (Make sure we include all the options including internal ones)
 			containerScope,
 			logger,
 			existing,
@@ -1560,9 +1557,8 @@ export class ContainerRuntime
 			snapshotWithContents,
 		} = context;
 
-		this.runtimeOptions = runtimeOptions as Readonly<
-			Required<IContainerRuntimeOptionsInternal>
-		>;
+		// Note that this is implicitly down-casting to the internal type (so we can access internal options)
+		this.runtimeOptions = runtimeOptions;
 
 		this.logger = createChildLogger({ logger: this.baseLogger });
 		this.mc = createChildMonitoringContext({

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -533,6 +533,31 @@ export interface IContainerRuntimeOptions {
 }
 
 /**
+ * Internal extension of @see IContainerRuntimeOptions
+ *
+ * These options are not available to consumers when creating a new container runtime,
+ * but we do need to expose them for internal use, e.g. when configuring the container runtime
+ * to ensure compability with older versions.
+ *
+ * @internal
+ */
+export interface IContainerRuntimeOptionsInternal extends IContainerRuntimeOptions {
+	/**
+	 * Sets the flush mode for the runtime. In Immediate flush mode the runtime will immediately
+	 * send all operations to the driver layer, while in TurnBased the operations will be buffered
+	 * and then sent them as a single batch at the end of the turn.
+	 * By default, flush mode is TurnBased.
+	 */
+	readonly flushMode?: FlushMode;
+
+	/**
+	 * Allows Grouped Batching to be disabled by setting to false (default is true).
+	 * In that case, batched messages will be sent individually (but still all at the same time).
+	 */
+	readonly enableGroupedBatching?: boolean;
+}
+
+/**
  * Error responses when requesting a deleted object will have this header set to true
  * @legacy
  * @alpha
@@ -867,7 +892,7 @@ export class ContainerRuntime
 		context: IContainerContext;
 		registryEntries: NamedFluidDataStoreRegistryEntries;
 		existing: boolean;
-		runtimeOptions?: IContainerRuntimeOptions;
+		runtimeOptions?: IContainerRuntimeOptions; // May also include options from IContainerRuntimeOptionsInternal
 		containerScope?: FluidObject;
 		containerRuntimeCtor?: typeof ContainerRuntime;
 		/** @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md */
@@ -914,7 +939,7 @@ export class ContainerRuntime
 			chunkSizeInBytes = defaultChunkSizeInBytes,
 			enableGroupedBatching = true,
 			explicitSchemaControl = false,
-		} = runtimeOptions;
+		} = runtimeOptions as IContainerRuntimeOptionsInternal;
 
 		const registry = new FluidDataStoreRegistry(registryEntries);
 
@@ -1093,6 +1118,21 @@ export class ContainerRuntime
 
 		const featureGatesForTelemetry: Record<string, boolean | number | undefined> = {};
 
+		// Make sure we've got all the options including internal ones (even though we have to cast back to IContainerRuntimeOptions below)
+		const internalRuntimeOptions: Readonly<Required<IContainerRuntimeOptionsInternal>> = {
+			summaryOptions,
+			gcOptions,
+			loadSequenceNumberVerification,
+			flushMode,
+			compressionOptions,
+			maxBatchSizeInBytes,
+			chunkSizeInBytes,
+			// Requires<> drops undefined from IdCompressorType
+			enableRuntimeIdCompressor: enableRuntimeIdCompressor as "on" | "delayed",
+			enableGroupedBatching,
+			explicitSchemaControl,
+		};
+
 		const runtime = new containerRuntimeCtor(
 			context,
 			registry,
@@ -1100,19 +1140,7 @@ export class ContainerRuntime
 			electedSummarizerData,
 			chunks ?? [],
 			aliases ?? [],
-			{
-				summaryOptions,
-				gcOptions,
-				loadSequenceNumberVerification,
-				flushMode,
-				compressionOptions,
-				maxBatchSizeInBytes,
-				chunkSizeInBytes,
-				// Requires<> drops undefined from IdCompressorType
-				enableRuntimeIdCompressor: enableRuntimeIdCompressor as "on" | "delayed",
-				enableGroupedBatching,
-				explicitSchemaControl,
-			},
+			internalRuntimeOptions as Readonly<Required<IContainerRuntimeOptions>>,
 			containerScope,
 			logger,
 			existing,
@@ -1474,6 +1502,11 @@ export class ContainerRuntime
 		expiry: { policy: "absolute", durationMs: 60000 },
 	});
 
+	/**
+	 * The options to apply to this ContainerRuntime instance (including internal options hidden from the public API)
+	 */
+	private readonly runtimeOptions: Readonly<Required<IContainerRuntimeOptionsInternal>>;
+
 	/***/
 	protected constructor(
 		context: IContainerContext,
@@ -1482,7 +1515,7 @@ export class ContainerRuntime
 		electedSummarizerData: ISerializedElection | undefined,
 		chunks: [string, string[]][],
 		dataStoreAliasMap: [string, string][],
-		private readonly runtimeOptions: Readonly<Required<IContainerRuntimeOptions>>,
+		runtimeOptions: Readonly<Required<IContainerRuntimeOptions>>,
 		private readonly containerScope: FluidObject,
 		// Create a custom ITelemetryBaseLogger to output telemetry events.
 		public readonly baseLogger: ITelemetryBaseLogger,
@@ -1526,6 +1559,10 @@ export class ContainerRuntime
 			supportedFeatures,
 			snapshotWithContents,
 		} = context;
+
+		this.runtimeOptions = runtimeOptions as Readonly<
+			Required<IContainerRuntimeOptionsInternal>
+		>;
 
 		this.logger = createChildLogger({ logger: this.baseLogger });
 		this.mc = createChildMonitoringContext({
@@ -1697,14 +1734,15 @@ export class ContainerRuntime
 			this.defaultMaxConsecutiveReconnects;
 
 		if (
-			runtimeOptions.flushMode === (FlushModeExperimental.Async as unknown as FlushMode) &&
+			this.runtimeOptions.flushMode ===
+				(FlushModeExperimental.Async as unknown as FlushMode) &&
 			supportedFeatures?.get("referenceSequenceNumbers") !== true
 		) {
 			// The loader does not support reference sequence numbers, falling back on FlushMode.TurnBased
 			this.mc.logger.sendErrorEvent({ eventName: "FlushModeFallback" });
 			this._flushMode = FlushMode.TurnBased;
 		} else {
-			this._flushMode = runtimeOptions.flushMode;
+			this._flushMode = this.runtimeOptions.flushMode;
 		}
 		this.offlineEnabled =
 			this.mc.config.getBoolean("Fluid.Container.enableOfflineLoad") ?? false;

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -10,6 +10,7 @@ export {
 	ISummaryConfigurationDisableSummarizer,
 	ISummaryConfigurationDisableHeuristics,
 	IContainerRuntimeOptions,
+	IContainerRuntimeOptionsInternal,
 	loadContainerRuntime,
 	LoadContainerRuntimeParams,
 	agentSchedulerId,


### PR DESCRIPTION
## Description

See [AB#6789](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6789) and [AB#8124](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8124) -- We are working towards removing support for certain `IContainerRuntimeOptions`.  `flushMode.Immediate` and `enableGroupedBatching` in particular.

We can remove them from the public (meaning alpha/legacy) API now, but we need to be able to include them internally for compatibility configuration needed for apps needing to support collaboration between 1.x and 2.x clients.

So this PR adds a new internal interface `IContainerRuntimeOptionInternal` which has these two options, and uses it for compat config.  We can now deprecate/remove the options from the main interface.
