### PR TITLE
eslint(test-end-to-end-tests): Prefix test-end-to-end-tests before enabling no-unchecked-record-access

### DIFF
--- a/packages/test/test-end-to-end-tests/src/mocking.ts
+++ b/packages/test/test-end-to-end-tests/src/mocking.ts
@@ -21,7 +21,7 @@ export function wrapObjectAndOverride<T extends Record<string, any>>(
 ): T {
 	return new Proxy(obj, {
 		get: (target: T, property: string, r) => {
-			const override = overrides[property as keyof T];
+			const override = overrides?.[property as keyof T];
 			// check if the current property has an override
 			if (override) {
 				// check if the override is a function, which means it is factory
@@ -35,7 +35,7 @@ export function wrapObjectAndOverride<T extends Record<string, any>>(
 				// it is an object which nests more overrides, so
 				// get the property from the passed in object,
 				// so we can proxy nested overrides to it
-				const real = target[property as keyof T];
+				const real = target?.[property as keyof T];
 				// if the real property is a function, we'll
 				// call it, so whatever it returns can have
 				// the nested overrides applied to it

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
@@ -13,7 +13,11 @@ import {
 	ContainerRuntime,
 	DefaultSummaryConfiguration,
 } from "@fluidframework/container-runtime/internal";
-import { ISummaryBlob, SummaryType } from "@fluidframework/driver-definitions";
+import {
+	ISummaryBlob,
+	SummaryType,
+	type SummaryObject,
+} from "@fluidframework/driver-definitions";
 import { channelsTreeName } from "@fluidframework/runtime-definitions/internal";
 import {
 	ITestContainerConfig,
@@ -83,7 +87,7 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 					summary.tree[".metadata"]?.type === SummaryType.Blob,
 					"Expected .metadata blob in summary root.",
 				);
-				const metadata = readBlobContent(summary.tree[".metadata"].content) as Record<
+				const metadata = readBlobContent(summary.tree[".metadata"]?.content) as Record<
 					string,
 					unknown
 				>;
@@ -96,13 +100,14 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 					"Unexpected metadata blob disableIsolatedChannels",
 				);
 
-				const channelsTree = summary.tree[channelsTreeName];
+				const channelsTree: SummaryObject | undefined = summary.tree[channelsTreeName];
 				assert(
 					channelsTree?.type === SummaryType.Tree,
 					"Expected .channels tree in summary root.",
 				);
 
-				const defaultDataStoreNode = channelsTree.tree[defaultDataStore._context.id];
+				const defaultDataStoreNode: SummaryObject | undefined =
+					channelsTree.tree[defaultDataStore._context.id];
 				assert(
 					defaultDataStoreNode?.type === SummaryType.Tree,
 					"Expected default data store tree in summary.",
@@ -112,9 +117,10 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 					defaultDataStoreNode.tree[".component"]?.type === SummaryType.Blob,
 					"Expected .component blob in default data store summary tree.",
 				);
-				const dataStoreChannelsTree = defaultDataStoreNode.tree[channelsTreeName];
+				const dataStoreChannelsTree: SummaryObject | undefined =
+					defaultDataStoreNode.tree[channelsTreeName];
 				const attributes = readBlobContent(
-					defaultDataStoreNode.tree[".component"].content,
+					defaultDataStoreNode.tree[".component"]?.content,
 				) as Record<string, unknown>;
 				assert(
 					attributes.snapshotFormatVersion === undefined,
@@ -133,7 +139,7 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 					"Expected .channels tree in default data store.",
 				);
 
-				const defaultDdsNode = dataStoreChannelsTree.tree.root;
+				const defaultDdsNode: SummaryObject | undefined = dataStoreChannelsTree.tree.root;
 				assert(
 					defaultDdsNode?.type === SummaryType.Tree,
 					"Expected default root DDS in summary.",

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
@@ -13,7 +13,11 @@ import {
 	ContainerRuntime,
 	DefaultSummaryConfiguration,
 } from "@fluidframework/container-runtime/internal";
-import { ISummaryBlob, SummaryType } from "@fluidframework/driver-definitions";
+import {
+	ISummaryBlob,
+	SummaryType,
+	type SummaryObject,
+} from "@fluidframework/driver-definitions";
 import { channelsTreeName } from "@fluidframework/runtime-definitions/internal";
 import {
 	ITestContainerConfig,
@@ -82,7 +86,7 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 				summary.tree[".metadata"]?.type === SummaryType.Blob,
 				"Expected .metadata blob in summary root.",
 			);
-			const metadata = readBlobContent(summary.tree[".metadata"].content) as Record<
+			const metadata = readBlobContent(summary.tree[".metadata"]?.content) as Record<
 				string,
 				unknown
 			>;
@@ -95,13 +99,14 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 				"Unexpected metadata blob disableIsolatedChannels",
 			);
 
-			const channelsTree = summary.tree[channelsTreeName];
+			const channelsTree: SummaryObject | undefined = summary.tree[channelsTreeName];
 			assert(
 				channelsTree?.type === SummaryType.Tree,
 				"Expected .channels tree in summary root.",
 			);
 
-			const defaultDataStoreNode = channelsTree.tree[defaultDataStore._context.id];
+			const defaultDataStoreNode: SummaryObject | undefined =
+				channelsTree.tree[defaultDataStore._context.id];
 			assert(
 				defaultDataStoreNode?.type === SummaryType.Tree,
 				"Expected default data store tree in summary.",
@@ -111,9 +116,10 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 				defaultDataStoreNode.tree[".component"]?.type === SummaryType.Blob,
 				"Expected .component blob in default data store summary tree.",
 			);
-			const dataStoreChannelsTree = defaultDataStoreNode.tree[channelsTreeName];
+			const dataStoreChannelsTree: SummaryObject | undefined =
+				defaultDataStoreNode.tree[channelsTreeName];
 			const attributes = readBlobContent(
-				defaultDataStoreNode.tree[".component"].content,
+				defaultDataStoreNode.tree[".component"]?.content,
 			) as Record<string, unknown>;
 			assert(
 				attributes.snapshotFormatVersion === undefined,
@@ -132,7 +138,7 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 				"Expected .channels tree in default data store.",
 			);
 
-			const defaultDdsNode = dataStoreChannelsTree.tree.root;
+			const defaultDdsNode: SummaryObject | undefined = dataStoreChannelsTree.tree.root;
 			assert(
 				defaultDdsNode?.type === SummaryType.Tree,
 				"Expected default root DDS in summary.",

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -15,7 +15,11 @@ import type {
 	IFluidHandle,
 } from "@fluidframework/core-interfaces";
 import { SummaryType } from "@fluidframework/driver-definitions";
-import type { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
+import type {
+	ISnapshot,
+	ISnapshotTree,
+	SummaryObject,
+} from "@fluidframework/driver-definitions/internal";
 import { getSnapshotTree } from "@fluidframework/driver-utils/internal";
 import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
 import {
@@ -263,10 +267,10 @@ describeCompat(
 			);
 			await provider.ensureSynchronized();
 			const { summaryVersion, summaryTree } = await summarizeNow(summarizer);
-			const channelsTree = summaryTree.tree[".channels"];
+			const channelsTree: SummaryObject | undefined = summaryTree.tree[".channels"];
 			assert(channelsTree.type === SummaryType.Tree, "channels should be a tree");
-			const dataObjectTreeA = channelsTree.tree[dataObjectA.id];
-			const dataObjectTreeB = channelsTree.tree[dataObjectB.id];
+			const dataObjectTreeA: SummaryObject | undefined = channelsTree.tree[dataObjectA.id];
+			const dataObjectTreeB: SummaryObject | undefined = channelsTree.tree[dataObjectB.id];
 			assert(dataObjectTreeA !== undefined, "dataObjectTree should exist");
 			assert(dataObjectTreeA.type === SummaryType.Tree, "dataObjectTree should be a tree");
 			assert(
@@ -345,10 +349,10 @@ describeCompat(
 			);
 			await provider.ensureSynchronized();
 			const { summaryVersion, summaryTree } = await summarizeNow(summarizer);
-			const channelsTree = summaryTree.tree[".channels"];
+			const channelsTree: SummaryObject | undefined = summaryTree.tree[".channels"];
 			assert(channelsTree.type === SummaryType.Tree, "channels should be a tree");
-			const dataObjectTreeA = channelsTree.tree[dataObjectA.id];
-			const dataObjectTreeB = channelsTree.tree[dataObjectB.id];
+			const dataObjectTreeA: SummaryObject | undefined = channelsTree.tree[dataObjectA.id];
+			const dataObjectTreeB: SummaryObject | undefined = channelsTree.tree[dataObjectB.id];
 			assert(dataObjectTreeA !== undefined, "dataObjectTree should exist");
 			assert(dataObjectTreeA.type === SummaryType.Tree, "dataObjectTree should be a tree");
 			assert(
@@ -514,12 +518,13 @@ describeCompat(
 
 				const blobContents = loadingSnapshot.blobContents;
 				// Snapshot validation (a snapshot call with NO loadingGroupIds)
-				const channelsTree = loadingSnapshot.snapshotTree.trees[".channels"];
-				const mainObjectTree = channelsTree.trees[mainObject.id];
-				const dataObjectATree = channelsTree.trees[dataObjectA.id];
-				const dataObjectBTree = channelsTree.trees[dataObjectB.id];
-				const dataObjectCTree = channelsTree.trees[dataObjectC.id];
-				const dataObjectDTree = channelsTree.trees[dataObjectD.id];
+				const channelsTree: ISnapshotTree | undefined =
+					loadingSnapshot.snapshotTree.trees[".channels"];
+				const mainObjectTree: ISnapshotTree | undefined = channelsTree.trees[mainObject.id];
+				const dataObjectATree: ISnapshotTree | undefined = channelsTree.trees[dataObjectA.id];
+				const dataObjectBTree: ISnapshotTree | undefined = channelsTree.trees[dataObjectB.id];
+				const dataObjectCTree: ISnapshotTree | undefined = channelsTree.trees[dataObjectC.id];
+				const dataObjectDTree: ISnapshotTree | undefined = channelsTree.trees[dataObjectD.id];
 
 				assertPopulatedTree(mainObjectTree, noId, blobContents, "mainObject tree not right");
 				assertOmittedBlobContents(
@@ -641,12 +646,17 @@ describeCompat(
 				);
 
 				// Snapshot validation (a snapshot call for loadingGroupIds = [loadingGroupId])
-				const channelsTree2 = groupSnapshot.snapshotTree.trees[".channels"];
-				const mainObjectTree2 = channelsTree2.trees[mainObject.id];
-				const dataObjectATree2 = channelsTree2.trees[dataObjectA.id];
-				const dataObjectBTree2 = channelsTree2.trees[dataObjectB.id];
-				const dataObjectCTree2 = channelsTree2.trees[dataObjectC.id];
-				const dataObjectDTree2 = channelsTree2.trees[dataObjectD.id];
+				const channelsTree2: ISnapshotTree | undefined =
+					groupSnapshot.snapshotTree.trees[".channels"];
+				const mainObjectTree2: ISnapshotTree | undefined = channelsTree2.trees[mainObject.id];
+				const dataObjectATree2: ISnapshotTree | undefined =
+					channelsTree2.trees[dataObjectA.id];
+				const dataObjectBTree2: ISnapshotTree | undefined =
+					channelsTree2.trees[dataObjectB.id];
+				const dataObjectCTree2: ISnapshotTree | undefined =
+					channelsTree2.trees[dataObjectC.id];
+				const dataObjectDTree2: ISnapshotTree | undefined =
+					channelsTree2.trees[dataObjectD.id];
 
 				assertOmittedTree(mainObjectTree2, noId, blobContents, "mainObject tree incorrect");
 				assertPopulatedTree(
@@ -690,12 +700,18 @@ describeCompat(
 				assert(group2Snapshot !== undefined, "should have captured group2 snapshot!");
 				const blobContents = group2Snapshot.blobContents;
 				assert.deepEqual(group2Snapshot.sequenceNumber, summaryRefSeq, "Unexpected snapshot");
-				const channels2Tree2 = group2Snapshot.snapshotTree.trees[".channels"];
-				const mainObject2Tree2 = channels2Tree2.trees[mainObject.id];
-				const dataObjectA2Tree2 = channels2Tree2.trees[dataObjectA.id];
-				const dataObjectB2Tree2 = channels2Tree2.trees[dataObjectB.id];
-				const dataObjectC2Tree2 = channels2Tree2.trees[dataObjectC.id];
-				const dataObjectD2Tree2 = channels2Tree2.trees[dataObjectD.id];
+				const channels2Tree2: ISnapshotTree | undefined =
+					group2Snapshot.snapshotTree.trees[".channels"];
+				const mainObject2Tree2: ISnapshotTree | undefined =
+					channels2Tree2.trees[mainObject.id];
+				const dataObjectA2Tree2: ISnapshotTree | undefined =
+					channels2Tree2.trees[dataObjectA.id];
+				const dataObjectB2Tree2: ISnapshotTree | undefined =
+					channels2Tree2.trees[dataObjectB.id];
+				const dataObjectC2Tree2: ISnapshotTree | undefined =
+					channels2Tree2.trees[dataObjectC.id];
+				const dataObjectD2Tree2: ISnapshotTree | undefined =
+					channels2Tree2.trees[dataObjectD.id];
 
 				assertOmittedTree(
 					mainObject2Tree2,

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/loadNewerGroupIdSnapshot.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/loadNewerGroupIdSnapshot.spec.ts
@@ -235,7 +235,7 @@ describeCompat(
 			if (isGroupIdLoaderVersion(apis.loader.version)) {
 				const groupSnapshot = await snapshotADeferred.promise;
 				const snapshotTreeA =
-					groupSnapshot.snapshotTree.trees[".channels"].trees[dataObjectA2.id];
+					groupSnapshot.snapshotTree.trees[".channels"]?.trees[dataObjectA2.id];
 				assertPopulatedGroupIdTree(
 					snapshotTreeA,
 					groupSnapshot.blobContents,

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -138,7 +138,7 @@ describeCompat(
 			SparseMatrix,
 		} = apis.dds;
 		function assertSubtree(tree: ISnapshotTree, key: string, msg?: string): ISnapshotTree {
-			const subTree = tree.trees[key];
+			const subTree: ISnapshotTree | undefined = tree.trees[key];
 			assert(subTree, msg ?? `${key} subtree not present`);
 			return subTree;
 		}
@@ -162,9 +162,9 @@ describeCompat(
 			blobs: ISerializableBlobContents,
 			key: string,
 		): T {
-			const id = subtree.blobs[key];
+			const id: string | undefined = subtree.blobs[key];
 			assert(id, `blob id for ${key} missing`);
-			const contents = blobs[id];
+			const contents: string | undefined = blobs[id];
 
 			assert(contents, `blob contents for ${key} missing`);
 			return JSON.parse(contents) as T;
@@ -318,7 +318,7 @@ describeCompat(
 				);
 
 				// Check blobs contents for protocolAttributes
-				const protocolAttributesBlobId = baseSnapshot.trees[".protocol"].blobs.attributes;
+				const protocolAttributesBlobId = baseSnapshot.trees[".protocol"]?.blobs.attributes;
 				assert(
 					snapshotBlobs[protocolAttributesBlobId] !== undefined,
 					"Blobs should contain attributes blob",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDataVirtualization.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDataVirtualization.spec.ts
@@ -13,7 +13,11 @@ import {
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
 import type { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
-import type { ISnapshot } from "@fluidframework/driver-definitions/internal";
+import type {
+	ISnapshot,
+	ISnapshotTree,
+	SummaryObject,
+} from "@fluidframework/driver-definitions/internal";
 import {
 	createSummarizer,
 	ITestContainerConfig,
@@ -83,10 +87,10 @@ describeCompat("GC & Data Virtualization", "NoCompat", (getTestObjectProvider) =
 	};
 
 	function getDataStoreInSummaryTree(summaryTree: ISummaryTree, dataStoreId: string) {
-		const channelsTree = summaryTree.tree[".channels"];
+		const channelsTree: SummaryObject | undefined = summaryTree.tree[".channels"];
 		assert(channelsTree !== undefined, "Expected a .channels tree");
 		assert(channelsTree.type === SummaryType.Tree, "Expected a tree");
-		return channelsTree.tree[dataStoreId];
+		return channelsTree.tree?.[dataStoreId];
 	}
 
 	async function isDataStoreInSummaryTree(summaryTree: ISummaryTree, dataStoreId: string) {
@@ -164,7 +168,7 @@ describeCompat("GC & Data Virtualization", "NoCompat", (getTestObjectProvider) =
 		assert(callCount === 0, "Expected no snapshot call");
 		const gcState = getGCStateFromSummary(summaryTree);
 		assert(gcState !== undefined, "Expected GC state to be generated");
-		const gcNodeA = gcState.gcNodes[handleA.absolutePath];
+		const gcNodeA = gcState.gcNodes?.[handleA.absolutePath];
 		assert(gcNodeA !== undefined, "Data Store should exist on gc graph");
 		const unreferencedTimestampMs = gcNodeA.unreferencedTimestampMs;
 		assert(unreferencedTimestampMs !== undefined, "Data Store should be unreferenced");
@@ -197,8 +201,8 @@ describeCompat("GC & Data Virtualization", "NoCompat", (getTestObjectProvider) =
 		assert(snapshotCaptured !== undefined, "Expected snapshot to be captured");
 
 		// Validate that we loaded the snapshot without datastoreA on the snapshot
-		const tree = (snapshotCaptured as ISnapshot).snapshotTree.trees[".channels"].trees;
-		const datastoreATree = tree[dataStoreId];
+		const tree = (snapshotCaptured as ISnapshot).snapshotTree.trees[".channels"]?.trees;
+		const datastoreATree: ISnapshotTree | undefined = tree[dataStoreId];
 		assert(datastoreATree !== undefined, "DataStoreA should be in the snapshot");
 
 		// Summarize and verify datastoreA is still unreferenced
@@ -210,7 +214,7 @@ describeCompat("GC & Data Virtualization", "NoCompat", (getTestObjectProvider) =
 		assert(callCount === 0, "Expected no snapshot call");
 		const gcState2 = getGCStateFromSummary(summaryTree2);
 		assert(gcState2 !== undefined, "Expected GC state to be generated");
-		const gcNodeA2 = gcState2.gcNodes[handleA.absolutePath];
+		const gcNodeA2 = gcState2.gcNodes?.[handleA.absolutePath];
 		assert(gcNodeA2 !== undefined, "DataStoreA should exist on gc graph");
 		assert(
 			gcNodeA2.unreferencedTimestampMs === unreferencedTimestampMs,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -70,7 +70,7 @@ describeCompat("GC Data Store Aliased Full Compat", "FullCompat", (getTestObject
 		const gcStatePreAlias = getGCStateFromSummary(summaryWithStats.summary);
 		assert(gcStatePreAlias !== undefined, "Should get gc pre state from summary!");
 		assert(
-			gcStatePreAlias.gcNodes[toFluidHandleInternal(dataObject2.handle).absolutePath]
+			gcStatePreAlias.gcNodes?.[toFluidHandleInternal(dataObject2.handle).absolutePath]
 				.unreferencedTimestampMs !== undefined,
 			"dataStore2 should be unreferenced as it is not aliased and not root!",
 		);
@@ -95,7 +95,7 @@ describeCompat("GC Data Store Aliased Full Compat", "FullCompat", (getTestObject
 		const gcStatePostAlias = getGCStateFromSummary(summaryWithStats.summary);
 		assert(gcStatePostAlias !== undefined, "Should get gc post state from summary!");
 		assert(
-			gcStatePostAlias.gcNodes[toFluidHandleInternal(dataObject2.handle).absolutePath]
+			gcStatePostAlias.gcNodes?.[toFluidHandleInternal(dataObject2.handle).absolutePath]
 				.unreferencedTimestampMs === undefined,
 			"dataStore2 should be referenced as it is aliased and thus a root datastore!",
 		);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
@@ -14,7 +14,11 @@ import { IContainer } from "@fluidframework/container-definitions/internal";
 import { ISummarizer } from "@fluidframework/container-runtime/internal";
 // eslint-disable-next-line import/no-internal-modules
 import { IGarbageCollectionState } from "@fluidframework/container-runtime/internal/test/gc";
-import { ISummaryBlob, SummaryType } from "@fluidframework/driver-definitions";
+import {
+	ISummaryBlob,
+	SummaryType,
+	type SummaryObject,
+} from "@fluidframework/driver-definitions";
 import { gcBlobPrefix, gcTreeKey } from "@fluidframework/runtime-definitions/internal";
 import {
 	ITestObjectProvider,
@@ -65,7 +69,7 @@ describeCompat("GC Data Store Duplicates", "NoCompat", (getTestObjectProvider, a
 			summaryResult.summaryVersion,
 		);
 		summaryResult = await waitForSummary(summarizer2);
-		const gcObject = summaryResult.summaryTree.tree[gcTreeKey];
+		const gcObject: SummaryObject | undefined = summaryResult.summaryTree.tree[gcTreeKey];
 		assert(gcObject !== undefined, "Expected a gc blob!");
 		assert(gcObject.type === SummaryType.Handle, "Expected a handle!");
 		assert(gcObject.handleType === SummaryType.Tree, "Expected a gc tree handle!");
@@ -96,7 +100,7 @@ describeCompat("GC Data Store Duplicates", "NoCompat", (getTestObjectProvider, a
 
 		// Get GC State
 		summaryResult = await waitForSummary(summarizer2);
-		const gcTree = summaryResult.summaryTree.tree[gcTreeKey];
+		const gcTree: SummaryObject | undefined = summaryResult.summaryTree.tree[gcTreeKey];
 		assert(gcTree?.type === SummaryType.Tree, "Expected a Tree!");
 		const gcBlob = gcTree.tree[`${gcBlobPrefix}_root`] as ISummaryBlob;
 		const gcState = JSON.parse(gcBlob.content as string) as IGarbageCollectionState;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
@@ -13,7 +13,11 @@ import {
 } from "@fluid-private/test-version-utils";
 import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
-import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
+import {
+	ISummaryTree,
+	SummaryType,
+	type SummaryObject,
+} from "@fluidframework/driver-definitions";
 import { channelsTreeName } from "@fluidframework/runtime-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import {
@@ -368,7 +372,7 @@ async function validateBlobsReferenceState(
 	}
 
 	if (!blobFound) {
-		const redirectTable = blobsTree[".redirectTable"];
+		const redirectTable: SummaryObject | undefined = blobsTree[".redirectTable"];
 		assert(redirectTable.type === SummaryType.Blob);
 		assert(typeof redirectTable.content === "string");
 		blobFound = redirectTable.content.indexOf(blobId) > 0;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -80,7 +80,7 @@ function validateBlobStateInSummary(
 
 	if (expectGCStateHandle) {
 		assert.equal(
-			summaryTree.tree[gcTreeKey].type,
+			summaryTree.tree[gcTreeKey]?.type,
 			SummaryType.Handle,
 			"Expecting the GC tree to be handle",
 		);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -85,7 +85,7 @@ function validateDataStoreStateInSummary(
 
 	if (expectGCStateHandle) {
 		assert.equal(
-			summaryTree.tree[gcTreeKey].type,
+			summaryTree.tree[gcTreeKey]?.type,
 			SummaryType.Handle,
 			"Expecting the GC tree to be handle",
 		);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
@@ -13,7 +13,11 @@ import {
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import { IGCRuntimeOptions } from "@fluidframework/container-runtime/internal";
 import { delay } from "@fluidframework/core-utils/internal";
-import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
+import {
+	ISummaryTree,
+	SummaryType,
+	type SummaryObject,
+} from "@fluidframework/driver-definitions";
 import { gcTreeKey } from "@fluidframework/runtime-definitions/internal";
 import { toFluidHandleInternal } from "@fluidframework/runtime-utils/internal";
 import {
@@ -132,7 +136,7 @@ describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
 			"Data Store should exist on gc graph",
 		);
 		assert(
-			gcState.gcNodes[dataStoreHandle.absolutePath].unreferencedTimestampMs !== undefined,
+			gcState.gcNodes[dataStoreHandle.absolutePath]?.unreferencedTimestampMs !== undefined,
 			"Data Store should be unreferenced",
 		);
 		let tombstoneState = getGCTombstoneStateFromSummary(summaryTree);
@@ -153,7 +157,7 @@ describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
 		summaryTree = (await summarizeNow(summarizer)).summaryTree;
 		// GC state is a handle meaning it is the same as before, meaning nothing is tombstoned.
 		assert.equal(
-			summaryTree.tree[gcTreeKey].type,
+			summaryTree.tree[gcTreeKey]?.type,
 			SummaryType.Handle,
 			"GC tree should not have changed (indicated by incremental summary using the SummaryType.Handle)",
 		);
@@ -167,7 +171,7 @@ describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
 		await provider.ensureSynchronized();
 		summaryTree = (await summarizeNow(summarizer)).summaryTree;
 
-		const rootGCTree = summaryTree.tree[gcTreeKey];
+		const rootGCTree: SummaryObject | undefined = summaryTree.tree[gcTreeKey];
 		assert.equal(rootGCTree?.type, SummaryType.Tree, "GC data should be a tree");
 		tombstoneState = getGCTombstoneStateFromSummary(summaryTree);
 		// After tombstoneTimeoutMs the object should be tombstoned.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTestSummaryUtils.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTestSummaryUtils.ts
@@ -15,7 +15,11 @@ import {
 	IFluidHandleContext,
 	type IFluidHandleInternal,
 } from "@fluidframework/core-interfaces/internal";
-import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
+import {
+	ISummaryTree,
+	SummaryType,
+	type SummaryObject,
+} from "@fluidframework/driver-definitions";
 import {
 	gcBlobPrefix,
 	gcDeletedBlobKey,
@@ -34,7 +38,7 @@ import { waitForContainerConnection } from "@fluidframework/test-utils/internal"
 export function getGCStateFromSummary(
 	summaryTree: ISummaryTree,
 ): IGarbageCollectionState | undefined {
-	const rootGCTree = summaryTree.tree[gcTreeKey];
+	const rootGCTree: SummaryObject | undefined = summaryTree.tree[gcTreeKey];
 	if (rootGCTree === undefined) {
 		return undefined;
 	}
@@ -51,7 +55,7 @@ export function getGCStateFromSummary(
 			continue;
 		}
 
-		const gcBlob = rootGCTree.tree[key];
+		const gcBlob: SummaryObject | undefined = rootGCTree.tree[key];
 		assert(gcBlob !== undefined, "getGCStateFromSummary: GC state not available");
 		assert.equal(
 			gcBlob.type,
@@ -71,7 +75,7 @@ export function getGCStateFromSummary(
  * values for gcFeature.
  */
 export function getGCFeatureFromSummary(summaryTree: ISummaryTree): number {
-	const metadata = summaryTree.tree[".metadata"];
+	const metadata: SummaryObject | undefined = summaryTree.tree[".metadata"];
 	assert.equal(metadata.type, SummaryType.Blob, "Expected to find metadata blob in summary");
 	assert(typeof metadata.content === "string", "Expected metadata to be a string");
 	const content = JSON.parse(metadata.content) as { gcFeature: number };
@@ -87,7 +91,7 @@ export function getGCFeatureFromSummary(summaryTree: ISummaryTree): number {
 export function getGCTombstoneStateFromSummary(
 	summaryTree: ISummaryTree,
 ): string[] | undefined {
-	const rootGCTree = summaryTree.tree[gcTreeKey];
+	const rootGCTree: SummaryObject | undefined = summaryTree.tree[gcTreeKey];
 	if (rootGCTree === undefined) {
 		return undefined;
 	}
@@ -97,7 +101,7 @@ export function getGCTombstoneStateFromSummary(
 		SummaryType.Tree,
 		"getGCTombstoneStateFromSummary: GC data should be a tree",
 	);
-	const tombstoneBlob = rootGCTree.tree[gcTombstoneBlobKey];
+	const tombstoneBlob: SummaryObject | undefined = rootGCTree.tree[gcTombstoneBlobKey];
 	if (tombstoneBlob === undefined) {
 		return undefined;
 	}
@@ -117,7 +121,7 @@ export function getGCTombstoneStateFromSummary(
  * @returns The sweep data if it exists, undefined otherwise.
  */
 export function getGCDeletedStateFromSummary(summaryTree: ISummaryTree): string[] | undefined {
-	const rootGCTree = summaryTree.tree[gcTreeKey];
+	const rootGCTree: SummaryObject | undefined = summaryTree.tree[gcTreeKey];
 	if (rootGCTree === undefined) {
 		return undefined;
 	}
@@ -127,7 +131,7 @@ export function getGCDeletedStateFromSummary(summaryTree: ISummaryTree): string[
 		SummaryType.Tree,
 		"getGCDeletedStateFromSummary: GC data should be a tree",
 	);
-	const sweepBlob = rootGCTree.tree[gcDeletedBlobKey];
+	const sweepBlob: SummaryObject | undefined = rootGCTree.tree[gcDeletedBlobKey];
 	if (sweepBlob === undefined) {
 		return undefined;
 	}

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
@@ -11,6 +11,8 @@ import {
 	describeCompat,
 } from "@fluid-private/test-version-utils";
 import { IGCRuntimeOptions } from "@fluidframework/container-runtime/internal";
+// eslint-disable-next-line import/no-internal-modules
+import type { IGarbageCollectionNodeData } from "@fluidframework/container-runtime/internal/test/gc";
 import { delay } from "@fluidframework/core-utils/internal";
 import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
 import { channelsTreeName, gcTreeKey } from "@fluidframework/runtime-definitions/internal";
@@ -106,7 +108,7 @@ describeCompat("GC trailing ops tests", "NoCompat", (getTestObjectProvider) => {
 			// If expecting the GC state to be a handle, validate that and return.
 			if (expectGCStateHandle) {
 				assert.equal(
-					summaryTree.tree[gcTreeKey].type,
+					summaryTree.tree[gcTreeKey]?.type,
 					SummaryType.Handle,
 					"Expecting the GC tree to be handle",
 				);
@@ -116,7 +118,8 @@ describeCompat("GC trailing ops tests", "NoCompat", (getTestObjectProvider) => {
 			// Validate that the GC state does contains an entry for the data store.
 			const gcState = getGCStateFromSummary(summaryTree);
 			assert(gcState !== undefined, "GC tree is not available in the summary");
-			const dataStoreGCData = gcState.gcNodes[dataStoreNodePath];
+			const dataStoreGCData: IGarbageCollectionNodeData | undefined =
+				gcState.gcNodes[dataStoreNodePath];
 			assert(
 				dataStoreGCData !== undefined,
 				`Data store ${dataStoreNodePath} should be present in GC state`,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
@@ -19,6 +19,7 @@ import { SummaryType } from "@fluidframework/driver-definitions";
 import {
 	type ISummaryContext,
 	type ISummaryTree,
+	type SummaryObject,
 } from "@fluidframework/driver-definitions/internal";
 import { gcTreeKey } from "@fluidframework/runtime-definitions/internal";
 import {
@@ -55,7 +56,7 @@ describeCompat(
 		async function submitSummaryAndValidateState(summarizer: ISummarizer, isHandle: boolean) {
 			await provider.ensureSynchronized();
 			const { summaryTree, summaryVersion } = await summarizeNow(summarizer);
-			const gcObject = summaryTree.tree[gcTreeKey];
+			const gcObject: SummaryObject | undefined = summaryTree.tree[gcTreeKey];
 
 			if (isHandle) {
 				assert(gcObject.type === SummaryType.Handle, "Expected a gc handle!");
@@ -127,8 +128,8 @@ describeCompat(
 				summarizer2,
 				true /* isHandle */,
 			);
-			const tree1 = summaryResult1.summaryTree.tree[gcTreeKey];
-			const tree2 = summaryResult2.summaryTree.tree[gcTreeKey];
+			const tree1: SummaryObject | undefined = summaryResult1.summaryTree.tree[gcTreeKey];
+			const tree2: SummaryObject | undefined = summaryResult2.summaryTree.tree[gcTreeKey];
 			assert.deepEqual(
 				tree1,
 				tree2,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -118,7 +118,7 @@ describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, 
 			await provider.ensureSynchronized();
 			const summaryResult3 = await summarizeNow(summarizer);
 			assert.strictEqual(
-				summaryResult3.summaryTree.tree[gcTreeKey].type,
+				summaryResult3.summaryTree.tree[gcTreeKey]?.type,
 				SummaryType.Handle,
 				"GC state should be a handle",
 			);
@@ -171,7 +171,7 @@ describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, 
 			await provider.ensureSynchronized();
 			const summaryResult3 = await summarizeNow(summarizer);
 			assert.strictEqual(
-				summaryResult3.summaryTree.tree[gcTreeKey].type,
+				summaryResult3.summaryTree.tree[gcTreeKey]?.type,
 				SummaryType.Handle,
 				"GC state should be a handle",
 			);
@@ -241,7 +241,7 @@ describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, 
 			await provider.ensureSynchronized();
 			const summaryResult3 = await summarizeNow(summarizer2);
 			assert.strictEqual(
-				summaryResult3.summaryTree.tree[gcTreeKey].type,
+				summaryResult3.summaryTree.tree[gcTreeKey]?.type,
 				SummaryType.Handle,
 				"GC state should be a handle",
 			);

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -28,7 +28,10 @@ import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import { delay } from "@fluidframework/core-utils/internal";
 import type { IChannel } from "@fluidframework/datastore-definitions/internal";
 import { ISummaryTree } from "@fluidframework/driver-definitions";
-import { type ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import {
+	type ISequencedDocumentMessage,
+	type SummaryObject,
+} from "@fluidframework/driver-definitions/internal";
 import {
 	IIdCompressor,
 	SessionSpaceCompressedId,
@@ -839,7 +842,7 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 		sessionCount: number;
 		clusterCount: number;
 	} {
-		const compressorSummary = summaryTree.tree[".idCompressor"];
+		const compressorSummary: SummaryObject | undefined = summaryTree.tree[".idCompressor"];
 		assert(compressorSummary !== undefined, "IdCompressor should be present in summary");
 		const base64Content = (compressorSummary as any).content as string;
 		const floatView = new Float64Array(stringToBuffer(base64Content, "base64"));

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
@@ -19,7 +19,10 @@ import {
 	type ISummarizer,
 } from "@fluidframework/container-runtime/internal";
 import { ISummaryBlob, ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
-import { ISummaryContext } from "@fluidframework/driver-definitions/internal";
+import {
+	ISummaryContext,
+	type SummaryObject,
+} from "@fluidframework/driver-definitions/internal";
 import {
 	FlushMode,
 	IFluidDataStoreFactory,
@@ -233,7 +236,7 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 			summary.tree[".metadata"]?.type === SummaryType.Blob,
 			"Expected .metadata blob in summary root.",
 		);
-		const metadata = readBlobContent(summary.tree[".metadata"].content) as Record<
+		const metadata = readBlobContent(summary.tree[".metadata"]?.content) as Record<
 			string,
 			unknown
 		>;
@@ -246,13 +249,14 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 			"Unexpected metadata blob disableIsolatedChannels",
 		);
 
-		const channelsTree = summary.tree[channelsTreeName];
+		const channelsTree: SummaryObject | undefined = summary.tree[channelsTreeName];
 		assert(
 			channelsTree?.type === SummaryType.Tree,
 			"Expected .channels tree in summary root.",
 		);
 
-		const defaultDataStoreNode = channelsTree.tree[defaultDataStore._context.id];
+		const defaultDataStoreNode: SummaryObject | undefined =
+			channelsTree.tree[defaultDataStore._context.id];
 		assert(
 			defaultDataStoreNode?.type === SummaryType.Tree,
 			"Expected default data store tree in summary.",
@@ -262,9 +266,10 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 			defaultDataStoreNode.tree[".component"]?.type === SummaryType.Blob,
 			"Expected .component blob in default data store summary tree.",
 		);
-		const dataStoreChannelsTree = defaultDataStoreNode.tree[channelsTreeName];
+		const dataStoreChannelsTree: SummaryObject | undefined =
+			defaultDataStoreNode.tree[channelsTreeName];
 		const attributes = readBlobContent(
-			defaultDataStoreNode.tree[".component"].content,
+			defaultDataStoreNode.tree[".component"]?.content,
 		) as Record<string, unknown>;
 		assert(
 			attributes.snapshotFormatVersion === undefined,
@@ -283,7 +288,7 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 			"Expected .channels tree in default data store.",
 		);
 
-		const defaultDdsNode = dataStoreChannelsTree.tree.root;
+		const defaultDdsNode: SummaryObject | undefined = dataStoreChannelsTree.tree.root;
 		assert(defaultDdsNode?.type === SummaryType.Tree, "Expected default root DDS in summary.");
 		assert(!defaultDdsNode.unreferenced, "Default root DDS should be referenced.");
 		assert(

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementally.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementally.spec.ts
@@ -12,7 +12,11 @@ import {
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import { ISummarizer } from "@fluidframework/container-runtime/internal";
-import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
+import {
+	ISummaryTree,
+	SummaryType,
+	type SummaryObject,
+} from "@fluidframework/driver-definitions";
 import {
 	IContainerRuntimeBase,
 	channelsTreeName,
@@ -37,7 +41,7 @@ function validateDataStoreStateInSummary(
 	expectHandle: boolean,
 ) {
 	const channelsTree = (summaryTree.tree[channelsTreeName] as ISummaryTree).tree;
-	const dataStoreSummaryObject = channelsTree[dataStoreId];
+	const dataStoreSummaryObject: SummaryObject | undefined = channelsTree[dataStoreId];
 
 	if (!expectHandle) {
 		assert.strictEqual(
@@ -75,7 +79,7 @@ function validateDDSStateInSummary(
 	expectHandle: boolean,
 ) {
 	const dataStoreChannelsTree = (summaryTree.tree[channelsTreeName] as ISummaryTree).tree;
-	const dataStoreSummaryTree = dataStoreChannelsTree[dataStoreId];
+	const dataStoreSummaryTree: SummaryObject | undefined = dataStoreChannelsTree[dataStoreId];
 	assert.strictEqual(
 		dataStoreSummaryTree.type,
 		SummaryType.Tree,
@@ -83,7 +87,7 @@ function validateDDSStateInSummary(
 	);
 
 	const ddsChannelsTree = (dataStoreSummaryTree.tree[channelsTreeName] as ISummaryTree).tree;
-	const ddsSummaryObject = ddsChannelsTree[ddsId];
+	const ddsSummaryObject: SummaryObject | undefined = ddsChannelsTree[ddsId];
 
 	if (!expectHandle) {
 		assert.strictEqual(

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementallySubDds.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summarizeIncrementallySubDds.spec.ts
@@ -568,25 +568,26 @@ describeCompat(
 
 			// Verify the summary tree is generated as we expected it to be.
 			assert(
-				summaryTree.tree[".channels"].type === SummaryType.Tree,
+				summaryTree.tree[".channels"]?.type === SummaryType.Tree,
 				"Runtime summary tree not created for blob dds test",
 			);
-			const dataObjectTree = summaryTree.tree[".channels"].tree[datastore.runtime.id];
+			const dataObjectTree = summaryTree.tree[".channels"]?.tree[datastore.runtime.id];
 			assert(
 				dataObjectTree.type === SummaryType.Tree,
 				"Data store summary tree not created for blob dds test",
 			);
-			const dataObjectChannelsTree = dataObjectTree.tree[".channels"];
+			const dataObjectChannelsTree: SummaryObject | undefined =
+				dataObjectTree.tree[".channels"];
 			assert(
 				dataObjectChannelsTree.type === SummaryType.Tree,
 				"Data store channels tree not created for blob dds test",
 			);
-			const ddsTree = dataObjectChannelsTree.tree[dds.id];
+			const ddsTree: SummaryObject | undefined = dataObjectChannelsTree.tree[dds.id];
 			assert(ddsTree.type === SummaryType.Tree, "Blob dds tree not created");
 			validateHandle(ddsTree.tree["0"], datastore.context.id, dds.id, "0", "Blob 0");
 			validateHandle(ddsTree.tree["1"], datastore.context.id, dds.id, "1", "Blob 1");
 			validateHandle(ddsTree.tree["2"], datastore.context.id, dds.id, "2", "Blob 2");
-			assert(ddsTree.tree["3"].type === SummaryType.Blob, "Blob 3 should be a blob");
+			assert(ddsTree.tree["3"]?.type === SummaryType.Blob, "Blob 3 should be a blob");
 		});
 
 		it("can create summary handles for trees in DDSes that do not change", async function () {
@@ -628,22 +629,23 @@ describeCompat(
 			// Verify the summary tree is generated as we expected it to be.
 			// Handles for "a" and "c", "b" and "f" should be trees
 			assert(
-				summaryTree.tree[".channels"].type === SummaryType.Tree,
+				summaryTree.tree[".channels"]?.type === SummaryType.Tree,
 				"Runtime summary1 tree not created for tree dds test",
 			);
-			const dataObjectTree = summaryTree.tree[".channels"].tree[datastore.runtime.id];
+			const dataObjectTree = summaryTree.tree[".channels"]?.tree[datastore.runtime.id];
 			assert(
 				dataObjectTree.type === SummaryType.Tree,
 				"Data store summary1 tree not created for tree dds test",
 			);
-			const dataObjectChannelsTree = dataObjectTree.tree[".channels"];
+			const dataObjectChannelsTree: SummaryObject | undefined =
+				dataObjectTree.tree[".channels"];
 			assert(
 				dataObjectChannelsTree.type === SummaryType.Tree,
 				"Data store summary1 channels tree not created for tree dds test",
 			);
-			const ddsTree = dataObjectChannelsTree.tree[dds.id];
+			const ddsTree: SummaryObject | undefined = dataObjectChannelsTree.tree[dds.id];
 			assert(ddsTree.type === SummaryType.Tree, "Summary1 tree not created for tree dds");
-			const rootNode = ddsTree.tree[dds.rootNodeName];
+			const rootNode: SummaryObject | undefined = ddsTree.tree[dds.rootNodeName];
 			assert(
 				rootNode.type === SummaryType.Tree,
 				"Summary1 - 'rootNode' should be a summary tree",
@@ -656,11 +658,11 @@ describeCompat(
 				"Summary1 - 'a'",
 			);
 			assert(
-				rootNode.tree.b.type === SummaryType.Tree,
+				rootNode.tree?.b.type === SummaryType.Tree,
 				"Summary1 - 'b' should be a summary tree",
 			);
 			assert(
-				rootNode.tree.b.tree.f.type === SummaryType.Tree,
+				rootNode.tree.b.tree?.f.type === SummaryType.Tree,
 				"Summary1 - 'f' should be a summary tree",
 			);
 			validateHandle(
@@ -693,22 +695,23 @@ describeCompat(
 			// Verify the summary tree is generated as we expected it to be.
 			// Handles for "a" and "b", "c" and "g" should be trees, "f" is under "b" and thus shouldn't be in the summary.
 			assert(
-				summaryTree2.tree[".channels"].type === SummaryType.Tree,
+				summaryTree2.tree[".channels"]?.type === SummaryType.Tree,
 				"Runtime summary2 tree not created for tree dds test",
 			);
-			const dataObjectTree2 = summaryTree2.tree[".channels"].tree[datastore2.runtime.id];
+			const dataObjectTree2 = summaryTree2.tree[".channels"]?.tree[datastore2.runtime.id];
 			assert(
 				dataObjectTree2.type === SummaryType.Tree,
 				"Data store summary2 tree not created for tree dds test",
 			);
-			const dataObjectChannelsTree2 = dataObjectTree2.tree[".channels"];
+			const dataObjectChannelsTree2: SummaryObject | undefined =
+				dataObjectTree2.tree[".channels"];
 			assert(
 				dataObjectChannelsTree2.type === SummaryType.Tree,
 				"Data store summary2 channels tree not created for tree dds test",
 			);
-			const ddsTree2 = dataObjectChannelsTree2.tree[dds2.id];
+			const ddsTree2: SummaryObject | undefined = dataObjectChannelsTree2.tree[dds2.id];
 			assert(ddsTree2.type === SummaryType.Tree, "Summary2 tree not created for tree dds");
-			const rootNode2 = ddsTree2.tree[dds.rootNodeName];
+			const rootNode2: SummaryObject | undefined = ddsTree2.tree[dds.rootNodeName];
 			assert(
 				rootNode2.type === SummaryType.Tree,
 				"Summary2 - 'rootNode' should be a summary tree",
@@ -728,11 +731,11 @@ describeCompat(
 				"Summary1 - 'b'",
 			);
 			assert(
-				rootNode2.tree.c.type === SummaryType.Tree,
+				rootNode2.tree?.c.type === SummaryType.Tree,
 				"Summary2 - 'c' should be a summary tree",
 			);
 			assert(
-				rootNode2.tree.c.tree.g.type === SummaryType.Tree,
+				rootNode2.tree.c.tree?.g.type === SummaryType.Tree,
 				"Summary2 - 'g' should be a summary tree",
 			);
 		});


### PR DESCRIPTION
eslint(test-end-to-end-tests): Prefix test-end-to-end-tests before enabling no-unchecked-record-access
[AB#25378](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/25378)