### PR TITLE
refactor: Rename `ConfigurationBase` to `LoggingConfiguration`

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 Combines the separate "config" property bag parameters into a single "options" property bag for simplicity.
 
+#### Type-renames
+
+-   `ConfigurationBase` -\> `LoggingConfiguration`.
+
 ##### Example
 
 Before:

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -48,7 +48,7 @@ export { ApiItem }
 export { ApiItemKind }
 
 // @public
-export interface ApiItemTransformationConfiguration extends ApiItemTransformationOptions, DocumentationSuiteOptions, ConfigurationBase {
+export interface ApiItemTransformationConfiguration extends ApiItemTransformationOptions, DocumentationSuiteOptions, LoggingConfiguration {
     apiModel: ApiModel;
     readonly uriRoot: string;
 }
@@ -141,11 +141,6 @@ export class CodeSpanNode extends DocumentationParentNodeBase<SingleLineDocument
     static readonly Empty: CodeSpanNode;
     get singleLine(): true;
     readonly type = DocumentationNodeType.CodeSpan;
-}
-
-// @public
-export interface ConfigurationBase {
-    readonly logger?: Logger;
 }
 
 // @public
@@ -508,7 +503,7 @@ export class LinkNode extends DocumentationParentNodeBase<SingleLineDocumentatio
 export function lintApiModel(configuration: LintApiModelConfiguration): Promise<LinterErrors | undefined>;
 
 // @beta
-export interface LintApiModelConfiguration extends ConfigurationBase {
+export interface LintApiModelConfiguration extends LoggingConfiguration {
     apiModel: ApiModel;
 }
 
@@ -530,7 +525,7 @@ export interface LinterReferenceError {
 export function loadModel(options: LoadModelOptions): Promise<ApiModel>;
 
 // @public
-export interface LoadModelOptions extends ConfigurationBase {
+export interface LoadModelOptions extends LoggingConfiguration {
     readonly modelDirectoryPath: string;
 }
 
@@ -544,10 +539,15 @@ export interface Logger {
 }
 
 // @public
+export interface LoggingConfiguration {
+    readonly logger?: Logger;
+}
+
+// @public
 export type LoggingFunction = (message: string | Error, ...parameters: unknown[]) => void;
 
 // @public
-export interface MarkdownRenderConfiguration extends ConfigurationBase {
+export interface MarkdownRenderConfiguration extends LoggingConfiguration {
     readonly customRenderers?: MarkdownRenderers;
     readonly startingHeadingLevel?: number;
 }
@@ -773,7 +773,7 @@ export interface TextFormatting {
 }
 
 // @public
-export interface ToHtmlConfig extends ConfigurationBase {
+export interface ToHtmlConfig extends LoggingConfiguration {
     readonly customTransformations?: ToHtmlTransformations;
     readonly language?: string;
     readonly rootFormatting?: TextFormatting;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -48,7 +48,7 @@ export { ApiItem }
 export { ApiItemKind }
 
 // @public
-export interface ApiItemTransformationConfiguration extends ApiItemTransformationOptions, DocumentationSuiteOptions, ConfigurationBase {
+export interface ApiItemTransformationConfiguration extends ApiItemTransformationOptions, DocumentationSuiteOptions, LoggingConfiguration {
     apiModel: ApiModel;
     readonly uriRoot: string;
 }
@@ -141,11 +141,6 @@ export class CodeSpanNode extends DocumentationParentNodeBase<SingleLineDocument
     static readonly Empty: CodeSpanNode;
     get singleLine(): true;
     readonly type = DocumentationNodeType.CodeSpan;
-}
-
-// @public
-export interface ConfigurationBase {
-    readonly logger?: Logger;
 }
 
 // @public
@@ -508,7 +503,7 @@ export class LinkNode extends DocumentationParentNodeBase<SingleLineDocumentatio
 export function lintApiModel(configuration: LintApiModelConfiguration): Promise<LinterErrors | undefined>;
 
 // @beta
-export interface LintApiModelConfiguration extends ConfigurationBase {
+export interface LintApiModelConfiguration extends LoggingConfiguration {
     apiModel: ApiModel;
 }
 
@@ -530,7 +525,7 @@ export interface LinterReferenceError {
 export function loadModel(options: LoadModelOptions): Promise<ApiModel>;
 
 // @public
-export interface LoadModelOptions extends ConfigurationBase {
+export interface LoadModelOptions extends LoggingConfiguration {
     readonly modelDirectoryPath: string;
 }
 
@@ -544,10 +539,15 @@ export interface Logger {
 }
 
 // @public
+export interface LoggingConfiguration {
+    readonly logger?: Logger;
+}
+
+// @public
 export type LoggingFunction = (message: string | Error, ...parameters: unknown[]) => void;
 
 // @public
-export interface MarkdownRenderConfiguration extends ConfigurationBase {
+export interface MarkdownRenderConfiguration extends LoggingConfiguration {
     readonly customRenderers?: MarkdownRenderers;
     readonly startingHeadingLevel?: number;
 }
@@ -767,7 +767,7 @@ export interface TextFormatting {
 }
 
 // @public
-export interface ToHtmlConfig extends ConfigurationBase {
+export interface ToHtmlConfig extends LoggingConfiguration {
     readonly customTransformations?: ToHtmlTransformations;
     readonly language?: string;
     readonly rootFormatting?: TextFormatting;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -48,7 +48,7 @@ export { ApiItem }
 export { ApiItemKind }
 
 // @public
-export interface ApiItemTransformationConfiguration extends ApiItemTransformationOptions, DocumentationSuiteOptions, ConfigurationBase {
+export interface ApiItemTransformationConfiguration extends ApiItemTransformationOptions, DocumentationSuiteOptions, LoggingConfiguration {
     apiModel: ApiModel;
     readonly uriRoot: string;
 }
@@ -141,11 +141,6 @@ export class CodeSpanNode extends DocumentationParentNodeBase<SingleLineDocument
     static readonly Empty: CodeSpanNode;
     get singleLine(): true;
     readonly type = DocumentationNodeType.CodeSpan;
-}
-
-// @public
-export interface ConfigurationBase {
-    readonly logger?: Logger;
 }
 
 // @public
@@ -508,7 +503,7 @@ export class LinkNode extends DocumentationParentNodeBase<SingleLineDocumentatio
 export function loadModel(options: LoadModelOptions): Promise<ApiModel>;
 
 // @public
-export interface LoadModelOptions extends ConfigurationBase {
+export interface LoadModelOptions extends LoggingConfiguration {
     readonly modelDirectoryPath: string;
 }
 
@@ -522,10 +517,15 @@ export interface Logger {
 }
 
 // @public
+export interface LoggingConfiguration {
+    readonly logger?: Logger;
+}
+
+// @public
 export type LoggingFunction = (message: string | Error, ...parameters: unknown[]) => void;
 
 // @public
-export interface MarkdownRenderConfiguration extends ConfigurationBase {
+export interface MarkdownRenderConfiguration extends LoggingConfiguration {
     readonly customRenderers?: MarkdownRenderers;
     readonly startingHeadingLevel?: number;
 }
@@ -745,7 +745,7 @@ export interface TextFormatting {
 }
 
 // @public
-export interface ToHtmlConfig extends ConfigurationBase {
+export interface ToHtmlConfig extends LoggingConfiguration {
     readonly customTransformations?: ToHtmlTransformations;
     readonly language?: string;
     readonly rootFormatting?: TextFormatting;

--- a/tools/api-markdown-documenter/src/LintApiModel.ts
+++ b/tools/api-markdown-documenter/src/LintApiModel.ts
@@ -22,8 +22,8 @@ import {
 	DocNodeKind,
 } from "@microsoft/tsdoc";
 
-import type { ConfigurationBase } from "./ConfigurationBase.js";
 import { defaultConsoleLogger } from "./Logging.js";
+import type { LoggingConfiguration } from "./LoggingConfiguration.js";
 import { resolveSymbolicReference } from "./utilities/index.js";
 
 /**
@@ -31,7 +31,7 @@ import { resolveSymbolicReference } from "./utilities/index.js";
  *
  * @beta
  */
-export interface LintApiModelConfiguration extends ConfigurationBase {
+export interface LintApiModelConfiguration extends LoggingConfiguration {
 	/**
 	 * The API model to lint.
 	 */

--- a/tools/api-markdown-documenter/src/LoadModel.ts
+++ b/tools/api-markdown-documenter/src/LoadModel.ts
@@ -15,15 +15,15 @@ import {
 import type { DocComment, DocInheritDocTag } from "@microsoft/tsdoc";
 import { FileSystem } from "@rushstack/node-core-library";
 
-import type { ConfigurationBase } from "./ConfigurationBase.js";
 import { defaultConsoleLogger, type Logger } from "./Logging.js";
+import type { LoggingConfiguration } from "./LoggingConfiguration.js";
 
 /**
  * {@link loadModel} options.
  *
  * @public
  */
-export interface LoadModelOptions extends ConfigurationBase {
+export interface LoadModelOptions extends LoggingConfiguration {
 	/**
 	 * Path to the API model directory.
 	 * I.e., the directory containing the set of `.api.json` files that comprise the API model.

--- a/tools/api-markdown-documenter/src/LoggingConfiguration.ts
+++ b/tools/api-markdown-documenter/src/LoggingConfiguration.ts
@@ -10,7 +10,7 @@ import type { Logger } from "./Logging.js";
  *
  * @public
  */
-export interface ConfigurationBase {
+export interface LoggingConfiguration {
 	/**
 	 * Optional receiver of system log data.
 	 *

--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -20,8 +20,8 @@ import {
 	type DocHtmlStartTag,
 } from "@microsoft/tsdoc";
 
-import type { ConfigurationBase } from "../ConfigurationBase.js";
 import type { Link } from "../Link.js";
+import type { LoggingConfiguration } from "../LoggingConfiguration.js";
 import {
 	CodeSpanNode,
 	type DocumentationNode,
@@ -70,7 +70,7 @@ export function transformTsdocNode(
 /**
  * Options for {@link @microsoft/tsdoc#DocNode} transformations.
  */
-export interface TsdocNodeTransformOptions extends ConfigurationBase {
+export interface TsdocNodeTransformOptions extends LoggingConfiguration {
 	/**
 	 * The API item with which the documentation node(s) are associated.
 	 */

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/Configuration.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/Configuration.ts
@@ -5,8 +5,8 @@
 
 import type { ApiModel } from "@microsoft/api-extractor-model";
 
-import type { ConfigurationBase } from "../../ConfigurationBase.js";
 import { defaultConsoleLogger } from "../../Logging.js";
+import type { LoggingConfiguration } from "../../LoggingConfiguration.js";
 
 import {
 	type DocumentationSuiteOptions,
@@ -25,7 +25,7 @@ import {
 export interface ApiItemTransformationConfiguration
 	extends ApiItemTransformationOptions,
 		DocumentationSuiteOptions,
-		ConfigurationBase {
+		LoggingConfiguration {
 	/**
 	 * API Model for which the documentation is being generated.
 	 * This is the output of {@link https://api-extractor.com/ | API-Extractor}.

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/Configuration.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/Configuration.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import type { ConfigurationBase } from "../../ConfigurationBase.js";
 import { defaultConsoleLogger } from "../../Logging.js";
+import type { LoggingConfiguration } from "../../LoggingConfiguration.js";
 import type { TextFormatting } from "../../documentation-domain/index.js";
 
 import type { Transformations } from "./Transformation.js";
@@ -14,7 +14,7 @@ import type { Transformations } from "./Transformation.js";
  *
  * @public
  */
-export interface TransformationConfig extends ConfigurationBase {
+export interface TransformationConfig extends LoggingConfiguration {
 	/**
 	 * User-specified transformations.
 	 *

--- a/tools/api-markdown-documenter/src/index.ts
+++ b/tools/api-markdown-documenter/src/index.ts
@@ -49,7 +49,7 @@ export {
 	type MarkdownRenderers,
 	type MarkdownRenderConfiguration,
 } from "./renderers/index.js";
-export type { ConfigurationBase } from "./ConfigurationBase.js";
+export type { LoggingConfiguration } from "./LoggingConfiguration.js";
 export type { FileSystemConfiguration } from "./FileSystemConfiguration.js";
 export type { Heading } from "./Heading.js";
 export type { Link, UrlTarget } from "./Link.js";

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/configuration/Configuration.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/configuration/Configuration.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import type { ConfigurationBase } from "../../../ConfigurationBase.js";
 import { defaultConsoleLogger } from "../../../Logging.js";
+import type { LoggingConfiguration } from "../../../LoggingConfiguration.js";
 
 import type { Renderers } from "./RenderOptions.js";
 
@@ -13,7 +13,7 @@ import type { Renderers } from "./RenderOptions.js";
  *
  * @public
  */
-export interface RenderConfiguration extends ConfigurationBase {
+export interface RenderConfiguration extends LoggingConfiguration {
 	/**
 	 * User-specified renderers.
 	 *


### PR DESCRIPTION
The interface specifically existed to share a `logger` property among various config types. Renamed to better reflect the intention.