### PR TITLE
refactor(ci): Pipeline yml cleanup

### DIFF
--- a/tools/pipelines/build-api-markdown-documenter.yml
+++ b/tools/pipelines/build-api-markdown-documenter.yml
@@ -45,6 +45,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 
@@ -68,6 +69,7 @@ pr:
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 

--- a/tools/pipelines/build-api-markdown-documenter.yml
+++ b/tools/pipelines/build-api-markdown-documenter.yml
@@ -78,7 +78,6 @@ variables:
     parameters:
       publishOverride: '${{ parameters.publishOverride }}'
       releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-      buildNumberInPatch: ''
 
 extends:
   template: /tools/pipelines/templates/build-npm-package.yml@self

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -47,6 +47,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 
@@ -68,6 +69,7 @@ pr:
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -78,7 +78,6 @@ variables:
     parameters:
       publishOverride: '${{ parameters.publishOverride }}'
       releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-      buildNumberInPatch: ''
 
 extends:
   template: /tools/pipelines/templates/build-npm-package.yml@self

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -80,7 +80,6 @@ variables:
     parameters:
       publishOverride: '${{ parameters.publishOverride }}'
       releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-      buildNumberInPatch: ''
 
 extends:
   template: /tools/pipelines/templates/build-npm-package.yml@self

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -49,6 +49,7 @@ trigger:
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 
@@ -70,6 +71,7 @@ pr:
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -93,7 +93,6 @@ variables:
     parameters:
       publishOverride: '${{ parameters.publishOverride }}'
       releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-      buildNumberInPatch: ''
 
 extends:
   template: /tools/pipelines/templates/build-npm-package.yml@self

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -61,6 +61,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 
@@ -83,6 +84,7 @@ pr:
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -176,7 +176,6 @@ variables:
     parameters:
       publishOverride: '${{ parameters.publishOverride }}'
       releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-      buildNumberInPatch: ''
 
 extends:
   template: /tools/pipelines/templates/build-npm-package.yml@self

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -110,6 +110,7 @@ trigger:
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
 
 pr:

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -54,6 +54,7 @@ trigger:
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
 
 pr:
@@ -79,6 +80,7 @@ pr:
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
 
 variables:

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -88,7 +88,6 @@ variables:
     parameters:
       publishOverride: '${{ parameters.publishOverride }}'
       releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-      buildNumberInPatch: ''
 
 extends:
   template: /tools/pipelines/templates/build-npm-package.yml@self

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -50,6 +50,7 @@ trigger:
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 
@@ -72,6 +73,7 @@ pr:
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -82,7 +82,6 @@ variables:
     parameters:
       publishOverride: '${{ parameters.publishOverride }}'
       releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-      buildNumberInPatch: ''
 
 extends:
   template: /tools/pipelines/templates/build-npm-package.yml@self

--- a/tools/pipelines/build-eslint-plugin-fluid.yml
+++ b/tools/pipelines/build-eslint-plugin-fluid.yml
@@ -50,6 +50,7 @@ trigger:
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 
@@ -72,6 +73,7 @@ pr:
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 

--- a/tools/pipelines/build-eslint-plugin-fluid.yml
+++ b/tools/pipelines/build-eslint-plugin-fluid.yml
@@ -82,7 +82,6 @@ variables:
     parameters:
       publishOverride: '${{ parameters.publishOverride }}'
       releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-      buildNumberInPatch: ''
 
 extends:
   template: /tools/pipelines/templates/build-npm-package.yml@self

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -89,7 +89,6 @@ variables:
     parameters:
       publishOverride: '${{ parameters.publishOverride }}'
       releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-      buildNumberInPatch: ''
 
 extends:
   template: /tools/pipelines/templates/build-npm-package.yml@self

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -55,6 +55,7 @@ trigger:
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
 
 pr:
@@ -80,6 +81,7 @@ pr:
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
 
 variables:

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -46,6 +46,7 @@ trigger:
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 
@@ -66,6 +67,7 @@ pr:
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
+    - tools/pipelines/templates/include-policy-check.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
     - scripts/*
 

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -76,7 +76,6 @@ variables:
     parameters:
       publishOverride: '${{ parameters.publishOverride }}'
       releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
-      buildNumberInPatch: ''
 
 extends:
   template: /tools/pipelines/templates/build-npm-package.yml@self

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -31,7 +31,7 @@ parameters:
     default: /home/node/server
 
   - name: buildNumberInPatch
-    type: string
+    type: boolean
     default: true
 
   - name: setVersion

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -165,7 +165,6 @@ extends:
       - job: build
         displayName: Build Container - ${{ parameters.containerName }}
         variables:
-          releaseBuildVar: $[variables.releaseBuild]
           hostPathToPackArtifact: $(Build.ArtifactStagingDirectory)/pack
           hostPathToTestResultsArtifact: $(Build.ArtifactStagingDirectory)/${{ parameters.buildDirectory }}/nyc
           hostPathToApiExtractorArtifact: $(Build.ArtifactStagingDirectory)/_api-extractor-temp
@@ -193,7 +192,6 @@ extends:
               # Show all task group conditions
               echo "
               Pipeline Variables:
-                releaseBuild=$(releaseBuildVar)
 
               Tasks Parameters:
                 docs=${{ parameters.docs }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -211,8 +211,6 @@ extends:
             variables:
               - group: ado-feeds
               - group: storage-vars
-              - name: releaseBuildVar
-                value: '$[variables.releaseBuild]'
               - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
                 - name: targetBranchName
                   value: $(System.PullRequest.TargetBranch)
@@ -241,7 +239,6 @@ extends:
 
                     echo "
                     Pipeline Variables:
-                      releaseBuild=$(releaseBuildVar)
 
                     Override Parameters:
                       packageTypesOverride=${{ parameters.packageTypesOverride }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -648,7 +648,7 @@ extends:
 
       # Publish stage
       - ${{ if eq(parameters.publish, true) }}:
-        - template: include-publish-npm-package.yml
+        - template: /tools/pipelines/templates/include-publish-npm-package.yml@self
           parameters:
             tagName: ${{ parameters.tagName }}
             isReleaseGroup: ${{ parameters.isReleaseGroup }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -68,8 +68,8 @@ parameters:
   default: false
 
 - name: buildNumberInPatch
-  type: string
-  default:
+  type: boolean
+  default: false
 
 - name: publishOverride
   type: string
@@ -335,7 +335,7 @@ extends:
                   - template: /tools/pipelines/templates/include-set-package-version.yml@self
                     parameters:
                       buildDirectory: '${{ parameters.buildDirectory }}'
-                      buildNumberInPatch: '${{ parameters.buildNumberInPatch }}'
+                      buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
                       buildToolsVersionToInstall: '${{ parameters.buildToolsVersionToInstall }}'
                       tagName: '${{ parameters.tagName }}'
                       interdependencyRange: '${{ parameters.interdependencyRange }}'

--- a/tools/pipelines/templates/include-install-build-tools.yml
+++ b/tools/pipelines/templates/include-install-build-tools.yml
@@ -24,7 +24,7 @@ steps:
   # These steps should ONLY run if we're using the repo version of the build tools. These steps are mutually exclusive
   # with the next group of steps.
   - ${{ if eq(parameters.buildToolsVersionToInstall, 'repo') }}:
-    - template: include-install-pnpm.yml
+    - template: /tools/pipelines/templates/include-install-pnpm.yml@self
       parameters:
         buildDirectory: $(Build.SourcesDirectory)/build-tools
         pnpmStorePath: ${{ parameters.pnpmStorePath }}

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -15,7 +15,7 @@ parameters:
 
 steps:
   - ${{ if eq(parameters.packageManager, 'pnpm') }}:
-    - template: include-install-pnpm.yml
+    - template: /tools/pipelines/templates/include-install-pnpm.yml@self
       parameters:
         buildDirectory: ${{ parameters.buildDirectory }}
 

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -61,7 +61,7 @@ jobs:
           - download: current
             artifact: pack
           - template: /tools/pipelines/templates/include-use-node-version.yml@self
-          - template: include-install-build-tools.yml
+          - template: /tools/pipelines/templates/include-install-build-tools.yml@self
             parameters:
               buildDirectory: ${{ parameters.buildDirectory }}
               buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -35,7 +35,7 @@ parameters:
 # Set version
 steps:
 
-- template: include-install-build-tools.yml
+- template: /tools/pipelines/templates/include-install-build-tools.yml@self
   parameters:
     buildDirectory: ${{ parameters.buildDirectory }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -5,8 +5,8 @@ parameters:
 - name: buildDirectory
   type: string
 - name: buildNumberInPatch
-  type: string
-  default:
+  type: boolean
+  default: false
 - name: tagName
   type: string
 - name: includeInternalVersions

--- a/tools/pipelines/templates/include-telemetry-setup.yml
+++ b/tools/pipelines/templates/include-telemetry-setup.yml
@@ -35,7 +35,7 @@ steps:
   - checkout: self
     clean: true
 
-- template: include-use-node-version.yml
+- template: /tools/pipelines/templates/include-use-node-version.yml@self
 
 - task: Bash@3
   displayName: Print parameter/variable values for template

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -54,7 +54,7 @@ steps:
         SourceBranch=$(Build.SourceBranch)
       "
 
-- template: include-telemetry-setup.yml
+- template: /tools/pipelines/templates/include-telemetry-setup.yml@self
   parameters:
     devFeedUrl: ${{ parameters.devFeedUrl }}
     officeFeedUrl: ${{ parameters.officeFeedUrl }}

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -210,7 +210,7 @@ stages:
                 artifactBuildId=${{ parameters.artifactBuildId }}
               "
 
-        - template: include-use-node-version.yml
+        - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
         # Download artifact
         - task: DownloadPipelineArtifact@2
@@ -440,7 +440,7 @@ stages:
             continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
 
         # Log Test Failures
-        # - template: include-process-test-results.yml
+        # - template: /tools/pipelines/templates/include-process-test-results.yml@self
         #   parameters:
         #     buildDirectory: ${{ variables.testPackageDir }}
 

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -58,7 +58,6 @@ jobs:
     pool: ${{ parameters.poolBuild }}
     variables:
       testCoverage: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
-      releaseBuildVar: $[variables.releaseBuild]
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     steps:
     # Setup
@@ -79,7 +78,6 @@ jobs:
 
           echo "
           Pipeline Variables:
-            releaseBuild=$(releaseBuildVar)
 
           Tasks Parameters:
             BuildDir=${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -88,15 +88,15 @@ jobs:
             TestCoverage=$(testCoverage)
           "
 
-    - template: include-use-node-version.yml
+    - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
-    - template: include-install.yml
+    - template: /tools/pipelines/templates/include-install.yml@self
       parameters:
         packageManager: ${{ parameters.packageManager }}
         buildDirectory: ${{ parameters.buildDirectory }}
         packageManagerInstallCommand: ${{ parameters.packageManagerInstallCommand }}
 
-    - template: include-build-lint.yml
+    - template: /tools/pipelines/templates/include-build-lint.yml@self
       parameters:
         taskBuild: ${{ parameters.taskBuild }}
         taskLint: ${{ parameters.taskLint }}
@@ -111,7 +111,7 @@ jobs:
         displayName: Start Test
 
       - ${{ each taskTestStep in parameters.taskTest }}:
-        - template: include-test-task.yml
+        - template: /tools/pipelines/templates/include-test-task.yml@self
           parameters:
             taskTestStep: ${{ taskTestStep }}
             buildDirectory: ${{ parameters.buildDirectory }}
@@ -139,6 +139,6 @@ jobs:
           continueOnError: true
 
       # Process test result, include publishing and logging
-      - template: include-process-test-results.yml
+      - template: /tools/pipelines/templates/include-process-test-results.yml@self
         parameters:
           buildDirectory: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -66,8 +66,6 @@ variables:
         eq(variables.shouldPublish, true)
       )
     )}}
-- name: componentDetection
-  value: ${{ variables.publish }}
 - name: pushImage
   value: ${{ variables.publish }}
 - name: releaseImage

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -17,7 +17,8 @@ parameters:
   default: false
 
 - name: buildNumberInPatch
-  type: string
+  type: boolean
+  default: false
 
 variables:
 - group: prague-key-vault


### PR DESCRIPTION
## Description

Cleans up a few things we had noticed in our yml files.

- Some variables (`releaseBuildVar`, `componentDetection`) were not used anymore (if anything only printed, but not used for any functional purpose).
- Some templates were being referenced just by their filenames, where we've tried to move to absolute paths everywhere for clarity and consistency.
- `include-policy-check.yml` was not included as a PR/CI trigger for many build pipelines that depend on `build-npm-package.yml` (which in turn depends on `include-policy-check.yml`).
- Change `buildNumberInPatch` from a string to a boolean, like it could have been from the start, and gave it a default to avoid passing an empty string explicitly in several pipelines. Its value ends up as VERSION_PATCH [here](https://github.com/alexvy86/FluidFramework/blob/2701aab25efab47fe651949800e5149d802b93e2/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts#L42-L45), and that flag [gets checked against `"true"`](https://github.com/alexvy86/FluidFramework/blob/2701aab25efab47fe651949800e5149d802b93e2/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts#L83). So replacing with a boolean should be fine

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#6994](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6994)