### PR TITLE
fix(api-markdown-documenter): Fix `minimumReleaseLevel` property typing

### DIFF
--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -315,7 +315,7 @@ export interface DocumentationSuiteConfiguration {
     readonly hierarchyBoundaries: HierarchyBoundaries;
     readonly includeBreadcrumb: boolean;
     readonly includeTopLevelDocumentHeading: boolean;
-    readonly minimumReleaseLevel: Omit<ReleaseTag, ReleaseTag.None>;
+    readonly minimumReleaseLevel: Exclude<ReleaseTag, ReleaseTag.None>;
     readonly skipPackage: (apiPackage: ApiPackage) => boolean;
 }
 

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -315,7 +315,7 @@ export interface DocumentationSuiteConfiguration {
     readonly hierarchyBoundaries: HierarchyBoundaries;
     readonly includeBreadcrumb: boolean;
     readonly includeTopLevelDocumentHeading: boolean;
-    readonly minimumReleaseLevel: Omit<ReleaseTag, ReleaseTag.None>;
+    readonly minimumReleaseLevel: Exclude<ReleaseTag, ReleaseTag.None>;
     readonly skipPackage: (apiPackage: ApiPackage) => boolean;
 }
 

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -315,7 +315,7 @@ export interface DocumentationSuiteConfiguration {
     readonly hierarchyBoundaries: HierarchyBoundaries;
     readonly includeBreadcrumb: boolean;
     readonly includeTopLevelDocumentHeading: boolean;
-    readonly minimumReleaseLevel: Omit<ReleaseTag, ReleaseTag.None>;
+    readonly minimumReleaseLevel: Exclude<ReleaseTag, ReleaseTag.None>;
     readonly skipPackage: (apiPackage: ApiPackage) => boolean;
 }
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuite.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuite.ts
@@ -234,7 +234,7 @@ export interface DocumentationSuiteConfiguration {
 	 * releaseLevel: ReleaseTag.Beta
 	 * ```
 	 */
-	readonly minimumReleaseLevel: Omit<ReleaseTag, ReleaseTag.None>;
+	readonly minimumReleaseLevel: Exclude<ReleaseTag, ReleaseTag.None>;
 }
 
 /**


### PR DESCRIPTION
The property was incorrectly using `Omit` instead of `Exclude`, the latter being the correct options for excluding a member of a type union.