### PR TITLE
refactor(api-markdown-documenter): Add and use a `ValidApiItemKind` type alias which excludes the `None` value

### DIFF
--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -112,7 +112,7 @@ declare namespace ApiItemUtilities {
 export { ApiItemUtilities }
 
 // @public
-export type ApiMemberKind = Omit<ApiItemKind, ApiItemKind.EntryPoint | ApiItemKind.Model | ApiItemKind.None | ApiItemKind.Package>;
+export type ApiMemberKind = Exclude<ValidApiItemKind, ApiItemKind.EntryPoint | ApiItemKind.Model | ApiItemKind.Package>;
 
 export { ApiModel }
 
@@ -824,6 +824,9 @@ export class UnorderedListNode extends DocumentationParentNodeBase<SingleLineDoc
 
 // @public
 export type UrlTarget = string;
+
+// @public
+export type ValidApiItemKind = Exclude<ApiItemKind, ApiItemKind.None>;
 
 // @public
 export const verboseConsoleLogger: Logger;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -112,7 +112,7 @@ declare namespace ApiItemUtilities {
 export { ApiItemUtilities }
 
 // @public
-export type ApiMemberKind = Omit<ApiItemKind, ApiItemKind.EntryPoint | ApiItemKind.Model | ApiItemKind.None | ApiItemKind.Package>;
+export type ApiMemberKind = Exclude<ValidApiItemKind, ApiItemKind.EntryPoint | ApiItemKind.Model | ApiItemKind.Package>;
 
 export { ApiModel }
 
@@ -818,6 +818,9 @@ export class UnorderedListNode extends DocumentationParentNodeBase<SingleLineDoc
 
 // @public
 export type UrlTarget = string;
+
+// @public
+export type ValidApiItemKind = Exclude<ApiItemKind, ApiItemKind.None>;
 
 // @public
 export const verboseConsoleLogger: Logger;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -112,7 +112,7 @@ declare namespace ApiItemUtilities {
 export { ApiItemUtilities }
 
 // @public
-export type ApiMemberKind = Omit<ApiItemKind, ApiItemKind.EntryPoint | ApiItemKind.Model | ApiItemKind.None | ApiItemKind.Package>;
+export type ApiMemberKind = Exclude<ValidApiItemKind, ApiItemKind.EntryPoint | ApiItemKind.Model | ApiItemKind.Package>;
 
 export { ApiModel }
 
@@ -796,6 +796,9 @@ export class UnorderedListNode extends DocumentationParentNodeBase<SingleLineDoc
 
 // @public
 export type UrlTarget = string;
+
+// @public
+export type ValidApiItemKind = Exclude<ApiItemKind, ApiItemKind.None>;
 
 // @public
 export const verboseConsoleLogger: Logger;

--- a/tools/api-markdown-documenter/src/api-item-transforms/ApiItemTransformUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/ApiItemTransformUtilities.ts
@@ -438,6 +438,11 @@ function doesItemKindGenerateHierarchy(
 	kind: ValidApiItemKind,
 	hierarchyBoundaries: HierarchyBoundaries,
 ): boolean {
+	if (kind === ApiItemKind.Model) {
+		// Model items always yield a document, and never introduce hierarchy
+		return false;
+	}
+
 	if (kind === ApiItemKind.Package) {
 		return true;
 	}

--- a/tools/api-markdown-documenter/src/api-item-transforms/ApiItemTransformUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/ApiItemTransformUtilities.ts
@@ -9,7 +9,7 @@ import { type ApiItem, ApiItemKind, ReleaseTag } from "@microsoft/api-extractor-
 
 import type { Heading } from "../Heading.js";
 import type { Link } from "../Link.js";
-import { getQualifiedApiItemName, getReleaseTag } from "../utilities/index.js";
+import { getQualifiedApiItemName, getReleaseTag, getApiItemKind, type ValidApiItemKind } from "../utilities/index.js";
 
 import type {
 	ApiItemTransformationConfiguration,
@@ -268,7 +268,7 @@ function getHeadingIdForApiItem(
 	config: ApiItemTransformationConfiguration,
 ): string {
 	let baseName: string | undefined;
-	const apiItemKind: ApiItemKind = apiItem.kind;
+	const apiItemKind = getApiItemKind(apiItem);
 
 	// Walk parentage up until we reach the ancestor into whose document we're being rendered.
 	// Generate ID information for everything back to that point
@@ -367,7 +367,7 @@ export function getAncestralHierarchy(
  * @returns `true` if the item should be rendered to its own document. `false` otherwise.
  */
 export function doesItemKindRequireOwnDocument(
-	kind: ApiItemKind,
+	kind: ValidApiItemKind,
 	documentBoundaries: DocumentBoundaries,
 ): boolean {
 	if (
@@ -404,7 +404,7 @@ export function doesItemRequireOwnDocument(
 	apiItem: ApiItem,
 	documentBoundaries: DocumentBoundaries,
 ): boolean {
-	return doesItemKindRequireOwnDocument(apiItem.kind, documentBoundaries);
+	return doesItemKindRequireOwnDocument(getApiItemKind(apiItem), documentBoundaries);
 }
 
 /**
@@ -430,7 +430,7 @@ export function doesItemRequireOwnDocument(
  * @returns `true` if the item should contribute to directory-wise hierarchy in the output. `false` otherwise.
  */
 function doesItemKindGenerateHierarchy(
-	kind: ApiItemKind,
+	kind: ValidApiItemKind,
 	hierarchyBoundaries: HierarchyBoundaries,
 ): boolean {
 	if (kind === ApiItemKind.Package) {
@@ -458,7 +458,7 @@ function doesItemGenerateHierarchy(
 	apiItem: ApiItem,
 	hierarchyBoundaries: HierarchyBoundaries,
 ): boolean {
-	return doesItemKindGenerateHierarchy(apiItem.kind, hierarchyBoundaries);
+	return doesItemKindGenerateHierarchy(getApiItemKind(apiItem), hierarchyBoundaries);
 }
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/ApiItemTransformUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/ApiItemTransformUtilities.ts
@@ -9,7 +9,12 @@ import { type ApiItem, ApiItemKind, ReleaseTag } from "@microsoft/api-extractor-
 
 import type { Heading } from "../Heading.js";
 import type { Link } from "../Link.js";
-import { getQualifiedApiItemName, getReleaseTag, getApiItemKind, type ValidApiItemKind } from "../utilities/index.js";
+import {
+	getQualifiedApiItemName,
+	getReleaseTag,
+	getApiItemKind,
+	type ValidApiItemKind,
+} from "../utilities/index.js";
 
 import type {
 	ApiItemTransformationConfiguration,

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiItem.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiItem.ts
@@ -29,6 +29,7 @@ import { doesItemRequireOwnDocument, shouldItemBeIncluded } from "./ApiItemTrans
 import { createDocument } from "./Utilities.js";
 import type { ApiItemTransformationConfiguration } from "./configuration/index.js";
 import { createBreadcrumbParagraph, wrapInSection } from "./helpers/index.js";
+import { getApiItemKind } from "../utilities/ApiItemUtilities.js";
 
 /**
  * Creates a {@link DocumentNode} for the specified `apiItem`.
@@ -54,16 +55,14 @@ export function apiItemToDocument(
 	apiItem: ApiItem,
 	config: ApiItemTransformationConfiguration,
 ): DocumentNode {
-	if (apiItem.kind === ApiItemKind.None) {
-		throw new Error(`Encountered API item "${apiItem.displayName}" with a kind of "None".`);
-	}
+	const itemKind = getApiItemKind(apiItem);
 
 	if (
-		apiItem.kind === ApiItemKind.Model ||
-		apiItem.kind === ApiItemKind.Package ||
-		apiItem.kind === ApiItemKind.EntryPoint
+		itemKind === ApiItemKind.Model ||
+		itemKind === ApiItemKind.Package ||
+		itemKind === ApiItemKind.EntryPoint
 	) {
-		throw new Error(`Provided API item kind must be handled specially: "${apiItem.kind}".`);
+		throw new Error(`Provided API item kind must be handled specially: "${itemKind}".`);
 	}
 
 	if (!shouldItemBeIncluded(apiItem, config)) {
@@ -74,13 +73,13 @@ export function apiItemToDocument(
 
 	if (!doesItemRequireOwnDocument(apiItem, config.documentBoundaries)) {
 		throw new Error(
-			`"renderApiDocument" called for an API item kind that is not intended to be rendered to its own document. Provided item kind: "${apiItem.kind}".`,
+			`"renderApiDocument" called for an API item kind that is not intended to be rendered to its own document. Provided item kind: "${itemKind}".`,
 		);
 	}
 
 	const logger = config.logger;
 
-	logger.verbose(`Generating document for ${apiItem.displayName} (${apiItem.kind})...`);
+	logger.verbose(`Generating document for ${apiItem.displayName} (${itemKind})...`);
 
 	const sections: SectionNode[] = [];
 
@@ -112,16 +111,14 @@ export function apiItemToSections(
 	apiItem: ApiItem,
 	config: ApiItemTransformationConfiguration,
 ): SectionNode[] {
-	if (apiItem.kind === ApiItemKind.None) {
-		throw new Error(`Encountered API item "${apiItem.displayName}" with a kind of "None".`);
-	}
+	const itemKind = getApiItemKind(apiItem);
 
 	if (
-		apiItem.kind === ApiItemKind.Model ||
-		apiItem.kind === ApiItemKind.Package ||
-		apiItem.kind === ApiItemKind.EntryPoint
+		itemKind === ApiItemKind.Model ||
+		itemKind === ApiItemKind.Package ||
+		itemKind === ApiItemKind.EntryPoint
 	) {
-		throw new Error(`Provided API item kind must be handled specially: "${apiItem.kind}".`);
+		throw new Error(`Provided API item kind must be handled specially: "${itemKind}".`);
 	}
 
 	if (!shouldItemBeIncluded(apiItem, config)) {
@@ -135,7 +132,7 @@ export function apiItemToSections(
 	logger.verbose(`Rendering section for ${apiItem.displayName}...`);
 
 	let sections: SectionNode[];
-	switch (apiItem.kind) {
+	switch (itemKind) {
 		case ApiItemKind.CallSignature: {
 			sections = config.transformApiCallSignature(apiItem as ApiCallSignature, config);
 			break;
@@ -221,7 +218,7 @@ export function apiItemToSections(
 		}
 
 		default: {
-			throw new Error(`Unrecognized API item kind: "${apiItem.kind}".`);
+			throw new Error(`Unrecognized API item kind: "${itemKind}".`);
 		}
 	}
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiItem.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiItem.ts
@@ -24,12 +24,12 @@ import {
 } from "@microsoft/api-extractor-model";
 
 import type { DocumentNode, SectionNode } from "../documentation-domain/index.js";
+import { getApiItemKind } from "../utilities/index.js";
 
 import { doesItemRequireOwnDocument, shouldItemBeIncluded } from "./ApiItemTransformUtilities.js";
 import { createDocument } from "./Utilities.js";
 import type { ApiItemTransformationConfiguration } from "./configuration/index.js";
 import { createBreadcrumbParagraph, wrapInSection } from "./helpers/index.js";
-import { getApiItemKind } from "../utilities/ApiItemUtilities.js";
 
 /**
  * Creates a {@link DocumentNode} for the specified `apiItem`.

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuiteOptions.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuiteOptions.ts
@@ -20,6 +20,7 @@ import {
 	getSingleLineExcerptText,
 	isDeprecated,
 	getReleaseTag,
+	getApiItemKind,
 } from "../../utilities/index.js";
 
 /**
@@ -279,7 +280,8 @@ export namespace DefaultDocumentationSuiteOptions {
 	 * - Package: Uses the unscoped package name.
 	 */
 	export function defaultGetFileNameForItem(apiItem: ApiItem): string {
-		switch (apiItem.kind) {
+		const itemKind = getApiItemKind(apiItem);
+		switch (itemKind) {
 			case ApiItemKind.Model: {
 				return "index";
 			}
@@ -307,7 +309,8 @@ export namespace DefaultDocumentationSuiteOptions {
 	 * Uses the item's `displayName`, except for `Model` items, in which case the text "API Overview" is displayed.
 	 */
 	export function defaultGetHeadingTextForItem(apiItem: ApiItem): string {
-		switch (apiItem.kind) {
+		const itemKind = getApiItemKind(apiItem);
+		switch (itemKind) {
 			case ApiItemKind.Model: {
 				return "API Overview";
 			}
@@ -332,7 +335,8 @@ export namespace DefaultDocumentationSuiteOptions {
 	 * Uses the item's signature, except for `Model` items, in which case the text "Packages" is displayed.
 	 */
 	export function defaultGetLinkTextForItem(apiItem: ApiItem): string {
-		switch (apiItem.kind) {
+		const itemKind = getApiItemKind(apiItem);
+		switch (itemKind) {
 			case ApiItemKind.Model: {
 				return "Packages";
 			}

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
@@ -15,7 +15,7 @@ import {
 } from "@microsoft/api-extractor-model";
 
 import type { SectionNode } from "../../documentation-domain/index.js";
-import { ApiModifier, getScopedMemberNameForDiagnostics, isStatic } from "../../utilities/index.js";
+import { ApiModifier, getApiItemKind, getScopedMemberNameForDiagnostics, isStatic } from "../../utilities/index.js";
 import { filterChildMembers } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
@@ -75,7 +75,8 @@ export function transformApiClass(
 		const indexSignatures: ApiIndexSignature[] = [];
 		const allMethods: ApiMethod[] = [];
 		for (const child of filteredChildren) {
-			switch (child.kind) {
+			const childKind = getApiItemKind(child);
+			switch (childKind) {
 				case ApiItemKind.Constructor: {
 					constructors.push(child as ApiConstructor);
 					break;
@@ -102,7 +103,7 @@ export function transformApiClass(
 							child.displayName
 						}" of Class "${getScopedMemberNameForDiagnostics(
 							apiClass,
-						)}" is of unsupported API item kind: "${child.kind}"`,
+						)}" is of unsupported API item kind: "${childKind}"`,
 					);
 					break;
 				}

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
@@ -15,7 +15,12 @@ import {
 } from "@microsoft/api-extractor-model";
 
 import type { SectionNode } from "../../documentation-domain/index.js";
-import { ApiModifier, getApiItemKind, getScopedMemberNameForDiagnostics, isStatic } from "../../utilities/index.js";
+import {
+	ApiModifier,
+	getApiItemKind,
+	getScopedMemberNameForDiagnostics,
+	isStatic,
+} from "../../utilities/index.js";
 import { filterChildMembers } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
@@ -11,7 +11,7 @@ import {
 } from "@microsoft/api-extractor-model";
 
 import type { DocumentationNode, SectionNode } from "../../documentation-domain/index.js";
-import { getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
+import { getApiItemKind, getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
 import { filterChildMembers } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createMemberTables, wrapInSection } from "../helpers/index.js";
@@ -31,7 +31,8 @@ export function transformApiEnum(
 		// Accumulate child items
 		const flags: ApiEnumMember[] = [];
 		for (const child of filteredChildren) {
-			switch (child.kind) {
+			const childKind = getApiItemKind(child);
+			switch (childKind) {
 				case ApiItemKind.EnumMember: {
 					flags.push(child as ApiEnumMember);
 					break;
@@ -42,7 +43,7 @@ export function transformApiEnum(
 							child.displayName
 						}" of Enum "${getScopedMemberNameForDiagnostics(
 							apiEnum,
-						)}" is of unsupported API item kind: "${child.kind}"`,
+						)}" is of unsupported API item kind: "${childKind}"`,
 					);
 					break;
 				}

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
@@ -15,7 +15,7 @@ import {
 } from "@microsoft/api-extractor-model";
 
 import type { SectionNode } from "../../documentation-domain/index.js";
-import { getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
+import { getApiItemKind, getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
 import { filterChildMembers } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
@@ -69,7 +69,8 @@ export function transformApiInterface(
 		const indexSignatures: ApiIndexSignature[] = [];
 		const methods: ApiMethodSignature[] = [];
 		for (const child of filteredChildren) {
-			switch (child.kind) {
+			const childKind = getApiItemKind(child);
+			switch (childKind) {
 				case ApiItemKind.ConstructSignature: {
 					constructSignatures.push(child as ApiConstructSignature);
 					break;
@@ -97,7 +98,7 @@ export function transformApiInterface(
 							child.displayName
 						}" of Interface "${getScopedMemberNameForDiagnostics(
 							apiInterface,
-						)}" is of unsupported API item kind: "${child.kind}"`,
+						)}" is of unsupported API item kind: "${childKind}"`,
 					);
 					break;
 				}

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
@@ -109,9 +109,9 @@ export function transformApiModuleLike(
 				}
 				default: {
 					config.logger?.error(
-						`Child item "${child.displayName}" of ${
-							childKind
-						} "${getScopedMemberNameForDiagnostics(
+						`Child item "${
+							child.displayName
+						}" of ${childKind} "${getScopedMemberNameForDiagnostics(
 							apiItem,
 						)}" is of unsupported API item kind: "${childKind}"`,
 					);

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
@@ -17,7 +17,7 @@ import {
 
 import type { SectionNode } from "../../documentation-domain/index.js";
 import type { ApiModuleLike } from "../../utilities/index.js";
-import { getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
+import { getApiItemKind, getScopedMemberNameForDiagnostics } from "../../utilities/index.js";
 import { filterItems } from "../ApiItemTransformUtilities.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
@@ -77,7 +77,8 @@ export function transformApiModuleLike(
 		const enums: ApiEnum[] = [];
 		const variables: ApiVariable[] = [];
 		for (const child of filteredChildren) {
-			switch (child.kind) {
+			const childKind = getApiItemKind(child);
+			switch (childKind) {
 				case ApiItemKind.Interface: {
 					interfaces.push(child as ApiInterface);
 					break;
@@ -109,10 +110,10 @@ export function transformApiModuleLike(
 				default: {
 					config.logger?.error(
 						`Child item "${child.displayName}" of ${
-							apiItem.kind
+							childKind
 						} "${getScopedMemberNameForDiagnostics(
 							apiItem,
-						)}" is of unsupported API item kind: "${child.kind}"`,
+						)}" is of unsupported API item kind: "${childKind}"`,
 					);
 					break;
 				}

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -10,7 +10,6 @@ import {
 	type ApiEntryPoint,
 	ApiInterface,
 	type ApiItem,
-	type ApiItemKind,
 	ApiReturnTypeMixin,
 	ApiTypeParameterListMixin,
 	type Excerpt,
@@ -56,6 +55,7 @@ import {
 	getDeprecatedBlock,
 	getExampleBlocks,
 	getReturnsBlock,
+	type ValidApiItemKind,
 } from "../../utilities/index.js";
 import {
 	doesItemKindRequireOwnDocument,
@@ -960,7 +960,7 @@ export interface ChildSectionProperties {
 	/**
 	 * The API item kind of all child items.
 	 */
-	itemKind: ApiItemKind;
+	itemKind: ValidApiItemKind;
 
 	/**
 	 * The child items to be rendered.

--- a/tools/api-markdown-documenter/src/index.ts
+++ b/tools/api-markdown-documenter/src/index.ts
@@ -74,6 +74,7 @@ export {
 	type ApiModifier,
 	type ApiModuleLike,
 	type ApiSignatureLike,
+	type ValidApiItemKind,
 } from "./utilities/index.js";
 
 // #region Scoped exports

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -58,7 +58,7 @@ export function getApiItemKind(apiItem: ApiItem): ValidApiItemKind {
 			throw new Error(`Encountered an API item with kind "None": "${apiItem.displayName}".`);
 		}
 		default: {
-			return apiItem.kind as ValidApiItemKind;
+			return apiItem.kind;
 		}
 	}
 }

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -43,6 +43,27 @@ import type { Logger } from "../Logging.js";
  */
 
 /**
+ * Represents "valid" API item kinds. I.e., not `None`.
+ */
+export type ValidApiItemKind = Exclude<ApiItemKind, ApiItemKind.None>;
+
+/**
+ * Gets the {@link ValidApiItemKind} for the provided API item.
+ *
+ * @throws If the item's kind is "None".
+ */
+export function getApiItemKind(apiItem: ApiItem): ValidApiItemKind {
+	switch (apiItem.kind) {
+		case ApiItemKind.None: {
+			throw new Error(`Encountered an API item with kind "None": "${apiItem.displayName}".`);
+		}
+		default: {
+			return apiItem.kind as ValidApiItemKind;
+		}
+	}
+}
+
+/**
  * Represents "member" API item kinds.
  * These are the kinds of items the system supports generally for rendering, file-system configuration, etc.
  *

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -39,6 +39,7 @@ import type { Logger } from "../Logging.js";
 
 /**
  * This module contains general `ApiItem`-related types and utilities.
+ * @remarks Note: the utilities here should not require any specific context or configuration.
  */
 
 /**

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -44,6 +44,8 @@ import type { Logger } from "../Logging.js";
 
 /**
  * Represents "valid" API item kinds. I.e., not `None`.
+ *
+ * @public
  */
 export type ValidApiItemKind = Exclude<ApiItemKind, ApiItemKind.None>;
 
@@ -79,9 +81,9 @@ export function getApiItemKind(apiItem: ApiItem): ValidApiItemKind {
  *
  * @public
  */
-export type ApiMemberKind = Omit<
-	ApiItemKind,
-	ApiItemKind.EntryPoint | ApiItemKind.Model | ApiItemKind.None | ApiItemKind.Package
+export type ApiMemberKind = Exclude<
+	ValidApiItemKind,
+	ApiItemKind.EntryPoint | ApiItemKind.Model | ApiItemKind.Package
 >;
 
 /**


### PR DESCRIPTION
No valid `ApiItem` will have kind "None". There are a number of places where we are forced to assert that an item's kind is not "None" to make checks exhaustive, and there are other places where we probably _should_ have been.

This PR adds a helper type alias and a helper function to encapsulate the validity checking.