### PR TITLE
test(client-presence): refactor of presence manager unit tests

### DIFF
--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -178,13 +178,12 @@ describe("Presence", () => {
 					it('first time is announced via `attendeeJoined` with status "Connected"', () => {
 						// Act - simulate join message from client
 						const joinedAttendees = processJoinSignals([initialAttendeeSignal]);
-
 						// Verify
-						assert.ok(
-							joinedAttendees.length === 1 && joinedAttendees[0] !== undefined,
+						assert.strictEqual(
+							joinedAttendees.length,
+							1,
 							"Expected exactly one attendee to be announced",
 						);
-
 						verifyAttendee(joinedAttendees[0], initialAttendeeConnectionId, attendeeSessionId);
 					});
 
@@ -196,11 +195,11 @@ describe("Presence", () => {
 						const joinedAttendees = processJoinSignals([rejoinAttendeeSignal]);
 
 						// Verify
-						assert.ok(
-							joinedAttendees.length === 1 && joinedAttendees[0] !== undefined,
+						assert.strictEqual(
+							joinedAttendees.length,
+							1,
 							"Expected exactly one attendee to be announced",
 						);
-
 						verifyAttendee(joinedAttendees[0], rejoinAttendeeConnectionId, attendeeSessionId);
 					});
 
@@ -209,8 +208,9 @@ describe("Presence", () => {
 						const joinedAttendees = processJoinSignals([rejoinAttendeeSignal]);
 
 						// Verify
-						assert.ok(
-							joinedAttendees.length === 1 && joinedAttendees[0] !== undefined,
+						assert.strictEqual(
+							joinedAttendees.length,
+							1,
 							"Expected exactly one attendee to be announced",
 						);
 
@@ -225,8 +225,9 @@ describe("Presence", () => {
 						const joinedAttendees = processJoinSignals([initialAttendeeSignal]);
 
 						// Verify
-						assert.ok(
-							joinedAttendees.length === 1 && joinedAttendees[0] !== undefined,
+						assert.strictEqual(
+							joinedAttendees.length,
+							1,
 							"Expected exactly one attendee to be announced",
 						);
 
@@ -239,8 +240,9 @@ describe("Presence", () => {
 
 						// Act - simulate join message from client
 						const joinedAttendees = processJoinSignals([rejoinAttendeeSignal]);
-						assert.ok(
-							joinedAttendees.length === 1 && joinedAttendees[0] !== undefined,
+						assert.strictEqual(
+							joinedAttendees.length,
+							1,
 							"Expected exactly one attendee to be announced",
 						);
 
@@ -272,8 +274,9 @@ describe("Presence", () => {
 						const joinedAttendees = processJoinSignals([collateralAttendeeSignal]);
 
 						// Verify - only the rejoining attendee is announced
-						assert.ok(
-							joinedAttendees.length === 1 && joinedAttendees[0] !== undefined,
+						assert.strictEqual(
+							joinedAttendees.length,
+							1,
 							"Expected exactly one attendee to be announced",
 						);
 

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -97,24 +97,10 @@ describe("Presence", () => {
 				// initialization, but should go unnoticed by the presence manager
 				// until there is a join signal related to it.
 				const rejoinAttendeeConnectionId = "client7";
+				let initialAttendeeSignal: ReturnType<typeof generateBasicClientJoin>;
+				let rejoinAttendeeSignal: ReturnType<typeof generateBasicClientJoin>;
 
-				const initialAttendeeSignal = generateBasicClientJoin(clock.now - 50, {
-					averageLatency: 50,
-					clientSessionId: attendeeSessionId,
-					clientConnectionId: initialAttendeeConnectionId,
-					updateProviders: ["client2"],
-				});
-
-				const rejoinAttendeeSignal = generateBasicClientJoin(clock.now - 20, {
-					averageLatency: 20,
-					clientSessionId: attendeeSessionId, // Same session id
-					clientConnectionId: rejoinAttendeeConnectionId, // Different connection id
-					connectionOrder: 1,
-					updateProviders: ["client2"],
-					priorClientToSessionId:
-						initialAttendeeSignal.content.data["system:presence"].clientToSessionId,
-				});
-
+				// Processes join signals and returns the attendees that were announced via `attendeeJoined`
 				function processJoinSignals(
 					signals: ReturnType<typeof generateBasicClientJoin>[],
 				): ISessionClient[] {
@@ -158,6 +144,23 @@ describe("Presence", () => {
 				beforeEach(() => {
 					// Ignore submitted signals
 					runtime.submitSignal = () => {};
+
+					initialAttendeeSignal = generateBasicClientJoin(clock.now - 50, {
+						averageLatency: 50,
+						clientSessionId: attendeeSessionId,
+						clientConnectionId: initialAttendeeConnectionId,
+						updateProviders: ["client2"],
+					});
+
+					rejoinAttendeeSignal = generateBasicClientJoin(clock.now - 20, {
+						averageLatency: 20,
+						clientSessionId: attendeeSessionId, // Same session id
+						clientConnectionId: rejoinAttendeeConnectionId, // Different connection id
+						connectionOrder: 1,
+						updateProviders: ["client2"],
+						priorClientToSessionId:
+							initialAttendeeSignal.content.data["system:presence"].clientToSessionId,
+					});
 				});
 
 				it("is not announced via `attendeeDisconnected` when unknown connection is removed", () => {
@@ -393,6 +396,7 @@ describe("Presence", () => {
 							verifyAttendee(
 								disconnectedAttendee,
 								initialAttendeeConnectionId,
+								attendeeSessionId,
 								SessionClientStatus.Disconnected,
 							);
 						});

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -109,12 +109,11 @@ describe("Presence", () => {
 						joinedAttendees.push(attendee);
 					});
 
-					afterCleanUp.push(cleanUpListener);
-
 					for (const signal of signals) {
 						presence.processSignal("", signal, false);
 					}
 
+					cleanUpListener();
 					return joinedAttendees;
 				}
 

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -133,6 +133,8 @@ describe("Presence", () => {
 					>;
 				}
 
+				// Simulates receiving join messages from the attendee signal information provided
+				// Returns a list of attendees that were announced via `attendeeJoined` event.
 				function simulateAttendeeJoin(
 					attendeeSignalInfo: IAttendeeSignalInfo[],
 				): ISessionClient[] {

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -98,8 +98,28 @@ describe("Presence", () => {
 				// until there is a join signal related to it.
 				const rejoinAttendeeConnectionId = "client7";
 
-				let initialAttendeeSignalInfo: IAttendeeSignalInfo;
-				let rejoinAttendeeSignalInfo: IAttendeeSignalInfo;
+				const initialAttendeeSignalInfo: IAttendeeSignalInfo = {
+					clientSessionId: attendeeSessionId,
+					clientConnectionId: initialAttendeeConnectionId,
+					fixedTime: clock.now - 50,
+					averageLatency: 50,
+					updateProviders: ["client2"],
+				};
+				const rejoinAttendeeSignalInfo: IAttendeeSignalInfo = {
+					clientSessionId: attendeeSessionId,
+					clientConnectionId: rejoinAttendeeConnectionId,
+					fixedTime: clock.now - 20,
+					averageLatency: 20,
+					connectionOrder: 1,
+					updateProviders: ["client2"],
+					priorClientToSessionId: {
+						[initialAttendeeConnectionId]: {
+							rev: 0,
+							timestamp: initialAttendeeSignalInfo.fixedTime,
+							value: attendeeSessionId,
+						},
+					},
+				};
 				interface IAttendeeSignalInfo {
 					clientSessionId: string;
 					clientConnectionId: ClientConnectionId;
@@ -157,29 +177,6 @@ describe("Presence", () => {
 				beforeEach(() => {
 					// Ignore submitted signals
 					runtime.submitSignal = () => {};
-					initialAttendeeSignalInfo = {
-						clientSessionId: attendeeSessionId,
-						clientConnectionId: initialAttendeeConnectionId,
-						fixedTime: clock.now - 50,
-						averageLatency: 50,
-						updateProviders: ["client2"],
-					};
-
-					rejoinAttendeeSignalInfo = {
-						clientSessionId: attendeeSessionId,
-						clientConnectionId: rejoinAttendeeConnectionId,
-						fixedTime: clock.now - 20,
-						averageLatency: 20,
-						connectionOrder: 1,
-						updateProviders: ["client2"],
-						priorClientToSessionId: {
-							[initialAttendeeConnectionId]: {
-								rev: 0,
-								timestamp: initialAttendeeSignalInfo.fixedTime,
-								value: attendeeSessionId,
-							},
-						},
-					};
 				});
 
 				it("is not announced via `attendeeDisconnected` when unknown connection is removed", () => {

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -136,7 +136,7 @@ describe("Presence", () => {
 					assert.equal(
 						actualAttendee.getConnectionStatus(),
 						expectedConnectionStatus,
-						"Attendee connection status is not Connected",
+						`Attendee connection status is not ${expectedConnectionStatus}`,
 					);
 				}
 

--- a/packages/framework/presence/src/test/tsconfig.json
+++ b/packages/framework/presence/src/test/tsconfig.json
@@ -10,6 +10,7 @@
 		"noUnusedLocals": true,
 		"noImplicitOverride": true,
 		"exactOptionalPropertyTypes": true,
+		"noUncheckedIndexedAccess": false,
 	},
 	"references": [
 		{


### PR DESCRIPTION
## Description

This PR refactors the unit tests in presenceManager.spec.ts in response to [this comment](https://github.com/microsoft/FluidFramework/pull/23113#discussion_r1861350670). We now include a simulateAttendeeJoin helper function that can take in multiple client join signals and returns the joined attendees while maintaining order. This is to accomodate for future, more complicated test scenarios where we simulate multiple joining clients, as well as simulating join responses. 

To show the benefit of the refactor I added a failing test case "is announced via `attendeeJoined` when a second joining attendee is unknown to audience" where two clients join and one responds to the other with it's known information. Using the helper we simply send the signals in order then verify the joinedAttendees array using another helper verifyAttendee. 