### PR TITLE
Revert "eslint(telemetry-utils): Prefix telemetry-utils before enabling no-unchecked-record-access"

### DIFF
--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -87,9 +87,9 @@ function copyProps(
 	target: ITelemetryPropertiesExt | LoggingError,
 	source: ITelemetryPropertiesExt,
 ): void {
-	for (const [key, value] of Object.entries(source)) {
+	for (const key of Object.keys(source)) {
 		if (target[key] === undefined) {
-			target[key] = value;
+			target[key] = source[key];
 		}
 	}
 }

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -289,10 +289,11 @@ export abstract class TelemetryLogger implements ITelemetryLoggerExt {
 			}
 			for (const props of properties) {
 				if (props !== undefined) {
-					for (const [key, getterOrValue] of Object.entries(props)) {
+					for (const key of Object.keys(props)) {
 						if (eventLike[key] !== undefined) {
 							continue;
 						}
+						const getterOrValue = props[key];
 						// If this throws, hopefully it is handled elsewhere
 						const value =
 							typeof getterOrValue === "function" ? getterOrValue() : getterOrValue;
@@ -325,7 +326,8 @@ export class TaggedLoggerAdapter implements ITelemetryBaseLogger {
 			category: eventWithTagsMaybe.category,
 			eventName: eventWithTagsMaybe.eventName,
 		};
-		for (const [key, taggableProp] of Object.entries(eventWithTagsMaybe)) {
+		for (const key of Object.keys(eventWithTagsMaybe)) {
+			const taggableProp = eventWithTagsMaybe[key];
 			const { value, tag } =
 				typeof taggableProp === "object"
 					? taggableProp

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -7,7 +7,6 @@ import {
 	type ITelemetryBaseEvent,
 	type ITelemetryBaseLogger,
 	LogLevel,
-	type Tagged,
 } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 
@@ -16,7 +15,6 @@ import type {
 	ITelemetryEventExt,
 	ITelemetryLoggerExt,
 	ITelemetryPropertiesExt,
-	TelemetryEventPropertyTypeExt,
 } from "./telemetryTypes.js";
 
 /**
@@ -332,10 +330,7 @@ function matchObjects(
 	expected: ITelemetryPropertiesExt,
 ): boolean {
 	for (const [expectedKey, expectedValue] of Object.entries(expected)) {
-		const actualValue:
-			| TelemetryEventPropertyTypeExt
-			| Tagged<TelemetryEventPropertyTypeExt>
-			| undefined = actual[expectedKey];
+		const actualValue = actual[expectedKey];
 		if (
 			!Array.isArray(expectedValue) &&
 			expectedValue !== null &&

--- a/packages/utils/telemetry-utils/src/test/config.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/config.spec.ts
@@ -22,8 +22,7 @@ const getMockStore = (settings: Record<string, string>): Storage => {
 	return {
 		getItem: (key: string): string | null => {
 			ops.push(key);
-			// eslint-disable-next-line unicorn/no-null
-			return settings[key] ?? null;
+			return settings[key];
 		},
 		getOps: (): Readonly<string[]> => ops,
 		length: Object.keys(settings).length,

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -689,7 +689,7 @@ const annotationCases: Record<string, IFluidErrorAnnotations> = {
 describe("normalizeError", () => {
 	describe("Valid Errors (Legacy and Current)", () => {
 		for (const annotationCase of Object.keys(annotationCases)) {
-			const annotations: IFluidErrorAnnotations | undefined = annotationCases[annotationCase];
+			const annotations = annotationCases[annotationCase];
 			it(`Valid Fluid Error - untouched (annotations: ${annotationCase})`, () => {
 				// Arrange
 				const fluidError = new TestFluidError({ errorType: "et1", message: "m1" });
@@ -914,9 +914,11 @@ describe("normalizeError", () => {
 				expected.withExpectedTelemetryProps({ stack: inputStack });
 			}
 		}
-		for (const [annotationCase, annotations] of Object.entries(annotationCases)) {
+		for (const annotationCase of Object.keys(annotationCases)) {
+			const annotations = annotationCases[annotationCase];
 			let doneOnceForThisAnnotationCase = false;
-			for (const [caseName, getTestCase] of Object.entries(testCases)) {
+			for (const caseName of Object.keys(testCases)) {
+				const getTestCase = testCases[caseName];
 				if (!doneOnceForThisAnnotationCase) {
 					doneOnceForThisAnnotationCase = true;
 					// Each test case only differs by what stack/error are.  Test the rest only once per annotation case.


### PR DESCRIPTION
Reverts microsoft/FluidFramework#23428