### PR TITLE
Standardize segment typing based on exposure

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -21,6 +21,7 @@ import {
 	Client,
 	IJSONSegment,
 	IMergeTreeOp,
+	type ISegmentInternal,
 	type LocalReferencePosition,
 	MergeTreeDeltaType,
 	ReferenceType,
@@ -758,7 +759,7 @@ export class SharedMatrix<T = any>
 		ref: LocalReferencePosition,
 		localSeq: number,
 	): number | undefined {
-		const segment = ref.getSegment();
+		const segment: ISegmentInternal | undefined = ref.getSegment();
 		const offset = ref.getOffset();
 		// If the segment that contains the position is removed, then this setCell op should do nothing.
 		if (segment === undefined || offset === undefined || segment.removedSeq !== undefined) {

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -18,6 +18,7 @@ import {
 	IMergeTreeDeltaOpArgs,
 	IMergeTreeMaintenanceCallbackArgs,
 	ISegment,
+	ISegmentInternal,
 	MergeTreeDeltaType,
 	MergeTreeMaintenanceType,
 	type IMergeTreeInsertMsg,
@@ -200,7 +201,7 @@ export class PermutationVector extends Client {
 		pos: number,
 		op: Pick<ISequencedDocumentMessage, "referenceSequenceNumber" | "clientId">,
 	): number | undefined {
-		const { segment, offset } = this.getContainingSegment(pos, {
+		const { segment, offset } = this.getContainingSegment<ISegmentInternal>(pos, {
 			referenceSequenceNumber: op.referenceSequenceNumber,
 			clientId: op.clientId,
 		});

--- a/packages/dds/merge-tree/src/MergeTreeTextHelper.ts
+++ b/packages/dds/merge-tree/src/MergeTreeTextHelper.ts
@@ -5,7 +5,7 @@
 
 import { IIntegerRange } from "./client.js";
 import { MergeTree } from "./mergeTree.js";
-import { ISegment } from "./mergeTreeNodes.js";
+import { ISegmentLeaf } from "./mergeTreeNodes.js";
 // eslint-disable-next-line import/no-deprecated
 import { IMergeTreeTextHelper, TextSegment } from "./textSegment.js";
 
@@ -56,7 +56,7 @@ export class MergeTreeTextHelper implements IMergeTreeTextHelper {
 }
 
 function gatherText(
-	segment: ISegment,
+	segment: ISegmentLeaf,
 	pos: number,
 	refSeq: number,
 	clientId: number,

--- a/packages/dds/merge-tree/src/attributionPolicy.ts
+++ b/packages/dds/merge-tree/src/attributionPolicy.ts
@@ -19,6 +19,7 @@ import {
 	IMergeTreeSegmentDelta,
 	MergeTreeMaintenanceType,
 } from "./mergeTreeDeltaCallback.js";
+import type { ISegmentLeaf } from "./mergeTreeNodes.js";
 import { MergeTreeDeltaType } from "./ops.js";
 
 // Note: these thinly wrap MergeTreeDeltaCallback and MergeTreeMaintenanceCallback to provide the client.
@@ -102,7 +103,8 @@ const attributeInsertionOnSegments = (
 	key: AttributionKey,
 ): void => {
 	for (const { segment } of deltaSegments) {
-		if (segment.seq !== undefined) {
+		const seg: ISegmentLeaf = segment;
+		if (seg.seq !== undefined) {
 			segment.attribution?.update(
 				undefined,
 				new AttributionCollection(segment.cachedLength, key),

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -396,7 +396,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	): void {
 		let localInserts = 0;
 		let localRemoves = 0;
-		walkAllChildSegments(this._mergeTree.root, (seg) => {
+		walkAllChildSegments(this._mergeTree.root, (seg: ISegmentLeaf) => {
 			if (seg.seq === UnassignedSequenceNumber) {
 				localInserts++;
 			}

--- a/packages/dds/merge-tree/src/mergeTreeNodeWalk.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodeWalk.ts
@@ -74,7 +74,6 @@ export function depthFirstNodeWalk(
 
 		// walk the leaves if we reached them
 		if (start !== undefined) {
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			for (let i = start.index; i !== -1 && i !== childCount; i += increment) {
 				// the above loop ensures start is a leaf or undefined, so all children
 				// will be leaves if start exits, so the cast is safe

--- a/packages/dds/merge-tree/src/mergeTreeNodeWalk.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodeWalk.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type MergeBlock, IMergeNode, ISegment } from "./mergeTreeNodes.js";
+import { type ISegmentLeaf, type MergeBlock, IMergeNode } from "./mergeTreeNodes.js";
 
 export const LeafAction = {
 	Exit: false,
@@ -38,7 +38,7 @@ export function depthFirstNodeWalk(
 	startBlock: MergeBlock,
 	startChild: IMergeNode | undefined,
 	downAction?: (node: IMergeNode) => NodeAction,
-	leafActionOverride?: (seg: ISegment) => LeafAction,
+	leafActionOverride?: (seg: ISegmentLeaf) => LeafAction,
 	upAction?: (block: MergeBlock) => void,
 	forward: boolean = true,
 ): boolean {
@@ -74,10 +74,11 @@ export function depthFirstNodeWalk(
 
 		// walk the leaves if we reached them
 		if (start !== undefined) {
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			for (let i = start.index; i !== -1 && i !== childCount; i += increment) {
 				// the above loop ensures start is a leaf or undefined, so all children
 				// will be leaves if start exits, so the cast is safe
-				if (leafAction(block.children[i] as ISegment) === LeafAction.Exit) {
+				if (leafAction(block.children[i] as ISegmentLeaf) === LeafAction.Exit) {
 					exit = true;
 					break;
 				}
@@ -122,7 +123,7 @@ export function depthFirstNodeWalk(
  */
 export function forwardExcursion(
 	startNode: IMergeNode,
-	leafAction: (seg: ISegment) => boolean | undefined,
+	leafAction: (seg: ISegmentLeaf) => boolean | undefined,
 ): boolean {
 	if (startNode.parent === undefined) {
 		return true;
@@ -145,7 +146,7 @@ export function forwardExcursion(
  */
 export function backwardExcursion(
 	startNode: IMergeNode,
-	leafAction: (seg: ISegment) => boolean | undefined,
+	leafAction: (seg: ISegmentLeaf) => boolean | undefined,
 ): boolean {
 	if (startNode.parent === undefined) {
 		return true;
@@ -171,7 +172,7 @@ export function backwardExcursion(
  */
 export function walkAllChildSegments(
 	startBlock: MergeBlock,
-	leafAction: (segment: ISegment) => boolean | undefined | void,
+	leafAction: (segment: ISegmentLeaf) => boolean | undefined | void,
 ): boolean {
 	if (startBlock.childCount === 0) {
 		return true;

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -322,8 +322,8 @@ export interface ISegmentAction<TClientData> {
  * @internal
  */
 export interface ISegmentChanges {
-	next?: ISegment;
-	replaceCurrent?: ISegment;
+	next?: ISegmentInternal;
+	replaceCurrent?: ISegmentInternal;
 }
 /**
  * @internal
@@ -361,8 +361,12 @@ export interface NodeAction<TClientData> {
  * @internal
  */
 export interface InsertContext {
-	candidateSegment?: ISegment;
-	leaf: (segment: ISegment | undefined, pos: number, ic: InsertContext) => ISegmentChanges;
+	candidateSegment?: ISegmentInternal;
+	leaf: (
+		segment: ISegmentInternal | undefined,
+		pos: number,
+		ic: InsertContext,
+	) => ISegmentChanges;
 	continuePredicate?: (continueFromBlock: MergeBlock) => boolean;
 }
 
@@ -433,7 +437,7 @@ export class MergeBlock implements IMergeNodeCommon {
 	 */
 	public leftmostTiles: Readonly<MapLike<Marker>>;
 
-	isLeaf(): this is ISegment {
+	isLeaf(): this is ISegmentInternal {
 		return false;
 	}
 

--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -14,7 +14,7 @@ import {
 	IMergeNode,
 	IMoveInfo,
 	IRemovalInfo,
-	ISegment,
+	ISegmentLeaf,
 	compareNumbers,
 	seqLTE,
 	toMoveInfo,
@@ -504,7 +504,7 @@ export class PartialSequenceLengths {
 	 */
 	static accumulateMoveOverlapForExisting(
 		segmentLen: number,
-		segment: ISegment,
+		segment: ISegmentLeaf,
 		firstGte: PartialSequenceLength,
 		clientIds: number[],
 	): void {
@@ -537,7 +537,7 @@ export class PartialSequenceLengths {
 	 * segment
 	 */
 	private static getMoveOverlapForExisting(
-		segment: ISegment,
+		segment: ISegmentLeaf,
 		obliterateOverlapLen: number,
 		clientIds: number[],
 	): RedBlackTree<number, IOverlapClient> {
@@ -558,7 +558,7 @@ export class PartialSequenceLengths {
 	}
 
 	private static updatePartialsAfterInsertion(
-		segment: ISegment,
+		segment: ISegmentLeaf,
 		segmentLen: number,
 		remoteObliteratedLen: number | undefined,
 		obliterateOverlapLen: number = segmentLen,
@@ -638,7 +638,7 @@ export class PartialSequenceLengths {
 	 */
 	private static insertSegment(
 		combinedPartialLengths: PartialSequenceLengths,
-		segment: ISegment,
+		segment: ISegmentLeaf,
 		removalInfo?: IRemovalInfo,
 		moveInfo?: IMoveInfo,
 	): void {

--- a/packages/dds/merge-tree/src/perspective.ts
+++ b/packages/dds/merge-tree/src/perspective.ts
@@ -6,14 +6,14 @@
 import { UnassignedSequenceNumber } from "./constants.js";
 import { type MergeTree } from "./mergeTree.js";
 import { LeafAction, backwardExcursion, forwardExcursion } from "./mergeTreeNodeWalk.js";
-import { seqLTE, type ISegment } from "./mergeTreeNodes.js";
+import { seqLTE, type ISegmentLeaf } from "./mergeTreeNodes.js";
 
 /**
  * Provides a view of a MergeTree from the perspective of a specific client at a specific sequence number.
  */
 export interface Perspective {
-	nextSegment(segment: ISegment, forward?: boolean): ISegment;
-	previousSegment(segment: ISegment): ISegment;
+	nextSegment(segment: ISegmentLeaf, forward?: boolean): ISegmentLeaf;
+	previousSegment(segment: ISegmentLeaf): ISegmentLeaf;
 }
 
 /**
@@ -47,9 +47,9 @@ export class PerspectiveImpl implements Perspective {
 	 * @param forward - The direction to search.
 	 * @returns the next segment in the specified direction, or the start or end of the tree if there is no next segment.
 	 */
-	public nextSegment(segment: ISegment, forward: boolean = true): ISegment {
-		let next: ISegment | undefined;
-		const action = (seg: ISegment): boolean | undefined => {
+	public nextSegment(segment: ISegmentLeaf, forward: boolean = true): ISegmentLeaf {
+		let next: ISegmentLeaf | undefined;
+		const action = (seg: ISegmentLeaf): boolean | undefined => {
 			if (isSegmentPresent(seg, this._seqTime)) {
 				next = seg;
 				return LeafAction.Exit;
@@ -65,7 +65,7 @@ export class PerspectiveImpl implements Perspective {
 	 * @returns the previous segment, or the start of the tree if there is no previous segment.
 	 * @remarks This is a convenient equivalent to calling `nextSegment(segment, false)`.
 	 */
-	public previousSegment(segment: ISegment): ISegment {
+	public previousSegment(segment: ISegmentLeaf): ISegmentLeaf {
 		return this.nextSegment(segment, false);
 	}
 }
@@ -77,7 +77,7 @@ export class PerspectiveImpl implements Perspective {
  * @param localSeq - The latest local sequence number to consider.
  * @returns true iff this segment was removed in the given perspective.
  */
-export function wasRemovedBefore(seg: ISegment, { refSeq, localSeq }: SeqTime): boolean {
+export function wasRemovedBefore(seg: ISegmentLeaf, { refSeq, localSeq }: SeqTime): boolean {
 	if (
 		seg.removedSeq === UnassignedSequenceNumber &&
 		localSeq !== undefined &&
@@ -95,7 +95,7 @@ export function wasRemovedBefore(seg: ISegment, { refSeq, localSeq }: SeqTime): 
  * @param localSeq - The latest local sequence number to consider.
  * @returns true iff this segment was moved (aka obliterated) in the given perspective.
  */
-export function wasMovedBefore(seg: ISegment, { refSeq, localSeq }: SeqTime): boolean {
+export function wasMovedBefore(seg: ISegmentLeaf, { refSeq, localSeq }: SeqTime): boolean {
 	if (
 		seg.movedSeq === UnassignedSequenceNumber &&
 		localSeq !== undefined &&
@@ -109,7 +109,7 @@ export function wasMovedBefore(seg: ISegment, { refSeq, localSeq }: SeqTime): bo
 /**
  * See {@link wasRemovedBefore} and {@link wasMovedBefore}.
  */
-export function wasRemovedOrMovedBefore(seg: ISegment, seqTime: SeqTime): boolean {
+export function wasRemovedOrMovedBefore(seg: ISegmentLeaf, seqTime: SeqTime): boolean {
 	return wasRemovedBefore(seg, seqTime) || wasMovedBefore(seg, seqTime);
 }
 
@@ -120,7 +120,7 @@ export function wasRemovedOrMovedBefore(seg: ISegment, seqTime: SeqTime): boolea
  * @returns true iff this segment was inserted before the given perspective,
  * and it was not removed or moved in the given perspective.
  */
-export function isSegmentPresent(seg: ISegment, seqTime: SeqTime): boolean {
+export function isSegmentPresent(seg: ISegmentLeaf, seqTime: SeqTime): boolean {
 	const { refSeq, localSeq } = seqTime;
 	// If seg.seq is undefined, then this segment has existed since minSeq.
 	// It may have been moved or removed since.

--- a/packages/dds/merge-tree/src/revertibles.ts
+++ b/packages/dds/merge-tree/src/revertibles.ts
@@ -12,12 +12,7 @@ import { LocalReferenceCollection, LocalReferencePosition } from "./localReferen
 import { MergeTree, findRootMergeBlock } from "./mergeTree.js";
 import { IMergeTreeDeltaCallbackArgs } from "./mergeTreeDeltaCallback.js";
 import { depthFirstNodeWalk } from "./mergeTreeNodeWalk.js";
-import {
-	ISegment,
-	ISegmentInternal,
-	toRemovalInfo,
-	type ISegmentLeaf,
-} from "./mergeTreeNodes.js";
+import { toRemovalInfo, type ISegmentLeaf } from "./mergeTreeNodes.js";
 import { ITrackingGroup, Trackable, UnorderedTrackingGroup } from "./mergeTreeTracking.js";
 import { IJSONSegment, MergeTreeDeltaType, ReferenceType } from "./ops.js";
 import { PropertySet, matchProperties } from "./properties.js";
@@ -246,7 +241,7 @@ export function discardMergeTreeDeltaRevertible(
 			t.trackingCollection.unlink(r.trackingGroup);
 			// remove untracked local references
 			if (t.trackingCollection.empty && !t.isLeaf()) {
-				const segment: ISegmentInternal | undefined = t.getSegment();
+				const segment: ISegmentLeaf | undefined = t.getSegment();
 				segment?.localRefs?.removeLocalRef(t);
 			}
 		}
@@ -287,7 +282,7 @@ function revertLocalRemove(
 
 		assert(!tracked.isLeaf(), 0x3f4 /* removes must track local refs */);
 
-		const refSeg: ISegmentInternal | undefined = tracked.getSegment();
+		const refSeg: ISegmentLeaf | undefined = tracked.getSegment();
 		let realPos = mergeTreeWithRevert.referencePositionToLocalPosition(tracked);
 
 		// References which are on EndOfStringSegment don't return detached for pos,
@@ -340,7 +335,7 @@ function revertLocalRemove(
 			insertSegment.parent!,
 			insertSegment,
 			undefined,
-			(seg: ISegmentInternal) => {
+			(seg: ISegmentLeaf) => {
 				if (seg.localRefs?.empty === false) {
 					return seg.localRefs.walkReferences(refHandler, undefined, forward);
 				}
@@ -372,7 +367,7 @@ function revertLocalRemove(
 			tg.link(insertSegment);
 			tg.unlink(tracked);
 		}
-		const segment: ISegmentInternal | undefined = tracked.getSegment();
+		const segment: ISegmentLeaf | undefined = tracked.getSegment();
 		segment?.localRefs?.removeLocalRef(tracked);
 	}
 }
@@ -393,7 +388,7 @@ function revertLocalAnnotate(
 	}
 }
 
-function getPosition(mergeTreeWithRevert: MergeTreeWithRevert, segment: ISegment): number {
+function getPosition(mergeTreeWithRevert: MergeTreeWithRevert, segment: ISegmentLeaf): number {
 	return mergeTreeWithRevert.getPosition(
 		segment,
 		mergeTreeWithRevert.collabWindow.currentSeq,

--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -24,7 +24,7 @@ import {
 import { Client } from "./client.js";
 import { NonCollabClient, UniversalSequenceNumber } from "./constants.js";
 import { MergeTree } from "./mergeTree.js";
-import { ISegment } from "./mergeTreeNodes.js";
+import { ISegmentLeaf } from "./mergeTreeNodes.js";
 import { IJSONSegment } from "./ops.js";
 import {
 	IJSONSegmentWithMergeInfo,
@@ -96,8 +96,8 @@ export class SnapshotLoader {
 
 	private readonly specToSegment = (
 		spec: IJSONSegment | IJSONSegmentWithMergeInfo,
-	): ISegment => {
-		let seg: ISegment;
+	): ISegmentLeaf => {
+		let seg: ISegmentLeaf;
 
 		if (hasMergeInfo(spec)) {
 			seg = this.client.specToSegment(spec.json);
@@ -207,7 +207,7 @@ export class SnapshotLoader {
 		}
 
 		let chunksWithAttribution = chunk1.attribution === undefined ? 0 : 1;
-		const segs: ISegment[] = [];
+		const segs: ISegmentLeaf[] = [];
 		let lengthSofar = chunk1.length;
 		for (
 			let chunkIndex = 1;
@@ -244,7 +244,7 @@ export class SnapshotLoader {
 
 		// Helper to insert segments at the end of the MergeTree.
 		const mergeTree = this.mergeTree;
-		const append = (segments: ISegment[], cli: number, seq: number): void => {
+		const append = (segments: ISegmentLeaf[], cli: number, seq: number): void => {
 			mergeTree.insertSegments(
 				mergeTree.root.cachedLength ?? 0,
 				segments,
@@ -256,7 +256,7 @@ export class SnapshotLoader {
 		};
 
 		// Helpers to batch-insert segments that are below the min seq
-		const batch: ISegment[] = [];
+		const batch: ISegmentLeaf[] = [];
 		const flushBatch = (): void => {
 			if (batch.length > 0) {
 				append(batch, NonCollabClient, UniversalSequenceNumber);
@@ -280,7 +280,7 @@ export class SnapshotLoader {
 		flushBatch();
 	}
 
-	private extractAttribution(segments: ISegment[], chunk: MergeTreeChunkV1): void {
+	private extractAttribution(segments: ISegmentLeaf[], chunk: MergeTreeChunkV1): void {
 		if (chunk.attribution) {
 			const { attributionPolicy } = this.mergeTree;
 			if (attributionPolicy === undefined) {

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -22,7 +22,7 @@ import { IAttributionCollection } from "./attributionCollection.js";
 import { UnassignedSequenceNumber } from "./constants.js";
 import { MergeTree } from "./mergeTree.js";
 import { walkAllChildSegments } from "./mergeTreeNodeWalk.js";
-import { ISegment } from "./mergeTreeNodes.js";
+import { ISegmentLeaf } from "./mergeTreeNodes.js";
 import type { IJSONSegment } from "./ops.js";
 import { PropertySet, matchProperties } from "./properties.js";
 import {
@@ -208,7 +208,7 @@ export class SnapshotV1 {
 		};
 
 		// Helper to serialize the given `segment` and add it to the snapshot (if a segment is provided).
-		const pushSeg = (segment?: ISegment): void => {
+		const pushSeg = (segment?: ISegmentLeaf): void => {
 			if (segment) {
 				if (segment.properties !== undefined && Object.keys(segment.properties).length === 0) {
 					segment.properties = undefined;
@@ -221,8 +221,8 @@ export class SnapshotV1 {
 			}
 		};
 
-		let prev: ISegment | undefined;
-		const extractSegment = (segment: ISegment): boolean => {
+		let prev: ISegmentLeaf | undefined;
+		const extractSegment = (segment: ISegmentLeaf): boolean => {
 			// Elide segments that do not need to be included in the snapshot.  A segment may be elided if
 			// either condition is true:
 			//   a) The segment has not yet been ACKed.  We do not need to snapshot unACKed segments because

--- a/packages/dds/merge-tree/src/snapshotlegacy.ts
+++ b/packages/dds/merge-tree/src/snapshotlegacy.ts
@@ -18,7 +18,7 @@ import {
 
 import { NonCollabClient, UnassignedSequenceNumber } from "./constants.js";
 import { MergeTree } from "./mergeTree.js";
-import { ISegment, type ISegmentLeaf } from "./mergeTreeNodes.js";
+import { type ISegmentLeaf } from "./mergeTreeNodes.js";
 import { matchProperties } from "./properties.js";
 import {
 	JsonSegmentSpecs,
@@ -55,7 +55,7 @@ export class SnapshotLegacy {
 
 	private header: SnapshotHeader | undefined;
 	private seq: number | undefined;
-	private segments: ISegment[] | undefined;
+	private segments: ISegmentLeaf[] | undefined;
 	private readonly logger: ITelemetryLoggerExt;
 	private readonly chunkSize: number;
 
@@ -71,11 +71,11 @@ export class SnapshotLegacy {
 	}
 
 	private getSeqLengthSegs(
-		allSegments: ISegment[],
+		allSegments: ISegmentLeaf[],
 		approxSequenceLength: number,
 		startIndex = 0,
 	): MergeTreeChunkLegacy {
-		const segs: ISegment[] = [];
+		const segs: ISegmentLeaf[] = [];
 		let sequenceLength = 0;
 		let segCount = 0;
 		let segsWithAttribution = 0;
@@ -191,7 +191,7 @@ export class SnapshotLegacy {
 		return builder.getSummaryTree();
 	}
 
-	extractSync(): ISegment[] {
+	extractSync(): ISegmentLeaf[] {
 		const collabWindow = this.mergeTree.collabWindow;
 		const seq = (this.seq = collabWindow.minSeq);
 		this.header = {
@@ -204,7 +204,7 @@ export class SnapshotLegacy {
 
 		let originalSegments = 0;
 
-		const segs: ISegment[] = [];
+		const segs: ISegmentLeaf[] = [];
 		let prev: ISegmentLeaf | undefined;
 		const extractSegment = (
 			segment: ISegmentLeaf,

--- a/packages/dds/merge-tree/src/sortedSegmentSet.ts
+++ b/packages/dds/merge-tree/src/sortedSegmentSet.ts
@@ -4,7 +4,7 @@
  */
 
 import { LocalReferencePosition } from "./localReference.js";
-import { ISegment } from "./mergeTreeNodes.js";
+import { ISegmentInternal } from "./mergeTreeNodes.js";
 // eslint-disable-next-line import/no-deprecated
 import { SortedSet } from "./sortedSet.js";
 
@@ -12,9 +12,9 @@ import { SortedSet } from "./sortedSet.js";
  * @internal
  */
 export type SortedSegmentSetItem =
-	| ISegment
+	| ISegmentInternal
 	| LocalReferencePosition
-	| { readonly segment: ISegment };
+	| { readonly segment: ISegmentInternal };
 
 /**
  * Stores a unique and sorted set of segments, or objects with segments
@@ -29,10 +29,9 @@ export type SortedSegmentSetItem =
  * @internal
  */
 // eslint-disable-next-line import/no-deprecated
-export class SortedSegmentSet<T extends SortedSegmentSetItem = ISegment> extends SortedSet<
-	T,
-	string
-> {
+export class SortedSegmentSet<
+	T extends SortedSegmentSetItem = ISegmentInternal,
+> extends SortedSet<T, string> {
 	protected getKey(item: T): string {
 		const maybeRef = item as Partial<LocalReferencePosition>;
 		if (maybeRef.getSegment !== undefined && maybeRef.isLeaf?.() === false) {
@@ -43,12 +42,12 @@ export class SortedSegmentSet<T extends SortedSegmentSetItem = ISegment> extends
 			// All that matters is that it's consistent.
 			return lref.getSegment()?.ordinal ?? "";
 		}
-		const maybeObject = item as { readonly segment: ISegment };
+		const maybeObject = item as { readonly segment: ISegmentInternal };
 		if (maybeObject?.segment) {
 			return maybeObject.segment.ordinal;
 		}
 
-		const maybeSegment = item as ISegment;
+		const maybeSegment = item as ISegmentInternal;
 		return maybeSegment.ordinal;
 	}
 

--- a/packages/dds/merge-tree/src/test/beastTest.spec.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.spec.ts
@@ -36,10 +36,10 @@ import { IMergeTreeDeltaOpArgs } from "../mergeTreeDeltaCallback.js";
 import {
 	IJSONMarkerSegment,
 	IMergeNode,
-	ISegment,
 	compareNumbers,
 	compareStrings,
 	reservedMarkerIdKey,
+	type ISegmentLeaf,
 } from "../mergeTreeNodes.js";
 import { createRemoveRangeOp } from "../opBuilder.js";
 import { IMergeTreeOp, MergeTreeDeltaType, ReferenceType } from "../ops.js";
@@ -284,7 +284,7 @@ export function fileTest1(): void {
 	}
 }
 
-function printTextSegment(textSegment: ISegment, pos: number): boolean {
+function printTextSegment(textSegment: ISegmentLeaf, pos: number): boolean {
 	log(textSegment.toString());
 	log(`at [${pos}, ${pos + textSegment.cachedLength})`);
 	return true;
@@ -387,7 +387,11 @@ export function mergeTreeTest1(): void {
 	// checkRemoveSegTree(segTree, 4, 13);
 	checkInsertMergeTree(mergeTree, 4, makeCollabTextSegment("fi"));
 	mergeTree.mapRange(printTextSegment, UniversalSequenceNumber, LocalClientId, undefined);
-	const segoff = mergeTree.getContainingSegment(4, UniversalSequenceNumber, LocalClientId);
+	const segoff = mergeTree.getContainingSegment<ISegmentLeaf>(
+		4,
+		UniversalSequenceNumber,
+		LocalClientId,
+	);
 	log(mergeTree.getPosition(segoff.segment!, UniversalSequenceNumber, LocalClientId));
 	log(new MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId));
 	log(mergeTree.toString());
@@ -1526,7 +1530,7 @@ function findReplacePerf(filename: string): void {
 	let cFetches = 0;
 	let cReplaces = 0;
 	for (let pos = 0; pos < client.getLength(); ) {
-		const curSegOff = client.getContainingSegment(pos);
+		const curSegOff = client.getContainingSegment<ISegmentLeaf>(pos);
 		cFetches++;
 
 		const curSeg = curSegOff.segment;

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -13,7 +13,7 @@ import { isFluidError } from "@fluidframework/telemetry-utils/internal";
 
 import { UnassignedSequenceNumber } from "../constants.js";
 import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
-import { ISegment, ISegmentLeaf, SegmentGroup } from "../mergeTreeNodes.js";
+import { ISegmentLeaf, SegmentGroup } from "../mergeTreeNodes.js";
 import { TrackingGroup } from "../mergeTreeTracking.js";
 import { MergeTreeDeltaType, ReferenceType } from "../ops.js";
 import { Side } from "../sequencePlace.js";
@@ -670,7 +670,7 @@ describe("client.applyMsg", () => {
 		ops.push(clients.B.makeOpMessage(clients.B.regeneratePendingOp(bOp.op, bOp.sg), ++seq));
 
 		const trackingGroup = new TrackingGroup();
-		const trackedSegs: ISegment[] = [];
+		const trackedSegs: ISegmentLeaf[] = [];
 		walkAllChildSegments(clients.C.mergeTree.root, (seg) => {
 			trackedSegs.push(seg);
 			trackingGroup.link(seg);

--- a/packages/dds/merge-tree/src/test/client.attributionFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.attributionFarm.spec.ts
@@ -10,6 +10,7 @@ import { generatePairwiseOptions } from "@fluid-private/test-pairwise-generator"
 import { AttributionKey } from "@fluidframework/runtime-definitions/internal";
 
 import { createPropertyTrackingAndInsertionAttributionPolicyFactory } from "../attributionPolicy.js";
+import type { ISegmentLeaf } from "../mergeTreeNodes.js";
 
 import {
 	IConfigRange,
@@ -73,7 +74,7 @@ describeFuzz("MergeTree.Attribution", ({ testCount }) => {
 							[name: string]: AttributionKey | undefined;
 					  }
 					| undefined => {
-					const { segment, offset } = client.getContainingSegment(pos);
+					const { segment, offset } = client.getContainingSegment<ISegmentLeaf>(pos);
 					if (segment?.attribution === undefined || offset === undefined) {
 						return undefined;
 					}

--- a/packages/dds/merge-tree/src/test/client.getPosition.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.getPosition.spec.ts
@@ -7,6 +7,7 @@
 
 import { strict as assert } from "node:assert";
 
+import type { ISegmentLeaf } from "../mergeTreeNodes.js";
 import { TextSegment } from "../textSegment.js";
 
 import { TestClient } from "./testClient.js";
@@ -23,7 +24,7 @@ describe("client.getPosition", () => {
 		}
 		client.startOrUpdateCollaboration(localUserLongId);
 
-		const segOff = client.getContainingSegment(segPos);
+		const segOff = client.getContainingSegment<ISegmentLeaf>(segPos);
 		assert(TextSegment.is(segOff.segment!));
 		assert.strictEqual(segOff.offset, 0);
 		assert.strictEqual(segOff.segment.text, "o");

--- a/packages/dds/merge-tree/src/test/client.localReference.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReference.spec.ts
@@ -17,7 +17,7 @@ import {
 	setValidateRefCount,
 } from "../localReference.js";
 import { getSlideToSegoff } from "../mergeTree.js";
-import { toRemovalInfo, type ISegment, type ISegmentLeaf } from "../mergeTreeNodes.js";
+import { toRemovalInfo, type ISegmentLeaf } from "../mergeTreeNodes.js";
 import { TrackingGroup, UnorderedTrackingGroup } from "../mergeTreeTracking.js";
 import { MergeTreeDeltaType, ReferenceType } from "../ops.js";
 import { DetachedReferencePosition } from "../referencePositions.js";
@@ -32,7 +32,7 @@ function getSlideOnRemoveReferencePosition(
 	pos: number,
 	op: ISequencedDocumentMessage,
 ): {
-	segment: ISegment | undefined;
+	segment: ISegmentLeaf | undefined;
 	offset: number | undefined;
 } {
 	let segoff = client.getContainingSegment<ISegmentLeaf>(pos, {

--- a/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
@@ -10,6 +10,7 @@ import { strict as assert } from "node:assert";
 import { makeRandom } from "@fluid-private/stochastic-test-utils";
 
 import { SlidingPreference, setValidateRefCount } from "../localReference.js";
+import type { ISegmentLeaf } from "../mergeTreeNodes.js";
 import { ReferenceType } from "../ops.js";
 import { ReferencePosition } from "../referencePositions.js";
 
@@ -85,7 +86,7 @@ describe("MergeTree.Client", () => {
 				for (const [i, c] of clients.entries()) {
 					refs.push([]);
 					for (let t = 0; t < c.getLength(); t++) {
-						const seg = c.getContainingSegment(t);
+						const seg = c.getContainingSegment<ISegmentLeaf>(t);
 						const forwardLref = c.createLocalReferencePosition(
 							seg.segment!,
 							seg.offset,

--- a/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
@@ -8,6 +8,7 @@
 import { strict as assert } from "node:assert";
 
 import { UnassignedSequenceNumber } from "../constants.js";
+import type { ISegmentLeaf } from "../mergeTreeNodes.js";
 import { createInsertSegmentOp, createRemoveRangeOp } from "../opBuilder.js";
 import { TextSegment } from "../textSegment.js";
 
@@ -87,7 +88,7 @@ describe("MergeTree.markRangeRemoved", () => {
 			"remote",
 		);
 		const segmentExpectedRemovedSeq = seq;
-		const { segment } = client.getContainingSegment(0);
+		const { segment } = client.getContainingSegment<ISegmentLeaf>(0);
 		assert(segment !== undefined, "expected to find segment");
 		const localDeleteMessage = client.makeOpMessage(
 			client.removeRangeLocal(0, client.getLength()),

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -12,7 +12,7 @@ import { IRandom } from "@fluid-private/stochastic-test-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 
 import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
-import { ISegment, SegmentGroup, toMoveInfo, toRemovalInfo } from "../mergeTreeNodes.js";
+import { ISegmentLeaf, SegmentGroup, toMoveInfo, toRemovalInfo } from "../mergeTreeNodes.js";
 import { IMergeTreeOp, MergeTreeDeltaType, ReferenceType } from "../ops.js";
 import { Side } from "../sequencePlace.js";
 import { TextSegment } from "../textSegment.js";
@@ -96,7 +96,7 @@ export const insertAtRefPos: TestOperation = (
 	opEnd: number,
 	random: IRandom,
 ) => {
-	const segs: ISegment[] = [];
+	const segs: ISegmentLeaf[] = [];
 	// gather all the segments at the pos, including removed segments
 	walkAllChildSegments(client.mergeTree.root, (seg) => {
 		const pos = client.getPosition(seg);

--- a/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
+++ b/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
@@ -9,7 +9,12 @@ import { strict as assert } from "node:assert";
 
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 
-import { Marker, SegmentGroup, reservedMarkerIdKey } from "../mergeTreeNodes.js";
+import {
+	Marker,
+	SegmentGroup,
+	reservedMarkerIdKey,
+	type ISegmentLeaf,
+} from "../mergeTreeNodes.js";
 import { IMergeTreeOp, ReferenceType } from "../ops.js";
 import { clone } from "../properties.js";
 import { TextSegment } from "../textSegment.js";
@@ -233,7 +238,7 @@ describe("resetPendingSegmentsToOp", () => {
 				prop1: "foo",
 			});
 			assert(insertOp);
-			const { segment } = client.getContainingSegment(0);
+			const { segment } = client.getContainingSegment<ISegmentLeaf>(0);
 			assert(segment !== undefined && Marker.is(segment));
 			client.annotateMarker(segment, { prop2: "bar" });
 
@@ -245,7 +250,7 @@ describe("resetPendingSegmentsToOp", () => {
 			);
 			otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
-			const { segment: otherSegment } = otherClient.getContainingSegment(0);
+			const { segment: otherSegment } = otherClient.getContainingSegment<ISegmentLeaf>(0);
 			assert(otherSegment !== undefined && Marker.is(otherSegment));
 			// `clone` here is because properties use a Object.create(null); to compare strict equal the prototype chain
 			// should therefore not include Object.
@@ -268,7 +273,7 @@ describe("resetPendingSegmentsToOp", () => {
 			);
 			otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
-			const { segment: otherSegment } = otherClient.getContainingSegment(0);
+			const { segment: otherSegment } = otherClient.getContainingSegment<ISegmentLeaf>(0);
 			assert(otherSegment !== undefined && TextSegment.is(otherSegment));
 			assert.deepStrictEqual(otherSegment.properties, clone({ prop1: "foo" }));
 		});
@@ -286,7 +291,7 @@ describe("resetPendingSegmentsToOp", () => {
 			);
 			otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
-			const { segment: otherSegment } = otherClient.getContainingSegment(0);
+			const { segment: otherSegment } = otherClient.getContainingSegment<ISegmentLeaf>(0);
 			assert(otherSegment !== undefined && TextSegment.is(otherSegment));
 			assert.deepStrictEqual(otherSegment.properties, undefined);
 		});

--- a/packages/dds/merge-tree/src/test/snapshot.utils.ts
+++ b/packages/dds/merge-tree/src/test/snapshot.utils.ts
@@ -13,7 +13,7 @@ import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/in
 import { MockStorage } from "@fluidframework/test-runtime-utils/internal";
 
 import { type IMergeTreeOptionsInternal } from "../mergeTree.js";
-import { ISegment } from "../mergeTreeNodes.js";
+import { type ISegmentLeaf } from "../mergeTreeNodes.js";
 import { IMergeTreeOp, ReferenceType } from "../ops.js";
 import { PropertySet } from "../properties.js";
 import { SnapshotV1 } from "../snapshotV1.js";
@@ -174,8 +174,8 @@ export class TestString {
 		);
 	}
 
-	public getSegment(pos: number): ISegment {
-		const { segment } = this.client.getContainingSegment(pos);
+	public getSegment(pos: number): ISegmentLeaf {
+		const { segment } = this.client.getContainingSegment<ISegmentLeaf>(pos);
 		assert(segment !== undefined);
 		return segment;
 	}

--- a/packages/dds/merge-tree/src/test/sortedSegmentSet.spec.ts
+++ b/packages/dds/merge-tree/src/test/sortedSegmentSet.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import { LocalReferencePosition } from "../localReference.js";
-import { ISegment } from "../mergeTreeNodes.js";
+import { ISegment, type ISegmentLeaf } from "../mergeTreeNodes.js";
 import { TrackingGroup } from "../mergeTreeTracking.js";
 import { ReferenceType } from "../ops.js";
 import { SortedSegmentSet, SortedSegmentSetItem } from "../sortedSegmentSet.js";
@@ -65,7 +65,7 @@ describe("SortedSegmentSet", () => {
 		const set = new SortedSegmentSet<{ segment: ISegment }>();
 		for (let i = 0; i < client.getLength(); i++) {
 			for (const pos of [i, client.getLength() - 1 - i]) {
-				const segment = client.getContainingSegment(pos).segment;
+				const segment = client.getContainingSegment<ISegmentLeaf>(pos).segment;
 				assert(segment);
 				const item = { segment };
 				assert.equal(set.has(item), false);
@@ -81,7 +81,7 @@ describe("SortedSegmentSet", () => {
 		const set = new SortedSegmentSet();
 		for (let i = 0; i < client.getLength(); i++) {
 			for (const pos of [i, client.getLength() - 1 - i]) {
-				const segment = client.getContainingSegment(pos).segment;
+				const segment = client.getContainingSegment<ISegmentLeaf>(pos).segment;
 				assert(segment);
 				set.addOrUpdate(segment);
 				assert.equal(set.has(segment), true);
@@ -99,7 +99,7 @@ describe("SortedSegmentSet", () => {
 		const set = new TrackingGroup();
 		for (let i = 0; i < client.getLength(); i++) {
 			for (const pos of [i, client.getLength() - 1 - i]) {
-				const segmentInfo = client.getContainingSegment(pos);
+				const segmentInfo = client.getContainingSegment<ISegmentLeaf>(pos);
 				assert(segmentInfo?.segment);
 				const lref = client.createLocalReferencePosition(
 					segmentInfo.segment,

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -29,13 +29,7 @@ import {
 	forwardExcursion,
 	walkAllChildSegments,
 } from "../mergeTreeNodeWalk.js";
-import {
-	MergeBlock,
-	ISegment,
-	ISegmentLeaf,
-	Marker,
-	MaxNodesInBlock,
-} from "../mergeTreeNodes.js";
+import { MergeBlock, ISegmentLeaf, Marker, MaxNodesInBlock } from "../mergeTreeNodes.js";
 import {
 	createAnnotateRangeOp,
 	createInsertSegmentOp,
@@ -58,7 +52,7 @@ import { TextSegment } from "../textSegment.js";
 import { TestSerializer } from "./testSerializer.js";
 import { nodeOrdinalsHaveIntegrity } from "./testUtils.js";
 
-export function specToSegment(spec: IJSONSegment): ISegment {
+export function specToSegment(spec: IJSONSegment): ISegmentLeaf {
 	const maybeText = TextSegment.fromJSONObject(spec);
 	if (maybeText) {
 		return maybeText;
@@ -111,7 +105,7 @@ export class TestClient extends Client {
 	public static async createFromSnapshot(
 		snapshotTree: ITree,
 		newLongClientId: string,
-		specToSeg: (spec: IJSONSegment) => ISegment,
+		specToSeg: (spec: IJSONSegment) => ISegmentLeaf,
 		options?: PropertySet,
 	): Promise<TestClient> {
 		return TestClient.createFromStorage(
@@ -125,7 +119,7 @@ export class TestClient extends Client {
 	public static async createFromSummary(
 		summaryTree: ISummaryTree,
 		newLongClientId: string,
-		specToSeg: (spec: IJSONSegment) => ISegment,
+		specToSeg: (spec: IJSONSegment) => ISegmentLeaf,
 		options?: PropertySet,
 	): Promise<TestClient> {
 		return TestClient.createFromStorage(
@@ -139,7 +133,7 @@ export class TestClient extends Client {
 	public static async createFromStorage(
 		storage: MockStorage,
 		newLongClientId: string,
-		specToSeg: (spec: IJSONSegment) => ISegment,
+		specToSeg: (spec: IJSONSegment) => ISegmentLeaf,
 		options?: PropertySet,
 	): Promise<TestClient> {
 		const client2 = new TestClient(options, specToSeg);
@@ -354,7 +348,7 @@ export class TestClient extends Client {
 	public debugDumpTree(tree: MergeTree): void {
 		// want the segment's content and the state of insert/remove
 		const test: string[] = [];
-		walkAllChildSegments(tree.root, (segment: ISegment) => {
+		walkAllChildSegments(tree.root, (segment: ISegmentLeaf) => {
 			const prefixes: (string | undefined | number)[] = [];
 			prefixes.push(
 				segment.seq === UnassignedSequenceNumber ? `L${segment.localSeq}` : segment.seq,
@@ -377,16 +371,16 @@ export class TestClient extends Client {
 	 * slow-path computations in this function without leveraging the merge-tree's structure
 	 */
 	public rebasePosition(pos: number, seqNumberFrom: number, localSeq: number): number {
-		let segment: ISegment | undefined;
+		let segment: ISegmentLeaf | undefined;
 		let posAccumulated = 0;
 		let offset = pos;
-		const isInsertedInView = (seg: ISegment): boolean =>
+		const isInsertedInView = (seg: ISegmentLeaf): boolean =>
 			(seg.seq !== undefined &&
 				seg.seq !== UnassignedSequenceNumber &&
 				seg.seq <= seqNumberFrom) ||
 			(seg.localSeq !== undefined && seg.localSeq <= localSeq);
 
-		const isRemovedFromView = ({ removedSeq, localRemovedSeq }: ISegment): boolean =>
+		const isRemovedFromView = ({ removedSeq, localRemovedSeq }: ISegmentLeaf): boolean =>
 			(removedSeq !== undefined &&
 				removedSeq !== UnassignedSequenceNumber &&
 				removedSeq <= seqNumberFrom) ||
@@ -419,17 +413,17 @@ export class TestClient extends Client {
 		return this.findReconnectionPosition(segoff.segment, localSeq) + segoff.offset;
 	}
 
-	public findReconnectionPosition(segment: ISegment, localSeq: number): number {
+	public findReconnectionPosition(segment: ISegmentLeaf, localSeq: number): number {
 		const fasterComputedPosition = super.findReconnectionPosition(segment, localSeq);
 
 		let segmentPosition = 0;
-		const isInsertedInView = (seg: ISegment): boolean =>
+		const isInsertedInView = (seg: ISegmentLeaf): boolean =>
 			seg.localSeq === undefined || seg.localSeq <= localSeq;
-		const isRemovedFromView = ({ removedSeq, localRemovedSeq }: ISegment): boolean =>
+		const isRemovedFromView = ({ removedSeq, localRemovedSeq }: ISegmentLeaf): boolean =>
 			removedSeq !== undefined &&
 			(removedSeq !== UnassignedSequenceNumber ||
 				(localRemovedSeq !== undefined && localRemovedSeq <= localSeq));
-		const isMovedFromView = ({ movedSeq, localMovedSeq }: ISegment): boolean =>
+		const isMovedFromView = ({ movedSeq, localMovedSeq }: ISegmentLeaf): boolean =>
 			movedSeq !== undefined &&
 			(movedSeq !== UnassignedSequenceNumber ||
 				(localMovedSeq !== undefined && localMovedSeq <= localSeq));
@@ -529,7 +523,7 @@ export class TestClient extends Client {
 	): ReferencePosition | undefined {
 		let foundMarker: Marker | undefined;
 
-		const { segment } = this.getContainingSegment(startPos);
+		const { segment } = this.getContainingSegment<ISegmentLeaf>(startPos);
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const segWithParent: ISegmentLeaf = segment!;
 

--- a/packages/dds/merge-tree/src/test/testClientLogger.ts
+++ b/packages/dds/merge-tree/src/test/testClientLogger.ts
@@ -21,7 +21,7 @@ import {
 	seqLTE,
 	toMoveInfo,
 	toRemovalInfo,
-	type ISegment,
+	type ISegmentLeaf,
 } from "../mergeTreeNodes.js";
 import { IMergeTreeOp, MergeTreeDeltaType } from "../ops.js";
 import { PropertySet, matchProperties } from "../properties.js";
@@ -400,7 +400,7 @@ export class TestClientLogger {
 	}
 }
 
-function toMoveOrRemove(segment: ISegment): { seq: number } | undefined {
+function toMoveOrRemove(segment: ISegmentLeaf): { seq: number } | undefined {
 	const mi = toMoveInfo(segment);
 	const ri = toRemovalInfo(segment);
 	if (mi !== undefined || ri !== undefined) {

--- a/packages/dds/merge-tree/src/test/testUtils.ts
+++ b/packages/dds/merge-tree/src/test/testUtils.ts
@@ -15,7 +15,7 @@ import {
 	type IMergeTreeMaintenanceCallbackArgs,
 } from "../mergeTreeDeltaCallback.js";
 import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
-import { MergeBlock, ISegment, Marker } from "../mergeTreeNodes.js";
+import { MergeBlock, ISegmentLeaf, Marker } from "../mergeTreeNodes.js";
 import { ReferenceType } from "../ops.js";
 import {
 	PartialSequenceLengths,
@@ -110,7 +110,7 @@ export function insertText({
 interface InsertSegmentsArgs {
 	mergeTree: MergeTree;
 	pos: number;
-	segments: ISegment[];
+	segments: ISegmentLeaf[];
 	refSeq: number;
 	clientId: number;
 	seq: number;
@@ -234,7 +234,7 @@ function getPartialLengths(
 
 	let actualLen = 0;
 
-	const isInserted = (segment: ISegment): boolean =>
+	const isInserted = (segment: ISegmentLeaf): boolean =>
 		segment.seq === undefined ||
 		(segment.seq !== UnassignedSequenceNumber && segment.seq <= seq) ||
 		(localSeq !== undefined &&
@@ -242,7 +242,7 @@ function getPartialLengths(
 			segment.localSeq !== undefined &&
 			segment.localSeq <= localSeq);
 
-	const isRemoved = (segment: ISegment): boolean =>
+	const isRemoved = (segment: ISegmentLeaf): boolean =>
 		segment.removedSeq !== undefined &&
 		((localSeq !== undefined &&
 			segment.removedSeq === UnassignedSequenceNumber &&
@@ -250,7 +250,7 @@ function getPartialLengths(
 			segment.localRemovedSeq <= localSeq) ||
 			(segment.removedSeq !== UnassignedSequenceNumber && segment.removedSeq <= seq));
 
-	const isMoved = (segment: ISegment): boolean =>
+	const isMoved = (segment: ISegmentLeaf): boolean =>
 		segment.movedSeq !== undefined &&
 		((localSeq !== undefined &&
 			segment.movedSeq === UnassignedSequenceNumber &&

--- a/packages/dds/merge-tree/src/test/text.ts
+++ b/packages/dds/merge-tree/src/test/text.ts
@@ -4,7 +4,7 @@
  */
 
 import { MergeTree } from "../mergeTree.js";
-import { ISegment, Marker } from "../mergeTreeNodes.js";
+import { ISegmentLeaf, Marker } from "../mergeTreeNodes.js";
 import { ReferenceType } from "../ops.js";
 import { reservedTileLabelsKey } from "../referencePositions.js";
 import { TextSegment } from "../textSegment.js";
@@ -14,7 +14,7 @@ export function loadSegments(
 	segLimit: number,
 	markers: boolean = false,
 	withProps: boolean = true,
-): ISegment[] {
+): ISegmentLeaf[] {
 	const BOMFreeContent = content.replace(/^\uFEFF/, "");
 
 	const paragraphs = BOMFreeContent.split(/\r?\n/);
@@ -28,7 +28,7 @@ export function loadSegments(
 		}
 	}
 
-	const segments = [] as ISegment[];
+	const segments = [] as ISegmentLeaf[];
 	for (const paragraph of paragraphs) {
 		let pgMarker: Marker | undefined;
 		if (markers) {

--- a/packages/dds/merge-tree/src/test/tracking.spec.ts
+++ b/packages/dds/merge-tree/src/test/tracking.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
+import type { ISegmentLeaf } from "../mergeTreeNodes.js";
 import { TrackingGroup } from "../mergeTreeTracking.js";
 import { ReferenceType } from "../ops.js";
 
@@ -23,7 +24,7 @@ describe("MergeTree.tracking", () => {
 
 		assert.equal(testClient.getLength(), 3);
 
-		const segmentInfo = testClient.getContainingSegment(0);
+		const segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
 
 		assert(segmentInfo?.segment?.trackingCollection.empty);
 	});
@@ -40,7 +41,7 @@ describe("MergeTree.tracking", () => {
 
 		assert.equal(trackingGroup.size, 1);
 
-		const segmentInfo = testClient.getContainingSegment(0);
+		const segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
 
 		assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 
@@ -66,7 +67,7 @@ describe("MergeTree.tracking", () => {
 		assert.equal(testClient.getLength(), 4);
 
 		assert.equal(trackingGroup.size, 2);
-		const segmentInfo = testClient.getContainingSegment(0);
+		const segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
 		assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 	});
 
@@ -86,20 +87,20 @@ describe("MergeTree.tracking", () => {
 		assert.equal(testClient.getLength(), 4);
 
 		assert.equal(trackingGroup.size, 3);
-		let segmentInfo = testClient.getContainingSegment(0);
+		let segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
 		assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 
 		let seq = 1;
 		for (const op of ops) testClient.applyMsg(testClient.makeOpMessage(op, ++seq));
 
 		assert.equal(trackingGroup.size, 3);
-		segmentInfo = testClient.getContainingSegment(0);
+		segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
 		assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 
 		testClient.updateMinSeq(seq);
 
 		assert.equal(trackingGroup.size, 1);
-		segmentInfo = testClient.getContainingSegment(0);
+		segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
 		assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 	});
 
@@ -108,7 +109,7 @@ describe("MergeTree.tracking", () => {
 
 		assert.equal(testClient.getLength(), 3);
 
-		const segmentInfo = testClient.getContainingSegment(0);
+		const segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
 		assert(segmentInfo.segment);
 		const ref = testClient.createLocalReferencePosition(
 			segmentInfo.segment,
@@ -125,7 +126,7 @@ describe("MergeTree.tracking", () => {
 
 		assert.equal(testClient.getLength(), 3);
 
-		const segmentInfo = testClient.getContainingSegment(0);
+		const segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
 		assert(segmentInfo.segment);
 		const ref = testClient.createLocalReferencePosition(
 			segmentInfo.segment,
@@ -156,7 +157,7 @@ describe("MergeTree.tracking", () => {
 
 		testClient.insertTextLocal(0, "abc");
 
-		const { segment } = testClient.getContainingSegment(0);
+		const { segment } = testClient.getContainingSegment<ISegmentLeaf>(0);
 		segment?.trackingCollection.link(trackingGroup);
 
 		assert.equal(segment?.trackingCollection.trackingGroups.size, 1);
@@ -182,7 +183,7 @@ describe("MergeTree.tracking", () => {
 
 		testClient.insertTextLocal(0, "abc");
 
-		const { segment } = testClient.getContainingSegment(0);
+		const { segment } = testClient.getContainingSegment<ISegmentLeaf>(0);
 		segment?.trackingCollection.link(trackingGroup);
 
 		assert.equal(segment?.trackingCollection.trackingGroups.size, 1);

--- a/packages/dds/merge-tree/src/test/wordUnitTests.spec.ts
+++ b/packages/dds/merge-tree/src/test/wordUnitTests.spec.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { Trace } from "@fluid-internal/client-utils";
 import { makeRandom } from "@fluid-private/stochastic-test-utils";
 
+import type { ISegmentLeaf } from "../mergeTreeNodes.js";
 import { ReferenceType } from "../ops.js";
 import { MapLike, createMap, extend } from "../properties.js";
 import { ReferencePosition } from "../referencePositions.js";
@@ -135,7 +136,7 @@ function makeBookmarks(client: TestClient, bookmarkCount: number): ReferencePosi
 	const len = client.getLength();
 	for (let i = 0; i < bookmarkCount; i++) {
 		const pos = random.integer(0, len - 1);
-		const segoff = client.getContainingSegment(pos);
+		const segoff = client.getContainingSegment<ISegmentLeaf>(pos);
 		let refType = ReferenceType.Simple;
 		if (i & 1) {
 			refType = ReferenceType.SlideOnRemove;
@@ -167,7 +168,7 @@ function measureFetch(startFile: string, withBookmarks = false): void {
 			// curPG.pos is ca end
 			const curPG = client.searchForMarker(pos, "pg", true)!;
 			const properties = curPG.properties!;
-			const curSegOff = client.getContainingSegment(pos)!;
+			const curSegOff = client.getContainingSegment<ISegmentLeaf>(pos)!;
 			const curSeg = curSegOff.segment!;
 			// Combine paragraph and direct properties
 			extend(properties, curSeg.properties);

--- a/packages/dds/merge-tree/src/zamboni.ts
+++ b/packages/dds/merge-tree/src/zamboni.ts
@@ -11,7 +11,7 @@ import { MergeTreeMaintenanceType } from "./mergeTreeDeltaCallback.js";
 import {
 	type MergeBlock,
 	IMergeNode,
-	ISegment,
+	ISegmentLeaf,
 	Marker,
 	MaxNodesInBlock,
 	seqLTE,
@@ -136,7 +136,7 @@ export function packParent(parent: MergeBlock, mergeTree: MergeTree): void {
 function scourNode(node: MergeBlock, holdNodes: IMergeNode[], mergeTree: MergeTree): void {
 	// The previous segment is tracked while scouring for the purposes of merging adjacent segments
 	// when possible.
-	let prevSegment: ISegment | undefined;
+	let prevSegment: ISegmentLeaf | undefined;
 	for (let k = 0; k < node.childCount; k++) {
 		// TODO Non null asserting, why is this not null?
 		const childNode = node.children[k]!;


### PR DESCRIPTION
I merge tree we have three different layers of segment:

1. ISegment - This is the consumer facing type which is exposed via legacy
2. ISegmentInternal - This type is used internally between fluid framework packages that leverage merge-tree
3. ISegmentLeaf - This type is not exported from the merge-tree package.

This change standardizes usage in preparation for the upcoming changes which will move some properties between the layers. Doing this change first will reduce the number of lines modified when changes are made.

There are not functional changes in this PR, it is all typing, and there are not changes to any types which are exported to customers, so no type test or api markdowns are impacted
