### PR TITLE
doc(client): Clarify changeset wording and formatting

### DIFF
--- a/.changeset/dirty-crabs-try.md
+++ b/.changeset/dirty-crabs-try.md
@@ -7,4 +7,4 @@
 
 SummarizerStopReason, ISummarizeEventProps, and ISummarizerEvents are now deprecated
 
-`SummarizerStopReason`, `ISummarizeEventProps`, and `ISummarizerEvents` have all been deprecated from the `"@fluidframework/container-runtime"` package. Please migrate all uses of these APIs to their respective implementations in the `"@fluidframework/container-runtime-definitions"` package.
+`SummarizerStopReason`, `ISummarizeEventProps`, and `ISummarizerEvents` have all been deprecated from the `"@fluidframework/container-runtime"` package. Please migrate all uses of these APIs to their counterparts in the `"@fluidframework/container-runtime-definitions"` package.

--- a/.changeset/dirty-crabs-try.md
+++ b/.changeset/dirty-crabs-try.md
@@ -5,6 +5,6 @@
 "section": deprecation
 ---
 
-Deprecated SummarizerStopReason, ISummarizeEventProps, and ISummarizerEvents
+SummarizerStopReason, ISummarizeEventProps, and ISummarizerEvents are now deprecated
 
-`SummarizerStopReason`, `ISummarizeEventProps`, and `ISummarizerEvents` have all been deprecated from the `"@fluidframework/container-runtime"` package. Please migrate all uses of these APIs to their respective copies in the `"@fluidframework/container-runtime-definitions"` package.
+`SummarizerStopReason`, `ISummarizeEventProps`, and `ISummarizerEvents` have all been deprecated from the `"@fluidframework/container-runtime"` package. Please migrate all uses of these APIs to their respective implementations in the `"@fluidframework/container-runtime-definitions"` package.

--- a/.changeset/moody-files-argue.md
+++ b/.changeset/moody-files-argue.md
@@ -11,19 +11,18 @@
 "@fluidframework/tree": minor
 ---
 ---
-
 "section": feature
 ---
 
-Provide standalone APIs to create and load containers.
+New APIs to create and load containers without using the Loader object
 
-## Overview
+#### Overview
 
 Provide standalone APIs to create and load containers instead of using the Loader object to do so. Earlier hosts were
 supposed to create the Loader object first and then call methods on it to create and load containers. Now they can just
-utilize these APIs and get rid of the Loader object.
+utilize these APIs directly and get rid of the Loader object.
 
-### Use `createDetachedContainer` to create a detached container.
+##### Use `createDetachedContainer` to create a detached container
 
 ```typescript
 export async function createDetachedContainer(
@@ -32,9 +31,9 @@ export async function createDetachedContainer(
 ```
 
 `ICreateDetachedContainerProps` are the properties that needs to be supplied to the above API which contains props like
-URL Resolver, IDocumentServiceFactory etc which were same which were earlier used to create the `Loader` object.
+URL Resolver, IDocumentServiceFactory etc., which were previously used to create the `Loader` object.
 
-### Use `loadExistingContainer` to load an existing container.
+##### Use `loadExistingContainer` to load an existing container
 
 ```typescript
 export async function loadExistingContainer(
@@ -43,9 +42,9 @@ export async function loadExistingContainer(
 ```
 
 `ILoadExistingContainerProps` are the properties that needs to be supplied to the above API which contains props like
-URL Resolver, IDocumentServiceFactory etc which were same which were earlier used to create the `Loader` object.
+URL Resolver, IDocumentServiceFactory etc., which were earlier used to create the `Loader` object.
 
-### Use `rehydrateDetachedContainer` to create a detached container from a serializedState of another container.
+##### Use `rehydrateDetachedContainer` to create a detached container from a serializedState of another container
 
 ```typescript
 export async function rehydrateDetachedContainer(
@@ -54,13 +53,14 @@ export async function rehydrateDetachedContainer(
 ```
 
 `IRehydrateDetachedContainerProps` are the properties that needs to be supplied to the above API which contains props like
-URL Resolver, IDocumentServiceFactory etc which were same which were earlier used to create the `Loader` object.
+URL Resolver, IDocumentServiceFactory etc., which were earlier used to create the `Loader` object.
 
-### Note on `ICreateAndLoadContainerProps`.
+##### Note on `ICreateAndLoadContainerProps`.
 
-Earlier the props which were used to create the `Loader` object are now moved to the above interface. `ICreateDetachedContainerProps`,
-`ILoadExistingContainerProps` and `IRehydrateDetachedContainerProps` which extends  `ICreateAndLoadContainerProps` also contains
-some additional props which will be used to create and load containers like `IFluidCodeDetails`, `IRequest` etc. Earlier
-these were directly passed when calling APIs like `Loader.createDetachedContainer`, `Loader.resolve` and `Loader.rehydrateDetachedContainerFromSnapshot`
-on the `Loader` object. Also, `ILoaderProps.ILoaderOptions` are not replaced with `ICreateAndLoadContainerProps.IContainerPolicies`
+The props which were used to create the `Loader` object are now moved to the `ICreateAndLoadContainerProps` interface.
+`ICreateDetachedContainerProps`, `ILoadExistingContainerProps` and `IRehydrateDetachedContainerProps` which extends
+`ICreateAndLoadContainerProps` also contains some additional props which will be used to create and load containers like
+`IFluidCodeDetails`, `IRequest` etc. Previously these were directly passed when calling APIs like
+`Loader.createDetachedContainer`, `Loader.resolve` and `Loader.rehydrateDetachedContainerFromSnapshot` on the `Loader`
+object. Also, `ILoaderProps.ILoaderOptions` are not replaced with `ICreateAndLoadContainerProps.IContainerPolicies`
 since there will be no concept of `Loader`.

--- a/.changeset/moody-files-argue.md
+++ b/.changeset/moody-files-argue.md
@@ -31,7 +31,7 @@ export async function createDetachedContainer(
 ```
 
 `ICreateDetachedContainerProps` are the properties that needs to be supplied to the above API which contains props like
-URL Resolver, IDocumentServiceFactory etc., which were previously used to create the `Loader` object.
+URL Resolver, IDocumentServiceFactory, etc., which were previously used to create the `Loader` object.
 
 ##### Use `loadExistingContainer` to load an existing container
 
@@ -42,7 +42,7 @@ export async function loadExistingContainer(
 ```
 
 `ILoadExistingContainerProps` are the properties that needs to be supplied to the above API which contains props like
-URL Resolver, IDocumentServiceFactory etc., which were earlier used to create the `Loader` object.
+URL Resolver, IDocumentServiceFactory, etc., which were earlier used to create the `Loader` object.
 
 ##### Use `rehydrateDetachedContainer` to create a detached container from a serializedState of another container
 
@@ -53,14 +53,14 @@ export async function rehydrateDetachedContainer(
 ```
 
 `IRehydrateDetachedContainerProps` are the properties that needs to be supplied to the above API which contains props like
-URL Resolver, IDocumentServiceFactory etc., which were earlier used to create the `Loader` object.
+URL Resolver, IDocumentServiceFactory, etc., which were earlier used to create the `Loader` object.
 
 ##### Note on `ICreateAndLoadContainerProps`.
 
 The props which were used to create the `Loader` object are now moved to the `ICreateAndLoadContainerProps` interface.
 `ICreateDetachedContainerProps`, `ILoadExistingContainerProps` and `IRehydrateDetachedContainerProps` which extends
 `ICreateAndLoadContainerProps` also contains some additional props which will be used to create and load containers like
-`IFluidCodeDetails`, `IRequest` etc. Previously these were directly passed when calling APIs like
+`IFluidCodeDetails`, `IRequest`, etc. Previously these were directly passed when calling APIs like
 `Loader.createDetachedContainer`, `Loader.resolve` and `Loader.rehydrateDetachedContainerFromSnapshot` on the `Loader`
 object. Also, `ILoaderProps.ILoaderOptions` are not replaced with `ICreateAndLoadContainerProps.IContainerPolicies`
 since there will be no concept of `Loader`.


### PR DESCRIPTION
Updates some changesets to clarify wording, correct typos, and fix heading levels.