### PR TITLE
docs(tree): add missing links

### DIFF
--- a/docs/docs/data-structures/tree/index.mdx
+++ b/docs/docs/data-structures/tree/index.mdx
@@ -23,9 +23,9 @@ Provided below are links to more detailed information about `SharedTree` usage a
 	- [Node Types](./node-types.mdx): outlines the specific types that are stored by a `SharedTree`
 - [Schema Definition](./schema-definition.mdx): how the structure of a `SharedTree` is defined
 - [Reading and Editing](./reading-and-editing.mdx): how a `SharedTree` is read and edited through the APIs provided on the different node types
-- [Events]: the various events emitted by a `SharedTree` and what they can be used for
-- [Transactions]: how edits can be grouped into transactions
-- [Undo Redo Support]: how undo redo works on a `SharedTree`
+- [Events](./events.mdx): the various events emitted by a `SharedTree` and what they can be used for
+- [Transactions](./transactions.mdx): how edits can be grouped into transactions
+- [Undo Redo Support](./undo-redo.mdx): how undo redo works on a `SharedTree`
 
 ## API Documentation
 


### PR DESCRIPTION
This adds missing links to the tree's main doc page.