### PR TITLE
test: Reenable bogus load test

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
@@ -201,15 +201,16 @@ for (const testOpts of testMatrix) {
 		 *
 		 * Note: This test is currently skipped because it is failing when ran against tinylicious (azure-local-service).
 		 */
-		it.skip("cannot load improperly created container (cannot load a non-existent container)", async () => {
+		it("cannot load improperly created container (cannot load a non-existent container)", async () => {
 			const consoleErrorFn = console.error;
 			console.error = (): void => {};
 			const containerAndServicesP = client.getContainer("containerConfig", schema, "2");
 
 			const errorFn = (error: Error): boolean => {
 				assert.notStrictEqual(error.message, undefined, "Azure Client error is undefined");
+				// AFR gives R11s fetch error, T9s gives 0x8e4
 				assert.strict(
-					error.message.startsWith("R11s fetch error"),
+					error.message.startsWith("R11s fetch error") || error.message === "0x8e4",
 					`Unexpected error: ${error.message}`,
 				);
 				return true;

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
@@ -209,10 +209,17 @@ for (const testOpts of testMatrix) {
 			const errorFn = (error: Error): boolean => {
 				assert.notStrictEqual(error.message, undefined, "Azure Client error is undefined");
 				// AFR gives R11s fetch error, T9s gives 0x8e4
-				assert.strict(
-					error.message.startsWith("R11s fetch error") || error.message === "0x8e4",
-					`Unexpected error: ${error.message}`,
-				);
+				if (process.env.FLUID_CLIENT === "azure") {
+					assert.strict(
+						"errorType" in error &&
+							error.errorType === "fileNotFoundOrAccessDeniedError" &&
+							"statusCode" in error &&
+							error.statusCode === 404,
+						`Unexpected error: ${error.message}`,
+					);
+				} else {
+					assert.strict(error.message === "0x8e4", `Unexpected error: ${error.message}`);
+				}
 				return true;
 			};
 


### PR DESCRIPTION
The error is different for AFR vs. Tinylicious.  Made a note of that in comment and just expanded the test to be OK with either error.  Started conversation to determine if the AFR error is exactly what we expect, but still better either way to have some coverage here.

[AB#4374](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4374)