### PR TITLE
Remove unnecessary es-lint suppressions

### DIFF
--- a/experimental/PropertyDDS/packages/property-common/src/guidUtils.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/guidUtils.ts
@@ -245,7 +245,7 @@ const generateGUID = function (base64 = false): string {
 // by decoder, e.g. "+Q" and "+Z" result in the same decoding.
 // The only characters with last 4 bits set to 0 are A, Q, g, w.
 const reBase64 = /^[\w-]{21}[AQgw]$/;
-// eslint-disable-next-line unicorn/no-unsafe-regex
+
 const reBase16 = /^[\dA-Fa-f]{8}(?:-[\dA-Fa-f]{4}){3}-[\dA-Fa-f]{12}$/;
 
 /**

--- a/experimental/PropertyDDS/packages/property-common/src/test/guidUtils.spec.ts
+++ b/experimental/PropertyDDS/packages/property-common/src/test/guidUtils.spec.ts
@@ -165,7 +165,6 @@ const test16fromAndTo64 = function (base64, base16) {
 };
 
 describe("Base16", function () {
-	// eslint-disable-next-line unicorn/no-unsafe-regex
 	testGuid(/^[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}$/i, false);
 	testInitialization("492b176c-bdc9-0dec-7c70-087a6a7bdac2", false);
 	testCorrectness("893fa0d4-c767-4133-829f-27434bf38cc8", "893fa0d4-c?767-4133-829f-27434b-8");

--- a/experimental/dds/attributable-map/src/interfaces.ts
+++ b/experimental/dds/attributable-map/src/interfaces.ts
@@ -23,7 +23,7 @@ export interface IValueChanged {
 	 * The value that was stored at the key prior to the change.
 	 */
 	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	previousValue: any;
 }
 
@@ -71,7 +71,7 @@ export interface ISharedMapEvents extends ISharedObjectEvents {
  * @internal
  */
 // TODO: Use `unknown` instead (breaking change).
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string, any> {
 	/**
 	 * Retrieves the given key from the map if it exists.
@@ -79,7 +79,7 @@ export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string,
 	 * @returns The stored value, or undefined if the key is not set
 	 */
 	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	get<T = any>(key: string): T | undefined;
 
 	/**
@@ -137,7 +137,7 @@ export interface ISerializableValue {
 	/**
 	 * The JSONable representation of the value.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	value: any;
 
 	/**

--- a/experimental/dds/attributable-map/src/localValues.ts
+++ b/experimental/dds/attributable-map/src/localValues.ts
@@ -30,7 +30,7 @@ export interface ILocalValue {
 	 * The in-memory value stored within.
 	 */
 	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	readonly value: any;
 
 	/**
@@ -65,7 +65,7 @@ export function makeSerializable(
 	const value = localValue.makeSerialized(serializer, bind);
 	return {
 		type: value.type,
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
 		value: value.value && JSON.parse(value.value),
 	};
 }

--- a/experimental/dds/attributable-map/src/map.ts
+++ b/experimental/dds/attributable-map/src/map.ts
@@ -160,7 +160,7 @@ export class AttributableMapClass
 	 * @returns The iterator
 	 */
 	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	public entries(): IterableIterator<[string, any]> {
 		return this.kernel.entries();
 	}
@@ -170,7 +170,7 @@ export class AttributableMapClass
 	 * @returns The iterator
 	 */
 	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	public values(): IterableIterator<any> {
 		return this.kernel.values();
 	}
@@ -180,7 +180,7 @@ export class AttributableMapClass
 	 * @returns The iterator
 	 */
 	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	public [Symbol.iterator](): IterableIterator<[string, any]> {
 		return this.kernel.entries();
 	}
@@ -197,9 +197,8 @@ export class AttributableMapClass
 	 * @param callbackFn - Callback function
 	 */
 	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	public forEach(callbackFn: (value: any, key: string, map: Map<string, any>) => void): void {
-		// eslint-disable-next-line unicorn/no-array-for-each, unicorn/no-array-callback-reference
 		this.kernel.forEach(callbackFn);
 	}
 
@@ -207,7 +206,7 @@ export class AttributableMapClass
 	 * {@inheritDoc ISharedMap.get}
 	 */
 	// TODO: Use `unknown` instead (breaking change).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	public get<T = any>(key: string): T | undefined {
 		return this.kernel.get<T>(key);
 	}

--- a/experimental/dds/attributable-map/src/test/mocha/map.spec.ts
+++ b/experimental/dds/attributable-map/src/test/mocha/map.spec.ts
@@ -146,7 +146,6 @@ describe("Map", () => {
 					map.set(undefined as unknown as string, "one");
 				}, "Should throw for key of undefined");
 				assert.throws(() => {
-					// eslint-disable-next-line unicorn/no-null
 					map.set(null as unknown as string, "two");
 				}, "Should throw for key of null");
 			});
@@ -595,15 +594,11 @@ describe("Map", () => {
 
 					containerRuntimeFactory.processAllMessages();
 
-					/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call */
-
 					const retrieved = map1.get("object");
 					const retrievedSubMap: unknown = await retrieved.subMapHandle.get();
 					assert.equal(retrievedSubMap, subMap, "could not get nested map 1");
 					const retrievedSubMap2: unknown = await retrieved.nestedObj.subMap2Handle.get();
 					assert.equal(retrievedSubMap2, subMap2, "could not get nested map 2");
-
-					/* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call */
 				});
 
 				it("Shouldn't clear value if there is pending set", () => {

--- a/experimental/dds/ot/ot/src/ot.ts
+++ b/experimental/dds/ot/ot/src/ot.ts
@@ -127,7 +127,7 @@ export abstract class SharedOT<TState, TOp> extends SharedObject {
 		// TODO: Verify whether this should be able to handle server-generated ops (with null clientId)
 		this.sequencedOps.push({
 			seq: messageSeq,
-			// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 			client: remoteClient as string,
 			op: remoteOp as TOp,
 		});

--- a/packages/common/client-utils/src/test/jest/gitHash.spec.ts
+++ b/packages/common/client-utils/src/test/jest/gitHash.spec.ts
@@ -4,7 +4,6 @@
  */
 
 /* eslint-disable unicorn/prefer-code-point */
-/* eslint-disable unicorn/prefer-module */
 
 import fs from "node:fs";
 import http from "node:http";

--- a/packages/common/client-utils/src/typedEventEmitter.ts
+++ b/packages/common/client-utils/src/typedEventEmitter.ts
@@ -34,7 +34,6 @@ export type TypedEventTransform<TThis, TEvent> =
 	TransformedEvent<
 		TThis,
 		"newListener" | "removeListener",
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		Parameters<(event: string, listener: (...args: any[]) => void) => void>
 	> &
 		// Expose all the events provides by TEvent

--- a/packages/common/core-interfaces/src/events.ts
+++ b/packages/common/core-interfaces/src/events.ts
@@ -151,7 +151,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 	(event: infer E12, listener: (...args: infer A12) => void);
 	(event: infer E13, listener: (...args: infer A13) => void);
 	(event: infer E14, listener: (...args: infer A14) => void);
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	(event: string, listener: (...args: any[]) => void);
 }
 	? TransformedEvent<TThis, E0, A0> &
@@ -184,7 +184,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 				(event: infer E11, listener: (...args: infer A11) => void);
 				(event: infer E12, listener: (...args: infer A12) => void);
 				(event: infer E13, listener: (...args: infer A13) => void);
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 				(event: string, listener: (...args: any[]) => void);
 			}
 		? TransformedEvent<TThis, E0, A0> &
@@ -215,7 +215,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 					(event: infer E10, listener: (...args: infer A10) => void);
 					(event: infer E11, listener: (...args: infer A11) => void);
 					(event: infer E12, listener: (...args: infer A12) => void);
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 					(event: string, listener: (...args: any[]) => void);
 				}
 			? TransformedEvent<TThis, E0, A0> &
@@ -244,7 +244,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 						(event: infer E9, listener: (...args: infer A9) => void);
 						(event: infer E10, listener: (...args: infer A10) => void);
 						(event: infer E11, listener: (...args: infer A11) => void);
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 						(event: string, listener: (...args: any[]) => void);
 					}
 				? TransformedEvent<TThis, E0, A0> &
@@ -271,7 +271,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 							(event: infer E8, listener: (...args: infer A8) => void);
 							(event: infer E9, listener: (...args: infer A9) => void);
 							(event: infer E10, listener: (...args: infer A10) => void);
-							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 							(event: string, listener: (...args: any[]) => void);
 						}
 					? TransformedEvent<TThis, E0, A0> &
@@ -296,7 +296,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 								(event: infer E7, listener: (...args: infer A7) => void);
 								(event: infer E8, listener: (...args: infer A8) => void);
 								(event: infer E9, listener: (...args: infer A9) => void);
-								// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 								(event: string, listener: (...args: any[]) => void);
 							}
 						? TransformedEvent<TThis, E0, A0> &
@@ -319,7 +319,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 									(event: infer E6, listener: (...args: infer A6) => void);
 									(event: infer E7, listener: (...args: infer A7) => void);
 									(event: infer E8, listener: (...args: infer A8) => void);
-									// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 									(event: string, listener: (...args: any[]) => void);
 								}
 							? TransformedEvent<TThis, E0, A0> &
@@ -340,7 +340,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 										(event: infer E5, listener: (...args: infer A5) => void);
 										(event: infer E6, listener: (...args: infer A6) => void);
 										(event: infer E7, listener: (...args: infer A7) => void);
-										// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 										(event: string, listener: (...args: any[]) => void);
 									}
 								? TransformedEvent<TThis, E0, A0> &
@@ -359,7 +359,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 											(event: infer E4, listener: (...args: infer A4) => void);
 											(event: infer E5, listener: (...args: infer A5) => void);
 											(event: infer E6, listener: (...args: infer A6) => void);
-											// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 											(event: string, listener: (...args: any[]) => void);
 										}
 									? TransformedEvent<TThis, E0, A0> &
@@ -376,7 +376,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 												(event: infer E3, listener: (...args: infer A3) => void);
 												(event: infer E4, listener: (...args: infer A4) => void);
 												(event: infer E5, listener: (...args: infer A5) => void);
-												// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 												(event: string, listener: (...args: any[]) => void);
 											}
 										? TransformedEvent<TThis, E0, A0> &
@@ -391,7 +391,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 													(event: infer E2, listener: (...args: infer A2) => void);
 													(event: infer E3, listener: (...args: infer A3) => void);
 													(event: infer E4, listener: (...args: infer A4) => void);
-													// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 													(event: string, listener: (...args: any[]) => void);
 												}
 											? TransformedEvent<TThis, E0, A0> &
@@ -404,7 +404,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 														(event: infer E1, listener: (...args: infer A1) => void);
 														(event: infer E2, listener: (...args: infer A2) => void);
 														(event: infer E3, listener: (...args: infer A3) => void);
-														// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 														(event: string, listener: (...args: any[]) => void);
 													}
 												? TransformedEvent<TThis, E0, A0> &
@@ -415,7 +415,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 															(event: infer E0, listener: (...args: infer A0) => void);
 															(event: infer E1, listener: (...args: infer A1) => void);
 															(event: infer E2, listener: (...args: infer A2) => void);
-															// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 															(event: string, listener: (...args: any[]) => void);
 														}
 													? TransformedEvent<TThis, E0, A0> &
@@ -424,13 +424,13 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 													: TEvent extends {
 																(event: infer E0, listener: (...args: infer A0) => void);
 																(event: infer E1, listener: (...args: infer A1) => void);
-																// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 																(event: string, listener: (...args: any[]) => void);
 															}
 														? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1>
 														: TEvent extends {
 																	(event: infer E0, listener: (...args: infer A0) => void);
-																	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 																	(event: string, listener: (...args: any[]) => void);
 																}
 															? TransformedEvent<TThis, E0, A0>

--- a/packages/common/core-interfaces/src/fluidLoadable.ts
+++ b/packages/common/core-interfaces/src/fluidLoadable.ts
@@ -41,7 +41,7 @@ export interface IProvideFluidRunnable {
  */
 export interface IFluidRunnable {
 	// TODO: Use `unknown` instead (API-Breaking)
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	run(...args: any[]): Promise<void>;
 	stop(reason?: string): void;
 }

--- a/packages/dds/counter/src/counter.ts
+++ b/packages/dds/counter/src/counter.ts
@@ -160,7 +160,6 @@ export class SharedCounter
 
 		// TODO: Clean up error code linter violations repo-wide.
 
-		// eslint-disable-next-line unicorn/numeric-separators-style
 		assert(counterOp.type === "increment", 0x3ec /* Op type is not increment */);
 
 		this.increment(counterOp.incrementAmount);

--- a/packages/dds/merge-tree/src/MergeTreeTextHelper.ts
+++ b/packages/dds/merge-tree/src/MergeTreeTextHelper.ts
@@ -6,7 +6,6 @@
 import { IIntegerRange } from "./client.js";
 import { MergeTree } from "./mergeTree.js";
 import { ISegmentLeaf } from "./mergeTreeNodes.js";
-// eslint-disable-next-line import/no-deprecated
 import { IMergeTreeTextHelper, TextSegment } from "./textSegment.js";
 
 interface ITextAccumulator {
@@ -15,7 +14,6 @@ interface ITextAccumulator {
 	parallelArrays?: boolean;
 }
 
-// eslint-disable-next-line import/no-deprecated
 export class MergeTreeTextHelper implements IMergeTreeTextHelper {
 	constructor(private readonly mergeTree: MergeTree) {}
 

--- a/packages/dds/merge-tree/src/attributionPolicy.ts
+++ b/packages/dds/merge-tree/src/attributionPolicy.ts
@@ -8,9 +8,7 @@ import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/in
 import { AttributionKey } from "@fluidframework/runtime-definitions/internal";
 
 import { AttributionCollection } from "./attributionCollection.js";
-// eslint-disable-next-line import/no-deprecated
 import { Client } from "./client.js";
-// eslint-disable-next-line import/no-deprecated
 import { AttributionPolicy } from "./mergeTree.js";
 import {
 	IMergeTreeDeltaCallbackArgs,
@@ -29,13 +27,13 @@ interface AttributionCallbacks {
 	delta: (
 		opArgs: IMergeTreeDeltaOpArgs,
 		deltaArgs: IMergeTreeDeltaCallbackArgs,
-		// eslint-disable-next-line import/no-deprecated
+
 		client: Client,
 	) => void;
 	maintenance: (
 		maintenanceArgs: IMergeTreeMaintenanceCallbackArgs,
 		opArgs: IMergeTreeDeltaOpArgs | undefined,
-		// eslint-disable-next-line import/no-deprecated
+
 		client: Client,
 	) => void;
 }
@@ -43,11 +41,9 @@ interface AttributionCallbacks {
 function createAttributionPolicyFromCallbacks({
 	delta,
 	maintenance,
-	// eslint-disable-next-line import/no-deprecated
 }: AttributionCallbacks): AttributionPolicy {
 	let unsubscribe: undefined | (() => void);
 	return {
-		// eslint-disable-next-line import/no-deprecated
 		attach: (client: Client): void => {
 			assert(unsubscribe === undefined, 0x557 /* cannot attach to multiple clients at once */);
 
@@ -87,7 +83,6 @@ const ensureAttributionCollectionCallbacks: AttributionCallbacks = {
 };
 
 const getAttributionKey = (
-	// eslint-disable-next-line import/no-deprecated
 	client: Client,
 	msg: ISequencedDocumentMessage | undefined,
 ): AttributionKey => {
@@ -206,7 +201,7 @@ function combineMergeTreeCallbacks(callbacks: AttributionCallbacks[]): Attributi
  * Creates an {@link AttributionPolicy} which only tracks initial insertion of content.
  * @internal
  */
-// eslint-disable-next-line import/no-deprecated
+
 export function createInsertOnlyAttributionPolicy(): AttributionPolicy {
 	return createAttributionPolicyFromCallbacks(
 		combineMergeTreeCallbacks([
@@ -236,7 +231,6 @@ export function createInsertOnlyAttributionPolicy(): AttributionPolicy {
  */
 export function createPropertyTrackingAttributionPolicyFactory(
 	...propNames: string[]
-	// eslint-disable-next-line import/no-deprecated
 ): () => AttributionPolicy {
 	return () =>
 		createAttributionPolicyFromCallbacks(
@@ -255,7 +249,6 @@ export function createPropertyTrackingAttributionPolicyFactory(
  */
 export function createPropertyTrackingAndInsertionAttributionPolicyFactory(
 	...propNames: string[]
-	// eslint-disable-next-line import/no-deprecated
 ): () => AttributionPolicy {
 	return () =>
 		createAttributionPolicyFromCallbacks(

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -42,13 +42,11 @@ import type {
 } from "./mergeTreeDeltaCallback.js";
 import { walkAllChildSegments } from "./mergeTreeNodeWalk.js";
 import {
-	// eslint-disable-next-line import/no-deprecated
 	CollaborationWindow,
 	ISegment,
 	ISegmentAction,
 	ISegmentLeaf,
 	Marker,
-	// eslint-disable-next-line import/no-deprecated
 	SegmentGroup,
 	compareStrings,
 	toMoveInfo,
@@ -88,7 +86,6 @@ import { Side, type InteriorSequencePlace } from "./sequencePlace.js";
 import { SnapshotLoader } from "./snapshotLoader.js";
 import { SnapshotV1 } from "./snapshotV1.js";
 import { SnapshotLegacy } from "./snapshotlegacy.js";
-// eslint-disable-next-line import/no-deprecated
 import { IMergeTreeTextHelper } from "./textSegment.js";
 
 type IMergeTreeDeltaRemoteOpArgs = Omit<IMergeTreeDeltaOpArgs, "sequencedMessage"> &
@@ -194,20 +191,19 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	 * It is used to get the segment group(s) for the previous operations.
 	 * @param count - The number segment groups to get peek from the tail of the queue. Default 1.
 	 */
-	// eslint-disable-next-line import/no-deprecated
+
 	public peekPendingSegmentGroups(): SegmentGroup | undefined;
-	// eslint-disable-next-line import/no-deprecated
+
 	public peekPendingSegmentGroups(count: number): SegmentGroup | SegmentGroup[] | undefined;
 	public peekPendingSegmentGroups(
 		count: number = 1,
-		// eslint-disable-next-line import/no-deprecated
 	): SegmentGroup | SegmentGroup[] | undefined {
 		const pending = this._mergeTree.pendingSegments;
 		let node = pending?.last;
 		if (count === 1 || pending === undefined) {
 			return node?.data;
 		}
-		// eslint-disable-next-line import/no-deprecated
+
 		const taken: SegmentGroup[] = Array.from({ length: Math.min(count, pending.length) });
 		for (let i = taken.length - 1; i >= 0; i--) {
 			taken[i] = node!.data;
@@ -419,7 +415,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		}
 	}
 
-	// eslint-disable-next-line import/no-deprecated
 	public getCollabWindow(): CollaborationWindow {
 		return this._mergeTree.collabWindow;
 	}
@@ -509,7 +504,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	 * Revert an op
 	 */
 	public rollback?(op: unknown, localOpMetadata: unknown): void {
-		// eslint-disable-next-line import/no-deprecated
 		this._mergeTree.rollback(op as IMergeTreeDeltaOp, localOpMetadata as SegmentGroup);
 	}
 
@@ -881,7 +875,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 
 	private resetPendingDeltaToOps(
 		resetOp: IMergeTreeDeltaOp,
-		// eslint-disable-next-line import/no-deprecated
+
 		segmentGroup: SegmentGroup<ISegmentLeaf>,
 	): IMergeTreeDeltaOp[] {
 		assert(!!segmentGroup, 0x033 /* "Segment group undefined" */);
@@ -895,7 +889,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		}
 
 		// if this is an obliterate op, keep all segments in same segment group
-		// eslint-disable-next-line import/no-deprecated
+
 		const obliterateSegmentGroup: SegmentGroup = {
 			segments: [],
 			localSeq: segmentGroup.localSeq,
@@ -1191,7 +1185,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 
 	private lastNormalizationRefSeq = 0;
 
-	// eslint-disable-next-line import/no-deprecated
 	private pendingRebase: DoublyLinkedList<SegmentGroup> | undefined;
 
 	/**
@@ -1202,7 +1195,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	 */
 	public regeneratePendingOp(
 		resetOp: IMergeTreeOp,
-		// eslint-disable-next-line import/no-deprecated
+
 		segmentGroup: SegmentGroup | SegmentGroup[],
 	): IMergeTreeOp {
 		if (this.pendingRebase === undefined || this.pendingRebase.empty) {
@@ -1269,7 +1262,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		return opList.length === 1 ? opList[0] : createGroupOp(...opList);
 	}
 
-	// eslint-disable-next-line import/no-deprecated
 	public createTextHelper(): IMergeTreeTextHelper {
 		return new MergeTreeTextHelper(this._mergeTree);
 	}

--- a/packages/dds/merge-tree/src/endOfTreeSegment.ts
+++ b/packages/dds/merge-tree/src/endOfTreeSegment.ts
@@ -10,7 +10,6 @@ import { LocalClientId } from "./constants.js";
 import { LocalReferenceCollection } from "./localReference.js";
 import { MergeTree } from "./mergeTree.js";
 import { NodeAction, depthFirstNodeWalk } from "./mergeTreeNodeWalk.js";
-// eslint-disable-next-line import/no-deprecated
 import { ISegment, ISegmentLeaf, type MergeBlock } from "./mergeTreeNodes.js";
 
 /**

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -44,7 +44,6 @@ import {
 } from "./mergeTreeNodeWalk.js";
 import {
 	BlockAction,
-	// eslint-disable-next-line import/no-deprecated
 	CollaborationWindow,
 	IMergeNode,
 	// eslint-disable-next-line import/no-deprecated
@@ -58,14 +57,12 @@ import {
 	Marker,
 	MaxNodesInBlock,
 	MergeBlock,
-	// eslint-disable-next-line import/no-deprecated
 	SegmentGroup,
 	reservedMarkerIdKey,
 	seqLTE,
 	toMoveInfo,
 	toRemovalInfo,
 	type ISegmentInternal,
-	// eslint-disable-next-line import/no-deprecated
 	type ObliterateInfo,
 } from "./mergeTreeNodes.js";
 import type { TrackingGroup } from "./mergeTreeTracking.js";
@@ -90,9 +87,7 @@ import {
 	refHasTileLabel,
 	refTypeIncludesFlag,
 } from "./referencePositions.js";
-// eslint-disable-next-line import/no-deprecated
 import { SegmentGroupCollection } from "./segmentGroupCollection.js";
-// eslint-disable-next-line import/no-deprecated
 import {
 	copyPropertiesAndManager,
 	PropertiesManager,
@@ -527,7 +522,7 @@ class Obliterates {
 	 * See https://github.com/microsoft/FluidFramework/blob/main/packages/dds/merge-tree/docs/Obliterate.md#remote-perspective
 	 * for additional context
 	 */
-	// eslint-disable-next-line import/no-deprecated
+
 	private readonly seqOrdered = new DoublyLinkedList<ObliterateInfo>();
 
 	/**
@@ -549,7 +544,6 @@ class Obliterates {
 		}
 	}
 
-	// eslint-disable-next-line import/no-deprecated
 	public addOrUpdate(obliterateInfo: ObliterateInfo): void {
 		const { seq, start } = obliterateInfo;
 		if (seq !== UnassignedSequenceNumber) {
@@ -562,9 +556,7 @@ class Obliterates {
 		return this.startOrdered.size === 0;
 	}
 
-	// eslint-disable-next-line import/no-deprecated
 	public findOverlapping(seg: ISegmentLeaf): Iterable<ObliterateInfo> {
-		// eslint-disable-next-line import/no-deprecated
 		const overlapping: ObliterateInfo[] = [];
 		for (const start of this.startOrdered.items) {
 			if (start.getSegment()!.ordinal <= seg.ordinal) {
@@ -593,10 +585,8 @@ export class MergeTree {
 
 	private static readonly theUnfinishedNode = { childCount: -1 } as unknown as MergeBlock;
 
-	// eslint-disable-next-line import/no-deprecated
 	public readonly collabWindow = new CollaborationWindow();
 
-	// eslint-disable-next-line import/no-deprecated
 	public readonly pendingSegments = new DoublyLinkedList<SegmentGroup>();
 
 	public readonly segmentsToScour = new Heap<LRUSegment>(LRUSegmentComparer);
@@ -1091,7 +1081,6 @@ export class MergeTree {
 			return;
 		}
 
-		// eslint-disable-next-line import/no-deprecated
 		const rebaseCollabWindow = new CollaborationWindow();
 		rebaseCollabWindow.loadFrom(this.collabWindow);
 		if (refSeq < this.collabWindow.minSeq) {
@@ -1381,11 +1370,10 @@ export class MergeTree {
 
 	private addToPendingList(
 		segment: ISegmentLeaf,
-		// eslint-disable-next-line import/no-deprecated
+
 		segmentGroup?: SegmentGroup,
 		localSeq?: number,
 		previousProps?: PropertySet,
-		// eslint-disable-next-line import/no-deprecated
 	): SegmentGroup {
 		let _segmentGroup = segmentGroup;
 		if (_segmentGroup === undefined) {
@@ -1409,7 +1397,7 @@ export class MergeTree {
 		if (previousProps) {
 			_segmentGroup.previousProps!.push(previousProps);
 		}
-		// eslint-disable-next-line import/no-deprecated
+
 		const segmentGroups = (segment.segmentGroups ??= new SegmentGroupCollection(segment));
 		segmentGroups.enqueue(_segmentGroup);
 		return _segmentGroup;
@@ -1555,7 +1543,7 @@ export class MergeTree {
 			});
 			return siblingExists;
 		};
-		// eslint-disable-next-line import/no-deprecated
+
 		let segmentGroup: SegmentGroup;
 		const saveIfLocal = (locSegment: ISegmentLeaf): void => {
 			// Save segment so we can assign sequence number when acked by server
@@ -1937,7 +1925,7 @@ export class MergeTree {
 		clientId: number,
 		seq: number,
 		opArgs: IMergeTreeDeltaOpArgs,
-		// eslint-disable-next-line import/no-deprecated
+
 		rollback: PropertiesRollback = PropertiesRollback.None,
 	): void {
 		if (propsOrAdjust.adjust !== undefined) {
@@ -1949,7 +1937,7 @@ export class MergeTree {
 		const deltaSegments: IMergeTreeSegmentDelta[] = [];
 		const localSeq =
 			seq === UnassignedSequenceNumber ? ++this.collabWindow.localSeq : undefined;
-		// eslint-disable-next-line import/no-deprecated
+
 		let segmentGroup: SegmentGroup | undefined;
 		const opObj = propsOrAdjust.props ?? propsOrAdjust.adjust;
 		const annotateSegment = (segment: ISegmentLeaf): boolean => {
@@ -2027,7 +2015,7 @@ export class MergeTree {
 		const movedSegments: IMergeTreeSegmentDelta[] = [];
 		const localSeq =
 			seq === UnassignedSequenceNumber ? ++this.collabWindow.localSeq : undefined;
-		// eslint-disable-next-line import/no-deprecated
+
 		const obliterate: ObliterateInfo = {
 			clientId,
 			end: createDetachedLocalReferencePosition(undefined),
@@ -2255,7 +2243,7 @@ export class MergeTree {
 		let _overwrite = false;
 		this.ensureIntervalBoundary(start, refSeq, clientId);
 		this.ensureIntervalBoundary(end, refSeq, clientId);
-		// eslint-disable-next-line import/no-deprecated
+
 		let segmentGroup: SegmentGroup;
 		const removedSegments: IMergeTreeSegmentDelta[] = [];
 		const localOverlapWithRefs: ISegmentLeaf[] = [];
@@ -2354,7 +2342,7 @@ export class MergeTree {
 	/**
 	 * Revert an unacked local op
 	 */
-	// eslint-disable-next-line import/no-deprecated
+
 	public rollback(op: IMergeTreeDeltaOp, localOpMetadata: SegmentGroup): void {
 		if (op.type === MergeTreeDeltaType.REMOVE) {
 			const pendingSegmentGroup = this.pendingSegments.pop?.()?.data;

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
 import { assert } from "@fluidframework/core-utils/internal";
 import { AttributionKey } from "@fluidframework/runtime-definitions/internal";
 
@@ -26,9 +24,7 @@ import {
 	refGetTileLabels,
 	refTypeIncludesFlag,
 } from "./referencePositions.js";
-// eslint-disable-next-line import/no-deprecated
 import { SegmentGroupCollection } from "./segmentGroupCollection.js";
-// eslint-disable-next-line import/no-deprecated
 import { PropertiesManager } from "./segmentPropertiesManager.js";
 
 /**
@@ -78,9 +74,9 @@ export type ISegmentInternal = Omit<ISegment, keyof IRemovalInfo | keyof IMoveIn
  */
 export type ISegmentLeaf = ISegmentInternal & {
 	parent?: MergeBlock;
-	// eslint-disable-next-line import/no-deprecated
+
 	segmentGroups?: SegmentGroupCollection;
-	// eslint-disable-next-line import/no-deprecated
+
 	propertyManager?: PropertiesManager;
 	/**
 	 * If a segment is inserted into an obliterated range,

--- a/packages/dds/merge-tree/src/mergeTreeTracking.ts
+++ b/packages/dds/merge-tree/src/mergeTreeTracking.ts
@@ -5,7 +5,6 @@
 
 import { LocalReferencePosition } from "./localReference.js";
 import { ISegment } from "./mergeTreeNodes.js";
-// eslint-disable-next-line import/no-deprecated
 import { SortedSegmentSet } from "./sortedSegmentSet.js";
 
 /**
@@ -31,11 +30,9 @@ export interface ITrackingGroup {
  * @alpha
  */
 export class TrackingGroup implements ITrackingGroup {
-	// eslint-disable-next-line import/no-deprecated
 	private readonly trackedSet: SortedSegmentSet<Trackable>;
 
 	constructor() {
-		// eslint-disable-next-line import/no-deprecated
 		this.trackedSet = new SortedSegmentSet<Trackable>();
 	}
 

--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -9,7 +9,6 @@ import { Property, RedBlackTree } from "./collections/index.js";
 import { UnassignedSequenceNumber } from "./constants.js";
 import { MergeTree } from "./mergeTree.js";
 import {
-	// eslint-disable-next-line import/no-deprecated
 	CollaborationWindow,
 	IMergeNode,
 	// eslint-disable-next-line import/no-deprecated
@@ -23,10 +22,8 @@ import {
 	toRemovalInfo,
 	type MergeBlock,
 } from "./mergeTreeNodes.js";
-// eslint-disable-next-line import/no-deprecated
 import { SortedSet } from "./sortedSet.js";
 
-// eslint-disable-next-line import/no-deprecated
 class PartialSequenceLengthsSet extends SortedSet<PartialSequenceLength, number> {
 	protected getKey(item: PartialSequenceLength): number {
 		return item.seq;
@@ -289,7 +286,7 @@ export class PartialSequenceLengths {
 	 */
 	public static combine(
 		block: MergeBlock,
-		// eslint-disable-next-line import/no-deprecated
+
 		collabWindow: CollaborationWindow,
 		recur = false,
 		computeLocalPartials = false,
@@ -378,7 +375,7 @@ export class PartialSequenceLengths {
 	 */
 	private static fromLeaves(
 		block: MergeBlock,
-		// eslint-disable-next-line import/no-deprecated
+
 		collabWindow: CollaborationWindow,
 		computeLocalPartials: boolean,
 	): PartialSequenceLengths {
@@ -910,7 +907,7 @@ export class PartialSequenceLengths {
 		node: MergeBlock,
 		seq: number,
 		clientId: number,
-		// eslint-disable-next-line import/no-deprecated
+
 		collabWindow: CollaborationWindow,
 	): void {
 		let seqSeglen = 0;
@@ -1135,7 +1132,7 @@ export class PartialSequenceLengths {
 	}
 
 	// Clear away partial sums for sequence numbers earlier than the current window
-	// eslint-disable-next-line import/no-deprecated
+
 	private zamboni(segmentWindow: CollaborationWindow): void {
 		this.minLength += this.partialLengths.copyDown(segmentWindow.minSeq);
 		this.minSeq = segmentWindow.minSeq;

--- a/packages/dds/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/dds/merge-tree/src/segmentGroupCollection.ts
@@ -4,15 +4,12 @@
  */
 
 import { DoublyLinkedList, walkList } from "./collections/index.js";
-// eslint-disable-next-line import/no-deprecated
 import { SegmentGroup, type ISegmentLeaf } from "./mergeTreeNodes.js";
 
 export class SegmentGroupCollection {
-	// eslint-disable-next-line import/no-deprecated
 	private readonly segmentGroups: DoublyLinkedList<SegmentGroup<ISegmentLeaf>>;
 
 	constructor(private readonly segment: ISegmentLeaf) {
-		// eslint-disable-next-line import/no-deprecated
 		this.segmentGroups = new DoublyLinkedList<SegmentGroup<ISegmentLeaf>>();
 	}
 
@@ -24,18 +21,15 @@ export class SegmentGroupCollection {
 		return this.segmentGroups.empty;
 	}
 
-	// eslint-disable-next-line import/no-deprecated
 	public enqueue(segmentGroup: SegmentGroup<ISegmentLeaf>): void {
 		this.segmentGroups.push(segmentGroup);
 		segmentGroup.segments.push(this.segment);
 	}
 
-	// eslint-disable-next-line import/no-deprecated
 	public dequeue(): SegmentGroup<ISegmentLeaf> | undefined {
 		return this.segmentGroups.shift()?.data;
 	}
 
-	// eslint-disable-next-line import/no-deprecated
 	public remove?(segmentGroup: SegmentGroup<ISegmentLeaf>): boolean {
 		const found = this.segmentGroups.find((v) => v.data === segmentGroup);
 		if (found === undefined) {
@@ -45,7 +39,6 @@ export class SegmentGroupCollection {
 		return true;
 	}
 
-	// eslint-disable-next-line import/no-deprecated
 	public pop?(): SegmentGroup<ISegmentLeaf> | undefined {
 		return this.segmentGroups.pop ? this.segmentGroups.pop()?.data : undefined;
 	}
@@ -54,7 +47,6 @@ export class SegmentGroupCollection {
 		walkList(this.segmentGroups, (sg) => segmentGroups.enqueueOnCopy(sg.data, this.segment));
 	}
 
-	// eslint-disable-next-line import/no-deprecated
 	private enqueueOnCopy(
 		segmentGroup: SegmentGroup<ISegmentLeaf>,
 		sourceSegment: ISegmentLeaf,

--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -20,7 +20,6 @@ import {
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
 
-// eslint-disable-next-line import/no-deprecated
 import { Client } from "./client.js";
 import { NonCollabClient, UniversalSequenceNumber } from "./constants.js";
 import { MergeTree } from "./mergeTree.js";
@@ -39,7 +38,7 @@ export class SnapshotLoader {
 
 	constructor(
 		private readonly runtime: IFluidDataStoreRuntime,
-		// eslint-disable-next-line import/no-deprecated
+
 		private readonly client: Client,
 		private readonly mergeTree: MergeTree,
 		logger: ITelemetryLoggerExt,

--- a/packages/dds/merge-tree/src/sortedSegmentSet.ts
+++ b/packages/dds/merge-tree/src/sortedSegmentSet.ts
@@ -5,7 +5,6 @@
 
 import { LocalReferencePosition } from "./localReference.js";
 import { ISegmentInternal } from "./mergeTreeNodes.js";
-// eslint-disable-next-line import/no-deprecated
 import { SortedSet } from "./sortedSet.js";
 
 /**
@@ -28,7 +27,7 @@ export type SortedSegmentSetItem =
  *
  * @internal
  */
-// eslint-disable-next-line import/no-deprecated
+
 export class SortedSegmentSet<
 	T extends SortedSegmentSetItem = ISegmentInternal,
 > extends SortedSet<T, string> {

--- a/packages/dds/merge-tree/src/test/dirname.cts
+++ b/packages/dds/merge-tree/src/test/dirname.cts
@@ -10,5 +10,5 @@
 //   - Export '__dirname' from a .cjs file in the same directory.
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
-// eslint-disable-next-line unicorn/prefer-module
+
 export const _dirname = __dirname;

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -72,7 +72,6 @@ export const annotateRange: TestOperation = (
 	opEnd: number,
 	random: IRandom,
 ) => {
-	// eslint-disable-next-line unicorn/prefer-ternary
 	if (random.bool()) {
 		return client.annotateRangeLocal(opStart, opEnd, {
 			[random.integer(1, 5)]: client.longClientId,

--- a/packages/dds/merge-tree/src/test/wordUnitTests.spec.ts
+++ b/packages/dds/merge-tree/src/test/wordUnitTests.spec.ts
@@ -54,7 +54,7 @@ export function propertyCopy(): void {
 	clockStart = clock();
 	for (let j = 0; j < iterCount; j++) {
 		const bObj = createMap<number>();
-		// eslint-disable-next-line guard-for-in, no-restricted-syntax
+		// eslint-disable-next-line no-restricted-syntax
 		for (const key in obj) {
 			if (key in obj) {
 				bObj[key] = obj[key];

--- a/packages/dds/test-dds-utils/src/test/ddsSuiteCases/dirname.cts
+++ b/packages/dds/test-dds-utils/src/test/ddsSuiteCases/dirname.cts
@@ -10,5 +10,5 @@
 //   - Export '__dirname' from a .cjs file in the same directory.
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
-// eslint-disable-next-line unicorn/prefer-module
+
 export const _dirname = __dirname;

--- a/packages/dds/test-dds-utils/src/test/dirname.cts
+++ b/packages/dds/test-dds-utils/src/test/dirname.cts
@@ -10,5 +10,5 @@
 //   - Export '__dirname' from a .cjs file in the same directory.
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
-// eslint-disable-next-line unicorn/prefer-module
+
 export const _dirname = __dirname;

--- a/packages/drivers/driver-web-cache/src/test/FluidCache.test.ts
+++ b/packages/drivers/driver-web-cache/src/test/FluidCache.test.ts
@@ -62,7 +62,7 @@ function getMockCacheEntry(itemKey: string, options?: { docId: string }): ICache
 [true, false].forEach((immediateClose) => {
 	function getFluidCache(config?: {
 		maxCacheItemAge?: number;
-		// eslint-disable-next-line @rushstack/no-new-null
+
 		partitionKey?: string | null;
 	}) {
 		return new FluidCache({

--- a/packages/drivers/file-driver/src/fileDocumentService.ts
+++ b/packages/drivers/file-driver/src/fileDocumentService.ts
@@ -22,7 +22,6 @@ import { FileDeltaStorageService } from "./fileDeltaStorageService.js";
  */
 export class FileDocumentService
 	extends TypedEventEmitter<IDocumentServiceEvents>
-	// eslint-disable-next-line import/namespace
 	implements IDocumentService
 {
 	constructor(

--- a/packages/drivers/replay-driver/src/replayDocumentService.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentService.ts
@@ -26,7 +26,6 @@ import { ReplayDocumentDeltaConnection } from "./replayDocumentDeltaConnection.j
  */
 export class ReplayDocumentService
 	extends TypedEventEmitter<IDocumentServiceEvents>
-	// eslint-disable-next-line import/namespace
 	implements IDocumentService
 {
 	public static async create(

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -55,7 +55,6 @@ import { ITokenProvider } from "./tokens.js";
  */
 export class DocumentService
 	extends TypedEventEmitter<IDocumentServiceEvents>
-	// eslint-disable-next-line import/namespace
 	implements IDocumentService
 {
 	private storageManager: GitManager | undefined;

--- a/packages/framework/oldest-client-observer/src/oldestClientObserver.ts
+++ b/packages/framework/oldest-client-observer/src/oldestClientObserver.ts
@@ -117,7 +117,7 @@ export class OldestClientObserver
 		// TODO: Clean up error code linter violations repo-wide.
 		assert(
 			this.observable.clientId !== undefined,
-			// eslint-disable-next-line unicorn/numeric-separators-style
+
 			0x1da /* "Client id should be set if connected" */,
 		);
 

--- a/packages/loader/driver-utils/src/insecureUrlResolver.ts
+++ b/packages/loader/driver-utils/src/insecureUrlResolver.ts
@@ -144,7 +144,7 @@ export class InsecureUrlResolver implements IUrlResolver {
 	): Promise<string> {
 		const parsedUrl = new URL(resolvedUrl.url);
 		const [, , documentId] = parsedUrl.pathname?.split("/") ?? [];
-		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+
 		assert(!!documentId, 0x273 /* "Invalid document id from parsed URL" */);
 
 		let url = relativeUrl;

--- a/packages/loader/driver-utils/src/test/summaryCompressionData.ts
+++ b/packages/loader/driver-utils/src/test/summaryCompressionData.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable @typescript-eslint/dot-notation */
-
 export const summaryTemplate = {
 	type: 1,
 	tree: {

--- a/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
@@ -168,7 +168,7 @@ const newMessage = (
 	contents,
 	compression: undefined,
 	// TODO: It should already be the case that we're not modifying any metadata, not clear if/why this shallow clone should be required.
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 	metadata:
 		originalMessage.metadata === undefined
 			? undefined

--- a/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
@@ -190,7 +190,7 @@ export class OpSplitter {
 		const contents: IChunkedContents = message.contents;
 
 		// TODO: Verify whether this should be able to handle server-generated ops (with null clientId)
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 		const clientId = message.clientId as string;
 		const chunkedContent = contents.contents;
 		this.addChunk(clientId, chunkedContent, message);

--- a/packages/runtime/container-runtime/src/scheduleManager.ts
+++ b/packages/runtime/container-runtime/src/scheduleManager.ts
@@ -103,7 +103,7 @@ class ScheduleManagerCore {
 			// Set the batch flag to false on the last message to indicate the end of the send batch
 			const lastMessage = messages[messages.length - 1];
 			// TODO: It's not clear if this shallow clone is required, as opposed to just setting "batch" to false.
-			// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 			lastMessage.metadata = { ...(lastMessage.metadata as any), batch: false };
 		});
 
@@ -303,7 +303,7 @@ class ScheduleManagerCore {
 			);
 			this.pauseSequenceNumber = message.sequenceNumber;
 			// TODO: Verify whether this should be able to handle server-generated ops (with null clientId)
-			// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 			this.currentBatchClientId = message.clientId as string;
 			// Start of the batch
 			// Only pause processing if queue has no other ops!

--- a/packages/runtime/container-runtime/src/summary/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryCollection.ts
@@ -83,7 +83,7 @@ class Summary implements ISummary {
 	}
 	public static createFromOp(op: ISummaryOpMessage) {
 		// TODO: Verify whether this should be able to handle server-generated ops (with null clientId)
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 		const summary = new Summary(op.clientId as string, op.clientSequenceNumber);
 		summary.broadcast(op);
 		return summary;
@@ -408,7 +408,7 @@ export class SummaryCollection extends TypedEventEmitter<ISummaryCollectionOpEve
 
 		// Check if summary already being watched, broadcast if so
 		// TODO: Verify whether this should be able to handle server-generated ops (with null clientId)
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 		const watcher = this.summaryWatchers.get(op.clientId as string);
 		if (watcher) {
 			summary = watcher.tryGetSummary(op.clientSequenceNumber);

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opDecompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opDecompressor.spec.ts
@@ -57,7 +57,7 @@ function generateCompressedBatchMessage(length: number): ISequencedDocumentMessa
 	return {
 		...messageBase,
 		// TODO: It's not clear if this shallow clone is required, as opposed to just setting "batch" to false.
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 		metadata: { ...(messageBase.metadata as any), batch: true },
 	};
 }

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -305,7 +305,6 @@ describe("Runtime", () => {
 			};
 
 			before(() => {
-				// eslint-disable-next-line import/no-named-as-default-member
 				clock = sinon.useFakeTimers();
 			});
 

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -61,7 +61,6 @@ export interface IFluidDataStoreRuntime
 	readonly channelsRoutingContext: IFluidHandleContext;
 	readonly objectsRoutingContext: IFluidHandleContext;
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	readonly options: Record<string | number, any>;
 
 	readonly deltaManager: IDeltaManagerErased;

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -195,7 +195,7 @@ export class FluidDataStoreRuntime
 	private readonly pendingHandlesToMakeVisible: Set<IFluidHandleInternal> = new Set();
 
 	public readonly id: string;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	public readonly options: Record<string | number, any>;
 	public readonly deltaManagerInternal: IDeltaManager<
 		ISequencedDocumentMessage,

--- a/packages/runtime/id-compressor/src/finalSpace.ts
+++ b/packages/runtime/id-compressor/src/finalSpace.ts
@@ -33,7 +33,6 @@ export class FinalSpace {
 		const lastCluster = this.getLastCluster();
 		assert(
 			lastCluster === undefined ||
-				// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
 				newCluster.baseFinalId === lastCluster.baseFinalId + lastCluster.capacity,
 			0x753 /* Cluster insert to final_space is out of order. */,
 		);

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -1201,7 +1201,7 @@ describe("IdCompressor", () => {
 			network.deliverOperations(DestinationClient.All);
 			const id = network.getSequencedIdLog(Client.Client2)[0].id;
 			assert(isFinalId(id));
-			// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+
 			const emptyId = (id + 1) as SessionSpaceCompressedId;
 			assert.throws(
 				() => network.getCompressor(Client.Client2).decompress(emptyId),

--- a/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
@@ -638,7 +638,7 @@ export class IdCompressorTestNetwork {
 			assert(originatingSession !== undefined, "Expected originating client to be defined");
 			idIndicesAggregator.set(
 				originatingSession,
-				// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+
 				(idIndicesAggregator.get(originatingSession) ??
 					fail("Expected pre-existing index for originating client")) + 1,
 			);

--- a/packages/runtime/id-compressor/src/utilities.ts
+++ b/packages/runtime/id-compressor/src/utilities.ts
@@ -179,7 +179,6 @@ export function stableIdFromNumericUuid(numericUuid: NumericUuid): StableId {
 }
 
 export function offsetNumericUuid(numericUuid: NumericUuid, offset: number): NumericUuid {
-	// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
 	return (numericUuid + BigInt(offset)) as NumericUuid;
 }
 
@@ -188,6 +187,5 @@ export function subtractNumericUuids(a: NumericUuid, b: NumericUuid): NumericUui
 }
 
 export function addNumericUuids(a: NumericUuid, b: NumericUuid): NumericUuid {
-	// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
 	return (a + b) as NumericUuid;
 }

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -40,7 +40,7 @@ import { v4 as uuid } from "uuid";
 export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 	public isLocalDataStore: boolean = true;
 	public packagePath: readonly string[] = undefined as any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	public options: Record<string | number, any> = {};
 	public clientId: string | undefined = uuid();
 	public clientDetails: IClientDetails;

--- a/packages/tools/fetch-tool/src/fluidAnalyzeMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidAnalyzeMessages.ts
@@ -77,10 +77,7 @@ class ActiveSession {
 
 // Format a number separating 3 digits by comma
 export const formatNumber = (num: number): string =>
-	// eslint-disable-next-line unicorn/no-unsafe-regex
-	num
-		.toString()
-		.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+	num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 
 function dumpStats(
 	map: Map<string, [number, number]>,
@@ -561,15 +558,14 @@ function processOp(
 			case ContainerMessageType.ChunkedOp: {
 				const chunk = runtimeMessage.contents as IChunkedOp;
 				// TODO: Verify whether this should be able to handle server-generated ops (with null clientId)
-				// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 				if (!chunkMap.has(runtimeMessage.clientId as string)) {
-					// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 					chunkMap.set(runtimeMessage.clientId as string, {
 						chunks: new Array<string>(chunk.totalChunks),
 						totalSize: 0,
 					});
 				}
-				// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 				const value = chunkMap.get(runtimeMessage.clientId as string);
 				assert(value !== undefined, 0x2b8 /* "Chunk should be set in map" */);
 				const chunks = value.chunks;
@@ -590,7 +586,6 @@ function processOp(
 				} else {
 					return;
 				}
-				// eslint-disable-next-line no-fallthrough
 			}
 			case ContainerMessageType.IdAllocation:
 			case ContainerMessageType.FluidDataStoreOp:
@@ -793,7 +788,7 @@ function processQuorumMessages(
 	} else {
 		// message.clientId can be null
 		// TODO: Verify whether this should be able to handle server-generated ops (with null clientId)
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+
 		session = sessionsInProgress.get(message.clientId as string);
 		if (session === undefined) {
 			session = sessionsInProgress.get(noClientName);

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -79,7 +79,7 @@
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob dist lib \"*.d.ts\" \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc _api-extractor-temp outputFolder",
 		"eslint": "eslint --format stylish src \"bin/*\"",
-		"eslint:fix": "npm run eslint -- --fix --fix-type problem,suggestion,layout",
+		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
 		"format": "npm run format:biome",
 		"format:biome": "biome check . --write",
 		"format:prettier": "prettier --write . --cache --ignore-path ../../../.prettierignore",

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -428,7 +428,6 @@ export function throwOdspNetworkError(
 
 	networkError.addTelemetryProperties({ odspError: true, storageServiceError: true });
 
-	// eslint-disable-next-line @typescript-eslint/no-throw-literal
 	throw networkError;
 }
 

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -944,7 +944,6 @@ export const tagData = <
 			// The ternary form is less legible in this case.
 			// eslint-disable-next-line unicorn/prefer-ternary
 			if (typeof value === "function") {
-				// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 				pv[key] = () => {
 					return { tag, value: value() };
 				};


### PR DESCRIPTION
ran lint fix on all the client packages to remove unnecessary es-lint suppressions. This helps keep the command line output small when there are errors, as each one of these outputs as a warning.