### PR TITLE
Partially revert #23432 "Prefix ... no-unchecked-record-access..."

### DIFF
--- a/experimental/dds/attributable-map/src/mapKernel.ts
+++ b/experimental/dds/attributable-map/src/mapKernel.ts
@@ -216,7 +216,7 @@ export class AttributableMapKernel {
 				return nextVal.done
 					? { value: undefined, done: true }
 					: // Unpack the stored value
-						{ value: [nextVal.value[0], nextVal.value[1]?.value], done: false };
+						{ value: [nextVal.value[0], nextVal.value[1].value], done: false };
 			},
 			[Symbol.iterator](): IterableIterator<[string, unknown]> {
 				return this;

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -1607,7 +1607,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 				const nextVal = localEntriesIterator.next();
 				return nextVal.done
 					? { value: undefined, done: true }
-					: { value: [nextVal.value[0], nextVal.value[1]?.value], done: false };
+					: { value: [nextVal.value[0], nextVal.value[1].value], done: false };
 			},
 			[Symbol.iterator](): IterableIterator<[string, unknown]> {
 				return this;

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -208,7 +208,7 @@ export class MapKernel {
 				return nextVal.done
 					? { value: undefined, done: true }
 					: // Unpack the stored value
-						{ value: [nextVal.value[0], nextVal.value[1]?.value], done: false };
+						{ value: [nextVal.value[0], nextVal.value[1].value], done: false };
 			},
 			[Symbol.iterator](): IterableIterator<[string, unknown]> {
 				return this;

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -104,12 +104,12 @@ function serialize(directory1: ISharedDirectory): string {
 	assert.strictEqual(summaryObjectKeys.length, 1, "summary tree should only have one blob");
 	assert.strictEqual(summaryObjectKeys[0], "header", "summary should have a header blob");
 	assert.strictEqual(
-		summaryTree.tree.header?.type,
+		summaryTree.tree.header.type,
 		SummaryType.Blob,
 		"header is not of SummaryType.Blob",
 	);
 
-	const content = summaryTree.tree.header?.content as string;
+	const content = summaryTree.tree.header.content as string;
 	return JSON.stringify((JSON.parse(content) as IDirectoryNewStorageFormat).content);
 }
 
@@ -1725,15 +1725,15 @@ describe("Directory", () => {
 				const fooSubDirIterator = fooSubDir.entries();
 				const fooSubDirResult1 = fooSubDirIterator.next();
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDirResult1.value?.[0], "testKey");
+				assert.equal(fooSubDirResult1.value[0], "testKey");
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDirResult1.value?.[1], "testValue");
+				assert.equal(fooSubDirResult1.value[1], "testValue");
 				assert.equal(fooSubDirResult1.done, false);
 				const fooSubDirResult2 = fooSubDirIterator.next();
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDirResult2.value?.[0], "testKey2");
+				assert.equal(fooSubDirResult2.value[0], "testKey2");
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDirResult2.value?.[1], "testValue2");
+				assert.equal(fooSubDirResult2.value[1], "testValue2");
 				assert.equal(fooSubDirResult2.done, false);
 				const fooSubDirResult3 = fooSubDirIterator.next();
 				assert.equal(fooSubDirResult3.value, undefined);
@@ -1755,15 +1755,15 @@ describe("Directory", () => {
 				const fooSubDir2Iterator = fooSubDir2.entries();
 				const fooSubDir2Result1 = fooSubDir2Iterator.next();
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDir2Result1.value?.[0], "testKey");
+				assert.equal(fooSubDir2Result1.value[0], "testKey");
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDir2Result1.value?.[1], "testValue");
+				assert.equal(fooSubDir2Result1.value[1], "testValue");
 				assert.equal(fooSubDir2Result1.done, false);
 				const fooSubDir2Result2 = fooSubDir2Iterator.next();
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDir2Result2.value?.[0], "testKey2");
+				assert.equal(fooSubDir2Result2.value[0], "testKey2");
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDir2Result2.value?.[1], "testValue2");
+				assert.equal(fooSubDir2Result2.value[1], "testValue2");
 				assert.equal(fooSubDir2Result2.done, false);
 				const fooSubDir2Result3 = fooSubDir2Iterator.next();
 				assert.equal(fooSubDir2Result3.value, undefined);

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -341,7 +341,7 @@ export function appendSharedStringDeltaToRevertibles(
 
 				revertible.intervals.push({
 					intervalId: interval.getIntervalId(),
-					label: interval.properties.referenceRangeLabels?.[0],
+					label: interval.properties.referenceRangeLabels[0],
 					startOffset: offset,
 					endOffset,
 				});
@@ -351,7 +351,7 @@ export function appendSharedStringDeltaToRevertibles(
 			endIntervals.forEach(({ interval, offset }) => {
 				revertible.intervals.push({
 					intervalId: interval.getIntervalId(),
-					label: interval.properties.referenceRangeLabels?.[0],
+					label: interval.properties.referenceRangeLabels[0],
 					endOffset: offset,
 				});
 			});
@@ -433,7 +433,7 @@ function revertLocalAdd(
 	revertible: TypedRevertible<typeof IntervalOpType.ADD>,
 ) {
 	const id = getUpdatedIdFromInterval(revertible.interval);
-	const label = revertible.interval.properties.referenceRangeLabels?.[0];
+	const label = revertible.interval.properties.referenceRangeLabels[0];
 	string.getIntervalCollection(label).removeIntervalById(id);
 }
 
@@ -461,7 +461,7 @@ function revertLocalDelete(
 	string: ISharedString,
 	revertible: TypedRevertible<typeof IntervalOpType.DELETE>,
 ) {
-	const label = revertible.interval.properties.referenceRangeLabels?.[0];
+	const label = revertible.interval.properties.referenceRangeLabels[0];
 	const collection = string.getIntervalCollection(label);
 	const start = string.localReferencePositionToPosition(revertible.start);
 	const startSlidePos = getSlidePosition(string, revertible.start, start);
@@ -500,7 +500,7 @@ function revertLocalChange(
 	string: ISharedString,
 	revertible: TypedRevertible<typeof IntervalOpType.CHANGE>,
 ) {
-	const label = revertible.interval.properties.referenceRangeLabels?.[0];
+	const label = revertible.interval.properties.referenceRangeLabels[0];
 	const collection = string.getIntervalCollection(label);
 	const id = getUpdatedIdFromInterval(revertible.interval);
 	const start = string.localReferencePositionToPosition(revertible.start);
@@ -540,7 +540,7 @@ function revertLocalPropertyChanged(
 	string: ISharedString,
 	revertible: TypedRevertible<typeof IntervalOpType.PROPERTY_CHANGED>,
 ) {
-	const label = revertible.interval.properties.referenceRangeLabels?.[0];
+	const label = revertible.interval.properties.referenceRangeLabels[0];
 	const id = getUpdatedIdFromInterval(revertible.interval);
 	const newProps = revertible.propertyDeltas;
 	string.getIntervalCollection(label).change(id, { props: newProps });

--- a/packages/drivers/odsp-driver/src/WriteBufferUtils.ts
+++ b/packages/drivers/odsp-driver/src/WriteBufferUtils.ts
@@ -233,8 +233,8 @@ function serializeNodeCore(
 	for (const child of nodeCore.nodes) {
 		if (child instanceof NodeCore) {
 			// For a tree node start and end with set/list start and end marker codes.
-			const startCode: MarkerCodesStart | undefined = MarkerCodesStart[child.type];
-			const endCode: MarkerCodesEnd | undefined = MarkerCodesEnd[child.type];
+			const startCode = MarkerCodesStart[child.type];
+			const endCode = MarkerCodesEnd[child.type];
 			assert(startCode !== undefined, 0x285 /* "Start code should not undefined" */);
 			assert(endCode !== undefined, 0x286 /* "End code should not undefined" */);
 			buffer.write(startCode);

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -72,7 +72,7 @@ function readBlobSection(node: NodeTypes): {
 			const records = getNodeProps(blob);
 			assertBlobCoreInstance(records.data, "data should be of BlobCore type");
 			const id = getStringInstance(records.id, "blob id should be string");
-			blobContents.set(id, records.data?.arrayBuffer);
+			blobContents.set(id, records.data.arrayBuffer);
 		}
 	}
 	return { blobContents, slowBlobStructureCount };
@@ -88,15 +88,15 @@ function readOpsSection(node: NodeTypes): ISequencedDocumentMessage[] {
 	const records = getNodeProps(node);
 	assertNumberInstance(records.firstSequenceNumber, "Seq number should be a number");
 	assertNodeCoreInstance(records.deltas, "Deltas should be a Node");
-	for (let i = 0; i < records.deltas?.length; ++i) {
+	for (let i = 0; i < records.deltas.length; ++i) {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-		ops.push(JSON.parse(records.deltas?.getString(i)));
+		ops.push(JSON.parse(records.deltas.getString(i)));
 	}
 	// Due to a bug at service side, in an edge case service was serializing deltas even
 	// when there are no ops. So just make the code resilient to that bug. Service has also
 	// fixed that bug.
 	assert(
-		ops.length === 0 || records.firstSequenceNumber?.valueOf() === ops[0].sequenceNumber,
+		ops.length === 0 || records.firstSequenceNumber.valueOf() === ops[0].sequenceNumber,
 		0x280 /* "Validate first op seq number" */,
 	);
 	return ops;
@@ -244,7 +244,7 @@ function readSnapshotSection(node: NodeTypes): {
 	const { snapshotTree, slowTreeStructureCount, treeStructureCountWithGroupId } =
 		readTreeSection(records.treeNodes);
 	snapshotTree.id = getStringInstance(records.id, "snapshotId should be string");
-	const sequenceNumber = records.sequenceNumber?.valueOf();
+	const sequenceNumber = records.sequenceNumber.valueOf();
 	return {
 		sequenceNumber,
 		snapshotTree,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -257,9 +257,8 @@ export abstract class OdspDocumentStorageServiceBase implements IDocumentStorage
 	protected combineProtocolAndAppSnapshotTree(snapshotTree: ISnapshotTree): ISnapshotTree {
 		// When we upload the container snapshot, we upload appTree in ".app" and protocol tree in ".protocol"
 		// So when we request the snapshot we get ".app" as tree and not as commit node as in the case just above.
-		const hierarchicalAppTree: ISnapshotTree | undefined = snapshotTree.trees[".app"];
-		const hierarchicalProtocolTree: ISnapshotTree | undefined =
-			snapshotTree.trees[".protocol"];
+		const hierarchicalAppTree = snapshotTree.trees[".app"];
+		const hierarchicalProtocolTree = snapshotTree.trees[".protocol"];
 		const summarySnapshotTree: ISnapshotTree = {
 			blobs: {
 				...hierarchicalAppTree.blobs,

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -108,7 +108,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 
 			const searchParams = new URLSearchParams(queryString);
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-			const fileName: string = request.headers[DriverHeader.createNew]?.fileName;
+			const fileName: string = request.headers[DriverHeader.createNew].fileName;
 			const driveID = searchParams.get("driveId");
 			const filePath = searchParams.get("path");
 			const packageName = searchParams.get("containerPackageName");

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -7,11 +7,7 @@ import { strict as assert } from "node:assert";
 
 import { bufferToString, fromBase64ToUtf8 } from "@fluid-internal/client-utils";
 import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
-import {
-	ISnapshot,
-	IDocumentAttributes,
-	type ISnapshotTree,
-} from "@fluidframework/driver-definitions/internal";
+import { ISnapshot, IDocumentAttributes } from "@fluidframework/driver-definitions/internal";
 import {
 	IFileEntry,
 	IOdspResolvedUrl,
@@ -143,18 +139,18 @@ describe("Create New Utils Tests", () => {
 		);
 		assert.strictEqual(snapshot.blobContents.size, 2, "2 blobs should be there");
 
-		const appTree: ISnapshotTree | undefined = snapshotTree.trees[".app"];
-		const protocolTree: ISnapshotTree | undefined = snapshotTree.trees[".protocol"];
+		const appTree = snapshotTree.trees[".app"];
+		const protocolTree = snapshotTree.trees[".protocol"];
 		assert(appTree !== undefined, "App tree should be there");
 		assert(protocolTree !== undefined, "Protocol tree should be there");
 
-		const appTreeBlobId: string | undefined = appTree.blobs.attributes;
+		const appTreeBlobId = appTree.blobs.attributes;
 		const appTreeBlobValBuffer = snapshot.blobContents.get(appTreeBlobId);
 		assert(appTreeBlobValBuffer !== undefined, "app blob value should exist");
 		const appTreeBlobVal = bufferToString(appTreeBlobValBuffer, "utf8");
 		assert(appTreeBlobVal === blobContent, "Blob content should match");
 
-		const docAttributesBlobId: string | undefined = protocolTree.blobs.attributes;
+		const docAttributesBlobId = protocolTree.blobs.attributes;
 		const docAttributesBuffer = snapshot.blobContents.get(docAttributesBlobId);
 		assert(docAttributesBuffer !== undefined, "protocol attributes blob value should exist");
 		const docAttributesBlobValue = bufferToString(docAttributesBuffer, "utf8");

--- a/packages/drivers/odsp-driver/src/test/getUrlAndHeadersWithAuth.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getUrlAndHeadersWithAuth.spec.ts
@@ -24,7 +24,7 @@ describe("getHeadersWithAuth", () => {
 		result: { [index: string]: string },
 	): void => {
 		assert.strictEqual(
-			result.Authorization?.endsWith(token),
+			result.Authorization.endsWith(token),
 			true,
 			"Returned header must contain token",
 		);

--- a/packages/drivers/odsp-driver/src/test/prefetchSnapshotTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/prefetchSnapshotTests.spec.ts
@@ -626,9 +626,9 @@ describe("Tests for prefetching snapshot", () => {
 		};
 		const odspCompactSnapshotWithGroupId = convertToCompactSnapshot(snapshotWithGroupId);
 		const snapshotTreeWithGroupIdToCompare: ISnapshotTree = {
-			blobs: { ...snapshotTreeWithGroupId.trees[".app"]?.blobs },
+			blobs: { ...snapshotTreeWithGroupId.trees[".app"].blobs },
 			trees: {
-				...snapshotTreeWithGroupId.trees[".app"]?.trees,
+				...snapshotTreeWithGroupId.trees[".app"].trees,
 				".protocol": snapshotTreeWithGroupId.trees[".protocol"],
 			},
 			id: "SnapshotId",
@@ -866,9 +866,9 @@ describe("Tests for prefetching snapshot", () => {
 		};
 		const odspCompactSnapshotWithGroupId = convertToCompactSnapshot(snapshotWithGroupId);
 		const snapshotTreeWithGroupIdToCompare: ISnapshotTree = {
-			blobs: { ...snapshotTreeWithGroupId.trees[".app"]?.blobs },
+			blobs: { ...snapshotTreeWithGroupId.trees[".app"].blobs },
 			trees: {
-				...snapshotTreeWithGroupId.trees[".app"]?.trees,
+				...snapshotTreeWithGroupId.trees[".app"].trees,
 				".protocol": snapshotTreeWithGroupId.trees[".protocol"],
 			},
 			id: "SnapshotId",

--- a/packages/drivers/replay-driver/src/storageImplementations.ts
+++ b/packages/drivers/replay-driver/src/storageImplementations.ts
@@ -80,9 +80,9 @@ export class FileSnapshotReader
 			throw new Error(`Unknown version id: ${versionRequested}`);
 		}
 
-		let snapshotTree: ISnapshotTree | undefined = this.trees[versionRequested.id];
+		let snapshotTree = this.trees[versionRequested.id];
 		if (snapshotTree === undefined) {
-			const tree: ITree | undefined = this.commits[versionRequested.id];
+			const tree = this.commits[versionRequested.id];
 			if (tree === undefined) {
 				throw new Error(`Can't find version ${versionRequested.id}`);
 			}

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -302,9 +302,9 @@ export class DocumentService
 		}
 		const fluidResolvedUrl = response.resolvedUrl;
 		this._resolvedUrl = fluidResolvedUrl;
-		this.storageUrl = fluidResolvedUrl.endpoints?.storageUrl;
-		this.ordererUrl = fluidResolvedUrl.endpoints?.ordererUrl;
-		this.deltaStorageUrl = fluidResolvedUrl.endpoints?.deltaStorageUrl;
+		this.storageUrl = fluidResolvedUrl.endpoints.storageUrl;
+		this.ordererUrl = fluidResolvedUrl.endpoints.ordererUrl;
+		this.deltaStorageUrl = fluidResolvedUrl.endpoints.deltaStorageUrl;
 		this.deltaStreamUrl = fluidResolvedUrl.endpoints.deltaStreamUrl ?? this.ordererUrl;
 		return true;
 	}

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -213,7 +213,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 		}
 
 		parsedUrl.pathname = replaceDocumentIdInPath(parsedUrl.pathname, documentId);
-		const deltaStorageUrl = resolvedUrl.endpoints?.deltaStorageUrl;
+		const deltaStorageUrl = resolvedUrl.endpoints.deltaStorageUrl;
 		if (!deltaStorageUrl) {
 			throw new Error(
 				`All endpoints urls must be provided. [deltaStorageUrl:${deltaStorageUrl}]`,
@@ -303,9 +303,9 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			},
 		);
 
-		const storageUrl = fluidResolvedUrl.endpoints?.storageUrl;
-		const ordererUrl = fluidResolvedUrl.endpoints?.ordererUrl;
-		const deltaStorageUrl = fluidResolvedUrl.endpoints?.deltaStorageUrl;
+		const storageUrl = fluidResolvedUrl.endpoints.storageUrl;
+		const ordererUrl = fluidResolvedUrl.endpoints.ordererUrl;
+		const deltaStorageUrl = fluidResolvedUrl.endpoints.deltaStorageUrl;
 		const deltaStreamUrl = fluidResolvedUrl.endpoints.deltaStreamUrl || ordererUrl; // backward compatibility
 		if (!ordererUrl || !deltaStorageUrl) {
 			throw new Error(

--- a/packages/loader/driver-utils/src/test/summaryCompresssionTester.spec.ts
+++ b/packages/loader/driver-utils/src/test/summaryCompresssionTester.spec.ts
@@ -69,7 +69,7 @@ function generateSummaryWithContent(contentSize: number) {
 				".channels"
 			] as ISummaryTree
 		).tree["7a99532d-94ec-43ac-8a53-d9f978ad4ae9"] as ISummaryTree
-	).tree?.header;
+	).tree.header;
 	let contentString = "";
 	while (contentString.length < contentSize) {
 		if (contentString.length + 10 > contentSize) {
@@ -91,7 +91,7 @@ function generateSummaryWithBinaryContent(startsWith: number, contentSize: numbe
 				".channels"
 			] as ISummaryTree
 		).tree["7a99532d-94ec-43ac-8a53-d9f978ad4ae9"] as ISummaryTree
-	).tree?.header;
+	).tree.header;
 	const content = new Uint8Array(contentSize);
 	content[0] = startsWith;
 	for (let i = 1; i < contentSize; i = i + 10) {
@@ -621,7 +621,7 @@ function getHeaderContent(summary: ISummaryTree) {
 }
 
 function getHeader(summary: ISummaryTree) {
-	return getHeaderHolder(summary).tree?.header;
+	return getHeaderHolder(summary).tree.header;
 }
 
 function getHeaderHolder(summary: ISummaryTree) {

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -31,7 +31,6 @@ import {
 	type FetchSource,
 	type IDocumentAttributes,
 	SummaryType,
-	type SummaryObject,
 } from "@fluidframework/driver-definitions/internal";
 import {
 	ISummaryTreeWithStats,
@@ -2094,7 +2093,7 @@ describe("Runtime", () => {
 					false,
 				);
 				const { summary } = await containerRuntime.summarize({ fullTree: true });
-				const blob: SummaryObject | undefined = summary.tree[recentBatchInfoBlobName];
+				const blob = summary.tree[recentBatchInfoBlobName];
 				assert(blob.type === SummaryType.Blob, "Expected blob");
 				assert.equal(blob.content, '[[123,"batchId1"]]', "Expected single batchId mapping");
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -2424,7 +2424,7 @@ describe("Runtime", () => {
 					["missingDataStore"],
 				);
 				assert.deepStrictEqual(
-					snapshotTree.trees[".channels"]?.trees.missingDataStore,
+					snapshotTree.trees[".channels"].trees.missingDataStore,
 					snapshot.snapshotTree,
 					"snapshot should be equal",
 				);

--- a/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
@@ -276,7 +276,7 @@ describe("Garbage Collection Stats", () => {
 			);
 
 			// Add 2 new nodes and make one of them unreferenced.
-			defaultGCData.gcNodes["/"]?.push(nodes[4]);
+			defaultGCData.gcNodes["/"].push(nodes[4]);
 			defaultGCData.gcNodes[nodes[4]] = [];
 			defaultGCData.gcNodes[nodes[5]] = [];
 

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -1115,7 +1115,7 @@ describe("IdCompressor", () => {
 			const uuids = new Set<StableId>();
 			for (const [i, data1] of log1.entries()) {
 				const id1 = compressor1.normalizeToOpSpace(data1.id);
-				const id2 = compressor2.normalizeToOpSpace(log2[i]?.id);
+				const id2 = compressor2.normalizeToOpSpace(log2[i].id);
 				assert(isFinalId(id1));
 				ids.add(id1);
 				assert.equal(id1, id2);

--- a/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
@@ -491,7 +491,7 @@ describe("Summary Utils", () => {
 			const stats = summaryTreeWithStats.stats;
 			assert.strictEqual(stats.blobNodeCount, 1);
 			assert.strictEqual(stats.totalBlobSize, blobContent.length);
-			assert.strictEqual(summaryTree.tree.testBlob?.type, SummaryType.Blob);
+			assert.strictEqual(summaryTree.tree.testBlob.type, SummaryType.Blob);
 		});
 	});
 });

--- a/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/summaryUtils.spec.ts
@@ -411,7 +411,7 @@ describe("Summary Utils", () => {
 			const blobContent = "testBlobContent";
 			summaryTreeBuilder.addBlob("testBlob", blobContent);
 			const summaryTree = summaryTreeBuilder.summary;
-			const blob: SummaryObject | undefined = summaryTree.tree.testBlob;
+			const blob = summaryTree.tree.testBlob;
 			assert.strictEqual(blob.type, SummaryType.Blob);
 			assert.strictEqual(blob.content, blobContent);
 		});
@@ -432,7 +432,7 @@ describe("Summary Utils", () => {
 			const handle = "testHandle";
 			summaryTreeBuilder.addHandle("testHandleKey", SummaryType.Tree, handle);
 			const summaryTree = summaryTreeBuilder.summary;
-			const handleObject: SummaryObject | undefined = summaryTree.tree.testHandleKey;
+			const handleObject = summaryTree.tree.testHandleKey;
 			assert.strictEqual(handleObject.type, SummaryType.Handle);
 			assert.strictEqual(handleObject.handleType, SummaryType.Tree);
 			assert.strictEqual(handleObject.handle, handle);
@@ -453,7 +453,7 @@ describe("Summary Utils", () => {
 			const attachmentId = "testAttachmentId";
 			summaryTreeBuilder.addAttachment(attachmentId);
 			const summaryTree = summaryTreeBuilder.summary;
-			const attachment: SummaryObject | undefined = summaryTree.tree["0"];
+			const attachment = summaryTree.tree["0"];
 			assert.strictEqual(attachment.type, SummaryType.Attachment);
 			assert.strictEqual(attachment.id, attachmentId);
 		});
@@ -473,7 +473,7 @@ describe("Summary Utils", () => {
 			};
 			summaryTreeBuilder.addWithStats("testKey", summarizeResult);
 			const summaryTree = summaryTreeBuilder.summary;
-			const subTree: SummaryObject | undefined = summaryTree.tree.testKey;
+			const subTree = summaryTree.tree.testKey;
 			assert.strictEqual(subTree.type, SummaryType.Tree);
 			const stats = summaryTreeBuilder.stats;
 			assert.strictEqual(stats.blobNodeCount, 1);

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -100,8 +100,9 @@ export function getOdspCredentials(
 		const tenants: LoginTenants = JSON.parse(loginTenants);
 		const tenantNames = Object.keys(tenants);
 		const tenant = tenantNames[tenantIndex % tenantNames.length];
+		const tenantInfo = tenants[tenant];
 		// Translate all the user from that user to the full user principle name by appending the tenant domain
-		const range = tenants[tenant]?.range;
+		const range = tenantInfo.range;
 
 		// Return the set of account to choose from a single tenant
 		for (let i = 0; i < range.count; i++) {

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -87,8 +87,7 @@ function getLegacyConfigFromEnv() {
 }
 
 function getEndpointConfigFromEnv(r11sEndpointName: RouterliciousEndpoint) {
-	const configStr: string | undefined =
-		process.env[`fluid__test__driver__${r11sEndpointName}`];
+	const configStr = process.env[`fluid__test__driver__${r11sEndpointName}`];
 	if (r11sEndpointName === "docker") {
 		const dockerDriverPolicies =
 			configStr === undefined ? configStr : JSON.parse(configStr).driverPolicies;

--- a/packages/test/test-service-load/src/FileLogger.ts
+++ b/packages/test/test-service-load/src/FileLogger.ts
@@ -89,7 +89,7 @@ class FileLogger implements ITelemetryBufferedLogger {
 			event.category = event.testCategoryOverride;
 		} else if (
 			typeof event.message === "string" &&
-			event.message?.includes("FaultInjectionNack")
+			event.message.includes("FaultInjectionNack")
 		) {
 			event.category = "generic";
 		}

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DataVisualization.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DataVisualization.ts
@@ -263,8 +263,7 @@ export class DataVisualizerGraph
 				this.visualizers[sharedObject.attributes.type] ?? visualizeUnknownSharedObject;
 
 			// Create visualizer node for the shared object
-			const editorFunction: EditSharedObject | undefined =
-				this.editors[sharedObject.attributes.type];
+			const editorFunction = this.editors[sharedObject.attributes.type];
 
 			const visualizerNode = new VisualizerNode(
 				sharedObject,

--- a/packages/tools/devtools/devtools-view/src/components/graphs/DynamicComposedChart.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/graphs/DynamicComposedChart.tsx
@@ -62,7 +62,7 @@ const mergeDataSets = (dataSets: GraphDataSet[]): DataPoint[] => {
 	for (const dataSet of dataSets) {
 		const { yAxisDataKey, xAxisDataKey, uuid } = dataSet.schema;
 		for (const dataPoint of dataSet.data) {
-			const xAxisDataPoint: string | number | undefined = dataPoint[xAxisDataKey];
+			const xAxisDataPoint = dataPoint[xAxisDataKey];
 			xAxisDataPointToYAxisDataPointMap[xAxisDataPoint] = {
 				...xAxisDataPointToYAxisDataPointMap[xAxisDataPoint],
 				[uuid]: dataPoint[yAxisDataKey],


### PR DESCRIPTION
Partially revert "Prefix trivial issues when enabling no-unchecked-record-access for client packages (#23432)"

This reverts commit 88caebd330d8b44221ba4b011398a9c8218d38b5 where:
  1. `?` was used to address linter defect. TypeScript appears to mostly ignore that these cases may lead to `undefined` result which is not accepted per type specifications. Use of `?` is thus a behavior change that will shift point of failure away from where it could first be detected - revert those behavior changes. (Many of the test uses of `?` in original change are permissible as there is a follow-up assertion that will fail. But those were not separated during revert.)

  2. `T | undefined` was used to address linter defect. TypeScript will narrow without `undefined` without `noUncheckedIndexAccess` enabled.

The only files that retained changes from original commit are:
  packages/dds/merge-tree/src/test/beastTest.spec.ts
  packages/drivers/odsp-driver/src/WriteBufferUtils.ts
  packages/runtime/id-compressor/src/test/idCompressor.spec.ts
  packages/tools/fetch-tool/src/fluidFetchSnapshot.ts