### PR TITLE
Rename ISegmentLeaf to ISegmentPrivate

### DIFF
--- a/packages/dds/merge-tree/src/MergeTreeTextHelper.ts
+++ b/packages/dds/merge-tree/src/MergeTreeTextHelper.ts
@@ -5,7 +5,7 @@
 
 import { IIntegerRange } from "./client.js";
 import { MergeTree } from "./mergeTree.js";
-import { ISegmentLeaf } from "./mergeTreeNodes.js";
+import { ISegmentPrivate } from "./mergeTreeNodes.js";
 import { IMergeTreeTextHelper, TextSegment } from "./textSegment.js";
 
 interface ITextAccumulator {
@@ -54,7 +54,7 @@ export class MergeTreeTextHelper implements IMergeTreeTextHelper {
 }
 
 function gatherText(
-	segment: ISegmentLeaf,
+	segment: ISegmentPrivate,
 	pos: number,
 	refSeq: number,
 	clientId: number,

--- a/packages/dds/merge-tree/src/attributionPolicy.ts
+++ b/packages/dds/merge-tree/src/attributionPolicy.ts
@@ -17,7 +17,7 @@ import {
 	IMergeTreeSegmentDelta,
 	MergeTreeMaintenanceType,
 } from "./mergeTreeDeltaCallback.js";
-import type { ISegmentLeaf } from "./mergeTreeNodes.js";
+import type { ISegmentPrivate } from "./mergeTreeNodes.js";
 import { MergeTreeDeltaType } from "./ops.js";
 
 // Note: these thinly wrap MergeTreeDeltaCallback and MergeTreeMaintenanceCallback to provide the client.
@@ -98,7 +98,7 @@ const attributeInsertionOnSegments = (
 	key: AttributionKey,
 ): void => {
 	for (const { segment } of deltaSegments) {
-		const seg: ISegmentLeaf = segment;
+		const seg: ISegmentPrivate = segment;
 		if (seg.seq !== undefined) {
 			segment.attribution?.update(
 				undefined,

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -45,7 +45,7 @@ import {
 	CollaborationWindow,
 	ISegment,
 	ISegmentAction,
-	ISegmentLeaf,
+	ISegmentPrivate,
 	Marker,
 	SegmentGroup,
 	compareStrings,
@@ -392,7 +392,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	): void {
 		let localInserts = 0;
 		let localRemoves = 0;
-		walkAllChildSegments(this._mergeTree.root, (seg: ISegmentLeaf) => {
+		walkAllChildSegments(this._mergeTree.root, (seg: ISegmentPrivate) => {
 			if (seg.seq === UnassignedSequenceNumber) {
 				localInserts++;
 			}
@@ -425,7 +425,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	 * @param segment - The segment to get the position of
 	 */
 	public getPosition(segment: ISegment | undefined, localSeq?: number): number {
-		const mergeSegment: ISegmentLeaf | undefined = segment;
+		const mergeSegment: ISegmentPrivate | undefined = segment;
 		if (mergeSegment?.parent === undefined) {
 			return -1;
 		}
@@ -876,7 +876,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	private resetPendingDeltaToOps(
 		resetOp: IMergeTreeDeltaOp,
 
-		segmentGroup: SegmentGroup<ISegmentLeaf>,
+		segmentGroup: SegmentGroup<ISegmentPrivate>,
 	): IMergeTreeDeltaOp[] {
 		assert(!!segmentGroup, 0x033 /* "Segment group undefined" */);
 		const NACKedSegmentGroup = this.pendingRebase?.shift()?.data;

--- a/packages/dds/merge-tree/src/endOfTreeSegment.ts
+++ b/packages/dds/merge-tree/src/endOfTreeSegment.ts
@@ -10,7 +10,7 @@ import { LocalClientId } from "./constants.js";
 import { LocalReferenceCollection } from "./localReference.js";
 import { MergeTree } from "./mergeTree.js";
 import { NodeAction, depthFirstNodeWalk } from "./mergeTreeNodeWalk.js";
-import { ISegment, ISegmentLeaf, type MergeBlock } from "./mergeTreeNodes.js";
+import { ISegment, ISegmentPrivate, type MergeBlock } from "./mergeTreeNodes.js";
 
 /**
  * This is a special segment that is not bound or known by the merge tree itself,
@@ -114,7 +114,7 @@ export class StartOfTreeSegment extends BaseEndpointSegment implements ISegment 
 		index: number;
 		depth: number;
 	} {
-		let firstSegment: ISegmentLeaf | undefined;
+		let firstSegment: ISegmentPrivate | undefined;
 		let depth = 1;
 		const root = this.mergeTree.root;
 		depthFirstNodeWalk(
@@ -164,7 +164,7 @@ export class EndOfTreeSegment extends BaseEndpointSegment implements ISegment {
 		index: number;
 		depth: number;
 	} {
-		let lastSegment: ISegmentLeaf | undefined;
+		let lastSegment: ISegmentPrivate | undefined;
 		let depth = 1;
 		const root = this.mergeTree.root;
 		depthFirstNodeWalk(

--- a/packages/dds/merge-tree/src/mergeTreeNodeWalk.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodeWalk.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type ISegmentLeaf, type MergeBlock, IMergeNode } from "./mergeTreeNodes.js";
+import { type ISegmentPrivate, type MergeBlock, IMergeNode } from "./mergeTreeNodes.js";
 
 export const LeafAction = {
 	Exit: false,
@@ -38,7 +38,7 @@ export function depthFirstNodeWalk(
 	startBlock: MergeBlock,
 	startChild: IMergeNode | undefined,
 	downAction?: (node: IMergeNode) => NodeAction,
-	leafActionOverride?: (seg: ISegmentLeaf) => LeafAction,
+	leafActionOverride?: (seg: ISegmentPrivate) => LeafAction,
 	upAction?: (block: MergeBlock) => void,
 	forward: boolean = true,
 ): boolean {
@@ -77,7 +77,7 @@ export function depthFirstNodeWalk(
 			for (let i = start.index; i !== -1 && i !== childCount; i += increment) {
 				// the above loop ensures start is a leaf or undefined, so all children
 				// will be leaves if start exits, so the cast is safe
-				if (leafAction(block.children[i] as ISegmentLeaf) === LeafAction.Exit) {
+				if (leafAction(block.children[i] as ISegmentPrivate) === LeafAction.Exit) {
 					exit = true;
 					break;
 				}
@@ -122,7 +122,7 @@ export function depthFirstNodeWalk(
  */
 export function forwardExcursion(
 	startNode: IMergeNode,
-	leafAction: (seg: ISegmentLeaf) => boolean | undefined,
+	leafAction: (seg: ISegmentPrivate) => boolean | undefined,
 ): boolean {
 	if (startNode.parent === undefined) {
 		return true;
@@ -145,7 +145,7 @@ export function forwardExcursion(
  */
 export function backwardExcursion(
 	startNode: IMergeNode,
-	leafAction: (seg: ISegmentLeaf) => boolean | undefined,
+	leafAction: (seg: ISegmentPrivate) => boolean | undefined,
 ): boolean {
 	if (startNode.parent === undefined) {
 		return true;
@@ -171,7 +171,7 @@ export function backwardExcursion(
  */
 export function walkAllChildSegments(
 	startBlock: MergeBlock,
-	leafAction: (segment: ISegmentLeaf) => boolean | undefined | void,
+	leafAction: (segment: ISegmentPrivate) => boolean | undefined | void,
 ): boolean {
 	if (startBlock.childCount === 0) {
 		return true;

--- a/packages/dds/merge-tree/src/partialLengths.ts
+++ b/packages/dds/merge-tree/src/partialLengths.ts
@@ -11,7 +11,7 @@ import { MergeTree } from "./mergeTree.js";
 import {
 	CollaborationWindow,
 	IMergeNode,
-	ISegmentLeaf,
+	ISegmentPrivate,
 	compareNumbers,
 	seqLTE,
 	type MergeBlock,
@@ -506,7 +506,7 @@ export class PartialSequenceLengths {
 	 */
 	static accumulateMoveOverlapForExisting(
 		segmentLen: number,
-		segment: ISegmentLeaf,
+		segment: ISegmentPrivate,
 		firstGte: PartialSequenceLength,
 		clientIds: number[],
 	): void {
@@ -540,7 +540,7 @@ export class PartialSequenceLengths {
 	 * segment
 	 */
 	private static getMoveOverlapForExisting(
-		segment: ISegmentLeaf,
+		segment: ISegmentPrivate,
 		obliterateOverlapLen: number,
 		clientIds: number[],
 	): RedBlackTree<number, IOverlapClient> {
@@ -562,7 +562,7 @@ export class PartialSequenceLengths {
 	}
 
 	private static updatePartialsAfterInsertion(
-		segment: ISegmentLeaf,
+		segment: ISegmentPrivate,
 		segmentLen: number,
 		remoteObliteratedLen: number | undefined,
 		obliterateOverlapLen: number = segmentLen,
@@ -642,7 +642,7 @@ export class PartialSequenceLengths {
 	 */
 	private static insertSegment(
 		combinedPartialLengths: PartialSequenceLengths,
-		segment: ISegmentLeaf,
+		segment: ISegmentPrivate,
 		// eslint-disable-next-line import/no-deprecated
 		removalInfo?: IRemovalInfo,
 		// eslint-disable-next-line import/no-deprecated

--- a/packages/dds/merge-tree/src/perspective.ts
+++ b/packages/dds/merge-tree/src/perspective.ts
@@ -6,14 +6,14 @@
 import { UnassignedSequenceNumber } from "./constants.js";
 import { type MergeTree } from "./mergeTree.js";
 import { LeafAction, backwardExcursion, forwardExcursion } from "./mergeTreeNodeWalk.js";
-import { seqLTE, type ISegmentLeaf } from "./mergeTreeNodes.js";
+import { seqLTE, type ISegmentPrivate } from "./mergeTreeNodes.js";
 
 /**
  * Provides a view of a MergeTree from the perspective of a specific client at a specific sequence number.
  */
 export interface Perspective {
-	nextSegment(segment: ISegmentLeaf, forward?: boolean): ISegmentLeaf;
-	previousSegment(segment: ISegmentLeaf): ISegmentLeaf;
+	nextSegment(segment: ISegmentPrivate, forward?: boolean): ISegmentPrivate;
+	previousSegment(segment: ISegmentPrivate): ISegmentPrivate;
 }
 
 /**
@@ -47,9 +47,9 @@ export class PerspectiveImpl implements Perspective {
 	 * @param forward - The direction to search.
 	 * @returns the next segment in the specified direction, or the start or end of the tree if there is no next segment.
 	 */
-	public nextSegment(segment: ISegmentLeaf, forward: boolean = true): ISegmentLeaf {
-		let next: ISegmentLeaf | undefined;
-		const action = (seg: ISegmentLeaf): boolean | undefined => {
+	public nextSegment(segment: ISegmentPrivate, forward: boolean = true): ISegmentPrivate {
+		let next: ISegmentPrivate | undefined;
+		const action = (seg: ISegmentPrivate): boolean | undefined => {
 			if (isSegmentPresent(seg, this._seqTime)) {
 				next = seg;
 				return LeafAction.Exit;
@@ -65,7 +65,7 @@ export class PerspectiveImpl implements Perspective {
 	 * @returns the previous segment, or the start of the tree if there is no previous segment.
 	 * @remarks This is a convenient equivalent to calling `nextSegment(segment, false)`.
 	 */
-	public previousSegment(segment: ISegmentLeaf): ISegmentLeaf {
+	public previousSegment(segment: ISegmentPrivate): ISegmentPrivate {
 		return this.nextSegment(segment, false);
 	}
 }
@@ -77,7 +77,10 @@ export class PerspectiveImpl implements Perspective {
  * @param localSeq - The latest local sequence number to consider.
  * @returns true iff this segment was removed in the given perspective.
  */
-export function wasRemovedBefore(seg: ISegmentLeaf, { refSeq, localSeq }: SeqTime): boolean {
+export function wasRemovedBefore(
+	seg: ISegmentPrivate,
+	{ refSeq, localSeq }: SeqTime,
+): boolean {
 	if (
 		seg.removedSeq === UnassignedSequenceNumber &&
 		localSeq !== undefined &&
@@ -95,7 +98,7 @@ export function wasRemovedBefore(seg: ISegmentLeaf, { refSeq, localSeq }: SeqTim
  * @param localSeq - The latest local sequence number to consider.
  * @returns true iff this segment was moved (aka obliterated) in the given perspective.
  */
-export function wasMovedBefore(seg: ISegmentLeaf, { refSeq, localSeq }: SeqTime): boolean {
+export function wasMovedBefore(seg: ISegmentPrivate, { refSeq, localSeq }: SeqTime): boolean {
 	if (
 		seg.movedSeq === UnassignedSequenceNumber &&
 		localSeq !== undefined &&
@@ -109,7 +112,7 @@ export function wasMovedBefore(seg: ISegmentLeaf, { refSeq, localSeq }: SeqTime)
 /**
  * See {@link wasRemovedBefore} and {@link wasMovedBefore}.
  */
-export function wasRemovedOrMovedBefore(seg: ISegmentLeaf, seqTime: SeqTime): boolean {
+export function wasRemovedOrMovedBefore(seg: ISegmentPrivate, seqTime: SeqTime): boolean {
 	return wasRemovedBefore(seg, seqTime) || wasMovedBefore(seg, seqTime);
 }
 
@@ -120,7 +123,7 @@ export function wasRemovedOrMovedBefore(seg: ISegmentLeaf, seqTime: SeqTime): bo
  * @returns true iff this segment was inserted before the given perspective,
  * and it was not removed or moved in the given perspective.
  */
-export function isSegmentPresent(seg: ISegmentLeaf, seqTime: SeqTime): boolean {
+export function isSegmentPresent(seg: ISegmentPrivate, seqTime: SeqTime): boolean {
 	const { refSeq, localSeq } = seqTime;
 	// If seg.seq is undefined, then this segment has existed since minSeq.
 	// It may have been moved or removed since.

--- a/packages/dds/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/dds/merge-tree/src/segmentGroupCollection.ts
@@ -4,13 +4,13 @@
  */
 
 import { DoublyLinkedList, walkList } from "./collections/index.js";
-import { SegmentGroup, type ISegmentLeaf } from "./mergeTreeNodes.js";
+import { SegmentGroup, type ISegmentPrivate } from "./mergeTreeNodes.js";
 
 export class SegmentGroupCollection {
-	private readonly segmentGroups: DoublyLinkedList<SegmentGroup<ISegmentLeaf>>;
+	private readonly segmentGroups: DoublyLinkedList<SegmentGroup<ISegmentPrivate>>;
 
-	constructor(private readonly segment: ISegmentLeaf) {
-		this.segmentGroups = new DoublyLinkedList<SegmentGroup<ISegmentLeaf>>();
+	constructor(private readonly segment: ISegmentPrivate) {
+		this.segmentGroups = new DoublyLinkedList<SegmentGroup<ISegmentPrivate>>();
 	}
 
 	public get size(): number {
@@ -21,16 +21,16 @@ export class SegmentGroupCollection {
 		return this.segmentGroups.empty;
 	}
 
-	public enqueue(segmentGroup: SegmentGroup<ISegmentLeaf>): void {
+	public enqueue(segmentGroup: SegmentGroup<ISegmentPrivate>): void {
 		this.segmentGroups.push(segmentGroup);
 		segmentGroup.segments.push(this.segment);
 	}
 
-	public dequeue(): SegmentGroup<ISegmentLeaf> | undefined {
+	public dequeue(): SegmentGroup<ISegmentPrivate> | undefined {
 		return this.segmentGroups.shift()?.data;
 	}
 
-	public remove?(segmentGroup: SegmentGroup<ISegmentLeaf>): boolean {
+	public remove?(segmentGroup: SegmentGroup<ISegmentPrivate>): boolean {
 		const found = this.segmentGroups.find((v) => v.data === segmentGroup);
 		if (found === undefined) {
 			return false;
@@ -39,7 +39,7 @@ export class SegmentGroupCollection {
 		return true;
 	}
 
-	public pop?(): SegmentGroup<ISegmentLeaf> | undefined {
+	public pop?(): SegmentGroup<ISegmentPrivate> | undefined {
 		return this.segmentGroups.pop ? this.segmentGroups.pop()?.data : undefined;
 	}
 
@@ -48,8 +48,8 @@ export class SegmentGroupCollection {
 	}
 
 	private enqueueOnCopy(
-		segmentGroup: SegmentGroup<ISegmentLeaf>,
-		sourceSegment: ISegmentLeaf,
+		segmentGroup: SegmentGroup<ISegmentPrivate>,
+		sourceSegment: ISegmentPrivate,
 	): void {
 		this.enqueue(segmentGroup);
 		if (segmentGroup.previousProps) {

--- a/packages/dds/merge-tree/src/segmentInfos.ts
+++ b/packages/dds/merge-tree/src/segmentInfos.ts
@@ -5,7 +5,7 @@
 
 import { assert } from "@fluidframework/core-utils/internal";
 
-import type { ISegmentInternal, ISegmentLeaf } from "./mergeTreeNodes.js";
+import type { ISegmentInternal, ISegmentPrivate } from "./mergeTreeNodes.js";
 import type { ReferencePosition } from "./referencePositions.js";
 
 /**
@@ -253,7 +253,7 @@ export type SegmentInfo = IInsertionInfo | IMoveInfo | IRemovalInfo;
 /**
  * A type representing a segment with additional info.
  */
-export type SegmentWithInfo<T extends SegmentInfo> = ISegmentLeaf & T;
+export type SegmentWithInfo<T extends SegmentInfo> = ISegmentPrivate & T;
 
 /**
  * Overwrites the segment info on a segment-like object.
@@ -263,6 +263,6 @@ export type SegmentWithInfo<T extends SegmentInfo> = ISegmentLeaf & T;
  * @returns The segment-like object with the info set.
  */
 export const overwriteInfo = <T extends SegmentInfo>(
-	segmentLike: ISegmentLeaf,
+	segmentLike: ISegmentPrivate,
 	info: T,
 ): SegmentWithInfo<T> => Object.assign(segmentLike, info);

--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -23,7 +23,7 @@ import {
 import { Client } from "./client.js";
 import { NonCollabClient, UniversalSequenceNumber } from "./constants.js";
 import { MergeTree } from "./mergeTree.js";
-import { ISegmentLeaf } from "./mergeTreeNodes.js";
+import { ISegmentPrivate } from "./mergeTreeNodes.js";
 import { IJSONSegment } from "./ops.js";
 import {
 	// eslint-disable-next-line import/no-deprecated
@@ -249,7 +249,7 @@ export class SnapshotLoader {
 
 		// Helper to insert segments at the end of the MergeTree.
 		const mergeTree = this.mergeTree;
-		const append = (segments: ISegmentLeaf[], cli: number, seq: number): void => {
+		const append = (segments: ISegmentPrivate[], cli: number, seq: number): void => {
 			mergeTree.insertSegments(
 				mergeTree.root.cachedLength ?? 0,
 				segments,
@@ -283,7 +283,7 @@ export class SnapshotLoader {
 		flushBatch();
 	}
 
-	private extractAttribution(segments: ISegmentLeaf[], chunk: MergeTreeChunkV1): void {
+	private extractAttribution(segments: ISegmentPrivate[], chunk: MergeTreeChunkV1): void {
 		if (chunk.attribution) {
 			const { attributionPolicy } = this.mergeTree;
 			if (attributionPolicy === undefined) {

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -22,7 +22,7 @@ import { IAttributionCollection } from "./attributionCollection.js";
 import { UnassignedSequenceNumber } from "./constants.js";
 import { MergeTree } from "./mergeTree.js";
 import { walkAllChildSegments } from "./mergeTreeNodeWalk.js";
-import { ISegmentLeaf } from "./mergeTreeNodes.js";
+import { ISegmentPrivate } from "./mergeTreeNodes.js";
 import type { IJSONSegment } from "./ops.js";
 import { PropertySet, matchProperties } from "./properties.js";
 import { assertInserted } from "./segmentInfos.js";
@@ -209,7 +209,7 @@ export class SnapshotV1 {
 		};
 
 		// Helper to serialize the given `segment` and add it to the snapshot (if a segment is provided).
-		const pushSeg = (segment?: ISegmentLeaf): void => {
+		const pushSeg = (segment?: ISegmentPrivate): void => {
 			if (segment) {
 				if (segment.properties !== undefined && Object.keys(segment.properties).length === 0) {
 					segment.properties = undefined;
@@ -222,8 +222,8 @@ export class SnapshotV1 {
 			}
 		};
 
-		let prev: ISegmentLeaf | undefined;
-		const extractSegment = (segment: ISegmentLeaf): boolean => {
+		let prev: ISegmentPrivate | undefined;
+		const extractSegment = (segment: ISegmentPrivate): boolean => {
 			assertInserted(segment);
 			// Elide segments that do not need to be included in the snapshot.  A segment may be elided if
 			// either condition is true:

--- a/packages/dds/merge-tree/src/snapshotlegacy.ts
+++ b/packages/dds/merge-tree/src/snapshotlegacy.ts
@@ -18,7 +18,7 @@ import {
 
 import { NonCollabClient, UnassignedSequenceNumber } from "./constants.js";
 import { MergeTree } from "./mergeTree.js";
-import { type ISegmentLeaf } from "./mergeTreeNodes.js";
+import { type ISegmentPrivate } from "./mergeTreeNodes.js";
 import { matchProperties } from "./properties.js";
 import {
 	JsonSegmentSpecs,
@@ -55,7 +55,7 @@ export class SnapshotLegacy {
 
 	private header: SnapshotHeader | undefined;
 	private seq: number | undefined;
-	private segments: ISegmentLeaf[] | undefined;
+	private segments: ISegmentPrivate[] | undefined;
 	private readonly logger: ITelemetryLoggerExt;
 	private readonly chunkSize: number;
 
@@ -71,11 +71,11 @@ export class SnapshotLegacy {
 	}
 
 	private getSeqLengthSegs(
-		allSegments: ISegmentLeaf[],
+		allSegments: ISegmentPrivate[],
 		approxSequenceLength: number,
 		startIndex = 0,
 	): MergeTreeChunkLegacy {
-		const segs: ISegmentLeaf[] = [];
+		const segs: ISegmentPrivate[] = [];
 		let sequenceLength = 0;
 		let segCount = 0;
 		let segsWithAttribution = 0;
@@ -191,7 +191,7 @@ export class SnapshotLegacy {
 		return builder.getSummaryTree();
 	}
 
-	extractSync(): ISegmentLeaf[] {
+	extractSync(): ISegmentPrivate[] {
 		const collabWindow = this.mergeTree.collabWindow;
 		const seq = (this.seq = collabWindow.minSeq);
 		this.header = {
@@ -204,10 +204,10 @@ export class SnapshotLegacy {
 
 		let originalSegments = 0;
 
-		const segs: ISegmentLeaf[] = [];
-		let prev: ISegmentLeaf | undefined;
+		const segs: ISegmentPrivate[] = [];
+		let prev: ISegmentPrivate | undefined;
 		const extractSegment = (
-			segment: ISegmentLeaf,
+			segment: ISegmentPrivate,
 			pos: number,
 			refSeq: number,
 			clientId: number,

--- a/packages/dds/merge-tree/src/test/beastTest.spec.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.spec.ts
@@ -39,7 +39,7 @@ import {
 	compareNumbers,
 	compareStrings,
 	reservedMarkerIdKey,
-	type ISegmentLeaf,
+	type ISegmentPrivate,
 } from "../mergeTreeNodes.js";
 import { createRemoveRangeOp } from "../opBuilder.js";
 import { IMergeTreeOp, MergeTreeDeltaType, ReferenceType } from "../ops.js";
@@ -284,7 +284,7 @@ export function fileTest1(): void {
 	}
 }
 
-function printTextSegment(textSegment: ISegmentLeaf, pos: number): boolean {
+function printTextSegment(textSegment: ISegmentPrivate, pos: number): boolean {
 	log(textSegment.toString());
 	log(`at [${pos}, ${pos + textSegment.cachedLength})`);
 	return true;
@@ -387,7 +387,7 @@ export function mergeTreeTest1(): void {
 	// checkRemoveSegTree(segTree, 4, 13);
 	checkInsertMergeTree(mergeTree, 4, makeCollabTextSegment("fi"));
 	mergeTree.mapRange(printTextSegment, UniversalSequenceNumber, LocalClientId, undefined);
-	const segoff = mergeTree.getContainingSegment<ISegmentLeaf>(
+	const segoff = mergeTree.getContainingSegment<ISegmentPrivate>(
 		4,
 		UniversalSequenceNumber,
 		LocalClientId,
@@ -1530,7 +1530,7 @@ function findReplacePerf(filename: string): void {
 	let cFetches = 0;
 	let cReplaces = 0;
 	for (let pos = 0; pos < client.getLength(); ) {
-		const curSegOff = client.getContainingSegment<ISegmentLeaf>(pos);
+		const curSegOff = client.getContainingSegment<ISegmentPrivate>(pos);
 		cFetches++;
 
 		const curSeg = curSegOff.segment;

--- a/packages/dds/merge-tree/src/test/client.annotateMarker.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.annotateMarker.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import { UniversalSequenceNumber } from "../constants.js";
-import { Marker, reservedMarkerIdKey, type ISegmentLeaf } from "../mergeTreeNodes.js";
+import { Marker, reservedMarkerIdKey, type ISegmentPrivate } from "../mergeTreeNodes.js";
 import { ReferenceType } from "../ops.js";
 import { TextSegment } from "../textSegment.js";
 
@@ -37,7 +37,7 @@ describe("TestClient", () => {
 				[reservedMarkerIdKey]: "123",
 			});
 			assert(insertOp);
-			const markerInfo = client.getContainingSegment<ISegmentLeaf>(0);
+			const markerInfo = client.getContainingSegment<ISegmentPrivate>(0);
 			const marker = markerInfo.segment as Marker;
 			const annotateOp = client.annotateMarker(marker, { foo: "bar" });
 			assert(annotateOp);

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -13,7 +13,7 @@ import { isFluidError } from "@fluidframework/telemetry-utils/internal";
 
 import { UnassignedSequenceNumber } from "../constants.js";
 import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
-import { ISegmentLeaf, SegmentGroup } from "../mergeTreeNodes.js";
+import { ISegmentPrivate, SegmentGroup } from "../mergeTreeNodes.js";
 import { TrackingGroup } from "../mergeTreeTracking.js";
 import { MergeTreeDeltaType, ReferenceType } from "../ops.js";
 import { assertInserted, assertRemoved } from "../segmentInfos.js";
@@ -110,7 +110,7 @@ describe("client.applyMsg", () => {
 		}
 		assert.equal(client.mergeTree.pendingSegments?.length, 0);
 		for (let i = 0; i < client.getText().length; i++) {
-			const segmentInfo = client.getContainingSegment<ISegmentLeaf>(i);
+			const segmentInfo = client.getContainingSegment<ISegmentPrivate>(i);
 
 			assert.notEqual(
 				segmentInfo.segment?.seq,
@@ -127,7 +127,7 @@ describe("client.applyMsg", () => {
 	it("insertTextLocal", () => {
 		const op = client.insertTextLocal(0, "abc");
 
-		const segmentInfo = client.getContainingSegment<ISegmentLeaf>(0);
+		const segmentInfo = client.getContainingSegment<ISegmentPrivate>(0);
 
 		assert.equal(segmentInfo.segment?.seq, UnassignedSequenceNumber);
 
@@ -137,7 +137,7 @@ describe("client.applyMsg", () => {
 	});
 
 	it("removeRangeLocal", () => {
-		const segmentInfo = client.getContainingSegment<ISegmentLeaf>(0);
+		const segmentInfo = client.getContainingSegment<ISegmentPrivate>(0);
 
 		const removeOp = client.removeRangeLocal(0, 1);
 
@@ -162,7 +162,7 @@ describe("client.applyMsg", () => {
 	});
 
 	it("annotateSegmentLocal then removeRangeLocal", () => {
-		const segmentInfo = client.getContainingSegment<ISegmentLeaf>(0);
+		const segmentInfo = client.getContainingSegment<ISegmentPrivate>(0);
 
 		const start = 0;
 		const end = client.getText().length;
@@ -215,7 +215,7 @@ describe("client.applyMsg", () => {
 	});
 
 	it("overlapping deletes", () => {
-		const segmentInfo = client.getContainingSegment<ISegmentLeaf>(0);
+		const segmentInfo = client.getContainingSegment<ISegmentPrivate>(0);
 
 		const start = 0;
 		const end = 5;
@@ -535,7 +535,7 @@ describe("client.applyMsg", () => {
 
 		// op with no reference sequence should count removed segment
 		const insertMessage2 = clientB.makeOpMessage(insertOp2, ++seq);
-		let seg = clientA.getContainingSegment<ISegmentLeaf>(2, {
+		let seg = clientA.getContainingSegment<ISegmentPrivate>(2, {
 			referenceSequenceNumber: insertMessage2.referenceSequenceNumber,
 			clientId: insertMessage2.clientId,
 		});
@@ -544,7 +544,7 @@ describe("client.applyMsg", () => {
 
 		// op with reference sequence >= remove op sequence should not count removed segment
 		const insertMessage3 = clientB.makeOpMessage(insertOp2, seq, removeSequence);
-		seg = clientA.getContainingSegment<ISegmentLeaf>(2, {
+		seg = clientA.getContainingSegment<ISegmentPrivate>(2, {
 			referenceSequenceNumber: insertMessage3.referenceSequenceNumber,
 			clientId: insertMessage3.clientId,
 		});
@@ -643,7 +643,7 @@ describe("client.applyMsg", () => {
 		};
 
 		// TODO: tracking group
-		const { segment, offset } = clients.C.getContainingSegment<ISegmentLeaf>(5);
+		const { segment, offset } = clients.C.getContainingSegment<ISegmentPrivate>(5);
 		assert(segment !== undefined, "expected segment");
 		const ref = clients.C.createLocalReferencePosition(
 			segment,
@@ -673,7 +673,7 @@ describe("client.applyMsg", () => {
 		ops.push(clients.B.makeOpMessage(clients.B.regeneratePendingOp(bOp.op, bOp.sg), ++seq));
 
 		const trackingGroup = new TrackingGroup();
-		const trackedSegs: ISegmentLeaf[] = [];
+		const trackedSegs: ISegmentPrivate[] = [];
 		walkAllChildSegments(clients.C.mergeTree.root, (seg) => {
 			trackedSegs.push(seg);
 			trackingGroup.link(seg);

--- a/packages/dds/merge-tree/src/test/client.attributionFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.attributionFarm.spec.ts
@@ -10,7 +10,7 @@ import { generatePairwiseOptions } from "@fluid-private/test-pairwise-generator"
 import { AttributionKey } from "@fluidframework/runtime-definitions/internal";
 
 import { createPropertyTrackingAndInsertionAttributionPolicyFactory } from "../attributionPolicy.js";
-import type { ISegmentLeaf } from "../mergeTreeNodes.js";
+import type { ISegmentPrivate } from "../mergeTreeNodes.js";
 
 import {
 	IConfigRange,
@@ -74,7 +74,7 @@ describeFuzz("MergeTree.Attribution", ({ testCount }) => {
 							[name: string]: AttributionKey | undefined;
 					  }
 					| undefined => {
-					const { segment, offset } = client.getContainingSegment<ISegmentLeaf>(pos);
+					const { segment, offset } = client.getContainingSegment<ISegmentPrivate>(pos);
 					if (segment?.attribution === undefined || offset === undefined) {
 						return undefined;
 					}

--- a/packages/dds/merge-tree/src/test/client.getPosition.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.getPosition.spec.ts
@@ -7,7 +7,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { segmentIsRemoved, type ISegmentLeaf } from "../mergeTreeNodes.js";
+import { segmentIsRemoved, type ISegmentPrivate } from "../mergeTreeNodes.js";
 import { TextSegment } from "../textSegment.js";
 
 import { TestClient } from "./testClient.js";
@@ -24,7 +24,7 @@ describe("client.getPosition", () => {
 		}
 		client.startOrUpdateCollaboration(localUserLongId);
 
-		const segOff = client.getContainingSegment<ISegmentLeaf>(segPos);
+		const segOff = client.getContainingSegment<ISegmentPrivate>(segPos);
 		assert(TextSegment.is(segOff.segment!));
 		assert.strictEqual(segOff.offset, 0);
 		assert.strictEqual(segOff.segment.text, "o");

--- a/packages/dds/merge-tree/src/test/client.localReference.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReference.spec.ts
@@ -17,7 +17,7 @@ import {
 	setValidateRefCount,
 } from "../localReference.js";
 import { getSlideToSegoff } from "../mergeTree.js";
-import { type ISegmentLeaf } from "../mergeTreeNodes.js";
+import { type ISegmentPrivate } from "../mergeTreeNodes.js";
 import { TrackingGroup, UnorderedTrackingGroup } from "../mergeTreeTracking.js";
 import { MergeTreeDeltaType, ReferenceType } from "../ops.js";
 import { DetachedReferencePosition } from "../referencePositions.js";
@@ -33,10 +33,10 @@ function getSlideOnRemoveReferencePosition(
 	pos: number,
 	op: ISequencedDocumentMessage,
 ): {
-	segment: ISegmentLeaf | undefined;
+	segment: ISegmentPrivate | undefined;
 	offset: number | undefined;
 } {
-	let segoff = client.getContainingSegment<ISegmentLeaf>(pos, {
+	let segoff = client.getContainingSegment<ISegmentPrivate>(pos, {
 		referenceSequenceNumber: op.referenceSequenceNumber,
 		clientId: op.clientId,
 	});
@@ -70,7 +70,7 @@ describe("MergeTree.Client", () => {
 			client2.applyMsg(insert);
 		}
 
-		const segInfo = client1.getContainingSegment<ISegmentLeaf>(2);
+		const segInfo = client1.getContainingSegment<ISegmentPrivate>(2);
 		const c1LocalRef = client1.createLocalReferencePosition(
 			segInfo.segment!,
 			segInfo.offset,
@@ -126,7 +126,7 @@ describe("MergeTree.Client", () => {
 			client2.applyMsg(insert);
 		}
 
-		const segInfo = client1.getContainingSegment<ISegmentLeaf>(2);
+		const segInfo = client1.getContainingSegment<ISegmentPrivate>(2);
 		const c1LocalRef = client1.createLocalReferencePosition(
 			segInfo.segment!,
 			segInfo.offset,
@@ -173,7 +173,7 @@ describe("MergeTree.Client", () => {
 			client2.applyMsg(insert);
 		}
 
-		const segInfo = client1.getContainingSegment<ISegmentLeaf>(2);
+		const segInfo = client1.getContainingSegment<ISegmentPrivate>(2);
 		const c1LocalRef = client1.createLocalReferencePosition(
 			segInfo.segment!,
 			segInfo.offset,
@@ -206,7 +206,7 @@ describe("MergeTree.Client", () => {
 		insert.minimumSequenceNumber = seq - 1;
 		client1.applyMsg(insert);
 
-		const segInfo = client1.getContainingSegment<ISegmentLeaf>(3);
+		const segInfo = client1.getContainingSegment<ISegmentPrivate>(3);
 		const c1LocalRef = client1.createLocalReferencePosition(
 			segInfo.segment!,
 			segInfo.offset,
@@ -318,7 +318,7 @@ describe("MergeTree.Client", () => {
 			client2.applyMsg(insert);
 		}
 
-		const segInfo = client1.getContainingSegment<ISegmentLeaf>(2);
+		const segInfo = client1.getContainingSegment<ISegmentPrivate>(2);
 		const c1LocalRef = client1.createLocalReferencePosition(
 			segInfo.segment!,
 			segInfo.offset,
@@ -355,14 +355,14 @@ describe("MergeTree.Client", () => {
 		client1.applyMsg(insert1);
 		client2.applyMsg(insert1);
 
-		const segInfo1 = client1.getContainingSegment<ISegmentLeaf>(1);
+		const segInfo1 = client1.getContainingSegment<ISegmentPrivate>(1);
 		const LocalRef1 = client1.createLocalReferencePosition(
 			segInfo1.segment!,
 			segInfo1.offset,
 			ReferenceType.SlideOnRemove,
 			undefined,
 		);
-		const segInfo3 = client1.getContainingSegment<ISegmentLeaf>(3);
+		const segInfo3 = client1.getContainingSegment<ISegmentPrivate>(3);
 		const LocalRef2 = client1.createLocalReferencePosition(
 			segInfo3.segment!,
 			segInfo3.offset,
@@ -375,8 +375,8 @@ describe("MergeTree.Client", () => {
 		assert.equal(client1.localReferencePositionToPosition(LocalRef1), 1);
 		assert.equal(client1.localReferencePositionToPosition(LocalRef2), 5);
 
-		const c2SegInfo1 = client2.getContainingSegment<ISegmentLeaf>(1);
-		const c2SegInfo3 = client2.getContainingSegment<ISegmentLeaf>(3);
+		const c2SegInfo1 = client2.getContainingSegment<ISegmentPrivate>(1);
+		const c2SegInfo3 = client2.getContainingSegment<ISegmentPrivate>(3);
 		const remove = client2.makeOpMessage(
 			client2.removeRangeLocal(0, client2.getLength()),
 			++seq,
@@ -429,7 +429,7 @@ describe("MergeTree.Client", () => {
 		const opFromBeforeRemovePerspective = client2.makeOpMessage(
 			client2.insertTextLocal(3, "X"),
 		);
-		const { segment, offset } = client1.getContainingSegment<ISegmentLeaf>(0, {
+		const { segment, offset } = client1.getContainingSegment<ISegmentPrivate>(0, {
 			referenceSequenceNumber: opFromBeforeRemovePerspective.referenceSequenceNumber,
 			clientId: opFromBeforeRemovePerspective.clientId,
 		});
@@ -456,7 +456,7 @@ describe("MergeTree.Client", () => {
 		client1.applyMsg(insert1);
 		client2.applyMsg(insert1);
 
-		const segInfo = client1.getContainingSegment<ISegmentLeaf>(4);
+		const segInfo = client1.getContainingSegment<ISegmentPrivate>(4);
 		const localRef = client1.createLocalReferencePosition(
 			segInfo.segment!,
 			segInfo.offset,
@@ -513,7 +513,7 @@ describe("MergeTree.Client", () => {
 		messages.push(clients.A.makeOpMessage(clients.A.insertTextLocal(0, "0123456789"), ++seq));
 		// initialize the local reference collection on the segment, but keep it empty
 		{
-			const segInfo = clients.A.getContainingSegment<ISegmentLeaf>(9);
+			const segInfo = clients.A.getContainingSegment<ISegmentPrivate>(9);
 			const segment = segInfo.segment;
 			assert(segment !== undefined && TextSegment.is(segment));
 			assert.strictEqual(segment.text[segInfo.offset!], "9");
@@ -530,7 +530,7 @@ describe("MergeTree.Client", () => {
 
 		// add a local reference to the newly inserted segment that caused the split
 		{
-			const segInfo = clients.A.getContainingSegment<ISegmentLeaf>(6);
+			const segInfo = clients.A.getContainingSegment<ISegmentPrivate>(6);
 			const segment = segInfo.segment;
 			assert(segment !== undefined && TextSegment.is(segment));
 			assert.strictEqual(segment.text[segInfo.offset!], "B");
@@ -565,13 +565,13 @@ describe("MergeTree.Client", () => {
 			client.applyMessages(2);
 			assert.equal(client.getText(), "AB");
 			localRefA = client.createLocalReferencePosition(
-				client.getContainingSegment<ISegmentLeaf>(0).segment!,
+				client.getContainingSegment<ISegmentPrivate>(0).segment!,
 				0,
 				ReferenceType.StayOnRemove,
 				{},
 			);
 			localRefB = client.createLocalReferencePosition(
-				client.getContainingSegment<ISegmentLeaf>(1).segment!,
+				client.getContainingSegment<ISegmentPrivate>(1).segment!,
 				0,
 				ReferenceType.StayOnRemove,
 				{},
@@ -618,7 +618,7 @@ describe("MergeTree.Client", () => {
 		client1.applyMsg(insert1);
 		client2.applyMsg(insert1);
 
-		const segInfo = client1.getContainingSegment<ISegmentLeaf>(3);
+		const segInfo = client1.getContainingSegment<ISegmentPrivate>(3);
 
 		const localRef = client1.createLocalReferencePosition(
 			segInfo.segment!,
@@ -681,7 +681,7 @@ describe("MergeTree.Client", () => {
 				client1.applyMsg(insert1);
 				client2.applyMsg(insert1);
 
-				const segInfo = client1.getContainingSegment<ISegmentLeaf>(3);
+				const segInfo = client1.getContainingSegment<ISegmentPrivate>(3);
 
 				assert(segInfo.segment);
 
@@ -727,7 +727,7 @@ describe("MergeTree.Client", () => {
 				client1.applyMsg(insert1);
 				client2.applyMsg(insert1);
 
-				const segInfo = client1.getContainingSegment<ISegmentLeaf>(3);
+				const segInfo = client1.getContainingSegment<ISegmentPrivate>(3);
 
 				assert(segInfo.segment);
 

--- a/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
@@ -10,7 +10,7 @@ import { strict as assert } from "node:assert";
 import { makeRandom } from "@fluid-private/stochastic-test-utils";
 
 import { SlidingPreference, setValidateRefCount } from "../localReference.js";
-import type { ISegmentLeaf } from "../mergeTreeNodes.js";
+import type { ISegmentPrivate } from "../mergeTreeNodes.js";
 import { ReferenceType } from "../ops.js";
 import { ReferencePosition } from "../referencePositions.js";
 
@@ -86,7 +86,7 @@ describe("MergeTree.Client", () => {
 				for (const [i, c] of clients.entries()) {
 					refs.push([]);
 					for (let t = 0; t < c.getLength(); t++) {
-						const seg = c.getContainingSegment<ISegmentLeaf>(t);
+						const seg = c.getContainingSegment<ISegmentPrivate>(t);
 						const forwardLref = c.createLocalReferencePosition(
 							seg.segment!,
 							seg.offset,

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -8,7 +8,12 @@
 import { strict as assert } from "node:assert";
 
 import { UniversalSequenceNumber } from "../constants.js";
-import { ISegmentLeaf, Marker, SegmentGroup, reservedMarkerIdKey } from "../mergeTreeNodes.js";
+import {
+	ISegmentPrivate,
+	Marker,
+	SegmentGroup,
+	reservedMarkerIdKey,
+} from "../mergeTreeNodes.js";
 import { MergeTreeDeltaType, ReferenceType } from "../ops.js";
 import { TextSegment } from "../textSegment.js";
 
@@ -80,7 +85,7 @@ describe("client.rollback", () => {
 		client.insertTextLocal(0, "aefg");
 		client.insertTextLocal(1, "bcd");
 		const segmentGroup = client.peekPendingSegmentGroups() as SegmentGroup;
-		const segment: ISegmentLeaf = segmentGroup.segments[0];
+		const segment: ISegmentPrivate = segmentGroup.segments[0];
 		client.rollback?.({ type: MergeTreeDeltaType.INSERT }, segmentGroup);
 
 		// do some work and move the client's min seq forward, so zamboni runs
@@ -302,7 +307,7 @@ describe("client.rollback", () => {
 		);
 		client.annotateRangeLocal(2, 3, { foo: "bar" });
 		const segmentGroup = client.peekPendingSegmentGroups() as SegmentGroup;
-		const segment: ISegmentLeaf = segmentGroup.segments[0];
+		const segment: ISegmentPrivate = segmentGroup.segments[0];
 		client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, segmentGroup);
 
 		// do some work and move the client's min seq forward, so zamboni runs
@@ -400,8 +405,8 @@ describe("client.rollback", () => {
 		client.insertTextLocal(0, "efg");
 		client.insertTextLocal(0, "d");
 		client.insertTextLocal(0, "abc");
-		const segInfo1 = client.getContainingSegment<ISegmentLeaf>(2);
-		const segInfo3 = client.getContainingSegment<ISegmentLeaf>(5);
+		const segInfo1 = client.getContainingSegment<ISegmentPrivate>(2);
+		const segInfo3 = client.getContainingSegment<ISegmentPrivate>(5);
 		const ref1 = client.createLocalReferencePosition(
 			segInfo1.segment!,
 			0,
@@ -431,12 +436,12 @@ describe("client.rollback", () => {
 		client.rollback?.({ type: MergeTreeDeltaType.REMOVE }, client.peekPendingSegmentGroups());
 
 		assert.equal(client.getText(), "abcdefg");
-		const segInfo1After = client.getContainingSegment<ISegmentLeaf>(2);
+		const segInfo1After = client.getContainingSegment<ISegmentPrivate>(2);
 		assert.notEqual(segInfo1After, undefined);
 		assert.notEqual(segInfo1After.segment?.localRefs, undefined);
 		assert(segInfo1After.segment?.localRefs!.has(ref1));
 		assert(segInfo1After.segment?.localRefs!.has(refSlide));
-		const segInfo3After = client.getContainingSegment<ISegmentLeaf>(5);
+		const segInfo3After = client.getContainingSegment<ISegmentPrivate>(5);
 		assert.notEqual(segInfo3After, undefined);
 		assert.notEqual(segInfo3After.segment?.localRefs, undefined);
 		assert(segInfo3After.segment?.localRefs!.has(ref2));
@@ -454,7 +459,7 @@ describe("client.rollback", () => {
 		);
 		client.removeRangeLocal(1, 4);
 		const segmentGroup = client.peekPendingSegmentGroups() as SegmentGroup;
-		const segment: ISegmentLeaf = segmentGroup.segments[0];
+		const segment: ISegmentPrivate = segmentGroup.segments[0];
 		client.rollback?.({ type: MergeTreeDeltaType.REMOVE }, segmentGroup);
 
 		// do some work and move the client's min seq forward, so zamboni runs

--- a/packages/dds/merge-tree/src/test/mergeTree.annotate.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.annotate.spec.ts
@@ -13,15 +13,15 @@ import {
 	UniversalSequenceNumber,
 } from "../constants.js";
 import { MergeTree } from "../mergeTree.js";
-import { Marker, type ISegmentLeaf } from "../mergeTreeNodes.js";
+import { Marker, type ISegmentPrivate } from "../mergeTreeNodes.js";
 import { MergeTreeDeltaType, ReferenceType } from "../ops.js";
 import type { PropsOrAdjust } from "../segmentPropertiesManager.js";
 import { TextSegment } from "../textSegment.js";
 
 import { insertSegments } from "./testUtils.js";
 
-function splitAt(mergeTree: MergeTree, pos: number): ISegmentLeaf | undefined {
-	let segment: ISegmentLeaf | undefined;
+function splitAt(mergeTree: MergeTree, pos: number): ISegmentPrivate | undefined {
+	let segment: ISegmentPrivate | undefined;
 	mergeTree.mapRange(
 		(seg) => {
 			segment = seg;
@@ -87,12 +87,12 @@ describe("MergeTree", () => {
 					undefined as never,
 				);
 
-				const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+				const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 					annotateStart,
 					currentSequenceNumber,
 					localClientId,
 				);
-				const segment = segmentInfo.segment as ISegmentLeaf;
+				const segment = segmentInfo.segment as ISegmentPrivate;
 				assert.equal(segment?.properties?.propertySource, "remote");
 			});
 
@@ -109,12 +109,12 @@ describe("MergeTree", () => {
 					undefined as never,
 				);
 
-				const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+				const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 					annotateStart,
 					currentSequenceNumber,
 					localClientId,
 				);
-				const segment = segmentInfo.segment as ISegmentLeaf;
+				const segment = segmentInfo.segment as ISegmentPrivate;
 				assert.equal(segment.properties?.propertySource, "local");
 			});
 		});
@@ -143,12 +143,12 @@ describe("MergeTree", () => {
 				});
 
 				it("unsequenced local", () => {
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 					assert.equal(segment.properties?.propertySource, "local");
 				});
 
@@ -165,17 +165,17 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 					assert.equal(segment.properties?.secondProperty, "local");
 				});
 
 				it("unsequenced local split", () => {
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
@@ -218,19 +218,19 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 
-					const splitSegmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const splitSegmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						splitPos,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const splitSegment = splitSegmentInfo.segment as ISegmentLeaf;
+					const splitSegment = splitSegmentInfo.segment as ISegmentPrivate;
 
 					assert.equal(segment.segmentGroups?.size, 2);
 					assert.equal(segment.properties?.propertySource, "local");
@@ -322,12 +322,12 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 
 					assert.equal(segment.segmentGroups?.size, 1);
 					assert.equal(segment.properties?.propertySource, "local");
@@ -347,12 +347,12 @@ describe("MergeTree", () => {
 						} as unknown as ISequencedDocumentMessage,
 					});
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 					assert.equal(segment.segmentGroups?.size, 0);
 					assert.equal(segment.properties?.propertySource, "local");
 				});
@@ -382,12 +382,12 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 
 					assert.equal(segment.segmentGroups?.size, 0);
 					assert.equal(segment.properties?.propertySource, "remote");
@@ -395,12 +395,12 @@ describe("MergeTree", () => {
 				});
 
 				it("three local changes", () => {
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 
 					assert.equal(segment.properties?.propertySource, "local");
 
@@ -525,12 +525,12 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 
 					assert.equal(segment.properties?.remoteOnly, 1);
 					assert.equal(segment.properties?.propertySource, "remote");
@@ -551,7 +551,7 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
@@ -559,18 +559,18 @@ describe("MergeTree", () => {
 					assert(segmentInfo.segment?.segmentGroups?.size !== 0);
 				});
 				it("remote only", () => {
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 					assert.equal(segment.properties?.propertySource, "remote");
 					assert.equal(segment.properties?.remoteProperty, 1);
 				});
 
 				it("split remote", () => {
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
@@ -596,12 +596,12 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 					assert.equal(segment.properties?.propertySource, "local");
 					assert.equal(segment.properties?.remoteProperty, 1);
 				});
@@ -611,7 +611,7 @@ describe("MergeTree", () => {
 						props: { propertySource: "local" },
 					};
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
@@ -676,12 +676,12 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 					assert.equal(segment.properties?.propertySource, "local2");
 					assert.equal(segment.properties?.secondProperty, "local");
 				});
@@ -699,12 +699,12 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 
 					assert.equal(segment.segmentGroups?.size, 1);
 					assert.equal(segment.properties?.propertySource, "local");
@@ -736,12 +736,12 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 
 					assert.equal(segment.segmentGroups?.size, 0);
 					assert.equal(segment.properties?.propertySource, "remote");
@@ -785,12 +785,12 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					const segmentInfo = mergeTree.getContainingSegment<ISegmentLeaf>(
+					const segmentInfo = mergeTree.getContainingSegment<ISegmentPrivate>(
 						annotateStart,
 						currentSequenceNumber,
 						localClientId,
 					);
-					const segment = segmentInfo.segment as ISegmentLeaf;
+					const segment = segmentInfo.segment as ISegmentPrivate;
 
 					assert.equal(segment.properties?.remoteOnly, 1);
 					assert.equal(segment.properties?.propertySource, "remote");

--- a/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
@@ -8,7 +8,7 @@
 import { strict as assert } from "node:assert";
 
 import { UnassignedSequenceNumber } from "../constants.js";
-import type { ISegmentLeaf } from "../mergeTreeNodes.js";
+import type { ISegmentPrivate } from "../mergeTreeNodes.js";
 import { createInsertSegmentOp, createRemoveRangeOp } from "../opBuilder.js";
 import { TextSegment } from "../textSegment.js";
 
@@ -88,7 +88,7 @@ describe("MergeTree.markRangeRemoved", () => {
 			"remote",
 		);
 		const segmentExpectedRemovedSeq = seq;
-		const { segment } = client.getContainingSegment<ISegmentLeaf>(0);
+		const { segment } = client.getContainingSegment<ISegmentPrivate>(0);
 		assert(segment !== undefined, "expected to find segment");
 		const localDeleteMessage = client.makeOpMessage(
 			client.removeRangeLocal(0, client.getLength()),

--- a/packages/dds/merge-tree/src/test/mergeTree.walk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.walk.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "node:assert";
 import { LocalClientId, UniversalSequenceNumber } from "../constants.js";
 import { MergeTree } from "../mergeTree.js";
 import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
-import { MergeBlock, ISegmentLeaf, MaxNodesInBlock } from "../mergeTreeNodes.js";
+import { MergeBlock, ISegmentPrivate, MaxNodesInBlock } from "../mergeTreeNodes.js";
 import { TextSegment } from "../textSegment.js";
 
 import { insertText } from "./testUtils.js";
@@ -58,7 +58,7 @@ describe("MergeTree walks", () => {
 		it("visits only descendants", () => {
 			for (const block of getAllDescendantBlocks(mergeTree.root)) {
 				let walkedAnySegments = false;
-				walkAllChildSegments(block, (seg: ISegmentLeaf) => {
+				walkAllChildSegments(block, (seg: ISegmentPrivate) => {
 					walkedAnySegments = true;
 					let current = seg.parent;
 					while (current !== block && current !== undefined) {

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -12,7 +12,7 @@ import { IRandom } from "@fluid-private/stochastic-test-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 
 import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
-import { ISegmentLeaf, SegmentGroup } from "../mergeTreeNodes.js";
+import { ISegmentPrivate, SegmentGroup } from "../mergeTreeNodes.js";
 import { IMergeTreeOp, MergeTreeDeltaType, ReferenceType } from "../ops.js";
 import { toMoveInfo, toRemovalInfo } from "../segmentInfos.js";
 import { Side } from "../sequencePlace.js";
@@ -96,7 +96,7 @@ export const insertAtRefPos: TestOperation = (
 	opEnd: number,
 	random: IRandom,
 ) => {
-	const segs: ISegmentLeaf[] = [];
+	const segs: ISegmentPrivate[] = [];
 	// gather all the segments at the pos, including removed segments
 	walkAllChildSegments(client.mergeTree.root, (seg) => {
 		const pos = client.getPosition(seg);

--- a/packages/dds/merge-tree/src/test/obliterate.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import type { ISegmentLeaf, ObliterateInfo } from "../mergeTreeNodes.js";
+import type { ISegmentPrivate, ObliterateInfo } from "../mergeTreeNodes.js";
 import { MergeTreeDeltaType } from "../ops.js";
 
 import { TestClient } from "./testClient.js";
@@ -179,8 +179,8 @@ describe("obliterate", () => {
 
 			const obliterateStart = 0;
 			const obliterateEnd = client.getLength();
-			const startSeg = client.getContainingSegment<ISegmentLeaf>(obliterateStart);
-			const endSeg = client.getContainingSegment<ISegmentLeaf>(obliterateEnd);
+			const startSeg = client.getContainingSegment<ISegmentPrivate>(obliterateStart);
+			const endSeg = client.getContainingSegment<ISegmentPrivate>(obliterateEnd);
 			obliterateRange({
 				mergeTree: client.mergeTree,
 				start: obliterateStart,

--- a/packages/dds/merge-tree/src/test/propertyManager.spec.ts
+++ b/packages/dds/merge-tree/src/test/propertyManager.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import { UnassignedSequenceNumber } from "../constants.js";
-import type { ISegmentLeaf } from "../mergeTreeNodes.js";
+import type { ISegmentPrivate } from "../mergeTreeNodes.js";
 import { matchProperties } from "../properties.js";
 import {
 	PropertiesManager,
@@ -18,7 +18,7 @@ describe("PropertiesManager", () => {
 	describe("handleProperties", () => {
 		it("should handle properties without collaboration", () => {
 			const propertiesManager = new PropertiesManager();
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = {
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = {
 				properties: { key: "value" },
 			};
 			const op: PropsOrAdjust = { props: { key: "newValue" } };
@@ -29,7 +29,7 @@ describe("PropertiesManager", () => {
 
 		it("should handle properties with collaboration", () => {
 			const propertiesManager = new PropertiesManager();
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = {
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = {
 				properties: { key: "value" },
 			};
 			const op: PropsOrAdjust = { props: { key: "newValue" } };
@@ -46,7 +46,7 @@ describe("PropertiesManager", () => {
 
 		it("should handle properties with rollback", () => {
 			const propertiesManager = new PropertiesManager();
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = {
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = {
 				properties: { key: "value" },
 			};
 			const op: PropsOrAdjust = { props: { key: "newValue" } };
@@ -66,7 +66,7 @@ describe("PropertiesManager", () => {
 
 		it("should handle properties with seq as a number and collaborating true", () => {
 			const propertiesManager = new PropertiesManager();
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = {
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = {
 				properties: { key: "value" },
 			};
 			const op: PropsOrAdjust = { props: { key: "newValue" } };
@@ -77,7 +77,7 @@ describe("PropertiesManager", () => {
 
 		it("should handle properties with seq as a number and collaborating false", () => {
 			const propertiesManager = new PropertiesManager();
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = {
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = {
 				properties: { key: "value" },
 			};
 			const op: PropsOrAdjust = { props: { key: "newValue" } };
@@ -88,7 +88,7 @@ describe("PropertiesManager", () => {
 
 		it("should handle properties with adjusts", () => {
 			const propertiesManager = new PropertiesManager();
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = {
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = {
 				properties: { key: 1 },
 			};
 			const op: PropsOrAdjust = { adjust: { key: { delta: 1 } } };
@@ -99,7 +99,7 @@ describe("PropertiesManager", () => {
 
 		it("should handle properties with props and adjusts interleaved", () => {
 			const propertiesManager = new PropertiesManager();
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = {
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = {
 				properties: { key: 1, otherKey: "value" },
 			};
 			const op1: PropsOrAdjust = { props: { otherKey: "newValue" } };
@@ -114,7 +114,7 @@ describe("PropertiesManager", () => {
 	describe("rollbackProperties", () => {
 		it("should rollback properties when collaborating is true", () => {
 			const propertiesManager = new PropertiesManager();
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = {
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = {
 				properties: { key: "value" },
 			};
 			const op: PropsOrAdjust = { props: { key: "newValue" } };
@@ -136,7 +136,7 @@ describe("PropertiesManager", () => {
 
 		it("should rollback properties when collaborating is false", () => {
 			const propertiesManager = new PropertiesManager();
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = {
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = {
 				properties: { key: "value" },
 			};
 			const op: PropsOrAdjust = { props: { key: "newValue" } };
@@ -161,7 +161,7 @@ describe("PropertiesManager", () => {
 		it("should acknowledge property changes", () => {
 			const propertiesManager = new PropertiesManager();
 			const op: PropsOrAdjust = { props: { key: "value" } };
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = { properties: {} };
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = { properties: {} };
 
 			propertiesManager.handleProperties(op, seg, UnassignedSequenceNumber, 1, true);
 			assert(propertiesManager.hasPendingProperties({ key: "value" }));
@@ -173,11 +173,11 @@ describe("PropertiesManager", () => {
 		it("should copy properties and manager state", () => {
 			const propertiesManager = new PropertiesManager();
 			const op: PropsOrAdjust = { props: { key: "value" } };
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = { properties: {} };
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = { properties: {} };
 
 			propertiesManager.handleProperties(op, seg, UnassignedSequenceNumber, 1, true);
 			assert(propertiesManager.hasPendingProperties({ key: "value" }));
-			const dest: Pick<ISegmentLeaf, "properties" | "propertyManager"> = {};
+			const dest: Pick<ISegmentPrivate, "properties" | "propertyManager"> = {};
 			propertiesManager.copyTo({ key: "value" }, dest);
 			assert(dest.propertyManager instanceof PropertiesManager);
 			assert(dest.propertyManager.hasPendingProperties({ key: "value" }));
@@ -188,7 +188,7 @@ describe("PropertiesManager", () => {
 		it("should retrieve properties at a specific sequence number", () => {
 			const propertiesManager = new PropertiesManager();
 			const op: PropsOrAdjust = { adjust: { key: { delta: 5 } } };
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = { properties: {} };
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = { properties: {} };
 
 			propertiesManager.handleProperties(op, seg, 1, 0, true);
 			const properties = propertiesManager.getAtSeq(seg.properties, 0);
@@ -200,7 +200,7 @@ describe("PropertiesManager", () => {
 		it("should check for pending properties", () => {
 			const propertiesManager = new PropertiesManager();
 			const op: PropsOrAdjust = { props: { key: "value" } };
-			const seg: Pick<ISegmentLeaf, "properties" | "propertyManager"> = { properties: {} };
+			const seg: Pick<ISegmentPrivate, "properties" | "propertyManager"> = { properties: {} };
 
 			propertiesManager.handleProperties(op, seg, UnassignedSequenceNumber, 1, true);
 			assert(propertiesManager.hasPendingProperties({ key: "value" }));

--- a/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
+++ b/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
@@ -13,7 +13,7 @@ import {
 	Marker,
 	SegmentGroup,
 	reservedMarkerIdKey,
-	type ISegmentLeaf,
+	type ISegmentPrivate,
 } from "../mergeTreeNodes.js";
 import { IMergeTreeOp, ReferenceType } from "../ops.js";
 import { clone } from "../properties.js";
@@ -238,7 +238,7 @@ describe("resetPendingSegmentsToOp", () => {
 				prop1: "foo",
 			});
 			assert(insertOp);
-			const { segment } = client.getContainingSegment<ISegmentLeaf>(0);
+			const { segment } = client.getContainingSegment<ISegmentPrivate>(0);
 			assert(segment !== undefined && Marker.is(segment));
 			client.annotateMarker(segment, { prop2: "bar" });
 
@@ -250,7 +250,7 @@ describe("resetPendingSegmentsToOp", () => {
 			);
 			otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
-			const { segment: otherSegment } = otherClient.getContainingSegment<ISegmentLeaf>(0);
+			const { segment: otherSegment } = otherClient.getContainingSegment<ISegmentPrivate>(0);
 			assert(otherSegment !== undefined && Marker.is(otherSegment));
 			// `clone` here is because properties use a Object.create(null); to compare strict equal the prototype chain
 			// should therefore not include Object.
@@ -273,7 +273,7 @@ describe("resetPendingSegmentsToOp", () => {
 			);
 			otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
-			const { segment: otherSegment } = otherClient.getContainingSegment<ISegmentLeaf>(0);
+			const { segment: otherSegment } = otherClient.getContainingSegment<ISegmentPrivate>(0);
 			assert(otherSegment !== undefined && TextSegment.is(otherSegment));
 			assert.deepStrictEqual(otherSegment.properties, clone({ prop1: "foo" }));
 		});
@@ -291,7 +291,7 @@ describe("resetPendingSegmentsToOp", () => {
 			);
 			otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
-			const { segment: otherSegment } = otherClient.getContainingSegment<ISegmentLeaf>(0);
+			const { segment: otherSegment } = otherClient.getContainingSegment<ISegmentPrivate>(0);
 			assert(otherSegment !== undefined && TextSegment.is(otherSegment));
 			assert.deepStrictEqual(otherSegment.properties, undefined);
 		});

--- a/packages/dds/merge-tree/src/test/revertibleFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/revertibleFarm.spec.ts
@@ -13,7 +13,7 @@ import type {
 	IMergeTreeDeltaOpArgs,
 } from "../mergeTreeDeltaCallback.js";
 import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
-import { SegmentGroup, type ISegmentLeaf } from "../mergeTreeNodes.js";
+import { SegmentGroup, type ISegmentPrivate } from "../mergeTreeNodes.js";
 import {
 	MergeTreeDeltaRevertible,
 	MergeTreeWithRevert,
@@ -172,7 +172,7 @@ describe("MergeTree.Client", () => {
 						revertMergeTreeDeltaRevertibles(clientBDriver, clientB_Revertibles.splice(0));
 						seq = applyMessages(seq, msgs.splice(0), clients.all, logger);
 
-						walkAllChildSegments(clients.B.mergeTree.root, (seg: ISegmentLeaf) => {
+						walkAllChildSegments(clients.B.mergeTree.root, (seg: ISegmentPrivate) => {
 							if (seg?.trackingCollection.empty === false) {
 								assert.notDeepStrictEqual(
 									seg?.trackingCollection.empty,

--- a/packages/dds/merge-tree/src/test/segmentGroupCollection.spec.ts
+++ b/packages/dds/merge-tree/src/test/segmentGroupCollection.spec.ts
@@ -5,12 +5,12 @@
 
 import { strict as assert } from "node:assert";
 
-import { type ISegmentLeaf } from "../mergeTreeNodes.js";
+import { type ISegmentPrivate } from "../mergeTreeNodes.js";
 import { SegmentGroupCollection } from "../segmentGroupCollection.js";
 import { TextSegment } from "../textSegment.js";
 
 describe("segmentGroupCollection", () => {
-	let segment: ISegmentLeaf;
+	let segment: ISegmentPrivate;
 	let segmentGroups: SegmentGroupCollection;
 	beforeEach(() => {
 		segment = TextSegment.make("abc");

--- a/packages/dds/merge-tree/src/test/snapshot.utils.ts
+++ b/packages/dds/merge-tree/src/test/snapshot.utils.ts
@@ -13,7 +13,7 @@ import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/in
 import { MockStorage } from "@fluidframework/test-runtime-utils/internal";
 
 import { type IMergeTreeOptionsInternal } from "../mergeTree.js";
-import { type ISegmentLeaf } from "../mergeTreeNodes.js";
+import { type ISegmentPrivate } from "../mergeTreeNodes.js";
 import { IMergeTreeOp, ReferenceType } from "../ops.js";
 import { PropertySet } from "../properties.js";
 import { SnapshotV1 } from "../snapshotV1.js";
@@ -174,8 +174,8 @@ export class TestString {
 		);
 	}
 
-	public getSegment(pos: number): ISegmentLeaf {
-		const { segment } = this.client.getContainingSegment<ISegmentLeaf>(pos);
+	public getSegment(pos: number): ISegmentPrivate {
+		const { segment } = this.client.getContainingSegment<ISegmentPrivate>(pos);
 		assert(segment !== undefined);
 		return segment;
 	}

--- a/packages/dds/merge-tree/src/test/sortedSegmentSet.spec.ts
+++ b/packages/dds/merge-tree/src/test/sortedSegmentSet.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import { LocalReferencePosition } from "../localReference.js";
-import { ISegment, type ISegmentLeaf } from "../mergeTreeNodes.js";
+import { ISegment, type ISegmentPrivate } from "../mergeTreeNodes.js";
 import { TrackingGroup } from "../mergeTreeTracking.js";
 import { ReferenceType } from "../ops.js";
 import { SortedSegmentSet, SortedSegmentSetItem } from "../sortedSegmentSet.js";
@@ -65,7 +65,7 @@ describe("SortedSegmentSet", () => {
 		const set = new SortedSegmentSet<{ segment: ISegment }>();
 		for (let i = 0; i < client.getLength(); i++) {
 			for (const pos of [i, client.getLength() - 1 - i]) {
-				const segment = client.getContainingSegment<ISegmentLeaf>(pos).segment;
+				const segment = client.getContainingSegment<ISegmentPrivate>(pos).segment;
 				assert(segment);
 				const item = { segment };
 				assert.equal(set.has(item), false);
@@ -81,7 +81,7 @@ describe("SortedSegmentSet", () => {
 		const set = new SortedSegmentSet();
 		for (let i = 0; i < client.getLength(); i++) {
 			for (const pos of [i, client.getLength() - 1 - i]) {
-				const segment = client.getContainingSegment<ISegmentLeaf>(pos).segment;
+				const segment = client.getContainingSegment<ISegmentPrivate>(pos).segment;
 				assert(segment);
 				set.addOrUpdate(segment);
 				assert.equal(set.has(segment), true);
@@ -99,7 +99,7 @@ describe("SortedSegmentSet", () => {
 		const set = new TrackingGroup();
 		for (let i = 0; i < client.getLength(); i++) {
 			for (const pos of [i, client.getLength() - 1 - i]) {
-				const segmentInfo = client.getContainingSegment<ISegmentLeaf>(pos);
+				const segmentInfo = client.getContainingSegment<ISegmentPrivate>(pos);
 				assert(segmentInfo?.segment);
 				const lref = client.createLocalReferencePosition(
 					segmentInfo.segment,

--- a/packages/dds/merge-tree/src/test/testClientLogger.ts
+++ b/packages/dds/merge-tree/src/test/testClientLogger.ts
@@ -16,7 +16,7 @@ import {
 	type IMergeTreeMaintenanceCallbackArgs,
 } from "../mergeTreeDeltaCallback.js";
 import { depthFirstNodeWalk } from "../mergeTreeNodeWalk.js";
-import { Marker, seqLTE, type ISegmentLeaf } from "../mergeTreeNodes.js";
+import { Marker, seqLTE, type ISegmentPrivate } from "../mergeTreeNodes.js";
 import { IMergeTreeOp, MergeTreeDeltaType } from "../ops.js";
 import { PropertySet, matchProperties } from "../properties.js";
 import { toInsertionInfo, toMoveInfo, toRemovalInfo } from "../segmentInfos.js";
@@ -396,7 +396,7 @@ export class TestClientLogger {
 	}
 }
 
-function toMoveOrRemove(segment: ISegmentLeaf): { seq: number } | undefined {
+function toMoveOrRemove(segment: ISegmentPrivate): { seq: number } | undefined {
 	const mi = toMoveInfo(segment);
 	const ri = toRemovalInfo(segment);
 	if (mi !== undefined || ri !== undefined) {

--- a/packages/dds/merge-tree/src/test/testUtils.ts
+++ b/packages/dds/merge-tree/src/test/testUtils.ts
@@ -15,7 +15,7 @@ import {
 	type IMergeTreeMaintenanceCallbackArgs,
 } from "../mergeTreeDeltaCallback.js";
 import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
-import { MergeBlock, ISegmentLeaf, Marker } from "../mergeTreeNodes.js";
+import { MergeBlock, ISegmentPrivate, Marker } from "../mergeTreeNodes.js";
 import { ReferenceType } from "../ops.js";
 import {
 	PartialSequenceLengths,
@@ -110,7 +110,7 @@ export function insertText({
 interface InsertSegmentsArgs {
 	mergeTree: MergeTree;
 	pos: number;
-	segments: ISegmentLeaf[];
+	segments: ISegmentPrivate[];
 	refSeq: number;
 	clientId: number;
 	seq: number;
@@ -234,7 +234,7 @@ function getPartialLengths(
 
 	let actualLen = 0;
 
-	const isInserted = (segment: ISegmentLeaf): boolean =>
+	const isInserted = (segment: ISegmentPrivate): boolean =>
 		segment.seq === undefined ||
 		(segment.seq !== UnassignedSequenceNumber && segment.seq <= seq) ||
 		(localSeq !== undefined &&
@@ -242,7 +242,7 @@ function getPartialLengths(
 			segment.localSeq !== undefined &&
 			segment.localSeq <= localSeq);
 
-	const isRemoved = (segment: ISegmentLeaf): boolean =>
+	const isRemoved = (segment: ISegmentPrivate): boolean =>
 		segment.removedSeq !== undefined &&
 		((localSeq !== undefined &&
 			segment.removedSeq === UnassignedSequenceNumber &&
@@ -250,7 +250,7 @@ function getPartialLengths(
 			segment.localRemovedSeq <= localSeq) ||
 			(segment.removedSeq !== UnassignedSequenceNumber && segment.removedSeq <= seq));
 
-	const isMoved = (segment: ISegmentLeaf): boolean =>
+	const isMoved = (segment: ISegmentPrivate): boolean =>
 		segment.movedSeq !== undefined &&
 		((localSeq !== undefined &&
 			segment.movedSeq === UnassignedSequenceNumber &&

--- a/packages/dds/merge-tree/src/test/tracking.spec.ts
+++ b/packages/dds/merge-tree/src/test/tracking.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import type { ISegmentLeaf } from "../mergeTreeNodes.js";
+import type { ISegmentPrivate } from "../mergeTreeNodes.js";
 import { TrackingGroup } from "../mergeTreeTracking.js";
 import { ReferenceType } from "../ops.js";
 
@@ -24,7 +24,7 @@ describe("MergeTree.tracking", () => {
 
 		assert.equal(testClient.getLength(), 3);
 
-		const segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
+		const segmentInfo = testClient.getContainingSegment<ISegmentPrivate>(0);
 
 		assert(segmentInfo?.segment?.trackingCollection.empty);
 	});
@@ -41,7 +41,7 @@ describe("MergeTree.tracking", () => {
 
 		assert.equal(trackingGroup.size, 1);
 
-		const segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
+		const segmentInfo = testClient.getContainingSegment<ISegmentPrivate>(0);
 
 		assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 
@@ -67,7 +67,7 @@ describe("MergeTree.tracking", () => {
 		assert.equal(testClient.getLength(), 4);
 
 		assert.equal(trackingGroup.size, 2);
-		const segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
+		const segmentInfo = testClient.getContainingSegment<ISegmentPrivate>(0);
 		assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 	});
 
@@ -87,20 +87,20 @@ describe("MergeTree.tracking", () => {
 		assert.equal(testClient.getLength(), 4);
 
 		assert.equal(trackingGroup.size, 3);
-		let segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
+		let segmentInfo = testClient.getContainingSegment<ISegmentPrivate>(0);
 		assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 
 		let seq = 1;
 		for (const op of ops) testClient.applyMsg(testClient.makeOpMessage(op, ++seq));
 
 		assert.equal(trackingGroup.size, 3);
-		segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
+		segmentInfo = testClient.getContainingSegment<ISegmentPrivate>(0);
 		assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 
 		testClient.updateMinSeq(seq);
 
 		assert.equal(trackingGroup.size, 1);
-		segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
+		segmentInfo = testClient.getContainingSegment<ISegmentPrivate>(0);
 		assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 	});
 
@@ -109,7 +109,7 @@ describe("MergeTree.tracking", () => {
 
 		assert.equal(testClient.getLength(), 3);
 
-		const segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
+		const segmentInfo = testClient.getContainingSegment<ISegmentPrivate>(0);
 		assert(segmentInfo.segment);
 		const ref = testClient.createLocalReferencePosition(
 			segmentInfo.segment,
@@ -126,7 +126,7 @@ describe("MergeTree.tracking", () => {
 
 		assert.equal(testClient.getLength(), 3);
 
-		const segmentInfo = testClient.getContainingSegment<ISegmentLeaf>(0);
+		const segmentInfo = testClient.getContainingSegment<ISegmentPrivate>(0);
 		assert(segmentInfo.segment);
 		const ref = testClient.createLocalReferencePosition(
 			segmentInfo.segment,
@@ -157,7 +157,7 @@ describe("MergeTree.tracking", () => {
 
 		testClient.insertTextLocal(0, "abc");
 
-		const { segment } = testClient.getContainingSegment<ISegmentLeaf>(0);
+		const { segment } = testClient.getContainingSegment<ISegmentPrivate>(0);
 		segment?.trackingCollection.link(trackingGroup);
 
 		assert.equal(segment?.trackingCollection.trackingGroups.size, 1);
@@ -183,7 +183,7 @@ describe("MergeTree.tracking", () => {
 
 		testClient.insertTextLocal(0, "abc");
 
-		const { segment } = testClient.getContainingSegment<ISegmentLeaf>(0);
+		const { segment } = testClient.getContainingSegment<ISegmentPrivate>(0);
 		segment?.trackingCollection.link(trackingGroup);
 
 		assert.equal(segment?.trackingCollection.trackingGroups.size, 1);

--- a/packages/dds/merge-tree/src/test/wordUnitTests.spec.ts
+++ b/packages/dds/merge-tree/src/test/wordUnitTests.spec.ts
@@ -11,7 +11,7 @@ import path from "node:path";
 import { Trace } from "@fluid-internal/client-utils";
 import { makeRandom } from "@fluid-private/stochastic-test-utils";
 
-import type { ISegmentLeaf } from "../mergeTreeNodes.js";
+import type { ISegmentPrivate } from "../mergeTreeNodes.js";
 import { ReferenceType } from "../ops.js";
 import { MapLike, createMap, extend } from "../properties.js";
 import { ReferencePosition } from "../referencePositions.js";
@@ -136,7 +136,7 @@ function makeBookmarks(client: TestClient, bookmarkCount: number): ReferencePosi
 	const len = client.getLength();
 	for (let i = 0; i < bookmarkCount; i++) {
 		const pos = random.integer(0, len - 1);
-		const segoff = client.getContainingSegment<ISegmentLeaf>(pos);
+		const segoff = client.getContainingSegment<ISegmentPrivate>(pos);
 		let refType = ReferenceType.Simple;
 		if (i & 1) {
 			refType = ReferenceType.SlideOnRemove;
@@ -168,7 +168,7 @@ function measureFetch(startFile: string, withBookmarks = false): void {
 			// curPG.pos is ca end
 			const curPG = client.searchForMarker(pos, "pg", true)!;
 			const properties = curPG.properties!;
-			const curSegOff = client.getContainingSegment<ISegmentLeaf>(pos)!;
+			const curSegOff = client.getContainingSegment<ISegmentPrivate>(pos)!;
 			const curSeg = curSegOff.segment!;
 			// Combine paragraph and direct properties
 			extend(properties, curSeg.properties);

--- a/packages/dds/merge-tree/src/zamboni.ts
+++ b/packages/dds/merge-tree/src/zamboni.ts
@@ -11,7 +11,7 @@ import { MergeTreeMaintenanceType } from "./mergeTreeDeltaCallback.js";
 import {
 	type MergeBlock,
 	IMergeNode,
-	ISegmentLeaf,
+	ISegmentPrivate,
 	Marker,
 	MaxNodesInBlock,
 	seqLTE,
@@ -135,7 +135,7 @@ export function packParent(parent: MergeBlock, mergeTree: MergeTree): void {
 function scourNode(node: MergeBlock, holdNodes: IMergeNode[], mergeTree: MergeTree): void {
 	// The previous segment is tracked while scouring for the purposes of merging adjacent segments
 	// when possible.
-	let prevSegment: ISegmentLeaf | undefined;
+	let prevSegment: ISegmentPrivate | undefined;
 	for (let k = 0; k < node.childCount; k++) {
 		// TODO Non null asserting, why is this not null?
 		const childNode = node.children[k]!;


### PR DESCRIPTION
ISegmentPrivate is a better name for this interface, as ISegmentPrivate contains properties that are privately available within the packages itself and are not exported. This in in contrast to ISegmentInternal, which contains internal properties available to all fluidframework packages, and ISegment, which is currently exported under the Legacy Api and usable by customers of that API.