### PR TITLE
fix(tree): change stack cursor assert message to be more helpful when a node can't be found

### DIFF
--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -20,6 +20,7 @@ import {
 	rootField,
 } from "../core/index.js";
 import { fail } from "../util/index.js";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 /**
  * {@link ITreeCursorSynchronous} that can return the underlying node objects.
@@ -177,7 +178,11 @@ class StackCursor<TNode> extends SynchronousCursor implements CursorWithNode<TNo
 	public enterNode(index: number): void {
 		// assert(this.mode === CursorLocationType.Fields, "must be in fields mode");
 		const siblings = this.getField();
-		assert(index in siblings, "a child does not exist at the specified index, check the status of a node using `Tree.status()`");
+		if (!(index in siblings)) {
+			throw new UsageError(
+				"A child does not exist at the specified index, check the status of a node using `Tree.status()`.",
+			);
+		}
 		this.siblingStack.push(this.siblings);
 		this.indexStack.push(this.index);
 		this.index = index;

--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -177,7 +177,7 @@ class StackCursor<TNode> extends SynchronousCursor implements CursorWithNode<TNo
 	public enterNode(index: number): void {
 		// assert(this.mode === CursorLocationType.Fields, "must be in fields mode");
 		const siblings = this.getField();
-		assert(index in siblings, 0x405 /* child must exist at index */);
+		assert(index in siblings, "a child does not exist at the specified index, check the status of a node using `Tree.status()`");
 		this.siblingStack.push(this.siblings);
 		this.indexStack.push(this.index);
 		this.index = index;


### PR DESCRIPTION
Changes the assert message when a node can't be found at a particular index to include instructions to check the status of a node.