### PR TITLE
[LTS] refactor(ci): Remove scheduled run for e2e tests pipeline

### DIFF
--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -7,13 +7,6 @@ name: $(Build.BuildId)
 
 trigger: none
 pr: none
-schedules:
-- cron: "0 14 * * *" # Run every day at 7 am PST
-  displayName: LTS Branch Daily E2E Test Run
-  branches:
-    include:
-    - lts
-  always: true
 
 resources:
   pipelines:


### PR DESCRIPTION
## Description

Removes the scheduled run of the e2e tests pipeline in the LTS branch. Since we added the scheduled run of the build pipeline, we've been getting 2 runs of the e2e tests one every day because it also triggers in response to the completed build pipeline run. That one is enough for our purposes. 

E.g. (notice the alternating "Scheduled" and "Automatically triggered" reasons):

![image](https://github.com/user-attachments/assets/36384a24-e9aa-4161-bb7c-75bd94c5b846)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).