### PR TITLE
Remove duplicative definition of getGCData

### DIFF
--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
@@ -15,7 +15,6 @@ export interface IFluidSerializer {
 // @alpha
 export interface ISharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends IChannel, IEventProvider<TEvent> {
     bindToContext(): void;
-    getGCData(fullGC?: boolean): IGarbageCollectionData;
 }
 
 // @alpha

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -353,7 +353,7 @@ export abstract class SharedObjectCore<
 	): Promise<ISummaryTreeWithStats>;
 
 	/**
-	 * {@inheritDoc (ISharedObject:interface).getGCData}
+	 * {@inheritDoc @fluidframework/datastore-definitions#(IChannel:interface).getGCData}
 	 */
 	public abstract getGCData(fullGC?: boolean): IGarbageCollectionData;
 
@@ -766,7 +766,7 @@ export abstract class SharedObject<
 	}
 
 	/**
-	 * {@inheritDoc (ISharedObject:interface).getGCData}
+	 * {@inheritDoc @fluidframework/datastore-definitions#(IChannel:interface).getGCData}
 	 */
 	public getGCData(fullGC: boolean = false): IGarbageCollectionData {
 		// Set _isGCing to true. This flag is used to ensure that we only use SummarySerializer to serialize handles

--- a/packages/dds/shared-object-base/src/types.ts
+++ b/packages/dds/shared-object-base/src/types.ts
@@ -10,7 +10,6 @@ import {
 } from "@fluidframework/core-interfaces";
 import { IChannel } from "@fluidframework/datastore-definitions/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
-import { IGarbageCollectionData } from "@fluidframework/runtime-definitions/internal";
 
 /**
  * Events emitted by {@link ISharedObject}.
@@ -66,11 +65,4 @@ export interface ISharedObject<TEvent extends ISharedObjectEvents = ISharedObjec
 	 * the runtime attaches.
 	 */
 	bindToContext(): void;
-
-	/**
-	 * Returns the GC data for this shared object. It contains a list of GC nodes that contains references to
-	 * other GC nodes.
-	 * @param fullGC - true to bypass optimizations and force full generation of GC data.
-	 */
-	getGCData(fullGC?: boolean): IGarbageCollectionData;
 }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -743,7 +743,6 @@ export interface ISharedMapEvents extends ISharedObjectEvents {
 // @alpha
 export interface ISharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends IChannel, IEventProvider<TEvent> {
     bindToContext(): void;
-    getGCData(fullGC?: boolean): IGarbageCollectionData;
 }
 
 // @alpha


### PR DESCRIPTION
Minor change - getGCData is defined on IChannel, no need to define it a second time on ISharedObject.  Just trying to separate the requirements of the channel from what is unique about SharedObject as an implementation of an IChannel.