### PR TITLE
Use eventing library for DDS fuzz harness

### DIFF
--- a/packages/common/client-utils/src/test/types/validateClientUtilsPrevious.generated.ts
+++ b/packages/common/client-utils/src/test/types/validateClientUtilsPrevious.generated.ts
@@ -128,15 +128,6 @@ declare type current_as_old_for_ClassStatics_TypedEventEmitter = requireAssignab
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "Function_createEmitter": {"backCompat": false}
- */
-declare type current_as_old_for_Function_createEmitter = requireAssignableTo<TypeOnly<typeof current.createEmitter>, TypeOnly<typeof old.createEmitter>>
-
-/*
- * Validate backward compatibility by using the current type in place of the old type.
- * If this test starts failing, it indicates a change that is not backward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
  * "Function_gitHashFile": {"backCompat": false}
  */
 declare type current_as_old_for_Function_gitHashFile = requireAssignableTo<TypeOnly<typeof current.gitHashFile>, TypeOnly<typeof old.gitHashFile>>

--- a/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
+++ b/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
@@ -385,15 +385,6 @@ declare type old_as_current_for_Interface_IThrottlingWarning = requireAssignable
 declare type current_as_old_for_Interface_IThrottlingWarning = requireAssignableTo<TypeOnly<current.IThrottlingWarning>, TypeOnly<old.IThrottlingWarning>>
 
 /*
- * Validate backward compatibility by using the current type in place of the old type.
- * If this test starts failing, it indicates a change that is not backward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
- * "Interface_Listenable": {"backCompat": false}
- */
-declare type current_as_old_for_Interface_Listenable = requireAssignableTo<TypeOnly<current.Listenable<never>>, TypeOnly<old.Listenable<never>>>
-
-/*
  * Validate forward compatibility by using the old type in place of the current type.
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
@@ -560,42 +551,6 @@ declare type current_as_old_for_TypeAlias_IEventTransformer = requireAssignableT
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "TypeAlias_IsListener": {"forwardCompat": false}
- */
-declare type old_as_current_for_TypeAlias_IsListener = requireAssignableTo<TypeOnly<old.IsListener<never>>, TypeOnly<current.IsListener<never>>>
-
-/*
- * Validate backward compatibility by using the current type in place of the old type.
- * If this test starts failing, it indicates a change that is not backward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
- * "TypeAlias_IsListener": {"backCompat": false}
- */
-declare type current_as_old_for_TypeAlias_IsListener = requireAssignableTo<TypeOnly<current.IsListener<never>>, TypeOnly<old.IsListener<never>>>
-
-/*
- * Validate forward compatibility by using the old type in place of the current type.
- * If this test starts failing, it indicates a change that is not forward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
- * "TypeAlias_Listeners": {"forwardCompat": false}
- */
-declare type old_as_current_for_TypeAlias_Listeners = requireAssignableTo<TypeOnly<old.Listeners<never>>, TypeOnly<current.Listeners<never>>>
-
-/*
- * Validate backward compatibility by using the current type in place of the old type.
- * If this test starts failing, it indicates a change that is not backward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
- * "TypeAlias_Listeners": {"backCompat": false}
- */
-declare type current_as_old_for_TypeAlias_Listeners = requireAssignableTo<TypeOnly<current.Listeners<never>>, TypeOnly<old.Listeners<never>>>
-
-/*
- * Validate forward compatibility by using the old type in place of the current type.
- * If this test starts failing, it indicates a change that is not forward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
  * "TypeAlias_LogLevel": {"forwardCompat": false}
  */
 declare type old_as_current_for_TypeAlias_LogLevel = requireAssignableTo<TypeOnly<old.LogLevel>, TypeOnly<current.LogLevel>>
@@ -608,24 +563,6 @@ declare type old_as_current_for_TypeAlias_LogLevel = requireAssignableTo<TypeOnl
  * "TypeAlias_LogLevel": {"backCompat": false}
  */
 declare type current_as_old_for_TypeAlias_LogLevel = requireAssignableTo<TypeOnly<current.LogLevel>, TypeOnly<old.LogLevel>>
-
-/*
- * Validate forward compatibility by using the old type in place of the current type.
- * If this test starts failing, it indicates a change that is not forward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
- * "TypeAlias_Off": {"forwardCompat": false}
- */
-declare type old_as_current_for_TypeAlias_Off = requireAssignableTo<TypeOnly<old.Off>, TypeOnly<current.Off>>
-
-/*
- * Validate backward compatibility by using the current type in place of the old type.
- * If this test starts failing, it indicates a change that is not backward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
- * "TypeAlias_Off": {"backCompat": false}
- */
-declare type current_as_old_for_TypeAlias_Off = requireAssignableTo<TypeOnly<current.Off>, TypeOnly<old.Off>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.

--- a/packages/dds/sequence/src/test/fuzz/intervalRevertibles.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/fuzz/intervalRevertibles.fuzz.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 
-import { TypedEventEmitter } from "@fluid-internal/client-utils";
+import { createEmitter } from "@fluid-internal/client-utils";
 import {
 	AsyncGenerator as Generator,
 	createWeightedAsyncGenerator as createWeightedGenerator,
@@ -40,7 +40,7 @@ import {
 	makeIntervalOperationGenerator,
 } from "./fuzzUtils.js";
 
-const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
+const emitter = createEmitter<DDSFuzzHarnessEvents>();
 
 emitter.on("clientCreate", (client) => {
 	const channel = client.channel as RevertibleSharedString;

--- a/packages/dds/test-dds-utils/src/minification.ts
+++ b/packages/dds/test-dds-utils/src/minification.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { TypedEventEmitter } from "@fluid-internal/client-utils";
+import { createEmitter } from "@fluid-internal/client-utils";
 import type { SaveInfo } from "@fluid-private/stochastic-test-utils";
 import { makeRandom } from "@fluid-private/stochastic-test-utils";
 import type { IChannelFactory } from "@fluidframework/datastore-definitions/internal";
@@ -195,8 +195,7 @@ export class FuzzTestMinimizer<
 	 * to avoid dealing with transforms that would result in invalid ops
 	 */
 	private async assertFails(): Promise<boolean> {
-		const emitter = (this.providedOptions.emitter ??=
-			new TypedEventEmitter<DDSFuzzHarnessEvents>());
+		const emitter = (this.providedOptions.emitter ??= createEmitter<DDSFuzzHarnessEvents>());
 
 		let lastOp: BaseOperation = { type: "___none___" };
 		const lastOpTracker = (op: BaseOperation): void => {

--- a/packages/dds/tree/src/test/shared-tree/fuzz/anchorStability.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/anchorStability.fuzz.spec.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "node:assert";
 
-import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { takeAsync } from "@fluid-private/stochastic-test-utils";
 import {
 	type DDSFuzzHarnessEvents,
@@ -37,6 +36,7 @@ import type { Operation } from "./operationTypes.js";
 import type { NodeBuilderData } from "../../../internalTypes.js";
 // eslint-disable-next-line import/no-internal-modules
 import { jsonableTreeFromForest } from "../../../feature-libraries/treeTextCursor.js";
+import { createEmitter } from "@fluid-internal/client-utils";
 
 interface AnchorFuzzTestState extends FuzzTestState {
 	// Parallel array to `clients`: set in testStart
@@ -95,7 +95,7 @@ describe("Fuzz - anchor stability", () => {
 			validateConsistency: () => {},
 		};
 
-		const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
+		const emitter = createEmitter<DDSFuzzHarnessEvents>();
 		emitter.on("testStart", (initialState: AnchorFuzzTestState) => {
 			const tree = viewFromState(initialState, initialState.clients[0]).checkout;
 			tree.transaction.start();
@@ -165,7 +165,7 @@ describe("Fuzz - anchor stability", () => {
 			validateConsistency: () => {},
 		};
 
-		const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
+		const emitter = createEmitter<DDSFuzzHarnessEvents>();
 		emitter.on("testStart", (initialState: AnchorFuzzTestState) => {
 			// Kludge: we force schematization and synchronization here to ensure that the clients all have the same
 			// starting tree as opposed to isomorphic copies.

--- a/packages/dds/tree/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert, fail } from "node:assert";
 
-import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import {
 	type AsyncGenerator,
 	combineReducersAsync,
@@ -48,6 +47,7 @@ import {
 } from "./fuzzUtils.js";
 import type { Operation } from "./operationTypes.js";
 import { TreeViewConfiguration } from "../../../simple-tree/index.js";
+import { createEmitter } from "@fluid-internal/client-utils";
 
 /**
  * This interface is meant to be used for tests that require you to store a branch of a tree
@@ -143,7 +143,7 @@ describe("Fuzz - composed vs individual changes", () => {
 			reducer: fuzzComposedVsIndividualReducer,
 			validateConsistency: () => {},
 		};
-		const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
+		const emitter = createEmitter<DDSFuzzHarnessEvents>();
 		emitter.on("testStart", (initialState: BranchedTreeFuzzTestState) => {
 			initialState.main = viewFromState(initialState, initialState.clients[0]);
 

--- a/packages/dds/tree/src/test/shared-tree/fuzz/move.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/move.fuzz.spec.ts
@@ -28,7 +28,7 @@ import {
 	populatedInitialState,
 } from "./fuzzUtils.js";
 import type { Operation } from "./operationTypes.js";
-import { TypedEventEmitter } from "@fluid-internal/client-utils";
+import { createEmitter } from "@fluid-internal/client-utils";
 
 describe("Fuzz - move", () => {
 	const runsPerBatch = 50;
@@ -60,7 +60,7 @@ describe("Fuzz - move", () => {
 		validateConsistency: validateFuzzTreeConsistency,
 	};
 
-	const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
+	const emitter = createEmitter<DDSFuzzHarnessEvents>();
 	emitter.on("testStart", (state: FuzzTestState) => {
 		viewFromState(state, state.clients[0]);
 	});

--- a/packages/dds/tree/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "node:assert";
 
-import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { type AsyncGenerator, takeAsync } from "@fluid-private/stochastic-test-utils";
 import {
 	type DDSFuzzHarnessEvents,
@@ -44,6 +43,7 @@ import {
 	validateAnchors,
 } from "./fuzzUtils.js";
 import type { Operation } from "./operationTypes.js";
+import { createEmitter } from "@fluid-internal/client-utils";
 
 interface UndoRedoFuzzTestState extends FuzzTestState {
 	initialTreeState?: JsonableTree[];
@@ -82,7 +82,7 @@ describe("Fuzz - revert", () => {
 			reducer: fuzzReducer,
 			validateConsistency: validateFuzzTreeConsistency,
 		};
-		const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
+		const emitter = createEmitter<DDSFuzzHarnessEvents>();
 		emitter.on("testStart", (state: UndoRedoFuzzTestState) => {
 			init(state);
 			state.anchors = [];
@@ -173,7 +173,7 @@ describe("Fuzz - revert", () => {
 			reducer: fuzzReducer,
 			validateConsistency: validateFuzzTreeConsistency,
 		};
-		const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
+		const emitter = createEmitter<DDSFuzzHarnessEvents>();
 		emitter.on("testStart", init);
 		emitter.on("testEnd", (state: UndoRedoFuzzTestState) => {
 			const undoStack = state.undoStack ?? assert.fail("undoStack should be defined");

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -758,24 +758,6 @@ declare type current_as_old_for_TypeAlias_NamedFluidDataStoreRegistryEntry = req
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "TypeAlias_NamedFluidDataStoreRegistryEntry2": {"forwardCompat": false}
- */
-declare type old_as_current_for_TypeAlias_NamedFluidDataStoreRegistryEntry2 = requireAssignableTo<TypeOnly<old.NamedFluidDataStoreRegistryEntry2>, TypeOnly<current.NamedFluidDataStoreRegistryEntry2>>
-
-/*
- * Validate backward compatibility by using the current type in place of the old type.
- * If this test starts failing, it indicates a change that is not backward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
- * "TypeAlias_NamedFluidDataStoreRegistryEntry2": {"backCompat": false}
- */
-declare type current_as_old_for_TypeAlias_NamedFluidDataStoreRegistryEntry2 = requireAssignableTo<TypeOnly<current.NamedFluidDataStoreRegistryEntry2>, TypeOnly<old.NamedFluidDataStoreRegistryEntry2>>
-
-/*
- * Validate forward compatibility by using the old type in place of the current type.
- * If this test starts failing, it indicates a change that is not forward compatible.
- * To acknowledge the breaking change, add the following to package.json under
- * typeValidation.broken:
  * "TypeAlias_SummarizeInternalFn": {"forwardCompat": false}
  */
 declare type old_as_current_for_TypeAlias_SummarizeInternalFn = requireAssignableTo<TypeOnly<old.SummarizeInternalFn>, TypeOnly<current.SummarizeInternalFn>>

--- a/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
+++ b/packages/tools/devtools/devtools-core/src/test/types/validateDevtoolsCorePrevious.generated.ts
@@ -70,6 +70,24 @@ declare type old_as_current_for_Interface_FluidDevtoolsProps = requireAssignable
 declare type current_as_old_for_Interface_FluidDevtoolsProps = requireAssignableTo<TypeOnly<current.FluidDevtoolsProps>, TypeOnly<old.FluidDevtoolsProps>>
 
 /*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_HasContainerKey": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_HasContainerKey = requireAssignableTo<TypeOnly<old.HasContainerKey>, TypeOnly<current.HasContainerKey>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_HasContainerKey": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_HasContainerKey = requireAssignableTo<TypeOnly<current.HasContainerKey>, TypeOnly<old.HasContainerKey>>
+
+/*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under

--- a/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
+++ b/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
@@ -34,6 +34,15 @@ declare type current_as_old_for_Function_createDevtoolsLogger = requireAssignabl
 declare type current_as_old_for_Function_initializeDevtools = requireAssignableTo<TypeOnly<typeof current.initializeDevtools>, TypeOnly<typeof old.initializeDevtools>>
 
 /*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ContainerDevtoolsProps": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_ContainerDevtoolsProps = requireAssignableTo<TypeOnly<old.ContainerDevtoolsProps>, TypeOnly<current.ContainerDevtoolsProps>>
+
+/*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
@@ -43,6 +52,15 @@ declare type current_as_old_for_Function_initializeDevtools = requireAssignableT
 declare type current_as_old_for_Interface_ContainerDevtoolsProps = requireAssignableTo<TypeOnly<current.ContainerDevtoolsProps>, TypeOnly<old.ContainerDevtoolsProps>>
 
 /*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_DevtoolsProps": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_DevtoolsProps = requireAssignableTo<TypeOnly<old.DevtoolsProps>, TypeOnly<current.DevtoolsProps>>
+
+/*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
@@ -50,6 +68,33 @@ declare type current_as_old_for_Interface_ContainerDevtoolsProps = requireAssign
  * "Interface_DevtoolsProps": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_DevtoolsProps = requireAssignableTo<TypeOnly<current.DevtoolsProps>, TypeOnly<old.DevtoolsProps>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_HasContainerKey": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_HasContainerKey = requireAssignableTo<TypeOnly<old.HasContainerKey>, TypeOnly<current.HasContainerKey>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_HasContainerKey": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_HasContainerKey = requireAssignableTo<TypeOnly<current.HasContainerKey>, TypeOnly<old.HasContainerKey>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IDevtools": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IDevtools = requireAssignableTo<TypeOnly<old.IDevtools>, TypeOnly<current.IDevtools>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.


### PR DESCRIPTION
## Description

This migrates the DDS fuzz harness code and any in-repo consumers to use the FF eventing library rather than the NodeJS TypedEventEmitter class.