### PR TITLE
Update json2csv

### DIFF
--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -126,7 +126,7 @@
 		"@fluidframework/odsp-driver": "workspace:~",
 		"@fluidframework/odsp-driver-definitions": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"json2csv": "^5.0.7",
+		"@json2csv/plainjs": "^7.0.6",
 		"yargs": "17.7.2"
 	},
 	"devDependencies": {

--- a/packages/tools/fluid-runner/src/logger/csvFileLogger.ts
+++ b/packages/tools/fluid-runner/src/logger/csvFileLogger.ts
@@ -6,7 +6,7 @@
 import * as fs from "fs";
 
 import { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
-import { parse } from "json2csv";
+import { Parser } from "@json2csv/plainjs";
 
 import { BaseFileLogger } from "./baseFileLogger.js";
 
@@ -15,8 +15,12 @@ import { BaseFileLogger } from "./baseFileLogger.js";
  * @internal
  */
 export class CSVFileLogger extends BaseFileLogger {
-	/** Store the column names to write as the CSV header */
-	private readonly columns = new Set();
+	/**
+	 * Store the column names to write as the CSV header.
+	 *
+	 * Order of this set is used for the oder of columns.
+	 */
+	private readonly columns = new Set<string>();
 
 	protected async flush(): Promise<void> {
 		// No flushing is performed since we need all log entries to determine set of CSV columns
@@ -25,6 +29,7 @@ export class CSVFileLogger extends BaseFileLogger {
 	public send(event: ITelemetryBaseEvent): void {
 		// eslint-disable-next-line guard-for-in, no-restricted-syntax
 		for (const prop in event) {
+			// Include "prop" as a column, moving it to the end of the column set if already included.
 			this.columns.add(prop);
 		}
 		super.send(event);
@@ -34,9 +39,13 @@ export class CSVFileLogger extends BaseFileLogger {
 		await super.close();
 		// eslint-disable-next-line guard-for-in, no-restricted-syntax
 		for (const field in this.defaultProps) {
+			// Include "field" as a column, moving it to the end of the column set if already included.
 			this.columns.add(field);
 		}
-
-		fs.writeFileSync(this.filePath, parse(this.events, Array.from(this.columns)));
+		const parser = new Parser({
+			// Orders columns based on order of the set, which puts most recently seen fields from send at the end.
+			fields: Array.from(this.columns),
+		});
+		fs.writeFileSync(this.filePath, parser.parse(this.events));
 	}
 }

--- a/packages/tools/fluid-runner/src/test/telemetryExpectedOutputs/expectedOutput4.csv
+++ b/packages/tools/fluid-runner/src/test/telemetryExpectedOutputs/expectedOutput4.csv
@@ -1,5 +1,5 @@
-"eventName","category","prop1","extraProp1","extraProp2","prop2"
-"event1","category1","value1","value1","value2",
-"event2","category1",,"value1","value2","value2"
-"event3","category2","value3","value1","value2",
-"event4","category2",,"value1","value2","value4"
+"eventName","category","prop1","prop2","extraProp1","extraProp2"
+"event1","category1","value1",,"value1","value2"
+"event2","category1",,"value2","value1","value2"
+"event3","category2","value3",,"value1","value2"
+"event4","category2",,"value4","value1","value2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15857,9 +15857,9 @@ importers:
       '@fluidframework/telemetry-utils':
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
-      json2csv:
-        specifier: ^5.0.7
-        version: 5.0.7
+      '@json2csv/plainjs':
+        specifier: ^7.0.6
+        version: 7.0.6
       yargs:
         specifier: 17.7.2
         version: 17.7.2
@@ -22026,6 +22026,17 @@ packages:
       '@jridgewell/sourcemap-codec': 1.5.0
     dev: true
 
+  /@json2csv/formatters@7.0.6:
+    resolution: {integrity: sha512-hjIk1H1TR4ydU5ntIENEPgoMGW+Q7mJ+537sDFDbsk+Y3EPl2i4NfFVjw0NJRgT+ihm8X30M67mA8AS6jPidSA==}
+    dev: false
+
+  /@json2csv/plainjs@7.0.6:
+    resolution: {integrity: sha512-4Md7RPDCSYpmW1HWIpWBOqCd4vWfIqm53S3e/uzQ62iGi7L3r34fK/8nhOMEe+/eVfCx8+gdSCt1d74SlacQHw==}
+    dependencies:
+      '@json2csv/formatters': 7.0.6
+      '@streamparser/json': 0.0.20
+    dev: false
+
   /@jsonjoy.com/base64@1.1.2(tslib@2.7.0):
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
     engines: {node: '>=10.0'}
@@ -23841,6 +23852,10 @@ packages:
 
   /@socket.io/sticky@1.0.4:
     resolution: {integrity: sha512-VuauT5CJLvzYtKIgouFSQ8rUaygseR+zRutnwh6ZA2QYcXx+8g52EoJ8V2SLxfo+Tfs3ELUDy08oEXxlWNrxaw==}
+
+  /@streamparser/json@0.0.20:
+    resolution: {integrity: sha512-VqAAkydywPpkw63WQhPVKCD3SdwXuihCUVZbbiY3SfSTGQyHmwRoq27y4dmJdZuJwd5JIlQoMPyGvMbUPY0RKQ==}
+    dev: false
 
   /@swc/counter@0.1.3:
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -27013,6 +27028,7 @@ packages:
   /commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
+    dev: true
 
   /commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -32141,6 +32157,7 @@ packages:
       commander: 6.2.1
       jsonparse: 1.3.1
       lodash.get: 4.4.2
+    dev: true
 
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -32179,6 +32196,7 @@ packages:
   /jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
+    dev: true
 
   /jsonpath@1.1.1:
     resolution: {integrity: sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==}


### PR DESCRIPTION
## Description

CSVFileLogger used an abandoned package to generate its CSV data. This updates it to use a supported successor of the portion of the json2csv package it was using.

## Breaking Changes

The desired ordering of the columns in the output was unclear, and changed with this update.

The new ordering makes sense as it's derived from the order of the set containing the columns: I'm unclear where the old order came from, but it was not preserved. How the new ordering happens still seems questionable, but it has been documented internally.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

