### PR TITLE
tree: Refactor RangeMap to use a B-tree

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -32,6 +32,7 @@ import {
 	brand,
 	fail,
 	idAllocatorFromMaxId,
+	newTupleBTree,
 } from "../../util/index.js";
 import {
 	type FieldBatchCodec,
@@ -65,7 +66,7 @@ import type {
 	NodeId,
 } from "./modularChangeTypes.js";
 import type { FieldChangeEncodingContext, FieldChangeHandler } from "./fieldChangeHandler.js";
-import { newCrossFieldKeyTable, newTupleBTree } from "./modularChangeFamily.js";
+import { newCrossFieldKeyTable } from "./modularChangeFamily.js";
 
 export function makeModularChangeCodecFamily(
 	fieldKindConfigurations: ReadonlyMap<number, FieldKindConfiguration>,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -86,9 +86,9 @@ import type {
 	ModularChangeset,
 	NodeChangeset,
 	NodeId,
-	TupleBTree,
 } from "./modularChangeTypes.js";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
+import { mergeTupleBTrees, newTupleBTree, type TupleBTree } from "../../util/index.js";
 
 /**
  * Implementation of ChangeFamily which delegates work in a given field to the appropriate FieldKind
@@ -272,14 +272,14 @@ export class ModularChangeFamily
 		// (since we assume that if two changesets use the same node ID they are referring to the same node),
 		// therefore all collisions will be addressed when processing the intersection of the changesets.
 		const composedNodeChanges: ChangeAtomIdBTree<NodeChangeset> = brand(
-			mergeBTrees(change1.nodeChanges, change2.nodeChanges),
+			mergeTupleBTrees(change1.nodeChanges, change2.nodeChanges),
 		);
 
 		const composedNodeToParent: ChangeAtomIdBTree<FieldId> = brand(
-			mergeBTrees(change1.nodeToParent, change2.nodeToParent),
+			mergeTupleBTrees(change1.nodeToParent, change2.nodeToParent),
 		);
 		const composedNodeAliases: ChangeAtomIdBTree<NodeId> = brand(
-			mergeBTrees(change1.nodeAliases, change2.nodeAliases),
+			mergeTupleBTrees(change1.nodeAliases, change2.nodeAliases),
 		);
 
 		const crossFieldTable = newComposeTable(change1, change2, composedNodeToParent);
@@ -304,7 +304,10 @@ export class ModularChangeFamily
 		);
 
 		// Currently no field kinds require making changes to cross-field keys during composition, so we can just merge the two tables.
-		const composedCrossFieldKeys = mergeBTrees(change1.crossFieldKeys, change2.crossFieldKeys);
+		const composedCrossFieldKeys = mergeTupleBTrees(
+			change1.crossFieldKeys,
+			change2.crossFieldKeys,
+		);
 		return {
 			fieldChanges: composedFields,
 			nodeChanges: composedNodeChanges,
@@ -1816,15 +1819,19 @@ function composeBuildsDestroysAndRefreshers(
 	// composition all the changes already reflected on the tree, but that is not something we
 	// care to support at this time.
 	const allBuilds: ChangeAtomIdBTree<TreeChunk> = brand(
-		mergeBTrees(change1.builds ?? newTupleBTree(), change2.builds ?? newTupleBTree(), true),
+		mergeTupleBTrees(
+			change1.builds ?? newTupleBTree(),
+			change2.builds ?? newTupleBTree(),
+			true,
+		),
 	);
 
 	const allDestroys: ChangeAtomIdBTree<number> = brand(
-		mergeBTrees(change1.destroys ?? newTupleBTree(), change2.destroys ?? newTupleBTree()),
+		mergeTupleBTrees(change1.destroys ?? newTupleBTree(), change2.destroys ?? newTupleBTree()),
 	);
 
 	const allRefreshers: ChangeAtomIdBTree<TreeChunk> = brand(
-		mergeBTrees(
+		mergeTupleBTrees(
 			change1.refreshers ?? newTupleBTree(),
 			change2.refreshers ?? newTupleBTree(),
 			true,
@@ -2975,27 +2982,6 @@ function revisionInfoFromTaggedChange(
 	return revInfos;
 }
 
-function mergeBTrees<K extends readonly unknown[], V>(
-	tree1: TupleBTree<K, V> | undefined,
-	tree2: TupleBTree<K, V> | undefined,
-	preferLeft = true,
-): TupleBTree<K, V> {
-	if (tree1 === undefined) {
-		return tree2 !== undefined ? brand(tree2.clone()) : newTupleBTree<K, V>();
-	}
-
-	const result: TupleBTree<K, V> = brand(tree1.clone());
-	if (tree2 === undefined) {
-		return result;
-	}
-
-	for (const [key, value] of tree2.entries()) {
-		result.set(key, value, !preferLeft);
-	}
-
-	return result;
-}
-
 function fieldChangeFromId(
 	fields: FieldChangeMap,
 	nodes: ChangeAtomIdBTree<NodeChangeset>,
@@ -3197,36 +3183,6 @@ function hasConflicts(change: ModularChangeset): boolean {
 
 export function newCrossFieldKeyTable(): CrossFieldKeyTable {
 	return newTupleBTree();
-}
-
-export function newTupleBTree<K extends readonly unknown[], V>(
-	entries?: [K, V][],
-): TupleBTree<K, V> {
-	return brand(new BTree<K, V>(entries, compareTuples));
-}
-
-// This assumes that the arrays are the same length.
-function compareTuples(arrayA: readonly unknown[], arrayB: readonly unknown[]): number {
-	for (let i = 0; i < arrayA.length; i++) {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const a = arrayA[i] as any;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const b = arrayB[i] as any;
-
-		// Less-than and greater-than always return false if either value is undefined,
-		// so we handle undefined separately, treating it as less than all other values.
-		if (a === undefined && b !== undefined) {
-			return -1;
-		} else if (b === undefined && a !== undefined) {
-			return 1;
-		} else if (a < b) {
-			return -1;
-		} else if (a > b) {
-			return 1;
-		}
-	}
-
-	return 0;
 }
 
 interface ModularChangesetContent {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -51,6 +51,9 @@ import {
 	idAllocatorFromState,
 	type RangeQueryResult,
 	getOrAddInMapLazy,
+	newTupleBTree,
+	mergeTupleBTrees,
+	type TupleBTree,
 } from "../../util/index.js";
 import {
 	type TreeChunk,
@@ -88,7 +91,6 @@ import type {
 	NodeId,
 } from "./modularChangeTypes.js";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
-import { mergeTupleBTrees, newTupleBTree, type TupleBTree } from "../../util/index.js";
 
 /**
  * Implementation of ChangeFamily which delegates work in a given field to the appropriate FieldKind

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeTypes.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { BTree } from "@tylerbu/sorted-btree-es6";
 import type {
 	ChangeAtomId,
 	ChangesetLocalId,
@@ -12,7 +11,7 @@ import type {
 	RevisionInfo,
 	RevisionTag,
 } from "../../core/index.js";
-import type { Brand } from "../../util/index.js";
+import type { Brand, TupleBTree } from "../../util/index.js";
 import type { TreeChunk } from "../chunked-forest/index.js";
 import type { CrossFieldTarget } from "./crossFieldQueries.js";
 
@@ -71,7 +70,6 @@ export interface ModularChangeset extends HasFieldChanges {
 	readonly refreshers?: ChangeAtomIdBTree<TreeChunk>;
 }
 
-export type TupleBTree<K, V> = Brand<BTree<K, V>, "TupleBTree">;
 export type ChangeAtomIdBTree<V> = TupleBTree<[RevisionTag | undefined, ChangesetLocalId], V>;
 export type CrossFieldKeyTable = TupleBTree<CrossFieldKeyRange, FieldId>;
 export type CrossFieldKeyRange = readonly [

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -57,6 +57,7 @@ import {
 	brand,
 	idAllocatorFromMaxId,
 	nestedMapFromFlatList,
+	newTupleBTree,
 	setInNestedMap,
 	tryGetFromNestedMap,
 } from "../../../util/index.js";
@@ -87,7 +88,6 @@ import {
 	updateRefreshers,
 	relevantRemovedRoots as relevantDetachedTreesImplementation,
 	newCrossFieldKeyTable,
-	newTupleBTree,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/modular-schema/modularChangeFamily.js";
 import type {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangesetUtil.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangesetUtil.ts
@@ -31,13 +31,13 @@ import {
 	brand,
 	fail,
 	idAllocatorFromMaxId,
+	newTupleBTree,
 } from "../../../util/index.js";
 import {
 	getChangeHandler,
 	getFieldsForCrossFieldKey,
 	getParentFieldId,
 	newCrossFieldKeyTable,
-	newTupleBTree,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/modular-schema/modularChangeFamily.js";
 import { strict as assert } from "node:assert";
@@ -235,8 +235,9 @@ function addNodeToField(
 }
 
 const dummyCrossFieldManager: CrossFieldManager = {
-	get: (_target, _revision, _id, count, _addDependency) => ({
+	get: (_target, _revision, id, count, _addDependency) => ({
 		value: undefined,
+		start: id,
 		length: count,
 	}),
 	set: () => fail("Not supported"),

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/rangeMap.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/rangeMap.spec.ts
@@ -16,7 +16,7 @@ describe("RangeMap", () => {
 	it("query on empty map returns undefined", () => {
 		const map = newRangeMap();
 		const entry = map.get(5, 4);
-		assert.deepEqual(entry, { length: 4, value: undefined });
+		assert.deepEqual(entry, { start: 5, length: 4, value: undefined });
 	});
 
 	it("read one entry", () => {
@@ -27,22 +27,22 @@ describe("RangeMap", () => {
 
 		// Read keys 0-2
 		const entryBefore = map.get(0, 3);
-		assert.deepEqual(entryBefore, { length: 3, value: undefined });
+		assert.deepEqual(entryBefore, { start: 0, length: 3, value: undefined });
 
 		// Read keys 1-3
 		const entryBeginning = map.get(1, 3);
-		assert.deepEqual(entryBeginning, { length: 2, value: undefined });
+		assert.deepEqual(entryBeginning, { start: 1, length: 2, value: undefined });
 
 		// Read keys 2-7
 		const entryWhole = map.get(2, 6);
-		assert.deepEqual(entryWhole, { length: 1, value: undefined });
+		assert.deepEqual(entryWhole, { start: 2, length: 1, value: undefined });
 
 		const entryEnd = map.get(6, 2);
-		assert.deepEqual(entryEnd, { length: 1, value: "a" });
+		assert.deepEqual(entryEnd, { start: 6, length: 1, value: "a" });
 
 		// Read key 7
 		const entryAfter = map.get(7, 1);
-		assert.deepEqual(entryAfter, { length: 1, value: undefined });
+		assert.deepEqual(entryAfter, { start: 7, length: 1, value: undefined });
 	});
 
 	it("read two entries", () => {
@@ -56,19 +56,19 @@ describe("RangeMap", () => {
 
 		// Read key 3
 		const entryFirst = map.get(3, 1);
-		assert.deepEqual(entryFirst, { length: 1, value: "a" });
+		assert.deepEqual(entryFirst, { start: 3, length: 1, value: "a" });
 
 		// Read keys 5-7
 		const entrySecond = map.get(5, 3);
-		assert.deepEqual(entrySecond, { length: 1, value: undefined });
+		assert.deepEqual(entrySecond, { start: 5, length: 1, value: undefined });
 
 		// Read keys 4-5
 		const entryBetween = map.get(4, 2);
-		assert.deepEqual(entryBetween, { length: 2, value: undefined });
+		assert.deepEqual(entryBetween, { start: 4, length: 2, value: undefined });
 
 		// Read keys 3-6
 		const entryBoth = map.get(3, 4);
-		assert.deepEqual(entryBoth, { length: 1, value: "a" });
+		assert.deepEqual(entryBoth, { start: 3, length: 1, value: "a" });
 	});
 
 	it("write overlapping ranges", () => {
@@ -90,25 +90,25 @@ describe("RangeMap", () => {
 		map.set(1, 7, "e");
 
 		const entry0 = map.get(0, 8);
-		assert.deepEqual(entry0, { length: 1, value: "a" });
+		assert.deepEqual(entry0, { start: 0, length: 1, value: "a" });
 
 		const entry1 = map.get(1, 1);
-		assert.deepEqual(entry1, { length: 1, value: "e" });
+		assert.deepEqual(entry1, { start: 1, length: 1, value: "e" });
 
 		const entry3 = map.get(3, 2);
-		assert.deepEqual(entry3, { length: 2, value: "e" });
+		assert.deepEqual(entry3, { start: 3, length: 2, value: "e" });
 
 		const entry5 = map.get(5, 1);
-		assert.deepEqual(entry5, { length: 1, value: "e" });
+		assert.deepEqual(entry5, { start: 5, length: 1, value: "e" });
 
 		const entry6 = map.get(6, 1);
-		assert.deepEqual(entry6, { length: 1, value: "e" });
+		assert.deepEqual(entry6, { start: 6, length: 1, value: "e" });
 
 		const entry7 = map.get(7, 2);
-		assert.deepEqual(entry7, { length: 1, value: "e" });
+		assert.deepEqual(entry7, { start: 7, length: 1, value: "e" });
 
 		const entry8 = map.get(8, 1);
-		assert.deepEqual(entry8, { length: 1, value: "d" });
+		assert.deepEqual(entry8, { start: 8, length: 1, value: "d" });
 	});
 
 	it("write range which splits existing range", () => {
@@ -121,13 +121,13 @@ describe("RangeMap", () => {
 		map.set(4, 3, "b");
 
 		const entry1 = map.get(1, 10);
-		assert.deepEqual(entry1, { length: 3, value: "a" });
+		assert.deepEqual(entry1, { start: 1, length: 3, value: "a" });
 
 		const entry4 = map.get(4, 8);
-		assert.deepEqual(entry4, { length: 3, value: "b" });
+		assert.deepEqual(entry4, { start: 4, length: 3, value: "b" });
 
 		const entry7 = map.get(7, 4);
-		assert.deepEqual(entry7, { length: 4, value: "a" });
+		assert.deepEqual(entry7, { start: 7, length: 4, value: "a" });
 	});
 
 	describe("deleteFromRange", () => {

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
@@ -35,8 +35,7 @@ import { brand } from "../../util/brand.js";
 import { ajvValidator } from "../codec/index.js";
 import { testIdCompressor, testRevisionTagCodec } from "../utils.js";
 import { BTree } from "@tylerbu/sorted-btree-es6";
-// eslint-disable-next-line import/no-internal-modules
-import { newTupleBTree } from "../../feature-libraries/modular-schema/modularChangeFamily.js";
+import { newTupleBTree } from "../../util/index.js";
 
 const codecOptions: ICodecOptions = { jsonValidator: ajvValidator };
 

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -128,7 +128,6 @@ import {
 	SchematizingSimpleTreeView,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../shared-tree/schematizingTreeView.js";
-// eslint-disable-next-line import/no-internal-modules
 import type {
 	SharedTreeOptions,
 	SharedTreeOptionsInternal,

--- a/packages/dds/tree/src/util/bTreeUtils.ts
+++ b/packages/dds/tree/src/util/bTreeUtils.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { BTree } from "@tylerbu/sorted-btree-es6";
+import { brand, type Brand } from "./brand.js";
+
+export type TupleBTree<K, V> = Brand<BTree<K, V>, "TupleBTree">;
+
+export function newTupleBTree<K extends readonly unknown[], V>(
+	entries?: [K, V][],
+): TupleBTree<K, V> {
+	return brand(new BTree<K, V>(entries, compareTuples));
+}
+
+// This assumes that the arrays are the same length.
+function compareTuples(arrayA: readonly unknown[], arrayB: readonly unknown[]): number {
+	for (let i = 0; i < arrayA.length; i++) {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const a = arrayA[i] as any;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const b = arrayB[i] as any;
+
+		// Less-than and greater-than always return false if either value is undefined,
+		// so we handle undefined separately, treating it as less than all other values.
+		if (a === undefined && b !== undefined) {
+			return -1;
+		} else if (b === undefined && a !== undefined) {
+			return 1;
+		} else if (a < b) {
+			return -1;
+		} else if (a > b) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+export function mergeTupleBTrees<K extends readonly unknown[], V>(
+	tree1: TupleBTree<K, V> | undefined,
+	tree2: TupleBTree<K, V> | undefined,
+	preferLeft = true,
+): TupleBTree<K, V> {
+	if (tree1 === undefined) {
+		return tree2 !== undefined ? brand(tree2.clone()) : newTupleBTree<K, V>();
+	}
+
+	const result: TupleBTree<K, V> = brand(tree1.clone());
+	if (tree2 === undefined) {
+		return result;
+	}
+
+	for (const [key, value] of tree2.entries()) {
+		result.set(key, value, !preferLeft);
+	}
+
+	return result;
+}

--- a/packages/dds/tree/src/util/idAllocator.ts
+++ b/packages/dds/tree/src/util/idAllocator.ts
@@ -26,8 +26,6 @@ export interface IdAllocationState {
 	maxId: number;
 }
 
-/**
- */
 export function idAllocatorFromMaxId(maxId: number | undefined = undefined): IdAllocator {
 	return idAllocatorFromState({ maxId: maxId ?? -1 });
 }

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -140,3 +140,5 @@ export {
 	throwIfBroken,
 	breakingClass,
 } from "./breakable.js";
+
+export { type TupleBTree, newTupleBTree, mergeTupleBTrees } from "./bTreeUtils.js";

--- a/packages/dds/tree/src/util/rangeMap.ts
+++ b/packages/dds/tree/src/util/rangeMap.ts
@@ -18,7 +18,7 @@ export class RangeMap<T> {
 
 	/**
 	 * Retrieves all entries from the rangeMap.
-	 * @returns An array of RangeEntryResult objects, each containing the start index, length, and value of a contiguous range.
+	 * @returns An array of RangeQueryResult objects, each containing the start index, length, and value of a contiguous range.
 	 */
 	public getAllEntries(): RangeQueryResult<T>[] {
 		const entries: RangeQueryResult<T>[] = [];

--- a/packages/dds/tree/src/util/rangeMap.ts
+++ b/packages/dds/tree/src/util/rangeMap.ts
@@ -180,6 +180,9 @@ interface RangeEntry<T> {
  * Describes the result of a range query, including the value and length of the matching prefix.
  */
 export interface RangeQueryResult<T> {
+	/**
+	 * The key for the first element in the range.
+	 */
 	readonly start: number;
 
 	/**

--- a/packages/dds/tree/src/util/rangeMap.ts
+++ b/packages/dds/tree/src/util/rangeMap.ts
@@ -3,25 +3,30 @@
  * Licensed under the MIT License.
  */
 
-import { oob } from "@fluidframework/core-utils/internal";
+import { newTupleBTree, type TupleBTree } from "./bTreeUtils.js";
 
 /**
  * RangeMap represents a mapping from integers to values of type T or undefined.
  * The values for a range of consecutive keys can be changed or queried in a single operation.
  */
 export class RangeMap<T> {
-	private readonly entries: RangeEntry<T>[];
+	private readonly tree: TupleBTree<[number], RangeEntry<T>>;
 
-	public constructor(initialEntries?: RangeEntry<T>[]) {
-		this.entries = initialEntries ? [...initialEntries] : [];
+	public constructor() {
+		this.tree = newTupleBTree();
 	}
 
 	/**
 	 * Retrieves all entries from the rangeMap.
 	 * @returns An array of RangeEntryResult objects, each containing the start index, length, and value of a contiguous range.
 	 */
-	public getAllEntries(): readonly RangeQueryResult<T>[] {
-		return this.entries;
+	public getAllEntries(): RangeQueryResult<T>[] {
+		const entries: RangeQueryResult<T>[] = [];
+		for (const [[start], entry] of this.tree.entries()) {
+			entries.push({ start, length: entry.length, value: entry.value });
+		}
+
+		return entries;
 	}
 
 	/**
@@ -33,20 +38,36 @@ export class RangeMap<T> {
 	 * and the number of consecutive keys with that same value.
 	 */
 	public get(start: number, length: number): RangeQueryResult<T> {
-		for (const entry of this.entries) {
-			if (entry.start > start) {
-				return { value: undefined, length: Math.min(entry.start - start, length) };
-			}
+		// We first check for an entry with a key less than or equal to `start`.
+		{
+			const entry = this.tree.getPairOrNextLower([start]);
+			if (entry !== undefined) {
+				const [entryKey] = entry[0];
+				const { value, length: entryLength } = entry[1];
 
-			const lastRangeKey = entry.start + entry.length - 1;
-			if (lastRangeKey >= start) {
-				const overlapLength = lastRangeKey - start + 1;
-				return { value: entry.value, length: Math.min(overlapLength, length) };
+				const entryLastId = entryKey + entryLength - 1;
+				const overlappingLength = Math.min(entryLastId - start + 1, length);
+				if (overlappingLength > 0) {
+					return { value, start, length: overlappingLength };
+				}
 			}
 		}
 
-		// There were no entries intersecting the query range, so the entire query range has undefined value.
-		return { value: undefined, length };
+		{
+			// There is no value associated with `start`.
+			// Now we need to determine how many of the following keys are also undefined.
+			const key = this.tree.nextHigherKey([start]);
+			if (key !== undefined) {
+				const [entryKey] = key;
+
+				const lastQueryId = start + length - 1;
+				if (entryKey <= lastQueryId) {
+					return { value: undefined, start, length: entryKey - start };
+				}
+			}
+
+			return { value: undefined, start, length };
+		}
 	}
 
 	/**
@@ -57,73 +78,10 @@ export class RangeMap<T> {
 	 * @param value - The value to associate with the range.
 	 */
 	public set(start: number, length: number, value: T | undefined): void {
-		if (value === undefined) {
-			this.delete(start, length);
-			return;
+		this.delete(start, length);
+		if (value !== undefined) {
+			this.tree.set([start], { value, length });
 		}
-
-		const end = start + length - 1;
-		const newEntry: RangeEntry<T> = { start, length, value };
-
-		let iBefore = -1;
-		let iAfter = this.entries.length;
-		for (const [i, entry] of this.entries.entries()) {
-			const entryLastKey = entry.start + entry.length - 1;
-			if (entryLastKey < start) {
-				iBefore = i;
-			} else if (entry.start > end) {
-				iAfter = i;
-				break;
-			}
-		}
-
-		const numOverlappingEntries = iAfter - iBefore - 1;
-		if (numOverlappingEntries === 0) {
-			this.entries.splice(iAfter, 0, newEntry);
-			return;
-		}
-
-		const iFirst = iBefore + 1;
-		const firstEntry = this.entries[iFirst] ?? oob();
-		const iLast = iAfter - 1;
-		const lastEntry = this.entries[iLast] ?? oob();
-		const lengthBeforeFirst = start - firstEntry.start;
-		const lastEntryKey = lastEntry.start + lastEntry.length - 1;
-		const lengthAfterLast = lastEntryKey - end;
-
-		if (lengthBeforeFirst > 0 && lengthAfterLast > 0 && iFirst === iLast) {
-			// The new entry fits in the middle of an existing entry.
-			// We replace the existing entry with:
-			// 1) the portion which comes before `newEntry`
-			// 2) `newEntry`
-			// 3) the portion which comes after `newEntry`
-			this.entries.splice(iFirst, 1, { ...firstEntry, length: lengthBeforeFirst }, newEntry, {
-				...lastEntry,
-				start: end + 1,
-				length: lengthAfterLast,
-			});
-			return;
-		}
-
-		if (lengthBeforeFirst > 0) {
-			this.entries[iFirst] = { ...firstEntry, length: lengthBeforeFirst };
-			// The entry at `iFirst` is no longer overlapping with `newEntry`.
-			iBefore = iFirst;
-		}
-
-		if (lengthAfterLast > 0) {
-			this.entries[iLast] = {
-				...lastEntry,
-				start: end + 1,
-				length: lengthAfterLast,
-			};
-
-			// The entry at `iLast` is no longer overlapping with `newEntry`.
-			iAfter = iLast;
-		}
-
-		const numContainedEntries = iAfter - iBefore - 1;
-		this.entries.splice(iBefore + 1, numContainedEntries, newEntry);
 	}
 
 	/**
@@ -147,58 +105,57 @@ export class RangeMap<T> {
 	 * @param length - The length of the range to delete.
 	 */
 	public delete(start: number, length: number): void {
-		const end = start + length - 1;
+		const lastDeletedKey = start + length - 1;
+		{
+			const entry = this.tree.getPairOrNextLower([start]);
+			if (entry !== undefined) {
+				const [key] = entry[0];
+				const { length: entryLength, value } = entry[1];
+				const lastEntryKey = key + entryLength - 1;
+				if (lastEntryKey >= start) {
+					// This entry overlaps with the deleted range, so we remove it.
+					this.tree.delete([key]);
+					if (key < start) {
+						// A portion of the entry comes before the delete range, so we reinsert that portion.
+						this.tree.set([key], { value, length: start - key });
+					}
 
-		let iBefore = -1;
-		let iAfter = this.entries.length;
+					if (lastEntryKey > lastDeletedKey) {
+						// A portion of the entry comes after the delete range, so we reinsert that portion.
+						this.tree.set([lastDeletedKey + 1], {
+							value,
+							length: lastEntryKey - lastDeletedKey,
+						});
 
-		for (const [i, entry] of this.entries.entries()) {
-			const entryLastKey = entry.start + entry.length - 1;
-			if (entryLastKey < start) {
-				iBefore = i;
-			} else if (entry.start > end) {
-				iAfter = i;
-				break;
+						return;
+					}
+				}
 			}
 		}
 
-		const numOverlappingEntries = iAfter - iBefore - 1;
-
-		if (numOverlappingEntries === 0) {
-			// No entry will be removed
-			return;
-		}
-
-		const iFirst = iBefore + 1;
-		const iLast = iAfter - 1;
-
-		for (let i = iFirst; i <= iLast; ++i) {
-			const entry = this.entries[i] ?? oob();
-			const entryLastKey = entry.start + entry.length - 1;
-			let isDirty = false;
-
-			if (entry.start >= start && entryLastKey <= end) {
-				// If the entry lies within the range to be deleted, remove it
-				this.entries.splice(i, 1);
-			} else {
-				// If the entry partially or completely overlaps with the range to be deleted
-				if (entry.start < start) {
-					// Update the endpoint and length of the portion before the range to be deleted
-					const lengthBefore = start - entry.start;
-					this.entries[i] = { ...entry, length: lengthBefore };
-					isDirty = true;
+		{
+			let entry = this.tree.nextHigherPair([start]);
+			while (entry !== undefined) {
+				const [key] = entry[0];
+				if (key > lastDeletedKey) {
+					return;
 				}
 
-				if (entryLastKey > end) {
-					// Update the startpoint and length of the portion after the range to be deleted
-					const newStart = end + 1;
-					const newLength = entryLastKey - end;
-					this.entries.splice(isDirty ? i + 1 : i, isDirty ? 0 : 1, {
-						start: newStart,
-						length: newLength,
-						value: entry.value,
+				const { length: entryLength, value } = entry[1];
+				const lastEntryKey = key + entryLength - 1;
+
+				this.tree.delete([key]);
+				if (lastEntryKey > lastDeletedKey) {
+					// A portion of the entry comes after the delete range, so we reinsert that portion.
+					this.tree.set([lastDeletedKey + 1], {
+						value,
+						length: lastEntryKey - lastDeletedKey,
 					});
+
+					return;
 				}
+
+				entry = this.tree.nextHigherPair([lastEntryKey]);
 			}
 		}
 	}
@@ -206,14 +163,8 @@ export class RangeMap<T> {
 
 /**
  * Represents a contiguous range of values in the RangeMap.
- * This interface is used internally and should not be exposed to consumers.
  */
 interface RangeEntry<T> {
-	/**
-	 * The starting index of the range (inclusive).
-	 */
-	readonly start: number;
-
 	/**
 	 * The length of the range.
 	 */
@@ -229,6 +180,8 @@ interface RangeEntry<T> {
  * Describes the result of a range query, including the value and length of the matching prefix.
  */
 export interface RangeQueryResult<T> {
+	readonly start: number;
+
 	/**
 	 * The value of the first key in the query range.
 	 * If no matching range is found, this will be undefined.

--- a/packages/dds/tree/src/util/rangeMap.ts
+++ b/packages/dds/tree/src/util/rangeMap.ts
@@ -17,8 +17,7 @@ export class RangeMap<T> {
 	}
 
 	/**
-	 * Retrieves all entries from the rangeMap.
-	 * @returns An array of RangeQueryResult objects, each containing the start index, length, and value of a contiguous range.
+	 * Retrieves all entries from the RangeMap.
 	 */
 	public getAllEntries(): RangeQueryResult<T>[] {
 		const entries: RangeQueryResult<T>[] = [];

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -47,8 +47,6 @@ export function asMutable<T>(readonly: T): Mutable<T> {
 
 export const clone = structuredClone;
 
-/**
- */
 export function fail(message: string): never {
 	throw new Error(message);
 }


### PR DESCRIPTION
## Description

Reimplemented RangeMap to store entries in a B-tree instead of an array to improve asymptotic performance.