### PR TITLE
Add legacy tags to the added apis for creating and loading container

### DIFF
--- a/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
@@ -197,6 +197,11 @@ export interface IContainerLoadMode {
     opsBeforeReturn?: undefined | "cached" | "all";
 }
 
+// @alpha
+export type IContainerPolicies = {
+    maxClientLeaveWaitTime?: number;
+};
+
 // @public
 export type ICriticalContainerError = IErrorBase_2;
 

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -629,6 +629,7 @@ export type ILoaderOptions = {
 
 /**
  * Policies to have various behaviors during container create and load.
+ * @legacy
  * @alpha
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -12,6 +12,9 @@ export enum ConnectionState {
     EstablishingConnection = 3
 }
 
+// @alpha
+export function createDetachedContainer(createDetachedContainerProps: ICreateDetachedContainerProps): Promise<IContainer>;
+
 // @alpha (undocumented)
 export interface IBaseProtocolHandler {
     // (undocumented)
@@ -33,6 +36,25 @@ export interface IBaseProtocolHandler {
 // @alpha @deprecated (undocumented)
 export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComparer> {
     load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails>;
+}
+
+// @alpha
+export interface ICreateAndLoadContainerProps {
+    readonly allowReconnect?: boolean | undefined;
+    readonly clientDetailsOverride?: IClientDetails | undefined;
+    readonly codeLoader: ICodeDetailsLoader_2;
+    readonly configProvider?: IConfigProviderBase | undefined;
+    readonly documentServiceFactory: IDocumentServiceFactory;
+    readonly logger?: ITelemetryBaseLogger | undefined;
+    readonly options?: IContainerPolicies | undefined;
+    readonly protocolHandlerBuilder?: ProtocolHandlerBuilder | undefined;
+    readonly scope?: FluidObject | undefined;
+    readonly urlResolver: IUrlResolver;
+}
+
+// @alpha
+export interface ICreateDetachedContainerProps extends ICreateAndLoadContainerProps {
+    readonly codeDetails: IFluidCodeDetails;
 }
 
 // @alpha @deprecated
@@ -81,6 +103,12 @@ export interface ILoaderServices {
 }
 
 // @alpha
+export interface ILoadExistingContainerProps extends ICreateAndLoadContainerProps {
+    readonly pendingLocalState?: string | undefined;
+    readonly request: IRequest;
+}
+
+// @alpha
 export interface IParsedUrl {
     id: string;
     path: string;
@@ -104,6 +132,11 @@ export interface IQuorumSnapshot {
     proposals: QuorumProposalsSnapshot["proposals"];
     // (undocumented)
     values: QuorumProposalsSnapshot["values"];
+}
+
+// @alpha
+export interface IRehydrateDetachedContainerProps extends ICreateAndLoadContainerProps {
+    readonly serializedState: string;
 }
 
 // @alpha (undocumented)
@@ -140,6 +173,9 @@ export class Loader implements IHostLoader {
 }
 
 // @alpha
+export function loadExistingContainer(loadExistingContainerProps: ILoadExistingContainerProps): Promise<IContainer>;
+
+// @alpha
 export type ProtocolHandlerBuilder = (attributes: IDocumentAttributes, snapshot: IQuorumSnapshot, sendProposal: (key: string, value: any) => number) => IProtocolHandler;
 
 // @alpha
@@ -150,6 +186,9 @@ export type QuorumProposalsSnapshot = {
     proposals: [number, ISequencedProposal, string[]][];
     values: [string, ICommittedProposal][];
 };
+
+// @alpha
+export function rehydrateDetachedContainer(rehydrateDetachedContainerProps: IRehydrateDetachedContainerProps): Promise<IContainer>;
 
 // @alpha
 export function resolveWithLocationRedirectionHandling<T>(api: (request: IRequest) => Promise<T>, request: IRequest, urlResolver: IUrlResolver, logger?: ITelemetryBaseLogger): Promise<T>;

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -26,6 +26,7 @@ import { ProtocolHandlerBuilder } from "./protocol.js";
 
 /**
  * Properties necessary for creating and loading a container.
+ * @legacy
  * @alpha
  */
 export interface ICreateAndLoadContainerProps {
@@ -88,6 +89,7 @@ export interface ICreateAndLoadContainerProps {
 
 /**
  * Props used to load a container.
+ * @legacy
  * @alpha
  */
 export interface ILoadExistingContainerProps extends ICreateAndLoadContainerProps {
@@ -104,6 +106,7 @@ export interface ILoadExistingContainerProps extends ICreateAndLoadContainerProp
 
 /**
  * Props used to create a detached container.
+ * @legacy
  * @alpha
  */
 export interface ICreateDetachedContainerProps extends ICreateAndLoadContainerProps {
@@ -115,6 +118,7 @@ export interface ICreateDetachedContainerProps extends ICreateAndLoadContainerPr
 
 /**
  * Props used to rehydrate a detached container.
+ * @legacy
  * @alpha
  */
 export interface IRehydrateDetachedContainerProps extends ICreateAndLoadContainerProps {
@@ -128,6 +132,7 @@ export interface IRehydrateDetachedContainerProps extends ICreateAndLoadContaine
  * Creates a new container using the specified code details but in an unattached state. While unattached, all
  * updates will only be local until the user explicitly attaches the container to a service provider.
  * @param createDetachedContainerProps - Services and properties necessary for creating detached container.
+ * @legacy
  * @alpha
  */
 export async function createDetachedContainer(
@@ -144,6 +149,7 @@ export async function createDetachedContainer(
  * Creates a new container using the specified snapshot but in an unattached state. While unattached, all
  * updates will only be local until the user explicitly attaches the container to a service provider.
  * @param rehydrateDetachedContainerProps - Services and properties necessary for rehydrating detached container from a previously serialized container's state.
+ * @legacy
  * @alpha
  */
 export async function rehydrateDetachedContainer(
@@ -162,6 +168,7 @@ export async function rehydrateDetachedContainer(
 /**
  * Loads a container with an existing snapshot from the service.
  * @param loadExistingContainerProps - Services and properties necessary for loading an existing container.
+ * @legacy
  * @alpha
  */
 export async function loadExistingContainer(


### PR DESCRIPTION
## Description

Add legacy tags to the added apis for creating and loading container. Earlier these apis only had the alpha tag which is not correct as Loop would not consume the alpha apis in prod code and also these depends on legacy things as well. So these apis could not just be alpha.