### PR TITLE
fix: Use node-option as array in logic for e2e routerlicious tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/.mocharc.cjs
+++ b/packages/test/test-end-to-end-tests/src/test/.mocharc.cjs
@@ -44,11 +44,14 @@ if (runningAgainstInternalRouterliciousCluster) {
 	// https://nodejs.org/api/tls.html#x509-certificate-error-codes).
 	// The flag used to be passed in the npm script in package.json, but adding node-option to the
 	// base mocharc-common.cjs caused it to be ignored, so we need to append it here.
-	if (config["node-option"] === undefined) {
-		config["node-option"] = "use-openssl-ca";
-	} else {
-		config["node-option"] += ",use-openssl-ca";
-	}
+	const baseNodeOptions =
+		config["node-option"] !== undefined
+			? Array.isArray(config["node-option"])
+				? config["node-option"]
+				: [config["node-option"]] // If string, wrap with array
+			: []; // If undefined, use an empty array
+
+	config["node-option"] = [...baseNodeOptions, "use-openssl-ca"];
 }
 
 module.exports = config;


### PR DESCRIPTION
## Description

Updates logic to append to the `node-option` flag when we run e2e tests against routerlicious, to treat it as an array instead of a string. Follow up to https://github.com/microsoft/FluidFramework/pull/23433 where we started defining `node-option` as an array.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).