### PR TITLE
[LTS] Disable bundle analysis on forks

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -373,7 +373,12 @@ stages:
 
           - task: Npm@1
             displayName: run bundle size comparison
-            condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+            condition:
+              and(
+                succeeded(),
+                eq(variables['Build.Reason'], 'PullRequest'),
+                ne(variables['System.PullRequest.IsFork'], 'true')
+              )
             env:
               ADO_API_TOKEN: $(System.AccessToken)
               DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)


### PR DESCRIPTION
## Description

Removes known-bad bundle analysis steps from the CI gate. Bundle analysis with the current setup does not work from forks due to recent changes to availability of secrets. This produces warnings in the main build, but fails in LTS.