### PR TITLE
refactor(api-markdown-documenter): Make property `readonly`

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -68,6 +68,7 @@ await MarkdownRenderer.renderApiModel({
 -   `ApiItemTransformations`
 -   `ApiItemTransformationConfiguration`
 -   `DocumentationSuiteOptions`
+-   `FileSystemConfiguration`
 -   `HtmlRenderer.RenderHtmlConfig`
 -   `LintApiModelConfiguration`
 -   `MarkdownRenderer.Renderers`

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -374,7 +374,7 @@ export class FencedCodeBlockNode extends DocumentationParentNodeBase implements 
 // @public
 export interface FileSystemConfiguration {
     readonly newlineKind?: NewlineKind;
-    outputDirectoryPath: string;
+    readonly outputDirectoryPath: string;
 }
 
 // @public

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -374,7 +374,7 @@ export class FencedCodeBlockNode extends DocumentationParentNodeBase implements 
 // @public
 export interface FileSystemConfiguration {
     readonly newlineKind?: NewlineKind;
-    outputDirectoryPath: string;
+    readonly outputDirectoryPath: string;
 }
 
 // @public

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -374,7 +374,7 @@ export class FencedCodeBlockNode extends DocumentationParentNodeBase implements 
 // @public
 export interface FileSystemConfiguration {
     readonly newlineKind?: NewlineKind;
-    outputDirectoryPath: string;
+    readonly outputDirectoryPath: string;
 }
 
 // @public

--- a/tools/api-markdown-documenter/src/FileSystemConfiguration.ts
+++ b/tools/api-markdown-documenter/src/FileSystemConfiguration.ts
@@ -14,7 +14,7 @@ export interface FileSystemConfiguration {
 	/**
 	 * The directory under which the document files will be generated.
 	 */
-	outputDirectoryPath: string;
+	readonly outputDirectoryPath: string;
 
 	/**
 	 * Specifies what type of newlines API Documenter should use when writing output files.


### PR DESCRIPTION
Makes `FileSystemConfiguration.outputDirectoryPath` readonly. 