### PR TITLE
Remove `IContainerRuntimeOptions.flushMode`

### DIFF
--- a/.changeset/fancy-insects-sing.md
+++ b/.changeset/fancy-insects-sing.md
@@ -7,5 +7,5 @@
 
 Deprecating `IContainerRuntimeOptions.flushMode`
 
-Only the default value `FlushMode.TurnBased` is supported, so there's no need for consumers to pass this option in.
-It will be removed in the future for simplicity.
+Only the default value `FlushMode.TurnBased` is supported when calling `ContainerRuntime.loadRuntime` directly,
+so there's no need for consumers to pass this option in.  We'll remove the option altogether in `2.20.0`.

--- a/.changeset/fancy-insects-sing.md
+++ b/.changeset/fancy-insects-sing.md
@@ -1,0 +1,11 @@
+---
+"@fluidframework/container-runtime": minor
+---
+---
+"section": deprecation
+---
+
+Deprecating `IContainerRuntimeOptions.flushMode`
+
+Only the default value `FlushMode.TurnBased` is supported, so there's no need for consumers to pass this option in.
+It will be removed in the future for simplicity.

--- a/.changeset/twelve-ads-say.md
+++ b/.changeset/twelve-ads-say.md
@@ -1,0 +1,11 @@
+---
+"@fluidframework/container-runtime": minor
+---
+---
+"section": legacy
+---
+
+Removing `IContainerRuntimeOptions.flushMode`
+
+Only the default value `FlushMode.TurnBased` is supported when calling `ContainerRuntime.loadRuntime` directly,
+so there's no need for consumers to pass this option in.

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -343,8 +343,6 @@ export interface IContainerRuntimeOptions {
     readonly enableGroupedBatching?: boolean;
     readonly enableRuntimeIdCompressor?: IdCompressorMode;
     readonly explicitSchemaControl?: boolean;
-    // @deprecated
-    readonly flushMode?: FlushMode;
     // (undocumented)
     readonly gcOptions?: IGCRuntimeOptions;
     readonly loadSequenceNumberVerification?: "close" | "log" | "bypass";

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -343,6 +343,7 @@ export interface IContainerRuntimeOptions {
     readonly enableGroupedBatching?: boolean;
     readonly enableRuntimeIdCompressor?: IdCompressorMode;
     readonly explicitSchemaControl?: boolean;
+    // @deprecated
     readonly flushMode?: FlushMode;
     // (undocumented)
     readonly gcOptions?: IGCRuntimeOptions;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -474,6 +474,8 @@ export interface IContainerRuntimeOptions {
 	 * send all operations to the driver layer, while in TurnBased the operations will be buffered
 	 * and then sent them as a single batch at the end of the turn.
 	 * By default, flush mode is TurnBased.
+	 *
+	 * @deprecated Only the default value TurnBased is supported. This option will be removed in the future.
 	 */
 	readonly flushMode?: FlushMode;
 	/**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -470,15 +470,6 @@ export interface IContainerRuntimeOptions {
 	 */
 	readonly loadSequenceNumberVerification?: "close" | "log" | "bypass";
 	/**
-	 * Sets the flush mode for the runtime. In Immediate flush mode the runtime will immediately
-	 * send all operations to the driver layer, while in TurnBased the operations will be buffered
-	 * and then sent them as a single batch at the end of the turn.
-	 * By default, flush mode is TurnBased.
-	 *
-	 * @deprecated Only the default value TurnBased is supported. This option will be removed in the future.
-	 */
-	readonly flushMode?: FlushMode;
-	/**
 	 * Enables the runtime to compress ops. See {@link ICompressionRuntimeOptions}.
 	 */
 	readonly compressionOptions?: ICompressionRuntimeOptions;
@@ -1561,7 +1552,11 @@ export class ContainerRuntime
 			snapshotWithContents,
 		} = context;
 
-		this.runtimeOptions = runtimeOptions;
+		// Fill in the internal options with defaults in case they were not provided
+		this.runtimeOptions = {
+			flushMode: defaultFlushMode,
+			...runtimeOptions,
+		};
 
 		this.logger = createChildLogger({ logger: this.baseLogger });
 		this.mc = createChildMonitoringContext({

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -68,6 +68,7 @@ import {
 	IPendingRuntimeState,
 	defaultPendingOpsWaitTimeoutMs,
 	getSingleUseLegacyLogCallback,
+	type IContainerRuntimeOptionsInternal,
 } from "../containerRuntime.js";
 import {
 	ContainerMessageType,
@@ -266,7 +267,6 @@ describe("Runtime", () => {
 					registryEntries: [],
 					existing: false,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -308,7 +308,7 @@ describe("Runtime", () => {
 					existing: false,
 					runtimeOptions: {
 						flushMode: FlushMode.Immediate,
-					},
+					} satisfies IContainerRuntimeOptionsInternal as IContainerRuntimeOptions,
 					provideEntryPoint: mockProvideEntryPoint,
 				});
 
@@ -327,9 +327,7 @@ describe("Runtime", () => {
 					}) as IContainerContext,
 					registryEntries: [],
 					existing: false,
-					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
-					},
+					runtimeOptions: {},
 					provideEntryPoint: mockProvideEntryPoint,
 				});
 				(containerRuntime as any).ensureNoDataModelChanges = (callback) => {
@@ -374,9 +372,7 @@ describe("Runtime", () => {
 						}) as IContainerContext,
 						registryEntries: [],
 						existing: false,
-						runtimeOptions: {
-							flushMode: FlushMode.TurnBased,
-						},
+						runtimeOptions: {},
 						provideEntryPoint: mockProvideEntryPoint,
 					});
 
@@ -492,7 +488,7 @@ describe("Runtime", () => {
 									},
 								},
 								flushMode,
-							},
+							} satisfies IContainerRuntimeOptionsInternal as IContainerRuntimeOptions,
 							provideEntryPoint: mockProvideEntryPoint,
 						});
 						containerErrors.length = 0;
@@ -698,7 +694,7 @@ describe("Runtime", () => {
 									summaryConfigOverrides: { state: "disabled" },
 								},
 								flushMode,
-							},
+							} satisfies IContainerRuntimeOptionsInternal as IContainerRuntimeOptions,
 							provideEntryPoint: mockProvideEntryPoint,
 						});
 						containerErrors.length = 0;
@@ -1400,9 +1396,9 @@ describe("Runtime", () => {
 				chunkSizeInBytes: 800 * 1024,
 				flushMode: FlushModeExperimental.Async as unknown as FlushMode,
 				enableGroupedBatching: true,
-			};
+			} satisfies IContainerRuntimeOptionsInternal as IContainerRuntimeOptions;
 
-			const defaultRuntimeOptions = {
+			const defaultRuntimeOptions: IContainerRuntimeOptionsInternal = {
 				summaryOptions: {},
 				gcOptions: {},
 				loadSequenceNumberVerification: "close",
@@ -1416,7 +1412,7 @@ describe("Runtime", () => {
 				enableRuntimeIdCompressor: undefined,
 				enableGroupedBatching: false,
 				explicitSchemaControl: false,
-			} satisfies IContainerRuntimeOptions;
+			};
 			const mergedRuntimeOptions = { ...defaultRuntimeOptions, ...runtimeOptions };
 
 			it("Container load stats", async () => {
@@ -1505,7 +1501,7 @@ describe("Runtime", () => {
 						existing: false,
 						runtimeOptions: {
 							flushMode: FlushModeExperimental.Async as unknown as FlushMode,
-						},
+						} satisfies IContainerRuntimeOptionsInternal as IContainerRuntimeOptions,
 						provideEntryPoint: mockProvideEntryPoint,
 					});
 
@@ -1528,7 +1524,7 @@ describe("Runtime", () => {
 					existing: false,
 					runtimeOptions: {
 						flushMode: FlushModeExperimental.Async as unknown as FlushMode,
-					},
+					} satisfies IContainerRuntimeOptionsInternal as IContainerRuntimeOptions,
 					provideEntryPoint: mockProvideEntryPoint,
 				});
 
@@ -1840,7 +1836,6 @@ describe("Runtime", () => {
 					registryEntries: [],
 					existing: false,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -1872,7 +1867,6 @@ describe("Runtime", () => {
 					registryEntries: [],
 					existing: false,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -1914,7 +1908,6 @@ describe("Runtime", () => {
 					registryEntries: [],
 					existing: false,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -1961,7 +1954,6 @@ describe("Runtime", () => {
 					registryEntries: [],
 					existing: false,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -1983,7 +1975,6 @@ describe("Runtime", () => {
 					registryEntries: [],
 					existing: false,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -2031,7 +2022,6 @@ describe("Runtime", () => {
 						registryEntries: [],
 						existing: false,
 						runtimeOptions: {
-							flushMode: FlushMode.TurnBased,
 							enableRuntimeIdCompressor: "on",
 						},
 						provideEntryPoint: mockProvideEntryPoint,
@@ -2081,7 +2071,6 @@ describe("Runtime", () => {
 					registryEntries: [],
 					existing: false,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -2120,7 +2109,6 @@ describe("Runtime", () => {
 					registryEntries: [],
 					existing: false,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -2334,7 +2322,6 @@ describe("Runtime", () => {
 					registryEntries: [["@fluid-example/smde", Promise.resolve(entryDefault)]],
 					existing: true,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -2363,7 +2350,6 @@ describe("Runtime", () => {
 					registryEntries: [["@fluid-example/smde", Promise.resolve(entryDefault)]],
 					existing: true,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -2412,7 +2398,6 @@ describe("Runtime", () => {
 					registryEntries: [["@fluid-example/smde", Promise.resolve(entryDefault)]],
 					existing: true,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -2472,7 +2457,6 @@ describe("Runtime", () => {
 					registryEntries: [["@fluid-example/smde", Promise.resolve(entryDefault)]],
 					existing: true,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -2514,7 +2498,6 @@ describe("Runtime", () => {
 					registryEntries: [["@fluid-example/smde", Promise.resolve(entryDefault)]],
 					existing: true,
 					runtimeOptions: {
-						flushMode: FlushMode.TurnBased,
 						enableRuntimeIdCompressor: "on",
 					},
 					provideEntryPoint: mockProvideEntryPoint,
@@ -2608,7 +2591,6 @@ describe("Runtime", () => {
 					requestHandler: undefined,
 					runtimeOptions: {
 						enableGroupedBatching: false,
-						flushMode: FlushMode.TurnBased,
 					},
 					provideEntryPoint: mockProvideEntryPoint,
 				});
@@ -3184,7 +3166,6 @@ describe("Runtime", () => {
 						requestHandler: undefined,
 						runtimeOptions: {
 							enableGroupedBatching: false,
-							flushMode: FlushMode.TurnBased,
 						},
 						provideEntryPoint: mockProvideEntryPoint,
 					});

--- a/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
@@ -15,6 +15,7 @@ import {
 import {
 	ContainerMessageType,
 	IContainerRuntimeOptions,
+	type IContainerRuntimeOptionsInternal,
 } from "@fluidframework/container-runtime/internal";
 import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
@@ -105,7 +106,7 @@ describe("Ops on Reconnect", () => {
 	}
 
 	async function setupFirstContainer(
-		runtimeOptions: IContainerRuntimeOptions = { flushMode: FlushMode.Immediate },
+		runtimeOptions: IContainerRuntimeOptionsInternal = { flushMode: FlushMode.Immediate },
 	) {
 		// Create the first container, dataObject and DDSes.
 		container1 = await createContainer(runtimeOptions);

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -10,7 +10,7 @@ import { IContainer } from "@fluidframework/container-definitions/internal";
 import {
 	CompressionAlgorithms,
 	ContainerMessageType,
-	IContainerRuntimeOptions,
+	type IContainerRuntimeOptionsInternal,
 } from "@fluidframework/container-runtime/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
@@ -123,7 +123,7 @@ describeCompat("Flushing ops", "NoCompat", (getTestObjectProvider, apis) => {
 	let dataObject2map2: ISharedMap;
 
 	async function setupContainers(
-		runtimeOptions?: IContainerRuntimeOptions,
+		runtimeOptions?: IContainerRuntimeOptionsInternal,
 		disableOfflineLoad = false,
 	) {
 		if (disableOfflineLoad) {
@@ -169,7 +169,7 @@ describeCompat("Flushing ops", "NoCompat", (getTestObjectProvider, apis) => {
 		let dataObject2BatchMessages: ISequencedDocumentMessage[] = [];
 
 		function testFlushingUsingOrderSequentially(
-			options: IContainerRuntimeOptions,
+			options: IContainerRuntimeOptionsInternal,
 			disableOfflineLoad,
 		) {
 			beforeEach("setupBatchMessageListeners", async () => {
@@ -550,7 +550,7 @@ describeCompat("Flushing ops", "NoCompat", (getTestObjectProvider, apis) => {
 		}
 
 		function testAutomaticFlushingUsingOrderSequentially(
-			options: IContainerRuntimeOptions,
+			options: IContainerRuntimeOptionsInternal,
 			disableOfflineLoad,
 		) {
 			beforeEach("setupContainers", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
-import { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
+import { type IContainerRuntimeOptionsInternal } from "@fluidframework/container-runtime/internal";
 import type { ISharedMap } from "@fluidframework/map/internal";
 import { FlushMode } from "@fluidframework/runtime-definitions/internal";
 import {
@@ -43,7 +43,7 @@ describeCompat("Flush mode validation", "NoCompat", (getTestObjectProvider, apis
 		}
 	});
 
-	async function setupContainer(runtimeOptions?: IContainerRuntimeOptions) {
+	async function setupContainer(runtimeOptions?: IContainerRuntimeOptionsInternal) {
 		const configCopy = { ...testContainerConfig, runtimeOptions };
 
 		// Create a Container for the first client.

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -14,9 +14,9 @@ import {
 import { ILoaderOptions } from "@fluidframework/container-loader/internal";
 import {
 	CompressionAlgorithms,
-	IContainerRuntimeOptions,
 	IGCRuntimeOptions,
 	ISummaryRuntimeOptions,
+	type IContainerRuntimeOptionsInternal,
 } from "@fluidframework/container-runtime/internal";
 import { ConfigTypes } from "@fluidframework/core-interfaces";
 import { LoggingError } from "@fluidframework/telemetry-utils/internal";
@@ -88,7 +88,7 @@ const summaryOptionsMatrix: OptionsMatrix<ISummaryRuntimeOptions> = {
 
 export function generateRuntimeOptions(
 	seed: number,
-	overrides: Partial<OptionsMatrix<IContainerRuntimeOptions>> | undefined,
+	overrides: Partial<OptionsMatrix<IContainerRuntimeOptionsInternal>> | undefined,
 ) {
 	const gcOptions = generatePairwiseOptions(
 		applyOverrides(gcOptionsMatrix, overrides?.gcOptions as any),
@@ -100,7 +100,7 @@ export function generateRuntimeOptions(
 		seed,
 	);
 
-	const runtimeOptionsMatrix: OptionsMatrix<IContainerRuntimeOptions> = {
+	const runtimeOptionsMatrix: OptionsMatrix<IContainerRuntimeOptionsInternal> = {
 		gcOptions: [undefined, ...gcOptions],
 		summaryOptions: [undefined, ...summaryOptions],
 		loadSequenceNumberVerification: [undefined],
@@ -116,7 +116,7 @@ export function generateRuntimeOptions(
 		explicitSchemaControl: [true, false],
 	};
 
-	return generatePairwiseOptions<IContainerRuntimeOptions>(
+	return generatePairwiseOptions<IContainerRuntimeOptionsInternal>(
 		applyOverrides(runtimeOptionsMatrix, {
 			...overrides,
 			gcOptions: undefined,

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -15,7 +15,7 @@ import {
 	Loader,
 	waitContainerToCatchUp as waitContainerToCatchUp_original,
 } from "@fluidframework/container-loader/internal";
-import { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
+import { type IContainerRuntimeOptionsInternal } from "@fluidframework/container-runtime/internal";
 import {
 	IRequestHeader,
 	ITelemetryBaseEvent,
@@ -235,7 +235,7 @@ export interface ITestContainerConfig {
 	registry?: ChannelFactoryRegistry;
 
 	/** Container runtime options for the container instance */
-	runtimeOptions?: IContainerRuntimeOptions;
+	runtimeOptions?: IContainerRuntimeOptionsInternal;
 
 	/** Whether this runtime should be instantiated using a mixed-in attributor class */
 	enableAttribution?: boolean;


### PR DESCRIPTION
DO NOT MERGE UNTIL MAIN IS TAKING BREAKING CHANGES FOR 2.20.0

## Description

Fixes [AB#26496](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26496)

Remove deprecated option `flushMode`.  See #23287

## Breaking Changes

This is a Legacy-Alpha breaking change.  See #23287

## Reviewer Guidance

* I think I will move the last commit to a separate PR, it is non-breaking and can be merged now.
* Oops I forgot to use the right branch location / namespace...  Will redo it on the right branch.
