### PR TITLE
(tree): Support for adding constraints on revert to view.runTransaction API

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -704,12 +704,14 @@ export function singletonSchema<TScope extends string, TName extends string | nu
 }, Record<string, never>, true, Record<string, never>, undefined>;
 
 // @alpha
-export type TransactionCallbackStatus<TSuccessValue, TFailureValue> = {
+export type TransactionCallbackStatus<TSuccessValue, TFailureValue> = ({
     rollback?: false;
     value: TSuccessValue;
 } | {
     rollback: true;
     value: TFailureValue;
+}) & {
+    preconditionsOnRevert?: readonly TransactionConstraint[];
 };
 
 // @public

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -245,9 +245,9 @@ export class SchematizingSimpleTreeView<
 			| void,
 		params?: RunTransactionParams,
 	): TransactionResultExt<TSuccessValue, TFailureValue> | TransactionResult {
-		const validateConstraints = (
-			constraints: readonly TransactionConstraint[],
+		const addConstraints = (
 			constraintsOnRevert: boolean,
+			constraints: readonly TransactionConstraint[] = [],
 		): void => {
 			for (const constraint of constraints) {
 				switch (constraint.type) {
@@ -276,7 +276,7 @@ export class SchematizingSimpleTreeView<
 		this.checkout.transaction.start();
 
 		// Validate preconditions before running the transaction callback.
-		validateConstraints(params?.preconditions ?? [], false /* constraintsOnRevert */);
+		addConstraints(false /* constraintsOnRevert */, params?.preconditions);
 		const transactionCallbackStatus = transaction();
 		const rollback = transactionCallbackStatus?.rollback;
 		const value = (
@@ -291,9 +291,9 @@ export class SchematizingSimpleTreeView<
 		}
 
 		// Validate preconditions on revert after running the transaction callback and was successful.
-		validateConstraints(
-			transactionCallbackStatus?.preconditionsOnRevert ?? [],
+		addConstraints(
 			true /* constraintsOnRevert */,
+			transactionCallbackStatus?.preconditionsOnRevert,
 		);
 
 		this.checkout.transaction.commit();

--- a/packages/dds/tree/src/shared-tree/transactionTypes.ts
+++ b/packages/dds/tree/src/shared-tree/transactionTypes.ts
@@ -53,11 +53,10 @@ export type TransactionCallbackStatus<TSuccessValue, TFailureValue> = (
 ) & {
 	/**
 	 * An optional list of {@link TransactionConstraint | constraints} that will be checked when the commit corresponding
-	 * to this transaction is reverted.
-	 * If any of the constraints are not met after the transaction callback runs, an error will be thrown. Basically,
-	 * these constraints have to be met after the transaction is applied.
-	 * If any of the constraints are not met when the revert is being applied either locally or on remote clients, the
-	 * revert will be ignored.
+	 * to this transaction is reverted. If any of these constraints are not met when the revert is being applied either
+	 * locally or on remote clients, the revert will be ignored.
+	 * These constraints must also be met at the time they are first introduced. If they are not met after the transaction
+	 * callback returns, then `runTransaction` (which invokes the transaction callback) will throw a `UsageError`.
 	 */
 	preconditionsOnRevert?: readonly TransactionConstraint[];
 };

--- a/packages/dds/tree/src/shared-tree/transactionTypes.ts
+++ b/packages/dds/tree/src/shared-tree/transactionTypes.ts
@@ -37,7 +37,7 @@ export interface NodeInDocumentConstraint {
  * The status of the transaction callback in the {@link RunTransaction | RunTransaction} API.
  * @alpha
  */
-export type TransactionCallbackStatus<TSuccessValue, TFailureValue> =
+export type TransactionCallbackStatus<TSuccessValue, TFailureValue> = (
 	| {
 			/** Indicates that the transaction callback ran successfully. */
 			rollback?: false;
@@ -49,7 +49,18 @@ export type TransactionCallbackStatus<TSuccessValue, TFailureValue> =
 			rollback: true;
 			/** The user defined value when the transaction failed. */
 			value: TFailureValue;
-	  };
+	  }
+) & {
+	/**
+	 * An optional list of {@link TransactionConstraint | constraints} that will be checked when the commit corresponding
+	 * to this transaction is reverted.
+	 * If any of the constraints are not met after the transaction callback runs, an error will be thrown. Basically,
+	 * these constraints have to be met after the transaction is applied.
+	 * If any of the constraints are not met when the revert is being applied either locally or on remote clients, the
+	 * revert will be ignored.
+	 */
+	preconditionsOnRevert?: readonly TransactionConstraint[];
+};
 
 /**
  * The status of a the transaction callback in the {@link RunTransaction | RunTransaction} API where the transaction doesn't
@@ -107,7 +118,7 @@ export type TransactionResult =
 export interface RunTransactionParams {
 	/**
 	 * An optional list of {@link TransactionConstraint | constraints} that are checked just before the transaction begins.
-	 * If any of the constraints are not met when `runTransaction` is called, it will throw an error.
+	 * If any of the constraints are not met when `runTransaction` is called, an error will be thrown.
 	 * If any of the constraints are not met after the transaction has been ordered by the service, it will be rolled back on
 	 * this client and ignored by all other clients.
 	 */

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1085,12 +1085,14 @@ export interface Tagged<V, T extends string = string> {
 export type TelemetryBaseEventPropertyType = string | number | boolean | undefined;
 
 // @alpha
-export type TransactionCallbackStatus<TSuccessValue, TFailureValue> = {
+export type TransactionCallbackStatus<TSuccessValue, TFailureValue> = ({
     rollback?: false;
     value: TSuccessValue;
 } | {
     rollback: true;
     value: TFailureValue;
+}) & {
+    preconditionsOnRevert?: readonly TransactionConstraint[];
 };
 
 // @public


### PR DESCRIPTION
Added support to `view.runTransaction` API to allow transaction authors to specify constraints that should apply to the revert of a changeset. These constraints called `preconditionsOnRevert` should be returned by the transaction callback. An alternative would have been to specify these in the `runTransaction` params. However, transaction authors may need to know the status of the tree when specifying the constraints. For example, the constraint may be applied on a node that is created in the transaction body and so, specifying them beforehand would not be possible or rather, would not be straightforward.

These constraints will be checked and validated after the transaction body has run and if they fail, the `runTransaction` API will throw a usage error. Once the transaction is committed, the constraints will be checked if and when the commit corresponding to the transaction is reverted. If the constraints are violated at that time, the revert will be ignored.
 
[AB#8069](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8069)