### PR TITLE
fix(docs): Better trailing slash omission

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,6 +41,7 @@
 		"fluidframework",
 		"handlecache",
 		"handletable",
+		"incrementality",
 		"injective",
 		"losslessly",
 		"mitigations",
@@ -48,6 +49,7 @@
 		"multinomial",
 		"nonfinite",
 		"pseudorandomly",
+		"reconnections",
 		"Routerlicious",
 		"runtimes",
 		"snapshotlegacy",
@@ -59,7 +61,7 @@
 		"unacked",
 		"unaugmented",
 		"undoprovider",
-		"unsequenced",
+		"unsequenced"
 	],
 
 	// Enable biome as default formatter, and disable rules that disagree with it

--- a/docs/README.md
+++ b/docs/README.md
@@ -177,7 +177,7 @@ For more details about leveraging Mermaid diagrams in Docusaurus, see [here](htt
 Generally, it is recommended to include file extensions in links when possible.
 E.g., prefer `[foo](./foo.mdx)` over `[foo](./foo)`.
 
--   Docusaurus applies a different resolution strategy for relative *file path* links than it does for URL links.
+-   Docusaurus applies a different resolution strategy for relative _file path_ links than it does for URL links.
     See: <https://docusaurus.io/docs/markdown-features/links>
 
 #### Assets

--- a/docs/README.md
+++ b/docs/README.md
@@ -174,8 +174,11 @@ For more details about leveraging Mermaid diagrams in Docusaurus, see [here](htt
 
 ##### Links
 
--   Don't include file extensions in links. E.g., prefer `[foo](./foo)` over `[foo](./foo.md)`.
-    -   Rationale: more portable (if a document changes from `.md` to `.mdx`, for example, links will not need to be updated).
+Generally, it is recommended to include file extensions in links when possible.
+E.g., prefer `[foo](./foo.mdx)` over `[foo](./foo)`.
+
+-   Docusaurus applies a different resolution strategy for relative *file path* links than it does for URL links.
+    See: <https://docusaurus.io/docs/markdown-features/links>
 
 #### Assets
 

--- a/docs/docs/api/index.mdx
+++ b/docs/docs/api/index.mdx
@@ -11,8 +11,8 @@ To get started with the Fluid Framework, you'll want to take a dependency on our
 You'll then want to pair that with the appropriate service client implementation based on your service.
 These include:
 
--   [@fluidframework/azure-client](./azure-client.md) (for use with [Azure Fluid Relay](../deployment/azure-fluid-relay))
--   [@fluidframework/odsp-client](./odsp-client.md) (for use with [SharePoint Embedded](../deployment/sharepoint-embedded))
--   [@fluidframework/tinylicious-client](./tinylicious-client) (for testing with [Tinylicious](../testing/tinylicious))
+-   [@fluidframework/azure-client](./azure-client.md) (for use with [Azure Fluid Relay](../deployment/azure-fluid-relay.mdx))
+-   [@fluidframework/odsp-client](./odsp-client.md) (for use with [SharePoint Embedded](../deployment/sharepoint-embedded.mdx))
+-   [@fluidframework/tinylicious-client](./tinylicious-client.md) (for testing with [Tinylicious](../testing/tinylicious.mdx))
 
-For more information on our service client implementations, see [Fluid Services](../deployment/service-options).
+For more information on our service client implementations, see [Fluid Services](../deployment/service-options.mdx).

--- a/docs/docs/concepts/signals.mdx
+++ b/docs/docs/concepts/signals.mdx
@@ -7,7 +7,7 @@ sidebar_position: 6
 
 Signaler/SignalManager are now deprecated and no longer supported by Fluid team.
 
-Please checkout our new Presence offering [here](../build/presence).
+Please checkout our new Presence offering [here](../build/presence.md).
 
 **We highly recommend moving to the new Presence APIs**
 

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -60,12 +60,12 @@ The following is a typical flow.
 ## Next steps
 
 If you want to learn a lot more about how Fluid works, start with our
-**[architecture](./concepts/architecture)** overview.
+**[architecture](./concepts/architecture.mdx)** overview.
 
-If you prefer to get your hands dirty right away, head for our coding **[tutorial](./start/tutorial)** and
-**[examples](./start/examples)**.
-But first, get your **[dev environment](./start/quick-start)** set up.
+If you prefer to get your hands dirty right away, head for our coding **[tutorial](./start/tutorial.mdx)** and
+**[examples](./start/examples.mdx)**.
+But first, get your **[dev environment](./start/quick-start.mdx)** set up.
 
-Still have questions? Maybe we've answered them in our **[FAQ](./faq)**.
+Still have questions? Maybe we've answered them in our **[FAQ](./faq.mdx)**.
 If not, check out our
 **[Community page](/community)**.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -69,6 +69,7 @@ const config: Config = {
 		defaultLocale: "en",
 		locales: ["en"],
 	},
+	trailingSlash: false,
 	plugins: ["docusaurus-plugin-sass"],
 	presets: [
 		[

--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -14,6 +14,5 @@
 			"route": "/404",
 			"statusCode": 404
 		}
-	],
-	"trailingSlash": "never"
+	]
 }

--- a/docs/versioned_docs/version-1/api/index.mdx
+++ b/docs/versioned_docs/version-1/api/index.mdx
@@ -6,12 +6,12 @@ sidebar_position: 10
 
 {/* Note: these contents are new and should be reviewed. The current website's API docs landing page has no description about what the packages do / when to use them. It's not very useful. */}
 
-To get started with the Fluid Framework, you'll want to take a dependency on our client library, [fluid-framework](./fluid-framework).
+To get started with the Fluid Framework, you'll want to take a dependency on our client library, [fluid-framework](./fluid-framework.mdx).
 
 You'll then want to pair that with the appropriate service client implementation based on your service.
 These include:
 
--   [@fluidframework/azure-client](./azure-client) (for use with [Azure Fluid Relay](../deployment/azure-fluid-relay))
--   [@fluidframework/tinylicious-client](./tinylicious-client) (for testing with [Tinylicious](../testing/tinylicious))
+-   [@fluidframework/azure-client](./azure-client.md) (for use with [Azure Fluid Relay](../deployment/azure-fluid-relay.mdx))
+-   [@fluidframework/tinylicious-client](./tinylicious-client.md) (for testing with [Tinylicious](../testing/tinylicious.mdx))
 
-For more information on our service client implementations, see [Fluid Services](../deployment/service-options).
+For more information on our service client implementations, see [Fluid Services](../deployment/service-options.mdx).


### PR DESCRIPTION
Partial reversion of #23286.

SWA's implementation of `"trailingSlash": "never"` is currently flawed. The resulting redirect ends up exposing the underlying SWA URL of the site, rather than our configured front door URL. E.g. `https://fluidframework.com/docs/concepts/signals/` ends up redirecting to `https://salmon-sand-0b7fa7c1e.1.azurestaticapps.net/docs/concepts/signals`.
- See https://github.com/Azure/static-web-apps/issues/1036

This PR removes that configuration flag, and instead leverages Docusaurus's [trailingSlash](https://docusaurus.io/docs/api/docusaurus-config#trailingSlash) configuration option to not emit trailing slashes.

This required updating a handful of relative URL links to use file path links. The guidance documentation in the README has been updated to offer new guidance around relative links in light of new learnings.

[AB#25895](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/25895)