### PR TITLE
refactor(api-markdown-documenter): Make configuration properties `readonly`

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -12,6 +12,17 @@ Combines the separate "config" property bag parameters into a single "options" p
 
 -   `ConfigurationBase` -\> `LoggingConfiguration`.
 
+#### Configuration properties made `readonly`
+
+-   `ApiItemTransformationConfiguration`
+-   `ApiItemTransformationOptions`
+-   `DocumentationSuiteOptions`
+-   `HtmlRenderer.RenderHtmlConfig`
+-   `LintApiModelConfiguration`
+-   `MarkdownRenderer.Renderers`
+-   `MarkdownRenderer.RenderContext`
+-   `ToHtmlTransformations`
+
 ##### Example
 
 Before:

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -49,28 +49,28 @@ export { ApiItemKind }
 
 // @public
 export interface ApiItemTransformationConfiguration extends ApiItemTransformationOptions, DocumentationSuiteOptions, LoggingConfiguration {
-    apiModel: ApiModel;
+    readonly apiModel: ApiModel;
     readonly uriRoot: string;
 }
 
 // @public
 export interface ApiItemTransformationOptions {
-    createDefaultLayout?: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: Required<ApiItemTransformationConfiguration>) => SectionNode[];
-    transformApiCallSignature?: TransformApiItemWithoutChildren<ApiCallSignature>;
-    transformApiClass?: TransformApiItemWithChildren<ApiClass>;
-    transformApiConstructor?: TransformApiItemWithoutChildren<ApiConstructSignature | ApiConstructor>;
-    transformApiEntryPoint?: TransformApiItemWithChildren<ApiEntryPoint>;
-    transformApiEnum?: TransformApiItemWithChildren<ApiEnum>;
-    transformApiEnumMember?: TransformApiItemWithoutChildren<ApiEnumMember>;
-    transformApiFunction?: TransformApiItemWithoutChildren<ApiFunction>;
-    transformApiIndexSignature?: TransformApiItemWithoutChildren<ApiIndexSignature>;
-    transformApiInterface?: TransformApiItemWithChildren<ApiInterface>;
-    transformApiMethod?: TransformApiItemWithoutChildren<ApiMethod | ApiMethodSignature>;
-    transformApiModel?: TransformApiItemWithoutChildren<ApiModel>;
-    transformApiNamespace?: TransformApiItemWithChildren<ApiNamespace>;
-    transformApiProperty?: TransformApiItemWithoutChildren<ApiPropertyItem>;
-    transformApiTypeAlias?: TransformApiItemWithoutChildren<ApiTypeAlias>;
-    transformApiVariable?: TransformApiItemWithoutChildren<ApiVariable>;
+    readonly createDefaultLayout?: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: Required<ApiItemTransformationConfiguration>) => SectionNode[];
+    readonly transformApiCallSignature?: TransformApiItemWithoutChildren<ApiCallSignature>;
+    readonly transformApiClass?: TransformApiItemWithChildren<ApiClass>;
+    readonly transformApiConstructor?: TransformApiItemWithoutChildren<ApiConstructSignature | ApiConstructor>;
+    readonly transformApiEntryPoint?: TransformApiItemWithChildren<ApiEntryPoint>;
+    readonly transformApiEnum?: TransformApiItemWithChildren<ApiEnum>;
+    readonly transformApiEnumMember?: TransformApiItemWithoutChildren<ApiEnumMember>;
+    readonly transformApiFunction?: TransformApiItemWithoutChildren<ApiFunction>;
+    readonly transformApiIndexSignature?: TransformApiItemWithoutChildren<ApiIndexSignature>;
+    readonly transformApiInterface?: TransformApiItemWithChildren<ApiInterface>;
+    readonly transformApiMethod?: TransformApiItemWithoutChildren<ApiMethod | ApiMethodSignature>;
+    readonly transformApiModel?: TransformApiItemWithoutChildren<ApiModel>;
+    readonly transformApiNamespace?: TransformApiItemWithChildren<ApiNamespace>;
+    readonly transformApiProperty?: TransformApiItemWithoutChildren<ApiPropertyItem>;
+    readonly transformApiTypeAlias?: TransformApiItemWithoutChildren<ApiTypeAlias>;
+    readonly transformApiVariable?: TransformApiItemWithoutChildren<ApiVariable>;
 }
 
 declare namespace ApiItemUtilities {
@@ -275,17 +275,17 @@ export abstract class DocumentationParentNodeBase<TDocumentationNode extends Doc
 
 // @public
 export interface DocumentationSuiteOptions {
-    documentBoundaries?: DocumentBoundaries;
-    getAlertsForItem?: (apiItem: ApiItem) => string[];
-    getFileNameForItem?: (apiItem: ApiItem) => string;
-    getHeadingTextForItem?: (apiItem: ApiItem) => string;
-    getLinkTextForItem?: (apiItem: ApiItem) => string;
-    getUriBaseOverrideForItem?: (apiItem: ApiItem) => string | undefined;
-    hierarchyBoundaries?: HierarchyBoundaries;
-    includeBreadcrumb?: boolean;
-    includeTopLevelDocumentHeading?: boolean;
-    minimumReleaseLevel?: Omit<ReleaseTag, ReleaseTag.None>;
-    skipPackage?: (apiPackage: ApiPackage) => boolean;
+    readonly documentBoundaries?: DocumentBoundaries;
+    readonly getAlertsForItem?: (apiItem: ApiItem) => string[];
+    readonly getFileNameForItem?: (apiItem: ApiItem) => string;
+    readonly getHeadingTextForItem?: (apiItem: ApiItem) => string;
+    readonly getLinkTextForItem?: (apiItem: ApiItem) => string;
+    readonly getUriBaseOverrideForItem?: (apiItem: ApiItem) => string | undefined;
+    readonly hierarchyBoundaries?: HierarchyBoundaries;
+    readonly includeBreadcrumb?: boolean;
+    readonly includeTopLevelDocumentHeading?: boolean;
+    readonly minimumReleaseLevel?: Omit<ReleaseTag, ReleaseTag.None>;
+    readonly skipPackage?: (apiPackage: ApiPackage) => boolean;
 }
 
 // @public
@@ -504,7 +504,7 @@ export function lintApiModel(configuration: LintApiModelConfiguration): Promise<
 
 // @beta
 export interface LintApiModelConfiguration extends LoggingConfiguration {
-    apiModel: ApiModel;
+    readonly apiModel: ApiModel;
 }
 
 // @beta
@@ -554,8 +554,8 @@ export interface MarkdownRenderConfiguration extends LoggingConfiguration {
 
 // @public
 export interface MarkdownRenderContext extends TextFormatting {
-    customRenderers?: MarkdownRenderers;
-    headingLevel: number;
+    readonly customRenderers?: MarkdownRenderers;
+    readonly headingLevel: number;
     readonly insideCodeBlock?: boolean;
     readonly insideTable?: boolean;
 }
@@ -575,7 +575,7 @@ export { MarkdownRenderer }
 
 // @public
 export interface MarkdownRenderers {
-    [documentationNodeKind: string]: (node: DocumentationNode, writer: DocumentWriter, context: MarkdownRenderContext) => void;
+    readonly [documentationNodeKind: string]: (node: DocumentationNode, writer: DocumentWriter, context: MarkdownRenderContext) => void;
 }
 
 // @public
@@ -661,7 +661,7 @@ function renderHtml(html: Nodes, { prettyFormatting }: {
 
 // @public @sealed
 export interface RenderHtmlConfig {
-    prettyFormatting?: boolean;
+    readonly prettyFormatting?: boolean;
 }
 
 // @public
@@ -792,7 +792,7 @@ export type ToHtmlTransformation = (node: DocumentationNode, context: ToHtmlCont
 
 // @public
 export interface ToHtmlTransformations {
-    [documentationNodeKind: string]: ToHtmlTransformation;
+    readonly [documentationNodeKind: string]: ToHtmlTransformation;
 }
 
 // @public

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -49,28 +49,28 @@ export { ApiItemKind }
 
 // @public
 export interface ApiItemTransformationConfiguration extends ApiItemTransformationOptions, DocumentationSuiteOptions, LoggingConfiguration {
-    apiModel: ApiModel;
+    readonly apiModel: ApiModel;
     readonly uriRoot: string;
 }
 
 // @public
 export interface ApiItemTransformationOptions {
-    createDefaultLayout?: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: Required<ApiItemTransformationConfiguration>) => SectionNode[];
-    transformApiCallSignature?: TransformApiItemWithoutChildren<ApiCallSignature>;
-    transformApiClass?: TransformApiItemWithChildren<ApiClass>;
-    transformApiConstructor?: TransformApiItemWithoutChildren<ApiConstructSignature | ApiConstructor>;
-    transformApiEntryPoint?: TransformApiItemWithChildren<ApiEntryPoint>;
-    transformApiEnum?: TransformApiItemWithChildren<ApiEnum>;
-    transformApiEnumMember?: TransformApiItemWithoutChildren<ApiEnumMember>;
-    transformApiFunction?: TransformApiItemWithoutChildren<ApiFunction>;
-    transformApiIndexSignature?: TransformApiItemWithoutChildren<ApiIndexSignature>;
-    transformApiInterface?: TransformApiItemWithChildren<ApiInterface>;
-    transformApiMethod?: TransformApiItemWithoutChildren<ApiMethod | ApiMethodSignature>;
-    transformApiModel?: TransformApiItemWithoutChildren<ApiModel>;
-    transformApiNamespace?: TransformApiItemWithChildren<ApiNamespace>;
-    transformApiProperty?: TransformApiItemWithoutChildren<ApiPropertyItem>;
-    transformApiTypeAlias?: TransformApiItemWithoutChildren<ApiTypeAlias>;
-    transformApiVariable?: TransformApiItemWithoutChildren<ApiVariable>;
+    readonly createDefaultLayout?: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: Required<ApiItemTransformationConfiguration>) => SectionNode[];
+    readonly transformApiCallSignature?: TransformApiItemWithoutChildren<ApiCallSignature>;
+    readonly transformApiClass?: TransformApiItemWithChildren<ApiClass>;
+    readonly transformApiConstructor?: TransformApiItemWithoutChildren<ApiConstructSignature | ApiConstructor>;
+    readonly transformApiEntryPoint?: TransformApiItemWithChildren<ApiEntryPoint>;
+    readonly transformApiEnum?: TransformApiItemWithChildren<ApiEnum>;
+    readonly transformApiEnumMember?: TransformApiItemWithoutChildren<ApiEnumMember>;
+    readonly transformApiFunction?: TransformApiItemWithoutChildren<ApiFunction>;
+    readonly transformApiIndexSignature?: TransformApiItemWithoutChildren<ApiIndexSignature>;
+    readonly transformApiInterface?: TransformApiItemWithChildren<ApiInterface>;
+    readonly transformApiMethod?: TransformApiItemWithoutChildren<ApiMethod | ApiMethodSignature>;
+    readonly transformApiModel?: TransformApiItemWithoutChildren<ApiModel>;
+    readonly transformApiNamespace?: TransformApiItemWithChildren<ApiNamespace>;
+    readonly transformApiProperty?: TransformApiItemWithoutChildren<ApiPropertyItem>;
+    readonly transformApiTypeAlias?: TransformApiItemWithoutChildren<ApiTypeAlias>;
+    readonly transformApiVariable?: TransformApiItemWithoutChildren<ApiVariable>;
 }
 
 declare namespace ApiItemUtilities {
@@ -275,17 +275,17 @@ export abstract class DocumentationParentNodeBase<TDocumentationNode extends Doc
 
 // @public
 export interface DocumentationSuiteOptions {
-    documentBoundaries?: DocumentBoundaries;
-    getAlertsForItem?: (apiItem: ApiItem) => string[];
-    getFileNameForItem?: (apiItem: ApiItem) => string;
-    getHeadingTextForItem?: (apiItem: ApiItem) => string;
-    getLinkTextForItem?: (apiItem: ApiItem) => string;
-    getUriBaseOverrideForItem?: (apiItem: ApiItem) => string | undefined;
-    hierarchyBoundaries?: HierarchyBoundaries;
-    includeBreadcrumb?: boolean;
-    includeTopLevelDocumentHeading?: boolean;
-    minimumReleaseLevel?: Omit<ReleaseTag, ReleaseTag.None>;
-    skipPackage?: (apiPackage: ApiPackage) => boolean;
+    readonly documentBoundaries?: DocumentBoundaries;
+    readonly getAlertsForItem?: (apiItem: ApiItem) => string[];
+    readonly getFileNameForItem?: (apiItem: ApiItem) => string;
+    readonly getHeadingTextForItem?: (apiItem: ApiItem) => string;
+    readonly getLinkTextForItem?: (apiItem: ApiItem) => string;
+    readonly getUriBaseOverrideForItem?: (apiItem: ApiItem) => string | undefined;
+    readonly hierarchyBoundaries?: HierarchyBoundaries;
+    readonly includeBreadcrumb?: boolean;
+    readonly includeTopLevelDocumentHeading?: boolean;
+    readonly minimumReleaseLevel?: Omit<ReleaseTag, ReleaseTag.None>;
+    readonly skipPackage?: (apiPackage: ApiPackage) => boolean;
 }
 
 // @public
@@ -504,7 +504,7 @@ export function lintApiModel(configuration: LintApiModelConfiguration): Promise<
 
 // @beta
 export interface LintApiModelConfiguration extends LoggingConfiguration {
-    apiModel: ApiModel;
+    readonly apiModel: ApiModel;
 }
 
 // @beta
@@ -554,8 +554,8 @@ export interface MarkdownRenderConfiguration extends LoggingConfiguration {
 
 // @public
 export interface MarkdownRenderContext extends TextFormatting {
-    customRenderers?: MarkdownRenderers;
-    headingLevel: number;
+    readonly customRenderers?: MarkdownRenderers;
+    readonly headingLevel: number;
     readonly insideCodeBlock?: boolean;
     readonly insideTable?: boolean;
 }
@@ -575,7 +575,7 @@ export { MarkdownRenderer }
 
 // @public
 export interface MarkdownRenderers {
-    [documentationNodeKind: string]: (node: DocumentationNode, writer: DocumentWriter, context: MarkdownRenderContext) => void;
+    readonly [documentationNodeKind: string]: (node: DocumentationNode, writer: DocumentWriter, context: MarkdownRenderContext) => void;
 }
 
 // @public
@@ -655,7 +655,7 @@ function renderHtml(html: Nodes, { prettyFormatting }: {
 
 // @public @sealed
 export interface RenderHtmlConfig {
-    prettyFormatting?: boolean;
+    readonly prettyFormatting?: boolean;
 }
 
 // @public
@@ -786,7 +786,7 @@ export type ToHtmlTransformation = (node: DocumentationNode, context: ToHtmlCont
 
 // @public
 export interface ToHtmlTransformations {
-    [documentationNodeKind: string]: ToHtmlTransformation;
+    readonly [documentationNodeKind: string]: ToHtmlTransformation;
 }
 
 // @public

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -49,28 +49,28 @@ export { ApiItemKind }
 
 // @public
 export interface ApiItemTransformationConfiguration extends ApiItemTransformationOptions, DocumentationSuiteOptions, LoggingConfiguration {
-    apiModel: ApiModel;
+    readonly apiModel: ApiModel;
     readonly uriRoot: string;
 }
 
 // @public
 export interface ApiItemTransformationOptions {
-    createDefaultLayout?: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: Required<ApiItemTransformationConfiguration>) => SectionNode[];
-    transformApiCallSignature?: TransformApiItemWithoutChildren<ApiCallSignature>;
-    transformApiClass?: TransformApiItemWithChildren<ApiClass>;
-    transformApiConstructor?: TransformApiItemWithoutChildren<ApiConstructSignature | ApiConstructor>;
-    transformApiEntryPoint?: TransformApiItemWithChildren<ApiEntryPoint>;
-    transformApiEnum?: TransformApiItemWithChildren<ApiEnum>;
-    transformApiEnumMember?: TransformApiItemWithoutChildren<ApiEnumMember>;
-    transformApiFunction?: TransformApiItemWithoutChildren<ApiFunction>;
-    transformApiIndexSignature?: TransformApiItemWithoutChildren<ApiIndexSignature>;
-    transformApiInterface?: TransformApiItemWithChildren<ApiInterface>;
-    transformApiMethod?: TransformApiItemWithoutChildren<ApiMethod | ApiMethodSignature>;
-    transformApiModel?: TransformApiItemWithoutChildren<ApiModel>;
-    transformApiNamespace?: TransformApiItemWithChildren<ApiNamespace>;
-    transformApiProperty?: TransformApiItemWithoutChildren<ApiPropertyItem>;
-    transformApiTypeAlias?: TransformApiItemWithoutChildren<ApiTypeAlias>;
-    transformApiVariable?: TransformApiItemWithoutChildren<ApiVariable>;
+    readonly createDefaultLayout?: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: Required<ApiItemTransformationConfiguration>) => SectionNode[];
+    readonly transformApiCallSignature?: TransformApiItemWithoutChildren<ApiCallSignature>;
+    readonly transformApiClass?: TransformApiItemWithChildren<ApiClass>;
+    readonly transformApiConstructor?: TransformApiItemWithoutChildren<ApiConstructSignature | ApiConstructor>;
+    readonly transformApiEntryPoint?: TransformApiItemWithChildren<ApiEntryPoint>;
+    readonly transformApiEnum?: TransformApiItemWithChildren<ApiEnum>;
+    readonly transformApiEnumMember?: TransformApiItemWithoutChildren<ApiEnumMember>;
+    readonly transformApiFunction?: TransformApiItemWithoutChildren<ApiFunction>;
+    readonly transformApiIndexSignature?: TransformApiItemWithoutChildren<ApiIndexSignature>;
+    readonly transformApiInterface?: TransformApiItemWithChildren<ApiInterface>;
+    readonly transformApiMethod?: TransformApiItemWithoutChildren<ApiMethod | ApiMethodSignature>;
+    readonly transformApiModel?: TransformApiItemWithoutChildren<ApiModel>;
+    readonly transformApiNamespace?: TransformApiItemWithChildren<ApiNamespace>;
+    readonly transformApiProperty?: TransformApiItemWithoutChildren<ApiPropertyItem>;
+    readonly transformApiTypeAlias?: TransformApiItemWithoutChildren<ApiTypeAlias>;
+    readonly transformApiVariable?: TransformApiItemWithoutChildren<ApiVariable>;
 }
 
 declare namespace ApiItemUtilities {
@@ -275,17 +275,17 @@ export abstract class DocumentationParentNodeBase<TDocumentationNode extends Doc
 
 // @public
 export interface DocumentationSuiteOptions {
-    documentBoundaries?: DocumentBoundaries;
-    getAlertsForItem?: (apiItem: ApiItem) => string[];
-    getFileNameForItem?: (apiItem: ApiItem) => string;
-    getHeadingTextForItem?: (apiItem: ApiItem) => string;
-    getLinkTextForItem?: (apiItem: ApiItem) => string;
-    getUriBaseOverrideForItem?: (apiItem: ApiItem) => string | undefined;
-    hierarchyBoundaries?: HierarchyBoundaries;
-    includeBreadcrumb?: boolean;
-    includeTopLevelDocumentHeading?: boolean;
-    minimumReleaseLevel?: Omit<ReleaseTag, ReleaseTag.None>;
-    skipPackage?: (apiPackage: ApiPackage) => boolean;
+    readonly documentBoundaries?: DocumentBoundaries;
+    readonly getAlertsForItem?: (apiItem: ApiItem) => string[];
+    readonly getFileNameForItem?: (apiItem: ApiItem) => string;
+    readonly getHeadingTextForItem?: (apiItem: ApiItem) => string;
+    readonly getLinkTextForItem?: (apiItem: ApiItem) => string;
+    readonly getUriBaseOverrideForItem?: (apiItem: ApiItem) => string | undefined;
+    readonly hierarchyBoundaries?: HierarchyBoundaries;
+    readonly includeBreadcrumb?: boolean;
+    readonly includeTopLevelDocumentHeading?: boolean;
+    readonly minimumReleaseLevel?: Omit<ReleaseTag, ReleaseTag.None>;
+    readonly skipPackage?: (apiPackage: ApiPackage) => boolean;
 }
 
 // @public
@@ -532,8 +532,8 @@ export interface MarkdownRenderConfiguration extends LoggingConfiguration {
 
 // @public
 export interface MarkdownRenderContext extends TextFormatting {
-    customRenderers?: MarkdownRenderers;
-    headingLevel: number;
+    readonly customRenderers?: MarkdownRenderers;
+    readonly headingLevel: number;
     readonly insideCodeBlock?: boolean;
     readonly insideTable?: boolean;
 }
@@ -553,7 +553,7 @@ export { MarkdownRenderer }
 
 // @public
 export interface MarkdownRenderers {
-    [documentationNodeKind: string]: (node: DocumentationNode, writer: DocumentWriter, context: MarkdownRenderContext) => void;
+    readonly [documentationNodeKind: string]: (node: DocumentationNode, writer: DocumentWriter, context: MarkdownRenderContext) => void;
 }
 
 // @public
@@ -633,7 +633,7 @@ function renderHtml(html: Nodes, { prettyFormatting }: {
 
 // @public @sealed
 export interface RenderHtmlConfig {
-    prettyFormatting?: boolean;
+    readonly prettyFormatting?: boolean;
 }
 
 // @public
@@ -764,7 +764,7 @@ export type ToHtmlTransformation = (node: DocumentationNode, context: ToHtmlCont
 
 // @public
 export interface ToHtmlTransformations {
-    [documentationNodeKind: string]: ToHtmlTransformation;
+    readonly [documentationNodeKind: string]: ToHtmlTransformation;
 }
 
 // @public

--- a/tools/api-markdown-documenter/src/LintApiModel.ts
+++ b/tools/api-markdown-documenter/src/LintApiModel.ts
@@ -35,7 +35,7 @@ export interface LintApiModelConfiguration extends LoggingConfiguration {
 	/**
 	 * The API model to lint.
 	 */
-	apiModel: ApiModel;
+	readonly apiModel: ApiModel;
 }
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/Configuration.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/Configuration.ts
@@ -36,7 +36,7 @@ export interface ApiItemTransformationConfiguration
 	 *
 	 * If you need to generate a model from API reports on disk, see {@link loadModel}.
 	 */
-	apiModel: ApiModel;
+	readonly apiModel: ApiModel;
 
 	/**
 	 * Default root URI used when generating content links.

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuiteOptions.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuiteOptions.ts
@@ -102,7 +102,7 @@ export interface DocumentationSuiteOptions {
 	 * @remarks If you will be rendering the document contents into some other document content that will inject its
 	 * own root heading, this can be used to omit that heading from what is rendered by this system.
 	 */
-	includeTopLevelDocumentHeading?: boolean;
+	readonly includeTopLevelDocumentHeading?: boolean;
 
 	/**
 	 * Whether or not to include a navigation breadcrumb at the top of rendered documents.
@@ -111,21 +111,21 @@ export interface DocumentationSuiteOptions {
 	 *
 	 * @remarks Note: `Model` items will never have a breadcrumb rendered, even if this is specfied.
 	 */
-	includeBreadcrumb?: boolean;
+	readonly includeBreadcrumb?: boolean;
 
 	/**
 	 * See {@link DocumentBoundaries}.
 	 *
 	 * @defaultValue {@link DefaultDocumentationSuiteOptions.defaultDocumentBoundaries}
 	 */
-	documentBoundaries?: DocumentBoundaries;
+	readonly documentBoundaries?: DocumentBoundaries;
 
 	/**
 	 * See {@link HierarchyBoundaries}.
 	 *
 	 * @defaultValue {@link DefaultDocumentationSuiteOptions.defaultHierarchyBoundaries}
 	 */
-	hierarchyBoundaries?: HierarchyBoundaries;
+	readonly hierarchyBoundaries?: HierarchyBoundaries;
 
 	/**
 	 * Generate a file name for the provided `ApiItem`.
@@ -148,7 +148,7 @@ export interface DocumentationSuiteOptions {
 	 *
 	 * @defaultValue {@link DefaultDocumentationSuiteOptions.defaultGetFileNameForItem}
 	 */
-	getFileNameForItem?: (apiItem: ApiItem) => string;
+	readonly getFileNameForItem?: (apiItem: ApiItem) => string;
 
 	/**
 	 * Optionally provide an override for the URI base used in links generated for the provided `ApiItem`.
@@ -164,7 +164,7 @@ export interface DocumentationSuiteOptions {
 	 *
 	 * @defaultValue Always use the default URI base.
 	 */
-	getUriBaseOverrideForItem?: (apiItem: ApiItem) => string | undefined;
+	readonly getUriBaseOverrideForItem?: (apiItem: ApiItem) => string | undefined;
 
 	/**
 	 * Generate heading text for the provided `ApiItem`.
@@ -175,7 +175,7 @@ export interface DocumentationSuiteOptions {
 	 *
 	 * @defaultValue {@link DefaultDocumentationSuiteOptions.defaultGetHeadingTextForItem}
 	 */
-	getHeadingTextForItem?: (apiItem: ApiItem) => string;
+	readonly getHeadingTextForItem?: (apiItem: ApiItem) => string;
 
 	/**
 	 * Generate link text for the provided `ApiItem`.
@@ -186,7 +186,7 @@ export interface DocumentationSuiteOptions {
 	 *
 	 * @defaultValue {@link DefaultDocumentationSuiteOptions.defaultGetLinkTextForItem}
 	 */
-	getLinkTextForItem?: (apiItem: ApiItem) => string;
+	readonly getLinkTextForItem?: (apiItem: ApiItem) => string;
 
 	/**
 	 * Generate a list of "alerts" to display in API items tables for a given API item.
@@ -197,7 +197,7 @@ export interface DocumentationSuiteOptions {
 	 *
 	 * @defaultValue {@link DefaultDocumentationSuiteOptions.defaultGetAlertsForItem}
 	 */
-	getAlertsForItem?: (apiItem: ApiItem) => string[];
+	readonly getAlertsForItem?: (apiItem: ApiItem) => string[];
 
 	/**
 	 * Whether or not the provided `ApiPackage` should be skipped during documentation generation.
@@ -210,7 +210,7 @@ export interface DocumentationSuiteOptions {
 	 *
 	 * @defaultValue No packages are skipped.
 	 */
-	skipPackage?: (apiPackage: ApiPackage) => boolean;
+	readonly skipPackage?: (apiPackage: ApiPackage) => boolean;
 
 	/**
 	 * Minimal release scope to include in generated documentation suite.
@@ -233,7 +233,7 @@ export interface DocumentationSuiteOptions {
 	 * releaseLevel: ReleaseTag.Beta
 	 * ```
 	 */
-	minimumReleaseLevel?: Omit<ReleaseTag, ReleaseTag.None>;
+	readonly minimumReleaseLevel?: Omit<ReleaseTag, ReleaseTag.None>;
 }
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/TransformationOptions.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/TransformationOptions.ts
@@ -71,7 +71,7 @@ export interface ApiItemTransformationOptions {
 	 *
 	 * @returns The list of {@link SectionNode}s that comprise the top-level section body for the API item.
 	 */
-	createDefaultLayout?: (
+	readonly createDefaultLayout?: (
 		apiItem: ApiItem,
 		childSections: SectionNode[] | undefined,
 		config: Required<ApiItemTransformationConfiguration>,
@@ -80,17 +80,17 @@ export interface ApiItemTransformationOptions {
 	/**
 	 * Transformation to generate a {@link SectionNode} for a `Call Signature`.
 	 */
-	transformApiCallSignature?: TransformApiItemWithoutChildren<ApiCallSignature>;
+	readonly transformApiCallSignature?: TransformApiItemWithoutChildren<ApiCallSignature>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for a `Class`.
 	 */
-	transformApiClass?: TransformApiItemWithChildren<ApiClass>;
+	readonly transformApiClass?: TransformApiItemWithChildren<ApiClass>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for a `Constructor`.
 	 */
-	transformApiConstructor?: TransformApiItemWithoutChildren<
+	readonly transformApiConstructor?: TransformApiItemWithoutChildren<
 		ApiConstructSignature | ApiConstructor
 	>;
 
@@ -102,37 +102,37 @@ export interface ApiItemTransformationOptions {
 	 * Note: for packages that have a single entry-point, this content will be bubbled up to the generated
 	 * package-level document to reduce unecessary indirection in the generated suite.
 	 */
-	transformApiEntryPoint?: TransformApiItemWithChildren<ApiEntryPoint>;
+	readonly transformApiEntryPoint?: TransformApiItemWithChildren<ApiEntryPoint>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for an `Enum`.
 	 */
-	transformApiEnum?: TransformApiItemWithChildren<ApiEnum>;
+	readonly transformApiEnum?: TransformApiItemWithChildren<ApiEnum>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for an `Enum Member` (flag).
 	 */
-	transformApiEnumMember?: TransformApiItemWithoutChildren<ApiEnumMember>;
+	readonly transformApiEnumMember?: TransformApiItemWithoutChildren<ApiEnumMember>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for a `Function`.
 	 */
-	transformApiFunction?: TransformApiItemWithoutChildren<ApiFunction>;
+	readonly transformApiFunction?: TransformApiItemWithoutChildren<ApiFunction>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for an `Index Signature`.
 	 */
-	transformApiIndexSignature?: TransformApiItemWithoutChildren<ApiIndexSignature>;
+	readonly transformApiIndexSignature?: TransformApiItemWithoutChildren<ApiIndexSignature>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for an `Interface`.
 	 */
-	transformApiInterface?: TransformApiItemWithChildren<ApiInterface>;
+	readonly transformApiInterface?: TransformApiItemWithChildren<ApiInterface>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for a `Method`.
 	 */
-	transformApiMethod?: TransformApiItemWithoutChildren<ApiMethod | ApiMethodSignature>;
+	readonly transformApiMethod?: TransformApiItemWithoutChildren<ApiMethod | ApiMethodSignature>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for an `ApiModel`.
@@ -143,27 +143,27 @@ export interface ApiItemTransformationOptions {
 	 * and `Package` items specially. We never render `Package` child details directly to the `Model` document.
 	 * These are always rendered to separate documents from each other.
 	 */
-	transformApiModel?: TransformApiItemWithoutChildren<ApiModel>;
+	readonly transformApiModel?: TransformApiItemWithoutChildren<ApiModel>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for a `Namespace`.
 	 */
-	transformApiNamespace?: TransformApiItemWithChildren<ApiNamespace>;
+	readonly transformApiNamespace?: TransformApiItemWithChildren<ApiNamespace>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for a `Property`.
 	 */
-	transformApiProperty?: TransformApiItemWithoutChildren<ApiPropertyItem>;
+	readonly transformApiProperty?: TransformApiItemWithoutChildren<ApiPropertyItem>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for a `Type Alias`.
 	 */
-	transformApiTypeAlias?: TransformApiItemWithoutChildren<ApiTypeAlias>;
+	readonly transformApiTypeAlias?: TransformApiItemWithoutChildren<ApiTypeAlias>;
 
 	/**
 	 * Transformation to generate a {@link SectionNode} for an `Variable`.
 	 */
-	transformApiVariable?: TransformApiItemWithoutChildren<ApiVariable>;
+	readonly transformApiVariable?: TransformApiItemWithoutChildren<ApiVariable>;
 }
 
 /**

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/Transformation.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/Transformation.ts
@@ -61,7 +61,7 @@ export interface Transformations {
 	 * Maps from a {@link DocumentationNode}'s {@link DocumentationNode."type"} to a transformation implementation
 	 * for that kind of node.
 	 */
-	[documentationNodeKind: string]: Transformation;
+	readonly [documentationNodeKind: string]: Transformation;
 }
 
 /**

--- a/tools/api-markdown-documenter/src/renderers/html-renderer/Render.ts
+++ b/tools/api-markdown-documenter/src/renderers/html-renderer/Render.ts
@@ -24,7 +24,7 @@ export interface RenderHtmlConfig {
 	 * Whether or not to render the generated HTML "pretty", human-readable formatting.
 	 * @defaultValue `true`
 	 */
-	prettyFormatting?: boolean;
+	readonly prettyFormatting?: boolean;
 }
 
 /**

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/RenderContext.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/RenderContext.ts
@@ -46,7 +46,7 @@ export interface RenderContext extends TextFormatting {
 	 * Will automatically increment based on {@link SectionNode}s encountered, such that heading
 	 * levels can be increased automatically based on content hierarchy.
 	 */
-	headingLevel: number;
+	readonly headingLevel: number;
 
 	/**
 	 * Configuration for rendering different kinds of {@link DocumentationNode}s.
@@ -56,7 +56,7 @@ export interface RenderContext extends TextFormatting {
 	 * Will include default renderers for all {@link DocumentationNode} types enumerated in
 	 * {@link DocumentationNodeType}.
 	 */
-	customRenderers?: Renderers;
+	readonly customRenderers?: Renderers;
 }
 
 /**

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/configuration/RenderOptions.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/configuration/RenderOptions.ts
@@ -65,7 +65,7 @@ export interface Renderers {
 	 * @param writer - The writing context to render into.
 	 * @param context - Recursive contextual state.
 	 */
-	[documentationNodeKind: string]: (
+	readonly [documentationNodeKind: string]: (
 		node: DocumentationNode,
 		writer: DocumentWriter,
 		context: RenderContext,


### PR DESCRIPTION
Makes a number of configuration properties `readonly`.