### PR TITLE
fix(BlobManager): Don't log getBlob errors if the runtime is disposed

### DIFF
--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -763,12 +763,16 @@ export class PerformanceEvent {
 			this.reportEvent("end");
 		}
 		this.performanceEndMark();
+
+		// To prevent the event from being reported again later
 		this.event = undefined;
 	}
 
 	public end(props?: ITelemetryPropertiesExt): void {
 		this.reportEvent("end", props);
 		this.performanceEndMark();
+
+		// To prevent the event from being reported again later
 		this.event = undefined;
 	}
 
@@ -785,6 +789,8 @@ export class PerformanceEvent {
 		if (this.markers.cancel !== undefined) {
 			this.reportEvent("cancel", { category: this.markers.cancel, ...props }, error);
 		}
+
+		// To prevent the event from being reported again later
 		this.event = undefined;
 	}
 
@@ -796,9 +802,8 @@ export class PerformanceEvent {
 		props?: ITelemetryPropertiesExt,
 		error?: unknown,
 	): void {
-		// There are strange sequences involving multiple Promise chains
-		// where the event can be cancelled and then later a callback is invoked
-		// and the caller attempts to end directly, e.g. issue #3936. Just return.
+		// If the caller invokes cancel or end directly inside the callback for timedExec[Async],
+		// then it's possible to come back through reportEvent twice.  Only the first time counts.
 		if (!this.event) {
 			return;
 		}


### PR DESCRIPTION
## Description

Fixes [AB#26394](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26394)

There's a race condition where the application may be closed while the BlobManager is awaiting a blob to be downloaded from the service.  When this happens, the error "Storage Service is disposed. Cannot retry" is thrown, and the BlobManager logs it as an error.  But this isn't really an interesting error (because we don't care about the result at this point anyway) and shouldn't be logged as such.

This change downgrades the `BlobManager:AttachmentReadBlob_cancel` log to "generic" category, not "error".

## Reviewer Guidance

An alternate design was considered where we could introduce a new errorType for errors thrown after the runtime is closed/disposed, but I decided on this more scoped fix for now to avoid spending the team's time debating that design.  The downside of this approach is that partner teams will have to handle this as well (and I have seen this same fix made in a 1P partner codebase already), whereas adding the new errorType would provide a general API feature for knowing how to interpret this kind of error.  If it comes up again we can reconsider.