### PR TITLE
Added a cluster draining check in the create doc api

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -39,6 +39,8 @@ import {
 	NetworkError,
 	DocDeleteScopeType,
 	TokenRevokeScopeType,
+	createFluidServiceNetworkError,
+	InternalErrorCode,
 } from "@fluidframework/server-services-client";
 import {
 	getLumberBaseProperties,
@@ -256,6 +258,21 @@ export function create(
 		}),
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		async (request, response, next) => {
+			// Reject create document request if cluster is in draining process.
+			if (
+				clusterDrainingChecker &&
+				(await clusterDrainingChecker.isClusterDraining().catch((error) => {
+					Lumberjack.error("Failed to get cluster draining status", undefined, error);
+					return false;
+				}))
+			) {
+				Lumberjack.info("Cluster is in draining process. Reject create document request.");
+				const error = createFluidServiceNetworkError(503, {
+					message: "Server is unavailable. Please retry create document later.",
+					internalErrorCode: InternalErrorCode.ClusterDraining,
+				});
+				handleResponse(Promise.reject(error), response);
+			}
 			// Tenant and document
 			const tenantId = request.params.tenantId;
 			// If enforcing server generated document id, ignore id parameter
@@ -387,6 +404,23 @@ export function create(
 			);
 			// Tracks the different stages of getSessionMetric
 			const connectionTrace = new StageTrace<string>("GetSession");
+			// Reject get session request on existing, inactive sessions if cluster is in draining process.
+			if (
+				clusterDrainingChecker &&
+				(await clusterDrainingChecker.isClusterDraining().catch((error) => {
+					Lumberjack.error("Failed to get cluster draining status", undefined, error);
+					return false;
+				}))
+			) {
+				Lumberjack.info("Cluster is in draining process. Reject get session request.");
+				connectionTrace?.stampStage("ClusterIsDraining");
+				const error = createFluidServiceNetworkError(503, {
+					message: "Server is unavailable. Please retry session discovery later.",
+					internalErrorCode: InternalErrorCode.ClusterDraining,
+				});
+				handleResponse(Promise.reject(error), response);
+			}
+			connectionTrace?.stampStage("ClusterDrainingChecked");
 			const readDocumentRetryDelay: number = config.get("getSession:readDocumentRetryDelay");
 			const readDocumentMaxRetries: number = config.get("getSession:readDocumentMaxRetries");
 

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -388,24 +388,6 @@ export async function getSession(
 	}
 	connectionTrace?.stampStage("SessionLivenessChecked");
 
-	// Reject get session request on existing, inactive sessions if cluster is in draining process.
-	if (clusterDrainingChecker) {
-		try {
-			const isClusterDraining = await clusterDrainingChecker.isClusterDraining();
-			if (isClusterDraining) {
-				Lumberjack.info("Cluster is in draining process. Reject get session request.");
-				connectionTrace?.stampStage("ClusterIsDraining");
-				throw new NetworkError(
-					503,
-					"Server is unavailable. Please retry session discovery later.",
-				);
-			}
-		} catch (error) {
-			Lumberjack.error("Failed to get cluster draining status", lumberjackProperties, error);
-		}
-	}
-	connectionTrace?.stampStage("ClusterDrainingChecked");
-
 	// Session is not alive/discovered, so update and persist changes to DB.
 	const ignoreSessionStickiness = existingSession.ignoreSessionStickiness ?? false;
 

--- a/server/routerlicious/packages/test-utils/src/index.ts
+++ b/server/routerlicious/packages/test-utils/src/index.ts
@@ -24,3 +24,4 @@ export { TestThrottlerHelper } from "./testThrottlerHelper";
 export { TestRedisClientConnectionManager } from "./testRedisClientConnectionManager";
 export { TestReadinessCheck, TestCheck } from "./testReadinessCheck";
 export { TestFluidAccessTokenGenerator } from "./testFluidAccessTokenGenerator";
+export { TestClusterDrainingStatusChecker } from "./testClusterDrainingStatusChecker";

--- a/server/routerlicious/packages/test-utils/src/testClusterDrainingStatusChecker.ts
+++ b/server/routerlicious/packages/test-utils/src/testClusterDrainingStatusChecker.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { IClusterDrainingChecker } from "@fluidframework/server-services-core";
+
+export class TestClusterDrainingStatusChecker implements IClusterDrainingChecker {
+	private clusterDrainingStatus: boolean = false;
+
+	public async isClusterDraining(cluster?: string): Promise<boolean> {
+		return this.clusterDrainingStatus;
+	}
+
+	public setClusterDrainingStatus(status: boolean): void {
+		this.clusterDrainingStatus = status;
+	}
+}


### PR DESCRIPTION
## Description

This PR has two changes:

1) Adds a check to see if the cluster is being drained in the create doc api. If this is the case, then the request is rejected.
2) Fixes a bug in getSession which throws an error in case a getSession request is received and the clsuter is draining.