### PR TITLE
fix(build-cli): Update promptToGenerateReleaseNotes to use non-deprecated flag

### DIFF
--- a/build-tools/packages/build-cli/src/handlers/promptFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/promptFunctions.ts
@@ -506,7 +506,7 @@ export const promptToGenerateReleaseNotes: StateHandlerFunction = async (
 			{
 				title: "FIRST: generate:releaseNotes",
 				message: `To generate the release notes, run the following command from the root of your release repo:`,
-				cmd: `flub generate releaseNotes -g ${releaseGroup} -t ${bumpType} --out RELEASE_NOTES/${releaseVersion}.md`,
+				cmd: `flub generate releaseNotes -g ${releaseGroup} -t ${bumpType} --outFile RELEASE_NOTES/${releaseVersion}.md`,
 			},
 			{
 				title: "FINALLY: merge the resulting changes",


### PR DESCRIPTION
## Description

Update promptToGenerateReleaseNotes to use non-deprecated flag

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

