### PR TITLE
refactor(api-markdown-documenter): Consistent release levels

### DIFF
--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -650,7 +650,7 @@ export { ReleaseTag }
 // @alpha
 function renderApiModelAsHtml(options: RenderApiModelAsHtmlOptions): Promise<void>;
 
-// @public
+// @alpha
 interface RenderApiModelAsHtmlOptions extends ApiItemTransformationOptions, RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
 }
 
@@ -674,7 +674,7 @@ export interface RenderDocumentAsHtmlConfiguration extends ToHtmlConfiguration, 
 // @alpha
 function renderDocumentsAsHtml(documents: DocumentNode[], options: RenderDocumentsAsHtmlOptions): Promise<void>;
 
-// @public
+// @alpha
 interface RenderDocumentsAsHtmlOptions extends RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
 }
 

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -648,10 +648,6 @@ export class PlainTextNode extends DocumentationLiteralNodeBase<string> implemen
 export { ReleaseTag }
 
 // @public
-interface RenderApiModelAsHtmlOptions extends ApiItemTransformationOptions, RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
-}
-
-// @public
 function renderApiModelAsMarkdown(options: RenderApiModelAsMarkdownOptions): Promise<void>;
 
 // @public
@@ -666,10 +662,6 @@ function renderDocument_2(document: DocumentNode, config: MarkdownRenderConfigur
 
 // @public @sealed
 export interface RenderDocumentAsHtmlConfiguration extends ToHtmlConfiguration, RenderHtmlConfiguration {
-}
-
-// @public
-interface RenderDocumentsAsHtmlOptions extends RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
 }
 
 // @public

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -626,10 +626,6 @@ export class PlainTextNode extends DocumentationLiteralNodeBase<string> implemen
 export { ReleaseTag }
 
 // @public
-interface RenderApiModelAsHtmlOptions extends ApiItemTransformationOptions, RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
-}
-
-// @public
 function renderApiModelAsMarkdown(options: RenderApiModelAsMarkdownOptions): Promise<void>;
 
 // @public
@@ -644,10 +640,6 @@ function renderDocument_2(document: DocumentNode, config: MarkdownRenderConfigur
 
 // @public @sealed
 export interface RenderDocumentAsHtmlConfiguration extends ToHtmlConfiguration, RenderHtmlConfiguration {
-}
-
-// @public
-interface RenderDocumentsAsHtmlOptions extends RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
 }
 
 // @public

--- a/tools/api-markdown-documenter/src/RenderHtml.ts
+++ b/tools/api-markdown-documenter/src/RenderHtml.ts
@@ -18,7 +18,7 @@ import { type RenderDocumentAsHtmlConfiguration, renderDocumentAsHtml } from "./
 /**
  * API Model HTML rendering options.
  *
- * @public
+ * @alpha
  */
 export interface RenderApiModelAsHtmlOptions
 	extends ApiItemTransformationOptions,
@@ -55,7 +55,7 @@ export async function renderApiModelAsHtml(options: RenderApiModelAsHtmlOptions)
 /**
  * Options for rendering {@link DocumentNode}s as HTML.
  *
- * @public
+ * @alpha
  */
 export interface RenderDocumentsAsHtmlOptions
 	extends RenderDocumentAsHtmlConfiguration,


### PR DESCRIPTION
Interfaces were previously introduced to represent parameters to HTML rendering functions. They were added as `@public`, but the related functions are `@alpha`. This PR makes the interfaces `@alpha` to align with their corresponding functions.

While this is technically a breaking change, the types strictly exist for input to functions that are `@alpha`, so this shouldn't have any impact on users.