### PR TITLE
Build: more retries on npm install failures

### DIFF
--- a/tools/pipelines/templates/include-telemetry-setup.yml
+++ b/tools/pipelines/templates/include-telemetry-setup.yml
@@ -88,7 +88,7 @@ steps:
 
 - task: Npm@1
   displayName: 'Install telemetry-generator'
-  retryCountOnTaskFailure: 1
+  retryCountOnTaskFailure: 4
   inputs:
     workingDir: ${{ parameters.pathForTelemetryGeneratorInstall }}
     command: 'custom'

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -129,7 +129,7 @@ steps:
 # Install aria-logger
 - task: Npm@1
   displayName: 'npm install aria logger'
-  retryCountOnTaskFailure: 1
+  retryCountOnTaskFailure: 4
   inputs:
     workingDir: ${{ parameters.testWorkspace }}
     command: 'custom'

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -154,7 +154,7 @@ stages:
             targetFolder: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
         - task: Npm@1
           displayName: Install dependencies - ${{ testPackage }}
-          retryCountOnTaskFailure: 1
+          retryCountOnTaskFailure: 4
           inputs:
             command: 'install'
             workingDir: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
@@ -290,7 +290,7 @@ stages:
             targetFolder: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
         - task: Npm@1
           displayName: Install dependencies - ${{ testPackage }}
-          retryCountOnTaskFailure: 1
+          retryCountOnTaskFailure: 4
           inputs:
             command: 'install'
             workingDir: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
@@ -427,7 +427,7 @@ stages:
 
         - task: Npm@1
           displayName: Install dependencies - ${{ testPackage }}
-          retryCountOnTaskFailure: 1
+          retryCountOnTaskFailure: 4
           inputs:
             command: 'install'
             workingDir: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
@@ -549,7 +549,7 @@ stages:
             targetFolder: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}
         - task: Npm@1
           displayName: Install dependencies - ${{ endpointObject.endpointName }}
-          retryCountOnTaskFailure: 1
+          retryCountOnTaskFailure: 4
           inputs:
             command: 'install'
             workingDir: ${{ variables.testWorkspace }}/node_modules/${{ variables.testPackage }}


### PR DESCRIPTION
## Description

NPM installs are prone to failing with ECONNRESET when fetching from pkgs.dev.azure.com. Increasing the number of retries should reduce the number of definitive failures (and the number of pipeline alerts).

See conversation [here](https://teams.microsoft.com/l/message/19:07c78dc203f74d24a204f097ffa0fd6b@thread.skype/1736278532976?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=9ce27575-2f82-4689-abdb-bcff07e8063b&parentMessageId=1736278532976&teamName=Fluid%20Framework&channelName=FF%20Hot&createdTime=1736278532976) for more details.

## Breaking Changes

None