### PR TITLE
Allow for passing client display name used when attributing changes to the current client in the collab session

### DIFF
--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.legacy.alpha.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.legacy.alpha.api.md
@@ -37,6 +37,7 @@ export interface ICacheEntry extends IEntry {
 
 // @alpha (undocumented)
 export interface ICollabSessionOptions {
+    displayName?: string;
     // @deprecated
     forceAccessTokenViaAuthorizationHeader?: boolean;
     // @deprecated

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -83,6 +83,11 @@ export interface ICollabSessionOptions {
 	 * @deprecated Due to security reasons we will be passing the token via Authorization header only.
 	 */
 	forceAccessTokenViaAuthorizationHeader?: boolean;
+	/**
+	 * Value indicating the client display name for current session.
+	 * This name will be used in attribution associated with edits made during session.
+	 */
+	displayName?: string;
 }
 
 /**

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -86,6 +86,8 @@ export interface ICollabSessionOptions {
 	/**
 	 * Value indicating the client display name for current session.
 	 * This name will be used in attribution associated with edits made during session.
+	 * This is optional and used only when collab session is being joined by client acting in app-only mode (i.e. without user context).
+	 * If not specified client display name is extracted from the access token that is used to join session.
 	 */
 	displayName?: string;
 }

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -319,7 +319,7 @@ export class OdspDelayLoadedDeltaStream {
 		options: TokenFetchOptionsEx,
 		isRefreshingJoinSession: boolean,
 		clientId: string | undefined,
-		displayName: string | undefined
+		displayName: string | undefined,
 	): Promise<ISocketStorageDiscovery> {
 		// If this call is to refresh the join session for the current connection but we are already disconnected in
 		// the meantime or disconnected and then reconnected then do not make the call. However, we should not have

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -39,8 +39,8 @@ interface IJoinSessionBody {
  * @param disableJoinSessionRefresh - Whether the caller wants to disable refreshing join session periodically.
  * @param isRefreshingJoinSession - whether call is to refresh the session before expiry.
  * @param displayName - display name used to identify client joining a session.
- * This is optional and used only when collab session is being joined in app-only mode.
- * If not specified app display name is extracted from the access token that is used to join session.
+ * This is optional and used only when collab session is being joined by client acting in app-only mode (i.e. without user context).
+ * If not specified client display name is extracted from the access token that is used to join session.
  */
 export async function fetchJoinSession(
 	urlParts: IOdspUrlParts,

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -53,7 +53,7 @@ export async function fetchJoinSession(
 	options: TokenFetchOptionsEx,
 	disableJoinSessionRefresh: boolean | undefined,
 	isRefreshingJoinSession: boolean,
-	displayName: string | undefined
+	displayName: string | undefined,
 ): Promise<ISocketStorageDiscovery> {
 	const apiRoot = getApiRoot(new URL(urlParts.siteUrl));
 	const url = `${apiRoot}/drives/${urlParts.driveId}/items/${urlParts.itemId}/${path}?ump=1`;
@@ -93,10 +93,10 @@ export async function fetchJoinSession(
 
 			let requestBody: IJoinSessionBody | undefined;
 			if (requestSocketToken) {
-				requestBody = {	...requestBody, requestSocketToken: true };
+				requestBody = { ...requestBody, requestSocketToken: true };
 			}
 			if (displayName) {
-				requestBody = {	...requestBody, displayName };
+				requestBody = { ...requestBody, displayName };
 			}
 			if (requestBody) {
 				postBody += `\r\n${JSON.stringify(requestBody)}\r\n`;

--- a/packages/test/test-drivers/src/odspDriverApi.ts
+++ b/packages/test/test-drivers/src/odspDriverApi.ts
@@ -57,6 +57,7 @@ const odspOpsCaching: OptionsMatrix<IOpsCachingPolicy> = {
 const odspSessionOptions: OptionsMatrix<ICollabSessionOptions> = {
 	unauthenticatedUserDisplayName: [undefined],
 	forceAccessTokenViaAuthorizationHeader: [undefined],
+	displayName: [undefined],
 };
 
 /**


### PR DESCRIPTION
Allow for passing client display name used when attributing changes to the current client in the collab session

[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The sections included below are suggestions for what you may want to include.
Feel free to remove or alter parts of this template that do not offer value for your specific change.

## Description

This change introduces support for overriding the client display name used when attributing changes to the current client in the collab session. This can be used in scenarios where the client display name should be different from the default client display name, for instance, when client is running in app-only context.

This is achieved by adding a new optional property `displayName` to the `ICollabSessionOptions` interface. This interface is passed inside `HostStoragePolicy` which is specified when constructing document service factory. If `displayName` is specified, then it is used when establishing collab session and passed in the body of /joinSession request to Push service. 

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).