### PR TITLE
fix(docs): Configure SWA to never emit trailing slashes for website URLs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -40,7 +40,7 @@
 		"prettier:fix": "prettier --write . --cache --ignore-path ../.prettierignore",
 		"rebuild": "npm run clean && npm run build",
 		"serve": "docusaurus serve",
-		"serve-with-azure-emulation": "swa start",
+		"serve-with-azure-emulation": "swa start --config-name ff-doc-site",
 		"prestart": "npm run generate-versions",
 		"start": "docusaurus start",
 		"pretest": "playwright install --with-deps",

--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -14,5 +14,6 @@
 			"route": "/404",
 			"statusCode": 404
 		}
-	]
+	],
+	"trailingSlash": "never"
 }

--- a/docs/swa-cli.config.json
+++ b/docs/swa-cli.config.json
@@ -7,7 +7,7 @@
       "appBuildCommand": "npm run build",
       "run": "npm run serve",
       "appDevserverUrl": "http://localhost:3000",
-      "swaConfigLocation": "./build",
+      "swaConfigLocation": ".",
       "apiLocation": "./api",
       "appName": "ff-doc-site",
       "resourceGroup": "website"

--- a/docs/swa-cli.config.json
+++ b/docs/swa-cli.config.json
@@ -7,7 +7,7 @@
       "appBuildCommand": "npm run build",
       "run": "npm run serve",
       "appDevserverUrl": "http://localhost:3000",
-      "swaConfigLocation": ".",
+      "swaConfigLocation": "./build",
       "apiLocation": "./api",
       "appName": "ff-doc-site",
       "resourceGroup": "website"


### PR DESCRIPTION
Ensures consistent relative file path link behavior by ensuring resolved site URLs never include a trailing slash. See <https://learn.microsoft.com/en-us/azure/static-web-apps/configuration#never>

Also makes some small fixes to config files for local development.

[AB#25895](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/25895)