### PR TITLE
Work around mocha node options limitation

### DIFF
--- a/packages/test/mocha-test-setup/mocharc-common.cjs
+++ b/packages/test/mocha-test-setup/mocharc-common.cjs
@@ -50,11 +50,15 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 		"recursive": true,
 		"require": requiredModulePaths,
 		"unhandled-rejections": "strict",
-		// Allow test-only indexes to be imported. Search the FF repo for package.json files with this condition to see example usage.
-		"node-option": "conditions=allow-ff-test-exports",
-		// Performance tests benefit from having access to GC, and memory tests require it.
-		// Exposing it here avoids all packages which do perf testing from having to expose it.
-		"v8-expose-gc": true,
+		"node-option": [
+			// Allow test-only indexes to be imported. Search the FF repo for package.json files with this condition to see example usage.
+			"conditions=allow-ff-test-exports",
+			// Performance tests benefit from having access to GC, and memory tests require it.
+			// Exposing it here avoids all packages which do perf testing from having to expose it.
+			// Node that since "node-option" is explicitly set,
+			// these must be provided here and not via mocha's --v8-expose-gc.
+			"expose-gc",
+		],
 	};
 
 	if (process.env.FLUID_TEST_TIMEOUT !== undefined) {

--- a/packages/test/mocha-test-setup/mocharc-common.cjs
+++ b/packages/test/mocha-test-setup/mocharc-common.cjs
@@ -55,7 +55,7 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 			"conditions=allow-ff-test-exports",
 			// Performance tests benefit from having access to GC, and memory tests require it.
 			// Exposing it here avoids all packages which do perf testing from having to expose it.
-			// Node that since "node-option" is explicitly set,
+			// Note that since "node-option" is explicitly set,
 			// these must be provided here and not via mocha's --v8-expose-gc.
 			"expose-gc",
 		],

--- a/tools/benchmark/.mocharc.cjs
+++ b/tools/benchmark/.mocharc.cjs
@@ -12,5 +12,6 @@ const config = getFluidTestMochaConfig(packageDir);
 // Setting node options prevents mocha's node options from getting use (like --v8-expose-gc)
 // This is done (instead of the workaround by adding stuff to "node-option")
 // so --v8-expose-gc can be tested as that is the documented (in the readme) approach.
+// This is ok as this package does not need the node-options from the default config.
 delete config["node-option"];
 module.exports = config;

--- a/tools/benchmark/.mocharc.cjs
+++ b/tools/benchmark/.mocharc.cjs
@@ -9,4 +9,8 @@ const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mochar
 
 const packageDir = __dirname;
 const config = getFluidTestMochaConfig(packageDir);
+// Setting node options prevents mocha's node options from getting use (like --v8-expose-gc)
+// This is done (instead of the workaround by adding stuff to "node-option")
+// so --v8-expose-gc can be tested as that is the documented (in the readme) approach.
+delete config["node-option"];
 module.exports = config;


### PR DESCRIPTION
## Description

In benchmark, running `pnpm run perf` was failing on a memory test due to `--v8-expose-gc` not working.

Our actual memory tests on other packages work around this by providing a custom mocha config that does:

```javascript
/**
 * Mocha configuration file for memory profiling tests
 */

const baseConfig = require("../../../.mocharc.cjs");

const baseNodeOptions =
	baseConfig["node-option"] !== undefined
		? Array.isArray(baseConfig["node-option"])
			? baseConfig["node-option"]
			: [baseConfig["node-option"]] // If string, wrap as array to use spread operator
		: []; // If undefined, use an empty array

const extendedConfig = {
	...baseConfig,
	"fgrep": ["@Benchmark", "@MemoryUsage"],
	"node-option": [...baseNodeOptions, "unhandled-rejections=strict"], // without leading "--"
	"reporter": "@fluid-tools/benchmark/dist/MochaReporter.js",
	"reporterOptions": ["reportDir=.memoryTestsOutput/"],
};

module.exports = extendedConfig;
```

To fix benchmark, I have removed the use of node-options from its config.
This allows it to test the convention how it is documented in the readme, using `--v8-expose-gc`.

Additionally our base config was updated to remove the no longer working v8-expose-gc and replace it with the working "expose-gc" via `node-option`.

Converting `node-option` to an array will also allow simplifying the memory test mocha configs once integrated into the relevant release groups.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
