### PR TITLE
[LTS] Disable coverage reports

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -114,7 +114,9 @@ stages:
         displayName: Build
         pool: ${{ parameters.poolBuild }}
         variables:
-          testCoverage: ${{ and(eq(parameters.taskTest, 'ci:test'), ne(variables['Build.Reason'], 'PullRequest')) }}
+          # Coverage has quality issues in LTS, and root-causing + fixing is not a priority given changes to LTS at this point
+          # will be things like upgrading node or security fixes, not adding new features.
+          testCoverage: false
           releaseBuildVar: $[variables.releaseBuild]
         steps:
         # Setup


### PR DESCRIPTION
## Description

Code coverage has been reporting incorrect results on LTS for a while but we haven't noticed: most recent results show only various files in PropertyDDS as being covered, despite the configs intending to verify coverage from all of our tests.

More recently, the removal of various property DDS packages caused the coverage upload step to start failing.

We could invest in fixing this, but it seems low value as LTS basically only receives security + infrastructure patches at this point, and code coverage is not a particularly relevant metric.