### PR TITLE
Pass simplifiedCustomData to fs mkdir call during slimInit.

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -5,6 +5,7 @@
 
 import fsPromises from "fs/promises";
 import * as git from "@fluidframework/gitresources";
+import type { MakeDirectoryOptions } from "fs";
 
 export enum Constants {
 	StorageRoutingIdHeader = "Storage-Routing-Id",
@@ -102,6 +103,10 @@ export interface IFileSystemManagerFactory {
 export interface IFileSystemManagerFactories {
 	defaultFileSystemManagerFactory: IFileSystemManagerFactory;
 	ephemeralFileSystemManagerFactory?: IFileSystemManagerFactory;
+}
+
+export interface IFileSystemMakeDirectoryOptions extends MakeDirectoryOptions {
+	simplifiedCustomData?: string;
 }
 
 export interface IStorageRoutingId {

--- a/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/definitions.ts
@@ -4,8 +4,8 @@
  */
 
 import fsPromises from "fs/promises";
-import * as git from "@fluidframework/gitresources";
 import type { MakeDirectoryOptions } from "fs";
+import * as git from "@fluidframework/gitresources";
 
 export enum Constants {
 	StorageRoutingIdHeader = "Storage-Routing-Id",

--- a/server/gitrest/packages/gitrest-base/src/utils/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/index.ts
@@ -12,6 +12,7 @@ export {
 	IFileSystemManagerFactories,
 	IFileSystemManagerFactory,
 	IFileSystemManagerParams,
+	IFileSystemMakeDirectoryOptions,
 	IFileSystemPromises,
 	IRepoManagerParams,
 	IRepositoryManager,

--- a/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/isomorphicgitManager.ts
@@ -453,12 +453,12 @@ export class IsomorphicGitManagerFactory extends RepositoryManagerFactoryBase<vo
 		gitdir: string,
 		fsParams: IFileSystemManagerParams | undefined,
 	): Promise<void> {
-		const simplifiedCustomData = fsParams?.simplifiedCustomData;
-		if (simplifiedCustomData) {
-			// Only pass valid simplifiedCustomData to fs mkdir call during slimInit
+		const splfCustomData = fsParams?.simplifiedCustomData;
+		if (splfCustomData) {
+			// Only pass valid simplifiedCustomData to rootdir in fs mkdir call during slimInit
 			const mkdirOptions: IFileSystemMakeDirectoryOptions = {
 				recursive: false,
-				simplifiedCustomData: simplifiedCustomData,
+				simplifiedCustomData: splfCustomData,
 			};
 			await fs.promises.mkdir(gitdir, mkdirOptions);
 		}

--- a/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/repositoryManagerFactoryBase.ts
@@ -12,6 +12,7 @@ import {
 	Constants,
 	IFileSystemManager,
 	IFileSystemManagerFactories,
+	IFileSystemManagerParams,
 	IRepoManagerParams,
 	IRepositoryManager,
 	IRepositoryManagerFactory,
@@ -42,7 +43,11 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
 	) => Promise<IRepositoryManager>;
 	// Cache repositories to allow for reuse
 	protected readonly repositoryCache = new Map<string, TRepo>();
-	protected abstract initGitRepo(fs: IFileSystemManager, gitdir: string): Promise<TRepo>;
+	protected abstract initGitRepo(
+		fs: IFileSystemManager,
+		gitdir: string,
+		fsParams: IFileSystemManagerParams | undefined,
+	): Promise<TRepo>;
 	protected abstract openGitRepo(gitdir: string): Promise<TRepo>;
 	protected abstract createRepoManager(
 		fileSystemManager: IFileSystemManager,
@@ -81,7 +86,11 @@ export abstract class RepositoryManagerFactoryBase<TRepo> implements IRepository
 			lumberjackBaseProperties: Record<string, any>,
 		) => {
 			// Create and then cache the repository
-			const repository = await this.initGitRepo(fileSystemManager, gitdir);
+			const repository = await this.initGitRepo(
+				fileSystemManager,
+				gitdir,
+				params.fileSystemManagerParams,
+			);
 			this.repositoryCache.set(repoPath, repository);
 			Lumberjack.info("Created a new repo", {
 				...lumberjackBaseProperties,


### PR DESCRIPTION

## Description
Pass simplifiedCustomData to fs mkdir call during slimInit, to support a particular AFR use case during container creation, which requires information from simplifiedCustomData.
This is a follow up change of https://github.com/microsoft/FluidFramework/pull/23354


