### PR TITLE
Pass simplified customData to gitrest then filesystem layer as a parameter.

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -10,6 +10,7 @@ export enum Constants {
 	StorageRoutingIdHeader = "Storage-Routing-Id",
 	StorageNameHeader = "Storage-Name",
 	IsEphemeralContainer = "Is-Ephemeral-Container",
+	SimplifiedCustomDataHeader = "SimplifiedCustomData",
 }
 
 export interface IStorageDirectoryConfig {
@@ -90,6 +91,7 @@ export interface IFileSystemManager {
 export interface IFileSystemManagerParams {
 	storageName?: string;
 	rootDir?: string;
+	simplifiedCustomData?: string;
 }
 
 export interface IFileSystemManagerFactory {

--- a/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/helpers.ts
@@ -74,6 +74,7 @@ export function getExternalWriterParams(
 export function getRepoManagerParamsFromRequest(request: Request): IRepoManagerParams {
 	const storageName: string | undefined = request.get(Constants.StorageNameHeader);
 	const storageRoutingId = parseStorageRoutingId(request.get(Constants.StorageRoutingIdHeader));
+	const simplifiedCustomData = request.get(Constants.SimplifiedCustomDataHeader);
 
 	const isEphemeralFromRequest = request.get(Constants.IsEphemeralContainer);
 
@@ -86,6 +87,7 @@ export function getRepoManagerParamsFromRequest(request: Request): IRepoManagerP
 		storageRoutingId,
 		fileSystemManagerParams: {
 			storageName,
+			simplifiedCustomData,
 		},
 		isEphemeralContainer,
 	};

--- a/server/historian/packages/historian-base/src/app.ts
+++ b/server/historian/packages/historian-base/src/app.ts
@@ -24,7 +24,7 @@ import {
 import { BaseTelemetryProperties, HttpProperties } from "@fluidframework/server-services-telemetry";
 import { RestLessServer, createHealthCheckEndpoints } from "@fluidframework/server-services-shared";
 import * as routes from "./routes";
-import { ICache, IDenyList, ITenantService } from "./services";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "./services";
 import { Constants, getDocumentIdFromRequest, getTenantIdFromRequest } from "./utils";
 
 export function create(
@@ -40,6 +40,7 @@ export function create(
 	denyList?: IDenyList,
 	ephemeralDocumentTTLSec?: number,
 	readinessCheck?: IReadinessCheck,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
 ) {
 	// Express app configuration
 	const app: express.Express = express();

--- a/server/historian/packages/historian-base/src/customizations.ts
+++ b/server/historian/packages/historian-base/src/customizations.ts
@@ -9,6 +9,7 @@ import {
 	IReadinessCheck,
 } from "@fluidframework/server-services-core";
 import { IRedisClientConnectionManager } from "@fluidframework/server-services-utils";
+import { ISimplifiedCustomDataRetriever } from "./services";
 
 export interface IHistorianResourcesCustomizations {
 	storageNameRetriever?: IStorageNameRetriever;
@@ -16,4 +17,5 @@ export interface IHistorianResourcesCustomizations {
 	redisClientConnectionManager?: IRedisClientConnectionManager;
 	redisClientConnectionManagerForThrottling?: IRedisClientConnectionManager;
 	readinessCheck?: IReadinessCheck;
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever;
 }

--- a/server/historian/packages/historian-base/src/routes/git/blobs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/blobs.ts
@@ -15,7 +15,7 @@ import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, IDenyList, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -30,6 +30,7 @@ export function create(
 	revokedTokenChecker?: IRevokedTokenChecker,
 	denyList?: IDenyList,
 	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
 ): Router {
 	const router: Router = Router();
 

--- a/server/historian/packages/historian-base/src/routes/git/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/git/commits.ts
@@ -15,7 +15,7 @@ import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, IDenyList, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -30,6 +30,7 @@ export function create(
 	revokedTokenChecker?: IRevokedTokenChecker,
 	denyList?: IDenyList,
 	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
 ): Router {
 	const router: Router = Router();
 

--- a/server/historian/packages/historian-base/src/routes/git/refs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/refs.ts
@@ -19,7 +19,7 @@ import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, IDenyList, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -34,6 +34,7 @@ export function create(
 	revokedTokenChecker?: IRevokedTokenChecker,
 	denyList?: IDenyList,
 	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
 ): Router {
 	const router: Router = Router();
 

--- a/server/historian/packages/historian-base/src/routes/git/tags.ts
+++ b/server/historian/packages/historian-base/src/routes/git/tags.ts
@@ -15,7 +15,7 @@ import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, IDenyList, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -30,6 +30,7 @@ export function create(
 	revokedTokenChecker?: IRevokedTokenChecker,
 	denyList?: IDenyList,
 	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
 ): Router {
 	const router: Router = Router();
 

--- a/server/historian/packages/historian-base/src/routes/git/trees.ts
+++ b/server/historian/packages/historian-base/src/routes/git/trees.ts
@@ -15,7 +15,7 @@ import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, IDenyList, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -30,6 +30,7 @@ export function create(
 	revokedTokenChecker?: IRevokedTokenChecker,
 	denyList?: IDenyList,
 	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
 ): Router {
 	const router: Router = Router();
 

--- a/server/historian/packages/historian-base/src/routes/repository/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/commits.ts
@@ -18,7 +18,7 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, IDenyList, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 import { NetworkError } from "@fluidframework/server-services-client";
@@ -34,6 +34,7 @@ export function create(
 	revokedTokenChecker?: IRevokedTokenChecker,
 	denyList?: IDenyList,
 	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
 ): Router {
 	const router: Router = Router();
 

--- a/server/historian/packages/historian-base/src/routes/repository/contents.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/contents.ts
@@ -14,7 +14,7 @@ import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, IDenyList, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -29,6 +29,7 @@ export function create(
 	revokedTokenChecker?: IRevokedTokenChecker,
 	denyList?: IDenyList,
 	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
 ): Router {
 	const router: Router = Router();
 

--- a/server/historian/packages/historian-base/src/routes/repository/headers.ts
+++ b/server/historian/packages/historian-base/src/routes/repository/headers.ts
@@ -15,7 +15,7 @@ import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, IDenyList, ITenantService } from "../../services";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
 import * as utils from "../utils";
 import { Constants } from "../../utils";
 
@@ -30,6 +30,7 @@ export function create(
 	revokedTokenChecker?: IRevokedTokenChecker,
 	denyList?: IDenyList,
 	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
 ): Router {
 	const router: Router = Router();
 

--- a/server/historian/packages/historian-base/src/routes/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/summaries.ts
@@ -20,7 +20,7 @@ import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
 import { BaseTelemetryProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
-import { ICache, IDenyList, ITenantService } from "../services";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../services";
 import { parseToken, Constants } from "../utils";
 import * as utils from "./utils";
 
@@ -35,6 +35,7 @@ export function create(
 	revokedTokenChecker?: IRevokedTokenChecker,
 	denyList?: IDenyList,
 	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
 ): Router {
 	const router: Router = Router();
 	const ignoreIsEphemeralFlag: boolean = config.get("ignoreEphemeralFlag") ?? true;
@@ -125,6 +126,7 @@ export function create(
 			isEphemeralContainer,
 			denyList,
 			ephemeralDocumentTTLSec,
+			simplifiedCustomDataRetriever,
 		});
 		return service.createSummary(params, initial);
 	}

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -28,6 +28,7 @@ import {
 	RestGitService,
 	ITenantCustomDataExternal,
 	IDenyList,
+	ISimplifiedCustomDataRetriever,
 } from "../services";
 import { containsPathTraversal, parseToken } from "../utils";
 
@@ -44,6 +45,7 @@ export type CommonRouteParams = [
 	revokedTokenChecker?: IRevokedTokenChecker,
 	denyList?: IDenyList,
 	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
 ];
 
 export interface ICreateGitServiceArgs {
@@ -60,6 +62,7 @@ export interface ICreateGitServiceArgs {
 	isEphemeralContainer?: boolean;
 	ephemeralDocumentTTLSec?: number; // 24 hours
 	denyList?: IDenyList;
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever;
 }
 
 const defaultCreateGitServiceArgs: Required<
@@ -273,6 +276,7 @@ export async function createGitService(createArgs: ICreateGitServiceArgs): Promi
 		isEphemeralContainer,
 		ephemeralDocumentTTLSec,
 		denyList,
+		simplifiedCustomDataRetriever,
 	} = { ...defaultCreateGitServiceArgs, ...createArgs };
 	if (!authorization) {
 		throw new NetworkError(403, "Authorization header is missing.");
@@ -292,6 +296,7 @@ export async function createGitService(createArgs: ICreateGitServiceArgs): Promi
 	}
 	const details = await tenantService.getTenant(tenantId, token, allowDisabledTenant);
 	const customData: ITenantCustomDataExternal = details.customData;
+	const simplifiedCustomData = simplifiedCustomDataRetriever?.get(customData);
 	const writeToExternalStorage = !!customData?.externalStorageData;
 	const storageUrl = config.get("storageUrl") as string | undefined;
 	const ignoreEphemeralFlag: boolean = config.get("ignoreEphemeralFlag");
@@ -326,6 +331,7 @@ export async function createGitService(createArgs: ICreateGitServiceArgs): Promi
 		storageUrl,
 		isEphemeral,
 		maxCacheableSummarySize,
+		simplifiedCustomData,
 	);
 	return service;
 }

--- a/server/historian/packages/historian-base/src/runner.ts
+++ b/server/historian/packages/historian-base/src/runner.ts
@@ -17,7 +17,7 @@ import {
 import { Provider } from "nconf";
 import * as winston from "winston";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
-import { ICache, IDenyList, ITenantService } from "./services";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "./services";
 import * as app from "./app";
 
 export class HistorianRunner implements IRunner {
@@ -39,6 +39,7 @@ export class HistorianRunner implements IRunner {
 		private readonly denyList?: IDenyList,
 		private readonly ephemeralDocumentTTLSec?: number,
 		private readonly readinessCheck?: IReadinessCheck,
+		private readonly simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
 	) {}
 
 	// eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -58,6 +59,7 @@ export class HistorianRunner implements IRunner {
 			this.denyList,
 			this.ephemeralDocumentTTLSec,
 			this.readinessCheck,
+			this.simplifiedCustomDataRetriever,
 		);
 		historian.set("port", this.port);
 

--- a/server/historian/packages/historian-base/src/runnerFactory.ts
+++ b/server/historian/packages/historian-base/src/runnerFactory.ts
@@ -33,6 +33,7 @@ export class HistorianResources implements core.IResources {
 		public readonly denyList?: historianServices.IDenyList,
 		public readonly ephemeralDocumentTTLSec?: number,
 		public readonly readinessCheck?: core.IReadinessCheck,
+		public readonly simplifiedCustomDataRetriever?: historianServices.ISimplifiedCustomDataRetriever,
 	) {
 		const httpServerConfig: services.IHttpServerConfig = config.get("system:httpServer");
 		this.webServerFactory = new services.BasicWebServerFactory(httpServerConfig);

--- a/server/historian/packages/historian-base/src/services/definitions.ts
+++ b/server/historian/packages/historian-base/src/services/definitions.ts
@@ -113,3 +113,7 @@ export interface IDenyList {
 	 */
 	isDenied(tenantId: string, documentId: string): boolean;
 }
+
+export interface ISimplifiedCustomDataRetriever {
+	get(customData: ITenantCustomData): string;
+}

--- a/server/historian/packages/historian-base/src/services/index.ts
+++ b/server/historian/packages/historian-base/src/services/index.ts
@@ -14,9 +14,11 @@ export {
 	ITenant,
 	ITenantCustomDataExternal,
 	ITenantService,
+	ISimplifiedCustomDataRetriever,
 } from "./definitions";
 export { DenyList } from "./denyList";
 export { RedisCache } from "./redisCache";
 export { RedisTenantCache } from "./redisTenantCache";
 export { IDocument, RestGitService } from "./restGitService";
 export { RiddlerService } from "./riddlerService";
+export { SimplifiedCustomDataRetriever } from "./simplifiedCustomDataRetriever";

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -65,6 +65,7 @@ export class RestGitService {
 		private readonly storageUrl?: string,
 		private readonly isEphemeralContainer?: boolean,
 		private readonly maxCacheableSummarySize?: number,
+		private readonly simplifiedCustomData?: string,
 	) {
 		const defaultHeaders: RawAxiosRequestHeaders =
 			storageName !== undefined
@@ -82,6 +83,9 @@ export class RestGitService {
 				`${storage.credentials.user}:${storage.credentials.password}`,
 			);
 			defaultHeaders.Authorization = `Basic ${token.toString("base64")}`;
+		}
+		if (this.simplifiedCustomData) {
+			defaultHeaders[Constants.SimplifiedCustomData] = this.simplifiedCustomData;
 		}
 
 		// We set the flag only for ephemeral containers

--- a/server/historian/packages/historian-base/src/services/simplifiedCustomDataRetriever.ts
+++ b/server/historian/packages/historian-base/src/services/simplifiedCustomDataRetriever.ts
@@ -1,0 +1,14 @@
+import type { ITenantCustomData } from "@fluidframework/server-services-core";
+import type { ISimplifiedCustomDataRetriever } from "./definitions";
+
+/**
+ * Retrieve simplified customData.
+ * @internal
+ */
+export class SimplifiedCustomDataRetriever implements ISimplifiedCustomDataRetriever {
+	public constructor() {}
+
+	public get(customData: ITenantCustomData): string {
+		return "";
+	}
+}

--- a/server/historian/packages/historian-base/src/utils.ts
+++ b/server/historian/packages/historian-base/src/utils.ts
@@ -39,6 +39,7 @@ export const Constants = Object.freeze({
 	generalRestCallThrottleIdPrefix: "generalRestCall",
 	IsEphemeralContainer: "Is-Ephemeral-Container",
 	isInitialSummary: "isInitialSummary",
+	SimplifiedCustomData: "SimplifiedCustomData",
 });
 
 export function getTokenLifetimeInSec(token: string): number | undefined {


### PR DESCRIPTION
Blob container per doc is a storage optimization for FRS Durable Container. In container per doc mode, the document vs azure blob container is 1:1 mapping. The blob container was created before the initial summary uploaded.

To support a cmk-related case in containerPerDoc mode, there is specific tenant-level info needs to be read from tenantDB, and passed to storage layer in document creation flow. In oss, just wrap this info as a generic message, and pass it all the way into filesystemFactory parameters without editing, in this way most of implementation details specific to this case can be contained in FRS.

This PR address this read and passing through the generic message in oss.

Main Changes:

- In historian, abstract an interface ISimplifiedCustomDataRetriever.get() to convert customData to a simple string (customized implementation in FRS), then pass to gitrest via http header.
- In gitrest, get SimplifiedCustomData from header and add as part of FileSystemManagerFactory parameter.