### PR TITLE
refactor(api-markdown-documenter): Rename types to use "Configuration" instead of "Config"

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -10,7 +10,8 @@ Combines the separate "config" property bag parameters into a single "options" p
 
 #### Type-renames
 
--   `ConfigurationBase` -\> `LoggingConfiguration`.
+-   `ConfigurationBase` -> `LoggingConfiguration`.
+-   `ToHtmlConfig` -> `ToHtmlConfiguration`
 
 ##### Example
 

--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -10,10 +10,10 @@ Combines the separate "config" property bag parameters into a single "options" p
 
 #### Type-renames
 
--   `ConfigurationBase` -> `LoggingConfiguration`.
+-   `ConfigurationBase` -> `LoggingConfiguration`
+-   `RenderDocumentAsHtmlConfig` -> `RenderDocumentAsHtmlConfiguration`
+-   `RenderHtmlConfig` -> `RenderHtmlConfiguration`
 -   `ToHtmlConfig` -> `ToHtmlConfiguration`
--   `RenderDocumentAsHtmlConfig` -> `RenderDocumentAsHtmlConfiguration`,
--   `RenderHtmlConfig` -> `RenderHtmlConfiguration`,
 
 ##### Example
 

--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -12,6 +12,8 @@ Combines the separate "config" property bag parameters into a single "options" p
 
 -   `ConfigurationBase` -> `LoggingConfiguration`.
 -   `ToHtmlConfig` -> `ToHtmlConfiguration`
+-   `RenderDocumentAsHtmlConfig` -> `RenderDocumentAsHtmlConfiguration`,
+-   `RenderHtmlConfig` -> `RenderHtmlConfiguration`,
 
 ##### Example
 

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -220,13 +220,13 @@ export interface DocumentationNode<TData extends object = Data> extends Node_2<T
 }
 
 // @public
-export function documentationNodesToHtml(nodes: DocumentationNode[], config: ToHtmlConfig): Nodes[];
+export function documentationNodesToHtml(nodes: DocumentationNode[], config: ToHtmlConfiguration): Nodes[];
 
 // @public
 export function documentationNodesToHtml(nodes: DocumentationNode[], transformationContext: ToHtmlContext): Nodes[];
 
 // @public
-export function documentationNodeToHtml(node: DocumentationNode, config: ToHtmlConfig): Nodes;
+export function documentationNodeToHtml(node: DocumentationNode, config: ToHtmlConfiguration): Nodes;
 
 // @public
 export function documentationNodeToHtml(node: DocumentationNode, context: ToHtmlContext): Nodes;
@@ -308,7 +308,7 @@ export interface DocumentNodeProps {
 }
 
 // @public
-export function documentToHtml(document: DocumentNode, config: ToHtmlConfig): Root;
+export function documentToHtml(document: DocumentNode, config: ToHtmlConfiguration): Root;
 
 // @public
 export interface DocumentWriter {
@@ -637,7 +637,7 @@ function renderDocument(document: DocumentNode, config: RenderDocumentAsHtmlConf
 function renderDocument_2(document: DocumentNode, config: MarkdownRenderConfiguration): string;
 
 // @public @sealed
-export interface RenderDocumentAsHtmlConfig extends ToHtmlConfig, RenderHtmlConfig {
+export interface RenderDocumentAsHtmlConfig extends ToHtmlConfiguration, RenderHtmlConfig {
 }
 
 // @alpha
@@ -773,7 +773,7 @@ export interface TextFormatting {
 }
 
 // @public
-export interface ToHtmlConfig extends LoggingConfiguration {
+export interface ToHtmlConfiguration extends LoggingConfiguration {
     readonly customTransformations?: ToHtmlTransformations;
     readonly language?: string;
     readonly rootFormatting?: TextFormatting;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -620,7 +620,7 @@ export { ReleaseTag }
 function renderApiModelAsHtml(options: RenderApiModelAsHtmlOptions): Promise<void>;
 
 // @public
-interface RenderApiModelAsHtmlOptions extends ApiItemTransformationConfiguration, RenderDocumentAsHtmlConfig, FileSystemConfiguration {
+interface RenderApiModelAsHtmlOptions extends ApiItemTransformationConfiguration, RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
 }
 
 // @public
@@ -631,20 +631,20 @@ interface RenderApiModelAsMarkdownOptions extends ApiItemTransformationConfigura
 }
 
 // @public
-function renderDocument(document: DocumentNode, config: RenderDocumentAsHtmlConfig): string;
+function renderDocument(document: DocumentNode, config: RenderDocumentAsHtmlConfiguration): string;
 
 // @public
 function renderDocument_2(document: DocumentNode, config: MarkdownRenderConfiguration): string;
 
 // @public @sealed
-export interface RenderDocumentAsHtmlConfig extends ToHtmlConfiguration, RenderHtmlConfig {
+export interface RenderDocumentAsHtmlConfiguration extends ToHtmlConfiguration, RenderHtmlConfiguration {
 }
 
 // @alpha
 function renderDocumentsAsHtml(documents: DocumentNode[], options: RenderDocumentsAsHtmlOptions): Promise<void>;
 
 // @public
-interface RenderDocumentsAsHtmlOptions extends RenderDocumentAsHtmlConfig, FileSystemConfiguration {
+interface RenderDocumentsAsHtmlOptions extends RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
 }
 
 // @public
@@ -655,12 +655,10 @@ interface RenderDocumentsAsMarkdownOptions extends MarkdownRenderConfiguration, 
 }
 
 // @public
-function renderHtml(html: Nodes, { prettyFormatting }: {
-    prettyFormatting?: boolean;
-}): string;
+function renderHtml(html: Nodes, config: RenderHtmlConfiguration): string;
 
 // @public @sealed
-export interface RenderHtmlConfig {
+export interface RenderHtmlConfiguration {
     prettyFormatting?: boolean;
 }
 

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -617,7 +617,7 @@ export class PlainTextNode extends DocumentationLiteralNodeBase<string> implemen
 export { ReleaseTag }
 
 // @public
-interface RenderApiModelAsHtmlOptions extends ApiItemTransformationConfiguration, RenderDocumentAsHtmlConfig, FileSystemConfiguration {
+interface RenderApiModelAsHtmlOptions extends ApiItemTransformationConfiguration, RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
 }
 
 // @public
@@ -628,17 +628,17 @@ interface RenderApiModelAsMarkdownOptions extends ApiItemTransformationConfigura
 }
 
 // @public
-function renderDocument(document: DocumentNode, config: RenderDocumentAsHtmlConfig): string;
+function renderDocument(document: DocumentNode, config: RenderDocumentAsHtmlConfiguration): string;
 
 // @public
 function renderDocument_2(document: DocumentNode, config: MarkdownRenderConfiguration): string;
 
 // @public @sealed
-export interface RenderDocumentAsHtmlConfig extends ToHtmlConfiguration, RenderHtmlConfig {
+export interface RenderDocumentAsHtmlConfiguration extends ToHtmlConfiguration, RenderHtmlConfiguration {
 }
 
 // @public
-interface RenderDocumentsAsHtmlOptions extends RenderDocumentAsHtmlConfig, FileSystemConfiguration {
+interface RenderDocumentsAsHtmlOptions extends RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
 }
 
 // @public
@@ -649,12 +649,10 @@ interface RenderDocumentsAsMarkdownOptions extends MarkdownRenderConfiguration, 
 }
 
 // @public
-function renderHtml(html: Nodes, { prettyFormatting }: {
-    prettyFormatting?: boolean;
-}): string;
+function renderHtml(html: Nodes, config: RenderHtmlConfiguration): string;
 
 // @public @sealed
-export interface RenderHtmlConfig {
+export interface RenderHtmlConfiguration {
     prettyFormatting?: boolean;
 }
 

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -220,13 +220,13 @@ export interface DocumentationNode<TData extends object = Data> extends Node_2<T
 }
 
 // @public
-export function documentationNodesToHtml(nodes: DocumentationNode[], config: ToHtmlConfig): Nodes[];
+export function documentationNodesToHtml(nodes: DocumentationNode[], config: ToHtmlConfiguration): Nodes[];
 
 // @public
 export function documentationNodesToHtml(nodes: DocumentationNode[], transformationContext: ToHtmlContext): Nodes[];
 
 // @public
-export function documentationNodeToHtml(node: DocumentationNode, config: ToHtmlConfig): Nodes;
+export function documentationNodeToHtml(node: DocumentationNode, config: ToHtmlConfiguration): Nodes;
 
 // @public
 export function documentationNodeToHtml(node: DocumentationNode, context: ToHtmlContext): Nodes;
@@ -308,7 +308,7 @@ export interface DocumentNodeProps {
 }
 
 // @public
-export function documentToHtml(document: DocumentNode, config: ToHtmlConfig): Root;
+export function documentToHtml(document: DocumentNode, config: ToHtmlConfiguration): Root;
 
 // @public
 export interface DocumentWriter {
@@ -634,7 +634,7 @@ function renderDocument(document: DocumentNode, config: RenderDocumentAsHtmlConf
 function renderDocument_2(document: DocumentNode, config: MarkdownRenderConfiguration): string;
 
 // @public @sealed
-export interface RenderDocumentAsHtmlConfig extends ToHtmlConfig, RenderHtmlConfig {
+export interface RenderDocumentAsHtmlConfig extends ToHtmlConfiguration, RenderHtmlConfig {
 }
 
 // @public
@@ -767,7 +767,7 @@ export interface TextFormatting {
 }
 
 // @public
-export interface ToHtmlConfig extends LoggingConfiguration {
+export interface ToHtmlConfiguration extends LoggingConfiguration {
     readonly customTransformations?: ToHtmlTransformations;
     readonly language?: string;
     readonly rootFormatting?: TextFormatting;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -220,13 +220,13 @@ export interface DocumentationNode<TData extends object = Data> extends Node_2<T
 }
 
 // @public
-export function documentationNodesToHtml(nodes: DocumentationNode[], config: ToHtmlConfig): Nodes[];
+export function documentationNodesToHtml(nodes: DocumentationNode[], config: ToHtmlConfiguration): Nodes[];
 
 // @public
 export function documentationNodesToHtml(nodes: DocumentationNode[], transformationContext: ToHtmlContext): Nodes[];
 
 // @public
-export function documentationNodeToHtml(node: DocumentationNode, config: ToHtmlConfig): Nodes;
+export function documentationNodeToHtml(node: DocumentationNode, config: ToHtmlConfiguration): Nodes;
 
 // @public
 export function documentationNodeToHtml(node: DocumentationNode, context: ToHtmlContext): Nodes;
@@ -308,7 +308,7 @@ export interface DocumentNodeProps {
 }
 
 // @public
-export function documentToHtml(document: DocumentNode, config: ToHtmlConfig): Root;
+export function documentToHtml(document: DocumentNode, config: ToHtmlConfiguration): Root;
 
 // @public
 export interface DocumentWriter {
@@ -612,7 +612,7 @@ function renderDocument(document: DocumentNode, config: RenderDocumentAsHtmlConf
 function renderDocument_2(document: DocumentNode, config: MarkdownRenderConfiguration): string;
 
 // @public @sealed
-export interface RenderDocumentAsHtmlConfig extends ToHtmlConfig, RenderHtmlConfig {
+export interface RenderDocumentAsHtmlConfig extends ToHtmlConfiguration, RenderHtmlConfig {
 }
 
 // @public
@@ -745,7 +745,7 @@ export interface TextFormatting {
 }
 
 // @public
-export interface ToHtmlConfig extends LoggingConfiguration {
+export interface ToHtmlConfiguration extends LoggingConfiguration {
     readonly customTransformations?: ToHtmlTransformations;
     readonly language?: string;
     readonly rootFormatting?: TextFormatting;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -595,7 +595,7 @@ export class PlainTextNode extends DocumentationLiteralNodeBase<string> implemen
 export { ReleaseTag }
 
 // @public
-interface RenderApiModelAsHtmlOptions extends ApiItemTransformationConfiguration, RenderDocumentAsHtmlConfig, FileSystemConfiguration {
+interface RenderApiModelAsHtmlOptions extends ApiItemTransformationConfiguration, RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
 }
 
 // @public
@@ -606,17 +606,17 @@ interface RenderApiModelAsMarkdownOptions extends ApiItemTransformationConfigura
 }
 
 // @public
-function renderDocument(document: DocumentNode, config: RenderDocumentAsHtmlConfig): string;
+function renderDocument(document: DocumentNode, config: RenderDocumentAsHtmlConfiguration): string;
 
 // @public
 function renderDocument_2(document: DocumentNode, config: MarkdownRenderConfiguration): string;
 
 // @public @sealed
-export interface RenderDocumentAsHtmlConfig extends ToHtmlConfiguration, RenderHtmlConfig {
+export interface RenderDocumentAsHtmlConfiguration extends ToHtmlConfiguration, RenderHtmlConfiguration {
 }
 
 // @public
-interface RenderDocumentsAsHtmlOptions extends RenderDocumentAsHtmlConfig, FileSystemConfiguration {
+interface RenderDocumentsAsHtmlOptions extends RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
 }
 
 // @public
@@ -627,12 +627,10 @@ interface RenderDocumentsAsMarkdownOptions extends MarkdownRenderConfiguration, 
 }
 
 // @public
-function renderHtml(html: Nodes, { prettyFormatting }: {
-    prettyFormatting?: boolean;
-}): string;
+function renderHtml(html: Nodes, config: RenderHtmlConfiguration): string;
 
 // @public @sealed
-export interface RenderHtmlConfig {
+export interface RenderHtmlConfiguration {
     prettyFormatting?: boolean;
 }
 

--- a/tools/api-markdown-documenter/src/RenderHtml.ts
+++ b/tools/api-markdown-documenter/src/RenderHtml.ts
@@ -13,7 +13,7 @@ import {
 	transformApiModel,
 } from "./api-item-transforms/index.js";
 import type { DocumentNode } from "./documentation-domain/index.js";
-import { type RenderDocumentAsHtmlConfig, renderDocumentAsHtml } from "./renderers/index.js";
+import { type RenderDocumentAsHtmlConfiguration, renderDocumentAsHtml } from "./renderers/index.js";
 
 /**
  * API Model HTML rendering options.
@@ -22,7 +22,7 @@ import { type RenderDocumentAsHtmlConfig, renderDocumentAsHtml } from "./rendere
  */
 export interface RenderApiModelAsHtmlOptions
 	extends ApiItemTransformationConfiguration,
-		RenderDocumentAsHtmlConfig,
+		RenderDocumentAsHtmlConfiguration,
 		FileSystemConfiguration {}
 
 /**
@@ -58,7 +58,7 @@ export async function renderApiModelAsHtml(options: RenderApiModelAsHtmlOptions)
  * @public
  */
 export interface RenderDocumentsAsHtmlOptions
-	extends RenderDocumentAsHtmlConfig,
+	extends RenderDocumentAsHtmlConfiguration,
 		FileSystemConfiguration {}
 
 /**

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/ToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/ToHtml.ts
@@ -12,7 +12,7 @@ import {
 	createTransformationContext,
 	type TransformationContext,
 } from "./TransformationContext.js";
-import type { TransformationConfig } from "./configuration/index.js";
+import type { TransformationConfiguration } from "./configuration/index.js";
 
 /**
  * Generates an HTML AST from the provided {@link DocumentNode}.
@@ -22,7 +22,10 @@ import type { TransformationConfig } from "./configuration/index.js";
  *
  * @public
  */
-export function documentToHtml(document: DocumentNode, config: TransformationConfig): HastRoot {
+export function documentToHtml(
+	document: DocumentNode,
+	config: TransformationConfiguration,
+): HastRoot {
 	const transformationContext = createTransformationContext(config);
 
 	const transformedChildren = documentationNodesToHtml(document.children, transformationContext);
@@ -34,7 +37,7 @@ export function documentToHtml(document: DocumentNode, config: TransformationCon
  *
  * @privateRemarks Exported for testing purposes. Not intended for external use.
  */
-export function treeFromBody(body: HastTree[], config: TransformationConfig): HastRoot {
+export function treeFromBody(body: HastTree[], config: TransformationConfiguration): HastRoot {
 	const rootBodyContents: HastTree[] = [];
 	rootBodyContents.push({
 		type: "doctype",
@@ -63,7 +66,7 @@ export function treeFromBody(body: HastTree[], config: TransformationConfig): Ha
  */
 export function documentationNodeToHtml(
 	node: DocumentationNode,
-	config: TransformationConfig,
+	config: TransformationConfiguration,
 ): HastTree;
 /**
  * Generates an HTML AST from the provided {@link DocumentationNode}.
@@ -82,7 +85,7 @@ export function documentationNodeToHtml(
  */
 export function documentationNodeToHtml(
 	node: DocumentationNode,
-	configOrContext: TransformationConfig | TransformationContext,
+	configOrContext: TransformationConfiguration | TransformationContext,
 ): HastTree {
 	const context = getContext(configOrContext);
 
@@ -102,7 +105,7 @@ export function documentationNodeToHtml(
  */
 export function documentationNodesToHtml(
 	nodes: DocumentationNode[],
-	config: TransformationConfig,
+	config: TransformationConfiguration,
 ): HastTree[];
 /**
  * Generates a series of HTML ASTs from the provided {@link DocumentationNode}s.
@@ -118,14 +121,14 @@ export function documentationNodesToHtml(
  */
 export function documentationNodesToHtml(
 	nodes: DocumentationNode[],
-	configOrContext: TransformationConfig | TransformationContext,
+	configOrContext: TransformationConfiguration | TransformationContext,
 ): HastTree[] {
 	const context = getContext(configOrContext);
 	return nodes.map((node) => documentationNodeToHtml(node, context));
 }
 
 function getContext(
-	configOrContext: TransformationConfig | TransformationContext,
+	configOrContext: TransformationConfiguration | TransformationContext,
 ): TransformationContext {
 	return (configOrContext as Partial<TransformationContext>).transformations === undefined
 		? createTransformationContext(configOrContext)

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/TransformationContext.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/TransformationContext.ts
@@ -8,7 +8,7 @@ import type { TextFormatting } from "../documentation-domain/index.js";
 
 import {
 	defaultTransformations,
-	type TransformationConfig,
+	type TransformationConfiguration,
 	type Transformations,
 } from "./configuration/index.js";
 
@@ -44,7 +44,7 @@ export interface TransformationContext extends TextFormatting {
  * system defaults.
  */
 export function createTransformationContext(
-	config: TransformationConfig | undefined,
+	config: TransformationConfiguration | undefined,
 ): TransformationContext {
 	const headingLevel = config?.startingHeadingLevel ?? 1;
 	const transformations: Transformations = {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/Configuration.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/Configuration.ts
@@ -14,7 +14,7 @@ import type { Transformations } from "./Transformation.js";
  *
  * @public
  */
-export interface TransformationConfig extends LoggingConfiguration {
+export interface TransformationConfiguration extends LoggingConfiguration {
 	/**
 	 * User-specified transformations.
 	 *
@@ -47,12 +47,12 @@ export interface TransformationConfig extends LoggingConfiguration {
 }
 
 /**
- * Gets a complete {@link TransformationConfig} using the provided partial configuration, and filling
+ * Gets a complete {@link TransformationConfiguration} using the provided partial configuration, and filling
  * in the remainder with the documented defaults.
  */
 export function getConfigurationWithDefaults(
-	inputConfig: Partial<TransformationConfig> | undefined,
-): TransformationConfig {
+	inputConfig: Partial<TransformationConfiguration> | undefined,
+): TransformationConfiguration {
 	const logger = inputConfig?.logger ?? defaultConsoleLogger;
 	const startingHeadingLevel = inputConfig?.startingHeadingLevel ?? 1;
 	return {

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/index.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export { getConfigurationWithDefaults, type TransformationConfig } from "./Configuration.js";
+export { getConfigurationWithDefaults, type TransformationConfiguration } from "./Configuration.js";
 export {
 	defaultTransformations,
 	type Transformation,

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/index.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/index.ts
@@ -4,7 +4,7 @@
  */
 
 export type {
-	TransformationConfig,
+	TransformationConfiguration,
 	Transformation,
 	Transformations,
 } from "./configuration/index.js";

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/Utilities.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/Utilities.ts
@@ -9,14 +9,14 @@ import type { Nodes as HastNodes } from "hast";
 import type { DocumentationNode } from "../../documentation-domain/index.js";
 import { documentationNodeToHtml } from "../ToHtml.js";
 import { createTransformationContext } from "../TransformationContext.js";
-import type { TransformationConfig } from "../configuration/index.js";
+import type { TransformationConfiguration } from "../configuration/index.js";
 
 /**
  * Tests transforming an individual {@link DocumentationNode} to HTML.
  */
 export function testTransformation(
 	node: DocumentationNode,
-	config?: Partial<TransformationConfig>,
+	config?: Partial<TransformationConfiguration>,
 ): HastNodes {
 	return documentationNodeToHtml(node, createTransformationContext(config));
 }
@@ -28,7 +28,7 @@ export function testTransformation(
 export function assertTransformation(
 	input: DocumentationNode,
 	expected: HastNodes,
-	transformationConfig?: TransformationConfig,
+	transformationConfig?: TransformationConfiguration,
 ): void {
 	const actual = testTransformation(input, transformationConfig);
 	expect(actual).to.deep.equal(expected);

--- a/tools/api-markdown-documenter/src/index.ts
+++ b/tools/api-markdown-documenter/src/index.ts
@@ -43,8 +43,8 @@ export {
 } from "./documentation-domain-to-html/index.js";
 export {
 	DocumentWriter,
-	type RenderDocumentAsHtmlConfig,
-	type RenderHtmlConfig,
+	type RenderDocumentAsHtmlConfiguration,
+	type RenderHtmlConfiguration,
 	type MarkdownRenderContext,
 	type MarkdownRenderers,
 	type MarkdownRenderConfiguration,

--- a/tools/api-markdown-documenter/src/index.ts
+++ b/tools/api-markdown-documenter/src/index.ts
@@ -38,7 +38,7 @@ export {
 	documentationNodesToHtml,
 	type Transformation as ToHtmlTransformation,
 	type Transformations as ToHtmlTransformations,
-	type TransformationConfig as ToHtmlConfig,
+	type TransformationConfiguration as ToHtmlConfiguration,
 	type TransformationContext as ToHtmlContext,
 } from "./documentation-domain-to-html/index.js";
 export {

--- a/tools/api-markdown-documenter/src/renderers/html-renderer/Render.ts
+++ b/tools/api-markdown-documenter/src/renderers/html-renderer/Render.ts
@@ -10,7 +10,7 @@ import { toHtml as toHtmlString } from "hast-util-to-html";
 import type { DocumentNode } from "../../documentation-domain/index.js";
 import {
 	documentToHtml,
-	type TransformationConfig,
+	type TransformationConfiguration,
 } from "../../documentation-domain-to-html/index.js";
 
 /**
@@ -33,7 +33,7 @@ export interface RenderHtmlConfig {
  * @sealed
  * @public
  */
-export interface RenderDocumentConfig extends TransformationConfig, RenderHtmlConfig {}
+export interface RenderDocumentConfig extends TransformationConfiguration, RenderHtmlConfig {}
 
 /**
  * Renders a {@link DocumentNode} as HTML, and returns the resulting file contents as a string.

--- a/tools/api-markdown-documenter/src/renderers/html-renderer/Render.ts
+++ b/tools/api-markdown-documenter/src/renderers/html-renderer/Render.ts
@@ -19,7 +19,7 @@ import {
  * @sealed
  * @public
  */
-export interface RenderHtmlConfig {
+export interface RenderHtmlConfiguration {
 	/**
 	 * Whether or not to render the generated HTML "pretty", human-readable formatting.
 	 * @defaultValue `true`
@@ -33,7 +33,9 @@ export interface RenderHtmlConfig {
  * @sealed
  * @public
  */
-export interface RenderDocumentConfig extends TransformationConfiguration, RenderHtmlConfig {}
+export interface RenderDocumentConfiguration
+	extends TransformationConfiguration,
+		RenderHtmlConfiguration {}
 
 /**
  * Renders a {@link DocumentNode} as HTML, and returns the resulting file contents as a string.
@@ -43,7 +45,10 @@ export interface RenderDocumentConfig extends TransformationConfiguration, Rende
  *
  * @public
  */
-export function renderDocument(document: DocumentNode, config: RenderDocumentConfig): string {
+export function renderDocument(
+	document: DocumentNode,
+	config: RenderDocumentConfiguration,
+): string {
 	const htmlTree = documentToHtml(document, config);
 	return renderHtml(htmlTree, config);
 }
@@ -56,10 +61,8 @@ export function renderDocument(document: DocumentNode, config: RenderDocumentCon
  *
  * @public
  */
-export function renderHtml(
-	html: HastTree,
-	{ prettyFormatting }: { prettyFormatting?: boolean },
-): string {
+export function renderHtml(html: HastTree, config: RenderHtmlConfiguration): string {
+	const { prettyFormatting } = config;
 	if (prettyFormatting !== false) {
 		// Pretty formatting. Modifies the tree in place.
 		// Note: this API is specifically typed to only accept a `Root` node, but its code only requires any `Nodes`.

--- a/tools/api-markdown-documenter/src/renderers/html-renderer/index.ts
+++ b/tools/api-markdown-documenter/src/renderers/html-renderer/index.ts
@@ -9,7 +9,7 @@
 
 export {
 	renderDocument,
-	type RenderDocumentConfig,
+	type RenderDocumentConfiguration,
 	renderHtml,
-	type RenderHtmlConfig,
+	type RenderHtmlConfiguration,
 } from "./Render.js";

--- a/tools/api-markdown-documenter/src/renderers/html-renderer/test/Utilities.ts
+++ b/tools/api-markdown-documenter/src/renderers/html-renderer/test/Utilities.ts
@@ -8,12 +8,15 @@ import {
 	documentationNodeToHtml,
 	treeFromBody,
 } from "../../../documentation-domain-to-html/index.js";
-import { renderHtml, type RenderDocumentConfig } from "../Render.js";
+import { renderHtml, type RenderDocumentConfiguration } from "../Render.js";
 
 /**
  * Tests the rendering of an individual {@link DocumentationNode}, returning the generated string content.
  */
-export function testRender(node: DocumentationNode, maybeConfig?: RenderDocumentConfig): string {
+export function testRender(
+	node: DocumentationNode,
+	maybeConfig?: RenderDocumentConfiguration,
+): string {
 	const config = maybeConfig ?? {};
 	const html = treeFromBody([documentationNodeToHtml(node, config)], config);
 	return renderHtml(html, config);

--- a/tools/api-markdown-documenter/src/renderers/index.ts
+++ b/tools/api-markdown-documenter/src/renderers/index.ts
@@ -6,9 +6,9 @@
 export { DocumentWriter } from "./DocumentWriter.js";
 export {
 	renderDocument as renderDocumentAsHtml,
-	type RenderDocumentConfig as RenderDocumentAsHtmlConfig,
+	type RenderDocumentConfiguration as RenderDocumentAsHtmlConfiguration,
 	renderHtml,
-	type RenderHtmlConfig,
+	type RenderHtmlConfiguration,
 } from "./html-renderer/index.js";
 export {
 	type RenderConfiguration as MarkdownRenderConfiguration,

--- a/tools/api-markdown-documenter/src/test/HtmlEndToEnd.test.ts
+++ b/tools/api-markdown-documenter/src/test/HtmlEndToEnd.test.ts
@@ -10,7 +10,10 @@ import { ApiItemKind, ReleaseTag } from "@microsoft/api-extractor-model";
 import { FileSystem, NewlineKind } from "@rushstack/node-core-library";
 
 import type { DocumentNode } from "../documentation-domain/index.js";
-import { type RenderDocumentAsHtmlConfig, renderDocumentAsHtml } from "../renderers/index.js";
+import {
+	type RenderDocumentAsHtmlConfiguration,
+	renderDocumentAsHtml,
+} from "../renderers/index.js";
 
 import {
 	endToEndTests,
@@ -50,7 +53,7 @@ const apiModels: ApiModelTestOptions[] = [
 	// TODO: add other models
 ];
 
-const testConfigs: EndToEndTestConfig<RenderDocumentAsHtmlConfig>[] = [
+const testConfigs: EndToEndTestConfig<RenderDocumentAsHtmlConfiguration>[] = [
 	/**
 	 * A sample "flat" configuration, which renders every item kind under a package to the package parent document.
 	 */
@@ -118,7 +121,7 @@ const testConfigs: EndToEndTestConfig<RenderDocumentAsHtmlConfig>[] = [
 
 async function renderDocumentToFile(
 	document: DocumentNode,
-	renderConfig: RenderDocumentAsHtmlConfig,
+	renderConfig: RenderDocumentAsHtmlConfiguration,
 	outputDirectoryPath: string,
 ): Promise<void> {
 	const renderedDocument = renderDocumentAsHtml(document, renderConfig);
@@ -130,7 +133,7 @@ async function renderDocumentToFile(
 	});
 }
 
-endToEndTests<RenderDocumentAsHtmlConfig>({
+endToEndTests<RenderDocumentAsHtmlConfiguration>({
 	suiteName: "Markdown End-to-End Tests",
 	temporaryOutputDirectoryPath: testTemporaryDirectoryPath,
 	snapshotsDirectoryPath,


### PR DESCRIPTION
The code currently has a mix of types named `...Config` and `...Configuration`. This PR aims to make things more consistent, while adhering to our general guidance to avoid abbreviations.