### PR TITLE
fix(docs): Remove trailing slash fix for now

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -69,7 +69,9 @@ const config: Config = {
 		defaultLocale: "en",
 		locales: ["en"],
 	},
-	trailingSlash: false,
+	// TODO: consider re-enabling after the following issue is resolved:
+	// <https://github.com/Azure/static-web-apps/issues/1036>
+	// trailingSlash: false,
 	plugins: ["docusaurus-plugin-sass"],
 	presets: [
 		[


### PR DESCRIPTION
Reverts a change made in #23304, which ultimately results in the unwanted redirects resulting from the following SWA bug: <https://github.com/Azure/static-web-apps/issues/1036>.