### PR TITLE
refactor(telemetry-utils): Merge MockLogger2 into MockLogger

### DIFF
--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -10,7 +10,7 @@ import {
 	MessageType,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
-import { MockLogger2, createChildLogger } from "@fluidframework/telemetry-utils/internal";
+import { MockLogger, createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import Deque from "double-ended-queue";
 
 import type { InboundSequencedContainerRuntimeMessage } from "../messageTypes.js";
@@ -30,7 +30,7 @@ type PendingStateManager_WithPrivates = Omit<PendingStateManager, "initialMessag
 };
 
 describe("Pending State Manager", () => {
-	const mockLogger = new MockLogger2();
+	const mockLogger = new MockLogger();
 	const logger = createChildLogger({ logger: mockLogger });
 
 	afterEach("ThrowOnErrorLogs", () => {

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -153,7 +153,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_MockLogger": {
+				"forwardCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/utils/telemetry-utils/src/index.ts
+++ b/packages/utils/telemetry-utils/src/index.ts
@@ -67,7 +67,6 @@ export {
 	createMockLoggerExt,
 	type IMockLoggerExt,
 	MockLogger,
-	MockLogger2,
 } from "./mockLogger.js";
 export { ThresholdCounter } from "./thresholdCounter.js";
 export {

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -308,6 +308,23 @@ ${JSON.stringify(actualEvents)}`);
 		}
 		return matchObjects(actual, expected);
 	}
+
+	/**
+	 * Throws if any errors were logged
+	 */
+	public assertNoErrors(message?: string, clearEventsAfterCheck: boolean = true): void {
+		const actualEvents = this.events;
+		const errors = actualEvents.filter((event) => event.category === "error");
+		if (clearEventsAfterCheck) {
+			this.clear();
+		}
+		if (errors.length > 0) {
+			throw new Error(`${message ?? "Errors found in logs"}
+
+error logs:
+${JSON.stringify(errors)}`);
+		}
+	}
 }
 
 function matchObjects(
@@ -369,29 +386,4 @@ export function createMockLoggerExt(minLogLevel?: LogLevel): IMockLoggerExt {
 			mockLogger.events.map((e) => e as ITelemetryEventExt),
 	});
 	return childLogger as IMockLoggerExt;
-}
-
-/**
- * Temporary extension to add new functionality during breaking change freeze,
- * since MockLogger wasn't able to be made internal yet.
- *
- * @internal
- */
-export class MockLogger2 extends MockLogger {
-	/**
-	 * Throws if any errors were logged
-	 */
-	public assertNoErrors(message?: string, clearEventsAfterCheck: boolean = true): void {
-		const actualEvents = this.events;
-		const errors = actualEvents.filter((event) => event.category === "error");
-		if (clearEventsAfterCheck) {
-			this.clear();
-		}
-		if (errors.length > 0) {
-			throw new Error(`${message ?? "Errors found in logs"}
-
-error logs:
-${JSON.stringify(errors)}`);
-		}
-	}
 }

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
@@ -40,6 +40,7 @@ declare type current_as_old_for_Class_EventEmitterWithErrorHandling = requireAss
  * typeValidation.broken:
  * "Class_MockLogger": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockLogger = requireAssignableTo<TypeOnly<old.MockLogger>, TypeOnly<current.MockLogger>>
 
 /*


### PR DESCRIPTION
## Description

Merges the MockLogger2 and MockLogger classes now that MockLogger has been made `@internal`. Just one method needed to be moved over since MockLogger2 already extended MockLogger.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).