### PR TITLE
improvement(api-markdown-documenter): Strip trailing slashes when generating paths for "index" documents

### DIFF
--- a/tools/api-markdown-documenter/src/api-item-transforms/ApiItemTransformUtilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/ApiItemTransformUtilities.ts
@@ -87,8 +87,10 @@ function getLinkUrlForApiItem(
 	// Omit "index" file name from path generated in links.
 	// This can be considered an optimization in most cases, but some documentation systems also special-case
 	// "index" files, so this can also prevent issues in some cases.
-	if (documentPath === "index" || documentPath.endsWith("/index")) {
-		documentPath = documentPath.slice(0, documentPath.length - "index".length);
+	if (documentPath === "index") {
+		documentPath = "";
+	} else if (documentPath.endsWith("/index")) {
+		documentPath = documentPath.slice(0, documentPath.length - "/index".length);
 	}
 
 	// Don't bother with heading ID if we are linking to the root item of a document

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/index.html
@@ -17,11 +17,11 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="/test-suite-a/">test-suite-a</a></td>
+              <td><a href="/test-suite-a">test-suite-a</a></td>
               <td>Test package</td>
             </tr>
             <tr>
-              <td><a href="/test-suite-b/">test-suite-b</a></td>
+              <td><a href="/test-suite-b">test-suite-b</a></td>
               <td></td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>test-suite-a</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a></p>
       </section>
       <section>
         <p>Test package</p>
@@ -23,7 +23,7 @@
           <p>2. List item 2</p>
           <p>3. List item 3</p>
           <p>Also, here is a link test, including a bad link, because we should have some reasonable support if this happens:</p>
-          <p>- Good link (no alias): <a href="/test-suite-a/testclass-class/">TestClass</a></p>
+          <p>- Good link (no alias): <a href="/test-suite-a/testclass-class">TestClass</a></p>
           <p>- Good link (with alias): <a href="/test-suite-a/testfunction-function">function alias text</a></p>
           <p>- Bad link (no alias): <span><i>InvalidItem</i></span></p>
           <p>- Bad link (with alias): <span><i>even though I link to an invalid item, I would still like this text to be rendered</i></span></p>
@@ -46,23 +46,23 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="/test-suite-a/testemptyinterface-interface/">TestEmptyInterface</a></td>
+              <td><a href="/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a></td>
               <td>An empty interface</td>
             </tr>
             <tr>
-              <td><a href="/test-suite-a/testinterface-interface/">TestInterface</a></td>
+              <td><a href="/test-suite-a/testinterface-interface">TestInterface</a></td>
               <td>Test interface</td>
             </tr>
             <tr>
-              <td><a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface/">TestInterfaceExtendingOtherInterfaces</a></td>
+              <td><a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface">TestInterfaceExtendingOtherInterfaces</a></td>
               <td>Test interface that extends other interfaces</td>
             </tr>
             <tr>
-              <td><a href="/test-suite-a/testinterfacewithindexsignature-interface/">TestInterfaceWithIndexSignature</a></td>
+              <td><a href="/test-suite-a/testinterfacewithindexsignature-interface">TestInterfaceWithIndexSignature</a></td>
               <td>An interface with an index signature.</td>
             </tr>
             <tr>
-              <td><a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a></td>
+              <td><a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a></td>
               <td>Test interface with generic type parameter</td>
             </tr>
           </tbody>
@@ -79,11 +79,11 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a></td>
+              <td><a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a></td>
               <td>A test abstract class.</td>
             </tr>
             <tr>
-              <td><a href="/test-suite-a/testclass-class/">TestClass</a></td>
+              <td><a href="/test-suite-a/testclass-class">TestClass</a></td>
               <td>Test class</td>
             </tr>
           </tbody>
@@ -100,7 +100,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="/test-suite-a/testenum-enum/">TestEnum</a></td>
+              <td><a href="/test-suite-a/testenum-enum">TestEnum</a></td>
               <td>Test Enum</td>
             </tr>
           </tbody>
@@ -117,11 +117,11 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></td>
-              <td>Test Mapped Type, using <a href="/test-suite-a/testenum-enum/">TestEnum</a></td>
+              <td><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></td>
+              <td>Test Mapped Type, using <a href="/test-suite-a/testenum-enum">TestEnum</a></td>
             </tr>
             <tr>
-              <td><a href="/test-suite-a/typealias-typealias/">TypeAlias</a></td>
+              <td><a href="/test-suite-a/typealias-typealias">TypeAlias</a></td>
               <td>Test Type-Alias</td>
             </tr>
           </tbody>
@@ -148,19 +148,19 @@
             <tr>
               <td><a href="/test-suite-a/testfunctionreturninginlinetype-function">testFunctionReturningInlineType()</a></td>
               <td></td>
-              <td><span>{ foo: number; bar: <a href="/test-suite-a/testenum-enum/">TestEnum</a>; }</span></td>
+              <td><span>{ foo: number; bar: <a href="/test-suite-a/testenum-enum">TestEnum</a>; }</span></td>
               <td>Test function that returns an inline type</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testfunctionreturningintersectiontype-function">testFunctionReturningIntersectionType()</a></td>
               <td><code>Deprecated</code></td>
-              <td><span><a href="/test-suite-a/testemptyinterface-interface/">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;number></span></td>
+              <td><span><a href="/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></td>
               <td>Test function that returns an inline type</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testfunctionreturninguniontype-function">testFunctionReturningUnionType()</a></td>
               <td></td>
-              <td><span>string | <a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></td>
+              <td><span>string | <a href="/test-suite-a/testinterface-interface">TestInterface</a></span></td>
               <td>Test function that returns an inline type</td>
             </tr>
           </tbody>
@@ -207,11 +207,11 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="/test-suite-a/testmodule-namespace/">TestModule</a></td>
+              <td><a href="/test-suite-a/testmodule-namespace">TestModule</a></td>
               <td></td>
             </tr>
             <tr>
-              <td><a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace">TestNamespace</a></td>
               <td>Test Namespace</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.html
@@ -7,7 +7,7 @@
     <section>
       <h1>(constructor)</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/_constructor_-constructor">(constructor)(privateProperty, protectedProperty)</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/_constructor_-constructor">(constructor)(privateProperty, protectedProperty)</a></p>
       </section>
       <section>
         <p>This is a <span><i>{@customTag constructor}</i></span>.</p>
@@ -33,7 +33,7 @@
             </tr>
             <tr>
               <td>protectedProperty</td>
-              <td><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></td>
+              <td><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></td>
               <td></td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.html
@@ -7,14 +7,14 @@
     <section>
       <h1>abstractPropertyGetter</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></p>
       </section>
       <section>
         <p>A test abstract getter property.</p>
       </section>
       <section>
         <h2 id="abstractpropertygetter-signature">Signature</h2><code>abstract get abstractPropertyGetter(): TestMappedType;</code>
-        <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span></span></p>
+        <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></span></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestAbstractClass</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a></p>
       </section>
       <section>
         <p>A test abstract class.</p>
@@ -47,13 +47,13 @@
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span></td>
+              <td><span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></td>
               <td>A test abstract getter property.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></td>
+              <td><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></td>
               <td>A test protected property.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/protectedproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/protectedproperty-property.html
@@ -7,14 +7,14 @@
     <section>
       <h1>protectedProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a></p>
       </section>
       <section>
         <p>A test protected property.</p>
       </section>
       <section>
         <h2 id="protectedproperty-signature">Signature</h2><code>protected readonly protectedProperty: TestEnum;</code>
-        <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></span></p>
+        <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></span></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/publicabstractmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/publicabstractmethod-method.html
@@ -7,7 +7,7 @@
     <section>
       <h1>publicAbstractMethod</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/publicabstractmethod-method">publicAbstractMethod()</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/publicabstractmethod-method">publicAbstractMethod()</a></p>
       </section>
       <section>
         <p>A test public abstract method.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/sealedmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/sealedmethod-method.html
@@ -7,7 +7,7 @@
     <section>
       <h1>sealedMethod</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/sealedmethod-method">sealedMethod()</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/sealedmethod-method">sealedMethod()</a></p>
       </section>
       <section>
         <p>A test <code>@sealed</code> method.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/virtualmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/virtualmethod-method.html
@@ -7,7 +7,7 @@
     <section>
       <h1>virtualMethod</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/virtualmethod-method">virtualMethod()</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/virtualmethod-method">virtualMethod()</a></p>
       </section>
       <section>
         <p>A test <code>@virtual</code> method.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.html
@@ -7,7 +7,7 @@
     <section>
       <h1>(constructor)</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/_constructor_-constructor">(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testclass-class">TestClass</a> > <a href="/test-suite-a/testclass-class/_constructor_-constructor">(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)</a></p>
       </section>
       <section>
         <p>Test class constructor</p>
@@ -33,11 +33,11 @@
             <tr>
               <td>privateProperty</td>
               <td><span>number</span></td>
-              <td>See <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a>'s constructor.</td>
+              <td>See <a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a>'s constructor.</td>
             </tr>
             <tr>
               <td>protectedProperty</td>
-              <td><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></td>
+              <td><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></td>
               <td>
                 <p>Some notes about the parameter.</p>
                 <p>See <a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a>.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.html
@@ -7,14 +7,14 @@
     <section>
       <h1>abstractPropertyGetter</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testclass-class">TestClass</a> > <a href="/test-suite-a/testclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></p>
       </section>
       <section>
         <p>A test abstract getter property.</p>
       </section>
       <section>
         <h2 id="abstractpropertygetter-signature">Signature</h2><code>get abstractPropertyGetter(): TestMappedType;</code>
-        <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span></span></p>
+        <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></span></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestClass</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testclass-class">TestClass</a></p>
       </section>
       <section>
         <p>Test class</p>
@@ -15,7 +15,7 @@
       <section>
         <h2 id="testclass-signature">Signature</h2><code>export declare class TestClass&#x3C;TTypeParameterA, TTypeParameterB> extends TestAbstractClass</code>
         <p>
-          <p><span><span><b>Extends: </b></span><span><a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a></span></span></p>
+          <p><span><span><b>Extends: </b></span><span><a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a></span></span></p>
           <p>
             <section>
               <h3>Type Parameters</h3>
@@ -136,7 +136,7 @@
             <tr>
               <td><a href="/test-suite-a/testclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span></td>
+              <td><span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></td>
               <td>A test abstract getter property.</td>
             </tr>
             <tr>
@@ -189,7 +189,7 @@
       </section>
       <section>
         <h2 id="testclass-see-also">See Also</h2>
-        <p><a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a></p>
+        <p><a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/publicabstractmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/publicabstractmethod-method.html
@@ -7,7 +7,7 @@
     <section>
       <h1>publicAbstractMethod</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/publicabstractmethod-method">publicAbstractMethod()</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testclass-class">TestClass</a> > <a href="/test-suite-a/testclass-class/publicabstractmethod-method">publicAbstractMethod()</a></p>
       </section>
       <section>
         <p>A test public abstract method.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclasseventproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclasseventproperty-property.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testClassEventProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/testclasseventproperty-property">testClassEventProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testclass-class">TestClass</a> > <a href="/test-suite-a/testclass-class/testclasseventproperty-property">testClassEventProperty</a></p>
       </section>
       <section>
         <p>Test class event property</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testClassGetterProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassgetterproperty-property">testClassGetterProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testclass-class">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassgetterproperty-property">testClassGetterProperty</a></p>
       </section>
       <section>
         <p>Test class property with both a getter and a setter.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testClassMethod</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassmethod-method">testClassMethod(input)</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testclass-class">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassmethod-method">testClassMethod(input)</a></p>
       </section>
       <section>
         <p>Test class method</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassproperty-property.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testClassProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassproperty-property">testClassProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testclass-class">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassproperty-property">testClassProperty</a></p>
       </section>
       <section>
         <p>Test class property</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testClassStaticMethod</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassstaticmethod-method">testClassStaticMethod(foo)</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testclass-class">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassstaticmethod-method">testClassStaticMethod(foo)</a></p>
       </section>
       <section>
         <p>Test class static method</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticproperty-property.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testClassStaticProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassstaticproperty-property">testClassStaticProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testclass-class">TestClass</a> > <a href="/test-suite-a/testclass-class/testclassstaticproperty-property">testClassStaticProperty</a></p>
       </section>
       <section>
         <p>Test static class property</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/virtualmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/virtualmethod-method.html
@@ -7,7 +7,7 @@
     <section>
       <h1>virtualMethod</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class/">TestClass</a> > <a href="/test-suite-a/testclass-class/virtualmethod-method">virtualMethod()</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testclass-class">TestClass</a> > <a href="/test-suite-a/testclass-class/virtualmethod-method">virtualMethod()</a></p>
       </section>
       <section>
         <p>Overrides <a href="/test-suite-a/testabstractclass-class/virtualmethod-method">virtualMethod()</a>.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconst-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconst-variable.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testConst</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testconst-variable">testConst</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testconst-variable">testConst</a></p>
       </section>
       <section>
         <p>Test Constant</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testConstWithEmptyDeprecatedBlock</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testconstwithemptydeprecatedblock-variable">testConstWithEmptyDeprecatedBlock</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testconstwithemptydeprecatedblock-variable">testConstWithEmptyDeprecatedBlock</a></p>
       </section>
       <section>
         <p>I have a <code>@deprecated</code> tag with an empty comment block.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testemptyinterface-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testemptyinterface-interface/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestEmptyInterface</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testemptyinterface-interface/">TestEmptyInterface</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a></p>
       </section>
       <section>
         <p>An empty interface</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestEnum</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testenum-enum/">TestEnum</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testenum-enum">TestEnum</a></p>
       </section>
       <section>
         <p>Test Enum</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue1-enummember.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue1-enummember.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestEnumValue1</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testenum-enum/">TestEnum</a> > <a href="/test-suite-a/testenum-enum/testenumvalue1-enummember">TestEnumValue1</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testenum-enum">TestEnum</a> > <a href="/test-suite-a/testenum-enum/testenumvalue1-enummember">TestEnumValue1</a></p>
       </section>
       <section>
         <p>Test enum value 1 (string)</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue2-enummember.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue2-enummember.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestEnumValue2</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testenum-enum/">TestEnum</a> > <a href="/test-suite-a/testenum-enum/testenumvalue2-enummember">TestEnumValue2</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testenum-enum">TestEnum</a> > <a href="/test-suite-a/testenum-enum/testenumvalue2-enummember">TestEnumValue2</a></p>
       </section>
       <section>
         <p>Test enum value 2 (number)</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue3-enummember.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue3-enummember.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestEnumValue3</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testenum-enum/">TestEnum</a> > <a href="/test-suite-a/testenum-enum/testenumvalue3-enummember">TestEnumValue3</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testenum-enum">TestEnum</a> > <a href="/test-suite-a/testenum-enum/testenumvalue3-enummember">TestEnumValue3</a></p>
       </section>
       <section>
         <p>Test enum value 3 (default)</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunction-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunction-function.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testFunction</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testfunction-function">testFunction(testParameter, testOptionalParameter)</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testfunction-function">testFunction(testParameter, testOptionalParameter)</a></p>
       </section>
       <section>
         <p>Test function</p>
@@ -30,8 +30,8 @@
               <tbody>
                 <tr>
                   <td>TTypeParameter</td>
-                  <td><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></td>
-                  <td><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></td>
+                  <td><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span></td>
+                  <td><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span></td>
                   <td>A test type parameter</td>
                 </tr>
               </tbody>
@@ -41,7 +41,7 @@
       </section>
       <section>
         <h2 id="testfunction-remarks">Remarks</h2>
-        <p>This is a test <a href="/test-suite-a/testinterface-interface/">link</a> to another API member</p>
+        <p>This is a test <a href="/test-suite-a/testinterface-interface">link</a> to another API member</p>
       </section>
       <section>
         <h2 id="testfunction-parameters">Parameters</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturninginlinetype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturninginlinetype-function.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testFunctionReturningInlineType</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testfunctionreturninginlinetype-function">testFunctionReturningInlineType()</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testfunctionreturninginlinetype-function">testFunctionReturningInlineType()</a></p>
       </section>
       <section>
         <p>Test function that returns an inline type</p>
@@ -18,7 +18,7 @@
       <section>
         <h2 id="testfunctionreturninginlinetype-returns">Returns</h2>
         <p>An inline type</p>
-        <p><span><b>Return type: </b></span><span>{ foo: number; bar: <a href="/test-suite-a/testenum-enum/">TestEnum</a>; }</span></p>
+        <p><span><b>Return type: </b></span><span>{ foo: number; bar: <a href="/test-suite-a/testenum-enum">TestEnum</a>; }</span></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testFunctionReturningIntersectionType</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testfunctionreturningintersectiontype-function">testFunctionReturningIntersectionType()</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testfunctionreturningintersectiontype-function">testFunctionReturningIntersectionType()</a></p>
       </section>
       <section>
         <p>Test function that returns an inline type</p>
@@ -21,7 +21,7 @@
       <section>
         <h2 id="testfunctionreturningintersectiontype-returns">Returns</h2>
         <p>an intersection type</p>
-        <p><span><b>Return type: </b></span><span><a href="/test-suite-a/testemptyinterface-interface/">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;number></span></p>
+        <p><span><b>Return type: </b></span><span><a href="/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturninguniontype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturninguniontype-function.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testFunctionReturningUnionType</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testfunctionreturninguniontype-function">testFunctionReturningUnionType()</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testfunctionreturninguniontype-function">testFunctionReturningUnionType()</a></p>
       </section>
       <section>
         <p>Test function that returns an inline type</p>
@@ -18,7 +18,7 @@
       <section>
         <h2 id="testfunctionreturninguniontype-returns">Returns</h2>
         <p>A union type</p>
-        <p><span><b>Return type: </b></span><span>string | <a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></p>
+        <p><span><b>Return type: </b></span><span>string | <a href="/test-suite-a/testinterface-interface">TestInterface</a></span></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call_-callsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call_-callsignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>(event: 'testCallSignature', listener: (input: unknown) => void): any</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/_call_-callsignature">(event: 'testCallSignature', listener: (input: unknown) => void): any</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/_call_-callsignature">(event: 'testCallSignature', listener: (input: unknown) => void): any</a></p>
       </section>
       <section>
         <p>Test interface event call signature</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call__1-callsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call__1-callsignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>(event: 'anotherTestCallSignature', listener: (input: number) => string): number</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/_call__1-callsignature">(event: 'anotherTestCallSignature', listener: (input: number) => string): number</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/_call__1-callsignature">(event: 'anotherTestCallSignature', listener: (input: number) => string): number</a></p>
       </section>
       <section>
         <p>Another example call signature</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_new_-constructsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_new_-constructsignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>new (): TestInterface</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/_new_-constructsignature">new (): TestInterface</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/_new_-constructsignature">new (): TestInterface</a></p>
       </section>
       <section>
         <p>Test construct signature.</p>
@@ -17,7 +17,7 @@
       </section>
       <section>
         <h2 id="_new_-returns">Returns</h2>
-        <p><span><b>Return type: </b></span><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></p>
+        <p><span><b>Return type: </b></span><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/getterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/getterproperty-property.html
@@ -7,7 +7,7 @@
     <section>
       <h1>getterProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/getterproperty-property">getterProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/getterproperty-property">getterProperty</a></p>
       </section>
       <section>
         <p>A test getter-only interface property.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestInterface</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface">TestInterface</a></p>
       </section>
       <section>
         <p>Test interface</p>
@@ -32,7 +32,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface/_new_-constructsignature">new (): TestInterface</a></td>
-              <td><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></td>
+              <td><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span></td>
               <td>Test construct signature.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>propertyWithBadInheritDocTarget</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature">propertyWithBadInheritDocTarget</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature">propertyWithBadInheritDocTarget</a></p>
       </section>
       <section>
         <p></p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.html
@@ -7,7 +7,7 @@
     <section>
       <h1>setterProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/setterproperty-property">setterProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/setterproperty-property">setterProperty</a></p>
       </section>
       <section>
         <p>A test property with a getter and a setter.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testClassEventProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature">testClassEventProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature">testClassEventProperty</a></p>
       </section>
       <section>
         <p>Test interface event property</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testInterfaceMethod</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature">testInterfaceMethod()</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature">testInterfaceMethod()</a></p>
       </section>
       <section>
         <p>Test interface method</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testInterfaceProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature">testInterfaceProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature">testInterfaceProperty</a></p>
       </section>
       <section>
         <p>Test interface property</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testOptionalInterfaceProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface">TestInterface</a> > <a href="/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></p>
       </section>
       <section>
         <p>Test optional property</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.html
@@ -7,14 +7,14 @@
     <section>
       <h1>TestInterfaceExtendingOtherInterfaces</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface/">TestInterfaceExtendingOtherInterfaces</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface">TestInterfaceExtendingOtherInterfaces</a></p>
       </section>
       <section>
         <p>Test interface that extends other interfaces</p>
       </section>
       <section>
         <h2 id="testinterfaceextendingotherinterfaces-signature">Signature</h2><code>export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter&#x3C;number></code>
-        <p><span><span><b>Extends: </b></span><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span>, <span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span>, <span><a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;number></span></span></p>
+        <p><span><span><b>Extends: </b></span><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span>, <span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span>, <span><a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></span></p>
       </section>
       <section>
         <h2 id="testinterfaceextendingotherinterfaces-remarks">Remarks</h2>
@@ -42,9 +42,9 @@
       <section>
         <h2 id="testinterfaceextendingotherinterfaces-see-also">See Also</h2>
         <p>
-          <p>- <a href="/test-suite-a/testinterface-interface/">TestInterface</a></p>
-          <p>- <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a></p>
-          <p>- <a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></p>
+          <p>- <a href="/test-suite-a/testinterface-interface">TestInterface</a></p>
+          <p>- <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a></p>
+          <p>- <a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></p>
         </p>
       </section>
     </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testMethod</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface/">TestInterfaceExtendingOtherInterfaces</a> > <a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature">testMethod(input)</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface">TestInterfaceExtendingOtherInterfaces</a> > <a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature">testMethod(input)</a></p>
       </section>
       <section>
         <p>Test interface method accepting a string and returning a number.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>[foo: number]: { bar: string; }</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithindexsignature-interface/">TestInterfaceWithIndexSignature</a> > <a href="/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature">[foo: number]: { bar: string; }</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithindexsignature-interface">TestInterfaceWithIndexSignature</a> > <a href="/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature">[foo: number]: { bar: string; }</a></p>
       </section>
       <section>
         <p>Test index signature.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestInterfaceWithIndexSignature</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithindexsignature-interface/">TestInterfaceWithIndexSignature</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithindexsignature-interface">TestInterfaceWithIndexSignature</a></p>
       </section>
       <section>
         <p>An interface with an index signature.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestInterfaceWithTypeParameter</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a></p>
       </section>
       <section>
         <p>Test interface with generic type parameter</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a> > <a href="/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature">testProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a> > <a href="/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature">testProperty</a></p>
       </section>
       <section>
         <p>A test interface property using generic type parameter</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testmappedtype-typealias/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testmappedtype-typealias/index.html
@@ -7,10 +7,10 @@
     <section>
       <h1>TestMappedType</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></p>
       </section>
       <section>
-        <p>Test Mapped Type, using <a href="/test-suite-a/testenum-enum/">TestEnum</a></p>
+        <p>Test Mapped Type, using <a href="/test-suite-a/testenum-enum">TestEnum</a></p>
       </section>
       <section>
         <h2 id="testmappedtype-signature">Signature</h2><code>export type TestMappedType = {<br>[K in TestEnum]: boolean;<br>};</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/foo-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/foo-variable.html
@@ -7,7 +7,7 @@
     <section>
       <h1>foo</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testmodule-namespace/">TestModule</a> > <a href="/test-suite-a/testmodule-namespace/foo-variable">foo</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testmodule-namespace">TestModule</a> > <a href="/test-suite-a/testmodule-namespace/foo-variable">foo</a></p>
       </section>
       <section>
         <p>Test constant in module.</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestModule</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testmodule-namespace/">TestModule</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testmodule-namespace">TestModule</a></p>
       </section>
       <section>
         <h2>Variables</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestNamespace</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a></p>
       </section>
       <section>
         <p>Test Namespace</p>
@@ -46,7 +46,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="/test-suite-a/testnamespace-namespace/testinterface-interface/">TestInterface</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testinterface-interface">TestInterface</a></td>
               <td><code>Alpha</code></td>
               <td>Test interface</td>
             </tr>
@@ -64,7 +64,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="/test-suite-a/testnamespace-namespace/testclass-class/">TestClass</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testclass-class">TestClass</a></td>
               <td>Test class</td>
             </tr>
           </tbody>
@@ -81,7 +81,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="/test-suite-a/testnamespace-namespace/testenum-enum/">TestEnum</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a></td>
               <td>Test Enum</td>
             </tr>
           </tbody>
@@ -98,7 +98,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="/test-suite-a/testnamespace-namespace/testtypealias-typealias/">TestTypeAlias</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testtypealias-typealias">TestTypeAlias</a></td>
               <td>Test Type-Alias</td>
             </tr>
           </tbody>
@@ -157,7 +157,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/">TestSubNamespace</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testsubnamespace-namespace">TestSubNamespace</a></td>
               <td>Test sub-namespace</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.html
@@ -7,7 +7,7 @@
     <section>
       <h1>(constructor)</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/">TestClass</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor">(constructor)(testClassProperty)</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class">TestClass</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor">(constructor)(testClassProperty)</a></p>
       </section>
       <section>
         <p>Test class constructor</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestClass</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/">TestClass</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class">TestClass</a></p>
       </section>
       <section>
         <p>Test class</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testClassMethod</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/">TestClass</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method">testClassMethod(testParameter)</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class">TestClass</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method">testClassMethod(testParameter)</a></p>
       </section>
       <section>
         <p>Test class method</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testClassProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/">TestClass</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property">testClassProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class">TestClass</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property">testClassProperty</a></p>
       </section>
       <section>
         <p>Test interface property</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testconst-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testconst-variable.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestConst</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testconst-variable">TestConst</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testconst-variable">TestConst</a></p>
       </section>
       <section>
         <p>Test Constant</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestEnum</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum/">TestEnum</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a></p>
       </section>
       <section>
         <p>Test Enum</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestEnumValue1</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum/">TestEnum</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember">TestEnumValue1</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember">TestEnumValue1</a></p>
       </section>
       <section>
         <p>Test enum value 1</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestEnumValue2</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum/">TestEnum</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember">TestEnumValue2</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember">TestEnumValue2</a></p>
       </section>
       <section>
         <p>Test enum value 2</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testFunction</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testfunction-function">testFunction(testParameter)</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testfunction-function">testFunction(testParameter)</a></p>
       </section>
       <section>
         <p>Test function</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestInterface</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface/">TestInterface</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface">TestInterface</a></p>
       </section>
       <section>
         <p>Test interface</p>
@@ -15,7 +15,7 @@
       <section><span><b>WARNING: This API is provided as an alpha preview and may change without notice. Use at your own risk.</b></span></section>
       <section>
         <h2 id="testinterface-signature">Signature</h2><code>interface TestInterface extends TestInterfaceWithTypeParameter&#x3C;TestEnum></code>
-        <p><span><span><b>Extends: </b></span><span><a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;<a href="/test-suite-a/testnamespace-namespace/testenum-enum/">TestEnum</a>></span></span></p>
+        <p><span><span><b>Extends: </b></span><span><a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;<a href="/test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a>></span></span></p>
       </section>
       <section>
         <h2>Properties</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testInterfaceMethod</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature">testInterfaceMethod()</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface">TestInterface</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature">testInterfaceMethod()</a></p>
       </section>
       <section>
         <p>Test interface method</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature.html
@@ -7,7 +7,7 @@
     <section>
       <h1>testInterfaceProperty</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface/">TestInterface</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature">testInterfaceProperty</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface">TestInterface</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature">testInterfaceProperty</a></p>
       </section>
       <section>
         <p>Test interface property</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestSubNamespace</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/">TestSubNamespace</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testsubnamespace-namespace">TestSubNamespace</a></p>
       </section>
       <section>
         <p>Test sub-namespace</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testtypealias-typealias/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testtypealias-typealias/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestTypeAlias</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testtypealias-typealias/">TestTypeAlias</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testtypealias-typealias">TestTypeAlias</a></p>
       </section>
       <section>
         <p>Test Type-Alias</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/typealias-typealias/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/typealias-typealias/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TypeAlias</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/typealias-typealias/">TypeAlias</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a">test-suite-a</a> > <a href="/test-suite-a/typealias-typealias">TypeAlias</a></p>
       </section>
       <section>
         <p>Test Type-Alias</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/foo-interface/bar-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/foo-interface/bar-propertysignature.html
@@ -7,14 +7,14 @@
     <section>
       <h1>bar</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-b/">test-suite-b</a> > <a href="/test-suite-b/foo-interface/">Foo</a> > <a href="/test-suite-b/foo-interface/bar-propertysignature">bar</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-b">test-suite-b</a> > <a href="/test-suite-b/foo-interface">Foo</a> > <a href="/test-suite-b/foo-interface/bar-propertysignature">bar</a></p>
       </section>
       <section>
         <p>Test Enum</p>
       </section>
       <section>
         <h2 id="bar-signature">Signature</h2><code>bar: TestEnum;</code>
-        <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></span></p>
+        <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></span></p>
       </section>
       <section>
         <h2 id="bar-remarks">Remarks</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/foo-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/foo-interface/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>Foo</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-b/">test-suite-b</a> > <a href="/test-suite-b/foo-interface/">Foo</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-b">test-suite-b</a> > <a href="/test-suite-b/foo-interface">Foo</a></p>
       </section>
       <section>
         <p>Bar</p>
@@ -28,7 +28,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-b/foo-interface/bar-propertysignature">bar</a></td>
-              <td><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></td>
+              <td><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></td>
               <td>Test Enum</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>test-suite-b</h1>
       <section>
-        <p><a href="/">Packages</a> > <a href="/test-suite-b/">test-suite-b</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-b">test-suite-b</a></p>
       </section>
       <section>
         <h2>Interfaces</h2>
@@ -20,7 +20,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="/test-suite-b/foo-interface/">Foo</a></td>
+              <td><a href="/test-suite-b/foo-interface">Foo</a></td>
               <td>Bar</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/index.md
@@ -4,5 +4,5 @@
 
 | Package | Description |
 | --- | --- |
-| [test-suite-a](/test-suite-a/) | Test package |
-| [test-suite-b](/test-suite-b/) |  |
+| [test-suite-a](/test-suite-a) | Test package |
+| [test-suite-b](/test-suite-b) |  |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
@@ -1,6 +1,6 @@
 # test-suite-a
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a)
 
 Test package
 
@@ -22,7 +22,7 @@ And an ordered list for good measure!
 
 Also, here is a link test, including a bad link, because we should have some reasonable support if this happens:
 
-- Good link (no alias): [TestClass](/test-suite-a/testclass-class/)
+- Good link (no alias): [TestClass](/test-suite-a/testclass-class)
 
 - Good link (with alias): [function alias text](/test-suite-a/testfunction-function)
 
@@ -42,40 +42,40 @@ const foo = bar;
 
 | Interface | Description |
 | --- | --- |
-| [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) | An empty interface |
-| [TestInterface](/test-suite-a/testinterface-interface/) | Test interface |
-| [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface/) | Test interface that extends other interfaces |
-| [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface/) | An interface with an index signature. |
-| [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/) | Test interface with generic type parameter |
+| [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) | An empty interface |
+| [TestInterface](/test-suite-a/testinterface-interface) | Test interface |
+| [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface) | Test interface that extends other interfaces |
+| [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface) | An interface with an index signature. |
+| [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface) | Test interface with generic type parameter |
 
 ## Classes
 
 | Class | Description |
 | --- | --- |
-| [TestAbstractClass](/test-suite-a/testabstractclass-class/) | A test abstract class. |
-| [TestClass](/test-suite-a/testclass-class/) | Test class |
+| [TestAbstractClass](/test-suite-a/testabstractclass-class) | A test abstract class. |
+| [TestClass](/test-suite-a/testclass-class) | Test class |
 
 ## Enumerations
 
 | Enum | Description |
 | --- | --- |
-| [TestEnum](/test-suite-a/testenum-enum/) | Test Enum |
+| [TestEnum](/test-suite-a/testenum-enum) | Test Enum |
 
 ## Types
 
 | TypeAlias | Description |
 | --- | --- |
-| [TestMappedType](/test-suite-a/testmappedtype-typealias/) | Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum/) |
-| [TypeAlias](/test-suite-a/typealias-typealias/) | Test Type-Alias |
+| [TestMappedType](/test-suite-a/testmappedtype-typealias) | Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum) |
+| [TypeAlias](/test-suite-a/typealias-typealias) | Test Type-Alias |
 
 ## Functions
 
 | Function | Alerts | Return Type | Description |
 | --- | --- | --- | --- |
 | [testFunction(testParameter, testOptionalParameter)](/test-suite-a/testfunction-function) | `Alpha` | TTypeParameter | Test function |
-| [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum/); } | Test function that returns an inline type |
-| [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) &amp; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)&lt;number&gt; | Test function that returns an inline type |
-| [testFunctionReturningUnionType()](/test-suite-a/testfunctionreturninguniontype-function) |  | string \| [TestInterface](/test-suite-a/testinterface-interface/) | Test function that returns an inline type |
+| [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum); } | Test function that returns an inline type |
+| [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) &amp; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)&lt;number&gt; | Test function that returns an inline type |
+| [testFunctionReturningUnionType()](/test-suite-a/testfunctionreturninguniontype-function) |  | string \| [TestInterface](/test-suite-a/testinterface-interface) | Test function that returns an inline type |
 
 ## Variables
 
@@ -88,5 +88,5 @@ const foo = bar;
 
 | Namespace | Description |
 | --- | --- |
-| [TestModule](/test-suite-a/testmodule-namespace/) |  |
-| [TestNamespace](/test-suite-a/testnamespace-namespace/) | Test Namespace |
+| [TestModule](/test-suite-a/testmodule-namespace) |  |
+| [TestNamespace](/test-suite-a/testnamespace-namespace) | Test Namespace |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.md
@@ -1,6 +1,6 @@
 # (constructor)
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/) &gt; [(constructor)(privateProperty, protectedProperty)](/test-suite-a/testabstractclass-class/_constructor_-constructor)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class) &gt; [(constructor)(privateProperty, protectedProperty)](/test-suite-a/testabstractclass-class/_constructor_-constructor)
 
 This is a _{@customTag constructor}_.
 
@@ -15,4 +15,4 @@ protected constructor(privateProperty: number, protectedProperty: TestEnum);
 | Parameter | Type | Description |
 | --- | --- | --- |
 | privateProperty | number |  |
-| protectedProperty | [TestEnum](/test-suite-a/testenum-enum/) |  |
+| protectedProperty | [TestEnum](/test-suite-a/testenum-enum) |  |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.md
@@ -1,6 +1,6 @@
 # abstractPropertyGetter
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/) &gt; [abstractPropertyGetter](/test-suite-a/testabstractclass-class/abstractpropertygetter-property)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class) &gt; [abstractPropertyGetter](/test-suite-a/testabstractclass-class/abstractpropertygetter-property)
 
 A test abstract getter property.
 
@@ -10,4 +10,4 @@ A test abstract getter property.
 abstract get abstractPropertyGetter(): TestMappedType;
 ```
 
-**Type:** [TestMappedType](/test-suite-a/testmappedtype-typealias/)
+**Type:** [TestMappedType](/test-suite-a/testmappedtype-typealias)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.md
@@ -1,6 +1,6 @@
 # TestAbstractClass
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class)
 
 A test abstract class.
 
@@ -20,8 +20,8 @@ export declare abstract class TestAbstractClass
 
 | Property | Modifiers | Type | Description |
 | --- | --- | --- | --- |
-| [abstractPropertyGetter](/test-suite-a/testabstractclass-class/abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias/) | A test abstract getter property. |
-| [protectedProperty](/test-suite-a/testabstractclass-class/protectedproperty-property) | `readonly` | [TestEnum](/test-suite-a/testenum-enum/) | A test protected property. |
+| [abstractPropertyGetter](/test-suite-a/testabstractclass-class/abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
+| [protectedProperty](/test-suite-a/testabstractclass-class/protectedproperty-property) | `readonly` | [TestEnum](/test-suite-a/testenum-enum) | A test protected property. |
 
 ## Methods
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/protectedproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/protectedproperty-property.md
@@ -1,6 +1,6 @@
 # protectedProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/) &gt; [protectedProperty](/test-suite-a/testabstractclass-class/protectedproperty-property)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class) &gt; [protectedProperty](/test-suite-a/testabstractclass-class/protectedproperty-property)
 
 A test protected property.
 
@@ -10,4 +10,4 @@ A test protected property.
 protected readonly protectedProperty: TestEnum;
 ```
 
-**Type:** [TestEnum](/test-suite-a/testenum-enum/)
+**Type:** [TestEnum](/test-suite-a/testenum-enum)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/publicabstractmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/publicabstractmethod-method.md
@@ -1,6 +1,6 @@
 # publicAbstractMethod
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/) &gt; [publicAbstractMethod()](/test-suite-a/testabstractclass-class/publicabstractmethod-method)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class) &gt; [publicAbstractMethod()](/test-suite-a/testabstractclass-class/publicabstractmethod-method)
 
 A test public abstract method.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/sealedmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/sealedmethod-method.md
@@ -1,6 +1,6 @@
 # sealedMethod
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/) &gt; [sealedMethod()](/test-suite-a/testabstractclass-class/sealedmethod-method)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class) &gt; [sealedMethod()](/test-suite-a/testabstractclass-class/sealedmethod-method)
 
 A test `@sealed` method.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/virtualmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/virtualmethod-method.md
@@ -1,6 +1,6 @@
 # virtualMethod
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class/) &gt; [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class) &gt; [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method)
 
 A test `@virtual` method.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.md
@@ -1,6 +1,6 @@
 # (constructor)
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)](/test-suite-a/testclass-class/_constructor_-constructor)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestClass](/test-suite-a/testclass-class) &gt; [(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)](/test-suite-a/testclass-class/_constructor_-constructor)
 
 Test class constructor
 
@@ -18,7 +18,7 @@ Here are some remarks about the constructor
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| privateProperty | number | See [TestAbstractClass](/test-suite-a/testabstractclass-class/)'s constructor. |
-| protectedProperty | [TestEnum](/test-suite-a/testenum-enum/) | <p>Some notes about the parameter.</p><p>See <a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a>.</p> |
+| privateProperty | number | See [TestAbstractClass](/test-suite-a/testabstractclass-class)'s constructor. |
+| protectedProperty | [TestEnum](/test-suite-a/testenum-enum) | <p>Some notes about the parameter.</p><p>See <a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a>.</p> |
 | testClassProperty | TTypeParameterB | See [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property). |
 | testClassEventProperty | () =&gt; void | See [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property). |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.md
@@ -1,6 +1,6 @@
 # abstractPropertyGetter
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [abstractPropertyGetter](/test-suite-a/testclass-class/abstractpropertygetter-property)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestClass](/test-suite-a/testclass-class) &gt; [abstractPropertyGetter](/test-suite-a/testclass-class/abstractpropertygetter-property)
 
 A test abstract getter property.
 
@@ -10,4 +10,4 @@ A test abstract getter property.
 get abstractPropertyGetter(): TestMappedType;
 ```
 
-**Type:** [TestMappedType](/test-suite-a/testmappedtype-typealias/)
+**Type:** [TestMappedType](/test-suite-a/testmappedtype-typealias)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/index.md
@@ -1,6 +1,6 @@
 # TestClass
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestClass](/test-suite-a/testclass-class)
 
 Test class
 
@@ -10,7 +10,7 @@ Test class
 export declare class TestClass<TTypeParameterA, TTypeParameterB> extends TestAbstractClass
 ```
 
-**Extends:** [TestAbstractClass](/test-suite-a/testabstractclass-class/)
+**Extends:** [TestAbstractClass](/test-suite-a/testabstractclass-class)
 
 ### Type Parameters
 
@@ -51,7 +51,7 @@ Here are some remarks about the class
 
 | Property | Modifiers | Type | Description |
 | --- | --- | --- | --- |
-| [abstractPropertyGetter](/test-suite-a/testclass-class/abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias/) | A test abstract getter property. |
+| [abstractPropertyGetter](/test-suite-a/testclass-class/abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
 | [testClassGetterProperty](/test-suite-a/testclass-class/testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
 | [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
 
@@ -65,4 +65,4 @@ Here are some remarks about the class
 
 ## See Also {#testclass-see-also}
 
-[TestAbstractClass](/test-suite-a/testabstractclass-class/)
+[TestAbstractClass](/test-suite-a/testabstractclass-class)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/publicabstractmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/publicabstractmethod-method.md
@@ -1,6 +1,6 @@
 # publicAbstractMethod
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [publicAbstractMethod()](/test-suite-a/testclass-class/publicabstractmethod-method)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestClass](/test-suite-a/testclass-class) &gt; [publicAbstractMethod()](/test-suite-a/testclass-class/publicabstractmethod-method)
 
 A test public abstract method.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclasseventproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclasseventproperty-property.md
@@ -1,6 +1,6 @@
 # testClassEventProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestClass](/test-suite-a/testclass-class) &gt; [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property)
 
 Test class event property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.md
@@ -1,6 +1,6 @@
 # testClassGetterProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [testClassGetterProperty](/test-suite-a/testclass-class/testclassgetterproperty-property)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestClass](/test-suite-a/testclass-class) &gt; [testClassGetterProperty](/test-suite-a/testclass-class/testclassgetterproperty-property)
 
 Test class property with both a getter and a setter.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.md
@@ -1,6 +1,6 @@
 # testClassMethod
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [testClassMethod(input)](/test-suite-a/testclass-class/testclassmethod-method)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestClass](/test-suite-a/testclass-class) &gt; [testClassMethod(input)](/test-suite-a/testclass-class/testclassmethod-method)
 
 Test class method
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassproperty-property.md
@@ -1,6 +1,6 @@
 # testClassProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestClass](/test-suite-a/testclass-class) &gt; [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property)
 
 Test class property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.md
@@ -1,6 +1,6 @@
 # testClassStaticMethod
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [testClassStaticMethod(foo)](/test-suite-a/testclass-class/testclassstaticmethod-method)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestClass](/test-suite-a/testclass-class) &gt; [testClassStaticMethod(foo)](/test-suite-a/testclass-class/testclassstaticmethod-method)
 
 Test class static method
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticproperty-property.md
@@ -1,6 +1,6 @@
 # testClassStaticProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [testClassStaticProperty](/test-suite-a/testclass-class/testclassstaticproperty-property)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestClass](/test-suite-a/testclass-class) &gt; [testClassStaticProperty](/test-suite-a/testclass-class/testclassstaticproperty-property)
 
 Test static class property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/virtualmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/virtualmethod-method.md
@@ -1,6 +1,6 @@
 # virtualMethod
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class/) &gt; [virtualMethod()](/test-suite-a/testclass-class/virtualmethod-method)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestClass](/test-suite-a/testclass-class) &gt; [virtualMethod()](/test-suite-a/testclass-class/virtualmethod-method)
 
 Overrides [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method).
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testconst-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testconst-variable.md
@@ -1,6 +1,6 @@
 # testConst
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [testConst](/test-suite-a/testconst-variable)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [testConst](/test-suite-a/testconst-variable)
 
 Test Constant
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.md
@@ -1,6 +1,6 @@
 # testConstWithEmptyDeprecatedBlock
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [testConstWithEmptyDeprecatedBlock](/test-suite-a/testconstwithemptydeprecatedblock-variable)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [testConstWithEmptyDeprecatedBlock](/test-suite-a/testconstwithemptydeprecatedblock-variable)
 
 I have a `@deprecated` tag with an empty comment block.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testemptyinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testemptyinterface-interface/index.md
@@ -1,6 +1,6 @@
 # TestEmptyInterface
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestEmptyInterface](/test-suite-a/testemptyinterface-interface)
 
 An empty interface
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.md
@@ -1,6 +1,6 @@
 # TestEnum
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestEnum](/test-suite-a/testenum-enum/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestEnum](/test-suite-a/testenum-enum)
 
 Test Enum
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue1-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue1-enummember.md
@@ -1,6 +1,6 @@
 # TestEnumValue1
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestEnum](/test-suite-a/testenum-enum/) &gt; [TestEnumValue1](/test-suite-a/testenum-enum/testenumvalue1-enummember)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestEnum](/test-suite-a/testenum-enum) &gt; [TestEnumValue1](/test-suite-a/testenum-enum/testenumvalue1-enummember)
 
 Test enum value 1 (string)
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue2-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue2-enummember.md
@@ -1,6 +1,6 @@
 # TestEnumValue2
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestEnum](/test-suite-a/testenum-enum/) &gt; [TestEnumValue2](/test-suite-a/testenum-enum/testenumvalue2-enummember)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestEnum](/test-suite-a/testenum-enum) &gt; [TestEnumValue2](/test-suite-a/testenum-enum/testenumvalue2-enummember)
 
 Test enum value 2 (number)
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue3-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue3-enummember.md
@@ -1,6 +1,6 @@
 # TestEnumValue3
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestEnum](/test-suite-a/testenum-enum/) &gt; [TestEnumValue3](/test-suite-a/testenum-enum/testenumvalue3-enummember)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestEnum](/test-suite-a/testenum-enum) &gt; [TestEnumValue3](/test-suite-a/testenum-enum/testenumvalue3-enummember)
 
 Test enum value 3 (default)
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunction-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunction-function.md
@@ -1,6 +1,6 @@
 # testFunction
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [testFunction(testParameter, testOptionalParameter)](/test-suite-a/testfunction-function)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [testFunction(testParameter, testOptionalParameter)](/test-suite-a/testfunction-function)
 
 Test function
 
@@ -16,11 +16,11 @@ export declare function testFunction<TTypeParameter extends TestInterface = Test
 
 | Parameter | Constraint | Default | Description |
 | --- | --- | --- | --- |
-| TTypeParameter | [TestInterface](/test-suite-a/testinterface-interface/) | [TestInterface](/test-suite-a/testinterface-interface/) | A test type parameter |
+| TTypeParameter | [TestInterface](/test-suite-a/testinterface-interface) | [TestInterface](/test-suite-a/testinterface-interface) | A test type parameter |
 
 ## Remarks {#testfunction-remarks}
 
-This is a test [link](/test-suite-a/testinterface-interface/) to another API member
+This is a test [link](/test-suite-a/testinterface-interface) to another API member
 
 ## Parameters {#testfunction-parameters}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturninginlinetype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturninginlinetype-function.md
@@ -1,6 +1,6 @@
 # testFunctionReturningInlineType
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function)
 
 Test function that returns an inline type
 
@@ -17,4 +17,4 @@ export declare function testFunctionReturningInlineType(): {
 
 An inline type
 
-**Return type:** {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum/); }
+**Return type:** {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum); }

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.md
@@ -1,6 +1,6 @@
 # testFunctionReturningIntersectionType
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function)
 
 Test function that returns an inline type
 
@@ -18,4 +18,4 @@ export declare function testFunctionReturningIntersectionType(): TestEmptyInterf
 
 an intersection type
 
-**Return type:** [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) &amp; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)&lt;number&gt;
+**Return type:** [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) &amp; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)&lt;number&gt;

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturninguniontype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturninguniontype-function.md
@@ -1,6 +1,6 @@
 # testFunctionReturningUnionType
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [testFunctionReturningUnionType()](/test-suite-a/testfunctionreturninguniontype-function)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [testFunctionReturningUnionType()](/test-suite-a/testfunctionreturninguniontype-function)
 
 Test function that returns an inline type
 
@@ -14,4 +14,4 @@ export declare function testFunctionReturningUnionType(): string | TestInterface
 
 A union type
 
-**Return type:** string \| [TestInterface](/test-suite-a/testinterface-interface/)
+**Return type:** string \| [TestInterface](/test-suite-a/testinterface-interface)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call_-callsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call_-callsignature.md
@@ -1,6 +1,6 @@
 # (event: 'testCallSignature', listener: (input: unknown) =&gt; void): any
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [(event: 'testCallSignature', listener: (input: unknown) =&gt; void): any](/test-suite-a/testinterface-interface/_call_-callsignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterface](/test-suite-a/testinterface-interface) &gt; [(event: 'testCallSignature', listener: (input: unknown) =&gt; void): any](/test-suite-a/testinterface-interface/_call_-callsignature)
 
 Test interface event call signature
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call__1-callsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call__1-callsignature.md
@@ -1,6 +1,6 @@
 # (event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [(event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number](/test-suite-a/testinterface-interface/_call__1-callsignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterface](/test-suite-a/testinterface-interface) &gt; [(event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number](/test-suite-a/testinterface-interface/_call__1-callsignature)
 
 Another example call signature
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_new_-constructsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_new_-constructsignature.md
@@ -1,6 +1,6 @@
 # new (): TestInterface
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [new (): TestInterface](/test-suite-a/testinterface-interface/_new_-constructsignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterface](/test-suite-a/testinterface-interface) &gt; [new (): TestInterface](/test-suite-a/testinterface-interface/_new_-constructsignature)
 
 Test construct signature.
 
@@ -12,4 +12,4 @@ new (): TestInterface;
 
 ## Returns {#\_new\_-returns}
 
-**Return type:** [TestInterface](/test-suite-a/testinterface-interface/)
+**Return type:** [TestInterface](/test-suite-a/testinterface-interface)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/getterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/getterproperty-property.md
@@ -1,6 +1,6 @@
 # getterProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [getterProperty](/test-suite-a/testinterface-interface/getterproperty-property)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterface](/test-suite-a/testinterface-interface) &gt; [getterProperty](/test-suite-a/testinterface-interface/getterproperty-property)
 
 A test getter-only interface property.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.md
@@ -1,6 +1,6 @@
 # TestInterface
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterface](/test-suite-a/testinterface-interface)
 
 Test interface
 
@@ -18,7 +18,7 @@ Here are some remarks about the interface
 
 | ConstructSignature | Return Type | Description |
 | --- | --- | --- |
-| [new (): TestInterface](/test-suite-a/testinterface-interface/_new_-constructsignature) | [TestInterface](/test-suite-a/testinterface-interface/) | Test construct signature. |
+| [new (): TestInterface](/test-suite-a/testinterface-interface/_new_-constructsignature) | [TestInterface](/test-suite-a/testinterface-interface) | Test construct signature. |
 
 ## Events
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature.md
@@ -1,6 +1,6 @@
 # propertyWithBadInheritDocTarget
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterface](/test-suite-a/testinterface-interface) &gt; [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature)
 
 ## Signature {#propertywithbadinheritdoctarget-signature}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.md
@@ -1,6 +1,6 @@
 # setterProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [setterProperty](/test-suite-a/testinterface-interface/setterproperty-property)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterface](/test-suite-a/testinterface-interface) &gt; [setterProperty](/test-suite-a/testinterface-interface/setterproperty-property)
 
 A test property with a getter and a setter.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature.md
@@ -1,6 +1,6 @@
 # testClassEventProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [testClassEventProperty](/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterface](/test-suite-a/testinterface-interface) &gt; [testClassEventProperty](/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature)
 
 Test interface event property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature.md
@@ -1,6 +1,6 @@
 # testInterfaceMethod
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [testInterfaceMethod()](/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterface](/test-suite-a/testinterface-interface) &gt; [testInterfaceMethod()](/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature)
 
 Test interface method
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature.md
@@ -1,6 +1,6 @@
 # testInterfaceProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [testInterfaceProperty](/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterface](/test-suite-a/testinterface-interface) &gt; [testInterfaceProperty](/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature)
 
 Test interface property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature.md
@@ -1,6 +1,6 @@
 # testOptionalInterfaceProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface/) &gt; [testOptionalInterfaceProperty](/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterface](/test-suite-a/testinterface-interface) &gt; [testOptionalInterfaceProperty](/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature)
 
 Test optional property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.md
@@ -1,6 +1,6 @@
 # TestInterfaceExtendingOtherInterfaces
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface)
 
 Test interface that extends other interfaces
 
@@ -10,7 +10,7 @@ Test interface that extends other interfaces
 export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter<number>
 ```
 
-**Extends:** [TestInterface](/test-suite-a/testinterface-interface/), [TestMappedType](/test-suite-a/testmappedtype-typealias/), [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)&lt;number&gt;
+**Extends:** [TestInterface](/test-suite-a/testinterface-interface), [TestMappedType](/test-suite-a/testmappedtype-typealias), [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)&lt;number&gt;
 
 ## Remarks {#testinterfaceextendingotherinterfaces-remarks}
 
@@ -24,8 +24,8 @@ Here are some remarks about the interface
 
 ## See Also {#testinterfaceextendingotherinterfaces-see-also}
 
-- [TestInterface](/test-suite-a/testinterface-interface/)
+- [TestInterface](/test-suite-a/testinterface-interface)
 
-- [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)
+- [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)
 
-- [TestMappedType](/test-suite-a/testmappedtype-typealias/)
+- [TestMappedType](/test-suite-a/testmappedtype-typealias)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.md
@@ -1,6 +1,6 @@
 # testMethod
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface/) &gt; [testMethod(input)](/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface) &gt; [testMethod(input)](/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature)
 
 Test interface method accepting a string and returning a number.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature.md
@@ -1,6 +1,6 @@
 # \[foo: number\]: { bar: string; }
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface/) &gt; [\[foo: number\]: { bar: string; }](/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface) &gt; [\[foo: number\]: { bar: string; }](/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature)
 
 Test index signature.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.md
@@ -1,6 +1,6 @@
 # TestInterfaceWithIndexSignature
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface)
 
 An interface with an index signature.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.md
@@ -1,6 +1,6 @@
 # TestInterfaceWithTypeParameter
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)
 
 Test interface with generic type parameter
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature.md
@@ -1,6 +1,6 @@
 # testProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/) &gt; [testProperty](/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface) &gt; [testProperty](/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature)
 
 A test interface property using generic type parameter
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmappedtype-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmappedtype-typealias/index.md
@@ -1,8 +1,8 @@
 # TestMappedType
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestMappedType](/test-suite-a/testmappedtype-typealias/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestMappedType](/test-suite-a/testmappedtype-typealias)
 
-Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum/)
+Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum)
 
 ## Signature {#testmappedtype-signature}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/foo-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/foo-variable.md
@@ -1,6 +1,6 @@
 # foo
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestModule](/test-suite-a/testmodule-namespace/) &gt; [foo](/test-suite-a/testmodule-namespace/foo-variable)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestModule](/test-suite-a/testmodule-namespace) &gt; [foo](/test-suite-a/testmodule-namespace/foo-variable)
 
 Test constant in module.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.md
@@ -1,6 +1,6 @@
 # TestModule
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestModule](/test-suite-a/testmodule-namespace/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestModule](/test-suite-a/testmodule-namespace)
 
 ## Variables
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.md
@@ -1,6 +1,6 @@
 # TestNamespace
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace)
 
 Test Namespace
 
@@ -38,25 +38,25 @@ const foo = {
 
 | Interface | Alerts | Description |
 | --- | --- | --- |
-| [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/) | `Alpha` | Test interface |
+| [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface) | `Alpha` | Test interface |
 
 ## Classes
 
 | Class | Description |
 | --- | --- |
-| [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) | Test class |
+| [TestClass](/test-suite-a/testnamespace-namespace/testclass-class) | Test class |
 
 ## Enumerations
 
 | Enum | Description |
 | --- | --- |
-| [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/) | Test Enum |
+| [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum) | Test Enum |
 
 ## Types
 
 | TypeAlias | Description |
 | --- | --- |
-| [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias/) | Test Type-Alias |
+| [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias) | Test Type-Alias |
 
 ## Functions
 
@@ -74,4 +74,4 @@ const foo = {
 
 | Namespace | Description |
 | --- | --- |
-| [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/) | Test sub-namespace |
+| [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace) | Test sub-namespace |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.md
@@ -1,6 +1,6 @@
 # (constructor)
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) &gt; [(constructor)(testClassProperty)](/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class) &gt; [(constructor)(testClassProperty)](/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor)
 
 Test class constructor
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.md
@@ -1,6 +1,6 @@
 # TestClass
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class)
 
 Test class
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.md
@@ -1,6 +1,6 @@
 # testClassMethod
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) &gt; [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class) &gt; [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method)
 
 Test class method
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property.md
@@ -1,6 +1,6 @@
 # testClassProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) &gt; [testClassProperty](/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class) &gt; [testClassProperty](/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property)
 
 Test interface property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testconst-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testconst-variable.md
@@ -1,6 +1,6 @@
 # TestConst
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestConst](/test-suite-a/testnamespace-namespace/testconst-variable)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestConst](/test-suite-a/testnamespace-namespace/testconst-variable)
 
 Test Constant
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/index.md
@@ -1,6 +1,6 @@
 # TestEnum
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum)
 
 Test Enum
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember.md
@@ -1,6 +1,6 @@
 # TestEnumValue1
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/) &gt; [TestEnumValue1](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum) &gt; [TestEnumValue1](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember)
 
 Test enum value 1
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember.md
@@ -1,6 +1,6 @@
 # TestEnumValue2
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/) &gt; [TestEnumValue2](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum) &gt; [TestEnumValue2](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember)
 
 Test enum value 2
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.md
@@ -1,6 +1,6 @@
 # testFunction
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [testFunction(testParameter)](/test-suite-a/testnamespace-namespace/testfunction-function)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [testFunction(testParameter)](/test-suite-a/testnamespace-namespace/testfunction-function)
 
 Test function
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.md
@@ -1,6 +1,6 @@
 # TestInterface
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface)
 
 Test interface
 
@@ -12,7 +12,7 @@ Test interface
 interface TestInterface extends TestInterfaceWithTypeParameter<TestEnum>
 ```
 
-**Extends:** [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)&lt;[TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/)&gt;
+**Extends:** [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)&lt;[TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum)&gt;
 
 ## Properties
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature.md
@@ -1,6 +1,6 @@
 # testInterfaceMethod
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/) &gt; [testInterfaceMethod()](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface) &gt; [testInterfaceMethod()](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature)
 
 Test interface method
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature.md
@@ -1,6 +1,6 @@
 # testInterfaceProperty
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/) &gt; [testInterfaceProperty](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface) &gt; [testInterfaceProperty](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature)
 
 Test interface property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.md
@@ -1,6 +1,6 @@
 # TestSubNamespace
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace)
 
 Test sub-namespace
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testtypealias-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testtypealias-typealias/index.md
@@ -1,6 +1,6 @@
 # TestTypeAlias
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace) &gt; [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias)
 
 Test Type-Alias
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/typealias-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/typealias-typealias/index.md
@@ -1,6 +1,6 @@
 # TypeAlias
 
-[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TypeAlias](/test-suite-a/typealias-typealias/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a) &gt; [TypeAlias](/test-suite-a/typealias-typealias)
 
 Test Type-Alias
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/bar-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/bar-propertysignature.md
@@ -1,6 +1,6 @@
 # bar
 
-[Packages](/) &gt; [test-suite-b](/test-suite-b/) &gt; [Foo](/test-suite-b/foo-interface/) &gt; [bar](/test-suite-b/foo-interface/bar-propertysignature)
+[Packages](/) &gt; [test-suite-b](/test-suite-b) &gt; [Foo](/test-suite-b/foo-interface) &gt; [bar](/test-suite-b/foo-interface/bar-propertysignature)
 
 Test Enum
 
@@ -10,7 +10,7 @@ Test Enum
 bar: TestEnum;
 ```
 
-**Type:** [TestEnum](/test-suite-a/testenum-enum/)
+**Type:** [TestEnum](/test-suite-a/testenum-enum)
 
 ## Remarks {#bar-remarks}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/index.md
@@ -1,6 +1,6 @@
 # Foo
 
-[Packages](/) &gt; [test-suite-b](/test-suite-b/) &gt; [Foo](/test-suite-b/foo-interface/)
+[Packages](/) &gt; [test-suite-b](/test-suite-b) &gt; [Foo](/test-suite-b/foo-interface)
 
 Bar
 
@@ -14,4 +14,4 @@ export interface Foo
 
 | Property | Type | Description |
 | --- | --- | --- |
-| [bar](/test-suite-b/foo-interface/bar-propertysignature) | [TestEnum](/test-suite-a/testenum-enum/) | Test Enum |
+| [bar](/test-suite-b/foo-interface/bar-propertysignature) | [TestEnum](/test-suite-a/testenum-enum) | Test Enum |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/index.md
@@ -1,9 +1,9 @@
 # test-suite-b
 
-[Packages](/) &gt; [test-suite-b](/test-suite-b/)
+[Packages](/) &gt; [test-suite-b](/test-suite-b)
 
 ## Interfaces
 
 | Interface | Description |
 | --- | --- |
-| [Foo](/test-suite-b/foo-interface/) | Bar |
+| [Foo](/test-suite-b/foo-interface) | Bar |


### PR DESCRIPTION
E.g., A link to `foo/index.md` previously would have been expressed as `foo/`. Now it will be expressed as `foo`.

Note: the code change is in `ApiItemTransformationUtilities`. All other changes are test asset updates.