### PR TITLE
[Proof of concept] Drop mixin pattern for ContainerRuntime

### DIFF
--- a/examples/apps/attributable-map/src/modelContainerRuntimeFactoryWithAttribution.ts
+++ b/examples/apps/attributable-map/src/modelContainerRuntimeFactoryWithAttribution.ts
@@ -4,7 +4,7 @@
  */
 
 import { IModelContainerRuntimeEntryPoint } from "@fluid-example/example-utils";
-import { mixinAttributor } from "@fluid-experimental/attributor";
+import { loadRuntimeWithAttribution } from "@fluid-experimental/attributor";
 import {
 	IContainer,
 	IContainerContext,
@@ -14,8 +14,6 @@ import {
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import { NamedFluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions/internal";
-
-const containerRuntimeWithAttribution = mixinAttributor();
 
 /**
  * ModelContainerRuntimeFactoryWithAttribution is an abstract class that gives a basic structure for container runtime initialization with attributor enabled.
@@ -41,7 +39,7 @@ export abstract class ModelContainerRuntimeFactoryWithAttribution<ModelType>
 		context: IContainerContext,
 		existing: boolean,
 	): Promise<IRuntime> {
-		const runtime = await containerRuntimeWithAttribution.loadRuntime({
+		const runtime = await loadRuntimeWithAttribution({
 			context,
 			registryEntries: this.registryEntries,
 			provideEntryPoint: async (

--- a/packages/framework/attributor/src/attributorContracts.ts
+++ b/packages/framework/attributor/src/attributorContracts.ts
@@ -55,7 +55,7 @@ export interface IRuntimeAttributor extends IProvideRuntimeAttributor {
 	/**
 	 * @returns Whether the runtime is currently tracking attribution information for the loaded container.
 	 * If enabled, the runtime attributor can be asked for the attribution info for different keys.
-	 * See {@link mixinAttributor} for more details on when this happens.
+	 * See {@link loadRuntimeWithAttribution} for more details on when this happens.
 	 */
 	readonly isEnabled: boolean;
 }

--- a/packages/framework/attributor/src/index.ts
+++ b/packages/framework/attributor/src/index.ts
@@ -4,7 +4,10 @@
  */
 
 export { type IAttributor } from "./attributor.js";
-export { mixinAttributor, getRuntimeAttributor } from "./mixinAttributor.js";
+export {
+	getRuntimeAttributor,
+	loadRuntimeWithAttribution,
+} from "./mixinAttributor.js";
 export {
 	attributorDataStoreAlias,
 	enableOnNewFileKey,

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { mixinAttributor } from "@fluid-experimental/attributor";
 import { TestDriverTypes } from "@fluid-internal/test-driver-definitions";
 import { FluidTestDriverConfig, createFluidTestDriver } from "@fluid-private/test-drivers";
 import {
@@ -235,11 +234,11 @@ export async function getVersionedTestObjectProviderFromApis(
 	const getDataStoreFactoryFn = createGetDataStoreFactoryFunction(apis.dataRuntime);
 	const containerFactoryFn = (containerOptions?: ITestContainerConfig) => {
 		const dataStoreFactory = getDataStoreFactoryFn(containerOptions);
-		const runtimeCtor =
+		const loadRuntimeFn =
 			containerOptions?.enableAttribution === true
-				? mixinAttributor(apis.containerRuntime.ContainerRuntime)
-				: apis.containerRuntime.ContainerRuntime;
-		const factoryCtor = createTestContainerRuntimeFactory(runtimeCtor);
+				? apis.containerRuntime.loadRuntimeWithAttribution
+				: apis.containerRuntime.loadContainerRuntime;
+		const factoryCtor = createTestContainerRuntimeFactory(loadRuntimeFn);
 		return new factoryCtor(
 			TestDataObjectType,
 			dataStoreFactory,
@@ -350,7 +349,7 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 	const createContainerFactoryFn = (containerOptions?: ITestContainerConfig) => {
 		const dataStoreFactory = getDataStoreFactoryFn(containerOptions);
 		const factoryCtor = createTestContainerRuntimeFactory(
-			apis.containerRuntime.ContainerRuntime,
+			apis.containerRuntime.loadContainerRuntime,
 		);
 		return new factoryCtor(
 			TestDataObjectType,
@@ -374,7 +373,7 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 			"containerRuntimeForLoading must be defined",
 		);
 		const factoryCtor = createTestContainerRuntimeFactory(
-			apis.containerRuntimeForLoading.ContainerRuntime,
+			apis.containerRuntimeForLoading.loadContainerRuntime,
 		);
 		return new factoryCtor(
 			TestDataObjectType,


### PR DESCRIPTION
## Description

We have used the mixin pattern to inject additional behavior into ContainerRuntime, most notably for adding support for Attribution.

This pattern is powerful because it allows arbitrary composition - each `loadRuntime` function takes in a base constructor, which could be an already-mixed in version.

The downside is that it requires access to the ContainerRuntime class itself.  We have just deprecated this class as an export from our packages; it's only to be used internally within FF now.

What this PR does is replace the mixin pattern for adding support for Attribution with a one-off function `loadRuntimeWithAttribution` that returns an instance of ContainerRuntime with the additional behavior.  (It adds a dataStore which it delegates that responsibility to).

We should consider if this pattern can be adjusted to allow composition. Our goal is to simplify the ContainerRuntime class and having this capability implemented in this simpler way could be advantageous.

## Reviewer Guidance

This is just to spark discussion.  Not intending to merge in its current state.