### PR TITLE
fix(docs): Don't inherit `@system` notices from ancestry

### DIFF
--- a/docs/infra/api-markdown-documenter/render-api-documentation.mjs
+++ b/docs/infra/api-markdown-documenter/render-api-documentation.mjs
@@ -92,7 +92,7 @@ export async function renderApiDocumentation(inputDir, outputDir, uriRootDir, ap
 		createDefaultLayout: layoutContent,
 		getAlertsForItem: (apiItem) => {
 			const alerts = [];
-			if (ApiItemUtilities.ancestryHasModifierTag(apiItem, "@system")) {
+			if (ApiItemUtilities.hasModifierTag(apiItem, "@system")) {
 				alerts.push("System");
 			} else {
 				if (ApiItemUtilities.isDeprecated(apiItem)) {


### PR DESCRIPTION
It is valid for a non-`@system` API to extend a `@system` one. See [here](https://fluidframework.com/docs/build/releases-and-apitags#api-support-levels) for more details on our tags, including `@system`. In fact, this is a common pattern - we introduce a base interface that some of our API members extend. We don't want customers to use that base interface directly, but it needs to exist for one reason or another. In this case, we don't want the implementations of that interface to inherit the `@system` notice.

[AB#22762](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/22762)