### PR TITLE
Add copyProperty utility function

### DIFF
--- a/packages/dds/tree/src/simple-tree/api/simpleSchemaToJsonSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleSchemaToJsonSchema.ts
@@ -6,7 +6,7 @@
 import { unreachableCase } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { ValueSchema } from "../../core/index.js";
-import { getOrCreate, hasSingle, type Mutable } from "../../util/index.js";
+import { copyProperty, getOrCreate, hasSingle, type Mutable } from "../../util/index.js";
 import type {
 	JsonArrayNodeSchema,
 	JsonFieldSchema,
@@ -149,11 +149,7 @@ function convertObjectNodeSchema(schema: SimpleObjectNodeSchema): JsonObjectNode
 					anyOf: allowedTypes,
 				};
 
-		// Don't include "description" property at all if it's not present in the input.
-		if (value.metadata?.description !== undefined) {
-			output.description = value.metadata.description;
-		}
-
+		copyProperty(value.metadata, "description", output);
 		properties[key] = output;
 
 		if (value.kind === FieldKind.Required) {

--- a/packages/dds/tree/src/simple-tree/api/viewSchemaToSimpleSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/viewSchemaToSimpleSchema.ts
@@ -20,7 +20,7 @@ import type {
 	SimpleTreeSchema,
 } from "./simpleSchema.js";
 import type { ValueSchema } from "../../core/index.js";
-import { getOrCreate, type Mutable } from "../../util/index.js";
+import { copyProperty, getOrCreate, type Mutable } from "../../util/index.js";
 import { isObjectNodeSchema, type ObjectNodeSchema } from "../objectNodeTypes.js";
 import { NodeKind, type TreeNodeSchema } from "../core/index.js";
 
@@ -41,11 +41,7 @@ export function toSimpleTreeSchema(schema: ImplicitFieldSchema): SimpleTreeSchem
 		definitions,
 	};
 
-	// Include the "description" property only if it's present on the input.
-	if (normalizedSchema.metadata !== undefined) {
-		output.metadata = normalizedSchema.metadata;
-	}
-
+	copyProperty(normalizedSchema, "metadata", output);
 	return output;
 }
 
@@ -140,10 +136,7 @@ function fieldSchemaToSimpleSchema(schema: FieldSchema): SimpleFieldSchema {
 		allowedTypes,
 	};
 
-	// Don't include "metadata" property at all if it's not present.
-	if (schema.metadata !== undefined) {
-		result.metadata = schema.metadata;
-	}
+	copyProperty(schema, "metadata", result);
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	(schema as any)[simpleFieldSchemaCacheSymbol] = result;

--- a/packages/dds/tree/src/test/util/utils.spec.ts
+++ b/packages/dds/tree/src/test/util/utils.spec.ts
@@ -86,7 +86,13 @@ describe("Utils", () => {
 			const destination = {};
 			copyProperty(undefined, "a", destination);
 			copyProperty(source, "a", destination);
-			// `destination` should not have a property "a", even if the value of "a" is `undefined`
+			assert.equal(Reflect.has(destination, "a"), false);
+		});
+
+		it("does nothing if the property is present but undefined", () => {
+			const source = { a: undefined };
+			const destination = {};
+			copyProperty(source, "a", destination);
 			assert.equal(Reflect.has(destination, "a"), false);
 		});
 	});

--- a/packages/dds/tree/src/test/util/utils.spec.ts
+++ b/packages/dds/tree/src/test/util/utils.spec.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "node:assert";
 
 import {
 	capitalize,
+	copyProperty,
 	defineLazyCachedProperty,
 	mapIterable,
 	transformObjectMap,
@@ -69,5 +70,24 @@ describe("Utils", () => {
 		assert.equal(count, 1);
 		assert.equal(objWithProperty.prop, 3);
 		assert.equal(count, 1);
+	});
+
+	describe("copyProperty", () => {
+		it("copies a known property", () => {
+			const source = { a: 3 };
+			const destination = {};
+			copyProperty(source, "a", destination);
+			// `destination` should now be typed to have a property "a"
+			assert.equal(destination.a, 3);
+		});
+
+		it("does nothing if the property is not present", () => {
+			const source = {};
+			const destination = {};
+			copyProperty(undefined, "a", destination);
+			copyProperty(source, "a", destination);
+			// `destination` should not have a property "a", even if the value of "a" is `undefined`
+			assert.equal(Reflect.has(destination, "a"), false);
+		});
 	});
 });

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -94,7 +94,7 @@ export {
 	hasSome,
 	hasSingle,
 	defineLazyCachedProperty,
-	copyProperty,
+	copyPropertyIfDefined as copyProperty,
 } from "./utils.js";
 export { ReferenceCountedBase, type ReferenceCounted } from "./referenceCounting.js";
 

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -94,6 +94,7 @@ export {
 	hasSome,
 	hasSingle,
 	defineLazyCachedProperty,
+	copyProperty,
 } from "./utils.js";
 export { ReferenceCountedBase, type ReferenceCounted } from "./referenceCounting.js";
 

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -565,26 +565,26 @@ export function defineLazyCachedProperty<
 }
 
 /**
- * Copies a given property from one object to another if and only if the property is present.
+ * Copies a given property from one object to another if and only if the property is defined.
  * @param source - The object to copy the property from.
- * If `source` is undefined or does not have the given property, then this function will do nothing.
+ * If `source` is undefined or does not have the property defined, then this function will do nothing.
  * @param property - The property to copy.
  * @param destination - The object to copy the property to.
- * @remarks This function is useful for copying properties from one object to another when the property may not be present.
- * If `property` is not present on `source`, then this function will leave `destination` untouched.
- * This is different from doing `destination.foo = source.foo`, which will define a `"foo"` property on `destination` with the value `undefined`.
+ * @remarks This function is useful for copying properties from one object to another while minimizing the presence of `undefined` values.
+ * If `property` is not present on `source` - or if `property` is present, but has a value of `undefined` - then this function will not modify `destination`.
+ * This is different from doing `destination.foo = source.foo`, which would define a `"foo"` property on `destination` with the value `undefined`.
  *
  * If the type of `source` is known to have `property`, then this function asserts that the type of `destination` has `property` as well after the call.
  *
  * This function first reads the property value (if present) from `source` and then sets it on `destination`, as opposed to e.g. directly copying the property descriptor.
  * @privateRemarks The first overload of this function allows auto-complete to suggest property names from `source`, but by having the second overload we still allow for arbitrary property names.
  */
-export function copyProperty<S extends object, K extends keyof S, D extends object>(
+export function copyPropertyIfDefined<S extends object, K extends keyof S, D extends object>(
 	source: S | undefined,
 	property: K,
 	destination: D,
 ): asserts destination is K extends keyof S ? D & { [P in K]: S[K] } : D;
-export function copyProperty<
+export function copyPropertyIfDefined<
 	S extends object,
 	K extends string | number | symbol,
 	D extends object,
@@ -593,7 +593,7 @@ export function copyProperty<
 	property: K,
 	destination: D,
 ): asserts destination is K extends keyof S ? D & { [P in K]: S[K] } : D;
-export function copyProperty<
+export function copyPropertyIfDefined<
 	S extends object,
 	K extends string | number | symbol,
 	D extends object,

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -563,3 +563,49 @@ export function defineLazyCachedProperty<
 	});
 	return obj as typeof obj & { [P in K]: V };
 }
+
+/**
+ * Copies a given property from one object to another if and only if the property is present.
+ * @param source - The object to copy the property from.
+ * If `source` is undefined or does not have the given property, then this function will do nothing.
+ * @param property - The property to copy.
+ * @param destination - The object to copy the property to.
+ * @remarks This function is useful for copying properties from one object to another when the property may not be present.
+ * If `property` is not present on `source`, then this function will leave `destination` untouched.
+ * This is different from doing `destination.foo = source.foo`, which will define a `"foo"` property on `destination` with the value `undefined`.
+ *
+ * If the type of `source` is known to have `property`, then this function asserts that the type of `destination` has `property` as well after the call.
+ *
+ * This function first reads the property value (if present) from `source` and then sets it on `destination`, as opposed to e.g. directly copying the property descriptor.
+ * @privateRemarks The first overload of this function allows auto-complete to suggest property names from `source`, but by having the second overload we still allow for arbitrary property names.
+ */
+export function copyProperty<S extends object, K extends keyof S, D extends object>(
+	source: S | undefined,
+	property: K,
+	destination: D,
+): asserts destination is K extends keyof S ? D & { [P in K]: S[K] } : D;
+export function copyProperty<
+	S extends object,
+	K extends string | number | symbol,
+	D extends object,
+>(
+	source: S | undefined,
+	property: K,
+	destination: D,
+): asserts destination is K extends keyof S ? D & { [P in K]: S[K] } : D;
+export function copyProperty<
+	S extends object,
+	K extends string | number | symbol,
+	D extends object,
+>(
+	source: S | undefined,
+	property: K,
+	destination: D,
+): asserts destination is K extends keyof S ? D & { [P in K]: S[K] } : D {
+	if (source !== undefined) {
+		const value = (source as { [P in K]?: unknown })[property];
+		if (value !== undefined) {
+			(destination as { [P in K]: unknown })[property] = value;
+		}
+	}
+}


### PR DESCRIPTION
## Description

This adds a general-purpose utility for copying properties from one object to another.

As noted in the docs, this is especially useful for copying properties without inadvertently adding a property with the value "undefined" on the destination object when the property does not exist on the source object.