### PR TITLE
test-fix(offline): Only run "applies stashed ops with no saved ops" test against local server

### DIFF
--- a/packages/test/test-end-to-end-tests/.vscode/launch.json
+++ b/packages/test/test-end-to-end-tests/.vscode/launch.json
@@ -11,7 +11,7 @@
 			"env": {
 				"fluid__test__driver": "local",
 				"fluid__test__backCompat": "${input:backCompat}",
-				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutput}",
+				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
 			"windows": {
@@ -55,7 +55,7 @@
 			"env": {
 				"fluid__test__driver": "t9s",
 				"fluid__test__backCompat": "${input:backCompat}",
-				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutput}",
+				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
 			"windows": {
@@ -109,10 +109,8 @@
 			"env": {
 				"fluid__test__driver": "odsp",
 				"fluid__test__backCompat": "${input:backCompat}",
-				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutput}",
+				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
 				"fluid__test__odspEndpointName": "${input:odspEndpoint}",
-				"login__odsp__test__tenants": "${input:login__odsp__test__tenants}",
-				"login__microsoft__clientId": "${input:login__microsoft__clientId}",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
 			"windows": {
@@ -148,8 +146,7 @@
 				"fluid__test__driver": "r11s",
 				"fluid__test__backCompat": "${input:backCompat}",
 				"fluid__test__r11sEndpointName": "${input:r11sEndpoint}",
-				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutput}",
-				"fluid__test__driver__frs": "${input:fluid__test__driver__frs}",
+				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
 			"windows": {
@@ -211,7 +208,7 @@
 			],
 		},
 		{
-			"id": "verboseConsoleOutput",
+			"id": "verboseConsoleOutputt",
 			"description": "Show console output?",
 			"default": "",
 			"type": "pickString",
@@ -247,24 +244,6 @@
 					"value": "docker",
 				},
 			],
-		},
-		{
-			"id": "fluid__test__driver__frs",
-			"description": "FRS Tenant info from our team key vault. Check your env vars after running getkeys",
-			"type": "promptString",
-			"password": true,
-		},
-		{
-			"id": "login__odsp__test__tenants",
-			"description": "ODSP Tenant info from our team key vault. Check your env vars after running getkeys",
-			"type": "promptString",
-			"password": true,
-		},
-		{
-			"id": "login__microsoft__clientId",
-			"description": "Client ID for authenticating to test ODSP tenants. Check your env vars after running getkeys",
-			"type": "promptString",
-			"password": true,
 		},
 	],
 }

--- a/packages/test/test-end-to-end-tests/.vscode/launch.json
+++ b/packages/test/test-end-to-end-tests/.vscode/launch.json
@@ -11,7 +11,7 @@
 			"env": {
 				"fluid__test__driver": "local",
 				"fluid__test__backCompat": "${input:backCompat}",
-				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
+				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutput}",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
 			"windows": {
@@ -55,7 +55,7 @@
 			"env": {
 				"fluid__test__driver": "t9s",
 				"fluid__test__backCompat": "${input:backCompat}",
-				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
+				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutput}",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
 			"windows": {
@@ -109,8 +109,10 @@
 			"env": {
 				"fluid__test__driver": "odsp",
 				"fluid__test__backCompat": "${input:backCompat}",
-				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
+				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutput}",
 				"fluid__test__odspEndpointName": "${input:odspEndpoint}",
+				"login__odsp__test__tenants": "${input:login__odsp__test__tenants}",
+				"login__microsoft__clientId": "${input:login__microsoft__clientId}",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
 			"windows": {
@@ -146,7 +148,8 @@
 				"fluid__test__driver": "r11s",
 				"fluid__test__backCompat": "${input:backCompat}",
 				"fluid__test__r11sEndpointName": "${input:r11sEndpoint}",
-				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
+				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutput}",
+				//* "fluid__test__driver__frs": "...",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
 			"windows": {
@@ -208,7 +211,7 @@
 			],
 		},
 		{
-			"id": "verboseConsoleOutputt",
+			"id": "verboseConsoleOutput",
 			"description": "Show console output?",
 			"default": "",
 			"type": "pickString",
@@ -244,6 +247,18 @@
 					"value": "docker",
 				},
 			],
+		},
+		{
+			"id": "login__odsp__test__tenants",
+			"description": "ODSP Tenant info from our team key vault. Check your env vars after running getkeys",
+			"type": "promptString",
+			"password": true,
+		},
+		{
+			"id": "login__microsoft__clientId",
+			"description": "Client ID for authenticating to test ODSP tenants. Check your env vars after running getkeys",
+			"type": "promptString",
+			"password": true,
 		},
 	],
 }

--- a/packages/test/test-end-to-end-tests/.vscode/launch.json
+++ b/packages/test/test-end-to-end-tests/.vscode/launch.json
@@ -149,7 +149,7 @@
 				"fluid__test__backCompat": "${input:backCompat}",
 				"fluid__test__r11sEndpointName": "${input:r11sEndpoint}",
 				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutput}",
-				//* "fluid__test__driver__frs": "...",
+				"fluid__test__driver__frs": "${input:fluid__test__driver__frs}",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
 			"windows": {
@@ -247,6 +247,12 @@
 					"value": "docker",
 				},
 			],
+		},
+		{
+			"id": "fluid__test__driver__frs",
+			"description": "FRS Tenant info from our team key vault. Check your env vars after running getkeys",
+			"type": "promptString",
+			"password": true,
 		},
 		{
 			"id": "login__odsp__test__tenants",

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -2025,38 +2025,40 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		assert.strictEqual(counter1.value, 5);
 	});
 
-	it.only("applies stashed ops with no saved ops", async function () {
-		const version = await waitForSummary(provider, container1, testContainerConfig);
+	for (let i = 0; i < 100; i++) {
+		it.only("applies stashed ops with no saved ops", async function () {
+			const version = await waitForSummary(provider, container1, testContainerConfig);
 
-		// avoid our join op being saved
-		const headers: IRequestHeader = {
-			[LoaderHeader.loadMode]: { deltaConnection: "none" },
-			[LoaderHeader.version]: version,
-		};
-		const container: IContainerExperimental = await loader.resolve({ url, headers });
-		const dataStore = (await container.getEntryPoint()) as ITestFluidObject;
-		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
-		// generate ops with RSN === summary SN
-		map.set(testKey, testValue);
-		const stashBlob = await container.closeAndGetPendingLocalState?.();
-		assert(stashBlob);
-		const pendingState = JSON.parse(stashBlob);
+			// avoid our join op being saved
+			const headers: IRequestHeader = {
+				[LoaderHeader.loadMode]: { deltaConnection: "none" },
+				[LoaderHeader.version]: version,
+			};
+			const container: IContainerExperimental = await loader.resolve({ url, headers });
+			const dataStore = (await container.getEntryPoint()) as ITestFluidObject;
+			const map = await dataStore.getSharedObject<ISharedMap>(mapId);
+			// generate ops with RSN === summary SN
+			map.set(testKey, testValue);
+			const stashBlob = await container.closeAndGetPendingLocalState?.();
+			assert(stashBlob);
+			const pendingState = JSON.parse(stashBlob);
 
-		// make sure the container loaded from summary and we have no saved ops
-		assert.strictEqual(pendingState.savedOps.length, 0);
-		assert(
-			pendingState.pendingRuntimeState.pending.pendingStates[0].referenceSequenceNumber > 0,
-		);
+			// make sure the container loaded from summary and we have no saved ops
+			assert.strictEqual(pendingState.savedOps.length, 0);
+			assert(
+				pendingState.pendingRuntimeState.pending.pendingStates[0].referenceSequenceNumber > 0,
+			);
 
-		// load container with pending ops, which should resend the op not sent by previous container
-		const container2 = await loader.resolve({ url }, stashBlob);
-		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
-		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
-		await waitForContainerConnection(container2);
-		await provider.ensureSynchronized();
-		assert.strictEqual(map1.get(testKey), testValue);
-		assert.strictEqual(map2.get(testKey), testValue);
-	});
+			// load container with pending ops, which should resend the op not sent by previous container
+			const container2 = await loader.resolve({ url }, stashBlob);
+			const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+			const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
+			await waitForContainerConnection(container2);
+			await provider.ensureSynchronized();
+			assert.strictEqual(map1.get(testKey), testValue);
+			assert.strictEqual(map2.get(testKey), testValue);
+		});
+	}
 });
 
 describeCompat(


### PR DESCRIPTION
## Description

Fixes [AB#18451](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/18451)

This test is covering sequence number gymnastics when loading from serialized pending state and applying stashed ops.  Server summary/op implementations and potential race conditions are not interesting, and only make the test run slow (4s on average for `waitForSummary`) if not time out (the cause of the bug this fixes).

So, only run against local server.

This also brings back the assert removed in #22712, but ensuring that we load from the summary (and don't end up with the original snapshot), which ensures we actually get coverage of the code this is supposed to test (see original PR adding the test, #17375)