### PR TITLE
test(api-markdown-documenter): Add "deep" config end-to-end test cases

### DIFF
--- a/tools/api-markdown-documenter/src/test/EndToEndTestUtilities.ts
+++ b/tools/api-markdown-documenter/src/test/EndToEndTestUtilities.ts
@@ -12,6 +12,7 @@ import { expect } from "chai";
 import { compare } from "dir-compare";
 
 import {
+	ApiItemUtilities,
 	FolderDocumentPlacement,
 	HierarchyKind,
 	type FolderHierarchyConfiguration,
@@ -99,55 +100,54 @@ export namespace HierarchyConfigurations {
 		[ApiItemKind.Variable]: HierarchyKind.Document,
 	};
 
-	// TODO
-	// const insideFolderOptions: FolderHierarchyConfiguration = {
-	// 	kind: HierarchyKind.Folder,
-	// 	documentPlacement: FolderDocumentPlacement.Inside,
-	// };
-	// /**
-	//  * "Deep" hierarchy: All "parent" API items generate hierarchy. All other items are rendered as documents under their parent hierarchy.
-	//  * @remarks Leads to many documents, but each document is likely to be relatively small.
-	//  */
-	// export const deep: HierarchyOptions = {
-	// 	// Items that introduce folder hierarchy:
-	// 	[ApiItemKind.Namespace]: insideFolderOptions,
-	// 	[ApiItemKind.Package]: insideFolderOptions,
-	// 	[ApiItemKind.Class]: insideFolderOptions,
-	// 	[ApiItemKind.Enum]: insideFolderOptions,
-	// 	[ApiItemKind.Interface]: insideFolderOptions,
-	// 	[ApiItemKind.TypeAlias]: insideFolderOptions,
+	const insideFolderOptions: FolderHierarchyConfiguration = {
+		kind: HierarchyKind.Folder,
+		documentPlacement: FolderDocumentPlacement.Inside,
+	};
+	/**
+	 * "Deep" hierarchy: All "parent" API items generate hierarchy. All other items are rendered as documents under their parent hierarchy.
+	 * @remarks Leads to many documents, but each document is likely to be relatively small.
+	 */
+	export const deep: HierarchyOptions = {
+		// Items that introduce folder hierarchy:
+		[ApiItemKind.Namespace]: insideFolderOptions,
+		[ApiItemKind.Package]: insideFolderOptions,
+		[ApiItemKind.Class]: insideFolderOptions,
+		[ApiItemKind.Enum]: insideFolderOptions,
+		[ApiItemKind.Interface]: insideFolderOptions,
+		[ApiItemKind.TypeAlias]: insideFolderOptions,
 
-	// 	// Items that get their own document, but do not introduce folder hierarchy:
-	// 	[ApiItemKind.CallSignature]: HierarchyKind.Document,
-	// 	[ApiItemKind.Constructor]: HierarchyKind.Document,
-	// 	[ApiItemKind.ConstructSignature]: HierarchyKind.Document,
-	// 	[ApiItemKind.EnumMember]: HierarchyKind.Document,
-	// 	[ApiItemKind.Function]: HierarchyKind.Document,
-	// 	[ApiItemKind.IndexSignature]: HierarchyKind.Document,
-	// 	[ApiItemKind.Method]: HierarchyKind.Document,
-	// 	[ApiItemKind.MethodSignature]: HierarchyKind.Document,
-	// 	[ApiItemKind.Property]: HierarchyKind.Document,
-	// 	[ApiItemKind.PropertySignature]: HierarchyKind.Document,
-	// 	[ApiItemKind.Variable]: HierarchyKind.Document,
+		// Items that get their own document, but do not introduce folder hierarchy:
+		[ApiItemKind.CallSignature]: HierarchyKind.Document,
+		[ApiItemKind.Constructor]: HierarchyKind.Document,
+		[ApiItemKind.ConstructSignature]: HierarchyKind.Document,
+		[ApiItemKind.EnumMember]: HierarchyKind.Document,
+		[ApiItemKind.Function]: HierarchyKind.Document,
+		[ApiItemKind.IndexSignature]: HierarchyKind.Document,
+		[ApiItemKind.Method]: HierarchyKind.Document,
+		[ApiItemKind.MethodSignature]: HierarchyKind.Document,
+		[ApiItemKind.Property]: HierarchyKind.Document,
+		[ApiItemKind.PropertySignature]: HierarchyKind.Document,
+		[ApiItemKind.Variable]: HierarchyKind.Document,
 
-	// 	getDocumentName: (apiItem, config): string => {
-	// 		switch (apiItem.kind) {
-	// 			case ApiItemKind.Model:
-	// 			case ApiItemKind.Package:
-	// 			case ApiItemKind.Namespace:
-	// 			case ApiItemKind.Class:
-	// 			case ApiItemKind.Enum:
-	// 			case ApiItemKind.Interface:
-	// 			case ApiItemKind.TypeAlias: {
-	// 				return "index";
-	// 			}
-	// 			default: {
-	// 				// Let the system generate a unique name that accounts for folder hierarchy.
-	// 				return ApiItemUtilities.createQualifiedDocumentNameForApiItem(apiItem, config);
-	// 			}
-	// 		}
-	// 	},
-	// };
+		getDocumentName: (apiItem, config): string => {
+			switch (apiItem.kind) {
+				case ApiItemKind.Model:
+				case ApiItemKind.Package:
+				case ApiItemKind.Namespace:
+				case ApiItemKind.Class:
+				case ApiItemKind.Enum:
+				case ApiItemKind.Interface:
+				case ApiItemKind.TypeAlias: {
+					return "index";
+				}
+				default: {
+					// Let the system generate a unique name that accounts for folder hierarchy.
+					return ApiItemUtilities.createQualifiedDocumentNameForApiItem(apiItem, config);
+				}
+			}
+		},
+	};
 }
 
 /**

--- a/tools/api-markdown-documenter/src/test/HtmlEndToEnd.test.ts
+++ b/tools/api-markdown-documenter/src/test/HtmlEndToEnd.test.ts
@@ -67,17 +67,16 @@ const testConfigs = new Map<
 		},
 	],
 
-	// TODO
-	// // A sample "deep" configuration.
-	// // All "parent" API items generate hierarchy.
-	// // All other items are rendered as documents under their parent hierarchy.
-	// [
-	// 	"deep-config",
-	// 	{
-	// 		uriRoot: ".",
-	// 		hierarchy: HierarchyConfigurations.deep,
-	// 	},
-	// ],
+	// A sample "deep" configuration.
+	// All "parent" API items generate hierarchy.
+	// All other items are rendered as documents under their parent hierarchy.
+	[
+		"deep-config",
+		{
+			uriRoot: "",
+			hierarchy: HierarchyConfigurations.deep,
+		},
+	],
 ]);
 
 describe("HTML end-to-end tests", () => {

--- a/tools/api-markdown-documenter/src/test/MarkdownEndToEnd.test.ts
+++ b/tools/api-markdown-documenter/src/test/MarkdownEndToEnd.test.ts
@@ -67,17 +67,16 @@ const testConfigs = new Map<
 		},
 	],
 
-	// TODO
-	// // A sample "deep" configuration.
-	// // All "parent" API items generate hierarchy.
-	// // All other items are rendered as documents under their parent hierarchy.
-	// [
-	// 	"deep-config",
-	// 	{
-	// 		uriRoot: ".",
-	// 		hierarchy: HierarchyConfigurations.deep,
-	// 	},
-	// ],
+	// A sample "deep" configuration.
+	// All "parent" API items generate hierarchy.
+	// All other items are rendered as documents under their parent hierarchy.
+	[
+		"deep-config",
+		{
+			uriRoot: "",
+			hierarchy: HierarchyConfigurations.deep,
+		},
+	],
 ]);
 
 describe("Markdown end-to-end tests", () => {

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>API Overview</h1>
+      <section>
+        <h2>Packages</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Package</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/">test-suite-a</a></td>
+              <td>Test package</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-b/">test-suite-b</a></td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/index.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>test-suite-a</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a></p>
+      </section>
+      <section>
+        <p>Test package</p>
+      </section>
+      <section>
+        <h2 id="test-suite-a-remarks">Remarks</h2>
+        <p>
+          <p>This remarks block includes a bulleted list!</p>
+          <p>- Bullet 1</p>
+          <p>- Bullet 2</p>
+          <p>And an ordered list for good measure!</p>
+          <p>1. List item 1</p>
+          <p>2. List item 2</p>
+          <p>3. List item 3</p>
+          <p>Also, here is a link test, including a bad link, because we should have some reasonable support if this happens:</p>
+          <p>- Good link (no alias): <a href="/test-suite-a/testclass-class/">TestClass</a></p>
+          <p>- Good link (with alias): <a href="/test-suite-a/testfunction-function">function alias text</a></p>
+          <p>- Bad link (no alias): <span><i>InvalidItem</i></span></p>
+          <p>- Bad link (with alias): <span><i>even though I link to an invalid item, I would still like this text to be rendered</i></span></p>
+        </p>
+      </section>
+      <section>
+        <h2 id="test-suite-a-example">Example</h2>
+        <p>
+          <p>A test example</p><code>const foo = bar;</code>
+        </p>
+      </section>
+      <section>
+        <h2>Interfaces</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Interface</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testemptyinterface-interface/">TestEmptyInterface</a></td>
+              <td>An empty interface</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testinterface-interface/">TestInterface</a></td>
+              <td>Test interface</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface/">TestInterfaceExtendingOtherInterfaces</a></td>
+              <td>Test interface that extends other interfaces</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testinterfacewithindexsignature-interface/">TestInterfaceWithIndexSignature</a></td>
+              <td>An interface with an index signature.</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a></td>
+              <td>Test interface with generic type parameter</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Classes</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Class</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a></td>
+              <td>A test abstract class.</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testclass-class/">TestClass</a></td>
+              <td>Test class</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Enumerations</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Enum</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testenum-enum/">TestEnum</a></td>
+              <td>Test Enum</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Types</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>TypeAlias</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></td>
+              <td>Test Mapped Type, using <a href="/test-suite-a/testenum-enum/">TestEnum</a></td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/typealias-typealias/">TypeAlias</a></td>
+              <td>Test Type-Alias</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Functions</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Function</th>
+              <th>Alerts</th>
+              <th>Return Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testfunction-function">testFunction(testParameter, testOptionalParameter)</a></td>
+              <td><code>Alpha</code></td>
+              <td><span>TTypeParameter</span></td>
+              <td>Test function</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testfunctionreturninginlinetype-function">testFunctionReturningInlineType()</a></td>
+              <td></td>
+              <td><span>{ foo: number; bar: <a href="/test-suite-a/testenum-enum/">TestEnum</a>; }</span></td>
+              <td>Test function that returns an inline type</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testfunctionreturningintersectiontype-function">testFunctionReturningIntersectionType()</a></td>
+              <td><code>Deprecated</code></td>
+              <td><span><a href="/test-suite-a/testemptyinterface-interface/">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;number></span></td>
+              <td>Test function that returns an inline type</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testfunctionreturninguniontype-function">testFunctionReturningUnionType()</a></td>
+              <td></td>
+              <td><span>string | <a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></td>
+              <td>Test function that returns an inline type</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Variables</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Variable</th>
+              <th>Alerts</th>
+              <th>Modifiers</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testconst-variable">testConst</a></td>
+              <td><code>Beta</code></td>
+              <td><code>readonly</code></td>
+              <td></td>
+              <td>Test Constant</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testconstwithemptydeprecatedblock-variable">testConstWithEmptyDeprecatedBlock</a></td>
+              <td><code>Deprecated</code></td>
+              <td><code>readonly</code></td>
+              <td><span>string</span></td>
+              <td>I have a <code>@deprecated</code> tag with an empty comment block.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Namespaces</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Namespace</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testmodule-namespace/">TestModule</a></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a></td>
+              <td>Test Namespace</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>(constructor)</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/_constructor_-constructor">(constructor)(privateProperty, protectedProperty)</a></p>
+      </section>
+      <section>
+        <p>This is a <span><i>{@customTag constructor}</i></span>.</p>
+      </section>
+      <section>
+        <h2 id="_constructor_-signature">Signature</h2><code>protected constructor(privateProperty: number, protectedProperty: TestEnum);</code>
+      </section>
+      <section>
+        <h2 id="_constructor_-parameters">Parameters</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>privateProperty</td>
+              <td><span>number</span></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>protectedProperty</td>
+              <td><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>abstractPropertyGetter</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></p>
+      </section>
+      <section>
+        <p>A test abstract getter property.</p>
+      </section>
+      <section>
+        <h2 id="abstractpropertygetter-signature">Signature</h2><code>abstract get abstractPropertyGetter(): TestMappedType;</code>
+        <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestAbstractClass</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a></p>
+      </section>
+      <section>
+        <p>A test abstract class.</p>
+      </section>
+      <section>
+        <h2 id="testabstractclass-signature">Signature</h2><code>export declare abstract class TestAbstractClass</code>
+      </section>
+      <section>
+        <h2>Constructors</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Constructor</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testabstractclass-class/_constructor_-constructor">(constructor)(privateProperty, protectedProperty)</a></td>
+              <td>This is a <span><i>{@customTag constructor}</i></span>.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Properties</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Modifiers</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testabstractclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></td>
+              <td><code>readonly</code></td>
+              <td><span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span></td>
+              <td>A test abstract getter property.</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a></td>
+              <td><code>readonly</code></td>
+              <td><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></td>
+              <td>A test protected property.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Methods</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Method</th>
+              <th>Modifiers</th>
+              <th>Return Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testabstractclass-class/publicabstractmethod-method">publicAbstractMethod()</a></td>
+              <td></td>
+              <td><span>void</span></td>
+              <td>A test public abstract method.</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testabstractclass-class/sealedmethod-method">sealedMethod()</a></td>
+              <td><code>sealed</code></td>
+              <td><span>string</span></td>
+              <td>A test <code>@sealed</code> method.</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testabstractclass-class/virtualmethod-method">virtualMethod()</a></td>
+              <td><code>virtual</code></td>
+              <td><span>number</span></td>
+              <td>A test <code>@virtual</code> method.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/protectedproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/protectedproperty-property.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>protectedProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a></p>
+      </section>
+      <section>
+        <p>A test protected property.</p>
+      </section>
+      <section>
+        <h2 id="protectedproperty-signature">Signature</h2><code>protected readonly protectedProperty: TestEnum;</code>
+        <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/publicabstractmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/publicabstractmethod-method.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>publicAbstractMethod</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/publicabstractmethod-method">publicAbstractMethod()</a></p>
+      </section>
+      <section>
+        <p>A test public abstract method.</p>
+      </section>
+      <section>
+        <h2 id="publicabstractmethod-signature">Signature</h2><code>abstract publicAbstractMethod(): void;</code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/sealedmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/sealedmethod-method.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>sealedMethod</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/sealedmethod-method">sealedMethod()</a></p>
+      </section>
+      <section>
+        <p>A test <code>@sealed</code> method.</p>
+      </section>
+      <section>
+        <h2 id="sealedmethod-signature">Signature</h2><code>/** @sealed */<br>protected sealedMethod(): string;</code>
+      </section>
+      <section>
+        <h2 id="sealedmethod-returns">Returns</h2>
+        <p>A string!</p>
+        <p><span><b>Return type: </b></span><span>string</span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/virtualmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/virtualmethod-method.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>virtualMethod</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/virtualmethod-method">virtualMethod()</a></p>
+      </section>
+      <section>
+        <p>A test <code>@virtual</code> method.</p>
+      </section>
+      <section>
+        <h2 id="virtualmethod-signature">Signature</h2><code>/** @virtual */<br>protected virtualMethod(): number;</code>
+      </section>
+      <section>
+        <h2 id="virtualmethod-returns">Returns</h2>
+        <p>A number!</p>
+        <p><span><b>Return type: </b></span><span>number</span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>(constructor)</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/_constructor_-constructor">(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)</a></p>
+      </section>
+      <section>
+        <p>Test class constructor</p>
+      </section>
+      <section>
+        <h2 id="_constructor_-signature">Signature</h2><code>constructor(privateProperty: number, protectedProperty: TestEnum, testClassProperty: TTypeParameterB, testClassEventProperty: () => void);</code>
+      </section>
+      <section>
+        <h2 id="_constructor_-remarks">Remarks</h2>
+        <p>Here are some remarks about the constructor</p>
+      </section>
+      <section>
+        <h2 id="_constructor_-parameters">Parameters</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>privateProperty</td>
+              <td><span>number</span></td>
+              <td>See <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a>'s constructor.</td>
+            </tr>
+            <tr>
+              <td>protectedProperty</td>
+              <td><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></td>
+              <td>
+                <p>Some notes about the parameter.</p>
+                <p>See <a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a>.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>testClassProperty</td>
+              <td><span>TTypeParameterB</span></td>
+              <td>See <a href="/test-suite-a/testclass-class/testclassproperty-property">testClassProperty</a>.</td>
+            </tr>
+            <tr>
+              <td>testClassEventProperty</td>
+              <td><span>() => void</span></td>
+              <td>See <a href="/test-suite-a/testclass-class/testclasseventproperty-property">testClassEventProperty</a>.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>abstractPropertyGetter</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></p>
+      </section>
+      <section>
+        <p>A test abstract getter property.</p>
+      </section>
+      <section>
+        <h2 id="abstractpropertygetter-signature">Signature</h2><code>get abstractPropertyGetter(): TestMappedType;</code>
+        <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/index.html
@@ -1,0 +1,196 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestClass</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a></p>
+      </section>
+      <section>
+        <p>Test class</p>
+      </section>
+      <section>
+        <h2 id="testclass-signature">Signature</h2><code>export declare class TestClass&#x3C;TTypeParameterA, TTypeParameterB> extends TestAbstractClass</code>
+        <p>
+          <p><span><span><b>Extends: </b></span><span><a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a></span></span></p>
+          <p>
+            <section>
+              <h3>Type Parameters</h3>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Parameter</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>TTypeParameterA</td>
+                    <td>A type parameter</td>
+                  </tr>
+                  <tr>
+                    <td>TTypeParameterB</td>
+                    <td>Another type parameter</td>
+                  </tr>
+                </tbody>
+              </table>
+            </section>
+          </p>
+        </p>
+      </section>
+      <section>
+        <h2 id="testclass-remarks">Remarks</h2>
+        <p>Here are some remarks about the class</p>
+      </section>
+      <section>
+        <h2>Constructors</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Constructor</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testclass-class/_constructor_-constructor">(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)</a></td>
+              <td>Test class constructor</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Static Properties</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testclass-class/testclassstaticproperty-property">testClassStaticProperty</a></td>
+              <td><span>(foo: number) => string</span></td>
+              <td>Test static class property</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Static Methods</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Method</th>
+              <th>Return Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testclass-class/testclassstaticmethod-method">testClassStaticMethod(foo)</a></td>
+              <td><span>string</span></td>
+              <td>Test class static method</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Events</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Modifiers</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testclass-class/testclasseventproperty-property">testClassEventProperty</a></td>
+              <td><code>readonly</code></td>
+              <td><span>() => void</span></td>
+              <td>Test class event property</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Properties</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Modifiers</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></td>
+              <td><code>readonly</code></td>
+              <td><span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span></td>
+              <td>A test abstract getter property.</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testclass-class/testclassgetterproperty-property">testClassGetterProperty</a></td>
+              <td><code>virtual</code></td>
+              <td><span>number</span></td>
+              <td>Test class property with both a getter and a setter.</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testclass-class/testclassproperty-property">testClassProperty</a></td>
+              <td><code>readonly</code></td>
+              <td><span>TTypeParameterB</span></td>
+              <td>Test class property</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Methods</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Method</th>
+              <th>Modifiers</th>
+              <th>Return Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testclass-class/publicabstractmethod-method">publicAbstractMethod()</a></td>
+              <td></td>
+              <td><span>void</span></td>
+              <td>A test public abstract method.</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testclass-class/testclassmethod-method">testClassMethod(input)</a></td>
+              <td><code>sealed</code></td>
+              <td><span>TTypeParameterA</span></td>
+              <td>Test class method</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testclass-class/virtualmethod-method">virtualMethod()</a></td>
+              <td></td>
+              <td><span>number</span></td>
+              <td>Overrides <a href="/test-suite-a/testabstractclass-class/virtualmethod-method">virtualMethod()</a>.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2 id="testclass-see-also">See Also</h2>
+        <p><a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/publicabstractmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/publicabstractmethod-method.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>publicAbstractMethod</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/publicabstractmethod-method">publicAbstractMethod()</a></p>
+      </section>
+      <section>
+        <p>A test public abstract method.</p>
+      </section>
+      <section>
+        <h2 id="publicabstractmethod-signature">Signature</h2><code>publicAbstractMethod(): void;</code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclasseventproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclasseventproperty-property.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testClassEventProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/testclasseventproperty-property">testClassEventProperty</a></p>
+      </section>
+      <section>
+        <p>Test class event property</p>
+      </section>
+      <section>
+        <h2 id="testclasseventproperty-signature">Signature</h2><code>readonly testClassEventProperty: () => void;</code>
+        <p><span><span><b>Type: </b></span><span>() => void</span></span></p>
+      </section>
+      <section>
+        <h2 id="testclasseventproperty-remarks">Remarks</h2>
+        <p>Here are some remarks about the property</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testClassGetterProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassgetterproperty-property">testClassGetterProperty</a></p>
+      </section>
+      <section>
+        <p>Test class property with both a getter and a setter.</p>
+      </section>
+      <section>
+        <h2 id="testclassgetterproperty-signature">Signature</h2><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br><br>set testClassGetterProperty(newValue: number);</code>
+        <p><span><span><b>Type: </b></span><span>number</span></span></p>
+      </section>
+      <section>
+        <h2 id="testclassgetterproperty-remarks">Remarks</h2>
+        <p>Here are some remarks about the getter-only property</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testClassMethod</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassmethod-method">testClassMethod(input)</a></p>
+      </section>
+      <section>
+        <p>Test class method</p>
+      </section>
+      <section>
+        <h2 id="testclassmethod-signature">Signature</h2><code>/** @sealed */<br>testClassMethod(input: TTypeParameterA): TTypeParameterA;</code>
+      </section>
+      <section>
+        <h2 id="testclassmethod-remarks">Remarks</h2>
+        <p>Here are some remarks about the method</p>
+      </section>
+      <section>
+        <h2 id="testclassmethod-parameters">Parameters</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>input</td>
+              <td><span>TTypeParameterA</span></td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2 id="testclassmethod-returns">Returns</h2>
+        <p><span><b>Return type: </b></span><span>TTypeParameterA</span></p>
+      </section>
+      <section>
+        <h2 id="testclassmethod-throws">Throws</h2>
+        <p>Some sort of error in 1 case.</p>
+        <p>Some other sort of error in another case. For example, a case where some thing happens.</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassproperty-property.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testClassProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassproperty-property">testClassProperty</a></p>
+      </section>
+      <section>
+        <p>Test class property</p>
+      </section>
+      <section>
+        <h2 id="testclassproperty-signature">Signature</h2><code>readonly testClassProperty: TTypeParameterB;</code>
+        <p><span><span><b>Type: </b></span><span>TTypeParameterB</span></span></p>
+      </section>
+      <section>
+        <h2 id="testclassproperty-remarks">Remarks</h2>
+        <p>Here are some remarks about the property</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testClassStaticMethod</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassstaticmethod-method">testClassStaticMethod(foo)</a></p>
+      </section>
+      <section>
+        <p>Test class static method</p>
+      </section>
+      <section>
+        <h2 id="testclassstaticmethod-signature">Signature</h2><code>static testClassStaticMethod(foo: number): string;</code>
+      </section>
+      <section>
+        <h2 id="testclassstaticmethod-parameters">Parameters</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>foo</td>
+              <td><span>number</span></td>
+              <td>Some number</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2 id="testclassstaticmethod-returns">Returns</h2>
+        <p>- Some string</p>
+        <p><span><b>Return type: </b></span><span>string</span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticproperty-property.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testClassStaticProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassstaticproperty-property">testClassStaticProperty</a></p>
+      </section>
+      <section>
+        <p>Test static class property</p>
+      </section>
+      <section>
+        <h2 id="testclassstaticproperty-signature">Signature</h2><code>static testClassStaticProperty: (foo: number) => string;</code>
+        <p><span><span><b>Type: </b></span><span>(foo: number) => string</span></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/virtualmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/virtualmethod-method.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>virtualMethod</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/virtualmethod-method">virtualMethod()</a></p>
+      </section>
+      <section>
+        <p>Overrides <a href="/test-suite-a/testabstractclass-class/virtualmethod-method">virtualMethod()</a>.</p>
+      </section>
+      <section>
+        <h2 id="virtualmethod-signature">Signature</h2><code>/** @override */<br>protected virtualMethod(): number;</code>
+      </section>
+      <section>
+        <h2 id="virtualmethod-returns">Returns</h2>
+        <p><span><b>Return type: </b></span><span>number</span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconst-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconst-variable.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testConst</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testconst-variable">testConst</a></p>
+      </section>
+      <section>
+        <p>Test Constant</p>
+      </section>
+      <section><span><b>WARNING: This API is provided as a beta preview and may change without notice. Use at your own risk.</b></span></section>
+      <section>
+        <h2 id="testconst-signature">Signature</h2><code>testConst = 42</code>
+      </section>
+      <section>
+        <h2 id="testconst-remarks">Remarks</h2>
+        <p>Here are some remarks about the variable</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testConstWithEmptyDeprecatedBlock</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testconstwithemptydeprecatedblock-variable">testConstWithEmptyDeprecatedBlock</a></p>
+      </section>
+      <section>
+        <p>I have a <code>@deprecated</code> tag with an empty comment block.</p>
+      </section>
+      <section>
+        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br><span><p></p></span></p>
+      </section>
+      <section>
+        <h2 id="testconstwithemptydeprecatedblock-signature">Signature</h2><code>testConstWithEmptyDeprecatedBlock: string</code>
+        <p><span><span><b>Type: </b></span><span>string</span></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testemptyinterface-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testemptyinterface-interface/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestEmptyInterface</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testemptyinterface-interface/">TestEmptyInterface</a></p>
+      </section>
+      <section>
+        <p>An empty interface</p>
+      </section>
+      <section>
+        <h2 id="testemptyinterface-signature">Signature</h2><code>export interface TestEmptyInterface</code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestEnum</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testenum-enum/">TestEnum</a></p>
+      </section>
+      <section>
+        <p>Test Enum</p>
+      </section>
+      <section>
+        <h2 id="testenum-signature">Signature</h2><code>export declare enum TestEnum</code>
+      </section>
+      <section>
+        <h2 id="testenum-remarks">Remarks</h2>
+        <p>Here are some remarks about the enum</p>
+      </section>
+      <section>
+        <h2 id="testenum-examples">Examples</h2>
+        <section>
+          <h3 id="testenum-example1">Example 1</h3>
+          <p>
+            <p>Some example</p><code>const foo = TestEnum.TestEnumValue1</code>
+          </p>
+        </section>
+        <section>
+          <h3 id="testenum-example2">Example 2</h3>
+          <p>
+            <p>Another example</p><code>const bar = TestEnum.TestEnumValue2</code>
+          </p>
+        </section>
+      </section>
+      <section>
+        <h2>Flags</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Flag</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testenum-enum/testenumvalue1-enummember">TestEnumValue1</a></td>
+              <td>Test enum value 1 (string)</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testenum-enum/testenumvalue2-enummember">TestEnumValue2</a></td>
+              <td>Test enum value 2 (number)</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testenum-enum/testenumvalue3-enummember">TestEnumValue3</a></td>
+              <td>Test enum value 3 (default)</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <section>
+          <p>Test enum value 1 (string)</p>
+        </section>
+        <section>
+          <h3 id="testenumvalue1-signature">Signature</h3><code>TestEnumValue1 = "test-enum-value-1"</code>
+        </section>
+        <section>
+          <h3 id="testenumvalue1-remarks">Remarks</h3>
+          <p>Here are some remarks about the enum value</p>
+        </section>
+        <section>
+          <p>Test enum value 2 (number)</p>
+        </section>
+        <section>
+          <h3 id="testenumvalue2-signature">Signature</h3><code>TestEnumValue2 = 3</code>
+        </section>
+        <section>
+          <h3 id="testenumvalue2-remarks">Remarks</h3>
+          <p>Here are some remarks about the enum value</p>
+        </section>
+        <section>
+          <p>Test enum value 3 (default)</p>
+        </section>
+        <section>
+          <h3 id="testenumvalue3-signature">Signature</h3><code>TestEnumValue3 = 4</code>
+        </section>
+        <section>
+          <h3 id="testenumvalue3-remarks">Remarks</h3>
+          <p>Here are some remarks about the enum value</p>
+        </section>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue1-enummember.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue1-enummember.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestEnumValue1</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testenum-enum/">TestEnum</a> > <a href="/test-suite-a/testenum-enum/testenumvalue1-enummember">TestEnumValue1</a></p>
+      </section>
+      <section>
+        <p>Test enum value 1 (string)</p>
+      </section>
+      <section>
+        <h2 id="testenumvalue1-signature">Signature</h2><code>TestEnumValue1 = "test-enum-value-1"</code>
+      </section>
+      <section>
+        <h2 id="testenumvalue1-remarks">Remarks</h2>
+        <p>Here are some remarks about the enum value</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue2-enummember.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue2-enummember.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestEnumValue2</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testenum-enum/">TestEnum</a> > <a href="/test-suite-a/testenum-enum/testenumvalue2-enummember">TestEnumValue2</a></p>
+      </section>
+      <section>
+        <p>Test enum value 2 (number)</p>
+      </section>
+      <section>
+        <h2 id="testenumvalue2-signature">Signature</h2><code>TestEnumValue2 = 3</code>
+      </section>
+      <section>
+        <h2 id="testenumvalue2-remarks">Remarks</h2>
+        <p>Here are some remarks about the enum value</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue3-enummember.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue3-enummember.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestEnumValue3</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testenum-enum/">TestEnum</a> > <a href="/test-suite-a/testenum-enum/testenumvalue3-enummember">TestEnumValue3</a></p>
+      </section>
+      <section>
+        <p>Test enum value 3 (default)</p>
+      </section>
+      <section>
+        <h2 id="testenumvalue3-signature">Signature</h2><code>TestEnumValue3 = 4</code>
+      </section>
+      <section>
+        <h2 id="testenumvalue3-remarks">Remarks</h2>
+        <p>Here are some remarks about the enum value</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunction-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunction-function.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testFunction</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testfunction-function">testFunction(testParameter, testOptionalParameter)</a></p>
+      </section>
+      <section>
+        <p>Test function</p>
+      </section>
+      <section><span><b>WARNING: This API is provided as an alpha preview and may change without notice. Use at your own risk.</b></span></section>
+      <section>
+        <h2 id="testfunction-signature">Signature</h2><code>export declare function testFunction&#x3C;TTypeParameter extends TestInterface = TestInterface>(testParameter: TTypeParameter, testOptionalParameter?: TTypeParameter): TTypeParameter;</code>
+        <p>
+          <section>
+            <h3>Type Parameters</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Parameter</th>
+                  <th>Constraint</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>TTypeParameter</td>
+                  <td><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></td>
+                  <td><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></td>
+                  <td>A test type parameter</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+        </p>
+      </section>
+      <section>
+        <h2 id="testfunction-remarks">Remarks</h2>
+        <p>This is a test <a href="/test-suite-a/testinterface-interface/">link</a> to another API member</p>
+      </section>
+      <section>
+        <h2 id="testfunction-parameters">Parameters</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Modifiers</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>testParameter</td>
+              <td></td>
+              <td><span>TTypeParameter</span></td>
+              <td>A test parameter</td>
+            </tr>
+            <tr>
+              <td>testOptionalParameter</td>
+              <td>optional</td>
+              <td><span>TTypeParameter</span></td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2 id="testfunction-returns">Returns</h2>
+        <p>The provided parameter</p>
+        <p><span><b>Return type: </b></span><span>TTypeParameter</span></p>
+      </section>
+      <section>
+        <h2 id="testfunction-throws">Throws</h2>
+        <p>An Error when something bad happens.</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturninginlinetype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturninginlinetype-function.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testFunctionReturningInlineType</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testfunctionreturninginlinetype-function">testFunctionReturningInlineType()</a></p>
+      </section>
+      <section>
+        <p>Test function that returns an inline type</p>
+      </section>
+      <section>
+        <h2 id="testfunctionreturninginlinetype-signature">Signature</h2><code>export declare function testFunctionReturningInlineType(): {<br>foo: number;<br>bar: TestEnum;<br>};</code>
+      </section>
+      <section>
+        <h2 id="testfunctionreturninginlinetype-returns">Returns</h2>
+        <p>An inline type</p>
+        <p><span><b>Return type: </b></span><span>{ foo: number; bar: <a href="/test-suite-a/testenum-enum/">TestEnum</a>; }</span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testFunctionReturningIntersectionType</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testfunctionreturningintersectiontype-function">testFunctionReturningIntersectionType()</a></p>
+      </section>
+      <section>
+        <p>Test function that returns an inline type</p>
+      </section>
+      <section>
+        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br><span><p><i>This is a test deprecation notice. Here is a </i><a href="/test-suite-a/testfunctionreturninguniontype-function"><i>link</i></a><i> to something else!</i></p></span></p>
+      </section>
+      <section>
+        <h2 id="testfunctionreturningintersectiontype-signature">Signature</h2><code>export declare function testFunctionReturningIntersectionType(): TestEmptyInterface &#x26; TestInterfaceWithTypeParameter&#x3C;number>;</code>
+      </section>
+      <section>
+        <h2 id="testfunctionreturningintersectiontype-returns">Returns</h2>
+        <p>an intersection type</p>
+        <p><span><b>Return type: </b></span><span><a href="/test-suite-a/testemptyinterface-interface/">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;number></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturninguniontype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturninguniontype-function.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testFunctionReturningUnionType</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testfunctionreturninguniontype-function">testFunctionReturningUnionType()</a></p>
+      </section>
+      <section>
+        <p>Test function that returns an inline type</p>
+      </section>
+      <section>
+        <h2 id="testfunctionreturninguniontype-signature">Signature</h2><code>export declare function testFunctionReturningUnionType(): string | TestInterface;</code>
+      </section>
+      <section>
+        <h2 id="testfunctionreturninguniontype-returns">Returns</h2>
+        <p>A union type</p>
+        <p><span><b>Return type: </b></span><span>string | <a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call_-callsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call_-callsignature.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>(event: 'testCallSignature', listener: (input: unknown) => void): any</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/_call_-callsignature">(event: 'testCallSignature', listener: (input: unknown) => void): any</a></p>
+      </section>
+      <section>
+        <p>Test interface event call signature</p>
+      </section>
+      <section>
+        <h2 id="_call_-signature">Signature</h2><code>(event: 'testCallSignature', listener: (input: unknown) => void): any;</code>
+      </section>
+      <section>
+        <h2 id="_call_-remarks">Remarks</h2>
+        <p>Here are some remarks about the event call signature</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call__1-callsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call__1-callsignature.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>(event: 'anotherTestCallSignature', listener: (input: number) => string): number</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/_call__1-callsignature">(event: 'anotherTestCallSignature', listener: (input: number) => string): number</a></p>
+      </section>
+      <section>
+        <p>Another example call signature</p>
+      </section>
+      <section>
+        <h2 id="_call__1-signature">Signature</h2><code>(event: 'anotherTestCallSignature', listener: (input: number) => string): number;</code>
+      </section>
+      <section>
+        <h2 id="_call__1-remarks">Remarks</h2>
+        <p>Here are some remarks about the event call signature</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_new_-constructsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_new_-constructsignature.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>new (): TestInterface</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/_new_-constructsignature">new (): TestInterface</a></p>
+      </section>
+      <section>
+        <p>Test construct signature.</p>
+      </section>
+      <section>
+        <h2 id="_new_-signature">Signature</h2><code>new (): TestInterface;</code>
+      </section>
+      <section>
+        <h2 id="_new_-returns">Returns</h2>
+        <p><span><b>Return type: </b></span><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/getterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/getterproperty-property.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>getterProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/getterproperty-property">getterProperty</a></p>
+      </section>
+      <section>
+        <p>A test getter-only interface property.</p>
+      </section>
+      <section>
+        <h2 id="getterproperty-signature">Signature</h2><code>get getterProperty(): boolean;</code>
+        <p><span><span><b>Type: </b></span><span>boolean</span></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestInterface</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a></p>
+      </section>
+      <section>
+        <p>Test interface</p>
+      </section>
+      <section>
+        <h2 id="testinterface-signature">Signature</h2><code>export interface TestInterface</code>
+      </section>
+      <section>
+        <h2 id="testinterface-remarks">Remarks</h2>
+        <p>Here are some remarks about the interface</p>
+      </section>
+      <section>
+        <h2>Construct Signatures</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>ConstructSignature</th>
+              <th>Return Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testinterface-interface/_new_-constructsignature">new (): TestInterface</a></td>
+              <td><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></td>
+              <td>Test construct signature.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Events</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Modifiers</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature">testClassEventProperty</a></td>
+              <td><code>readonly</code></td>
+              <td><span>() => void</span></td>
+              <td>Test interface event property</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Properties</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Modifiers</th>
+              <th>Default Value</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testinterface-interface/getterproperty-property">getterProperty</a></td>
+              <td><code>readonly</code></td>
+              <td></td>
+              <td><span>boolean</span></td>
+              <td>A test getter-only interface property.</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature">propertyWithBadInheritDocTarget</a></td>
+              <td></td>
+              <td></td>
+              <td><span>boolean</span></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testinterface-interface/setterproperty-property">setterProperty</a></td>
+              <td></td>
+              <td></td>
+              <td><span>boolean</span></td>
+              <td>A test property with a getter and a setter.</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature">testInterfaceProperty</a></td>
+              <td></td>
+              <td></td>
+              <td><span>number</span></td>
+              <td>Test interface property</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></td>
+              <td><code>optional</code></td>
+              <td>0</td>
+              <td><span>number</span></td>
+              <td>Test optional property</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Methods</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Method</th>
+              <th>Return Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature">testInterfaceMethod()</a></td>
+              <td><span>void</span></td>
+              <td>Test interface method</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Call Signatures</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>CallSignature</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testinterface-interface/_call_-callsignature">(event: 'testCallSignature', listener: (input: unknown) => void): any</a></td>
+              <td>Test interface event call signature</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testinterface-interface/_call__1-callsignature">(event: 'anotherTestCallSignature', listener: (input: number) => string): number</a></td>
+              <td>Another example call signature</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2 id="testinterface-see-also">See Also</h2>
+        <p><a href="/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature">testInterfaceMethod()</a></p>
+        <p><a href="/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature">testInterfaceProperty</a></p>
+        <p><a href="/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></p>
+        <p><a href="/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature">testClassEventProperty</a></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>propertyWithBadInheritDocTarget</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature">propertyWithBadInheritDocTarget</a></p>
+      </section>
+      <section>
+        <p></p>
+      </section>
+      <section>
+        <h2 id="propertywithbadinheritdoctarget-signature">Signature</h2><code>propertyWithBadInheritDocTarget: boolean;</code>
+        <p><span><span><b>Type: </b></span><span>boolean</span></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>setterProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/setterproperty-property">setterProperty</a></p>
+      </section>
+      <section>
+        <p>A test property with a getter and a setter.</p>
+      </section>
+      <section>
+        <h2 id="setterproperty-signature">Signature</h2><code>get setterProperty(): boolean;<br><br><br>set setterProperty(newValue: boolean);</code>
+        <p><span><span><b>Type: </b></span><span>boolean</span></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testClassEventProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature">testClassEventProperty</a></p>
+      </section>
+      <section>
+        <p>Test interface event property</p>
+      </section>
+      <section>
+        <h2 id="testclasseventproperty-signature">Signature</h2><code>readonly testClassEventProperty: () => void;</code>
+        <p><span><span><b>Type: </b></span><span>() => void</span></span></p>
+      </section>
+      <section>
+        <h2 id="testclasseventproperty-remarks">Remarks</h2>
+        <p>Here are some remarks about the event property</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testInterfaceMethod</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature">testInterfaceMethod()</a></p>
+      </section>
+      <section>
+        <p>Test interface method</p>
+      </section>
+      <section>
+        <h2 id="testinterfacemethod-signature">Signature</h2><code>testInterfaceMethod(): void;</code>
+      </section>
+      <section>
+        <h2 id="testinterfacemethod-remarks">Remarks</h2>
+        <p>Here are some remarks about the method</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testInterfaceProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature">testInterfaceProperty</a></p>
+      </section>
+      <section>
+        <p>Test interface property</p>
+      </section>
+      <section>
+        <h2 id="testinterfaceproperty-signature">Signature</h2><code>testInterfaceProperty: number;</code>
+        <p><span><span><b>Type: </b></span><span>number</span></span></p>
+      </section>
+      <section>
+        <h2 id="testinterfaceproperty-remarks">Remarks</h2>
+        <p>Here are some remarks about the property</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testOptionalInterfaceProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></p>
+      </section>
+      <section>
+        <p>Test optional property</p>
+      </section>
+      <section>
+        <h2 id="testoptionalinterfaceproperty-signature">Signature</h2><code>testOptionalInterfaceProperty?: number;</code>
+        <p><span><span><b>Type: </b></span><span>number</span></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestInterfaceExtendingOtherInterfaces</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface/">TestInterfaceExtendingOtherInterfaces</a></p>
+      </section>
+      <section>
+        <p>Test interface that extends other interfaces</p>
+      </section>
+      <section>
+        <h2 id="testinterfaceextendingotherinterfaces-signature">Signature</h2><code>export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter&#x3C;number></code>
+        <p><span><span><b>Extends: </b></span><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span>, <span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span>, <span><a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;number></span></span></p>
+      </section>
+      <section>
+        <h2 id="testinterfaceextendingotherinterfaces-remarks">Remarks</h2>
+        <p>Here are some remarks about the interface</p>
+      </section>
+      <section>
+        <h2>Methods</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Method</th>
+              <th>Return Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature">testMethod(input)</a></td>
+              <td><span>number</span></td>
+              <td>Test interface method accepting a string and returning a number.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2 id="testinterfaceextendingotherinterfaces-see-also">See Also</h2>
+        <p>
+          <p>- <a href="/test-suite-a/testinterface-interface/">TestInterface</a></p>
+          <p>- <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a></p>
+          <p>- <a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></p>
+        </p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testMethod</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface/">TestInterfaceExtendingOtherInterfaces</a> > <a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature">testMethod(input)</a></p>
+      </section>
+      <section>
+        <p>Test interface method accepting a string and returning a number.</p>
+      </section>
+      <section>
+        <h2 id="testmethod-signature">Signature</h2><code>testMethod(input: string): number;</code>
+      </section>
+      <section>
+        <h2 id="testmethod-remarks">Remarks</h2>
+        <p>Here are some remarks about the method</p>
+      </section>
+      <section>
+        <h2 id="testmethod-parameters">Parameters</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>input</td>
+              <td><span>string</span></td>
+              <td>A string</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2 id="testmethod-returns">Returns</h2>
+        <p>A number</p>
+        <p><span><b>Return type: </b></span><span>number</span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>[foo: number]: { bar: string; }</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithindexsignature-interface/">TestInterfaceWithIndexSignature</a> > <a href="/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature">[foo: number]: { bar: string; }</a></p>
+      </section>
+      <section>
+        <p>Test index signature.</p>
+      </section>
+      <section>
+        <h2 id="_indexer_-signature">Signature</h2><code>[foo: number]: {<br>bar: string;<br>};</code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestInterfaceWithIndexSignature</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithindexsignature-interface/">TestInterfaceWithIndexSignature</a></p>
+      </section>
+      <section>
+        <p>An interface with an index signature.</p>
+      </section>
+      <section>
+        <h2 id="testinterfacewithindexsignature-signature">Signature</h2><code>export interface TestInterfaceWithIndexSignature</code>
+      </section>
+      <section>
+        <h2>Index Signatures</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>IndexSignature</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature">[foo: number]: { bar: string; }</a></td>
+              <td>Test index signature.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestInterfaceWithTypeParameter</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a></p>
+      </section>
+      <section>
+        <p>Test interface with generic type parameter</p>
+      </section>
+      <section>
+        <h2 id="testinterfacewithtypeparameter-signature">Signature</h2><code>export interface TestInterfaceWithTypeParameter&#x3C;T></code>
+        <p>
+          <section>
+            <h3>Type Parameters</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Parameter</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>T</td>
+                  <td>A type parameter</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+        </p>
+      </section>
+      <section>
+        <h2 id="testinterfacewithtypeparameter-remarks">Remarks</h2>
+        <p>Here are some remarks about the interface</p>
+      </section>
+      <section>
+        <h2>Properties</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature">testProperty</a></td>
+              <td><span>T</span></td>
+              <td>A test interface property using generic type parameter</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a> > <a href="/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature">testProperty</a></p>
+      </section>
+      <section>
+        <p>A test interface property using generic type parameter</p>
+      </section>
+      <section>
+        <h2 id="testproperty-signature">Signature</h2><code>testProperty: T;</code>
+        <p><span><span><b>Type: </b></span><span>T</span></span></p>
+      </section>
+      <section>
+        <h2 id="testproperty-remarks">Remarks</h2>
+        <p>Here are some remarks about the property</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testmappedtype-typealias/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testmappedtype-typealias/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestMappedType</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></p>
+      </section>
+      <section>
+        <p>Test Mapped Type, using <a href="/test-suite-a/testenum-enum/">TestEnum</a></p>
+      </section>
+      <section>
+        <h2 id="testmappedtype-signature">Signature</h2><code>export type TestMappedType = {<br>[K in TestEnum]: boolean;<br>};</code>
+      </section>
+      <section>
+        <h2 id="testmappedtype-remarks">Remarks</h2>
+        <p>Here are some remarks about the mapped type</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/foo-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/foo-variable.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>foo</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testmodule-namespace/">TestModule</a> > <a href="/test-suite-a/testmodule-namespace/foo-variable">foo</a></p>
+      </section>
+      <section>
+        <p>Test constant in module.</p>
+      </section>
+      <section>
+        <h2 id="foo-signature">Signature</h2><code>foo = 2</code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestModule</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testmodule-namespace/">TestModule</a></p>
+      </section>
+      <section>
+        <h2>Variables</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Variable</th>
+              <th>Modifiers</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testmodule-namespace/foo-variable">foo</a></td>
+              <td><code>readonly</code></td>
+              <td></td>
+              <td>Test constant in module.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestNamespace</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a></p>
+      </section>
+      <section>
+        <p>Test Namespace</p>
+      </section>
+      <section>
+        <h2 id="testnamespace-signature">Signature</h2><code>export declare namespace TestNamespace</code>
+      </section>
+      <section>
+        <h2 id="testnamespace-remarks">Remarks</h2>
+        <p>Here are some remarks about the namespace</p>
+      </section>
+      <section>
+        <h2 id="testnamespace-examples">Examples</h2>
+        <section>
+          <h3 id="testnamespace-example1">Example: TypeScript Example</h3>
+          <p>
+            <p></p><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          </p>
+        </section>
+        <section>
+          <h3 id="testnamespace-example2">Example: JavaScript Example</h3>
+          <p>
+            <p></p><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          </p>
+        </section>
+      </section>
+      <section>
+        <h2>Interfaces</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Interface</th>
+              <th>Alerts</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testinterface-interface/">TestInterface</a></td>
+              <td><code>Alpha</code></td>
+              <td>Test interface</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Classes</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Class</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testclass-class/">TestClass</a></td>
+              <td>Test class</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Enumerations</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Enum</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testenum-enum/">TestEnum</a></td>
+              <td>Test Enum</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Types</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>TypeAlias</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testtypealias-typealias/">TestTypeAlias</a></td>
+              <td>Test Type-Alias</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Functions</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Function</th>
+              <th>Return Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testfunction-function">testFunction(testParameter)</a></td>
+              <td><span>number</span></td>
+              <td>Test function</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Variables</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Variable</th>
+              <th>Alerts</th>
+              <th>Modifiers</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testconst-variable">TestConst</a></td>
+              <td><code>Beta</code></td>
+              <td><code>readonly</code></td>
+              <td></td>
+              <td>Test Constant</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Namespaces</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Namespace</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/">TestSubNamespace</a></td>
+              <td>Test sub-namespace</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>(constructor)</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/">TestClass</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor">(constructor)(testClassProperty)</a></p>
+      </section>
+      <section>
+        <p>Test class constructor</p>
+      </section>
+      <section>
+        <h2 id="_constructor_-signature">Signature</h2><code>constructor(testClassProperty: string);</code>
+      </section>
+      <section>
+        <h2 id="_constructor_-parameters">Parameters</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>testClassProperty</td>
+              <td><span>string</span></td>
+              <td>See <a href="/test-suite-a/testclass-class/testclassproperty-property">testClassProperty</a></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestClass</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/">TestClass</a></p>
+      </section>
+      <section>
+        <p>Test class</p>
+      </section>
+      <section>
+        <h2 id="testclass-signature">Signature</h2><code>class TestClass</code>
+      </section>
+      <section>
+        <h2>Constructors</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Constructor</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor">(constructor)(testClassProperty)</a></td>
+              <td>Test class constructor</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Properties</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Modifiers</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property">testClassProperty</a></td>
+              <td><code>readonly</code></td>
+              <td><span>string</span></td>
+              <td>Test interface property</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Methods</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Method</th>
+              <th>Return Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method">testClassMethod(testParameter)</a></td>
+              <td><span>Promise&#x3C;string></span></td>
+              <td>Test class method</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testClassMethod</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/">TestClass</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method">testClassMethod(testParameter)</a></p>
+      </section>
+      <section>
+        <p>Test class method</p>
+      </section>
+      <section>
+        <h2 id="testclassmethod-signature">Signature</h2><code>testClassMethod(testParameter: string): Promise&#x3C;string>;</code>
+      </section>
+      <section>
+        <h2 id="testclassmethod-parameters">Parameters</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>testParameter</td>
+              <td><span>string</span></td>
+              <td>A string</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2 id="testclassmethod-returns">Returns</h2>
+        <p>A Promise</p>
+        <p><span><b>Return type: </b></span><span>Promise&#x3C;string></span></p>
+      </section>
+      <section>
+        <h2 id="testclassmethod-throws">Throws</h2>
+        <p>An Error when something happens for which an error should be thrown. Except in the cases where another kind of error is thrown. We don't throw this error in those cases.</p>
+        <p>
+          <p>A different kind of error when a thing happens, but not when the first kind of error is thrown instead.</p>
+          <p>😁</p>
+        </p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testClassProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/">TestClass</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property">testClassProperty</a></p>
+      </section>
+      <section>
+        <p>Test interface property</p>
+      </section>
+      <section>
+        <h2 id="testclassproperty-signature">Signature</h2><code>readonly testClassProperty: string;</code>
+        <p><span><span><b>Type: </b></span><span>string</span></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testconst-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testconst-variable.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestConst</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testconst-variable">TestConst</a></p>
+      </section>
+      <section>
+        <p>Test Constant</p>
+      </section>
+      <section><span><b>WARNING: This API is provided as a beta preview and may change without notice. Use at your own risk.</b></span></section>
+      <section>
+        <h2 id="testconst-signature">Signature</h2><code>TestConst = "Hello world!"</code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestEnum</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum/">TestEnum</a></p>
+      </section>
+      <section>
+        <p>Test Enum</p>
+      </section>
+      <section>
+        <h2 id="testenum-signature">Signature</h2><code>enum TestEnum</code>
+      </section>
+      <section>
+        <h2>Flags</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Flag</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember">TestEnumValue1</a></td>
+              <td>Test enum value 1</td>
+            </tr>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember">TestEnumValue2</a></td>
+              <td>Test enum value 2</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <section>
+          <p>Test enum value 1</p>
+        </section>
+        <section>
+          <h3 id="testenumvalue1-signature">Signature</h3><code>TestEnumValue1 = 0</code>
+        </section>
+        <section>
+          <p>Test enum value 2</p>
+        </section>
+        <section>
+          <h3 id="testenumvalue2-signature">Signature</h3><code>TestEnumValue2 = 1</code>
+        </section>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestEnumValue1</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum/">TestEnum</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember">TestEnumValue1</a></p>
+      </section>
+      <section>
+        <p>Test enum value 1</p>
+      </section>
+      <section>
+        <h2 id="testenumvalue1-signature">Signature</h2><code>TestEnumValue1 = 0</code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestEnumValue2</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum/">TestEnum</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember">TestEnumValue2</a></p>
+      </section>
+      <section>
+        <p>Test enum value 2</p>
+      </section>
+      <section>
+        <h2 id="testenumvalue2-signature">Signature</h2><code>TestEnumValue2 = 1</code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testFunction</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testfunction-function">testFunction(testParameter)</a></p>
+      </section>
+      <section>
+        <p>Test function</p>
+      </section>
+      <section>
+        <h2 id="testfunction-signature">Signature</h2><code>function testFunction(testParameter: number): number;</code>
+      </section>
+      <section>
+        <h2 id="testfunction-parameters">Parameters</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>testParameter</td>
+              <td><span>number</span></td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2 id="testfunction-returns">Returns</h2>
+        <p>A number</p>
+        <p><span><b>Return type: </b></span><span>number</span></p>
+      </section>
+      <section>
+        <h2 id="testfunction-throws">Throws</h2>
+        <p>An Error</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestInterface</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface/">TestInterface</a></p>
+      </section>
+      <section>
+        <p>Test interface</p>
+      </section>
+      <section><span><b>WARNING: This API is provided as an alpha preview and may change without notice. Use at your own risk.</b></span></section>
+      <section>
+        <h2 id="testinterface-signature">Signature</h2><code>interface TestInterface extends TestInterfaceWithTypeParameter&#x3C;TestEnum></code>
+        <p><span><span><b>Extends: </b></span><span><a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;<a href="/test-suite-a/testnamespace-namespace/testenum-enum/">TestEnum</a>></span></span></p>
+      </section>
+      <section>
+        <h2>Properties</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Alerts</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature">testInterfaceProperty</a></td>
+              <td><code>Alpha</code></td>
+              <td><span>boolean</span></td>
+              <td>Test interface property</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Methods</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Method</th>
+              <th>Alerts</th>
+              <th>Return Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature">testInterfaceMethod()</a></td>
+              <td><code>Alpha</code></td>
+              <td><span>void</span></td>
+              <td>Test interface method</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testInterfaceMethod</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature">testInterfaceMethod()</a></p>
+      </section>
+      <section>
+        <p>Test interface method</p>
+      </section>
+      <section><span><b>WARNING: This API is provided as an alpha preview and may change without notice. Use at your own risk.</b></span></section>
+      <section>
+        <h2 id="testinterfacemethod-signature">Signature</h2><code>testInterfaceMethod(): void;</code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>testInterfaceProperty</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature">testInterfaceProperty</a></p>
+      </section>
+      <section>
+        <p>Test interface property</p>
+      </section>
+      <section><span><b>WARNING: This API is provided as an alpha preview and may change without notice. Use at your own risk.</b></span></section>
+      <section>
+        <h2 id="testinterfaceproperty-signature">Signature</h2><code>testInterfaceProperty: boolean;</code>
+        <p><span><span><b>Type: </b></span><span>boolean</span></span></p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestSubNamespace</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/">TestSubNamespace</a></p>
+      </section>
+      <section>
+        <p>Test sub-namespace</p>
+      </section>
+      <section>
+        <h2 id="testsubnamespace-signature">Signature</h2><code>namespace TestSubNamespace</code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testtypealias-typealias/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testtypealias-typealias/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TestTypeAlias</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testtypealias-typealias/">TestTypeAlias</a></p>
+      </section>
+      <section>
+        <p>Test Type-Alias</p>
+      </section>
+      <section>
+        <h2 id="testtypealias-signature">Signature</h2><code>type TestTypeAlias = boolean;</code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/typealias-typealias/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/typealias-typealias/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>TypeAlias</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/typealias-typealias/">TypeAlias</a></p>
+      </section>
+      <section>
+        <p>Test Type-Alias</p>
+      </section>
+      <section>
+        <h2 id="typealias-signature">Signature</h2><code>export type TypeAlias = string;</code>
+      </section>
+      <section>
+        <h2 id="typealias-remarks">Remarks</h2>
+        <p>Here are some remarks about the type alias</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/foo-interface/bar-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/foo-interface/bar-propertysignature.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>bar</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-b/">test-suite-b</a> > <a href="/test-suite-b/foo-interface/">Foo</a> > <a href="/test-suite-b/foo-interface/bar-propertysignature">bar</a></p>
+      </section>
+      <section>
+        <p>Test Enum</p>
+      </section>
+      <section>
+        <h2 id="bar-signature">Signature</h2><code>bar: TestEnum;</code>
+        <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></span></p>
+      </section>
+      <section>
+        <h2 id="bar-remarks">Remarks</h2>
+        <p>Here are some remarks about the enum</p>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/foo-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/foo-interface/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>Foo</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-b/">test-suite-b</a> > <a href="/test-suite-b/foo-interface/">Foo</a></p>
+      </section>
+      <section>
+        <p>Bar</p>
+      </section>
+      <section>
+        <h2 id="foo-signature">Signature</h2><code>export interface Foo</code>
+      </section>
+      <section>
+        <h2>Properties</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-b/foo-interface/bar-propertysignature">bar</a></td>
+              <td><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></td>
+              <td>Test Enum</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <section>
+      <h1>test-suite-b</h1>
+      <section>
+        <p><a href="/">Packages</a> > <a href="/test-suite-b/">test-suite-b</a></p>
+      </section>
+      <section>
+        <h2>Interfaces</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Interface</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="/test-suite-b/foo-interface/">Foo</a></td>
+              <td>Bar</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/index.md
@@ -1,0 +1,8 @@
+# API Overview
+
+## Packages
+
+| Package | Description |
+| --- | --- |
+| [test-suite-a](/test-suite-a/) | Test package |
+| [test-suite-b](/test-suite-b/) |  |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
@@ -1,0 +1,92 @@
+# test-suite-a
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/)
+
+Test package
+
+## Remarks {#test-suite-a-remarks}
+
+This remarks block includes a bulleted list!
+
+- Bullet 1
+
+- Bullet 2
+
+And an ordered list for good measure!
+
+1. List item 1
+
+2. List item 2
+
+3. List item 3
+
+Also, here is a link test, including a bad link, because we should have some reasonable support if this happens:
+
+- Good link (no alias): [TestClass](/test-suite-a/testclass-class/)
+
+- Good link (with alias): [function alias text](/test-suite-a/testfunction-function)
+
+- Bad link (no alias): _InvalidItem_
+
+- Bad link (with alias): _even though I link to an invalid item, I would still like this text to be rendered_
+
+## Example {#test-suite-a-example}
+
+A test example
+
+```typescript
+const foo = bar;
+```
+
+## Interfaces
+
+| Interface | Description |
+| --- | --- |
+| [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) | An empty interface |
+| [TestInterface](/test-suite-a/testinterface-interface/) | Test interface |
+| [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface/) | Test interface that extends other interfaces |
+| [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface/) | An interface with an index signature. |
+| [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/) | Test interface with generic type parameter |
+
+## Classes
+
+| Class | Description |
+| --- | --- |
+| [TestAbstractClass](/test-suite-a/testabstractclass-class/) | A test abstract class. |
+| [TestClass](/test-suite-a/testclass-class/) | Test class |
+
+## Enumerations
+
+| Enum | Description |
+| --- | --- |
+| [TestEnum](/test-suite-a/testenum-enum/) | Test Enum |
+
+## Types
+
+| TypeAlias | Description |
+| --- | --- |
+| [TestMappedType](/test-suite-a/testmappedtype-typealias/) | Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum/) |
+| [TypeAlias](/test-suite-a/typealias-typealias/) | Test Type-Alias |
+
+## Functions
+
+| Function | Alerts | Return Type | Description |
+| --- | --- | --- | --- |
+| [testFunction(testParameter, testOptionalParameter)](/test-suite-a/testfunction-function) | `Alpha` | TTypeParameter | Test function |
+| [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum/); } | Test function that returns an inline type |
+| [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) &amp; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)&lt;number&gt; | Test function that returns an inline type |
+| [testFunctionReturningUnionType()](/test-suite-a/testfunctionreturninguniontype-function) |  | string \| [TestInterface](/test-suite-a/testinterface-interface/) | Test function that returns an inline type |
+
+## Variables
+
+| Variable | Alerts | Modifiers | Type | Description |
+| --- | --- | --- | --- | --- |
+| [testConst](/test-suite-a/testconst-variable) | `Beta` | `readonly` |  | Test Constant |
+| [testConstWithEmptyDeprecatedBlock](/test-suite-a/testconstwithemptydeprecatedblock-variable) | `Deprecated` | `readonly` | string | I have a `@deprecated` tag with an empty comment block. |
+
+## Namespaces
+
+| Namespace | Description |
+| --- | --- |
+| [TestModule](/test-suite-a/testmodule-namespace/) |  |
+| [TestNamespace](/test-suite-a/testnamespace-namespace/) | Test Namespace |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.md
@@ -1,0 +1,18 @@
+# (constructor)
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/) &gt; [(constructor)(privateProperty, protectedProperty)](/test-suite-a/testabstractclass-class/_constructor_-constructor)
+
+This is a _{@customTag constructor}_.
+
+## Signature {#\_constructor\_-signature}
+
+```typescript
+protected constructor(privateProperty: number, protectedProperty: TestEnum);
+```
+
+## Parameters {#\_constructor\_-parameters}
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| privateProperty | number |  |
+| protectedProperty | [TestEnum](/test-suite-a/testenum-enum/) |  |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.md
@@ -1,0 +1,13 @@
+# abstractPropertyGetter
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/) &gt; [abstractPropertyGetter](/test-suite-a/testabstractclass-class/abstractpropertygetter-property)
+
+A test abstract getter property.
+
+## Signature {#abstractpropertygetter-signature}
+
+```typescript
+abstract get abstractPropertyGetter(): TestMappedType;
+```
+
+**Type:** [TestMappedType](/test-suite-a/testmappedtype-typealias/)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.md
@@ -1,0 +1,32 @@
+# TestAbstractClass
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/)
+
+A test abstract class.
+
+## Signature {#testabstractclass-signature}
+
+```typescript
+export declare abstract class TestAbstractClass
+```
+
+## Constructors
+
+| Constructor | Description |
+| --- | --- |
+| [(constructor)(privateProperty, protectedProperty)](/test-suite-a/testabstractclass-class/_constructor_-constructor) | This is a _{@customTag constructor}_. |
+
+## Properties
+
+| Property | Modifiers | Type | Description |
+| --- | --- | --- | --- |
+| [abstractPropertyGetter](/test-suite-a/testabstractclass-class/abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias/) | A test abstract getter property. |
+| [protectedProperty](/test-suite-a/testabstractclass-class/protectedproperty-property) | `readonly` | [TestEnum](/test-suite-a/testenum-enum/) | A test protected property. |
+
+## Methods
+
+| Method | Modifiers | Return Type | Description |
+| --- | --- | --- | --- |
+| [publicAbstractMethod()](/test-suite-a/testabstractclass-class/publicabstractmethod-method) |  | void | A test public abstract method. |
+| [sealedMethod()](/test-suite-a/testabstractclass-class/sealedmethod-method) | `sealed` | string | A test `@sealed` method. |
+| [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method) | `virtual` | number | A test `@virtual` method. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/protectedproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/protectedproperty-property.md
@@ -1,0 +1,13 @@
+# protectedProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/) &gt; [protectedProperty](/test-suite-a/testabstractclass-class/protectedproperty-property)
+
+A test protected property.
+
+## Signature {#protectedproperty-signature}
+
+```typescript
+protected readonly protectedProperty: TestEnum;
+```
+
+**Type:** [TestEnum](/test-suite-a/testenum-enum/)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/publicabstractmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/publicabstractmethod-method.md
@@ -1,0 +1,11 @@
+# publicAbstractMethod
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/) &gt; [publicAbstractMethod()](/test-suite-a/testabstractclass-class/publicabstractmethod-method)
+
+A test public abstract method.
+
+## Signature {#publicabstractmethod-signature}
+
+```typescript
+abstract publicAbstractMethod(): void;
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/sealedmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/sealedmethod-method.md
@@ -1,0 +1,18 @@
+# sealedMethod
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/) &gt; [sealedMethod()](/test-suite-a/testabstractclass-class/sealedmethod-method)
+
+A test `@sealed` method.
+
+## Signature {#sealedmethod-signature}
+
+```typescript
+/** @sealed */
+protected sealedMethod(): string;
+```
+
+## Returns {#sealedmethod-returns}
+
+A string!
+
+**Return type:** string

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/virtualmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/virtualmethod-method.md
@@ -1,0 +1,18 @@
+# virtualMethod
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/) &gt; [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method)
+
+A test `@virtual` method.
+
+## Signature {#virtualmethod-signature}
+
+```typescript
+/** @virtual */
+protected virtualMethod(): number;
+```
+
+## Returns {#virtualmethod-returns}
+
+A number!
+
+**Return type:** number

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.md
@@ -1,0 +1,24 @@
+# (constructor)
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)](/test-suite-a/testclass-class/_constructor_-constructor)
+
+Test class constructor
+
+## Signature {#\_constructor\_-signature}
+
+```typescript
+constructor(privateProperty: number, protectedProperty: TestEnum, testClassProperty: TTypeParameterB, testClassEventProperty: () => void);
+```
+
+## Remarks {#\_constructor\_-remarks}
+
+Here are some remarks about the constructor
+
+## Parameters {#\_constructor\_-parameters}
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| privateProperty | number | See [TestAbstractClass](/test-suite-a/testabstractclass-class/)'s constructor. |
+| protectedProperty | [TestEnum](/test-suite-a/testenum-enum/) | <p>Some notes about the parameter.</p><p>See <a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a>.</p> |
+| testClassProperty | TTypeParameterB | See [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property). |
+| testClassEventProperty | () =&gt; void | See [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property). |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.md
@@ -1,0 +1,13 @@
+# abstractPropertyGetter
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [abstractPropertyGetter](/test-suite-a/testclass-class/abstractpropertygetter-property)
+
+A test abstract getter property.
+
+## Signature {#abstractpropertygetter-signature}
+
+```typescript
+get abstractPropertyGetter(): TestMappedType;
+```
+
+**Type:** [TestMappedType](/test-suite-a/testmappedtype-typealias/)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/index.md
@@ -1,0 +1,68 @@
+# TestClass
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/)
+
+Test class
+
+## Signature {#testclass-signature}
+
+```typescript
+export declare class TestClass<TTypeParameterA, TTypeParameterB> extends TestAbstractClass
+```
+
+**Extends:** [TestAbstractClass](/test-suite-a/testabstractclass-class/)
+
+### Type Parameters
+
+| Parameter | Description |
+| --- | --- |
+| TTypeParameterA | A type parameter |
+| TTypeParameterB | Another type parameter |
+
+## Remarks {#testclass-remarks}
+
+Here are some remarks about the class
+
+## Constructors
+
+| Constructor | Description |
+| --- | --- |
+| [(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)](/test-suite-a/testclass-class/_constructor_-constructor) | Test class constructor |
+
+## Static Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| [testClassStaticProperty](/test-suite-a/testclass-class/testclassstaticproperty-property) | (foo: number) =&gt; string | Test static class property |
+
+## Static Methods
+
+| Method | Return Type | Description |
+| --- | --- | --- |
+| [testClassStaticMethod(foo)](/test-suite-a/testclass-class/testclassstaticmethod-method) | string | Test class static method |
+
+## Events
+
+| Property | Modifiers | Type | Description |
+| --- | --- | --- | --- |
+| [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property) | `readonly` | () =&gt; void | Test class event property |
+
+## Properties
+
+| Property | Modifiers | Type | Description |
+| --- | --- | --- | --- |
+| [abstractPropertyGetter](/test-suite-a/testclass-class/abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias/) | A test abstract getter property. |
+| [testClassGetterProperty](/test-suite-a/testclass-class/testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
+| [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
+
+## Methods
+
+| Method | Modifiers | Return Type | Description |
+| --- | --- | --- | --- |
+| [publicAbstractMethod()](/test-suite-a/testclass-class/publicabstractmethod-method) |  | void | A test public abstract method. |
+| [testClassMethod(input)](/test-suite-a/testclass-class/testclassmethod-method) | `sealed` | TTypeParameterA | Test class method |
+| [virtualMethod()](/test-suite-a/testclass-class/virtualmethod-method) |  | number | Overrides [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method). |
+
+## See Also {#testclass-see-also}
+
+[TestAbstractClass](/test-suite-a/testabstractclass-class/)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/publicabstractmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/publicabstractmethod-method.md
@@ -1,0 +1,11 @@
+# publicAbstractMethod
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [publicAbstractMethod()](/test-suite-a/testclass-class/publicabstractmethod-method)
+
+A test public abstract method.
+
+## Signature {#publicabstractmethod-signature}
+
+```typescript
+publicAbstractMethod(): void;
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclasseventproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclasseventproperty-property.md
@@ -1,0 +1,17 @@
+# testClassEventProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property)
+
+Test class event property
+
+## Signature {#testclasseventproperty-signature}
+
+```typescript
+readonly testClassEventProperty: () => void;
+```
+
+**Type:** () =&gt; void
+
+## Remarks {#testclasseventproperty-remarks}
+
+Here are some remarks about the property

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.md
@@ -1,0 +1,19 @@
+# testClassGetterProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [testClassGetterProperty](/test-suite-a/testclass-class/testclassgetterproperty-property)
+
+Test class property with both a getter and a setter.
+
+## Signature {#testclassgetterproperty-signature}
+
+```typescript
+/** @virtual */
+get testClassGetterProperty(): number;
+set testClassGetterProperty(newValue: number);
+```
+
+**Type:** number
+
+## Remarks {#testclassgetterproperty-remarks}
+
+Here are some remarks about the getter-only property

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.md
@@ -1,0 +1,32 @@
+# testClassMethod
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [testClassMethod(input)](/test-suite-a/testclass-class/testclassmethod-method)
+
+Test class method
+
+## Signature {#testclassmethod-signature}
+
+```typescript
+/** @sealed */
+testClassMethod(input: TTypeParameterA): TTypeParameterA;
+```
+
+## Remarks {#testclassmethod-remarks}
+
+Here are some remarks about the method
+
+## Parameters {#testclassmethod-parameters}
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| input | TTypeParameterA |  |
+
+## Returns {#testclassmethod-returns}
+
+**Return type:** TTypeParameterA
+
+## Throws {#testclassmethod-throws}
+
+Some sort of error in 1 case.
+
+Some other sort of error in another case. For example, a case where some thing happens.

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassproperty-property.md
@@ -1,0 +1,17 @@
+# testClassProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property)
+
+Test class property
+
+## Signature {#testclassproperty-signature}
+
+```typescript
+readonly testClassProperty: TTypeParameterB;
+```
+
+**Type:** TTypeParameterB
+
+## Remarks {#testclassproperty-remarks}
+
+Here are some remarks about the property

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.md
@@ -1,0 +1,23 @@
+# testClassStaticMethod
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [testClassStaticMethod(foo)](/test-suite-a/testclass-class/testclassstaticmethod-method)
+
+Test class static method
+
+## Signature {#testclassstaticmethod-signature}
+
+```typescript
+static testClassStaticMethod(foo: number): string;
+```
+
+## Parameters {#testclassstaticmethod-parameters}
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| foo | number | Some number |
+
+## Returns {#testclassstaticmethod-returns}
+
+- Some string
+
+**Return type:** string

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticproperty-property.md
@@ -1,0 +1,13 @@
+# testClassStaticProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [testClassStaticProperty](/test-suite-a/testclass-class/testclassstaticproperty-property)
+
+Test static class property
+
+## Signature {#testclassstaticproperty-signature}
+
+```typescript
+static testClassStaticProperty: (foo: number) => string;
+```
+
+**Type:** (foo: number) =&gt; string

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/virtualmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/virtualmethod-method.md
@@ -1,0 +1,16 @@
+# virtualMethod
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [virtualMethod()](/test-suite-a/testclass-class/virtualmethod-method)
+
+Overrides [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method).
+
+## Signature {#virtualmethod-signature}
+
+```typescript
+/** @override */
+protected virtualMethod(): number;
+```
+
+## Returns {#virtualmethod-returns}
+
+**Return type:** number

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testconst-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testconst-variable.md
@@ -1,0 +1,17 @@
+# testConst
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [testConst](/test-suite-a/testconst-variable)
+
+Test Constant
+
+**WARNING: This API is provided as a beta preview and may change without notice. Use at your own risk.**
+
+## Signature {#testconst-signature}
+
+```typescript
+testConst = 42
+```
+
+## Remarks {#testconst-remarks}
+
+Here are some remarks about the variable

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.md
@@ -1,0 +1,15 @@
+# testConstWithEmptyDeprecatedBlock
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [testConstWithEmptyDeprecatedBlock](/test-suite-a/testconstwithemptydeprecatedblock-variable)
+
+I have a `@deprecated` tag with an empty comment block.
+
+**WARNING: This API is deprecated and will be removed in a future release.**
+
+## Signature {#testconstwithemptydeprecatedblock-signature}
+
+```typescript
+testConstWithEmptyDeprecatedBlock: string
+```
+
+**Type:** string

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testemptyinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testemptyinterface-interface/index.md
@@ -1,0 +1,11 @@
+# TestEmptyInterface
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/)
+
+An empty interface
+
+## Signature {#testemptyinterface-signature}
+
+```typescript
+export interface TestEmptyInterface
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.md
@@ -1,0 +1,77 @@
+# TestEnum
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestEnum](/test-suite-a/testenum-enum/)
+
+Test Enum
+
+## Signature {#testenum-signature}
+
+```typescript
+export declare enum TestEnum
+```
+
+## Remarks {#testenum-remarks}
+
+Here are some remarks about the enum
+
+## Examples {#testenum-examples}
+
+### Example 1 {#testenum-example1}
+
+Some example
+
+```typescript
+const foo = TestEnum.TestEnumValue1
+```
+
+### Example 2 {#testenum-example2}
+
+Another example
+
+```ts
+const bar = TestEnum.TestEnumValue2
+```
+
+## Flags
+
+| Flag | Description |
+| --- | --- |
+| [TestEnumValue1](/test-suite-a/testenum-enum/testenumvalue1-enummember) | Test enum value 1 (string) |
+| [TestEnumValue2](/test-suite-a/testenum-enum/testenumvalue2-enummember) | Test enum value 2 (number) |
+| [TestEnumValue3](/test-suite-a/testenum-enum/testenumvalue3-enummember) | Test enum value 3 (default) |
+
+Test enum value 1 (string)
+
+### Signature {#testenumvalue1-signature}
+
+```typescript
+TestEnumValue1 = "test-enum-value-1"
+```
+
+### Remarks {#testenumvalue1-remarks}
+
+Here are some remarks about the enum value
+
+Test enum value 2 (number)
+
+### Signature {#testenumvalue2-signature}
+
+```typescript
+TestEnumValue2 = 3
+```
+
+### Remarks {#testenumvalue2-remarks}
+
+Here are some remarks about the enum value
+
+Test enum value 3 (default)
+
+### Signature {#testenumvalue3-signature}
+
+```typescript
+TestEnumValue3 = 4
+```
+
+### Remarks {#testenumvalue3-remarks}
+
+Here are some remarks about the enum value

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue1-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue1-enummember.md
@@ -1,0 +1,15 @@
+# TestEnumValue1
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestEnum](/test-suite-a/testenum-enum/) &gt; [TestEnumValue1](/test-suite-a/testenum-enum/testenumvalue1-enummember)
+
+Test enum value 1 (string)
+
+## Signature {#testenumvalue1-signature}
+
+```typescript
+TestEnumValue1 = "test-enum-value-1"
+```
+
+## Remarks {#testenumvalue1-remarks}
+
+Here are some remarks about the enum value

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue2-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue2-enummember.md
@@ -1,0 +1,15 @@
+# TestEnumValue2
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestEnum](/test-suite-a/testenum-enum/) &gt; [TestEnumValue2](/test-suite-a/testenum-enum/testenumvalue2-enummember)
+
+Test enum value 2 (number)
+
+## Signature {#testenumvalue2-signature}
+
+```typescript
+TestEnumValue2 = 3
+```
+
+## Remarks {#testenumvalue2-remarks}
+
+Here are some remarks about the enum value

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue3-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue3-enummember.md
@@ -1,0 +1,15 @@
+# TestEnumValue3
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestEnum](/test-suite-a/testenum-enum/) &gt; [TestEnumValue3](/test-suite-a/testenum-enum/testenumvalue3-enummember)
+
+Test enum value 3 (default)
+
+## Signature {#testenumvalue3-signature}
+
+```typescript
+TestEnumValue3 = 4
+```
+
+## Remarks {#testenumvalue3-remarks}
+
+Here are some remarks about the enum value

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunction-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunction-function.md
@@ -1,0 +1,40 @@
+# testFunction
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [testFunction(testParameter, testOptionalParameter)](/test-suite-a/testfunction-function)
+
+Test function
+
+**WARNING: This API is provided as an alpha preview and may change without notice. Use at your own risk.**
+
+## Signature {#testfunction-signature}
+
+```typescript
+export declare function testFunction<TTypeParameter extends TestInterface = TestInterface>(testParameter: TTypeParameter, testOptionalParameter?: TTypeParameter): TTypeParameter;
+```
+
+### Type Parameters
+
+| Parameter | Constraint | Default | Description |
+| --- | --- | --- | --- |
+| TTypeParameter | [TestInterface](/test-suite-a/testinterface-interface/) | [TestInterface](/test-suite-a/testinterface-interface/) | A test type parameter |
+
+## Remarks {#testfunction-remarks}
+
+This is a test [link](/test-suite-a/testinterface-interface/) to another API member
+
+## Parameters {#testfunction-parameters}
+
+| Parameter | Modifiers | Type | Description |
+| --- | --- | --- | --- |
+| testParameter |  | TTypeParameter | A test parameter |
+| testOptionalParameter | optional | TTypeParameter |  |
+
+## Returns {#testfunction-returns}
+
+The provided parameter
+
+**Return type:** TTypeParameter
+
+## Throws {#testfunction-throws}
+
+An Error when something bad happens.

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturninginlinetype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturninginlinetype-function.md
@@ -1,0 +1,20 @@
+# testFunctionReturningInlineType
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function)
+
+Test function that returns an inline type
+
+## Signature {#testfunctionreturninginlinetype-signature}
+
+```typescript
+export declare function testFunctionReturningInlineType(): {
+    foo: number;
+    bar: TestEnum;
+};
+```
+
+## Returns {#testfunctionreturninginlinetype-returns}
+
+An inline type
+
+**Return type:** {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum/); }

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.md
@@ -1,0 +1,21 @@
+# testFunctionReturningIntersectionType
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function)
+
+Test function that returns an inline type
+
+**WARNING: This API is deprecated and will be removed in a future release.**
+
+_This is a test deprecation notice. Here is a_ [_link_](/test-suite-a/testfunctionreturninguniontype-function)<!-- --> _to something else!_
+
+## Signature {#testfunctionreturningintersectiontype-signature}
+
+```typescript
+export declare function testFunctionReturningIntersectionType(): TestEmptyInterface & TestInterfaceWithTypeParameter<number>;
+```
+
+## Returns {#testfunctionreturningintersectiontype-returns}
+
+an intersection type
+
+**Return type:** [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) &amp; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)&lt;number&gt;

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturninguniontype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturninguniontype-function.md
@@ -1,0 +1,17 @@
+# testFunctionReturningUnionType
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [testFunctionReturningUnionType()](/test-suite-a/testfunctionreturninguniontype-function)
+
+Test function that returns an inline type
+
+## Signature {#testfunctionreturninguniontype-signature}
+
+```typescript
+export declare function testFunctionReturningUnionType(): string | TestInterface;
+```
+
+## Returns {#testfunctionreturninguniontype-returns}
+
+A union type
+
+**Return type:** string \| [TestInterface](/test-suite-a/testinterface-interface/)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call_-callsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call_-callsignature.md
@@ -1,0 +1,15 @@
+# (event: 'testCallSignature', listener: (input: unknown) =&gt; void): any
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [(event: 'testCallSignature', listener: (input: unknown) =&gt; void): any](/test-suite-a/testinterface-interface/_call_-callsignature)
+
+Test interface event call signature
+
+## Signature {#\_call\_-signature}
+
+```typescript
+(event: 'testCallSignature', listener: (input: unknown) => void): any;
+```
+
+## Remarks {#\_call\_-remarks}
+
+Here are some remarks about the event call signature

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call__1-callsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call__1-callsignature.md
@@ -1,0 +1,15 @@
+# (event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [(event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number](/test-suite-a/testinterface-interface/_call__1-callsignature)
+
+Another example call signature
+
+## Signature {#\_call\_\_1-signature}
+
+```typescript
+(event: 'anotherTestCallSignature', listener: (input: number) => string): number;
+```
+
+## Remarks {#\_call\_\_1-remarks}
+
+Here are some remarks about the event call signature

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_new_-constructsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_new_-constructsignature.md
@@ -1,0 +1,15 @@
+# new (): TestInterface
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [new (): TestInterface](/test-suite-a/testinterface-interface/_new_-constructsignature)
+
+Test construct signature.
+
+## Signature {#\_new\_-signature}
+
+```typescript
+new (): TestInterface;
+```
+
+## Returns {#\_new\_-returns}
+
+**Return type:** [TestInterface](/test-suite-a/testinterface-interface/)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/getterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/getterproperty-property.md
@@ -1,0 +1,13 @@
+# getterProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [getterProperty](/test-suite-a/testinterface-interface/getterproperty-property)
+
+A test getter-only interface property.
+
+## Signature {#getterproperty-signature}
+
+```typescript
+get getterProperty(): boolean;
+```
+
+**Type:** boolean

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.md
@@ -1,0 +1,60 @@
+# TestInterface
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/)
+
+Test interface
+
+## Signature {#testinterface-signature}
+
+```typescript
+export interface TestInterface
+```
+
+## Remarks {#testinterface-remarks}
+
+Here are some remarks about the interface
+
+## Construct Signatures
+
+| ConstructSignature | Return Type | Description |
+| --- | --- | --- |
+| [new (): TestInterface](/test-suite-a/testinterface-interface/_new_-constructsignature) | [TestInterface](/test-suite-a/testinterface-interface/) | Test construct signature. |
+
+## Events
+
+| Property | Modifiers | Type | Description |
+| --- | --- | --- | --- |
+| [testClassEventProperty](/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature) | `readonly` | () =&gt; void | Test interface event property |
+
+## Properties
+
+| Property | Modifiers | Default Value | Type | Description |
+| --- | --- | --- | --- | --- |
+| [getterProperty](/test-suite-a/testinterface-interface/getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
+| [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature) |  |  | boolean |  |
+| [setterProperty](/test-suite-a/testinterface-interface/setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
+| [testInterfaceProperty](/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature) |  |  | number | Test interface property |
+| [testOptionalInterfaceProperty](/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature) | `optional` | 0 | number | Test optional property |
+
+## Methods
+
+| Method | Return Type | Description |
+| --- | --- | --- |
+| [testInterfaceMethod()](/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature) | void | Test interface method |
+
+## Call Signatures
+
+| CallSignature | Description |
+| --- | --- |
+| [(event: 'testCallSignature', listener: (input: unknown) =&gt; void): any](/test-suite-a/testinterface-interface/_call_-callsignature) | Test interface event call signature |
+| [(event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number](/test-suite-a/testinterface-interface/_call__1-callsignature) | Another example call signature |
+
+## See Also {#testinterface-see-also}
+
+[testInterfaceMethod()](/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature)
+
+[testInterfaceProperty](/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature)
+
+[testOptionalInterfaceProperty](/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature)
+
+[testClassEventProperty](/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature.md
@@ -1,0 +1,11 @@
+# propertyWithBadInheritDocTarget
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature)
+
+## Signature {#propertywithbadinheritdoctarget-signature}
+
+```typescript
+propertyWithBadInheritDocTarget: boolean;
+```
+
+**Type:** boolean

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.md
@@ -1,0 +1,14 @@
+# setterProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [setterProperty](/test-suite-a/testinterface-interface/setterproperty-property)
+
+A test property with a getter and a setter.
+
+## Signature {#setterproperty-signature}
+
+```typescript
+get setterProperty(): boolean;
+set setterProperty(newValue: boolean);
+```
+
+**Type:** boolean

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature.md
@@ -1,0 +1,17 @@
+# testClassEventProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [testClassEventProperty](/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature)
+
+Test interface event property
+
+## Signature {#testclasseventproperty-signature}
+
+```typescript
+readonly testClassEventProperty: () => void;
+```
+
+**Type:** () =&gt; void
+
+## Remarks {#testclasseventproperty-remarks}
+
+Here are some remarks about the event property

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature.md
@@ -1,0 +1,15 @@
+# testInterfaceMethod
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [testInterfaceMethod()](/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature)
+
+Test interface method
+
+## Signature {#testinterfacemethod-signature}
+
+```typescript
+testInterfaceMethod(): void;
+```
+
+## Remarks {#testinterfacemethod-remarks}
+
+Here are some remarks about the method

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature.md
@@ -1,0 +1,17 @@
+# testInterfaceProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [testInterfaceProperty](/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature)
+
+Test interface property
+
+## Signature {#testinterfaceproperty-signature}
+
+```typescript
+testInterfaceProperty: number;
+```
+
+**Type:** number
+
+## Remarks {#testinterfaceproperty-remarks}
+
+Here are some remarks about the property

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature.md
@@ -1,0 +1,13 @@
+# testOptionalInterfaceProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [testOptionalInterfaceProperty](/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature)
+
+Test optional property
+
+## Signature {#testoptionalinterfaceproperty-signature}
+
+```typescript
+testOptionalInterfaceProperty?: number;
+```
+
+**Type:** number

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.md
@@ -1,0 +1,31 @@
+# TestInterfaceExtendingOtherInterfaces
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface/)
+
+Test interface that extends other interfaces
+
+## Signature {#testinterfaceextendingotherinterfaces-signature}
+
+```typescript
+export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter<number>
+```
+
+**Extends:** [TestInterface](/test-suite-a/testinterface-interface/), [TestMappedType](/test-suite-a/testmappedtype-typealias/), [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)&lt;number&gt;
+
+## Remarks {#testinterfaceextendingotherinterfaces-remarks}
+
+Here are some remarks about the interface
+
+## Methods
+
+| Method | Return Type | Description |
+| --- | --- | --- |
+| [testMethod(input)](/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature) | number | Test interface method accepting a string and returning a number. |
+
+## See Also {#testinterfaceextendingotherinterfaces-see-also}
+
+- [TestInterface](/test-suite-a/testinterface-interface/)
+
+- [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)
+
+- [TestMappedType](/test-suite-a/testmappedtype-typealias/)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.md
@@ -1,0 +1,27 @@
+# testMethod
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface/) &gt; [testMethod(input)](/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature)
+
+Test interface method accepting a string and returning a number.
+
+## Signature {#testmethod-signature}
+
+```typescript
+testMethod(input: string): number;
+```
+
+## Remarks {#testmethod-remarks}
+
+Here are some remarks about the method
+
+## Parameters {#testmethod-parameters}
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| input | string | A string |
+
+## Returns {#testmethod-returns}
+
+A number
+
+**Return type:** number

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature.md
@@ -1,0 +1,13 @@
+# \[foo: number\]: { bar: string; }
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface/) &gt; [\[foo: number\]: { bar: string; }](/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature)
+
+Test index signature.
+
+## Signature {#\_indexer\_-signature}
+
+```typescript
+[foo: number]: {
+        bar: string;
+    };
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.md
@@ -1,0 +1,17 @@
+# TestInterfaceWithIndexSignature
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface/)
+
+An interface with an index signature.
+
+## Signature {#testinterfacewithindexsignature-signature}
+
+```typescript
+export interface TestInterfaceWithIndexSignature
+```
+
+## Index Signatures
+
+| IndexSignature | Description |
+| --- | --- |
+| [\[foo: number\]: { bar: string; }](/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature) | Test index signature. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.md
@@ -1,0 +1,27 @@
+# TestInterfaceWithTypeParameter
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)
+
+Test interface with generic type parameter
+
+## Signature {#testinterfacewithtypeparameter-signature}
+
+```typescript
+export interface TestInterfaceWithTypeParameter<T>
+```
+
+### Type Parameters
+
+| Parameter | Description |
+| --- | --- |
+| T | A type parameter |
+
+## Remarks {#testinterfacewithtypeparameter-remarks}
+
+Here are some remarks about the interface
+
+## Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| [testProperty](/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature) | T | A test interface property using generic type parameter |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature.md
@@ -1,0 +1,17 @@
+# testProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/) &gt; [testProperty](/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature)
+
+A test interface property using generic type parameter
+
+## Signature {#testproperty-signature}
+
+```typescript
+testProperty: T;
+```
+
+**Type:** T
+
+## Remarks {#testproperty-remarks}
+
+Here are some remarks about the property

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmappedtype-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmappedtype-typealias/index.md
@@ -1,0 +1,17 @@
+# TestMappedType
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestMappedType](/test-suite-a/testmappedtype-typealias/)
+
+Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum/)
+
+## Signature {#testmappedtype-signature}
+
+```typescript
+export type TestMappedType = {
+    [K in TestEnum]: boolean;
+};
+```
+
+## Remarks {#testmappedtype-remarks}
+
+Here are some remarks about the mapped type

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/foo-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/foo-variable.md
@@ -1,0 +1,11 @@
+# foo
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestModule](/test-suite-a/testmodule-namespace/) &gt; [foo](/test-suite-a/testmodule-namespace/foo-variable)
+
+Test constant in module.
+
+## Signature {#foo-signature}
+
+```typescript
+foo = 2
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.md
@@ -1,0 +1,9 @@
+# TestModule
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestModule](/test-suite-a/testmodule-namespace/)
+
+## Variables
+
+| Variable | Modifiers | Type | Description |
+| --- | --- | --- | --- |
+| [foo](/test-suite-a/testmodule-namespace/foo-variable) | `readonly` |  | Test constant in module. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.md
@@ -1,0 +1,77 @@
+# TestNamespace
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/)
+
+Test Namespace
+
+## Signature {#testnamespace-signature}
+
+```typescript
+export declare namespace TestNamespace
+```
+
+## Remarks {#testnamespace-remarks}
+
+Here are some remarks about the namespace
+
+## Examples {#testnamespace-examples}
+
+### Example: TypeScript Example {#testnamespace-example1}
+
+```typescript
+const foo: Foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
+```
+
+### Example: JavaScript Example {#testnamespace-example2}
+
+```javascript
+const foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
+```
+
+## Interfaces
+
+| Interface | Alerts | Description |
+| --- | --- | --- |
+| [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/) | `Alpha` | Test interface |
+
+## Classes
+
+| Class | Description |
+| --- | --- |
+| [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) | Test class |
+
+## Enumerations
+
+| Enum | Description |
+| --- | --- |
+| [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/) | Test Enum |
+
+## Types
+
+| TypeAlias | Description |
+| --- | --- |
+| [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias/) | Test Type-Alias |
+
+## Functions
+
+| Function | Return Type | Description |
+| --- | --- | --- |
+| [testFunction(testParameter)](/test-suite-a/testnamespace-namespace/testfunction-function) | number | Test function |
+
+## Variables
+
+| Variable | Alerts | Modifiers | Type | Description |
+| --- | --- | --- | --- | --- |
+| [TestConst](/test-suite-a/testnamespace-namespace/testconst-variable) | `Beta` | `readonly` |  | Test Constant |
+
+## Namespaces
+
+| Namespace | Description |
+| --- | --- |
+| [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/) | Test sub-namespace |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.md
@@ -1,0 +1,17 @@
+# (constructor)
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) &gt; [(constructor)(testClassProperty)](/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor)
+
+Test class constructor
+
+## Signature {#\_constructor\_-signature}
+
+```typescript
+constructor(testClassProperty: string);
+```
+
+## Parameters {#\_constructor\_-parameters}
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| testClassProperty | string | See [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property) |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.md
@@ -1,0 +1,29 @@
+# TestClass
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/)
+
+Test class
+
+## Signature {#testclass-signature}
+
+```typescript
+class TestClass
+```
+
+## Constructors
+
+| Constructor | Description |
+| --- | --- |
+| [(constructor)(testClassProperty)](/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor) | Test class constructor |
+
+## Properties
+
+| Property | Modifiers | Type | Description |
+| --- | --- | --- | --- |
+| [testClassProperty](/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property) | `readonly` | string | Test interface property |
+
+## Methods
+
+| Method | Return Type | Description |
+| --- | --- | --- |
+| [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method) | Promise&lt;string&gt; | Test class method |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.md
@@ -1,0 +1,31 @@
+# testClassMethod
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) &gt; [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method)
+
+Test class method
+
+## Signature {#testclassmethod-signature}
+
+```typescript
+testClassMethod(testParameter: string): Promise<string>;
+```
+
+## Parameters {#testclassmethod-parameters}
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| testParameter | string | A string |
+
+## Returns {#testclassmethod-returns}
+
+A Promise
+
+**Return type:** Promise&lt;string&gt;
+
+## Throws {#testclassmethod-throws}
+
+An Error when something happens for which an error should be thrown. Except in the cases where another kind of error is thrown. We don't throw this error in those cases.
+
+A different kind of error when a thing happens, but not when the first kind of error is thrown instead.
+
+😁

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property.md
@@ -1,0 +1,13 @@
+# testClassProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) &gt; [testClassProperty](/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property)
+
+Test interface property
+
+## Signature {#testclassproperty-signature}
+
+```typescript
+readonly testClassProperty: string;
+```
+
+**Type:** string

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testconst-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testconst-variable.md
@@ -1,0 +1,13 @@
+# TestConst
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestConst](/test-suite-a/testnamespace-namespace/testconst-variable)
+
+Test Constant
+
+**WARNING: This API is provided as a beta preview and may change without notice. Use at your own risk.**
+
+## Signature {#testconst-signature}
+
+```typescript
+TestConst = "Hello world!"
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/index.md
@@ -1,0 +1,34 @@
+# TestEnum
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/)
+
+Test Enum
+
+## Signature {#testenum-signature}
+
+```typescript
+enum TestEnum
+```
+
+## Flags
+
+| Flag | Description |
+| --- | --- |
+| [TestEnumValue1](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember) | Test enum value 1 |
+| [TestEnumValue2](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember) | Test enum value 2 |
+
+Test enum value 1
+
+### Signature {#testenumvalue1-signature}
+
+```typescript
+TestEnumValue1 = 0
+```
+
+Test enum value 2
+
+### Signature {#testenumvalue2-signature}
+
+```typescript
+TestEnumValue2 = 1
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember.md
@@ -1,0 +1,11 @@
+# TestEnumValue1
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/) &gt; [TestEnumValue1](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember)
+
+Test enum value 1
+
+## Signature {#testenumvalue1-signature}
+
+```typescript
+TestEnumValue1 = 0
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember.md
@@ -1,0 +1,11 @@
+# TestEnumValue2
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/) &gt; [TestEnumValue2](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember)
+
+Test enum value 2
+
+## Signature {#testenumvalue2-signature}
+
+```typescript
+TestEnumValue2 = 1
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.md
@@ -1,0 +1,27 @@
+# testFunction
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [testFunction(testParameter)](/test-suite-a/testnamespace-namespace/testfunction-function)
+
+Test function
+
+## Signature {#testfunction-signature}
+
+```typescript
+function testFunction(testParameter: number): number;
+```
+
+## Parameters {#testfunction-parameters}
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| testParameter | number |  |
+
+## Returns {#testfunction-returns}
+
+A number
+
+**Return type:** number
+
+## Throws {#testfunction-throws}
+
+An Error

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.md
@@ -1,0 +1,27 @@
+# TestInterface
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/)
+
+Test interface
+
+**WARNING: This API is provided as an alpha preview and may change without notice. Use at your own risk.**
+
+## Signature {#testinterface-signature}
+
+```typescript
+interface TestInterface extends TestInterfaceWithTypeParameter<TestEnum>
+```
+
+**Extends:** [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)&lt;[TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/)&gt;
+
+## Properties
+
+| Property | Alerts | Type | Description |
+| --- | --- | --- | --- |
+| [testInterfaceProperty](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature) | `Alpha` | boolean | Test interface property |
+
+## Methods
+
+| Method | Alerts | Return Type | Description |
+| --- | --- | --- | --- |
+| [testInterfaceMethod()](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature) | `Alpha` | void | Test interface method |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature.md
@@ -1,0 +1,13 @@
+# testInterfaceMethod
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/) &gt; [testInterfaceMethod()](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature)
+
+Test interface method
+
+**WARNING: This API is provided as an alpha preview and may change without notice. Use at your own risk.**
+
+## Signature {#testinterfacemethod-signature}
+
+```typescript
+testInterfaceMethod(): void;
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature.md
@@ -1,0 +1,15 @@
+# testInterfaceProperty
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/) &gt; [testInterfaceProperty](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature)
+
+Test interface property
+
+**WARNING: This API is provided as an alpha preview and may change without notice. Use at your own risk.**
+
+## Signature {#testinterfaceproperty-signature}
+
+```typescript
+testInterfaceProperty: boolean;
+```
+
+**Type:** boolean

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.md
@@ -1,0 +1,11 @@
+# TestSubNamespace
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/)
+
+Test sub-namespace
+
+## Signature {#testsubnamespace-signature}
+
+```typescript
+namespace TestSubNamespace
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testtypealias-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testtypealias-typealias/index.md
@@ -1,0 +1,11 @@
+# TestTypeAlias
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias/)
+
+Test Type-Alias
+
+## Signature {#testtypealias-signature}
+
+```typescript
+type TestTypeAlias = boolean;
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/typealias-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/typealias-typealias/index.md
@@ -1,0 +1,15 @@
+# TypeAlias
+
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TypeAlias](/test-suite-a/typealias-typealias/)
+
+Test Type-Alias
+
+## Signature {#typealias-signature}
+
+```typescript
+export type TypeAlias = string;
+```
+
+## Remarks {#typealias-remarks}
+
+Here are some remarks about the type alias

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/bar-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/bar-propertysignature.md
@@ -1,0 +1,17 @@
+# bar
+
+[Packages](/) &gt; [test-suite-b](/test-suite-b/) &gt; [Foo](/test-suite-b/foo-interface/) &gt; [bar](/test-suite-b/foo-interface/bar-propertysignature)
+
+Test Enum
+
+## Signature {#bar-signature}
+
+```typescript
+bar: TestEnum;
+```
+
+**Type:** [TestEnum](/test-suite-a/testenum-enum/)
+
+## Remarks {#bar-remarks}
+
+Here are some remarks about the enum

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/index.md
@@ -1,0 +1,17 @@
+# Foo
+
+[Packages](/) &gt; [test-suite-b](/test-suite-b/) &gt; [Foo](/test-suite-b/foo-interface/)
+
+Bar
+
+## Signature {#foo-signature}
+
+```typescript
+export interface Foo
+```
+
+## Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| [bar](/test-suite-b/foo-interface/bar-propertysignature) | [TestEnum](/test-suite-a/testenum-enum/) | Test Enum |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/index.md
@@ -1,0 +1,9 @@
+# test-suite-b
+
+[Packages](/) &gt; [test-suite-b](/test-suite-b/)
+
+## Interfaces
+
+| Interface | Description |
+| --- | --- |
+| [Foo](/test-suite-b/foo-interface/) | Bar |


### PR DESCRIPTION
Adds a test case that leverages new hierarchy options to create a "deep" suite configuration where documents that generate folder hierarchy yield documents named "index" _inside_ their folder,