### PR TITLE
docs(tree): reorganize shared tree docs

### DIFF
--- a/docs/docs/build/dds.mdx
+++ b/docs/docs/build/dds.mdx
@@ -110,7 +110,7 @@ see [Fluid handles](../concepts/handles.mdx).
 
 :::note
 
-If you are considering storing a DDS within another DDS in order to give your app's data a hierarchical structure, consider using a [SharedTree](../data-structures/tree.mdx) DDS instead.
+If you are considering storing a DDS within another DDS in order to give your app's data a hierarchical structure, consider using a [SharedTree](../data-structures/tree/index.mdx) DDS instead.
 
 :::
 

--- a/docs/docs/data-structures/overview.mdx
+++ b/docs/docs/data-structures/overview.mdx
@@ -40,7 +40,7 @@ Below we've enumerated the data structures and described when they may be most u
 
 ## SharedTree
 
-[SharedTree](./tree.mdx) is a hierarchical data structure that looks and feels like simple JavaScript objects.
+[SharedTree](./tree/index.mdx) is a hierarchical data structure that looks and feels like simple JavaScript objects.
 It is a tree of data with complex nodes, including maps that work similarly to [SharedMap](#sharedmap), and several kinds of leaf nodes, including boolean, string, number, null, and [Fluid handles](../concepts/handles.mdx).
 
 This is the recommended data structure for any new development.
@@ -84,7 +84,7 @@ Typical scenarios require the connected clients to "agree" on some course of act
 
 ## DDS Deprecation
 
-[SharedTree](./tree.mdx) is an incredibly flexible DDS that allows developers to represent a variety of data models (primitives, objects, lists, maps in any nested orientation).
+[SharedTree](./tree/index.mdx) is an incredibly flexible DDS that allows developers to represent a variety of data models (primitives, objects, lists, maps in any nested orientation).
 Due to this flexibility, it can also support features of various other DDSes in the Fluid repertoire.
 As SharedTree becomes more feature-rich, we plan to start reducing support for other DDSes that offer a sub-set of the functionality.
 This process takes the form of a deprecation journey for some of our existing DDSes, but rest assured, we will provide enough runway and support to migrate away from deprecated DDSes.

--- a/docs/docs/data-structures/tree/index.mdx
+++ b/docs/docs/data-structures/tree/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: SharedTree
-sidebar_position: 6
+sidebar_position: 5
 ---
 
 import { PackageLink } from "@site/src/components/shortLinks";
@@ -9,7 +9,7 @@ import { PackageLink } from "@site/src/components/shortLinks";
 
 The `SharedTree` distributed data structure (DDS), available starting with Fluid Framework 2.0, is used to store most or all of your application's shared data in a hierarchical structure.
 
-To get started working with `SharedTree` in your application, read this [quick start guide](../start/tree-start.mdx).
+To get started working with `SharedTree` in your application, read this [quick start guide](../../start/tree-start.mdx).
 
 A `SharedTree` has the following characteristics:
 
@@ -32,7 +32,7 @@ The following leaf node types are available:
 -   **number**: Works identically to a JavaScript JavaScript number.
 -   **string**: Works identically to a JavaScript string.
 -   **null**: Works identically to a JavaScript null.
--   **FluidHandle**: A handle to a Fluid DDS or Data Object in the current container. For more information about handles see [Handles](../concepts/handles.mdx).
+-   **FluidHandle**: A handle to a Fluid DDS or Data Object in the current container. For more information about handles see [Handles](../../concepts/handles.mdx).
 
 The following subsections describe the available internal node types.
 
@@ -56,22 +56,12 @@ An array node is an indexed sequence of zero or more values like a JavaScript ar
 
 For information about creating the schema for an array node, see [Array schema](#array-schema). For information about adding an array node to the `SharedTree` and about reading and writing to an array node, see [Array node APIs](#array-node-apis).
 
-## Installation
-
-The `SharedTree` library can be found in the [fluid-framework](https://www.npmjs.com/package/fluid-framework) package (version 2.x).
-
-To get started, run the following from a terminal in your project folder:
-
-```bash
-npm install fluid-framework@latest
-```
-
 ## Usage
 
 The major programming tasks for using `SharedTree`s are:
 
 -   Define a schema for the `SharedTree`. As you build out from prototype to full production application, you can add to this schema and create additional schemas for additional `ShareTree`s. See [Schema definition](#schema-definition).
--   Initialize the `TreeView` object. See [Creation](#creation).
+-   Initialize the `TreeView` object. See [creating a tree](../../start/tree-start.mdx#creating-a-tree).
 -   Create code that reads and edits the nodes of the `SharedTree`. See [API](#api).
 
 ### Schema definition
@@ -262,43 +252,6 @@ class Proposal = sf.object('Proposal', {
 });
 ```
 
-### Creation
-
-To create a `TreeView` object, create a container with an initial object of type `SharedTree` and then call `viewWith` with some schema. The code in this section continues the sticky note example. Start by creating a container schema with an initial object of type `SharedTree` and use it to create a container.
-
-```typescript
-const containerSchema: ContainerSchema = {
-	initialObjects: {
-		appData: SharedTree,
-	},
-};
-
-const { container, services } = await client.createContainer(containerSchema, "2");
-```
-
-Use `ITree.viewWith` to create a `TreeView` based on your tree configuration.
-Tree views provide schema-dependent APIs for viewing and editing tree data.
-
-```typescript
-const stickyNotesTreeView = container.initialObjects.appData.viewWith(appTreeConfiguration);
-```
-
-When the tree is first created, this schema along with some initial data can be applied to the tree using `TreeView.initialize`.
-Note that the data used to initialize the tree must conform to the root schema, `App`. So in this example, it has a single `items` property. The value of the `items` property specifies that the items array is empty. It is not a requirement that the initial tree be empty: you can assign one or more groups or notes to the initial tree.
-
-```typescript
-// Both of the following options are equivalent ways to initialize the tree.
-// See documentation about plain-old javascript objects (POJO) on `SchemaFactory` for more details.
-
-// Option 1:
-stickyNotesTreeView.initialize({ items: [] });
-
-// Option 2:
-stickyNotesTreeView.initialize(new App({ items: [] }));
-```
-
-You can now add child items to the `stickyNotesTreeView` object using the methods described in [API](#api) below.
-
 ### API
 
 The `TreeView` object and its children provide methods that enable your code to add nodes to the tree, remove nodes, and move nodes within the tree. You can also set and read the values of leaf nodes. The APIs have been designed to match as much as possible the syntax of TypeScript primitives, objects, maps, and arrays; although some editing APIs are different for the sake of making the merge semantics clearer.
@@ -418,13 +371,13 @@ set(key: string, value: T)
 The `set()` method sets/changes the value of the item with the specified key. If the key is not present, the item is added to the map. Note the following:
 
 -   The `T` can be any type that conforms to the map node's schema. For example, if the schema was defined with `class MyMap extends sf.map([sf.number, sf.string]);`, then `T` could be `number` or `string`.
--   If multiple clients set the same key simultaneously, the key gets the value set by the last edit to apply. For the meaning of "simultaneously", see [Types of distributed data structures](./overview.mdx).
+-   If multiple clients set the same key simultaneously, the key gets the value set by the last edit to apply. For the meaning of "simultaneously", see [Types of distributed data structures](../overview.mdx).
 
 ```typescript
 delete(key: string): void
 ```
 
-The `delete()` method removes the item with the specified key. If one client sets a key and another deletes it simultaneously, the key is deleted only if the deletion op is the last one applied. For the meaning of "simultaneously", see [Types of distributed data structures](./overview.mdx).
+The `delete()` method removes the item with the specified key. If one client sets a key and another deletes it simultaneously, the key is deleted only if the deletion op is the last one applied. For the meaning of "simultaneously", see [Types of distributed data structures](../overview.mdx).
 
 ##### Map node properties
 
@@ -474,7 +427,7 @@ Array nodes have two methods that remove items from the node. Note the following
 -   A removed item may be restored as a result of a simultaneous move operation from another client. For example, if one client removes items 3-5, and another client simultaneously moves items 4 and 5, then, if the move operation is ordered last, only item 3 is removed (items 4 and 5 are restored and moved to their destination by the move operation). If the remove operation is ordered last, then all three items will be removed, no matter where they reside.
 -   Removal of items never overrides inserting (or moving in) items. For example, if one client removes items 10-15, and another client simultaneously inserts an item at index 12, the original items 10-15 are removed, but new item is inserted between item 9 and the item that used to be at index 16. This is true regardless of the order of the remove and insert operations.
 
-For the meaning of "simultaneously", see [Types of distributed data structures](./overview.mdx).
+For the meaning of "simultaneously", see [Types of distributed data structures](../overview.mdx).
 
 ```typescript
 removeAt(index: number)
@@ -515,7 +468,7 @@ Note the following about these methods:
 -   If multiple clients simultaneously move an item, then that item will be moved to the destination indicated by the move of the client whose edit is ordered last.
 -   A moved item may be removed as a result of a simultaneous remove operation from another client. For example, if one client moves items 3-5, and another client simultaneously removes items 4 and 5, then, if the remove operation is ordered last, items 4 and 5 are removed from their destination by the remove operation. If the move operation is ordered last, then all three items will be moved to the destination.
 
-For the meaning of "simultaneously", see [Types of distributed data structures](./overview.mdx).
+For the meaning of "simultaneously", see [Types of distributed data structures](../overview.mdx).
 
 ### Events
 

--- a/docs/docs/data-structures/tree/index.mdx
+++ b/docs/docs/data-structures/tree/index.mdx
@@ -207,7 +207,7 @@ class App extends sf.object("App", {
 }) {}
 ```
 
-The final step is to create a configuration object that will be used when a `SharedTree` object is created or loaded. See [Creation](#creation). The following is an example of doing this.
+The final step is to create a configuration object that will be used when a `SharedTree` object is created or loaded. See [creating a tree](../../start/tree-start.mdx#creating-a-tree). The following is an example of doing this.
 
 ```typescript
 export const appTreeConfiguration = new TreeViewConfiguration({

--- a/docs/docs/start/tree-start.mdx
+++ b/docs/docs/start/tree-start.mdx
@@ -8,6 +8,16 @@ import { ApiLink } from "@site/src/components/shortLinks";
 `SharedTree` is a [distributed data structure](../data-structures/overview.mdx) that looks and feels like simple JavaScript objects with a type safe wrapper.
 This guide will walk you through the basics of creating, configuring, and interacting with a `SharedTree` in your application.
 
+## Installing SharedTree
+
+The `SharedTree` library can be found in the [fluid-framework](https://www.npmjs.com/package/fluid-framework) package (version 2.x).
+
+To get started, run the following from a terminal in your project folder:
+
+```bash
+npm install fluid-framework@latest
+```
+
 ## Creating a Tree
 
 A `SharedTree` can be created by defining a `ContainerSchema` with an initial object of type `SharedTree` and using this schema to create and load your container.
@@ -59,7 +69,7 @@ const schemaFactory = new SchemaFactory("some-schema-id-prob-a-uuid");
 ```
 
 `SchemaFactory` provides some methods for specifying collection types including `object()`, `array()`, and `map()`; and five primitive data types for specifying leaf nodes: `boolean`, `string`, `number`, `null`, and `handle`.
-See [schema definition](../data-structures/tree.mdx) for more info on the provided types.
+See [schema definition](../data-structures/tree/index.mdx) for more info on the provided types.
 
 You can define a schema by extending one of the built-in object types.
 As an example, let's write a schema for a todo list:
@@ -182,7 +192,7 @@ class TodoList extends schemaFactory.object("TodoList", {
 ```
 
 These methods are designed to merge well in collaborative settings without you having to think much about it.
-See [schema definition](../data-structures/tree.mdx) for more details on the built-in editing methods.
+See [schema definition](../data-structures/tree/index.mdx) for more details on the built-in editing methods.
 You can also read more about how these editing operations work in collaborative settings [here](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/docs/user-facing/merge-semantics.md).
 
 ### Grouping Edits into Transactions
@@ -201,7 +211,7 @@ Tree.runTransaction(myNode, (node) => {
 })
 ```
 
-See more information on transactions [here](../data-structures/tree.mdx).
+See more information on transactions [here](../data-structures/tree/index.mdx).
 
 ### Undoing and Redoing Edits
 
@@ -244,4 +254,4 @@ useEffect(() => {
 
 Note that any `Revertible`s obtained should be disposed of by the app author in order to free up the resources that are required to revert an edit.
 
-See [this blog post](https://devblogs.microsoft.com/microsoft365dev/fluid-framework-undo-redo-and-transactions-in-sharedtree/) or [undo redo support](../data-structures/tree.mdx) for more information.
+See [this blog post](https://devblogs.microsoft.com/microsoft365dev/fluid-framework-undo-redo-and-transactions-in-sharedtree/) or [undo redo support](../data-structures/tree/index.mdx) for more information.

--- a/docs/docs/start/tree-start.mdx
+++ b/docs/docs/start/tree-start.mdx
@@ -69,7 +69,7 @@ const schemaFactory = new SchemaFactory("some-schema-id-prob-a-uuid");
 ```
 
 `SchemaFactory` provides some methods for specifying collection types including `object()`, `array()`, and `map()`; and five primitive data types for specifying leaf nodes: `boolean`, `string`, `number`, `null`, and `handle`.
-See [schema definition](../data-structures/tree/index.mdx) for more info on the provided types.
+See [schema definition](../data-structures/tree/index.mdx#schema-definition) for more info on the provided types.
 
 You can define a schema by extending one of the built-in object types.
 As an example, let's write a schema for a todo list:
@@ -154,7 +154,7 @@ useEffect(() => {
 
 `nodeChanged` fires whenever one or more properties of the specified node change while `treeChanged` also fires whenever any node in its subtree changes.
 
-<ApiLink packageName="tree" apiName="TreeChangeEvents" apiType="interface">the API</ApiLink> docs for more details.
+See <ApiLink packageName="tree" apiName="TreeChangeEvents" apiType="interface">the API</ApiLink> docs for more details.
 
 ## Editing Tree Data
 
@@ -192,7 +192,7 @@ class TodoList extends schemaFactory.object("TodoList", {
 ```
 
 These methods are designed to merge well in collaborative settings without you having to think much about it.
-See [schema definition](../data-structures/tree/index.mdx) for more details on the built-in editing methods.
+See [schema definition](../data-structures/tree/index.mdx#schema-definition) for more details on the built-in editing methods.
 You can also read more about how these editing operations work in collaborative settings [here](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/docs/user-facing/merge-semantics.md).
 
 ### Grouping Edits into Transactions
@@ -211,7 +211,7 @@ Tree.runTransaction(myNode, (node) => {
 })
 ```
 
-See more information on transactions [here](../data-structures/tree/index.mdx).
+See more information on transactions [here](../data-structures/tree/index.mdx#transactions).
 
 ### Undoing and Redoing Edits
 


### PR DESCRIPTION
- creates and sets up a folder for tree docs in preparation for splitting the main tree docs into more specific sections
- moves the installation section to the quick start 
- dedupes the creation/initialization sections of the tree docs
- fixes some links