### PR TITLE
refactor(api-markdown-documenter): Move `getFilteredParent` utility function and use it more consistently

### DIFF
--- a/tools/api-markdown-documenter/src/api-item-transforms/ApiItemTransformUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/ApiItemTransformUtilities.ts
@@ -14,6 +14,7 @@ import {
 	getReleaseTag,
 	getApiItemKind,
 	type ValidApiItemKind,
+	getFilteredParent,
 } from "../utilities/index.js";
 
 import type {
@@ -294,25 +295,6 @@ function getHeadingIdForApiItem(
 	}
 
 	return `${baseName}-${apiItemKind.toLowerCase()}`;
-}
-
-/**
- * Gets the "filted" parent of the provided API item.
- *
- * @remarks This logic specifically skips items of the following kinds:
- *
- * - EntryPoint: skipped because any given Package item will have exactly 1 EntryPoint child with current version of
- * API-Extractor, making this redundant in the hierarchy. We may need to revisit this in the future if/when
- * API-Extractor adds support for multiple entrypoints.
- *
- * @param apiItem - The API item whose filtered parent will be returned.
- */
-function getFilteredParent(apiItem: ApiItem): ApiItem | undefined {
-	const parent = apiItem.parent;
-	if (parent?.kind === ApiItemKind.EntryPoint) {
-		return parent.parent;
-	}
-	return parent;
 }
 
 /**

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -267,10 +267,12 @@ export function hasModifierTag(apiItem: ApiItem, tagName: string): boolean {
  * @public
  */
 export function ancestryHasModifierTag(apiItem: ApiItem, tagName: string): boolean {
-	return (
-		hasModifierTag(apiItem, tagName) ||
-		(apiItem.parent !== undefined && ancestryHasModifierTag(apiItem.parent, tagName))
-	);
+	if (hasModifierTag(apiItem, tagName)) {
+		return true;
+	}
+
+	const parent = getFilteredParent(apiItem);
+	return parent !== undefined && ancestryHasModifierTag(parent, tagName);
 }
 
 /**

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -147,6 +147,25 @@ export enum ApiModifier {
 }
 
 /**
+ * Gets the "filtered" parent of the provided API item.
+ *
+ * @remarks This logic specifically skips items of the following kinds:
+ *
+ * - EntryPoint: skipped because any given Package item will have exactly 1 EntryPoint child with current version of
+ * API-Extractor, making this redundant in the hierarchy. We may need to revisit this in the future if/when
+ * API-Extractor adds support for multiple entrypoints.
+ *
+ * @param apiItem - The API item whose filtered parent will be returned.
+ */
+export function getFilteredParent(apiItem: ApiItem): ApiItem | undefined {
+	const parent = apiItem.parent;
+	if (parent?.kind === ApiItemKind.EntryPoint) {
+		return parent.parent;
+	}
+	return parent;
+}
+
+/**
  * Adjusts the name of the item as needed.
  * Accounts for method overloads by adding a suffix such as "myMethod_2".
  *


### PR DESCRIPTION
`getFilteredParent` is not transformation-specific (and does not depend on user configuration), so `ApiItemUtilities` is the more appropriate home for it. Additionally leverages it in `ancestryHasModifierTag` for consistency.