### PR TITLE
refactor: Make array parameters readonly and clean up stale documentation

### DIFF
--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -672,14 +672,14 @@ export interface RenderDocumentAsHtmlConfiguration extends ToHtmlConfiguration, 
 }
 
 // @alpha
-function renderDocumentsAsHtml(documents: DocumentNode[], options: RenderDocumentsAsHtmlOptions): Promise<void>;
+function renderDocumentsAsHtml(documents: readonly DocumentNode[], options: RenderDocumentsAsHtmlOptions): Promise<void>;
 
 // @alpha
 interface RenderDocumentsAsHtmlOptions extends RenderDocumentAsHtmlConfiguration, FileSystemConfiguration {
 }
 
 // @public
-function renderDocumentsAsMarkdown(documents: DocumentNode[], options: RenderDocumentsAsMarkdownOptions): Promise<void>;
+function renderDocumentsAsMarkdown(documents: readonly DocumentNode[], options: RenderDocumentsAsMarkdownOptions): Promise<void>;
 
 // @public
 interface RenderDocumentsAsMarkdownOptions extends MarkdownRenderConfiguration, FileSystemConfiguration {

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -665,7 +665,7 @@ export interface RenderDocumentAsHtmlConfiguration extends ToHtmlConfiguration, 
 }
 
 // @public
-function renderDocumentsAsMarkdown(documents: DocumentNode[], options: RenderDocumentsAsMarkdownOptions): Promise<void>;
+function renderDocumentsAsMarkdown(documents: readonly DocumentNode[], options: RenderDocumentsAsMarkdownOptions): Promise<void>;
 
 // @public
 interface RenderDocumentsAsMarkdownOptions extends MarkdownRenderConfiguration, FileSystemConfiguration {

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -643,7 +643,7 @@ export interface RenderDocumentAsHtmlConfiguration extends ToHtmlConfiguration, 
 }
 
 // @public
-function renderDocumentsAsMarkdown(documents: DocumentNode[], options: RenderDocumentsAsMarkdownOptions): Promise<void>;
+function renderDocumentsAsMarkdown(documents: readonly DocumentNode[], options: RenderDocumentsAsMarkdownOptions): Promise<void>;
 
 // @public
 interface RenderDocumentsAsMarkdownOptions extends MarkdownRenderConfiguration, FileSystemConfiguration {

--- a/tools/api-markdown-documenter/src/RenderHtml.ts
+++ b/tools/api-markdown-documenter/src/RenderHtml.ts
@@ -28,22 +28,6 @@ export interface RenderApiModelAsHtmlOptions
 /**
  * Renders the provided model and its contents, and writes each document to a file on disk.
  *
- * @remarks
- *
- * Which API members get their own documents and which get written to the contents of their parent is
- * determined by {@link DocumentationSuiteConfiguration.documentBoundaries}.
- *
- * The file paths under which the files will be generated is determined by the provided output path and the
- * following configuration properties:
- *
- * - {@link DocumentationSuiteConfiguration.documentBoundaries}
- * - {@link DocumentationSuiteConfiguration.hierarchyBoundaries}
- *
- * @param transformConfig - Configuration for transforming API items into {@link DocumentationNode}s.
- * @param renderConfig - Configuration for rendering {@link DocumentNode}s as HTML.
- * @param fileSystemConfig - Configuration for writing document files to disk.
- * @param logger - Receiver of system log data. Default: {@link defaultConsoleLogger}.
- *
  * @alpha
  */
 export async function renderApiModelAsHtml(options: RenderApiModelAsHtmlOptions): Promise<void> {
@@ -66,14 +50,11 @@ export interface RenderDocumentsAsHtmlOptions
  *
  * @param documents - The documents to render. Each will be rendered to its own file on disk per
  * {@link DocumentNode.documentPath} (relative to the provided output directory).
- * @param renderConfig - Configuration for rendering {@link DocumentNode}s as HTML.
- * @param fileSystemConfig - Configuration for writing document files to disk.
- * @param logger - Receiver of system log data. Default: {@link defaultConsoleLogger}.
  *
  * @alpha
  */
 export async function renderDocumentsAsHtml(
-	documents: DocumentNode[],
+	documents: readonly DocumentNode[],
 	options: RenderDocumentsAsHtmlOptions,
 ): Promise<void> {
 	const { logger, newlineKind, outputDirectoryPath } = options;

--- a/tools/api-markdown-documenter/src/RenderMarkdown.ts
+++ b/tools/api-markdown-documenter/src/RenderMarkdown.ts
@@ -28,22 +28,6 @@ export interface RenderApiModelAsMarkdownOptions
 /**
  * Renders the provided model and its contents, and writes each document to a file on disk.
  *
- * @remarks
- *
- * Which API members get their own documents and which get written to the contents of their parent is
- * determined by {@link DocumentationSuiteConfiguration.documentBoundaries}.
- *
- * The file paths under which the files will be generated is determined by the provided output path and the
- * following configuration properties:
- *
- * - {@link DocumentationSuiteConfiguration.documentBoundaries}
- * - {@link DocumentationSuiteConfiguration.hierarchyBoundaries}
- *
- * @param transformConfig - Configuration for transforming API items into {@link DocumentationNode}s.
- * @param renderConfig - Configuration for rendering {@link DocumentNode}s as Markdown.
- * @param fileSystemConfig - Configuration for writing document files to disk.
- * @param logger - Receiver of system log data. Default: {@link defaultConsoleLogger}.
- *
  * @public
  */
 export async function renderApiModelAsMarkdown(
@@ -68,14 +52,11 @@ export interface RenderDocumentsAsMarkdownOptions
  *
  * @param documents - The documents to render. Each will be rendered to its own file on disk per
  * {@link DocumentNode.documentPath} (relative to the provided output directory).
- * @param renderConfig - Configuration for rendering {@link DocumentNode}s as Markdown.
- * @param fileSystemConfig - Configuration for writing document files to disk.
- * @param logger - Receiver of system log data. Default: {@link defaultConsoleLogger}.
  *
  * @public
  */
 export async function renderDocumentsAsMarkdown(
-	documents: DocumentNode[],
+	documents: readonly DocumentNode[],
 	options: RenderDocumentsAsMarkdownOptions,
 ): Promise<void> {
 	const { logger, newlineKind, outputDirectoryPath } = options;

--- a/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TransformApiModel.ts
@@ -26,19 +26,6 @@ import { createBreadcrumbParagraph, createEntryPointList, wrapInSection } from "
 /**
  * Renders the provided model and its contents to a series of {@link DocumentNode}s.
  *
- * @remarks
- *
- * Which API members get their own documents and which get written to the contents of their parent is
- * determined by {@link DocumentationSuiteConfiguration.documentBoundaries}.
- *
- * The generated nodes' {@link DocumentNode.documentPath}s are determined by the provided output path and the
- * following configuration properties:
- *
- * - {@link DocumentationSuiteConfiguration.documentBoundaries}
- * - {@link DocumentationSuiteConfiguration.hierarchyBoundaries}
- *
- * @param options - Options for transforming API items into {@link DocumentationNode}s.
- *
  * @public
  */
 export function transformApiModel(options: ApiItemTransformationOptions): DocumentNode[] {

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuite.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuite.ts
@@ -356,7 +356,7 @@ export namespace DefaultDocumentationSuiteOptions {
 	}
 
 	/**
-	 * Default {@link DocumentationSuiteConfiguration.getHeadingTextForItem}.
+	 * Default {@link DocumentationSuiteConfiguration.getAlertsForItem}.
 	 *
 	 * Generates alerts for the following tags, if found:
 	 *

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuite.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuite.ts
@@ -332,7 +332,11 @@ export namespace DefaultDocumentationSuiteOptions {
 	/**
 	 * Default {@link DocumentationSuiteConfiguration.getLinkTextForItem}.
 	 *
-	 * Uses the item's signature, except for `Model` items, in which case the text "Packages" is displayed.
+	 * Uses the item's qualified API name, but is handled differently for the following items:
+	 *
+	 * - CallSignature, ConstructSignature, IndexSignature: Uses a cleaned up variation on the type signature.
+	 *
+	 * - Model: Uses "API Overview".
 	 */
 	export function defaultGetLinkTextForItem(apiItem: ApiItem): string {
 		const itemKind = getApiItemKind(apiItem);


### PR DESCRIPTION
Updates render APIs to accept arrays as readonly. Also cleans up stale API documentation.