### PR TITLE
merge tree: Validate exact range obliterate with expansion 

### DIFF
--- a/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -15,7 +15,7 @@ import {
 	insertAtRefPos,
 	insertField,
 	obliterateField,
-	// obliterateRange,
+	obliterateRange,
 	removeRange,
 	runMergeTreeOperationRunner,
 } from "./mergeTreeOperationRunner.js";
@@ -72,23 +72,22 @@ const clientNames = generateClientNames();
 function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): void {
 	doOverRange(opts.minLength, opts.growthFunc, (minLength) => {
 		for (const { name, config } of [
-			// {
-			// 	name: "applyOpsDuringGeneration",
-			// 	config: { ...opts, applyOpDuringGeneration: true },
-			// },
-			// {
-			// 	name: "obliterate with number endpoints",
-			// 	config: {
-			// 		...opts,
-			// 		operations: [...opts.operations, obliterateRange],
-			// 	},
-			// },
+			{
+				name: "applyOpsDuringGeneration",
+				config: { ...opts, applyOpDuringGeneration: true },
+			},
+			{
+				name: "obliterate with number endpoints",
+				config: {
+					...opts,
+					operations: [...opts.operations, obliterateRange],
+				},
+			},
 			{
 				name: "obliterate fields",
 				config: {
 					...opts,
-					// eslint-disable-next-line jsdoc/multiline-blocks
-					operations: [/** ...opts.operations, */ insertField, obliterateField],
+					operations: [...opts.operations, insertField, obliterateField],
 					// applyOpDuringGeneration: true,
 				},
 			},
@@ -136,7 +135,7 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 	});
 }
 
-describeFuzz.only("MergeTree.Client", ({ testCount, stressMode }) => {
+describeFuzz("MergeTree.Client", ({ testCount, stressMode }) => {
 	const opts = stressMode === StressMode.Short ? defaultOptions : stressOptions;
 	// defaultOptions;
 	// debugOptions;

--- a/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -15,7 +15,7 @@ import {
 	insertAtRefPos,
 	insertField,
 	obliterateField,
-	obliterateRange,
+	// obliterateRange,
 	removeRange,
 	runMergeTreeOperationRunner,
 } from "./mergeTreeOperationRunner.js";
@@ -72,22 +72,24 @@ const clientNames = generateClientNames();
 function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): void {
 	doOverRange(opts.minLength, opts.growthFunc, (minLength) => {
 		for (const { name, config } of [
-			{
-				name: "applyOpsDuringGeneration",
-				config: { ...opts, applyOpDuringGeneration: true },
-			},
-			{
-				name: "obliterate with number endpoints",
-				config: {
-					...opts,
-					operations: [...opts.operations, obliterateRange],
-				},
-			},
+			// {
+			// 	name: "applyOpsDuringGeneration",
+			// 	config: { ...opts, applyOpDuringGeneration: true },
+			// },
+			// {
+			// 	name: "obliterate with number endpoints",
+			// 	config: {
+			// 		...opts,
+			// 		operations: [...opts.operations, obliterateRange],
+			// 	},
+			// },
 			{
 				name: "obliterate fields",
 				config: {
 					...opts,
-					operations: [insertField, obliterateField],
+					// eslint-disable-next-line jsdoc/multiline-blocks
+					operations: [/** ...opts.operations, */ insertField, obliterateField],
+					// applyOpDuringGeneration: true,
 				},
 			},
 			// TODO: AB#15630
@@ -134,7 +136,7 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 	});
 }
 
-describeFuzz("MergeTree.Client", ({ testCount, stressMode }) => {
+describeFuzz.only("MergeTree.Client", ({ testCount, stressMode }) => {
 	const opts = stressMode === StressMode.Short ? defaultOptions : stressOptions;
 	// defaultOptions;
 	// debugOptions;

--- a/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -6,14 +6,17 @@
 import { describeFuzz, makeRandom, StressMode } from "@fluid-private/stochastic-test-utils";
 
 import {
-	IConfigRange,
-	IMergeTreeOperationRunnerConfig,
-	TestOperation,
+	type IConfigRange,
+	type IMergeTreeOperationRunnerConfig,
+	type TestOperation,
 	annotateRange,
 	doOverRange,
 	generateClientNames,
 	insertAtRefPos,
+	insertField,
+	obliterateField,
 	obliterateRange,
+	// obliterateRangeSided,
 	removeRange,
 	runMergeTreeOperationRunner,
 } from "./mergeTreeOperationRunner.js";
@@ -34,7 +37,7 @@ export const debugOptions: IConflictFarmConfig = {
 	operations: allOperations,
 	incrementalLog: true,
 	growthFunc: (input: number) => input * 2,
-	// resultsFilePostfix: `conflict-farm-with-obliterate-2.3.0.json`,
+	resultsFilePostfix: `conflict-farm-with-field-obliterate.json`,
 };
 
 export const defaultOptions: IConflictFarmConfig = {
@@ -81,6 +84,13 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 					operations: [...opts.operations, obliterateRange],
 				},
 			},
+			{
+				name: "obliterate fields",
+				config: {
+					...opts,
+					operations: [insertField, obliterateField],
+				},
+			},
 			// TODO: AB#15630
 			// {
 			// 	name: "obliterate with sided endpoints",
@@ -125,7 +135,7 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 	});
 }
 
-describeFuzz("MergeTree.Client", ({ testCount, stressMode }) => {
+describeFuzz.only("MergeTree.Client", ({ testCount, stressMode }) => {
 	const opts = stressMode === StressMode.Short ? defaultOptions : stressOptions;
 	// defaultOptions;
 	// debugOptions;

--- a/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -6,9 +6,9 @@
 import { describeFuzz, makeRandom, StressMode } from "@fluid-private/stochastic-test-utils";
 
 import {
-	type IConfigRange,
-	type IMergeTreeOperationRunnerConfig,
-	type TestOperation,
+	IConfigRange,
+	IMergeTreeOperationRunnerConfig,
+	TestOperation,
 	annotateRange,
 	doOverRange,
 	generateClientNames,
@@ -36,7 +36,7 @@ export const debugOptions: IConflictFarmConfig = {
 	operations: allOperations,
 	incrementalLog: true,
 	growthFunc: (input: number) => input * 2,
-	resultsFilePostfix: `conflict-farm-with-field-obliterate.json`,
+	// resultsFilePostfix: `conflict-farm-with-obliterate-2.3.0.json`,
 };
 
 export const defaultOptions: IConflictFarmConfig = {

--- a/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.conflictFarm.spec.ts
@@ -16,7 +16,6 @@ import {
 	insertField,
 	obliterateField,
 	obliterateRange,
-	// obliterateRangeSided,
 	removeRange,
 	runMergeTreeOperationRunner,
 } from "./mergeTreeOperationRunner.js";
@@ -135,7 +134,7 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 	});
 }
 
-describeFuzz.only("MergeTree.Client", ({ testCount, stressMode }) => {
+describeFuzz("MergeTree.Client", ({ testCount, stressMode }) => {
 	const opts = stressMode === StressMode.Short ? defaultOptions : stressOptions;
 	// defaultOptions;
 	// debugOptions;

--- a/packages/dds/merge-tree/src/test/client.obliterateFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.obliterateFarm.spec.ts
@@ -96,7 +96,7 @@ function runObliterateFarmTests(opts: IObliterateFarmConfig, extraSeed?: number)
 	});
 }
 
-describeFuzz("MergeTree.Client Obliterate", ({ testCount }) => {
+describeFuzz.skip("MergeTree.Client Obliterate", ({ testCount }) => {
 	if (testCount > 1) {
 		doOverRange(
 			{ min: 0, max: testCount - 1 },

--- a/packages/dds/merge-tree/src/test/client.obliterateFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.obliterateFarm.spec.ts
@@ -15,6 +15,8 @@ import {
 } from "./mergeTreeOperationRunner.js";
 import {
 	annotateWithField,
+	generateInsertWithField,
+	generateUpdatedEndpoints,
 	insertAvoidField,
 	insertField,
 	obliterateField,
@@ -42,6 +44,8 @@ export const defaultOptions: IObliterateFarmConfig = {
 	rounds: 8,
 	operations: allOperations,
 	growthFunc: (input: number) => input * 2,
+	insertText: generateInsertWithField,
+	updateEndpoints: generateUpdatedEndpoints,
 };
 
 // Generate a list of single character client names, support up to 69 clients

--- a/packages/dds/merge-tree/src/test/client.obliterateFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.obliterateFarm.spec.ts
@@ -22,7 +22,7 @@ import {
 } from "./obliterateOperations.js";
 import { TestClient } from "./testClient.js";
 
-interface IConflictFarmConfig extends IMergeTreeOperationRunnerConfig {
+interface IObliterateFarmConfig extends IMergeTreeOperationRunnerConfig {
 	minLength: IConfigRange;
 	clients: IConfigRange;
 }
@@ -35,7 +35,7 @@ const allOperations: TestOperation[] = [
 	obliterateField,
 ];
 
-export const defaultOptions: IConflictFarmConfig = {
+export const defaultOptions: IObliterateFarmConfig = {
 	minLength: { min: 1, max: 512 },
 	clients: { min: 1, max: 8 },
 	opsPerRoundRange: { min: 1, max: 128 },
@@ -47,7 +47,7 @@ export const defaultOptions: IConflictFarmConfig = {
 // Generate a list of single character client names, support up to 69 clients
 const clientNames = generateClientNames();
 
-function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): void {
+function runObliterateFarmTests(opts: IObliterateFarmConfig, extraSeed?: number): void {
 	doOverRange(opts.minLength, opts.growthFunc, (minLength) => {
 		for (const { name, config } of [
 			{
@@ -59,7 +59,7 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 				},
 			},
 		])
-			it(`${name}: ConflictFarm_${minLength}`, async () => {
+			it(`${name}: ObliterateFarm_${minLength}`, async () => {
 				const random = makeRandom(0xdeadbeef, 0xfeedbed, minLength, extraSeed ?? 0);
 
 				const clients: TestClient[] = [
@@ -94,18 +94,18 @@ function runConflictFarmTests(opts: IConflictFarmConfig, extraSeed?: number): vo
 	});
 }
 
-describeFuzz("MergeTree.Client Obliterate", ({ testCount, stressMode }) => {
+describeFuzz("MergeTree.Client Obliterate", ({ testCount }) => {
 	if (testCount > 1) {
 		doOverRange(
 			{ min: 0, max: testCount - 1 },
 			(x) => x + 1,
 			(seed) => {
 				describe(`with seed ${seed}`, () => {
-					runConflictFarmTests(defaultOptions, seed);
+					runObliterateFarmTests(defaultOptions, seed);
 				});
 			},
 		);
 	} else {
-		runConflictFarmTests(defaultOptions);
+		runObliterateFarmTests(defaultOptions);
 	}
 });

--- a/packages/dds/merge-tree/src/test/client.obliterateFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.obliterateFarm.spec.ts
@@ -16,7 +16,6 @@ import {
 import {
 	annotateWithField,
 	generateInsertWithField,
-	generateUpdatedEndpoints,
 	insertAvoidField,
 	insertField,
 	obliterateField,
@@ -45,7 +44,6 @@ export const defaultOptions: IObliterateFarmConfig = {
 	operations: allOperations,
 	growthFunc: (input: number) => input * 2,
 	insertText: generateInsertWithField,
-	updateEndpoints: generateUpdatedEndpoints,
 };
 
 // Generate a list of single character client names, support up to 69 clients

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -412,7 +412,7 @@ export function generateOperationMessagesForClients(
 		const sg = client.peekPendingSegmentGroups();
 		let op: IMergeTreeOp | undefined;
 		if (len === 0 || len < minLength) {
-			const text = client.longClientId as string;
+			const text = client.longClientId!.repeat(random.integer(1, 3));
 			op = client.insertTextLocal(random.integer(0, len), text);
 		} else {
 			let opIndex = random.integer(0, operations.length - 1);

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -15,10 +15,11 @@ import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
 import { ISegmentPrivate, SegmentGroup } from "../mergeTreeNodes.js";
 import { IMergeTreeOp, MergeTreeDeltaType, ReferenceType } from "../ops.js";
 import { toMoveInfo, toRemovalInfo } from "../segmentInfos.js";
-import { Side, type InteriorSequencePlace } from "../sequencePlace.js";
+import { Side } from "../sequencePlace.js";
 import { TextSegment } from "../textSegment.js";
 
 import { _dirname } from "./dirname.cjs";
+import { getFieldEndpoints, posInField } from "./obliterateOperations.js";
 import { TestClient } from "./testClient.js";
 import { TestClientLogger } from "./testClientLogger.js";
 
@@ -29,118 +30,11 @@ export type TestOperation = (
 	random: IRandom,
 ) => IMergeTreeOp | undefined;
 
-export const insertField: TestOperation = (
-	client: TestClient,
-	opStart: number,
-	opEnd: number,
-	random: IRandom,
-) => {
-	const chunkLength = random.integer(1, 10);
-	const numberText: string = (client.longClientId!.codePointAt(0)! % 10)
-		.toString()
-		.repeat(chunkLength);
-	if (posInField(client, opStart) === undefined) {
-		return client.insertTextLocal(opStart, `{${numberText}}`);
-	}
-};
-
-const posInField = (
-	client: TestClient,
-	pos: number,
-): { startPos: number; endPos: number } | undefined => {
-	if (
-		pos >= client.getLength() ||
-		(!Number.isInteger(Number(client.getText(pos, pos + 1))) &&
-			client.getText(pos, pos + 1) !== "{" &&
-			client.getText(pos, pos + 1) !== "}")
-	) {
-		return undefined;
-	}
-
-	let startPos = pos;
-	let endPos = pos;
-	// To find the start and end separators, walk backwards and forwards until the desired character is found.
-	while (
-		startPos > 0 &&
-		client.getText(startPos, startPos + 1) !== "{" &&
-		(client.getText(startPos, startPos + 1) === "}" ||
-			Number.isInteger(Number(client.getText(startPos, startPos + 1))))
-	) {
-		startPos--;
-	}
-
-	while (
-		endPos < client.getLength() &&
-		client.getText(endPos, endPos + 1) !== "}" &&
-		(client.getText(endPos, endPos + 1) === "{" ||
-			Number.isInteger(Number(client.getText(endPos, endPos + 1))))
-	) {
-		endPos++;
-	}
-
-	return { startPos, endPos };
-};
-
-const getFieldEndpoints = (
-	client: TestClient,
-	start: number,
-	end: number,
-): { startPos: number; endPos: number } | undefined => {
-	const startField = posInField(client, start);
-	const endField = posInField(client, end);
-
-	if (startField === undefined && endField === undefined) {
-		return undefined;
-	}
-	return startField ?? endField;
-};
-
-export const obliterateField: TestOperation = (
-	client: TestClient,
-	opStart: number,
-	opEnd: number,
-	random: IRandom,
-) => {
-	const fieldEndpoints = getFieldEndpoints(client, opStart, opEnd);
-
-	let endISP: InteriorSequencePlace | undefined;
-	if (fieldEndpoints !== undefined) {
-		const { startPos, endPos } = fieldEndpoints;
-		if (endPos >= client.getLength()) {
-			endISP = { pos: client.getLength() - 1, side: Side.After };
-		}
-		// Obliterate text bewteen the separators, but avoid the case where the obliterate range is zero length.
-		if (endPos - startPos > 1) {
-			const op = client.obliterateRangeLocal(
-				{ pos: startPos + 1, side: Side.Before },
-				endISP ?? { pos: endPos - 1, side: Side.After },
-			);
-			insertField(client, startPos + 1, endPos, random);
-			return op;
-		}
-	}
-	if (opEnd >= client.getLength()) {
-		endISP = { pos: client.getLength() - 1, side: Side.After };
-	}
-	return client.obliterateRangeLocal(
-		{ pos: opStart, side: Side.Before },
-		endISP ?? { pos: opEnd, side: Side.After },
-	);
-};
-
 export const removeRange: TestOperation = (
 	client: TestClient,
 	opStart: number,
 	opEnd: number,
-) => {
-	const fieldEndpoints = getFieldEndpoints(client, opStart, opEnd);
-	if (fieldEndpoints === undefined) {
-		return client.removeRangeLocal(opStart, opEnd);
-	} else {
-		const { startPos, endPos } = fieldEndpoints;
-		return client.removeRangeLocal(startPos, endPos + 1);
-	}
-};
+) => client.removeRangeLocal(opStart, opEnd);
 
 export const obliterateRange: TestOperation = (
 	client: TestClient,
@@ -180,22 +74,14 @@ export const annotateRange: TestOperation = (
 	opEnd: number,
 	random: IRandom,
 ) => {
-	let start: number | undefined;
-	let end: number | undefined;
-	const fieldEndpoints = getFieldEndpoints(client, opStart, opEnd);
-	if (fieldEndpoints !== undefined) {
-		start = fieldEndpoints.startPos;
-		end = fieldEndpoints.endPos + 1;
-	}
-
 	if (random.bool()) {
-		return client.annotateRangeLocal(start ?? opStart, end ?? opEnd, {
+		return client.annotateRangeLocal(opStart, opEnd, {
 			[random.integer(1, 5)]: client.longClientId,
 		});
 	} else {
 		const max = random.pick([undefined, random.integer(-10, 100)]);
 		const min = random.pick([undefined, random.integer(-100, 10)]);
-		return client.annotateAdjustRangeLocal(start ?? opStart, end ?? opEnd, {
+		return client.annotateAdjustRangeLocal(opStart, opEnd, {
 			[random.integer(0, 2).toString()]: {
 				delta: random.integer(-5, 5),
 				min: (min ?? max ?? 0) > (max ?? 0) ? undefined : min,
@@ -228,20 +114,9 @@ export const insertAtRefPos: TestOperation = (
 		const text = client.longClientId!.repeat(random.integer(1, 3));
 		const seg = random.pick(segs);
 		const movedOrRemoved = toRemovalInfo(seg) ?? toMoveInfo(seg);
-		const randomOffset = random.integer(0, seg.cachedLength - 1);
-		const initialPos = client.getPosition(seg) + randomOffset;
-		const endpoints = posInField(client, initialPos);
-
-		let offset = randomOffset;
-		if (endpoints !== undefined) {
-			const startSeg = client.getContainingSegment(endpoints.startPos);
-			assert(startSeg.offset !== undefined, "offset should be defined");
-			offset = startSeg.offset;
-		}
-
 		const lref = client.createLocalReferencePosition(
 			seg,
-			movedOrRemoved ? 0 : offset,
+			movedOrRemoved ? 0 : random.integer(0, seg.cachedLength - 1),
 			movedOrRemoved
 				? ReferenceType.SlideOnRemove
 				: random.pick([

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -8,18 +8,18 @@
 import { strict as assert } from "node:assert";
 import * as fs from "node:fs";
 
-import type { IRandom } from "@fluid-private/stochastic-test-utils";
-import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import { IRandom } from "@fluid-private/stochastic-test-utils";
+import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 
 import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
-import type { ISegmentPrivate, SegmentGroup } from "../mergeTreeNodes.js";
-import { type IMergeTreeOp, MergeTreeDeltaType, ReferenceType } from "../ops.js";
+import { ISegmentPrivate, SegmentGroup } from "../mergeTreeNodes.js";
+import { IMergeTreeOp, MergeTreeDeltaType, ReferenceType } from "../ops.js";
 import { toMoveInfo, toRemovalInfo } from "../segmentInfos.js";
 import { Side, type InteriorSequencePlace } from "../sequencePlace.js";
 import { TextSegment } from "../textSegment.js";
 
 import { _dirname } from "./dirname.cjs";
-import type { TestClient } from "./testClient.js";
+import { TestClient } from "./testClient.js";
 import { TestClientLogger } from "./testClientLogger.js";
 
 export type TestOperation = (

--- a/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
+++ b/packages/dds/merge-tree/src/test/mergeTreeOperationRunner.ts
@@ -29,26 +29,13 @@ export type TestOperation = (
 	random: IRandom,
 ) => IMergeTreeOp | undefined;
 
-/**
- * TBD: will be needed to avoid number chunks when chunk size \> 1
- */
-// const insertAvoidNumber = (client: TestClient): number => {
-// 	let pos = 0;
-// 	for (let i = 0; i < client.getLength(); i++) {
-// 		if (Number.isNaN(Number(client.getText(i, i + 1)))) {
-// 			pos = i;
-// 		}
-// 	}
-// 	return pos;
-// };
-
 export const insertField: TestOperation = (
 	client: TestClient,
 	opStart: number,
 	opEnd: number,
 	random: IRandom,
 ) => {
-	const numberText = random.string(2, "0123456789");
+	const numberText = random.string(5, "0123456789");
 	if (
 		// start is not a number
 		Number.isNaN(Number(client.getText(opStart, opStart + 1))) &&
@@ -64,22 +51,12 @@ export const insertField: TestOperation = (
 const numberRange = (
 	client: TestClient,
 	start: number,
-	end: number,
 ): { startPos: number | undefined; endPos: number | undefined } => {
-	/**
-	 * TUESDAY: ADAPT THIS FOR 3 CHAR CHUNKS (and code for 2+ char chunks)
-	 * pos 		char before 		char after		outcome
-	 * 0		letter				number			pos, pos + 1
-	 * 1		number				letter			pos - 1, pos
-	 */
-	let startPos = 0;
-	for (let i = 0; i < client.getLength(); i++) {
-		if (!Number.isNaN(Number(client.getText(i, i + 1)))) {
-			startPos = i;
-			break;
-		}
+	let startPos = start;
+	while (startPos > 0 && !Number.isNaN(Number(client.getText(startPos, startPos + 1)))) {
+		startPos--;
 	}
-	return { startPos, endPos: startPos + 1 };
+	return { startPos, endPos: startPos + 4 };
 };
 
 export const obliterateField: TestOperation = (
@@ -88,7 +65,7 @@ export const obliterateField: TestOperation = (
 	opEnd: number,
 	random: IRandom,
 ) => {
-	const { startPos, endPos } = numberRange(client, opStart, opEnd);
+	const { startPos, endPos } = numberRange(client, opStart);
 
 	let endISP: InteriorSequencePlace | undefined;
 	if (startPos !== undefined && endPos !== undefined) {

--- a/packages/dds/merge-tree/src/test/obliterateOperations.ts
+++ b/packages/dds/merge-tree/src/test/obliterateOperations.ts
@@ -5,18 +5,11 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import assert from "node:assert";
-
 import type { IRandom } from "@fluid-private/stochastic-test-utils";
 
-import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
-import type { ISegmentPrivate } from "../mergeTreeNodes.js";
-import { ReferenceType } from "../ops.js";
-import { toRemovalInfo, toMoveInfo } from "../segmentInfos.js";
 import { InteriorSequencePlace, Side } from "../sequencePlace.js";
-import { TextSegment } from "../textSegment.js";
 
-import type { TestOperation } from "./mergeTreeOperationRunner.js";
+import { annotateRange, type TestOperation } from "./mergeTreeOperationRunner.js";
 import type { TestClient } from "./testClient.js";
 
 export const posInField = (
@@ -124,49 +117,12 @@ export const insertAvoidField: TestOperation = (
 	opEnd: number,
 	random: IRandom,
 ) => {
-	const segs: ISegmentPrivate[] = [];
-	// gather all the segments at the pos, including removed segments
-	walkAllChildSegments(client.mergeTree.root, (seg) => {
-		const pos = client.getPosition(seg);
-		if (pos >= opStart) {
-			if (pos <= opStart) {
-				segs.push(seg);
-				return true;
-			}
-			return false;
-		}
-		return true;
-	});
-	if (segs.length > 0) {
-		const text = client.longClientId!.repeat(random.integer(1, 3));
-		const seg = random.pick(segs);
-		const movedOrRemoved = toRemovalInfo(seg) ?? toMoveInfo(seg);
-		const randomOffset = random.integer(0, seg.cachedLength - 1);
-		const initialPos = client.getPosition(seg) + randomOffset;
-		const endpoints = posInField(client, initialPos);
-
-		let offset = randomOffset;
-		if (endpoints !== undefined) {
-			const startSeg = client.getContainingSegment(endpoints.startPos);
-			assert(startSeg.offset !== undefined, "offset should be defined");
-			offset = startSeg.offset;
-		}
-
-		const lref = client.createLocalReferencePosition(
-			seg,
-			movedOrRemoved ? 0 : offset,
-			movedOrRemoved
-				? ReferenceType.SlideOnRemove
-				: random.pick([
-						ReferenceType.Simple,
-						ReferenceType.SlideOnRemove,
-						ReferenceType.Transient,
-					]),
-			undefined,
-		);
-
-		return client.insertAtReferencePositionLocal(lref, TextSegment.make(text));
+	let start = opStart;
+	const endpoints = posInField(client, opStart);
+	if (endpoints !== undefined) {
+		start = endpoints.startPos;
 	}
+	return client.insertTextLocal(start, client.longClientId!.repeat(random.integer(1, 3)));
 };
 
 export const removeWithField: TestOperation = (
@@ -174,13 +130,14 @@ export const removeWithField: TestOperation = (
 	opStart: number,
 	opEnd: number,
 ) => {
+	let start = opStart;
+	let end = opEnd;
 	const fieldEndpoints = getFieldEndpoints(client, opStart, opEnd);
-	if (fieldEndpoints === undefined) {
-		return client.removeRangeLocal(opStart, opEnd);
-	} else {
-		const { startPos, endPos } = fieldEndpoints;
-		return client.removeRangeLocal(startPos, endPos + 1);
+	if (fieldEndpoints !== undefined) {
+		start = fieldEndpoints.startPos;
+		end = fieldEndpoints.endPos + 1;
 	}
+	return client.removeRangeLocal(start, end);
 };
 
 export const annotateWithField: TestOperation = (
@@ -189,27 +146,12 @@ export const annotateWithField: TestOperation = (
 	opEnd: number,
 	random: IRandom,
 ) => {
-	let start: number | undefined;
-	let end: number | undefined;
+	let start = opStart;
+	let end = opEnd;
 	const fieldEndpoints = getFieldEndpoints(client, opStart, opEnd);
 	if (fieldEndpoints !== undefined) {
 		start = fieldEndpoints.startPos;
 		end = fieldEndpoints.endPos + 1;
 	}
-
-	if (random.bool()) {
-		return client.annotateRangeLocal(start ?? opStart, end ?? opEnd, {
-			[random.integer(1, 5)]: client.longClientId,
-		});
-	} else {
-		const max = random.pick([undefined, random.integer(-10, 100)]);
-		const min = random.pick([undefined, random.integer(-100, 10)]);
-		return client.annotateAdjustRangeLocal(start ?? opStart, end ?? opEnd, {
-			[random.integer(0, 2).toString()]: {
-				delta: random.integer(-5, 5),
-				min: (min ?? max ?? 0) > (max ?? 0) ? undefined : min,
-				max,
-			},
-		});
-	}
+	return annotateRange(client, start, end, random);
 };

--- a/packages/dds/merge-tree/src/test/obliterateOperations.ts
+++ b/packages/dds/merge-tree/src/test/obliterateOperations.ts
@@ -75,7 +75,6 @@ const generateFieldText = (client: TestClient, random: IRandom): string => {
 const insertFieldText = (
 	client: TestClient,
 	opStart: number,
-	opEnd: number,
 	random: IRandom,
 ): IMergeTreeInsertMsg | undefined => {
 	const text = generateFieldText(client, random);
@@ -111,7 +110,7 @@ export const obliterateField: TestOperation = (
 				{ pos: startPos, side: Side.After },
 				{ pos: endPos, side: Side.Before },
 			);
-			const insertOp = insertFieldText(client, startPos + 1, endPos, random);
+			const insertOp = insertFieldText(client, startPos + 1, random);
 			assert(insertOp !== undefined, "Insert op should not be undefined");
 			const op = createGroupOp(obliterateOp, insertOp);
 			return op;

--- a/packages/dds/merge-tree/src/test/obliterateOperations.ts
+++ b/packages/dds/merge-tree/src/test/obliterateOperations.ts
@@ -1,0 +1,215 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import assert from "node:assert";
+
+import type { IRandom } from "@fluid-private/stochastic-test-utils";
+
+import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
+import type { ISegmentPrivate } from "../mergeTreeNodes.js";
+import { ReferenceType } from "../ops.js";
+import { toRemovalInfo, toMoveInfo } from "../segmentInfos.js";
+import { InteriorSequencePlace, Side } from "../sequencePlace.js";
+import { TextSegment } from "../textSegment.js";
+
+import type { TestOperation } from "./mergeTreeOperationRunner.js";
+import type { TestClient } from "./testClient.js";
+
+export const posInField = (
+	client: TestClient,
+	pos: number,
+): { startPos: number; endPos: number } | undefined => {
+	if (
+		pos >= client.getLength() ||
+		(!Number.isInteger(Number(client.getText(pos, pos + 1))) &&
+			client.getText(pos, pos + 1) !== "{" &&
+			client.getText(pos, pos + 1) !== "}")
+	) {
+		return undefined;
+	}
+
+	let startPos = pos;
+	let endPos = pos;
+	// To find the start and end separators, walk backwards and forwards until the desired character is found.
+	while (
+		startPos > 0 &&
+		client.getText(startPos, startPos + 1) !== "{" &&
+		(client.getText(startPos, startPos + 1) === "}" ||
+			Number.isInteger(Number(client.getText(startPos, startPos + 1))))
+	) {
+		startPos--;
+	}
+
+	while (
+		endPos < client.getLength() &&
+		client.getText(endPos, endPos + 1) !== "}" &&
+		(client.getText(endPos, endPos + 1) === "{" ||
+			Number.isInteger(Number(client.getText(endPos, endPos + 1))))
+	) {
+		endPos++;
+	}
+
+	return { startPos, endPos };
+};
+
+export const getFieldEndpoints = (
+	client: TestClient,
+	start: number,
+	end: number,
+): { startPos: number; endPos: number } | undefined => {
+	const startField = posInField(client, start);
+	const endField = posInField(client, end);
+
+	if (startField === undefined && endField === undefined) {
+		return undefined;
+	}
+	return startField ?? endField;
+};
+
+export const insertField: TestOperation = (
+	client: TestClient,
+	opStart: number,
+	opEnd: number,
+	random: IRandom,
+) => {
+	const chunkLength = random.integer(1, 10);
+	const numberText: string = (client.longClientId!.codePointAt(0)! % 10)
+		.toString()
+		.repeat(chunkLength);
+	if (posInField(client, opStart) === undefined) {
+		return client.insertTextLocal(opStart, `{${numberText}}`);
+	}
+};
+
+export const obliterateField: TestOperation = (
+	client: TestClient,
+	opStart: number,
+	opEnd: number,
+	random: IRandom,
+) => {
+	const fieldEndpoints = getFieldEndpoints(client, opStart, opEnd);
+
+	let endISP: InteriorSequencePlace | undefined;
+	if (fieldEndpoints !== undefined) {
+		const { startPos, endPos } = fieldEndpoints;
+		if (endPos >= client.getLength()) {
+			endISP = { pos: client.getLength() - 1, side: Side.After };
+		}
+		// Obliterate text bewteen the separators, but avoid the case where the obliterate range is zero length.
+		if (endPos - startPos > 1) {
+			const op = client.obliterateRangeLocal(
+				{ pos: startPos + 1, side: Side.Before },
+				endISP ?? { pos: endPos - 1, side: Side.After },
+			);
+			insertField(client, startPos + 1, endPos, random);
+			return op;
+		}
+	}
+	if (opEnd >= client.getLength()) {
+		endISP = { pos: client.getLength() - 1, side: Side.After };
+	}
+	return client.obliterateRangeLocal(
+		{ pos: opStart, side: Side.Before },
+		endISP ?? { pos: opEnd, side: Side.After },
+	);
+};
+
+export const insertAvoidField: TestOperation = (
+	client: TestClient,
+	opStart: number,
+	opEnd: number,
+	random: IRandom,
+) => {
+	const segs: ISegmentPrivate[] = [];
+	// gather all the segments at the pos, including removed segments
+	walkAllChildSegments(client.mergeTree.root, (seg) => {
+		const pos = client.getPosition(seg);
+		if (pos >= opStart) {
+			if (pos <= opStart) {
+				segs.push(seg);
+				return true;
+			}
+			return false;
+		}
+		return true;
+	});
+	if (segs.length > 0) {
+		const text = client.longClientId!.repeat(random.integer(1, 3));
+		const seg = random.pick(segs);
+		const movedOrRemoved = toRemovalInfo(seg) ?? toMoveInfo(seg);
+		const randomOffset = random.integer(0, seg.cachedLength - 1);
+		const initialPos = client.getPosition(seg) + randomOffset;
+		const endpoints = posInField(client, initialPos);
+
+		let offset = randomOffset;
+		if (endpoints !== undefined) {
+			const startSeg = client.getContainingSegment(endpoints.startPos);
+			assert(startSeg.offset !== undefined, "offset should be defined");
+			offset = startSeg.offset;
+		}
+
+		const lref = client.createLocalReferencePosition(
+			seg,
+			movedOrRemoved ? 0 : offset,
+			movedOrRemoved
+				? ReferenceType.SlideOnRemove
+				: random.pick([
+						ReferenceType.Simple,
+						ReferenceType.SlideOnRemove,
+						ReferenceType.Transient,
+					]),
+			undefined,
+		);
+
+		return client.insertAtReferencePositionLocal(lref, TextSegment.make(text));
+	}
+};
+
+export const removeWithField: TestOperation = (
+	client: TestClient,
+	opStart: number,
+	opEnd: number,
+) => {
+	const fieldEndpoints = getFieldEndpoints(client, opStart, opEnd);
+	if (fieldEndpoints === undefined) {
+		return client.removeRangeLocal(opStart, opEnd);
+	} else {
+		const { startPos, endPos } = fieldEndpoints;
+		return client.removeRangeLocal(startPos, endPos + 1);
+	}
+};
+
+export const annotateWithField: TestOperation = (
+	client: TestClient,
+	opStart: number,
+	opEnd: number,
+	random: IRandom,
+) => {
+	let start: number | undefined;
+	let end: number | undefined;
+	const fieldEndpoints = getFieldEndpoints(client, opStart, opEnd);
+	if (fieldEndpoints !== undefined) {
+		start = fieldEndpoints.startPos;
+		end = fieldEndpoints.endPos + 1;
+	}
+
+	if (random.bool()) {
+		return client.annotateRangeLocal(start ?? opStart, end ?? opEnd, {
+			[random.integer(1, 5)]: client.longClientId,
+		});
+	} else {
+		const max = random.pick([undefined, random.integer(-10, 100)]);
+		const min = random.pick([undefined, random.integer(-100, 10)]);
+		return client.annotateAdjustRangeLocal(start ?? opStart, end ?? opEnd, {
+			[random.integer(0, 2).toString()]: {
+				delta: random.integer(-5, 5),
+				min: (min ?? max ?? 0) > (max ?? 0) ? undefined : min,
+				max,
+			},
+		});
+	}
+};


### PR DESCRIPTION
While some of the bugs with overlapping ranges are still being resolved, add coverage for conflicting obliterates with the exact range being replaced. 

[AB#26798](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26798)