### PR TITLE
Fix Test Flakiness: MigrationShim can drop v1 ops and migration ops

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts
@@ -16,7 +16,6 @@ import {
 	StablePlace,
 	type TraitLabel,
 } from "@fluid-experimental/tree";
-// eslint-disable-next-line import/no-internal-modules
 import { type EditLog } from "@fluid-experimental/tree/test/EditLog";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { LoaderHeader } from "@fluidframework/container-definitions/internal";
@@ -211,7 +210,6 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider, apis) => {
 		const container2 = await provider.loadContainer(runtimeFactory2);
 		await waitForContainerConnection(container2);
 		const testObj2 = (await container2.getEntryPoint()) as TestDataObject;
-		await provider.ensureSynchronized();
 		const shim2 = testObj2.getTree<MigrationShim>();
 		const legacyTree2 = shim2.currentTree as LegacySharedTree;
 


### PR DESCRIPTION
[AB#18574](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/18574)

Based on telemetry indicating that this `provider.ensureSynchronized` call is hanging as the error message indicates so and as there are disconnects called during the test that would send telemetry but aren't, we can assume that the one that is hanging should be removed to reduce flakiness.