### PR TITLE
Make ts-common-config.json extends tsconfig.base.json

### DIFF
--- a/common/build/build-common/ts-common-config.json
+++ b/common/build/build-common/ts-common-config.json
@@ -1,20 +1,13 @@
 {
+	// This configuration is deprecated and ussages should be migrated to other options.
+	// The "common" in this file name means either that this is commonjs, or that this is a shared config since both are true.
+	"extends": ["./tsconfig.base.json"],
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {
-		"target": "ES2020",
-		"declaration": true,
-		"declarationMap": true,
-		"esModuleInterop": true,
+		"composite": false,
 		"module": "commonjs",
 		"moduleResolution": "node",
-		"noUnusedLocals": true,
-		"sourceMap": true,
-		"inlineSources": true,
-		"noImplicitAny": false,
-		"incremental": true,
-		"types": [],
-		"strict": true,
-		"pretty": true,
-		"lib": ["ES2020", "DOM", "DOM.Iterable"]
+		"exactOptionalPropertyTypes": false,
+		"noUncheckedIndexedAccess": false
 	}
 }

--- a/common/build/build-common/ts-common-config.json
+++ b/common/build/build-common/ts-common-config.json
@@ -1,5 +1,5 @@
 {
-	// This configuration is deprecated and ussages should be migrated to other options.
+	// This configuration is deprecated and usages should be migrated to other options.
 	// The "common" in this file name means either that this is commonjs, or that this is a shared config since both are true.
 	"extends": ["./tsconfig.base.json"],
 	"exclude": ["dist", "node_modules"],


### PR DESCRIPTION
## Description

Make deprecated common/build/build-common/ts-common-config.json extend common/build/build-common/tsconfig.base.json.

This avoids duplicating things like selecting the target.

As noted in common/build/build-common/README.md, `tsconfig.base.json` is the "base config contains defaults that all packages within the repo should use as a baseline".
This change causes the packages which use `ts-common-config.json` to follow this pattern, allowing `tsconfig.base.json` to better fill its role as the actual base configuration which provides a single source of truth for some of our build options.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
