### PR TITLE
[bump] test-tools: 2.0.0 => 2.0.1 (patch)

### DIFF
--- a/tools/test-tools/CHANGELOG.md
+++ b/tools/test-tools/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 2.0.1
+
+- Support using `lerna` as a package manager in `assign-test-ports`.
+
 ## 2.0.0
 
 - Dependency updates.

--- a/tools/test-tools/package.json
+++ b/tools/test-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/test-tools",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Fluid test tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
## Description

Bump test-tools from 2.0.0 to 2.0.1 to prepare for release.

Process: `flub bump test-tools -t patch`, added short entry to changelog.