### PR TITLE
test(client-presence): old collateral connection and stale connection tests

### DIFF
--- a/packages/framework/presence/src/internalTypes.ts
+++ b/packages/framework/presence/src/internalTypes.ts
@@ -4,10 +4,8 @@
  */
 
 import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
-import type { IEvent, IEventProvider } from "@fluidframework/core-interfaces";
 import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 
-import type { ClientConnectionId } from "./baseTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { ClientSessionId, ISessionClient } from "./presence.js";
 
@@ -43,19 +41,9 @@ export const brandedObjectEntries = Object.entries as <K extends string, T>(
  */
 export type IEphemeralRuntime = Pick<
 	(IContainerRuntime & IRuntimeInternal) | IFluidDataStoreRuntime,
-	"clientId" | "connected" | "getAudience" | "getQuorum" | "submitSignal"
+	"clientId" | "connected" | "getAudience" | "getQuorum" | "off" | "on" | "submitSignal"
 > &
-	Partial<Pick<IFluidDataStoreRuntime, "logger">> &
-	IEventProvider<EphemeralRuntimeEvents>;
-
-/**
- * Events emitted by {@link IEphemeralRuntime}.
- * @internal
- */
-export interface EphemeralRuntimeEvents extends IEvent {
-	(event: "connected", listener: (clientId: ClientConnectionId) => void): void;
-	(event: "disconnected", listener: () => void): void;
-}
+	Partial<Pick<IFluidDataStoreRuntime, "logger">>;
 
 /**
  * @internal

--- a/packages/framework/presence/src/internalTypes.ts
+++ b/packages/framework/presence/src/internalTypes.ts
@@ -7,6 +7,7 @@ import type { IContainerRuntime } from "@fluidframework/container-runtime-defini
 import type { IEvent, IEventProvider } from "@fluidframework/core-interfaces";
 import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 
+import type { ClientConnectionId } from "./baseTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { ClientSessionId, ISessionClient } from "./presence.js";
 
@@ -52,7 +53,7 @@ export type IEphemeralRuntime = Pick<
  * @internal
  */
 export interface EphemeralRuntimeEvents extends IEvent {
-	(event: "connected", listener: (clientId: string) => void): void;
+	(event: "connected", listener: (clientId: ClientConnectionId) => void): void;
 	(event: "disconnected", listener: () => void): void;
 }
 

--- a/packages/framework/presence/src/internalTypes.ts
+++ b/packages/framework/presence/src/internalTypes.ts
@@ -4,6 +4,7 @@
  */
 
 import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
+import type { IEvent, IEventProvider } from "@fluidframework/core-interfaces";
 import type { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 
 import type { InternalTypes } from "./exposedInternalTypes.js";
@@ -41,9 +42,19 @@ export const brandedObjectEntries = Object.entries as <K extends string, T>(
  */
 export type IEphemeralRuntime = Pick<
 	(IContainerRuntime & IRuntimeInternal) | IFluidDataStoreRuntime,
-	"clientId" | "connected" | "getAudience" | "getQuorum" | "off" | "on" | "submitSignal"
+	"clientId" | "connected" | "getAudience" | "getQuorum" | "submitSignal"
 > &
-	Partial<Pick<IFluidDataStoreRuntime, "logger">>;
+	Partial<Pick<IFluidDataStoreRuntime, "logger">> &
+	IEventProvider<EphemeralRuntimeEvents>;
+
+/**
+ * Events emitted by {@link IEphemeralRuntime}.
+ * @internal
+ */
+export interface EphemeralRuntimeEvents extends IEvent {
+	(event: "connected", listener: (clientId: string) => void): void;
+	(event: "disconnected", listener: () => void): void;
+}
 
 /**
  * @internal

--- a/packages/framework/presence/src/test/mockEphemeralRuntime.ts
+++ b/packages/framework/presence/src/test/mockEphemeralRuntime.ts
@@ -5,12 +5,13 @@
 
 import { strict as assert } from "node:assert";
 
+import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import type { IClient, ISequencedClient } from "@fluidframework/driver-definitions";
 import { MockAudience, MockQuorumClients } from "@fluidframework/test-runtime-utils/internal";
 
 import type { ClientConnectionId } from "../baseTypes.js";
-import type { IEphemeralRuntime } from "../internalTypes.js";
+import type { EphemeralRuntimeEvents, IEphemeralRuntime } from "../internalTypes.js";
 
 type ClientData = [string, IClient];
 
@@ -66,26 +67,19 @@ function makeMockAudience(clients: ClientData[]): MockAudience {
 /**
  * Mock ephemeral runtime for testing
  */
-export class MockEphemeralRuntime implements IEphemeralRuntime {
+export class MockEphemeralRuntime
+	extends TypedEventEmitter<EphemeralRuntimeEvents>
+	implements IEphemeralRuntime
+{
 	public logger?: ITelemetryBaseLogger;
 	public readonly quorum: MockQuorumClients;
 	public readonly audience: MockAudience;
-
-	public readonly listeners: {
-		connected: ((clientId: ClientConnectionId) => void)[];
-		disconnected: (() => void)[];
-	} = {
-		connected: [],
-		disconnected: [],
-	};
-	private isSupportedEvent(event: string): event is keyof typeof this.listeners {
-		return event in this.listeners;
-	}
 
 	public constructor(
 		logger?: ITelemetryBaseLogger,
 		public readonly signalsExpected: Parameters<IEphemeralRuntime["submitSignal"]>[] = [],
 	) {
+		super();
 		if (logger !== undefined) {
 			this.logger = logger;
 		}
@@ -98,29 +92,6 @@ export class MockEphemeralRuntime implements IEphemeralRuntime {
 		this.getQuorum = () => this.quorum;
 		this.audience = makeMockAudience(clientsData);
 		this.getAudience = () => this.audience;
-		this.on = (
-			event: string,
-			listener: (...args: any[]) => void,
-			// Events style eventing does not lend itself to union that
-			// IEphemeralRuntime is derived from, so we are using `any` here
-			// but meet the intent of the interface.
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		): any => {
-			if (!this.isSupportedEvent(event)) {
-				throw new Error(`Event ${event} is not supported`);
-			}
-			// Switch to allowing a single listener as commented when
-			// implementation uses a single "connected" listener.
-			// if (this.listeners[event]) {
-			// 	throw new Error(`Event ${event} already has a listener`);
-			// }
-			// this.listeners[event] = listener;
-			if (this.listeners[event].length > 1) {
-				throw new Error(`Event ${event} already has multiple listeners`);
-			}
-			this.listeners[event].push(listener);
-			return this;
-		};
 	}
 
 	public assertAllSignalsSubmitted(): void {
@@ -149,14 +120,6 @@ export class MockEphemeralRuntime implements IEphemeralRuntime {
 
 	public clientId: string | undefined;
 	public connected: boolean = false;
-
-	public on: IEphemeralRuntime["on"];
-
-	public off: IEphemeralRuntime["off"] = (
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	): any => {
-		throw new Error("IEphemeralRuntime.off method not implemented.");
-	};
 
 	public getAudience: () => ReturnType<IEphemeralRuntime["getAudience"]>;
 

--- a/packages/framework/presence/src/test/mockEphemeralRuntime.ts
+++ b/packages/framework/presence/src/test/mockEphemeralRuntime.ts
@@ -116,6 +116,17 @@ export class MockEphemeralRuntime
 		this.audience.removeMember(clientId);
 	}
 
+	public connect(clientId: string): void {
+		this.clientId = clientId;
+		this.emit("connected", this.clientId);
+		this.connected = true;
+	}
+
+	public disconnect(): void {
+		this.emit("disconnected");
+		this.connected = false;
+	}
+
 	// #region IEphemeralRuntime
 
 	public clientId: string | undefined;

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -488,11 +488,11 @@ describe("Presence", () => {
 						it.skip("does not update stale attendee status if local client does not reconnect", () => {
 							assert(knownAttendee !== undefined, "No attendee was set in beforeEach");
 
-							// Act - disconnect local client and wait 60s
+							// Act - disconnect local client and advance timer
 							runtime.disconnect();
-							clock.tick(60_000);
+							clock.tick(600_000);
 
-							// Verify - stale attendee should still be 'Connected' after 30+ seconds
+							// Verify - stale attendee should still be 'Connected' if local client never reconnects
 							assert.strictEqual(
 								knownAttendee.getConnectionStatus(),
 								SessionClientStatus.Connected,
@@ -503,15 +503,15 @@ describe("Presence", () => {
 						it.skip("does not update stale attendee status if local client reconnection lasts less than 30s", () => {
 							assert(knownAttendee !== undefined, "No attendee was set in beforeEach");
 
-							// Act - disconnect, reconnect for 15 second, then disconnect local client again
+							// Act - disconnect, reconnect for 15 second, disconnect local client again, then advance timer
 							runtime.disconnect(); // First disconnect
 							clock.tick(1000);
 							runtime.connect("client6"); // Reconnect
 							clock.tick(15_000); // Advance 15 seconds
 							runtime.disconnect(); // Disconnect again
-							clock.tick(60_000); // Advance 60 seconds
+							clock.tick(600_000); // Advance 10 minutes
 
-							// Verify - stale attendee should still be 'Connected' after 30+ seconds post-reconnection
+							// Verify - stale attendee should still be 'Connected' if local client never reconnects for at least 30s
 							assert.strictEqual(
 								knownAttendee.getConnectionStatus(),
 								SessionClientStatus.Connected,
@@ -522,15 +522,15 @@ describe("Presence", () => {
 						it.skip("does not update attendee status to 'Disconnected' if stale attendee rejoins", () => {
 							assert(knownAttendee !== undefined, "No attendee was set in beforeEach");
 
-							// Act - disconnect, reconnect, then process rejoin signal from known attendee after 15s
+							// Act - disconnect, reconnect, process rejoin signal from known attendee after 15s, then advance timer
 							runtime.disconnect();
 							clock.tick(1000);
 							runtime.connect("client6");
 							clock.tick(15_000);
 							const joinedAttendees = processJoinSignals([rejoinAttendeeSignal]);
-							clock.tick(60_000);
+							clock.tick(600_000);
 
-							// Verify - rejoining attendee should still be 'Connected' with no `attendeeJoined` announced 30+ seconds post-reconnection
+							// Verify - rejoining attendee should still be 'Connected' with no `attendeeJoined` announced
 							assert.strictEqual(
 								knownAttendee.getConnectionStatus(),
 								SessionClientStatus.Connected,
@@ -546,7 +546,7 @@ describe("Presence", () => {
 						it.skip("does not update attendee status to 'Disconnected' if stale attendee sends datastore update", () => {
 							assert(knownAttendee !== undefined, "No attendee was set in beforeEach");
 
-							// Act - disconnect, reconnect, process datatstore update signal from known attendee before 30s delay, then wait 60s
+							// Act - disconnect, reconnect, process datatstore update signal from known attendee before 30s delay, then advance timer
 							runtime.disconnect();
 							clock.tick(1000);
 							runtime.connect("client6");
@@ -570,9 +570,9 @@ describe("Presence", () => {
 								},
 								false,
 							);
-							clock.tick(60_000);
+							clock.tick(600_000);
 
-							// Verify - active attendee should still be 'Connected' with no `attendeeDisconnected` announced 30+ seconds post-reconnection
+							// Verify - active attendee should still be 'Connected' with no `attendeeDisconnected` announced
 							assert.strictEqual(
 								knownAttendee.getConnectionStatus(),
 								SessionClientStatus.Connected,

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -442,7 +442,7 @@ describe("Presence", () => {
 						});
 					}
 
-					describe("when local client disconnects", () => {
+					describe("and then local client disconnects", () => {
 						let disconnectedAttendees: ISessionClient[];
 						beforeEach(() => {
 							// Setup

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -468,20 +468,20 @@ describe("Presence", () => {
 							clock.tick(1000);
 							runtime.connect("client6"); // Simulate local client reconnect with new connection id
 
-							// Verify - stale attendee should still be 'Connected' after 15 seconds
+							// Verify - attendee with stale connection should still be 'Connected' after 15 seconds
 							clock.tick(15_001);
 							assert.strictEqual(
 								knownAttendee.getConnectionStatus(),
 								SessionClientStatus.Connected,
-								"Stale attendee should still be 'Connected' after 15s",
+								"Attendee with stale connection should still be 'Connected' after 15s",
 							);
 
-							// Verify - stale attendee should be 'Disconnected' after 30 seconds and announced via `attendeeDisconnected`
+							// Verify - attendee with stale connection should be 'Disconnected' after 30 seconds and announced via `attendeeDisconnected`
 							clock.tick(15_001);
 							assert.strictEqual(
 								knownAttendee.getConnectionStatus(),
 								SessionClientStatus.Disconnected,
-								"Stale attendee should be 'Disconnected' 30s after reconnection",
+								"Attendee with stale connection should be 'Disconnected' 30s after reconnection",
 							);
 							assert.strictEqual(
 								disconnectedAttendees.length,
@@ -497,11 +497,11 @@ describe("Presence", () => {
 							runtime.disconnect();
 							clock.tick(600_000);
 
-							// Verify - stale attendee should still be 'Connected' if local client never reconnects
+							// Verify - attendee with stale connection should still be 'Connected' if local client never reconnects
 							assert.strictEqual(
 								knownAttendee.getConnectionStatus(),
 								SessionClientStatus.Connected,
-								"Stale attendee should still be 'Connected' after 30s",
+								"Attendee with stale connection should still be 'Connected' after 30s",
 							);
 						});
 
@@ -516,11 +516,11 @@ describe("Presence", () => {
 							runtime.disconnect(); // Disconnect again
 							clock.tick(600_000); // Advance 10 minutes
 
-							// Verify - stale attendee should still be 'Connected' if local client never reconnects for at least 30s
+							// Verify - attendee with stale connection should still be 'Connected' if local client never reconnects for at least 30s
 							assert.strictEqual(
 								knownAttendee.getConnectionStatus(),
 								SessionClientStatus.Connected,
-								"Stale attendee should still be 'Connected' after 30s",
+								"Attendee with stale connection should still be 'Connected' after 30s",
 							);
 						});
 
@@ -651,20 +651,20 @@ describe("Presence", () => {
 							clock.tick(1000);
 							runtime.connect("client7");
 
-							// Verify - stale attendee should still be connected after 15 seconds
+							// Verify - attendee with stale connection should still be connected after 15 seconds
 							clock.tick(15_001);
 							assert.strictEqual(
 								knownAttendee.getConnectionStatus(),
 								SessionClientStatus.Connected,
-								"Stale attendee should still be connected",
+								"Attendee with stale connection should still be connected",
 							);
 
-							// Verify - stale attendee should be disconnected after 30 seconds
+							// Verify - attendee with stale connection should be disconnected after 30 seconds
 							clock.tick(15_001);
 							assert.equal(
 								knownAttendee.getConnectionStatus(),
 								SessionClientStatus.Disconnected,
-								"Stale attendee has wrong status",
+								"Attendee with stale connection has wrong status",
 							);
 							assert.strictEqual(
 								disconnectedAttendees.length,

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -444,8 +444,8 @@ describe("Presence", () => {
 
 					// When local client disconnects, we lose the connectivity status updates for remote attendees in the session.
 					// Upon reconnect, we mark all remote attendees connections as "stale".
-					// Remote attendees with stale connections are given 30 seconds after local reconnection to show signs of life
-					// before their connection status set to "Disconnected".
+					// Remote attendees with stale connections are given 30 seconds after local reconnection to prove they are connected
+					// (e.g. being in audience, sending an update, (re)joining the session, etc.) before their connection status set to "Disconnected".
 					// If an attendee with a stale connection becomes active, their "stale" status is removed.
 					describe("and then local client disconnects", () => {
 						let disconnectedAttendees: ISessionClient[];

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -485,8 +485,12 @@ describe("Presence", () => {
 						});
 						it.skip("updates stale attendees status to 'Disconnected", () => {
 							// Setup
-							assert(knownAttendee !== undefined, "No attendee was set in beforeEach");
-							assert(knownAttendee.getConnectionStatus() === SessionClientStatus.Connected);
+							assert.ok(knownAttendee, "No attendee was set in beforeEach");
+							assert.strictEqual(
+								knownAttendee.getConnectionStatus(),
+								SessionClientStatus.Connected,
+								"Known attendee is not connected",
+							);
 
 							// Act - disconnect & reconnect local client
 							runtime.emit("disconnected"); // Simulate local client disconnect
@@ -495,9 +499,57 @@ describe("Presence", () => {
 
 							// Verify - stale attendee should still be connected after 15 seconds
 							clock.tick(15001);
-							assert(knownAttendee.getConnectionStatus() === SessionClientStatus.Connected);
+							assert.strictEqual(
+								knownAttendee.getConnectionStatus(),
+								SessionClientStatus.Connected,
+								"Stale attendee should still be connected",
+							);
 
 							// Verify - stale attendee should be disconnected after 30 seconds
+							clock.tick(15001);
+							assert.strictEqual(
+								knownAttendee.getConnectionStatus(),
+								SessionClientStatus.Disconnected,
+								"Stale attendee has wrong status",
+							);
+						});
+
+						it.skip("updates stale attendees status to 'Disconnected' afer multiple reconnects", () => {
+							// Setup
+							assert.ok(knownAttendee, "No attendee was set in beforeEach");
+							assert.strictEqual(
+								knownAttendee.getConnectionStatus(),
+								SessionClientStatus.Connected,
+								"Known attendee is not connected",
+							);
+
+							// Act - disconnect & reconnect local client
+							runtime.emit("disconnected"); // Simulate local client disconnect
+							clock.tick(1000);
+							runtime.emit("connected", rejoinAttendeeConnectionId); // Sinulate local client reconnect with new connection id
+
+							// Verify - stale attendee should still be connected after 15 seconds
+							clock.tick(15001);
+							assert.strictEqual(
+								knownAttendee.getConnectionStatus(),
+								SessionClientStatus.Connected,
+								"Stale attendee should still be connected",
+							);
+
+							// Act - disconnect & reconnect local client
+							runtime.emit("disconnected"); // Simulate local client disconnect
+							clock.tick(1000);
+							runtime.emit("connected", rejoinAttendeeConnectionId); // Sinulate local client reconnect with new connection id
+
+							// Verify - stale attendee should still be connected after 15 seconds
+							clock.tick(15001);
+							assert.strictEqual(
+								knownAttendee.getConnectionStatus(),
+								SessionClientStatus.Connected,
+								"Stale attendee should still be connected",
+							);
+
+							// Verify - stale attendee
 							clock.tick(15001);
 							assert.equal(
 								knownAttendee.getConnectionStatus(),

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -294,13 +294,13 @@ describe("Presence", () => {
 							clientConnectionId: newAttendeeConnectionId,
 							updateProviders: [initialAttendeeConnectionId],
 							connectionOrder: 1,
-							priorClientToSessionId:  {
+							priorClientToSessionId: {
 								[oldAttendeeConnectionId]: {
 									rev: 0,
 									timestamp: 0,
 									value: "collateral-id",
 								},
-							}
+							},
 						});
 
 						const responseSignal = generateBasicClientJoin(clock.now - 5, {
@@ -503,9 +503,9 @@ describe("Presence", () => {
 							);
 
 							// Act - disconnect & reconnect local client
-							runtime.emit("disconnected"); // Simulate local client disconnect
+							runtime.disconnect(); // Simulate local client disconnect
 							clock.tick(1000);
-							runtime.emit("connected", rejoinAttendeeConnectionId); // Sinulate local client reconnect with new connection id
+							runtime.connect(rejoinAttendeeConnectionId); // Sinulate local client reconnect with new connection id
 
 							// Verify - stale attendee should still be connected after 15 seconds
 							clock.tick(15001);
@@ -534,9 +534,9 @@ describe("Presence", () => {
 							);
 
 							// Act - disconnect & reconnect local client
-							runtime.emit("disconnected"); // Simulate local client disconnect
+							runtime.disconnect(); // Simulate local client disconnect
 							clock.tick(1000);
-							runtime.emit("connected", rejoinAttendeeConnectionId); // Sinulate local client reconnect with new connection id
+							runtime.connect(rejoinAttendeeConnectionId); // Sinulate local client reconnect with new connection id
 
 							// Verify - stale attendee should still be connected after 15 seconds
 							clock.tick(15001);
@@ -547,9 +547,9 @@ describe("Presence", () => {
 							);
 
 							// Act - disconnect & reconnect local client
-							runtime.emit("disconnected"); // Simulate local client disconnect
+							runtime.disconnect(); // Simulate local client disconnect
 							clock.tick(1000);
-							runtime.emit("connected", rejoinAttendeeConnectionId); // Sinulate local client reconnect with new connection id
+							runtime.connect("client7"); // Sinulate local client reconnect with new connection id
 
 							// Verify - stale attendee should still be connected after 15 seconds
 							clock.tick(15001);

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -489,9 +489,9 @@ describe("Presence", () => {
 							assert(knownAttendee.getConnectionStatus() === SessionClientStatus.Connected);
 
 							// Act - disconnect & reconnect local client
-							runtime.emit("disconnected");
+							runtime.emit("disconnected"); // Simulate local client disconnect
 							clock.tick(1000);
-							runtime.emit("connected", rejoinAttendeeConnectionId);
+							runtime.emit("connected", rejoinAttendeeConnectionId); // Sinulate local client reconnect with new connection id
 
 							// Verify - stale attendee should still be connected after 15 seconds
 							clock.tick(15001);

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -460,7 +460,7 @@ describe("Presence", () => {
 							);
 						});
 
-						it.skip("updates status of attendee with stale connection to 'Disconnected' after 30s delay upon local reconnection", () => {
+						it.skip("updates status of attendee with stale connection after 30s delay upon local reconnection", () => {
 							assert(knownAttendee !== undefined, "No attendee was set in beforeEach");
 
 							// Act - disconnect & reconnect local client
@@ -524,7 +524,7 @@ describe("Presence", () => {
 							);
 						});
 
-						it.skip("does not update status of attendee with stale connection to 'Disconnected' if attendee rejoins", () => {
+						it.skip("does not update status of attendee with stale connection if attendee rejoins", () => {
 							assert(knownAttendee !== undefined, "No attendee was set in beforeEach");
 
 							// Setup - fail if attendee joined is announced
@@ -552,7 +552,7 @@ describe("Presence", () => {
 							);
 						});
 
-						it.skip("does not update status of attendee with stale connection to 'Disconnected' if attendee sends datastore update", () => {
+						it.skip("does not update status of attendee with stale connection if attendee sends datastore update", () => {
 							assert(knownAttendee !== undefined, "No attendee was set in beforeEach");
 
 							// Setup - fail if attendee joined is announced
@@ -631,7 +631,7 @@ describe("Presence", () => {
 							);
 						});
 
-						it.skip("updates status of attendee with stale connection to 'Disconnected' only 30s after most recent local reconnection", () => {
+						it.skip("updates status of attendee with stale connection only 30s after most recent local reconnection", () => {
 							// Setup
 							assert(knownAttendee !== undefined, "No attendee was set in beforeEach");
 							assert.strictEqual(

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -294,6 +294,13 @@ describe("Presence", () => {
 							clientConnectionId: newAttendeeConnectionId,
 							updateProviders: [initialAttendeeConnectionId],
 							connectionOrder: 1,
+							priorClientToSessionId:  {
+								[oldAttendeeConnectionId]: {
+									rev: 0,
+									timestamp: 0,
+									value: "collateral-id",
+								},
+							}
 						});
 
 						const responseSignal = generateBasicClientJoin(clock.now - 5, {
@@ -312,6 +319,7 @@ describe("Presence", () => {
 							},
 						});
 
+						// Process initial join signal so initial attendee is known
 						const joinedAttendees = processJoinSignals([initialAttendeeSignal]);
 						assert.strictEqual(
 							joinedAttendees.length,
@@ -335,6 +343,8 @@ describe("Presence", () => {
 							0,
 							"Expected no attendees to be announced",
 						);
+						// Verify attendee information remains unchanged
+						verifyAttendee(rejoinAttendees[0], newAttendeeConnectionId, "collateral-id");
 					});
 				});
 

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -598,7 +598,7 @@ describe("Presence", () => {
 							);
 						});
 
-						it.skip("marks attendee with stale connection as active when attendee disconnects after local reconnection", () => {
+						it.skip("announces `attendeeDisconnected` once when remote client disconnects after local client reconnects", () => {
 							assert(knownAttendee !== undefined, "No attendee was set in beforeEach");
 
 							// Setup - initial attendee joins before local client disconnects

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -598,7 +598,7 @@ describe("Presence", () => {
 							);
 						});
 
-						it.skip("marks attendee with stale conneciton as active when attendee disconnects after local reconnection", () => {
+						it.skip("marks attendee with stale connection as active when attendee disconnects after local reconnection", () => {
 							assert(knownAttendee !== undefined, "No attendee was set in beforeEach");
 
 							// Setup - initial attendee joins before local client disconnects

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -445,7 +445,7 @@ describe("Presence", () => {
 					// When local client disconnects, we lose the connectivity status updates for remote attendees in the session.
 					// Upon reconnect, we mark all remote attendees connections as "stale".
 					// Remote attendees with stale connections are given 30 seconds after local reconnection to prove they are connected
-					// (e.g. being in audience, sending an update, (re)joining the session, etc.) before their connection status set to "Disconnected".
+					// (e.g. being in audience, sending an update, or (re)joining the session) before their connection status set to "Disconnected".
 					// If an attendee with a stale connection becomes active, their "stale" status is removed.
 					describe("and then local client disconnects", () => {
 						let disconnectedAttendees: ISessionClient[];

--- a/packages/framework/presence/src/test/presenceManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceManager.spec.ts
@@ -610,7 +610,7 @@ describe("Presence", () => {
 							runtime.connect("client6");
 							clock.tick(15_001);
 							runtime.audience.removeMember(initialAttendeeConnectionId); // Remove remote client connection before 30s timeout
-							// Confirm that `attendeeDisconnected` is emitted for when active attendee disconnects
+							// Confirm that `attendeeDisconnected` is announced for when active attendee disconnects
 							assert.strictEqual(
 								disconnectedAttendees.length,
 								1,
@@ -618,7 +618,7 @@ describe("Presence", () => {
 							);
 							clock.tick(600_000);
 
-							// Verify - active attendee status should be 'Disconnected' and no other `attendeeDisconnected` should be emitted.
+							// Verify - active attendee status should be 'Disconnected' and no other `attendeeDisconnected` should be announced.
 							assert.strictEqual(
 								knownAttendee.getConnectionStatus(),
 								SessionClientStatus.Disconnected,


### PR DESCRIPTION
## Description

There are 6 tests that are added (and disabled) in this PR. 

The first test is to verify that old collateral connections do not effect the connection status of remote attendees. This scenario was written as an edge case to [old solution](https://github.com/microsoft/FluidFramework/pull/23113#discussion_r1844596112) where old connection information sent in a join response would result in the attendee connection status being set to 'Disconnected'.

The next five have to do with stale remote attendee's connection status upon local client reconnect scenarios:

```
Presence
  PresenceManager
    when connected
      attendee
        that is joining
          - as collateral with old connection info and connected is NOT announced via `attendeeJoined
        that is already known
          and then local client disconnects
            - updates status of attendee with stale connection after 30s delay upon local reconnection
            - does not update status of attendee with stale connection if local client does not reconnect
            - does not update status of attendee with stale connection if local client reconnection lasts less than 30s
            - does not update status of attendee with stale connection if attendee rejoins
            - does not update status of attendee with stale connection if attendee sends datastore update
            - marks attendee with stale connection as active when attendee disconnects after local reconnection
            - updates status of attendee with stale connection only 30s after most recent local reconnection
```

I added connect() and disconnect() function to MockEphemeralRuntime that manipulates the connection state of the local client.