### PR TITLE
fix(client-presence): disabled (failing) attendees unit tests

### DIFF
--- a/packages/framework/presence/src/internalTypes.ts
+++ b/packages/framework/presence/src/internalTypes.ts
@@ -4,6 +4,7 @@
  */
 
 import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
+import type { IEvent, IEventProvider } from "@fluidframework/core-interfaces";
 import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 
 import type { InternalTypes } from "./exposedInternalTypes.js";
@@ -41,9 +42,18 @@ export const brandedObjectEntries = Object.entries as <K extends string, T>(
  */
 export type IEphemeralRuntime = Pick<
 	(IContainerRuntime & IRuntimeInternal) | IFluidDataStoreRuntime,
-	"clientId" | "connected" | "getAudience" | "getQuorum" | "off" | "on" | "submitSignal"
+	"clientId" | "connected" | "getAudience" | "getQuorum" | "submitSignal"
 > &
-	Partial<Pick<IFluidDataStoreRuntime, "logger">>;
+	Partial<Pick<IFluidDataStoreRuntime, "logger">> &
+	IEventProvider<MockEphemeralRuntimeEvents>;
+
+/**
+ *
+ */
+interface MockEphemeralRuntimeEvents extends IEvent {
+	(event: "connected", listener: (clientId: string) => void): void;
+	(event: "disconnected", listener: () => void): void;
+}
 
 /**
  * @internal

--- a/packages/framework/presence/src/test/mockEphemeralRuntime.ts
+++ b/packages/framework/presence/src/test/mockEphemeralRuntime.ts
@@ -5,7 +5,8 @@
 
 import { strict as assert } from "node:assert";
 
-import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import { TypedEventEmitter } from "@fluid-internal/client-utils";
+import type { IEvent, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import type { IClient, ISequencedClient } from "@fluidframework/driver-definitions";
 import { MockAudience, MockQuorumClients } from "@fluidframework/test-runtime-utils/internal";
 
@@ -64,28 +65,28 @@ function makeMockAudience(clients: ClientData[]): MockAudience {
 }
 
 /**
+ *
+ */
+interface MockEphemeralRuntimeEvents extends IEvent {
+	(event: "connected", listener: (clientId: string) => void): void;
+}
+
+/**
  * Mock ephemeral runtime for testing
  */
-export class MockEphemeralRuntime implements IEphemeralRuntime {
+export class MockEphemeralRuntime
+	extends TypedEventEmitter<MockEphemeralRuntimeEvents>
+	implements IEphemeralRuntime
+{
 	public logger?: ITelemetryBaseLogger;
 	public readonly quorum: MockQuorumClients;
 	public readonly audience: MockAudience;
-
-	public readonly listeners: {
-		connected: ((clientId: ClientConnectionId) => void)[];
-		disconnected: (() => void)[];
-	} = {
-		connected: [],
-		disconnected: [],
-	};
-	private isSupportedEvent(event: string): event is keyof typeof this.listeners {
-		return event in this.listeners;
-	}
 
 	public constructor(
 		logger?: ITelemetryBaseLogger,
 		public readonly signalsExpected: Parameters<IEphemeralRuntime["submitSignal"]>[] = [],
 	) {
+		super();
 		if (logger !== undefined) {
 			this.logger = logger;
 		}
@@ -98,29 +99,6 @@ export class MockEphemeralRuntime implements IEphemeralRuntime {
 		this.getQuorum = () => this.quorum;
 		this.audience = makeMockAudience(clientsData);
 		this.getAudience = () => this.audience;
-		this.on = (
-			event: string,
-			listener: (...args: any[]) => void,
-			// Events style eventing does not lend itself to union that
-			// IEphemeralRuntime is derived from, so we are using `any` here
-			// but meet the intent of the interface.
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		): any => {
-			if (!this.isSupportedEvent(event)) {
-				throw new Error(`Event ${event} is not supported`);
-			}
-			// Switch to allowing a single listener as commented when
-			// implementation uses a single "connected" listener.
-			// if (this.listeners[event]) {
-			// 	throw new Error(`Event ${event} already has a listener`);
-			// }
-			// this.listeners[event] = listener;
-			if (this.listeners[event].length > 1) {
-				throw new Error(`Event ${event} already has multiple listeners`);
-			}
-			this.listeners[event].push(listener);
-			return this;
-		};
 	}
 
 	public assertAllSignalsSubmitted(): void {
@@ -149,14 +127,6 @@ export class MockEphemeralRuntime implements IEphemeralRuntime {
 
 	public clientId: string | undefined;
 	public connected: boolean = false;
-
-	public on: IEphemeralRuntime["on"];
-
-	public off: IEphemeralRuntime["off"] = (
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	): any => {
-		throw new Error("IEphemeralRuntime.off method not implemented.");
-	};
 
 	public getAudience: () => ReturnType<IEphemeralRuntime["getAudience"]>;
 

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -317,25 +317,25 @@ describe("Presence", () => {
 							"Expected exactly one attendee to be announced",
 						);
 
-						// Act - simulate join message from client
+						// Act & Verify - simulate rejoin message from remote client
 						const rejoinAttendees = processJoinSignals([rejoinSignal]);
-						const responseAttendees = processJoinSignals([responseSignal]);
-
-						// Verify - only the rejoining attendee is announced
 						assert.strictEqual(
 							rejoinAttendees.length,
 							1,
 							"Expected exactly one attendee to be announced",
 						);
-						assert.strictEqual(
-							responseAttendees.length,
-							0,
-							"Expected no attendees to be announced",
-						);
 						verifyAttendee(
 							rejoinAttendees[0],
 							newCollateralAttendeeConnectionId,
 							"collateral-id",
+						);
+
+						// Act & Verify - simulate response message from remote client
+						const responseAttendees = processJoinSignals([responseSignal]);
+						assert.strictEqual(
+							responseAttendees.length,
+							0,
+							"Expected no attendees to be announced",
 						);
 					});
 				});

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -185,7 +185,7 @@ describe("Presence", () => {
 						verifyNewAttendee(rejoinAttendeeConnectionId);
 					});
 
-					it.skip('second time is announced once via `attendeeJoined` with status "Connected" when prior is still connected', () => {
+					it('second time is announced once via `attendeeJoined` with status "Connected" when prior is still connected', () => {
 						// Act - simulate join message from client
 						presence.processSignal("", rejoinAttendeeSignal, false);
 
@@ -193,7 +193,7 @@ describe("Presence", () => {
 						verifyNewAttendee(rejoinAttendeeConnectionId);
 					});
 
-					it.skip('first time is announced via `attendeeJoined` with status "Connected" even if unknown to audience', () => {
+					it('first time is announced via `attendeeJoined` with status "Connected" even if unknown to audience', () => {
 						// Setup - remove connection from audience
 						runtime.removeMember(initialAttendeeConnectionId);
 
@@ -276,7 +276,7 @@ describe("Presence", () => {
 					// To retain symmetry across Joined and Disconnected events, do not announce
 					// attendeeJoined when the attendee is already connected and we only see
 					// a connection id update. This can happen when audience removal is late.
-					it.skip('is not announced via `attendeeJoined` when already "Connected"', () => {
+					it('is not announced via `attendeeJoined` when already "Connected"', () => {
 						// Setup
 						afterCleanUp.push(
 							presence.events.on("attendeeJoined", () => {

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -485,6 +485,28 @@ describe("Presence", () => {
 								clientToDisconnect,
 							);
 						});
+
+						it("updates stale attendees status to 'Disconnected", () => {
+							// Setup
+							assert(knownAttendee !== undefined, "No attendee was set in beforeEach");
+							assert(knownAttendee.getConnectionStatus() === SessionClientStatus.Connected);
+
+							// Act - remove client connection id
+							runtime.emit("disconnected");
+							clock.tick(1000);
+							runtime.emit("connected", rejoinAttendeeConnectionId);
+							// Verify - stale attendee should still be connected after 15 seconds
+							clock.tick(15001);
+							assert(knownAttendee.getConnectionStatus() === SessionClientStatus.Connected);
+
+							// Verify - stale attendee should be disconnected after 30 seconds
+							clock.tick(15001);
+							assert.equal(
+								knownAttendee.getConnectionStatus(),
+								SessionClientStatus.Disconnected,
+								"Stale attendee has wrong status",
+							);
+						});
 					});
 				});
 


### PR DESCRIPTION
## Description

A few unit tests were added disabled as current implementation does not meet expectations. This PR enable these tests and updates implementation:

```
Presence
  PresenceManager
    when connected
      attendee
        that is joining
          - second time is announced once via `attendeeJoined` with status "Connected" when prior is still connected
          - first time is announced via `attendeeJoined` with status "Connected" even if unknown to audience
        that is already known
          - is not announced via `attendeeJoined` when already "Connected"`
```
Changes include:
- Additional test case that tests collateral client with old connection ID
- Defining a joining attendee as a connected attendee that has a connectionId that has not been seen before by the recipient. 
- When the local attendee disconnects, we temporarily lose connectivity status for remote attendees. To fix this we mark all remote attendee connections as stale upon reconnect and update their status to disconnected after 30 seconds of inactivity.  