### PR TITLE
Use public API entry point for bundle size testing of tree

### DIFF
--- a/examples/utils/bundle-size-tests/src/sharedTree.ts
+++ b/examples/utils/bundle-size-tests/src/sharedTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { SharedTree } from "@fluidframework/tree/internal";
+import { SharedTree } from "fluid-framework";
 
 export function apisToBundle() {
 	return SharedTree;


### PR DESCRIPTION
## Description

It's possible for the fluid-framework package to add overhead or pull in additional dependencies, so we might as well test it to we measure the actual worse case public API use in the bundle size tests.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
