### PR TITLE
feat(Container): Add IContainer.closedWithError to access the error that closed or disposed the container

### DIFF
--- a/.changeset/busy-mangos-ask.md
+++ b/.changeset/busy-mangos-ask.md
@@ -5,7 +5,7 @@
 "section": feature
 ---
 
-IContainer.criticalError added to access which error closed the container
+IContainer.closedWithError added to access which error closed the container
 
 Once the container is closed or disposed with an error, this property will be set to that error.
 

--- a/.changeset/busy-mangos-ask.md
+++ b/.changeset/busy-mangos-ask.md
@@ -1,0 +1,17 @@
+---
+"@fluidframework/container-definitions": minor
+---
+---
+"section": feature
+---
+
+IContainer.criticalError added to access which error closed the container
+
+Once the container is closed or disposed with an error, this property will be set to that error.
+
+Note that this error is also readily available via the "closed" and "disposed" events.
+
+However, there is a race condition during `Container.load` that results in a closed container being returned (as opposed to the error being thrown),
+with no opportunity for the caller to listen to the "closed" event.
+
+This API closes that gap, so after container load fails you always can determine the cause.

--- a/.changeset/busy-mangos-ask.md
+++ b/.changeset/busy-mangos-ask.md
@@ -7,9 +7,10 @@
 
 IContainer.closedWithError added to access which error closed the container
 
-Once the container is closed or disposed with an error, this property will be set to that error.
+Once the container is closed with an error, this property will be set to that error.
+(If the container is disposed with an error _without first being closed_, that error will be reported here)
 
-Note that this error is also readily available via the "closed" and "disposed" events.
+Note that this error is also readily available via the "closed" or "disposed" event.
 
 However, there is a race condition during `Container.load` that results in a closed container being returned (as opposed to the error being thrown),
 with no opportunity for the caller to listen to the "closed" event.

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
@@ -100,10 +100,10 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
     readonly clientId?: string | undefined;
     close(error?: ICriticalContainerError): void;
     readonly closed: boolean;
+    readonly closedWithError?: ICriticalContainerError | undefined;
     connect(): void;
     readonly connectionState: ConnectionState;
     containerMetadata: Record<string, string>;
-    readonly criticalError?: ICriticalContainerError;
     deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     disconnect(): void;
     dispose(error?: ICriticalContainerError): void;

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
@@ -103,6 +103,7 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
     connect(): void;
     readonly connectionState: ConnectionState;
     containerMetadata: Record<string, string>;
+    readonly criticalError?: ICriticalContainerError;
     deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     disconnect(): void;
     dispose(error?: ICriticalContainerError): void;

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -364,24 +364,6 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	 */
 	getContainerPackageInfo?(): IContainerPackageInfo | undefined;
 
-	//* Copilot's opinion :P
-	// readonly status: {
-	// 	readonly connected: boolean;
-	// 	readonly readonly: boolean;
-	// 	readonly dirty: boolean;
-	// 	readonly attached: boolean;
-	// 	readonly version: string | undefined;
-	// 	readonly audience: IAudience;
-	// 	readonly clientId: string | undefined;
-	// 	readonly connectionState: ConnectionState;
-	// 	readonly resolvedUrl: IResolvedUrl | undefined;
-	// 	readonly attachState: AttachState;
-	// 	readonly codeDetails: IFluidCodeDetails | undefined;
-	// 	readonly loadedCodeDetails: IFluidCodeDetails | undefined;
-	// 	readonly packageInfo: IContainerPackageInfo | undefined;
-	// 	readonly containerMetadata: Record<string, string>;
-	// }
-
 	/**
 	 * Returns true if the container has been closed and/or disposed, otherwise false.
 	 */
@@ -391,6 +373,13 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	 * Returns true if the container has been disposed, otherwise false.
 	 */
 	readonly disposed?: boolean;
+
+	/**
+	 * Critical/fatal error that caused the container to close or dispose.
+	 *
+	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
+	 */
+	readonly criticalError?: ICriticalContainerError;
 
 	/**
 	 * Whether or not there are any local changes that have not been saved.

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -364,6 +364,24 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	 */
 	getContainerPackageInfo?(): IContainerPackageInfo | undefined;
 
+	//* Copilot's opinion :P
+	// readonly status: {
+	// 	readonly connected: boolean;
+	// 	readonly readonly: boolean;
+	// 	readonly dirty: boolean;
+	// 	readonly attached: boolean;
+	// 	readonly version: string | undefined;
+	// 	readonly audience: IAudience;
+	// 	readonly clientId: string | undefined;
+	// 	readonly connectionState: ConnectionState;
+	// 	readonly resolvedUrl: IResolvedUrl | undefined;
+	// 	readonly attachState: AttachState;
+	// 	readonly codeDetails: IFluidCodeDetails | undefined;
+	// 	readonly loadedCodeDetails: IFluidCodeDetails | undefined;
+	// 	readonly packageInfo: IContainerPackageInfo | undefined;
+	// 	readonly containerMetadata: Record<string, string>;
+	// }
+
 	/**
 	 * Returns true if the container has been closed and/or disposed, otherwise false.
 	 */

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -377,7 +377,8 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	/**
 	 * The error that caused the container to close or dispose.
 	 *
-	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
+	 * @remarks If the container is closed first and then later disposed,
+	 * this will be the error from the close (even if undefined), not the dispose.
 	 */
 	readonly closedWithError?: ICriticalContainerError | undefined;
 

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -375,11 +375,11 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	readonly disposed?: boolean;
 
 	/**
-	 * Critical/fatal error that caused the container to close or dispose.
+	 * The error that caused the container to close or dispose.
 	 *
 	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
 	 */
-	readonly criticalError?: ICriticalContainerError | undefined;
+	readonly closedWithError?: ICriticalContainerError | undefined;
 
 	/**
 	 * Whether or not there are any local changes that have not been saved.

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -379,7 +379,7 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	 *
 	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
 	 */
-	readonly criticalError?: ICriticalContainerError;
+	readonly criticalError?: ICriticalContainerError | undefined;
 
 	/**
 	 * Whether or not there are any local changes that have not been saved.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -585,9 +585,9 @@ export class Container
 	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
 	 */
 	public get closedWithError(): ICriticalContainerError | undefined {
-		return this._criticalError;
+		return this._closedWithError;
 	}
-	private _criticalError?: ICriticalContainerError;
+	private _closedWithError?: ICriticalContainerError;
 
 	private readonly storageAdapter: ContainerStorageAdapter;
 
@@ -1138,7 +1138,7 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "closed";
-			this._criticalError = error;
+			this._closedWithError = error;
 
 			// There is no user for summarizer, so we need to ensure dispose is called
 			if (this.client.details.type === summarizerClientType) {
@@ -1160,9 +1160,9 @@ export class Container
 				this.mc.logger.sendTelemetryEvent(
 					{
 						eventName: "ContainerDispose",
-						// Use error category if there's an error, unless we already closed with an error (i.e. _criticalError is set)
+						// Use error category if there's an error, unless we already closed with an error (i.e. _closedWithError is set)
 						category:
-							error !== undefined && this._criticalError === undefined ? "error" : "generic",
+							error !== undefined && this._closedWithError === undefined ? "error" : "generic",
 					},
 					error,
 				);
@@ -1199,9 +1199,9 @@ export class Container
 			this._lifecycleState = "disposed";
 			// Corner cases that are expressed imprecisely here:
 			// When disposing with an error...
-			// - if we closed with an error, _criticalError doesn't expose the dispose error.
-			// - if we closed without an error, _criticalError doesn't distinguish whether this error came from close or dispose.
-			this._criticalError ??= error;
+			// - if we closed with an error, _closedWithError doesn't expose the dispose error.
+			// - if we closed without an error, _closedWithError doesn't distinguish whether this error came from close or dispose.
+			this._closedWithError ??= error;
 			this._lifecycleEvents.emit("disposed");
 		}
 	}

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1118,6 +1118,7 @@ export class Container
 				);
 
 				this._lifecycleState = "closing";
+				this._closedWithError = error;
 
 				// Back-compat for Old driver
 				if (this.service?.off !== undefined) {
@@ -1138,7 +1139,6 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "closed";
-			this._closedWithError = error;
 
 			// There is no user for summarizer, so we need to ensure dispose is called
 			if (this.client.details.type === summarizerClientType) {
@@ -1172,6 +1172,12 @@ export class Container
 					this._lifecycleState = "disposing";
 				}
 
+				// Corner cases that are expressed imprecisely here:
+				// When disposing with an error after the Container is already closed...
+				// - if we closed with an error, _closedWithError doesn't expose the dispose error.
+				// - if we closed without an error, _closedWithError doesn't distinguish whether this error came from close or dispose.
+				this._closedWithError ??= error;
+
 				this._protocolHandler?.close();
 
 				this.connectionStateHandler.dispose();
@@ -1197,11 +1203,6 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "disposed";
-			// Corner cases that are expressed imprecisely here:
-			// When disposing with an error...
-			// - if we closed with an error, _closedWithError doesn't expose the dispose error.
-			// - if we closed without an error, _closedWithError doesn't distinguish whether this error came from close or dispose.
-			this._closedWithError ??= error;
 			this._lifecycleEvents.emit("disposed");
 		}
 	}

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -580,11 +580,11 @@ export class Container
 	}
 
 	/**
-	 * Critical/fatal error that caused the container to close or dispose.
+	 * The error that caused the container to close or dispose.
 	 *
 	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
 	 */
-	public get criticalError(): ICriticalContainerError | undefined {
+	public get closedWithError(): ICriticalContainerError | undefined {
 		return this._criticalError;
 	}
 	private _criticalError?: ICriticalContainerError;
@@ -1197,12 +1197,11 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "disposed";
-			// Corner cases that are expressed imprecisely here: When disposing with an error...
-			// - If we closed with an error, _criticalError doesn't expose the dispose error.
-			// - If we closed without an error, _criticalError doesn't distinguish whether this error came from close or dispose.
-			if (this._criticalError === undefined) {
-				this._criticalError = error;
-			}
+			// Corner cases that are expressed imprecisely here:
+			// When disposing with an error...
+			// - if we closed with an error, _criticalError doesn't expose the dispose error.
+			// - if we closed without an error, _criticalError doesn't distinguish whether this error came from close or dispose.
+			this._criticalError ??= error;
 			this._lifecycleEvents.emit("disposed");
 		}
 	}

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -579,6 +579,15 @@ export class Container
 		return this._lifecycleState === "disposing" || this._lifecycleState === "disposed";
 	}
 
+	private _closedWithError?: ICriticalContainerError;
+
+	public get closedWithError(): ICriticalContainerError | undefined {
+		if (this.closed) {
+			return this._closedWithError;
+		}
+		return undefined;
+	}
+
 	private readonly storageAdapter: ContainerStorageAdapter;
 
 	private readonly _deltaManager: DeltaManager<ConnectionManager>;
@@ -1128,6 +1137,7 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "closed";
+			this._closedWithError = error;
 
 			// There is no user for summarizer, so we need to ensure dispose is called
 			if (this.client.details.type === summarizerClientType) {
@@ -1185,6 +1195,10 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "disposed";
+			//* Double-check this logic
+			if (this._closedWithError === undefined) {
+				this._closedWithError = error;
+			}
 			this._lifecycleEvents.emit("disposed");
 		}
 	}

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -579,14 +579,15 @@ export class Container
 		return this._lifecycleState === "disposing" || this._lifecycleState === "disposed";
 	}
 
-	private _closedWithError?: ICriticalContainerError;
-
-	public get closedWithError(): ICriticalContainerError | undefined {
-		if (this.closed) {
-			return this._closedWithError;
-		}
-		return undefined;
+	/**
+	 * Critical/fatal error that caused the container to close or dispose.
+	 *
+	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
+	 */
+	public get criticalError(): ICriticalContainerError | undefined {
+		return this._criticalError;
 	}
+	private _criticalError?: ICriticalContainerError;
 
 	private readonly storageAdapter: ContainerStorageAdapter;
 
@@ -1137,7 +1138,7 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "closed";
-			this._closedWithError = error;
+			this._criticalError = error;
 
 			// There is no user for summarizer, so we need to ensure dispose is called
 			if (this.client.details.type === summarizerClientType) {
@@ -1159,8 +1160,9 @@ export class Container
 				this.mc.logger.sendTelemetryEvent(
 					{
 						eventName: "ContainerDispose",
-						// Only log error if container isn't closed
-						category: !this.closed && error !== undefined ? "error" : "generic",
+						// Use error category if there's an error, unless we already closed with an error (i.e. _criticalError is set)
+						category:
+							error !== undefined && this._criticalError === undefined ? "error" : "generic",
 					},
 					error,
 				);
@@ -1195,9 +1197,11 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "disposed";
-			//* Double-check this logic
-			if (this._closedWithError === undefined) {
-				this._closedWithError = error;
+			// Corner cases that are expressed imprecisely here: When disposing with an error...
+			// - If we closed with an error, _criticalError doesn't expose the dispose error.
+			// - If we closed without an error, _criticalError doesn't distinguish whether this error came from close or dispose.
+			if (this._criticalError === undefined) {
+				this._criticalError = error;
 			}
 			this._lifecycleEvents.emit("disposed");
 		}

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -691,7 +691,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 				() => runtimeDispose++,
 			);
 
-			container.dispose(new DataCorruptionError("expected", {}));
+			container.dispose(new DataCorruptionError("dispose error", {}));
 			assert.strictEqual(
 				containerDisposed,
 				1,
@@ -716,6 +716,11 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 				runtimeDispose,
 				1,
 				"IContainerRuntime should send dispose event on container dispose",
+			);
+			assert.strictEqual(
+				container.criticalError?.message,
+				"dispose error",
+				"Expected the error that disposed the container",
 			);
 		},
 	);
@@ -744,13 +749,56 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 				() => runtimeDispose++,
 			);
 
-			container.close(new DataCorruptionError("expected", {}));
-			container.dispose(new DataCorruptionError("expected", {}));
+			container.close(new DataCorruptionError("close error", {}));
+			container.dispose(new DataCorruptionError("dispose error", {}));
 			assert.strictEqual(containerDisposed, 1, "Container should send disposed event");
 			assert.strictEqual(containerClosed, 1, "Container should send closed event");
 			assert.strictEqual(deltaManagerDisposed, 1, "DeltaManager should send disposed event");
 			assert.strictEqual(deltaManagerClosed, 1, "DeltaManager should send closed event");
 			assert.strictEqual(runtimeDispose, 1, "IContainerRuntime should send dispose event");
+			assert.strictEqual(
+				container.criticalError?.message,
+				"close error",
+				"Expected the error that closed the container (not the dispose one)",
+			);
+		},
+	);
+
+	itExpects(
+		"Closing (no error) then disposing (with error) container should set criticalError properly",
+		[
+			{ eventName: "fluid:telemetry:Container:ContainerClose", category: "generic" },
+			{ eventName: "fluid:telemetry:Container:ContainerDispose", category: "error" },
+		],
+		async () => {
+			const container = await createConnectedContainer();
+			container.close();
+			container.dispose(new DataCorruptionError("dispose error", {}));
+
+			assert.strictEqual(
+				container.criticalError?.message,
+				"dispose error",
+				"Expected the error that disposed the container",
+			);
+		},
+	);
+
+	itExpects(
+		"Closing (with error) then disposing (no error) container should set criticalError properly",
+		[
+			{ eventName: "fluid:telemetry:Container:ContainerClose", category: "error" },
+			{ eventName: "fluid:telemetry:Container:ContainerDispose", category: "generic" },
+		],
+		async () => {
+			const container = await createConnectedContainer();
+			container.close(new DataCorruptionError("close error", {}));
+			container.dispose();
+
+			assert.strictEqual(
+				container.criticalError?.message,
+				"close error",
+				"Expected the error that closed the container",
+			);
 		},
 	);
 

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -765,7 +765,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 	);
 
 	itExpects(
-		"Closing (no error) then disposing (with error) container should set closedWithError properly",
+		"Closing (no error) then disposing (with error) container leaves closedWithError unset",
 		[
 			{ eventName: "fluid:telemetry:Container:ContainerClose", category: "generic" },
 			{ eventName: "fluid:telemetry:Container:ContainerDispose", category: "error" },
@@ -776,9 +776,9 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 			container.dispose(new DataCorruptionError("dispose error", {}));
 
 			assert.strictEqual(
-				container.closedWithError?.message,
-				"dispose error",
-				"Expected the error that disposed the container",
+				container.closedWithError,
+				undefined,
+				"Expected undefined since the container was closed without error",
 			);
 		},
 	);

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -718,7 +718,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 				"IContainerRuntime should send dispose event on container dispose",
 			);
 			assert.strictEqual(
-				container.criticalError?.message,
+				container.closedWithError?.message,
 				"dispose error",
 				"Expected the error that disposed the container",
 			);
@@ -757,7 +757,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 			assert.strictEqual(deltaManagerClosed, 1, "DeltaManager should send closed event");
 			assert.strictEqual(runtimeDispose, 1, "IContainerRuntime should send dispose event");
 			assert.strictEqual(
-				container.criticalError?.message,
+				container.closedWithError?.message,
 				"close error",
 				"Expected the error that closed the container (not the dispose one)",
 			);
@@ -765,7 +765,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 	);
 
 	itExpects(
-		"Closing (no error) then disposing (with error) container should set criticalError properly",
+		"Closing (no error) then disposing (with error) container should set closedWithError properly",
 		[
 			{ eventName: "fluid:telemetry:Container:ContainerClose", category: "generic" },
 			{ eventName: "fluid:telemetry:Container:ContainerDispose", category: "error" },
@@ -776,7 +776,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 			container.dispose(new DataCorruptionError("dispose error", {}));
 
 			assert.strictEqual(
-				container.criticalError?.message,
+				container.closedWithError?.message,
 				"dispose error",
 				"Expected the error that disposed the container",
 			);
@@ -784,7 +784,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 	);
 
 	itExpects(
-		"Closing (with error) then disposing (no error) container should set criticalError properly",
+		"Closing (with error) then disposing (no error) container should set closedWithError properly",
 		[
 			{ eventName: "fluid:telemetry:Container:ContainerClose", category: "error" },
 			{ eventName: "fluid:telemetry:Container:ContainerDispose", category: "generic" },
@@ -795,7 +795,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 			container.dispose();
 
 			assert.strictEqual(
-				container.criticalError?.message,
+				container.closedWithError?.message,
 				"close error",
 				"Expected the error that closed the container",
 			);


### PR DESCRIPTION
## Description

Fixes [AB#13773](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/13773)

Two cases I know of where one would want to be able to inspect a closed container to see what the error was:

* A race condition where the container closes _while_ `Container.load` is returning it (interleaved microtasks), so the "closed" event never fires and the error is not thrown.
* If another API is called after the container is closed, resulting in a `UsageError`, and the caller didn't expect the container to be closed and wants to know why (for debugging or telemetry purposes)

## Breaking Changes

Nope, it's adding an optional property to an interface.

## Reviewer Guidance

@microsoft/fluid-cr-api -- Please provide feedback / suggestions on the naming and semantics of this new API.  I tried to keep it simple, at the cost of some ambiguity in corner cases (e.g. when you close and dispose with different errors).