### PR TITLE
Adds support to restrict HTTP response sizes

### DIFF
--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -62,3 +62,4 @@ export {
 	IRedisClientConnectionManager,
 } from "./redisClientConnectionManager";
 export { ITenantKeyGenerator, TenantKeyGenerator } from "./tenantKeyGenerator";
+export { ResponseSizeMiddleware } from "./responseSizeMiddleware";

--- a/server/routerlicious/packages/services-utils/src/responseSizeMiddleware.ts
+++ b/server/routerlicious/packages/services-utils/src/responseSizeMiddleware.ts
@@ -24,11 +24,11 @@ export class ResponseSizeMiddleware {
 
 				if (responseSize > this.maxResponseSizeInMegaBytes * 1024 * 1024) {
 					Lumberjack.error(
-						`Response size of ${responseSize} bytes, exceeds the maximum allowed size of ${this.maxResponseSizeInMegaBytes} bytes`,
+						`Response size of ${responseSize} bytes, exceeds the maximum allowed size of ${this.maxResponseSizeInMegaBytes} megabytes`,
 					);
 					return res.status(413).json({
 						error: "Response too large",
-						message: `Response size exceeds the maximum allowed size of ${this.maxResponseSizeInMegaBytes} bytes`,
+						message: `Response size exceeds the maximum allowed size of ${this.maxResponseSizeInMegaBytes} megabytes`,
 					});
 				}
 				return originalSend.call(res, body);

--- a/server/routerlicious/packages/services-utils/src/responseSizeMiddleware.ts
+++ b/server/routerlicious/packages/services-utils/src/responseSizeMiddleware.ts
@@ -1,0 +1,39 @@
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import type { RequestHandler } from "express";
+
+export class ResponseSizeMiddleware {
+	constructor(private readonly maxResponseSizeInMegaBytes: number) {}
+
+	public validateResponseSize(): RequestHandler {
+		// eslint-disable-next-line @typescript-eslint/no-misused-promises
+		return async (req, res, next) => {
+			const originalSend = res.send;
+			res.send = (body) => {
+				let responseSize: number;
+				try {
+					responseSize = Buffer.byteLength(
+						typeof body === "string" ? body : JSON.stringify(body),
+					);
+				} catch (error) {
+					Lumberjack.error("Invalid JSON string in response body");
+					return res.status(500).json({
+						error: "Invalid JSON",
+						message: "Response body is not a valid JSON string",
+					});
+				}
+
+				if (responseSize > this.maxResponseSizeInMegaBytes * 1024 * 1024) {
+					Lumberjack.error(
+						`Response size of ${responseSize} bytes, exceeds the maximum allowed size of ${this.maxResponseSizeInMegaBytes} bytes`,
+					);
+					return res.status(413).json({
+						error: "Response too large",
+						message: `Response size exceeds the maximum allowed size of ${this.maxResponseSizeInMegaBytes} bytes`,
+					});
+				}
+				return originalSend.call(res, body);
+			};
+			next();
+		};
+	}
+}

--- a/server/routerlicious/packages/services-utils/src/responseSizeMiddleware.ts
+++ b/server/routerlicious/packages/services-utils/src/responseSizeMiddleware.ts
@@ -20,11 +20,10 @@ export class ResponseSizeMiddleware {
 						typeof body === "string" ? body : JSON.stringify(body),
 					);
 				} catch (error) {
-					Lumberjack.error("Invalid JSON string in response body");
-					return res.status(500).json({
-						error: "Invalid JSON",
-						message: "Response body is not a valid JSON string",
-					});
+					Lumberjack.error("Invalid JSON string in response body", undefined, error);
+					// In case of JSON parsing errors, we log internally and send the
+					// original response to the client to prevent breaking the client's experience.
+					return originalSend.call(res, body);
 				}
 
 				if (responseSize > this.maxResponseSizeInMegaBytes * 1024 * 1024) {

--- a/server/routerlicious/packages/services-utils/src/responseSizeMiddleware.ts
+++ b/server/routerlicious/packages/services-utils/src/responseSizeMiddleware.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import type { RequestHandler } from "express";
 

--- a/server/routerlicious/packages/services-utils/src/test/responseSizeMiddleware.spec.ts
+++ b/server/routerlicious/packages/services-utils/src/test/responseSizeMiddleware.spec.ts
@@ -23,8 +23,8 @@ describe("Throttler Middleware", () => {
 	};
 	beforeEach(() => {
 		app = express();
-		responseSizeMiddler = new ResponseSizeMiddleware(responseMaxSizeInMb);
-		app.use(responseSizeMiddler.validateResponseSize());
+		responseSizeMiddleware = new ResponseSizeMiddleware(responseMaxSizeInMb);
+		app.use(responseSizeMiddleware.validateResponseSize());
 	});
 
 	describe("validateResponseSize", () => {

--- a/server/routerlicious/packages/services-utils/src/test/responseSizeMiddleware.spec.ts
+++ b/server/routerlicious/packages/services-utils/src/test/responseSizeMiddleware.spec.ts
@@ -1,0 +1,56 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import express from "express";
+import request from "supertest";
+import { ResponseSizeMiddleware } from "../responseSizeMiddleware";
+
+describe("Throttler Middleware", () => {
+	const endpoint = "/test";
+	const route = `${endpoint}/:id?`;
+	let responseSizeMiddler: ResponseSizeMiddleware;
+	const responseMaxSizeInMb = 1; // 1MB
+	let app: express.Application;
+	let supertest: request.SuperTest<request.Test>;
+	const setUpRoute = (data: any, subPath?: string): void => {
+		const routePath = `${route}${subPath ? `/${subPath}` : ""}`;
+		app.get(routePath, (req, res) => {
+			res.status(200).send(data);
+		});
+	};
+	beforeEach(() => {
+		app = express();
+		responseSizeMiddler = new ResponseSizeMiddleware(responseMaxSizeInMb);
+		app.use(responseSizeMiddler.validateResponseSize());
+	});
+
+	describe("validateResponseSize", () => {
+		it("sends 200 when limit not exceeded", async () => {
+			setUpRoute("test");
+			supertest = request(app);
+			await supertest.get(endpoint).expect((res) => {
+				assert.strictEqual(res.status, 200);
+			});
+		});
+
+		it("sends 413 with message when response size is greate than max response size", async () => {
+			const sizeInBytes = 5 * 1024 * 1024; // 5MB
+			const largeObject = {
+				data: "a".repeat(sizeInBytes),
+			};
+			setUpRoute(largeObject);
+			supertest = request(app);
+			await supertest.get(endpoint).expect((res) => {
+				assert.strictEqual(res.status, 413);
+				assert.strictEqual(res.body.error, "Response too large");
+				assert.strictEqual(
+					res.body.message,
+					`Response size exceeds the maximum allowed size of ${responseMaxSizeInMb} megabytes`,
+				);
+			});
+		});
+	});
+});

--- a/server/routerlicious/packages/services-utils/src/test/responseSizeMiddleware.spec.ts
+++ b/server/routerlicious/packages/services-utils/src/test/responseSizeMiddleware.spec.ts
@@ -11,7 +11,7 @@ import { ResponseSizeMiddleware } from "../responseSizeMiddleware";
 describe("Throttler Middleware", () => {
 	const endpoint = "/test";
 	const route = `${endpoint}/:id?`;
-	let responseSizeMiddler: ResponseSizeMiddleware;
+	let responseSizeMiddleware: ResponseSizeMiddleware;
 	const responseMaxSizeInMb = 1; // 1MB
 	let app: express.Application;
 	let supertest: request.SuperTest<request.Test>;


### PR DESCRIPTION
## Description

This PR adds a new module - `ResponseSizeMiddleware`. This class has a method to validate response sizes to ensure that their byte sizes is below a given a `maxResponseSizeInMegaBytes`. If the response body is greater than `maxResponseSizeInMegaBytes`, an `HTTP 413` is sent as a response, else the original response is sent back to the client. This is introduced to primarily enforce response sizes in the storage stack (Historian and Gitrest). A future PR will add this module to both Gitrest and Historian after the r11 changes are merged.

Historian and Gitrest both have request size limitations. Hence, this PR just adds support to limit response sizes. This is added to reduce the chances of Gitrest returning very large responses that could result in Historian running OOM.