### PR TITLE
refactor(api-markdown-documenter): Update structure of `ApiTransformationConfiguration` and `ApiItemTransformations`

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -87,6 +87,16 @@ This version of the library attempts to align its APIs with the following conven
 
 -   `ApiTransformationConfiguration` -> `ApiTransformationOptions` (user input) and `ApiTransformationConfiguration` (derived system configuration).
 
+#### Updated structure of `ApiTransformationConfiguration` and `ApiItemTransformations`
+
+Updated the structure of `ApiTransformationConfiguration` to contain a `transformations` property of type `ApiItemTransformations`, rather than implementing that interface directly.
+
+Also updates `ApiItemTransformations` methods to be keyed off of `ApiItemKind`, rather than being individually named.
+
+E.g. A call like `config.transformApiMethod(...)` would become `config.transformations["Method"](...)`.
+
+This better aligns with similar transformational API surfaces in this library, like the renderers.
+
 ## 0.17.3
 
 -   Fixes an issue where directories generated for API items configured to yield directory-wise hierarchy (via the `hierarchyBoundaries` option) would be generated with names that differed from their corresponding document names.

--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -97,6 +97,8 @@ E.g. A call like `config.transformApiMethod(...)` would become `config.transform
 
 This better aligns with similar transformational API surfaces in this library, like the renderers.
 
+The `createDefaultLayout` property of `ApiItemTransformations` now lives directly in `ApiTransformationConfiguration`, but has been renamed to `defaultSectionLayout`.
+
 ## 0.17.3
 
 -   Fixes an issue where directories generated for API items configured to yield directory-wise hierarchy (via the `hierarchyBoundaries` option) would be generated with names that differed from their corresponding document names.

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -5,15 +5,15 @@
 ```ts
 
 import { ApiCallSignature } from '@microsoft/api-extractor-model';
-import type { ApiClass } from '@microsoft/api-extractor-model';
+import { ApiClass } from '@microsoft/api-extractor-model';
 import { ApiConstructor } from '@microsoft/api-extractor-model';
 import { ApiConstructSignature } from '@microsoft/api-extractor-model';
 import { ApiEntryPoint } from '@microsoft/api-extractor-model';
-import type { ApiEnum } from '@microsoft/api-extractor-model';
-import type { ApiEnumMember } from '@microsoft/api-extractor-model';
+import { ApiEnum } from '@microsoft/api-extractor-model';
+import { ApiEnumMember } from '@microsoft/api-extractor-model';
 import { ApiFunction } from '@microsoft/api-extractor-model';
 import { ApiIndexSignature } from '@microsoft/api-extractor-model';
-import type { ApiInterface } from '@microsoft/api-extractor-model';
+import { ApiInterface } from '@microsoft/api-extractor-model';
 import { ApiItem } from '@microsoft/api-extractor-model';
 import { ApiItemKind } from '@microsoft/api-extractor-model';
 import { ApiMethod } from '@microsoft/api-extractor-model';
@@ -21,9 +21,10 @@ import { ApiMethodSignature } from '@microsoft/api-extractor-model';
 import { ApiModel } from '@microsoft/api-extractor-model';
 import { ApiNamespace } from '@microsoft/api-extractor-model';
 import { ApiPackage } from '@microsoft/api-extractor-model';
-import type { ApiPropertyItem } from '@microsoft/api-extractor-model';
-import type { ApiTypeAlias } from '@microsoft/api-extractor-model';
-import type { ApiVariable } from '@microsoft/api-extractor-model';
+import { ApiProperty } from '@microsoft/api-extractor-model';
+import { ApiPropertySignature } from '@microsoft/api-extractor-model';
+import { ApiTypeAlias } from '@microsoft/api-extractor-model';
+import { ApiVariable } from '@microsoft/api-extractor-model';
 import type { Data } from 'unist';
 import { DocNode } from '@microsoft/tsdoc';
 import { DocSection } from '@microsoft/tsdoc';
@@ -48,7 +49,8 @@ export { ApiItem }
 export { ApiItemKind }
 
 // @public
-export interface ApiItemTransformationConfiguration extends ApiItemTransformationConfigurationBase, ApiItemTransformations, Required<DocumentationSuiteOptions>, Required<LoggingConfiguration> {
+export interface ApiItemTransformationConfiguration extends ApiItemTransformationConfigurationBase, Required<DocumentationSuiteOptions>, Required<LoggingConfiguration> {
+    readonly transformations: ApiItemTransformations;
 }
 
 // @public @sealed
@@ -58,27 +60,47 @@ export interface ApiItemTransformationConfigurationBase {
 }
 
 // @public
-export interface ApiItemTransformationOptions extends ApiItemTransformationConfigurationBase, Partial<ApiItemTransformations>, DocumentationSuiteOptions, LoggingConfiguration {
+export interface ApiItemTransformationOptions extends ApiItemTransformationConfigurationBase, DocumentationSuiteOptions, LoggingConfiguration {
+    readonly transformations?: Partial<ApiItemTransformations>;
 }
 
 // @public
 export interface ApiItemTransformations {
+    // (undocumented)
+    readonly [ApiItemKind.CallSignature]: TransformApiItemWithoutChildren<ApiCallSignature>;
+    // (undocumented)
+    readonly [ApiItemKind.Class]: TransformApiItemWithChildren<ApiClass>;
+    // (undocumented)
+    readonly [ApiItemKind.Constructor]: TransformApiItemWithoutChildren<ApiConstructor>;
+    // (undocumented)
+    readonly [ApiItemKind.ConstructSignature]: TransformApiItemWithoutChildren<ApiConstructSignature>;
     readonly createDefaultLayout: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: ApiItemTransformationConfiguration) => SectionNode[];
-    readonly transformApiCallSignature: TransformApiItemWithoutChildren<ApiCallSignature>;
-    readonly transformApiClass: TransformApiItemWithChildren<ApiClass>;
-    readonly transformApiConstructor: TransformApiItemWithoutChildren<ApiConstructSignature | ApiConstructor>;
-    readonly transformApiEntryPoint: TransformApiItemWithChildren<ApiEntryPoint>;
-    readonly transformApiEnum: TransformApiItemWithChildren<ApiEnum>;
-    readonly transformApiEnumMember: TransformApiItemWithoutChildren<ApiEnumMember>;
-    readonly transformApiFunction: TransformApiItemWithoutChildren<ApiFunction>;
-    readonly transformApiIndexSignature: TransformApiItemWithoutChildren<ApiIndexSignature>;
-    readonly transformApiInterface: TransformApiItemWithChildren<ApiInterface>;
-    readonly transformApiMethod: TransformApiItemWithoutChildren<ApiMethod | ApiMethodSignature>;
-    readonly transformApiModel: TransformApiItemWithoutChildren<ApiModel>;
-    readonly transformApiNamespace: TransformApiItemWithChildren<ApiNamespace>;
-    readonly transformApiProperty: TransformApiItemWithoutChildren<ApiPropertyItem>;
-    readonly transformApiTypeAlias: TransformApiItemWithoutChildren<ApiTypeAlias>;
-    readonly transformApiVariable: TransformApiItemWithoutChildren<ApiVariable>;
+    readonly [ApiItemKind.EntryPoint]: TransformApiItemWithChildren<ApiEntryPoint>;
+    // (undocumented)
+    readonly [ApiItemKind.Enum]: TransformApiItemWithChildren<ApiEnum>;
+    // (undocumented)
+    readonly [ApiItemKind.EnumMember]: TransformApiItemWithoutChildren<ApiEnumMember>;
+    // (undocumented)
+    readonly [ApiItemKind.Function]: TransformApiItemWithoutChildren<ApiFunction>;
+    // (undocumented)
+    readonly [ApiItemKind.IndexSignature]: TransformApiItemWithoutChildren<ApiIndexSignature>;
+    // (undocumented)
+    readonly [ApiItemKind.Interface]: TransformApiItemWithChildren<ApiInterface>;
+    // (undocumented)
+    readonly [ApiItemKind.Method]: TransformApiItemWithoutChildren<ApiMethod>;
+    // (undocumented)
+    readonly [ApiItemKind.MethodSignature]: TransformApiItemWithoutChildren<ApiMethodSignature>;
+    readonly [ApiItemKind.Model]: TransformApiItemWithoutChildren<ApiModel>;
+    // (undocumented)
+    readonly [ApiItemKind.Namespace]: TransformApiItemWithChildren<ApiNamespace>;
+    // (undocumented)
+    readonly [ApiItemKind.Property]: TransformApiItemWithoutChildren<ApiProperty>;
+    // (undocumented)
+    readonly [ApiItemKind.PropertySignature]: TransformApiItemWithoutChildren<ApiPropertySignature>;
+    // (undocumented)
+    readonly [ApiItemKind.TypeAlias]: TransformApiItemWithoutChildren<ApiTypeAlias>;
+    // (undocumented)
+    readonly [ApiItemKind.Variable]: TransformApiItemWithoutChildren<ApiVariable>;
 }
 
 declare namespace ApiItemUtilities {

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -50,6 +50,7 @@ export { ApiItemKind }
 
 // @public
 export interface ApiItemTransformationConfiguration extends ApiItemTransformationConfigurationBase, Required<DocumentationSuiteOptions>, Required<LoggingConfiguration> {
+    readonly defaultSectionLayout: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: ApiItemTransformationConfiguration) => SectionNode[];
     readonly transformations: ApiItemTransformations;
 }
 
@@ -61,6 +62,7 @@ export interface ApiItemTransformationConfigurationBase {
 
 // @public
 export interface ApiItemTransformationOptions extends ApiItemTransformationConfigurationBase, DocumentationSuiteOptions, LoggingConfiguration {
+    readonly defaultSectionLayout?: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: ApiItemTransformationConfiguration) => SectionNode[];
     readonly transformations?: Partial<ApiItemTransformations>;
 }
 
@@ -74,7 +76,6 @@ export interface ApiItemTransformations {
     readonly [ApiItemKind.Constructor]: TransformApiItemWithoutChildren<ApiConstructor>;
     // (undocumented)
     readonly [ApiItemKind.ConstructSignature]: TransformApiItemWithoutChildren<ApiConstructSignature>;
-    readonly createDefaultLayout: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: ApiItemTransformationConfiguration) => SectionNode[];
     readonly [ApiItemKind.EntryPoint]: TransformApiItemWithChildren<ApiEntryPoint>;
     // (undocumented)
     readonly [ApiItemKind.Enum]: TransformApiItemWithChildren<ApiEnum>;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -5,15 +5,15 @@
 ```ts
 
 import { ApiCallSignature } from '@microsoft/api-extractor-model';
-import type { ApiClass } from '@microsoft/api-extractor-model';
+import { ApiClass } from '@microsoft/api-extractor-model';
 import { ApiConstructor } from '@microsoft/api-extractor-model';
 import { ApiConstructSignature } from '@microsoft/api-extractor-model';
 import { ApiEntryPoint } from '@microsoft/api-extractor-model';
-import type { ApiEnum } from '@microsoft/api-extractor-model';
-import type { ApiEnumMember } from '@microsoft/api-extractor-model';
+import { ApiEnum } from '@microsoft/api-extractor-model';
+import { ApiEnumMember } from '@microsoft/api-extractor-model';
 import { ApiFunction } from '@microsoft/api-extractor-model';
 import { ApiIndexSignature } from '@microsoft/api-extractor-model';
-import type { ApiInterface } from '@microsoft/api-extractor-model';
+import { ApiInterface } from '@microsoft/api-extractor-model';
 import { ApiItem } from '@microsoft/api-extractor-model';
 import { ApiItemKind } from '@microsoft/api-extractor-model';
 import { ApiMethod } from '@microsoft/api-extractor-model';
@@ -21,9 +21,10 @@ import { ApiMethodSignature } from '@microsoft/api-extractor-model';
 import { ApiModel } from '@microsoft/api-extractor-model';
 import { ApiNamespace } from '@microsoft/api-extractor-model';
 import { ApiPackage } from '@microsoft/api-extractor-model';
-import type { ApiPropertyItem } from '@microsoft/api-extractor-model';
-import type { ApiTypeAlias } from '@microsoft/api-extractor-model';
-import type { ApiVariable } from '@microsoft/api-extractor-model';
+import { ApiProperty } from '@microsoft/api-extractor-model';
+import { ApiPropertySignature } from '@microsoft/api-extractor-model';
+import { ApiTypeAlias } from '@microsoft/api-extractor-model';
+import { ApiVariable } from '@microsoft/api-extractor-model';
 import type { Data } from 'unist';
 import { DocNode } from '@microsoft/tsdoc';
 import { DocSection } from '@microsoft/tsdoc';
@@ -48,7 +49,8 @@ export { ApiItem }
 export { ApiItemKind }
 
 // @public
-export interface ApiItemTransformationConfiguration extends ApiItemTransformationConfigurationBase, ApiItemTransformations, Required<DocumentationSuiteOptions>, Required<LoggingConfiguration> {
+export interface ApiItemTransformationConfiguration extends ApiItemTransformationConfigurationBase, Required<DocumentationSuiteOptions>, Required<LoggingConfiguration> {
+    readonly transformations: ApiItemTransformations;
 }
 
 // @public @sealed
@@ -58,27 +60,47 @@ export interface ApiItemTransformationConfigurationBase {
 }
 
 // @public
-export interface ApiItemTransformationOptions extends ApiItemTransformationConfigurationBase, Partial<ApiItemTransformations>, DocumentationSuiteOptions, LoggingConfiguration {
+export interface ApiItemTransformationOptions extends ApiItemTransformationConfigurationBase, DocumentationSuiteOptions, LoggingConfiguration {
+    readonly transformations?: Partial<ApiItemTransformations>;
 }
 
 // @public
 export interface ApiItemTransformations {
+    // (undocumented)
+    readonly [ApiItemKind.CallSignature]: TransformApiItemWithoutChildren<ApiCallSignature>;
+    // (undocumented)
+    readonly [ApiItemKind.Class]: TransformApiItemWithChildren<ApiClass>;
+    // (undocumented)
+    readonly [ApiItemKind.Constructor]: TransformApiItemWithoutChildren<ApiConstructor>;
+    // (undocumented)
+    readonly [ApiItemKind.ConstructSignature]: TransformApiItemWithoutChildren<ApiConstructSignature>;
     readonly createDefaultLayout: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: ApiItemTransformationConfiguration) => SectionNode[];
-    readonly transformApiCallSignature: TransformApiItemWithoutChildren<ApiCallSignature>;
-    readonly transformApiClass: TransformApiItemWithChildren<ApiClass>;
-    readonly transformApiConstructor: TransformApiItemWithoutChildren<ApiConstructSignature | ApiConstructor>;
-    readonly transformApiEntryPoint: TransformApiItemWithChildren<ApiEntryPoint>;
-    readonly transformApiEnum: TransformApiItemWithChildren<ApiEnum>;
-    readonly transformApiEnumMember: TransformApiItemWithoutChildren<ApiEnumMember>;
-    readonly transformApiFunction: TransformApiItemWithoutChildren<ApiFunction>;
-    readonly transformApiIndexSignature: TransformApiItemWithoutChildren<ApiIndexSignature>;
-    readonly transformApiInterface: TransformApiItemWithChildren<ApiInterface>;
-    readonly transformApiMethod: TransformApiItemWithoutChildren<ApiMethod | ApiMethodSignature>;
-    readonly transformApiModel: TransformApiItemWithoutChildren<ApiModel>;
-    readonly transformApiNamespace: TransformApiItemWithChildren<ApiNamespace>;
-    readonly transformApiProperty: TransformApiItemWithoutChildren<ApiPropertyItem>;
-    readonly transformApiTypeAlias: TransformApiItemWithoutChildren<ApiTypeAlias>;
-    readonly transformApiVariable: TransformApiItemWithoutChildren<ApiVariable>;
+    readonly [ApiItemKind.EntryPoint]: TransformApiItemWithChildren<ApiEntryPoint>;
+    // (undocumented)
+    readonly [ApiItemKind.Enum]: TransformApiItemWithChildren<ApiEnum>;
+    // (undocumented)
+    readonly [ApiItemKind.EnumMember]: TransformApiItemWithoutChildren<ApiEnumMember>;
+    // (undocumented)
+    readonly [ApiItemKind.Function]: TransformApiItemWithoutChildren<ApiFunction>;
+    // (undocumented)
+    readonly [ApiItemKind.IndexSignature]: TransformApiItemWithoutChildren<ApiIndexSignature>;
+    // (undocumented)
+    readonly [ApiItemKind.Interface]: TransformApiItemWithChildren<ApiInterface>;
+    // (undocumented)
+    readonly [ApiItemKind.Method]: TransformApiItemWithoutChildren<ApiMethod>;
+    // (undocumented)
+    readonly [ApiItemKind.MethodSignature]: TransformApiItemWithoutChildren<ApiMethodSignature>;
+    readonly [ApiItemKind.Model]: TransformApiItemWithoutChildren<ApiModel>;
+    // (undocumented)
+    readonly [ApiItemKind.Namespace]: TransformApiItemWithChildren<ApiNamespace>;
+    // (undocumented)
+    readonly [ApiItemKind.Property]: TransformApiItemWithoutChildren<ApiProperty>;
+    // (undocumented)
+    readonly [ApiItemKind.PropertySignature]: TransformApiItemWithoutChildren<ApiPropertySignature>;
+    // (undocumented)
+    readonly [ApiItemKind.TypeAlias]: TransformApiItemWithoutChildren<ApiTypeAlias>;
+    // (undocumented)
+    readonly [ApiItemKind.Variable]: TransformApiItemWithoutChildren<ApiVariable>;
 }
 
 declare namespace ApiItemUtilities {

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -50,6 +50,7 @@ export { ApiItemKind }
 
 // @public
 export interface ApiItemTransformationConfiguration extends ApiItemTransformationConfigurationBase, Required<DocumentationSuiteOptions>, Required<LoggingConfiguration> {
+    readonly defaultSectionLayout: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: ApiItemTransformationConfiguration) => SectionNode[];
     readonly transformations: ApiItemTransformations;
 }
 
@@ -61,6 +62,7 @@ export interface ApiItemTransformationConfigurationBase {
 
 // @public
 export interface ApiItemTransformationOptions extends ApiItemTransformationConfigurationBase, DocumentationSuiteOptions, LoggingConfiguration {
+    readonly defaultSectionLayout?: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: ApiItemTransformationConfiguration) => SectionNode[];
     readonly transformations?: Partial<ApiItemTransformations>;
 }
 
@@ -74,7 +76,6 @@ export interface ApiItemTransformations {
     readonly [ApiItemKind.Constructor]: TransformApiItemWithoutChildren<ApiConstructor>;
     // (undocumented)
     readonly [ApiItemKind.ConstructSignature]: TransformApiItemWithoutChildren<ApiConstructSignature>;
-    readonly createDefaultLayout: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: ApiItemTransformationConfiguration) => SectionNode[];
     readonly [ApiItemKind.EntryPoint]: TransformApiItemWithChildren<ApiEntryPoint>;
     // (undocumented)
     readonly [ApiItemKind.Enum]: TransformApiItemWithChildren<ApiEnum>;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -5,15 +5,15 @@
 ```ts
 
 import { ApiCallSignature } from '@microsoft/api-extractor-model';
-import type { ApiClass } from '@microsoft/api-extractor-model';
+import { ApiClass } from '@microsoft/api-extractor-model';
 import { ApiConstructor } from '@microsoft/api-extractor-model';
 import { ApiConstructSignature } from '@microsoft/api-extractor-model';
 import { ApiEntryPoint } from '@microsoft/api-extractor-model';
-import type { ApiEnum } from '@microsoft/api-extractor-model';
-import type { ApiEnumMember } from '@microsoft/api-extractor-model';
+import { ApiEnum } from '@microsoft/api-extractor-model';
+import { ApiEnumMember } from '@microsoft/api-extractor-model';
 import { ApiFunction } from '@microsoft/api-extractor-model';
 import { ApiIndexSignature } from '@microsoft/api-extractor-model';
-import type { ApiInterface } from '@microsoft/api-extractor-model';
+import { ApiInterface } from '@microsoft/api-extractor-model';
 import { ApiItem } from '@microsoft/api-extractor-model';
 import { ApiItemKind } from '@microsoft/api-extractor-model';
 import { ApiMethod } from '@microsoft/api-extractor-model';
@@ -21,9 +21,10 @@ import { ApiMethodSignature } from '@microsoft/api-extractor-model';
 import { ApiModel } from '@microsoft/api-extractor-model';
 import { ApiNamespace } from '@microsoft/api-extractor-model';
 import { ApiPackage } from '@microsoft/api-extractor-model';
-import type { ApiPropertyItem } from '@microsoft/api-extractor-model';
-import type { ApiTypeAlias } from '@microsoft/api-extractor-model';
-import type { ApiVariable } from '@microsoft/api-extractor-model';
+import { ApiProperty } from '@microsoft/api-extractor-model';
+import { ApiPropertySignature } from '@microsoft/api-extractor-model';
+import { ApiTypeAlias } from '@microsoft/api-extractor-model';
+import { ApiVariable } from '@microsoft/api-extractor-model';
 import type { Data } from 'unist';
 import { DocNode } from '@microsoft/tsdoc';
 import { DocSection } from '@microsoft/tsdoc';
@@ -48,7 +49,8 @@ export { ApiItem }
 export { ApiItemKind }
 
 // @public
-export interface ApiItemTransformationConfiguration extends ApiItemTransformationConfigurationBase, ApiItemTransformations, Required<DocumentationSuiteOptions>, Required<LoggingConfiguration> {
+export interface ApiItemTransformationConfiguration extends ApiItemTransformationConfigurationBase, Required<DocumentationSuiteOptions>, Required<LoggingConfiguration> {
+    readonly transformations: ApiItemTransformations;
 }
 
 // @public @sealed
@@ -58,27 +60,47 @@ export interface ApiItemTransformationConfigurationBase {
 }
 
 // @public
-export interface ApiItemTransformationOptions extends ApiItemTransformationConfigurationBase, Partial<ApiItemTransformations>, DocumentationSuiteOptions, LoggingConfiguration {
+export interface ApiItemTransformationOptions extends ApiItemTransformationConfigurationBase, DocumentationSuiteOptions, LoggingConfiguration {
+    readonly transformations?: Partial<ApiItemTransformations>;
 }
 
 // @public
 export interface ApiItemTransformations {
+    // (undocumented)
+    readonly [ApiItemKind.CallSignature]: TransformApiItemWithoutChildren<ApiCallSignature>;
+    // (undocumented)
+    readonly [ApiItemKind.Class]: TransformApiItemWithChildren<ApiClass>;
+    // (undocumented)
+    readonly [ApiItemKind.Constructor]: TransformApiItemWithoutChildren<ApiConstructor>;
+    // (undocumented)
+    readonly [ApiItemKind.ConstructSignature]: TransformApiItemWithoutChildren<ApiConstructSignature>;
     readonly createDefaultLayout: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: ApiItemTransformationConfiguration) => SectionNode[];
-    readonly transformApiCallSignature: TransformApiItemWithoutChildren<ApiCallSignature>;
-    readonly transformApiClass: TransformApiItemWithChildren<ApiClass>;
-    readonly transformApiConstructor: TransformApiItemWithoutChildren<ApiConstructSignature | ApiConstructor>;
-    readonly transformApiEntryPoint: TransformApiItemWithChildren<ApiEntryPoint>;
-    readonly transformApiEnum: TransformApiItemWithChildren<ApiEnum>;
-    readonly transformApiEnumMember: TransformApiItemWithoutChildren<ApiEnumMember>;
-    readonly transformApiFunction: TransformApiItemWithoutChildren<ApiFunction>;
-    readonly transformApiIndexSignature: TransformApiItemWithoutChildren<ApiIndexSignature>;
-    readonly transformApiInterface: TransformApiItemWithChildren<ApiInterface>;
-    readonly transformApiMethod: TransformApiItemWithoutChildren<ApiMethod | ApiMethodSignature>;
-    readonly transformApiModel: TransformApiItemWithoutChildren<ApiModel>;
-    readonly transformApiNamespace: TransformApiItemWithChildren<ApiNamespace>;
-    readonly transformApiProperty: TransformApiItemWithoutChildren<ApiPropertyItem>;
-    readonly transformApiTypeAlias: TransformApiItemWithoutChildren<ApiTypeAlias>;
-    readonly transformApiVariable: TransformApiItemWithoutChildren<ApiVariable>;
+    readonly [ApiItemKind.EntryPoint]: TransformApiItemWithChildren<ApiEntryPoint>;
+    // (undocumented)
+    readonly [ApiItemKind.Enum]: TransformApiItemWithChildren<ApiEnum>;
+    // (undocumented)
+    readonly [ApiItemKind.EnumMember]: TransformApiItemWithoutChildren<ApiEnumMember>;
+    // (undocumented)
+    readonly [ApiItemKind.Function]: TransformApiItemWithoutChildren<ApiFunction>;
+    // (undocumented)
+    readonly [ApiItemKind.IndexSignature]: TransformApiItemWithoutChildren<ApiIndexSignature>;
+    // (undocumented)
+    readonly [ApiItemKind.Interface]: TransformApiItemWithChildren<ApiInterface>;
+    // (undocumented)
+    readonly [ApiItemKind.Method]: TransformApiItemWithoutChildren<ApiMethod>;
+    // (undocumented)
+    readonly [ApiItemKind.MethodSignature]: TransformApiItemWithoutChildren<ApiMethodSignature>;
+    readonly [ApiItemKind.Model]: TransformApiItemWithoutChildren<ApiModel>;
+    // (undocumented)
+    readonly [ApiItemKind.Namespace]: TransformApiItemWithChildren<ApiNamespace>;
+    // (undocumented)
+    readonly [ApiItemKind.Property]: TransformApiItemWithoutChildren<ApiProperty>;
+    // (undocumented)
+    readonly [ApiItemKind.PropertySignature]: TransformApiItemWithoutChildren<ApiPropertySignature>;
+    // (undocumented)
+    readonly [ApiItemKind.TypeAlias]: TransformApiItemWithoutChildren<ApiTypeAlias>;
+    // (undocumented)
+    readonly [ApiItemKind.Variable]: TransformApiItemWithoutChildren<ApiVariable>;
 }
 
 declare namespace ApiItemUtilities {

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -50,6 +50,7 @@ export { ApiItemKind }
 
 // @public
 export interface ApiItemTransformationConfiguration extends ApiItemTransformationConfigurationBase, Required<DocumentationSuiteOptions>, Required<LoggingConfiguration> {
+    readonly defaultSectionLayout: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: ApiItemTransformationConfiguration) => SectionNode[];
     readonly transformations: ApiItemTransformations;
 }
 
@@ -61,6 +62,7 @@ export interface ApiItemTransformationConfigurationBase {
 
 // @public
 export interface ApiItemTransformationOptions extends ApiItemTransformationConfigurationBase, DocumentationSuiteOptions, LoggingConfiguration {
+    readonly defaultSectionLayout?: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: ApiItemTransformationConfiguration) => SectionNode[];
     readonly transformations?: Partial<ApiItemTransformations>;
 }
 
@@ -74,7 +76,6 @@ export interface ApiItemTransformations {
     readonly [ApiItemKind.Constructor]: TransformApiItemWithoutChildren<ApiConstructor>;
     // (undocumented)
     readonly [ApiItemKind.ConstructSignature]: TransformApiItemWithoutChildren<ApiConstructSignature>;
-    readonly createDefaultLayout: (apiItem: ApiItem, childSections: SectionNode[] | undefined, config: ApiItemTransformationConfiguration) => SectionNode[];
     readonly [ApiItemKind.EntryPoint]: TransformApiItemWithChildren<ApiEntryPoint>;
     // (undocumented)
     readonly [ApiItemKind.Enum]: TransformApiItemWithChildren<ApiEnum>;

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiItem.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiItem.ts
@@ -18,7 +18,8 @@ import {
 	type ApiMethod,
 	type ApiMethodSignature,
 	type ApiNamespace,
-	type ApiPropertyItem,
+	type ApiProperty,
+	type ApiPropertySignature,
 	type ApiTypeAlias,
 	type ApiVariable,
 } from "@microsoft/api-extractor-model";
@@ -74,7 +75,7 @@ export function apiItemToDocument(
 
 	if (!doesItemRequireOwnDocument(apiItem, config.documentBoundaries)) {
 		throw new Error(
-			`"renderApiDocument" called for an API item kind that is not intended to be rendered to its own document. Provided item kind: "${apiItem.kind}".`,
+			`"apiItemToDocument" called for an API item kind that is configured to not generate its own document. Provided item kind: "${apiItem.kind}".`,
 		);
 	}
 
@@ -130,93 +131,123 @@ export function apiItemToSections(
 		return [];
 	}
 
-	const logger = config.logger;
+	const { logger, transformations } = config;
 
-	logger.verbose(`Rendering section for ${apiItem.displayName}...`);
+	const transformChildren = (childItem: ApiItem): SectionNode[] =>
+		apiItemToSections(childItem, config);
+
+	logger.verbose(`Generating documentation section for ${apiItem.displayName}...`);
 
 	let sections: SectionNode[];
 	switch (apiItem.kind) {
 		case ApiItemKind.CallSignature: {
-			sections = config.transformApiCallSignature(apiItem as ApiCallSignature, config);
+			sections = transformations[ApiItemKind.CallSignature](
+				apiItem as ApiCallSignature,
+				config,
+			);
 			break;
 		}
 
 		case ApiItemKind.Class: {
-			sections = config.transformApiClass(apiItem as ApiClass, config, (childItem) =>
-				apiItemToSections(childItem, config),
+			sections = transformations[ApiItemKind.Class](
+				apiItem as ApiClass,
+				config,
+				transformChildren,
 			);
 			break;
 		}
 
 		case ApiItemKind.ConstructSignature: {
-			sections = config.transformApiConstructor(apiItem as ApiConstructSignature, config);
+			sections = transformations[ApiItemKind.ConstructSignature](
+				apiItem as ApiConstructSignature,
+				config,
+			);
 			break;
 		}
 
 		case ApiItemKind.Constructor: {
-			sections = config.transformApiConstructor(apiItem as ApiConstructor, config);
+			sections = transformations[ApiItemKind.Constructor](apiItem as ApiConstructor, config);
 			break;
 		}
 
 		case ApiItemKind.Enum: {
-			sections = config.transformApiEnum(apiItem as ApiEnum, config, (childItem) =>
-				apiItemToSections(childItem, config),
+			sections = transformations[ApiItemKind.Enum](
+				apiItem as ApiEnum,
+				config,
+				transformChildren,
 			);
 			break;
 		}
 
 		case ApiItemKind.EnumMember: {
-			sections = config.transformApiEnumMember(apiItem as ApiEnumMember, config);
+			sections = transformations[ApiItemKind.EnumMember](apiItem as ApiEnumMember, config);
 			break;
 		}
 
 		case ApiItemKind.Function: {
-			sections = config.transformApiFunction(apiItem as ApiFunction, config);
+			sections = transformations[ApiItemKind.Function](apiItem as ApiFunction, config);
 			break;
 		}
 
 		case ApiItemKind.IndexSignature: {
-			sections = config.transformApiIndexSignature(apiItem as ApiIndexSignature, config);
+			sections = transformations[ApiItemKind.IndexSignature](
+				apiItem as ApiIndexSignature,
+				config,
+			);
 			break;
 		}
 
 		case ApiItemKind.Interface: {
-			sections = config.transformApiInterface(apiItem as ApiInterface, config, (childItem) =>
-				apiItemToSections(childItem, config),
+			sections = transformations[ApiItemKind.Interface](
+				apiItem as ApiInterface,
+				config,
+				transformChildren,
 			);
 			break;
 		}
 
 		case ApiItemKind.Method: {
-			sections = config.transformApiMethod(apiItem as ApiMethod, config);
+			sections = transformations[ApiItemKind.Method](apiItem as ApiMethod, config);
 			break;
 		}
 
 		case ApiItemKind.MethodSignature: {
-			sections = config.transformApiMethod(apiItem as ApiMethodSignature, config);
-			break;
-		}
-
-		case ApiItemKind.Namespace: {
-			sections = config.transformApiNamespace(apiItem as ApiNamespace, config, (childItem) =>
-				apiItemToSections(childItem, config),
+			sections = transformations[ApiItemKind.MethodSignature](
+				apiItem as ApiMethodSignature,
+				config,
 			);
 			break;
 		}
 
-		case ApiItemKind.Property:
+		case ApiItemKind.Namespace: {
+			sections = transformations[ApiItemKind.Namespace](
+				apiItem as ApiNamespace,
+				config,
+				transformChildren,
+			);
+			break;
+		}
+
+		case ApiItemKind.Property: {
+			sections = transformations[ApiItemKind.Property](apiItem as ApiProperty, config);
+			break;
+		}
+
 		case ApiItemKind.PropertySignature: {
-			sections = config.transformApiProperty(apiItem as ApiPropertyItem, config);
+			sections = transformations[ApiItemKind.PropertySignature](
+				apiItem as ApiPropertySignature,
+				config,
+			);
 			break;
 		}
 
 		case ApiItemKind.TypeAlias: {
-			sections = config.transformApiTypeAlias(apiItem as ApiTypeAlias, config);
+			sections = transformations[ApiItemKind.TypeAlias](apiItem as ApiTypeAlias, config);
 			break;
 		}
 
 		case ApiItemKind.Variable: {
-			sections = config.transformApiVariable(apiItem as ApiVariable, config);
+			sections = transformations[ApiItemKind.Variable](apiItem as ApiVariable, config);
 			break;
 		}
 
@@ -225,6 +256,6 @@ export function apiItemToSections(
 		}
 	}
 
-	logger.verbose(`${apiItem.displayName} section rendered successfully!`);
+	logger.verbose(`${apiItem.displayName} section generated successfully!`);
 	return sections;
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
@@ -211,7 +211,7 @@ function createDocumentForSingleEntryPointPackage(
 
 	// Wrap entry-point contents with package-level docs
 	// TODO: Make package transformation configurable
-	sections.push(...transformations.createDefaultLayout(apiPackage, entryPointSections, config));
+	sections.push(...config.defaultSectionLayout(apiPackage, entryPointSections, config));
 
 	logger.verbose(`Package document rendered successfully.`);
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
@@ -3,7 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import type { ApiEntryPoint, ApiItem, ApiModel, ApiPackage } from "@microsoft/api-extractor-model";
+import {
+	ApiItemKind,
+	type ApiEntryPoint,
+	type ApiItem,
+	type ApiModel,
+	type ApiPackage,
+} from "@microsoft/api-extractor-model";
 
 import type { DocumentNode, SectionNode } from "../documentation-domain/index.js";
 
@@ -154,14 +160,14 @@ function createDocumentForApiModel(
 	apiModel: ApiModel,
 	config: ApiItemTransformationConfiguration,
 ): DocumentNode {
-	const { logger, transformApiModel: createModelBodySections } = config;
+	const { logger, transformations } = config;
 
 	logger.verbose(`Generating API Model document...`);
 
 	// Note: We don't render the breadcrumb for Model document, as it is always the root of the file hierarchical
 
 	// Render body contents
-	const sections = createModelBodySections(apiModel, config);
+	const sections = transformations[ApiItemKind.Model](apiModel, config);
 
 	logger.verbose(`API Model document rendered successfully.`);
 
@@ -185,7 +191,7 @@ function createDocumentForSingleEntryPointPackage(
 	apiEntryPoint: ApiEntryPoint,
 	config: ApiItemTransformationConfiguration,
 ): DocumentNode {
-	const { includeBreadcrumb, logger, transformApiEntryPoint } = config;
+	const { includeBreadcrumb, logger, transformations } = config;
 
 	logger.verbose(`Generating ${apiPackage.name} package document...`);
 
@@ -197,12 +203,15 @@ function createDocumentForSingleEntryPointPackage(
 	}
 
 	// Render sub-sections for the single entry-point. We will bundle these with body comments from the package item.
-	const entryPointSections = transformApiEntryPoint(apiEntryPoint, config, (childItem) =>
-		apiItemToSections(childItem, config),
+	const entryPointSections = transformations[ApiItemKind.EntryPoint](
+		apiEntryPoint,
+		config,
+		(childItem) => apiItemToSections(childItem, config),
 	);
 
 	// Wrap entry-point contents with package-level docs
-	sections.push(...config.createDefaultLayout(apiPackage, entryPointSections, config));
+	// TODO: Make package transformation configurable
+	sections.push(...transformations.createDefaultLayout(apiPackage, entryPointSections, config));
 
 	logger.verbose(`Package document rendered successfully.`);
 
@@ -255,7 +264,7 @@ function createDocumentForApiEntryPoint(
 	apiEntryPoint: ApiEntryPoint,
 	config: ApiItemTransformationConfiguration,
 ): DocumentNode {
-	const { includeBreadcrumb, logger, transformApiEntryPoint } = config;
+	const { includeBreadcrumb, logger, transformations } = config;
 
 	logger.verbose(`Generating ${apiEntryPoint.displayName} API entry-point document...`);
 
@@ -268,7 +277,7 @@ function createDocumentForApiEntryPoint(
 
 	// Render body contents
 	sections.push(
-		...transformApiEntryPoint(apiEntryPoint, config, (childItem) =>
+		...transformations[ApiItemKind.EntryPoint](apiEntryPoint, config, (childItem) =>
 			apiItemToSections(childItem, config),
 		),
 	);

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/Configuration.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/Configuration.ts
@@ -3,10 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import type { ApiModel } from "@microsoft/api-extractor-model";
+import type { ApiItem, ApiModel } from "@microsoft/api-extractor-model";
 
 import { defaultConsoleLogger } from "../../Logging.js";
 import type { LoggingConfiguration } from "../../LoggingConfiguration.js";
+import type { SectionNode } from "../../documentation-domain/index.js";
+import { createSectionForApiItem } from "../default-implementations/index.js";
 
 import {
 	type DocumentationSuiteOptions,
@@ -61,6 +63,23 @@ export interface ApiItemTransformationConfiguration
 	 * {@inheritDoc ApiItemTransformations}
 	 */
 	readonly transformations: ApiItemTransformations;
+
+	/**
+	 * Generates the default section layout used by all default {@link ApiItemTransformations}.
+	 *
+	 * @remarks
+	 *
+	 * Can be used to uniformly control the default output layout for all API item kinds.
+	 *
+	 * API item kind-specific details are passed in, and can be displayed as desired.
+	 *
+	 * @returns The list of {@link SectionNode}s that comprise the top-level section body for the API item.
+	 */
+	readonly defaultSectionLayout: (
+		apiItem: ApiItem,
+		childSections: SectionNode[] | undefined,
+		config: ApiItemTransformationConfiguration,
+	) => SectionNode[];
 }
 
 /**
@@ -76,6 +95,15 @@ export interface ApiItemTransformationOptions
 	 * Optional overrides for the default transformations.
 	 */
 	readonly transformations?: Partial<ApiItemTransformations>;
+
+	/**
+	 * {@inheritDoc ApiItemTransformationConfiguration.defaultSectionLayout}
+	 */
+	readonly defaultSectionLayout?: (
+		apiItem: ApiItem,
+		childSections: SectionNode[] | undefined,
+		config: ApiItemTransformationConfiguration,
+	) => SectionNode[];
 }
 
 /**
@@ -88,6 +116,7 @@ export function getApiItemTransformationConfigurationWithDefaults(
 	options: ApiItemTransformationOptions,
 ): ApiItemTransformationConfiguration {
 	const logger = options.logger ?? defaultConsoleLogger;
+	const defaultSectionLayout = options.defaultSectionLayout ?? createSectionForApiItem;
 	const documentationSuiteOptions = getDocumentationSuiteOptionsWithDefaults(options);
 	const transformations = getApiItemTransformationsWithDefaults(options?.transformations);
 	return {
@@ -96,5 +125,6 @@ export function getApiItemTransformationConfigurationWithDefaults(
 		apiModel: options.apiModel,
 		uriRoot: options.uriRoot,
 		logger,
+		defaultSectionLayout,
 	};
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/Configuration.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/Configuration.ts
@@ -55,9 +55,13 @@ export interface ApiItemTransformationConfigurationBase {
  */
 export interface ApiItemTransformationConfiguration
 	extends ApiItemTransformationConfigurationBase,
-		ApiItemTransformations,
 		Required<DocumentationSuiteOptions>,
-		Required<LoggingConfiguration> {}
+		Required<LoggingConfiguration> {
+	/**
+	 * {@inheritDoc ApiItemTransformations}
+	 */
+	readonly transformations: ApiItemTransformations;
+}
 
 /**
  * Input options for API Item transformation APIs.
@@ -66,9 +70,13 @@ export interface ApiItemTransformationConfiguration
  */
 export interface ApiItemTransformationOptions
 	extends ApiItemTransformationConfigurationBase,
-		Partial<ApiItemTransformations>,
 		DocumentationSuiteOptions,
-		LoggingConfiguration {}
+		LoggingConfiguration {
+	/**
+	 * Optional overrides for the default transformations.
+	 */
+	readonly transformations?: Partial<ApiItemTransformations>;
+}
 
 /**
  * Gets a complete {@link ApiItemTransformationConfiguration} using the provided partial configuration, and filling
@@ -81,10 +89,10 @@ export function getApiItemTransformationConfigurationWithDefaults(
 ): ApiItemTransformationConfiguration {
 	const logger = options.logger ?? defaultConsoleLogger;
 	const documentationSuiteOptions = getDocumentationSuiteOptionsWithDefaults(options);
-	const transformations = getApiItemTransformationsWithDefaults(options);
+	const transformations = getApiItemTransformationsWithDefaults(options?.transformations);
 	return {
 		...documentationSuiteOptions,
-		...transformations,
+		transformations,
 		apiModel: options.apiModel,
 		uriRoot: options.uriRoot,
 		logger,

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/Transformations.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/Transformations.ts
@@ -3,25 +3,27 @@
  * Licensed under the MIT License.
  */
 
-import type {
-	ApiCallSignature,
-	ApiClass,
-	ApiConstructSignature,
-	ApiConstructor,
-	ApiEntryPoint,
-	ApiEnum,
-	ApiEnumMember,
-	ApiFunction,
-	ApiIndexSignature,
-	ApiInterface,
-	ApiItem,
-	ApiMethod,
-	ApiMethodSignature,
-	ApiModel,
-	ApiNamespace,
-	ApiPropertyItem,
-	ApiTypeAlias,
-	ApiVariable,
+import {
+	type ApiCallSignature,
+	type ApiClass,
+	type ApiConstructSignature,
+	type ApiConstructor,
+	type ApiEntryPoint,
+	type ApiEnum,
+	type ApiEnumMember,
+	type ApiFunction,
+	type ApiIndexSignature,
+	type ApiInterface,
+	type ApiItem,
+	ApiItemKind,
+	type ApiMethod,
+	type ApiMethodSignature,
+	type ApiModel,
+	type ApiNamespace,
+	type ApiProperty,
+	type ApiPropertySignature,
+	type ApiTypeAlias,
+	type ApiVariable,
 } from "@microsoft/api-extractor-model";
 
 import type { SectionNode } from "../../documentation-domain/index.js";
@@ -55,8 +57,6 @@ export type TransformApiItemWithoutChildren<TApiItem extends ApiItem> = (
 /**
  * Transformations for generating {@link DocumentationNode} trees from different kinds of API content.
  *
- * @remarks For any transformation not explicitly configured, a default will be used.
- *
  * @public
  */
 export interface ApiItemTransformations {
@@ -77,65 +77,30 @@ export interface ApiItemTransformations {
 		config: ApiItemTransformationConfiguration,
 	) => SectionNode[];
 
-	/**
-	 * Transformation to generate a {@link SectionNode} for a `Call Signature`.
-	 */
-	readonly transformApiCallSignature: TransformApiItemWithoutChildren<ApiCallSignature>;
+	readonly [ApiItemKind.CallSignature]: TransformApiItemWithoutChildren<ApiCallSignature>;
+	readonly [ApiItemKind.Class]: TransformApiItemWithChildren<ApiClass>;
+	readonly [ApiItemKind.Constructor]: TransformApiItemWithoutChildren<ApiConstructor>;
+	readonly [ApiItemKind.ConstructSignature]: TransformApiItemWithoutChildren<ApiConstructSignature>;
 
 	/**
-	 * Transformation to generate a {@link SectionNode} for a `Class`.
-	 */
-	readonly transformApiClass: TransformApiItemWithChildren<ApiClass>;
-
-	/**
-	 * Transformation to generate a {@link SectionNode} for a `Constructor`.
-	 */
-	readonly transformApiConstructor: TransformApiItemWithoutChildren<
-		ApiConstructSignature | ApiConstructor
-	>;
-
-	/**
-	 * Transformation to generate a {@link SectionNode} for a package `EntryPoint`.
+	 * `ApiEntryPoint` handler.
 	 *
 	 * @remarks
 	 *
 	 * Note: for packages that have a single entry-point, this content will be bubbled up to the generated
-	 * package-level document to reduce unecessary indirection in the generated suite.
+	 * package-level document to reduce unnecessary indirection in the generated suite.
 	 */
-	readonly transformApiEntryPoint: TransformApiItemWithChildren<ApiEntryPoint>;
+	readonly [ApiItemKind.EntryPoint]: TransformApiItemWithChildren<ApiEntryPoint>;
+	readonly [ApiItemKind.Enum]: TransformApiItemWithChildren<ApiEnum>;
+	readonly [ApiItemKind.EnumMember]: TransformApiItemWithoutChildren<ApiEnumMember>;
+	readonly [ApiItemKind.Function]: TransformApiItemWithoutChildren<ApiFunction>;
+	readonly [ApiItemKind.IndexSignature]: TransformApiItemWithoutChildren<ApiIndexSignature>;
+	readonly [ApiItemKind.Interface]: TransformApiItemWithChildren<ApiInterface>;
+	readonly [ApiItemKind.Method]: TransformApiItemWithoutChildren<ApiMethod>;
+	readonly [ApiItemKind.MethodSignature]: TransformApiItemWithoutChildren<ApiMethodSignature>;
 
 	/**
-	 * Transformation to generate a {@link SectionNode} for an `Enum`.
-	 */
-	readonly transformApiEnum: TransformApiItemWithChildren<ApiEnum>;
-
-	/**
-	 * Transformation to generate a {@link SectionNode} for an `Enum Member` (flag).
-	 */
-	readonly transformApiEnumMember: TransformApiItemWithoutChildren<ApiEnumMember>;
-
-	/**
-	 * Transformation to generate a {@link SectionNode} for a `Function`.
-	 */
-	readonly transformApiFunction: TransformApiItemWithoutChildren<ApiFunction>;
-
-	/**
-	 * Transformation to generate a {@link SectionNode} for an `Index Signature`.
-	 */
-	readonly transformApiIndexSignature: TransformApiItemWithoutChildren<ApiIndexSignature>;
-
-	/**
-	 * Transformation to generate a {@link SectionNode} for an `Interface`.
-	 */
-	readonly transformApiInterface: TransformApiItemWithChildren<ApiInterface>;
-
-	/**
-	 * Transformation to generate a {@link SectionNode} for a `Method`.
-	 */
-	readonly transformApiMethod: TransformApiItemWithoutChildren<ApiMethod | ApiMethodSignature>;
-
-	/**
-	 * Transformation to generate a {@link SectionNode} for an `ApiModel`.
+	 * `ApiModel` handler.
 	 *
 	 * @remarks
 	 *
@@ -143,50 +108,41 @@ export interface ApiItemTransformations {
 	 * and `Package` items specially. We never render `Package` child details directly to the `Model` document.
 	 * These are always rendered to separate documents from each other.
 	 */
-	readonly transformApiModel: TransformApiItemWithoutChildren<ApiModel>;
-
-	/**
-	 * Transformation to generate a {@link SectionNode} for a `Namespace`.
-	 */
-	readonly transformApiNamespace: TransformApiItemWithChildren<ApiNamespace>;
-
-	/**
-	 * Transformation to generate a {@link SectionNode} for a `Property`.
-	 */
-	readonly transformApiProperty: TransformApiItemWithoutChildren<ApiPropertyItem>;
-
-	/**
-	 * Transformation to generate a {@link SectionNode} for a `Type Alias`.
-	 */
-	readonly transformApiTypeAlias: TransformApiItemWithoutChildren<ApiTypeAlias>;
-
-	/**
-	 * Transformation to generate a {@link SectionNode} for an `Variable`.
-	 */
-	readonly transformApiVariable: TransformApiItemWithoutChildren<ApiVariable>;
+	readonly [ApiItemKind.Model]: TransformApiItemWithoutChildren<ApiModel>;
+	readonly [ApiItemKind.Namespace]: TransformApiItemWithChildren<ApiNamespace>;
+	readonly [ApiItemKind.Property]: TransformApiItemWithoutChildren<ApiProperty>;
+	readonly [ApiItemKind.PropertySignature]: TransformApiItemWithoutChildren<ApiPropertySignature>;
+	readonly [ApiItemKind.TypeAlias]: TransformApiItemWithoutChildren<ApiTypeAlias>;
+	readonly [ApiItemKind.Variable]: TransformApiItemWithoutChildren<ApiVariable>;
 }
 
 /**
  * The default {@link ApiItemTransformationConfiguration}.
  */
 const defaultApiItemTransformationOptions: ApiItemTransformations = {
-	transformApiCallSignature: DefaultTransformationImplementations.transformApiItemWithoutChildren,
-	transformApiClass: DefaultTransformationImplementations.transformApiClass,
-	transformApiConstructor: DefaultTransformationImplementations.transformApiFunctionLike,
-	transformApiEntryPoint: DefaultTransformationImplementations.transformApiEntryPoint,
-	transformApiEnum: DefaultTransformationImplementations.transformApiEnum,
-	transformApiEnumMember: DefaultTransformationImplementations.transformApiItemWithoutChildren,
-	transformApiFunction: DefaultTransformationImplementations.transformApiFunctionLike,
-	transformApiIndexSignature:
-		DefaultTransformationImplementations.transformApiItemWithoutChildren,
-	transformApiInterface: DefaultTransformationImplementations.transformApiInterface,
-	transformApiMethod: DefaultTransformationImplementations.transformApiFunctionLike,
-	transformApiModel: DefaultTransformationImplementations.transformApiModel,
-	transformApiNamespace: DefaultTransformationImplementations.transformApiNamespace,
-	transformApiProperty: DefaultTransformationImplementations.transformApiItemWithoutChildren,
-	transformApiTypeAlias: DefaultTransformationImplementations.transformApiItemWithoutChildren,
-	transformApiVariable: DefaultTransformationImplementations.transformApiItemWithoutChildren,
 	createDefaultLayout: DefaultTransformationImplementations.createDefaultLayout,
+	[ApiItemKind.CallSignature]:
+		DefaultTransformationImplementations.transformApiItemWithoutChildren,
+	[ApiItemKind.Class]: DefaultTransformationImplementations.transformApiClass,
+	[ApiItemKind.Constructor]: DefaultTransformationImplementations.transformApiFunctionLike,
+	[ApiItemKind.ConstructSignature]: DefaultTransformationImplementations.transformApiFunctionLike,
+	[ApiItemKind.EntryPoint]: DefaultTransformationImplementations.transformApiEntryPoint,
+	[ApiItemKind.Enum]: DefaultTransformationImplementations.transformApiEnum,
+	[ApiItemKind.EnumMember]: DefaultTransformationImplementations.transformApiItemWithoutChildren,
+	[ApiItemKind.Function]: DefaultTransformationImplementations.transformApiFunctionLike,
+	[ApiItemKind.IndexSignature]:
+		DefaultTransformationImplementations.transformApiItemWithoutChildren,
+	[ApiItemKind.Interface]: DefaultTransformationImplementations.transformApiInterface,
+	[ApiItemKind.Method]: DefaultTransformationImplementations.transformApiFunctionLike,
+	[ApiItemKind.MethodSignature]: DefaultTransformationImplementations.transformApiFunctionLike,
+	[ApiItemKind.Model]: DefaultTransformationImplementations.transformApiModel,
+	[ApiItemKind.Namespace]: DefaultTransformationImplementations.transformApiNamespace,
+	// TODO: Make package transformation configurable
+	[ApiItemKind.Property]: DefaultTransformationImplementations.transformApiItemWithoutChildren,
+	[ApiItemKind.PropertySignature]:
+		DefaultTransformationImplementations.transformApiItemWithoutChildren,
+	[ApiItemKind.TypeAlias]: DefaultTransformationImplementations.transformApiItemWithoutChildren,
+	[ApiItemKind.Variable]: DefaultTransformationImplementations.transformApiItemWithoutChildren,
 };
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/Transformations.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/Transformations.ts
@@ -60,23 +60,6 @@ export type TransformApiItemWithoutChildren<TApiItem extends ApiItem> = (
  * @public
  */
 export interface ApiItemTransformations {
-	/**
-	 * Generates the default layout used by all default API item transformations.
-	 *
-	 * @remarks
-	 *
-	 * Can be used to uniformly control the default content layout for all API item kinds.
-	 *
-	 * API item kind-specific details are passed in, and can be displayed as desired.
-	 *
-	 * @returns The list of {@link SectionNode}s that comprise the top-level section body for the API item.
-	 */
-	readonly createDefaultLayout: (
-		apiItem: ApiItem,
-		childSections: SectionNode[] | undefined,
-		config: ApiItemTransformationConfiguration,
-	) => SectionNode[];
-
 	readonly [ApiItemKind.CallSignature]: TransformApiItemWithoutChildren<ApiCallSignature>;
 	readonly [ApiItemKind.Class]: TransformApiItemWithChildren<ApiClass>;
 	readonly [ApiItemKind.Constructor]: TransformApiItemWithoutChildren<ApiConstructor>;
@@ -120,7 +103,6 @@ export interface ApiItemTransformations {
  * The default {@link ApiItemTransformationConfiguration}.
  */
 const defaultApiItemTransformationOptions: ApiItemTransformations = {
-	createDefaultLayout: DefaultTransformationImplementations.createDefaultLayout,
 	[ApiItemKind.CallSignature]:
 		DefaultTransformationImplementations.transformApiItemWithoutChildren,
 	[ApiItemKind.Class]: DefaultTransformationImplementations.transformApiClass,

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/Transformations.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/Transformations.ts
@@ -57,6 +57,8 @@ export type TransformApiItemWithoutChildren<TApiItem extends ApiItem> = (
 /**
  * Transformations for generating {@link DocumentationNode} trees from different kinds of API content.
  *
+ * @privateRemarks TODO: Make transformation for package items configurable
+ *
  * @public
  */
 export interface ApiItemTransformations {
@@ -119,7 +121,6 @@ const defaultApiItemTransformationOptions: ApiItemTransformations = {
 	[ApiItemKind.MethodSignature]: DefaultTransformationImplementations.transformApiFunctionLike,
 	[ApiItemKind.Model]: DefaultTransformationImplementations.transformApiModel,
 	[ApiItemKind.Namespace]: DefaultTransformationImplementations.transformApiNamespace,
-	// TODO: Make package transformation configurable
 	[ApiItemKind.Property]: DefaultTransformationImplementations.transformApiItemWithoutChildren,
 	[ApiItemKind.PropertySignature]:
 		DefaultTransformationImplementations.transformApiItemWithoutChildren,

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/CreateSectionForApiItem.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/CreateSectionForApiItem.ts
@@ -23,7 +23,7 @@ import {
 } from "../helpers/index.js";
 
 /**
- * Default content layout for all API items.
+ * Default {@link ApiItemTransformationConfiguration.defaultSectionLayout} implementation.
  *
  * @remarks Lays out the content in the following manner:
  *
@@ -51,7 +51,7 @@ import {
  * @param itemSpecificContent - API item-specific details to be included in the default layout.
  * @param config - See {@link MarkdownDocumenterConfiguration}.
  */
-export function createDefaultLayout(
+export function createSectionForApiItem(
 	apiItem: ApiItem,
 	itemSpecificContent: SectionNode[] | undefined,
 	config: ApiItemTransformationConfiguration,

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
@@ -250,5 +250,5 @@ export function transformApiClass(
 		}
 	}
 
-	return config.transformations.createDefaultLayout(apiClass, sections, config);
+	return config.defaultSectionLayout(apiClass, sections, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
@@ -250,5 +250,5 @@ export function transformApiClass(
 		}
 	}
 
-	return config.createDefaultLayout(apiClass, sections, config);
+	return config.transformations.createDefaultLayout(apiClass, sections, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
@@ -75,5 +75,5 @@ export function transformApiEnum(
 		}
 	}
 
-	return config.createDefaultLayout(apiEnum, sections, config);
+	return config.transformations.createDefaultLayout(apiEnum, sections, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
@@ -75,5 +75,5 @@ export function transformApiEnum(
 		}
 	}
 
-	return config.transformations.createDefaultLayout(apiEnum, sections, config);
+	return config.defaultSectionLayout(apiEnum, sections, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiFunctionLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiFunctionLike.ts
@@ -29,5 +29,5 @@ export function transformApiFunctionLike(
 		childSections.push(renderedReturnsSection);
 	}
 
-	return config.transformations.createDefaultLayout(apiFunctionLike, childSections, config);
+	return config.defaultSectionLayout(apiFunctionLike, childSections, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiFunctionLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiFunctionLike.ts
@@ -29,5 +29,5 @@ export function transformApiFunctionLike(
 		childSections.push(renderedReturnsSection);
 	}
 
-	return config.createDefaultLayout(apiFunctionLike, childSections, config);
+	return config.transformations.createDefaultLayout(apiFunctionLike, childSections, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
@@ -194,5 +194,5 @@ export function transformApiInterface(
 		}
 	}
 
-	return config.transformations.createDefaultLayout(apiInterface, childSections, config);
+	return config.defaultSectionLayout(apiInterface, childSections, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
@@ -194,5 +194,5 @@ export function transformApiInterface(
 		}
 	}
 
-	return config.createDefaultLayout(apiInterface, childSections, config);
+	return config.transformations.createDefaultLayout(apiInterface, childSections, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiItemWithoutChildren.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiItemWithoutChildren.ts
@@ -17,5 +17,5 @@ export function transformApiItemWithoutChildren(
 ): SectionNode[] {
 	// Items without children don't have much information to provide other than the default
 	// rendered details.
-	return config.createDefaultLayout(apiItem, undefined, config);
+	return config.transformations.createDefaultLayout(apiItem, undefined, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiItemWithoutChildren.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiItemWithoutChildren.ts
@@ -17,5 +17,5 @@ export function transformApiItemWithoutChildren(
 ): SectionNode[] {
 	// Items without children don't have much information to provide other than the default
 	// rendered details.
-	return config.transformations.createDefaultLayout(apiItem, undefined, config);
+	return config.defaultSectionLayout(apiItem, undefined, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
@@ -213,5 +213,5 @@ export function transformApiModuleLike(
 		}
 	}
 
-	return config.transformations.createDefaultLayout(apiItem, children, config);
+	return config.defaultSectionLayout(apiItem, children, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
@@ -213,5 +213,5 @@ export function transformApiModuleLike(
 		}
 	}
 
-	return config.createDefaultLayout(apiItem, children, config);
+	return config.transformations.createDefaultLayout(apiItem, children, config);
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/index.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/index.ts
@@ -7,7 +7,7 @@
  * Default {@link @microsoft/api-extractor-model#ApiItem} transformation implementations.
  */
 
-export { createDefaultLayout } from "./CreateDefaultLayout.js";
+export { createSectionForApiItem } from "./CreateSectionForApiItem.js";
 export { transformApiClass } from "./TransformApiClass.js";
 export { transformApiEntryPoint } from "./TransformApiEntryPoint.js";
 export { transformApiEnum } from "./TransformApiEnum.js";

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
@@ -136,7 +136,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 		const config = createConfig(defaultPartialConfig, model);
 
-		const result = config.transformApiVariable(apiVariable, config);
+		const result = config.transformations[ApiItemKind.Variable](apiVariable, config);
 
 		const expected = [
 			wrapInSection(
@@ -173,7 +173,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 		const config = createConfig(defaultPartialConfig, model);
 
-		const result = config.transformApiFunction(apiFunction, config);
+		const result = config.transformations[ApiItemKind.Function](apiFunction, config);
 
 		const expected = [
 			wrapInSection(
@@ -308,8 +308,10 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 		const config = createConfig(defaultPartialConfig, model);
 
-		const result = config.transformApiInterface(apiInterface, config, (childItem) =>
-			apiItemToSections(childItem, config),
+		const result = config.transformations[ApiItemKind.Interface](
+			apiInterface,
+			config,
+			(childItem) => apiItemToSections(childItem, config),
 		);
 
 		const expected: DocumentationNode[] = [
@@ -424,8 +426,10 @@ describe("ApiItem to Documentation transformation tests", () => {
 			model,
 		);
 
-		const result = config.transformApiNamespace(apiNamespace, config, (childItem) =>
-			apiItemToSections(childItem, config),
+		const result = config.transformations[ApiItemKind.Namespace](
+			apiNamespace,
+			config,
+			(childItem) => apiItemToSections(childItem, config),
 		);
 
 		// Note: the namespace being processed includes 3 const variables:


### PR DESCRIPTION
Updated the structure of `ApiTransformationConfiguration` to contain a `transformations` property of type `ApiItemTransformations`, rather than implementing that interface directly.

Also updates `ApiItemTransformations` methods to be keyed off of `ApiItemKind`, rather than being individually named.

E.g. A call like `config.transformApiMethod(...)` would become `config.transformations["Method"](...)`.

This better aligns with similar transformational API surfaces in this library, like the renderers. It also makes it easier to ensure we capture _all_ possible ApiItem kinds.

The `createDefaultLayout` property of `ApiItemTransformations` now lives directly in `ApiTransformationConfiguration`, but has been renamed to `defaultSectionLayout`.