### PR TITLE
Add copyright comment to simplifiedCustomDataRetriever

### DIFF
--- a/server/historian/packages/historian-base/src/services/simplifiedCustomDataRetriever.ts
+++ b/server/historian/packages/historian-base/src/services/simplifiedCustomDataRetriever.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+ 
 import type { ITenantCustomData } from "@fluidframework/server-services-core";
 
 import type { ISimplifiedCustomDataRetriever } from "./definitions";

--- a/server/historian/packages/historian-base/src/services/simplifiedCustomDataRetriever.ts
+++ b/server/historian/packages/historian-base/src/services/simplifiedCustomDataRetriever.ts
@@ -1,4 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
 import type { ITenantCustomData } from "@fluidframework/server-services-core";
+
 import type { ISimplifiedCustomDataRetriever } from "./definitions";
 
 /**


### PR DESCRIPTION
Missing copyright on simplifiedCustomDataRetriever.ts file. This is causing repo policy to fail.