### PR TITLE
refactor(build-cli): Make 'flub modify lockfile' support independent package names

### DIFF
--- a/build-tools/packages/build-cli/docs/modify.md
+++ b/build-tools/packages/build-cli/docs/modify.md
@@ -4,7 +4,7 @@
 Modify commands are used to modify projects to add or remove dependencies, update Fluid imports, etc.
 
 * [`flub modify fluid-imports`](#flub-modify-fluid-imports)
-* [`flub modify lockfile`](#flub-modify-lockfile)
+* [`flub modify lockfile PACKAGE_OR_RELEASE_GROUP`](#flub-modify-lockfile-package_or_release_group)
 
 ## `flub modify fluid-imports`
 
@@ -34,21 +34,22 @@ DESCRIPTION
 
 _See code: [src/commands/modify/fluid-imports.ts](https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/src/commands/modify/fluid-imports.ts)_
 
-## `flub modify lockfile`
+## `flub modify lockfile PACKAGE_OR_RELEASE_GROUP`
 
 Updates a dependency in the pnpm lockfile to the latest version of a specified semver range.
 
 ```
 USAGE
-  $ flub modify lockfile -g client|server|azure|build-tools|gitrest|historian --dependencyName <value> --version
-    <value> [--json] [-v | --quiet]
+  $ flub modify lockfile PACKAGE_OR_RELEASE_GROUP --dependencyName <value> --version <value> [--json] [-v | --quiet]
+
+ARGUMENTS
+  PACKAGE_OR_RELEASE_GROUP  [default: client] The name of a package or a release group. Defaults to the client release
+                            group if not specified.
 
 FLAGS
-  -g, --releaseGroup=<option>   (required) Name of a release group.
-                                <options: client|server|azure|build-tools|gitrest|historian>
-      --dependencyName=<value>  (required) Name of the dependency (npm package) to update.
-      --version=<value>         (required) A semver version or range specifier (e.g. ^1.2.3) to use when updating the
-                                dependency.
+  --dependencyName=<value>  (required) Name of the dependency (npm package) to update.
+  --version=<value>         (required) A semver version or range specifier (e.g. ^1.2.3) to use when updating the
+                            dependency.
 
 LOGGING FLAGS
   -v, --verbose  Enable verbose logging.

--- a/build-tools/packages/build-cli/src/commands/modify/lockfile.ts
+++ b/build-tools/packages/build-cli/src/commands/modify/lockfile.ts
@@ -7,7 +7,7 @@ import { updatePackageJsonFile } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
 import execa from "execa";
 
-import { releaseGroupFlag } from "../../flags.js";
+import { findPackageOrReleaseGroup, packageOrReleaseGroupArg } from "../../args.js";
 import { BaseCommand } from "../../library/index.js";
 
 /**
@@ -32,7 +32,6 @@ export default class UpdateDependencyInLockfileCommand extends BaseCommand<
 	static readonly enableJsonFlag = true;
 
 	static readonly flags = {
-		releaseGroup: releaseGroupFlag({ required: true }),
 		dependencyName: Flags.string({
 			description: "Name of the dependency (npm package) to update.",
 			required: true,
@@ -45,20 +44,29 @@ export default class UpdateDependencyInLockfileCommand extends BaseCommand<
 		}),
 	};
 
+	public static readonly args = {
+		package_or_release_group: packageOrReleaseGroupArg({
+			description:
+				"The name of a package or a release group. Defaults to the client release group if not specified.",
+			default: "client",
+		}),
+	} as const;
+
 	public async run(): Promise<void> {
 		const context = await this.getContext();
-		const releaseGroup = context.repo.releaseGroups.get(this.flags.releaseGroup);
 
-		if (releaseGroup === undefined) {
-			// exits the process
-			this.error(`Can't find release group: ${this.flags.releaseGroup}`, { exit: 1 });
+		const rgArg = this.args.package_or_release_group;
+		const pkgOrReleaseGroup = findPackageOrReleaseGroup(rgArg, context);
+		if (pkgOrReleaseGroup === undefined) {
+			this.error(`Can't find package or release group "${rgArg}"`, { exit: 1 });
 		}
+		this.verbose(`Release group or package found: ${pkgOrReleaseGroup.name}`);
 
 		// Add override to package.json
 		this.info(
 			`Adding pnpm override for ${this.flags.dependencyName}: ${this.flags.version} to package.json`,
 		);
-		updatePackageJsonFile(releaseGroup.directory, (json) => {
+		updatePackageJsonFile(pkgOrReleaseGroup.directory, (json) => {
 			if (json.pnpm === undefined) {
 				json.pnpm = {};
 			}
@@ -80,19 +88,19 @@ export default class UpdateDependencyInLockfileCommand extends BaseCommand<
 		// Update lockfile
 		this.info(`Updating lockfile`);
 		await execa(`pnpm`, [`install`, `--no-frozen-lockfile`], {
-			cwd: releaseGroup.directory,
+			cwd: pkgOrReleaseGroup.directory,
 		});
 
 		// Remove override after install
 		this.info(`Restoring package.json to original state`);
 		await execa(`git`, [`restore`, `--source=HEAD`, `package.json`], {
-			cwd: releaseGroup.directory,
+			cwd: pkgOrReleaseGroup.directory,
 		});
 
 		// Install again to remove the override from the lockfile
 		this.info(`Updating lockfile to remove override`);
 		await execa(`pnpm`, [`install`, `--no-frozen-lockfile`], {
-			cwd: releaseGroup.directory,
+			cwd: pkgOrReleaseGroup.directory,
 		});
 	}
 }


### PR DESCRIPTION
## Description

Updates the `flub modify lockfile` command to support independent package names in addition to release group names. It now expects the package/release group as an argument instead of a flag, leveraging the existing `packageOrReleaseGroupArg` used by other flub commands.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Confirmed this works fine by using it locally to update dependency versions in several independent packages.