### PR TITLE
test(api-markdown-documenter): Remove confusing `uriRoot` in test cases and examples

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -32,7 +32,7 @@ const apiModel = await loadModel({
 
 const transformConfig = {
 	apiModel,
-	uriRoot: ".",
+	uriRoot: "",
 };
 
 await MarkdownRenderer.renderApiModel(transformConfig, {}, { outputDirectoryPath });
@@ -53,7 +53,7 @@ const apiModel = await loadModel({
 
 await MarkdownRenderer.renderApiModel({
 	apiModel,
-	uriRoot: ".",
+	uriRoot: "",
 	outputDirectoryPath,
 });
 ```

--- a/tools/api-markdown-documenter/README.md
+++ b/tools/api-markdown-documenter/README.md
@@ -86,7 +86,7 @@ const apiModel = await loadModel({
 
 await MarkdownRenderer.renderApiModel({
 	apiModel,
-	uriRoot: ".",
+	uriRoot: "",
 	outputDirectoryPath,
 });
 ```

--- a/tools/api-markdown-documenter/examples/RenderHtml.ts
+++ b/tools/api-markdown-documenter/examples/RenderHtml.ts
@@ -15,6 +15,6 @@ const apiModel = await loadModel({
 
 await HtmlRenderer.renderApiModel({
 	apiModel,
-	uriRoot: ".",
+	uriRoot: "",
 	outputDirectoryPath,
 });

--- a/tools/api-markdown-documenter/examples/RenderMarkdown.ts
+++ b/tools/api-markdown-documenter/examples/RenderMarkdown.ts
@@ -15,6 +15,6 @@ const apiModel = await loadModel({
 
 await MarkdownRenderer.renderApiModel({
 	apiModel,
-	uriRoot: ".",
+	uriRoot: "",
 	outputDirectoryPath,
 });

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
@@ -50,7 +50,7 @@ import { betaWarningSpan, wrapInSection } from "../helpers/index.js";
  * Sample "default" configuration.
  */
 const defaultPartialConfig: Omit<ApiItemTransformationOptions, "apiModel"> = {
-	uriRoot: ".",
+	uriRoot: "",
 };
 
 // Relative to lib/api-item-transforms/test
@@ -344,7 +344,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 								new TableBodyCellNode([
 									LinkNode.createFromPlainText(
 										"testOptionalInterfaceProperty",
-										"./test-package/testinterface-interface#testoptionalinterfaceproperty-propertysignature",
+										"/test-package/testinterface-interface#testoptionalinterfaceproperty-propertysignature",
 									),
 								]),
 								new TableBodyCellNode([
@@ -463,7 +463,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 								new TableBodyCellNode([
 									LinkNode.createFromPlainText(
 										"bar",
-										"./test-package/testnamespace-namespace/#bar-variable",
+										"/test-package/testnamespace-namespace/#bar-variable",
 									),
 								]),
 								new TableBodyCellNode([CodeSpanNode.createFromPlainText("Beta")]), // Alert
@@ -478,7 +478,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 								new TableBodyCellNode([
 									LinkNode.createFromPlainText(
 										"foo",
-										"./test-package/testnamespace-namespace/#foo-variable",
+										"/test-package/testnamespace-namespace/#foo-variable",
 									),
 								]),
 								TableBodyCellNode.Empty, // No alert for `@public`
@@ -583,9 +583,9 @@ describe("ApiItem to Documentation transformation tests", () => {
 						// Breadcrumb
 						new SectionNode([
 							new ParagraphNode([
-								LinkNode.createFromPlainText("Packages", "./"),
+								LinkNode.createFromPlainText("Packages", "/"),
 								new PlainTextNode(" > "),
-								LinkNode.createFromPlainText("test-package", "./test-package/"),
+								LinkNode.createFromPlainText("test-package", "/test-package/"),
 							]),
 						]),
 
@@ -595,11 +595,11 @@ describe("ApiItem to Documentation transformation tests", () => {
 								new UnorderedListNode([
 									LinkNode.createFromPlainText(
 										"entry-point-a",
-										"./test-package/entry-point-a-entrypoint",
+										"/test-package/entry-point-a-entrypoint",
 									),
 									LinkNode.createFromPlainText(
 										"entry-point-b",
-										"./test-package/entry-point-b-entrypoint",
+										"/test-package/entry-point-b-entrypoint",
 									),
 								]),
 							],
@@ -621,13 +621,13 @@ describe("ApiItem to Documentation transformation tests", () => {
 						// Breadcrumb
 						new SectionNode([
 							new ParagraphNode([
-								LinkNode.createFromPlainText("Packages", "./"),
+								LinkNode.createFromPlainText("Packages", "/"),
 								new PlainTextNode(" > "),
-								LinkNode.createFromPlainText("test-package", "./test-package/"),
+								LinkNode.createFromPlainText("test-package", "/test-package/"),
 								new PlainTextNode(" > "),
 								LinkNode.createFromPlainText(
 									"entry-point-a",
-									"./test-package/entry-point-a-entrypoint",
+									"/test-package/entry-point-a-entrypoint",
 								),
 							]),
 						]),
@@ -641,7 +641,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 											new TableBodyCellNode([
 												LinkNode.createFromPlainText(
 													"hello",
-													"./test-package/#hello-variable",
+													"/test-package/#hello-variable",
 												),
 											]),
 											new TableBodyCellNode([
@@ -707,13 +707,13 @@ describe("ApiItem to Documentation transformation tests", () => {
 						// Breadcrumb
 						new SectionNode([
 							new ParagraphNode([
-								LinkNode.createFromPlainText("Packages", "./"),
+								LinkNode.createFromPlainText("Packages", "/"),
 								new PlainTextNode(" > "),
-								LinkNode.createFromPlainText("test-package", "./test-package/"),
+								LinkNode.createFromPlainText("test-package", "/test-package/"),
 								new PlainTextNode(" > "),
 								LinkNode.createFromPlainText(
 									"entry-point-b",
-									"./test-package/entry-point-b-entrypoint",
+									"/test-package/entry-point-b-entrypoint",
 								),
 							]),
 						]),
@@ -727,7 +727,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 											new TableBodyCellNode([
 												LinkNode.createFromPlainText(
 													"world",
-													"./test-package/#world-variable",
+													"/test-package/#world-variable",
 												),
 											]),
 											TableBodyCellNode.Empty, // Type

--- a/tools/api-markdown-documenter/src/test/HtmlEndToEnd.test.ts
+++ b/tools/api-markdown-documenter/src/test/HtmlEndToEnd.test.ts
@@ -37,7 +37,7 @@ const testConfigs = new Map<
 	[
 		"default-config",
 		{
-			uriRoot: ".",
+			uriRoot: "",
 		},
 	],
 

--- a/tools/api-markdown-documenter/src/test/MarkdownEndToEnd.test.ts
+++ b/tools/api-markdown-documenter/src/test/MarkdownEndToEnd.test.ts
@@ -37,7 +37,7 @@ const testConfigs = new Map<
 	[
 		"default-config",
 		{
-			uriRoot: ".",
+			uriRoot: "",
 		},
 	],
 

--- a/tools/api-markdown-documenter/src/test/TransformApiModelEndToEnd.test.ts
+++ b/tools/api-markdown-documenter/src/test/TransformApiModelEndToEnd.test.ts
@@ -18,7 +18,7 @@ const testConfigs = new Map<string, Omit<ApiItemTransformationOptions, "apiModel
 	[
 		"default-config",
 		{
-			uriRoot: ".",
+			uriRoot: "",
 		},
 	],
 

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/index.html
@@ -17,11 +17,11 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/">test-suite-a</a></td>
+              <td><a href="/test-suite-a/">test-suite-a</a></td>
               <td>Test package</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-b/">test-suite-b</a></td>
+              <td><a href="/test-suite-b/">test-suite-b</a></td>
               <td></td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>test-suite-a</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a></p>
       </section>
       <section>
         <p>Test package</p>
@@ -23,8 +23,8 @@
           <p>2. List item 2</p>
           <p>3. List item 3</p>
           <p>Also, here is a link test, including a bad link, because we should have some reasonable support if this happens:</p>
-          <p>- Good link (no alias): <a href="./test-suite-a/testclass-class">TestClass</a></p>
-          <p>- Good link (with alias): <a href="./test-suite-a/#testfunction-function">function alias text</a></p>
+          <p>- Good link (no alias): <a href="/test-suite-a/testclass-class">TestClass</a></p>
+          <p>- Good link (with alias): <a href="/test-suite-a/#testfunction-function">function alias text</a></p>
           <p>- Bad link (no alias): <span><i>InvalidItem</i></span></p>
           <p>- Bad link (with alias): <span><i>even though I link to an invalid item, I would still like this text to be rendered</i></span></p>
         </p>
@@ -46,23 +46,23 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testemptyinterface-interface">TestEmptyInterface</a></td>
+              <td><a href="/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a></td>
               <td>An empty interface</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testinterface-interface">TestInterface</a></td>
+              <td><a href="/test-suite-a/testinterface-interface">TestInterface</a></td>
               <td>Test interface</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testinterfaceextendingotherinterfaces-interface">TestInterfaceExtendingOtherInterfaces</a></td>
+              <td><a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface">TestInterfaceExtendingOtherInterfaces</a></td>
               <td>Test interface that extends other interfaces</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testinterfacewithindexsignature-interface">TestInterfaceWithIndexSignature</a></td>
+              <td><a href="/test-suite-a/testinterfacewithindexsignature-interface">TestInterfaceWithIndexSignature</a></td>
               <td>An interface with an index signature.</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a></td>
+              <td><a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a></td>
               <td>Test interface with generic type parameter</td>
             </tr>
           </tbody>
@@ -79,11 +79,11 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testabstractclass-class">TestAbstractClass</a></td>
+              <td><a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a></td>
               <td>A test abstract class.</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testclass-class">TestClass</a></td>
+              <td><a href="/test-suite-a/testclass-class">TestClass</a></td>
               <td>Test class</td>
             </tr>
           </tbody>
@@ -100,7 +100,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testenum-enum">TestEnum</a></td>
+              <td><a href="/test-suite-a/testenum-enum">TestEnum</a></td>
               <td>Test Enum</td>
             </tr>
           </tbody>
@@ -117,11 +117,11 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testmappedtype-typealias">TestMappedType</a></td>
-              <td>Test Mapped Type, using <a href="./test-suite-a/testenum-enum">TestEnum</a></td>
+              <td><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></td>
+              <td>Test Mapped Type, using <a href="/test-suite-a/testenum-enum">TestEnum</a></td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/typealias-typealias">TypeAlias</a></td>
+              <td><a href="/test-suite-a/typealias-typealias">TypeAlias</a></td>
               <td>Test Type-Alias</td>
             </tr>
           </tbody>
@@ -140,27 +140,27 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/#testfunction-function">testFunction(testParameter, testOptionalParameter)</a></td>
+              <td><a href="/test-suite-a/#testfunction-function">testFunction(testParameter, testOptionalParameter)</a></td>
               <td><code>Alpha</code></td>
               <td><span>TTypeParameter</span></td>
               <td>Test function</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/#testfunctionreturninginlinetype-function">testFunctionReturningInlineType()</a></td>
+              <td><a href="/test-suite-a/#testfunctionreturninginlinetype-function">testFunctionReturningInlineType()</a></td>
               <td></td>
-              <td><span>{ foo: number; bar: <a href="./test-suite-a/testenum-enum">TestEnum</a>; }</span></td>
+              <td><span>{ foo: number; bar: <a href="/test-suite-a/testenum-enum">TestEnum</a>; }</span></td>
               <td>Test function that returns an inline type</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/#testfunctionreturningintersectiontype-function">testFunctionReturningIntersectionType()</a></td>
+              <td><a href="/test-suite-a/#testfunctionreturningintersectiontype-function">testFunctionReturningIntersectionType()</a></td>
               <td><code>Deprecated</code></td>
-              <td><span><a href="./test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="./test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></td>
+              <td><span><a href="/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></td>
               <td>Test function that returns an inline type</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/#testfunctionreturninguniontype-function">testFunctionReturningUnionType()</a></td>
+              <td><a href="/test-suite-a/#testfunctionreturninguniontype-function">testFunctionReturningUnionType()</a></td>
               <td></td>
-              <td><span>string | <a href="./test-suite-a/testinterface-interface">TestInterface</a></span></td>
+              <td><span>string | <a href="/test-suite-a/testinterface-interface">TestInterface</a></span></td>
               <td>Test function that returns an inline type</td>
             </tr>
           </tbody>
@@ -180,14 +180,14 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/#testconst-variable">testConst</a></td>
+              <td><a href="/test-suite-a/#testconst-variable">testConst</a></td>
               <td><code>Beta</code></td>
               <td><code>readonly</code></td>
               <td></td>
               <td>Test Constant</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/#testconstwithemptydeprecatedblock-variable">testConstWithEmptyDeprecatedBlock</a></td>
+              <td><a href="/test-suite-a/#testconstwithemptydeprecatedblock-variable">testConstWithEmptyDeprecatedBlock</a></td>
               <td><code>Deprecated</code></td>
               <td><code>readonly</code></td>
               <td><span>string</span></td>
@@ -207,11 +207,11 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testmodule-namespace/">TestModule</a></td>
+              <td><a href="/test-suite-a/testmodule-namespace/">TestModule</a></td>
               <td></td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/">TestNamespace</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a></td>
               <td>Test Namespace</td>
             </tr>
           </tbody>
@@ -242,8 +242,8 @@
                   <tbody>
                     <tr>
                       <td>TTypeParameter</td>
-                      <td><span><a href="./test-suite-a/testinterface-interface">TestInterface</a></span></td>
-                      <td><span><a href="./test-suite-a/testinterface-interface">TestInterface</a></span></td>
+                      <td><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span></td>
+                      <td><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span></td>
                       <td>A test type parameter</td>
                     </tr>
                   </tbody>
@@ -253,7 +253,7 @@
           </section>
           <section>
             <h4 id="testfunction-remarks">Remarks</h4>
-            <p>This is a test <a href="./test-suite-a/testinterface-interface">link</a> to another API member</p>
+            <p>This is a test <a href="/test-suite-a/testinterface-interface">link</a> to another API member</p>
           </section>
           <section>
             <h4 id="testfunction-parameters">Parameters</h4>
@@ -303,7 +303,7 @@
           <section>
             <h4 id="testfunctionreturninginlinetype-returns">Returns</h4>
             <p>An inline type</p>
-            <p><span><b>Return type: </b></span><span>{ foo: number; bar: <a href="./test-suite-a/testenum-enum">TestEnum</a>; }</span></p>
+            <p><span><b>Return type: </b></span><span>{ foo: number; bar: <a href="/test-suite-a/testenum-enum">TestEnum</a>; }</span></p>
           </section>
         </section>
         <section>
@@ -312,7 +312,7 @@
             <p>Test function that returns an inline type</p>
           </section>
           <section>
-            <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br><span><p><i>This is a test deprecation notice. Here is a </i><a href="./test-suite-a/#testfunctionreturninguniontype-function"><i>link</i></a><i> to something else!</i></p></span></p>
+            <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br><span><p><i>This is a test deprecation notice. Here is a </i><a href="/test-suite-a/#testfunctionreturninguniontype-function"><i>link</i></a><i> to something else!</i></p></span></p>
           </section>
           <section>
             <h4 id="testfunctionreturningintersectiontype-signature">Signature</h4><code>export declare function testFunctionReturningIntersectionType(): TestEmptyInterface &#x26; TestInterfaceWithTypeParameter&#x3C;number>;</code>
@@ -320,7 +320,7 @@
           <section>
             <h4 id="testfunctionreturningintersectiontype-returns">Returns</h4>
             <p>an intersection type</p>
-            <p><span><b>Return type: </b></span><span><a href="./test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="./test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></p>
+            <p><span><b>Return type: </b></span><span><a href="/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></p>
           </section>
         </section>
         <section>
@@ -334,7 +334,7 @@
           <section>
             <h4 id="testfunctionreturninguniontype-returns">Returns</h4>
             <p>A union type</p>
-            <p><span><b>Return type: </b></span><span>string | <a href="./test-suite-a/testinterface-interface">TestInterface</a></span></p>
+            <p><span><b>Return type: </b></span><span>string | <a href="/test-suite-a/testinterface-interface">TestInterface</a></span></p>
           </section>
         </section>
       </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testabstractclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testabstractclass-class.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestAbstractClass</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testabstractclass-class">TestAbstractClass</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a></p>
       </section>
       <section>
         <p>A test abstract class.</p>
@@ -26,7 +26,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testabstractclass-class#_constructor_-constructor">(constructor)(privateProperty, protectedProperty)</a></td>
+              <td><a href="/test-suite-a/testabstractclass-class#_constructor_-constructor">(constructor)(privateProperty, protectedProperty)</a></td>
               <td>This is a <span><i>{@customTag constructor}</i></span>.</td>
             </tr>
           </tbody>
@@ -45,15 +45,15 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testabstractclass-class#abstractpropertygetter-property">abstractPropertyGetter</a></td>
+              <td><a href="/test-suite-a/testabstractclass-class#abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="./test-suite-a/testmappedtype-typealias">TestMappedType</a></span></td>
+              <td><span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></td>
               <td>A test abstract getter property.</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testabstractclass-class#protectedproperty-property">protectedProperty</a></td>
+              <td><a href="/test-suite-a/testabstractclass-class#protectedproperty-property">protectedProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="./test-suite-a/testenum-enum">TestEnum</a></span></td>
+              <td><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></td>
               <td>A test protected property.</td>
             </tr>
           </tbody>
@@ -72,19 +72,19 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testabstractclass-class#publicabstractmethod-method">publicAbstractMethod()</a></td>
+              <td><a href="/test-suite-a/testabstractclass-class#publicabstractmethod-method">publicAbstractMethod()</a></td>
               <td></td>
               <td><span>void</span></td>
               <td>A test public abstract method.</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testabstractclass-class#sealedmethod-method">sealedMethod()</a></td>
+              <td><a href="/test-suite-a/testabstractclass-class#sealedmethod-method">sealedMethod()</a></td>
               <td><code>sealed</code></td>
               <td><span>string</span></td>
               <td>A test <code>@sealed</code> method.</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testabstractclass-class#virtualmethod-method">virtualMethod()</a></td>
+              <td><a href="/test-suite-a/testabstractclass-class#virtualmethod-method">virtualMethod()</a></td>
               <td><code>virtual</code></td>
               <td><span>number</span></td>
               <td>A test <code>@virtual</code> method.</td>
@@ -120,7 +120,7 @@
                 </tr>
                 <tr>
                   <td>protectedProperty</td>
-                  <td><span><a href="./test-suite-a/testenum-enum">TestEnum</a></span></td>
+                  <td><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></td>
                   <td></td>
                 </tr>
               </tbody>
@@ -137,7 +137,7 @@
           </section>
           <section>
             <h4 id="abstractpropertygetter-signature">Signature</h4><code>abstract get abstractPropertyGetter(): TestMappedType;</code>
-            <p><span><span><b>Type: </b></span><span><a href="./test-suite-a/testmappedtype-typealias">TestMappedType</a></span></span></p>
+            <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></span></p>
           </section>
         </section>
         <section>
@@ -147,7 +147,7 @@
           </section>
           <section>
             <h4 id="protectedproperty-signature">Signature</h4><code>protected readonly protectedProperty: TestEnum;</code>
-            <p><span><span><b>Type: </b></span><span><a href="./test-suite-a/testenum-enum">TestEnum</a></span></span></p>
+            <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></span></p>
           </section>
         </section>
       </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testclass-class.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestClass</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testclass-class">TestClass</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testclass-class">TestClass</a></p>
       </section>
       <section>
         <p>Test class</p>
@@ -15,7 +15,7 @@
       <section>
         <h2 id="testclass-signature">Signature</h2><code>export declare class TestClass&#x3C;TTypeParameterA, TTypeParameterB> extends TestAbstractClass</code>
         <p>
-          <p><span><span><b>Extends: </b></span><span><a href="./test-suite-a/testabstractclass-class">TestAbstractClass</a></span></span></p>
+          <p><span><span><b>Extends: </b></span><span><a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a></span></span></p>
           <p>
             <section>
               <h3>Type Parameters</h3>
@@ -56,7 +56,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testclass-class#_constructor_-constructor">(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)</a></td>
+              <td><a href="/test-suite-a/testclass-class#_constructor_-constructor">(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)</a></td>
               <td>Test class constructor</td>
             </tr>
           </tbody>
@@ -74,7 +74,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testclass-class#testclassstaticproperty-property">testClassStaticProperty</a></td>
+              <td><a href="/test-suite-a/testclass-class#testclassstaticproperty-property">testClassStaticProperty</a></td>
               <td><span>(foo: number) => string</span></td>
               <td>Test static class property</td>
             </tr>
@@ -93,7 +93,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testclass-class#testclassstaticmethod-method">testClassStaticMethod(foo)</a></td>
+              <td><a href="/test-suite-a/testclass-class#testclassstaticmethod-method">testClassStaticMethod(foo)</a></td>
               <td><span>string</span></td>
               <td>Test class static method</td>
             </tr>
@@ -113,7 +113,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testclass-class#testclasseventproperty-property">testClassEventProperty</a></td>
+              <td><a href="/test-suite-a/testclass-class#testclasseventproperty-property">testClassEventProperty</a></td>
               <td><code>readonly</code></td>
               <td><span>() => void</span></td>
               <td>Test class event property</td>
@@ -134,19 +134,19 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testclass-class#abstractpropertygetter-property">abstractPropertyGetter</a></td>
+              <td><a href="/test-suite-a/testclass-class#abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="./test-suite-a/testmappedtype-typealias">TestMappedType</a></span></td>
+              <td><span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></td>
               <td>A test abstract getter property.</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testclass-class#testclassgetterproperty-property">testClassGetterProperty</a></td>
+              <td><a href="/test-suite-a/testclass-class#testclassgetterproperty-property">testClassGetterProperty</a></td>
               <td><code>virtual</code></td>
               <td><span>number</span></td>
               <td>Test class property with both a getter and a setter.</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testclass-class#testclassproperty-property">testClassProperty</a></td>
+              <td><a href="/test-suite-a/testclass-class#testclassproperty-property">testClassProperty</a></td>
               <td><code>readonly</code></td>
               <td><span>TTypeParameterB</span></td>
               <td>Test class property</td>
@@ -167,22 +167,22 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testclass-class#publicabstractmethod-method">publicAbstractMethod()</a></td>
+              <td><a href="/test-suite-a/testclass-class#publicabstractmethod-method">publicAbstractMethod()</a></td>
               <td></td>
               <td><span>void</span></td>
               <td>A test public abstract method.</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testclass-class#testclassmethod-method">testClassMethod(input)</a></td>
+              <td><a href="/test-suite-a/testclass-class#testclassmethod-method">testClassMethod(input)</a></td>
               <td><code>sealed</code></td>
               <td><span>TTypeParameterA</span></td>
               <td>Test class method</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testclass-class#virtualmethod-method">virtualMethod()</a></td>
+              <td><a href="/test-suite-a/testclass-class#virtualmethod-method">virtualMethod()</a></td>
               <td></td>
               <td><span>number</span></td>
-              <td>Overrides <a href="./test-suite-a/testabstractclass-class#virtualmethod-method">virtualMethod()</a>.</td>
+              <td>Overrides <a href="/test-suite-a/testabstractclass-class#virtualmethod-method">virtualMethod()</a>.</td>
             </tr>
           </tbody>
         </table>
@@ -215,25 +215,25 @@
                 <tr>
                   <td>privateProperty</td>
                   <td><span>number</span></td>
-                  <td>See <a href="./test-suite-a/testabstractclass-class">TestAbstractClass</a>'s constructor.</td>
+                  <td>See <a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a>'s constructor.</td>
                 </tr>
                 <tr>
                   <td>protectedProperty</td>
-                  <td><span><a href="./test-suite-a/testenum-enum">TestEnum</a></span></td>
+                  <td><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></td>
                   <td>
                     <p>Some notes about the parameter.</p>
-                    <p>See <a href="./test-suite-a/testabstractclass-class#protectedproperty-property">protectedProperty</a>.</p>
+                    <p>See <a href="/test-suite-a/testabstractclass-class#protectedproperty-property">protectedProperty</a>.</p>
                   </td>
                 </tr>
                 <tr>
                   <td>testClassProperty</td>
                   <td><span>TTypeParameterB</span></td>
-                  <td>See <a href="./test-suite-a/testclass-class#testclassproperty-property">testClassProperty</a>.</td>
+                  <td>See <a href="/test-suite-a/testclass-class#testclassproperty-property">testClassProperty</a>.</td>
                 </tr>
                 <tr>
                   <td>testClassEventProperty</td>
                   <td><span>() => void</span></td>
-                  <td>See <a href="./test-suite-a/testclass-class#testclasseventproperty-property">testClassEventProperty</a>.</td>
+                  <td>See <a href="/test-suite-a/testclass-class#testclasseventproperty-property">testClassEventProperty</a>.</td>
                 </tr>
               </tbody>
             </table>
@@ -266,7 +266,7 @@
           </section>
           <section>
             <h4 id="abstractpropertygetter-signature">Signature</h4><code>get abstractPropertyGetter(): TestMappedType;</code>
-            <p><span><span><b>Type: </b></span><span><a href="./test-suite-a/testmappedtype-typealias">TestMappedType</a></span></span></p>
+            <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></span></p>
           </section>
         </section>
         <section>
@@ -396,7 +396,7 @@
         <section>
           <h3 id="virtualmethod-method">virtualMethod</h3>
           <section>
-            <p>Overrides <a href="./test-suite-a/testabstractclass-class#virtualmethod-method">virtualMethod()</a>.</p>
+            <p>Overrides <a href="/test-suite-a/testabstractclass-class#virtualmethod-method">virtualMethod()</a>.</p>
           </section>
           <section>
             <h4 id="virtualmethod-signature">Signature</h4><code>/** @override */<br>protected virtualMethod(): number;</code>
@@ -409,7 +409,7 @@
       </section>
       <section>
         <h2 id="testclass-see-also">See Also</h2>
-        <p><a href="./test-suite-a/testabstractclass-class">TestAbstractClass</a></p>
+        <p><a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testemptyinterface-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testemptyinterface-interface.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestEmptyInterface</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testemptyinterface-interface">TestEmptyInterface</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a></p>
       </section>
       <section>
         <p>An empty interface</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testenum-enum.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testenum-enum.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestEnum</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testenum-enum">TestEnum</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testenum-enum">TestEnum</a></p>
       </section>
       <section>
         <p>Test Enum</p>
@@ -45,15 +45,15 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testenum-enum#testenumvalue1-enummember">TestEnumValue1</a></td>
+              <td><a href="/test-suite-a/testenum-enum#testenumvalue1-enummember">TestEnumValue1</a></td>
               <td>Test enum value 1 (string)</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testenum-enum#testenumvalue2-enummember">TestEnumValue2</a></td>
+              <td><a href="/test-suite-a/testenum-enum#testenumvalue2-enummember">TestEnumValue2</a></td>
               <td>Test enum value 2 (number)</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testenum-enum#testenumvalue3-enummember">TestEnumValue3</a></td>
+              <td><a href="/test-suite-a/testenum-enum#testenumvalue3-enummember">TestEnumValue3</a></td>
               <td>Test enum value 3 (default)</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterface-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterface-interface.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestInterface</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testinterface-interface">TestInterface</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterface-interface">TestInterface</a></p>
       </section>
       <section>
         <p>Test interface</p>
@@ -31,8 +31,8 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testinterface-interface#_new_-constructsignature">new (): TestInterface</a></td>
-              <td><span><a href="./test-suite-a/testinterface-interface">TestInterface</a></span></td>
+              <td><a href="/test-suite-a/testinterface-interface#_new_-constructsignature">new (): TestInterface</a></td>
+              <td><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span></td>
               <td>Test construct signature.</td>
             </tr>
           </tbody>
@@ -51,7 +51,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testinterface-interface#testclasseventproperty-propertysignature">testClassEventProperty</a></td>
+              <td><a href="/test-suite-a/testinterface-interface#testclasseventproperty-propertysignature">testClassEventProperty</a></td>
               <td><code>readonly</code></td>
               <td><span>() => void</span></td>
               <td>Test interface event property</td>
@@ -73,35 +73,35 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testinterface-interface#getterproperty-property">getterProperty</a></td>
+              <td><a href="/test-suite-a/testinterface-interface#getterproperty-property">getterProperty</a></td>
               <td><code>readonly</code></td>
               <td></td>
               <td><span>boolean</span></td>
               <td>A test getter-only interface property.</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testinterface-interface#propertywithbadinheritdoctarget-propertysignature">propertyWithBadInheritDocTarget</a></td>
+              <td><a href="/test-suite-a/testinterface-interface#propertywithbadinheritdoctarget-propertysignature">propertyWithBadInheritDocTarget</a></td>
               <td></td>
               <td></td>
               <td><span>boolean</span></td>
               <td></td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testinterface-interface#setterproperty-property">setterProperty</a></td>
+              <td><a href="/test-suite-a/testinterface-interface#setterproperty-property">setterProperty</a></td>
               <td></td>
               <td></td>
               <td><span>boolean</span></td>
               <td>A test property with a getter and a setter.</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testinterface-interface#testinterfaceproperty-propertysignature">testInterfaceProperty</a></td>
+              <td><a href="/test-suite-a/testinterface-interface#testinterfaceproperty-propertysignature">testInterfaceProperty</a></td>
               <td></td>
               <td></td>
               <td><span>number</span></td>
               <td>Test interface property</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testinterface-interface#testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></td>
+              <td><a href="/test-suite-a/testinterface-interface#testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></td>
               <td><code>optional</code></td>
               <td>0</td>
               <td><span>number</span></td>
@@ -122,7 +122,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testinterface-interface#testinterfacemethod-methodsignature">testInterfaceMethod()</a></td>
+              <td><a href="/test-suite-a/testinterface-interface#testinterfacemethod-methodsignature">testInterfaceMethod()</a></td>
               <td><span>void</span></td>
               <td>Test interface method</td>
             </tr>
@@ -140,11 +140,11 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testinterface-interface#_call_-callsignature">(event: 'testCallSignature', listener: (input: unknown) => void): any</a></td>
+              <td><a href="/test-suite-a/testinterface-interface#_call_-callsignature">(event: 'testCallSignature', listener: (input: unknown) => void): any</a></td>
               <td>Test interface event call signature</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testinterface-interface#_call__1-callsignature">(event: 'anotherTestCallSignature', listener: (input: number) => string): number</a></td>
+              <td><a href="/test-suite-a/testinterface-interface#_call__1-callsignature">(event: 'anotherTestCallSignature', listener: (input: number) => string): number</a></td>
               <td>Another example call signature</td>
             </tr>
           </tbody>
@@ -162,7 +162,7 @@
           </section>
           <section>
             <h4 id="_new_-returns">Returns</h4>
-            <p><span><b>Return type: </b></span><span><a href="./test-suite-a/testinterface-interface">TestInterface</a></span></p>
+            <p><span><b>Return type: </b></span><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span></p>
           </section>
         </section>
       </section>
@@ -287,10 +287,10 @@
       </section>
       <section>
         <h2 id="testinterface-see-also">See Also</h2>
-        <p><a href="./test-suite-a/testinterface-interface#testinterfacemethod-methodsignature">testInterfaceMethod()</a></p>
-        <p><a href="./test-suite-a/testinterface-interface#testinterfaceproperty-propertysignature">testInterfaceProperty</a></p>
-        <p><a href="./test-suite-a/testinterface-interface#testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></p>
-        <p><a href="./test-suite-a/testinterface-interface#testclasseventproperty-propertysignature">testClassEventProperty</a></p>
+        <p><a href="/test-suite-a/testinterface-interface#testinterfacemethod-methodsignature">testInterfaceMethod()</a></p>
+        <p><a href="/test-suite-a/testinterface-interface#testinterfaceproperty-propertysignature">testInterfaceProperty</a></p>
+        <p><a href="/test-suite-a/testinterface-interface#testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></p>
+        <p><a href="/test-suite-a/testinterface-interface#testclasseventproperty-propertysignature">testClassEventProperty</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.html
@@ -7,14 +7,14 @@
     <section>
       <h1>TestInterfaceExtendingOtherInterfaces</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testinterfaceextendingotherinterfaces-interface">TestInterfaceExtendingOtherInterfaces</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface">TestInterfaceExtendingOtherInterfaces</a></p>
       </section>
       <section>
         <p>Test interface that extends other interfaces</p>
       </section>
       <section>
         <h2 id="testinterfaceextendingotherinterfaces-signature">Signature</h2><code>export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter&#x3C;number></code>
-        <p><span><span><b>Extends: </b></span><span><a href="./test-suite-a/testinterface-interface">TestInterface</a></span>, <span><a href="./test-suite-a/testmappedtype-typealias">TestMappedType</a></span>, <span><a href="./test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></span></p>
+        <p><span><span><b>Extends: </b></span><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span>, <span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span>, <span><a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></span></p>
       </section>
       <section>
         <h2 id="testinterfaceextendingotherinterfaces-remarks">Remarks</h2>
@@ -32,7 +32,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testinterfaceextendingotherinterfaces-interface#testmethod-methodsignature">testMethod(input)</a></td>
+              <td><a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface#testmethod-methodsignature">testMethod(input)</a></td>
               <td><span>number</span></td>
               <td>Test interface method accepting a string and returning a number.</td>
             </tr>
@@ -82,9 +82,9 @@
       <section>
         <h2 id="testinterfaceextendingotherinterfaces-see-also">See Also</h2>
         <p>
-          <p>- <a href="./test-suite-a/testinterface-interface">TestInterface</a></p>
-          <p>- <a href="./test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a></p>
-          <p>- <a href="./test-suite-a/testmappedtype-typealias">TestMappedType</a></p>
+          <p>- <a href="/test-suite-a/testinterface-interface">TestInterface</a></p>
+          <p>- <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a></p>
+          <p>- <a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></p>
         </p>
       </section>
     </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterfacewithindexsignature-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterfacewithindexsignature-interface.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestInterfaceWithIndexSignature</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testinterfacewithindexsignature-interface">TestInterfaceWithIndexSignature</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithindexsignature-interface">TestInterfaceWithIndexSignature</a></p>
       </section>
       <section>
         <p>An interface with an index signature.</p>
@@ -26,7 +26,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testinterfacewithindexsignature-interface#_indexer_-indexsignature">[foo: number]: { bar: string; }</a></td>
+              <td><a href="/test-suite-a/testinterfacewithindexsignature-interface#_indexer_-indexsignature">[foo: number]: { bar: string; }</a></td>
               <td>Test index signature.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterfacewithtypeparameter-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterfacewithtypeparameter-interface.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestInterfaceWithTypeParameter</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a></p>
       </section>
       <section>
         <p>Test interface with generic type parameter</p>
@@ -50,7 +50,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testinterfacewithtypeparameter-interface#testproperty-propertysignature">testProperty</a></td>
+              <td><a href="/test-suite-a/testinterfacewithtypeparameter-interface#testproperty-propertysignature">testProperty</a></td>
               <td><span>T</span></td>
               <td>A test interface property using generic type parameter</td>
             </tr>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testmappedtype-typealias.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testmappedtype-typealias.html
@@ -7,10 +7,10 @@
     <section>
       <h1>TestMappedType</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testmappedtype-typealias">TestMappedType</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></p>
       </section>
       <section>
-        <p>Test Mapped Type, using <a href="./test-suite-a/testenum-enum">TestEnum</a></p>
+        <p>Test Mapped Type, using <a href="/test-suite-a/testenum-enum">TestEnum</a></p>
       </section>
       <section>
         <h2 id="testmappedtype-signature">Signature</h2><code>export type TestMappedType = {<br>[K in TestEnum]: boolean;<br>};</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testmodule-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testmodule-namespace/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestModule</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testmodule-namespace/">TestModule</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testmodule-namespace/">TestModule</a></p>
       </section>
       <section>
         <h2>Variables</h2>
@@ -22,7 +22,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testmodule-namespace/#foo-variable">foo</a></td>
+              <td><a href="/test-suite-a/testmodule-namespace/#foo-variable">foo</a></td>
               <td><code>readonly</code></td>
               <td></td>
               <td>Test constant in module.</td>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestNamespace</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testnamespace-namespace/">TestNamespace</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a></p>
       </section>
       <section>
         <p>Test Namespace</p>
@@ -46,7 +46,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/testinterface-interface">TestInterface</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testinterface-interface">TestInterface</a></td>
               <td><code>Alpha</code></td>
               <td>Test interface</td>
             </tr>
@@ -64,7 +64,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/testclass-class">TestClass</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testclass-class">TestClass</a></td>
               <td>Test class</td>
             </tr>
           </tbody>
@@ -81,7 +81,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a></td>
               <td>Test Enum</td>
             </tr>
           </tbody>
@@ -98,7 +98,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/testtypealias-typealias">TestTypeAlias</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testtypealias-typealias">TestTypeAlias</a></td>
               <td>Test Type-Alias</td>
             </tr>
           </tbody>
@@ -116,7 +116,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/#testfunction-function">testFunction(testParameter)</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/#testfunction-function">testFunction(testParameter)</a></td>
               <td><span>number</span></td>
               <td>Test function</td>
             </tr>
@@ -137,7 +137,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/#testconst-variable">TestConst</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/#testconst-variable">TestConst</a></td>
               <td><code>Beta</code></td>
               <td><code>readonly</code></td>
               <td></td>
@@ -157,7 +157,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/testsubnamespace-namespace/">TestSubNamespace</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/">TestSubNamespace</a></td>
               <td>Test sub-namespace</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testclass-class.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestClass</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="./test-suite-a/testnamespace-namespace/testclass-class">TestClass</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testclass-class">TestClass</a></p>
       </section>
       <section>
         <p>Test class</p>
@@ -26,7 +26,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/testclass-class#_constructor_-constructor">(constructor)(testClassProperty)</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testclass-class#_constructor_-constructor">(constructor)(testClassProperty)</a></td>
               <td>Test class constructor</td>
             </tr>
           </tbody>
@@ -45,7 +45,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/testclass-class#testclassproperty-property">testClassProperty</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testclass-class#testclassproperty-property">testClassProperty</a></td>
               <td><code>readonly</code></td>
               <td><span>string</span></td>
               <td>Test interface property</td>
@@ -65,7 +65,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/testclass-class#testclassmethod-method">testClassMethod(testParameter)</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testclass-class#testclassmethod-method">testClassMethod(testParameter)</a></td>
               <td><span>Promise&#x3C;string></span></td>
               <td>Test class method</td>
             </tr>
@@ -96,7 +96,7 @@
                 <tr>
                   <td>testClassProperty</td>
                   <td><span>string</span></td>
-                  <td>See <a href="./test-suite-a/testclass-class#testclassproperty-property">testClassProperty</a></td>
+                  <td>See <a href="/test-suite-a/testclass-class#testclassproperty-property">testClassProperty</a></td>
                 </tr>
               </tbody>
             </table>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testenum-enum.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testenum-enum.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestEnum</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="./test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a></p>
       </section>
       <section>
         <p>Test Enum</p>
@@ -26,11 +26,11 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/testenum-enum#testenumvalue1-enummember">TestEnumValue1</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testenum-enum#testenumvalue1-enummember">TestEnumValue1</a></td>
               <td>Test enum value 1</td>
             </tr>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/testenum-enum#testenumvalue2-enummember">TestEnumValue2</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testenum-enum#testenumvalue2-enummember">TestEnumValue2</a></td>
               <td>Test enum value 2</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testinterface-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testinterface-interface.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestInterface</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="./test-suite-a/testnamespace-namespace/testinterface-interface">TestInterface</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testinterface-interface">TestInterface</a></p>
       </section>
       <section>
         <p>Test interface</p>
@@ -15,7 +15,7 @@
       <section><span><b>WARNING: This API is provided as an alpha preview and may change without notice. Use at your own risk.</b></span></section>
       <section>
         <h2 id="testinterface-signature">Signature</h2><code>interface TestInterface extends TestInterfaceWithTypeParameter&#x3C;TestEnum></code>
-        <p><span><span><b>Extends: </b></span><span><a href="./test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;<a href="./test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a>></span></span></p>
+        <p><span><span><b>Extends: </b></span><span><a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;<a href="/test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a>></span></span></p>
       </section>
       <section>
         <h2>Properties</h2>
@@ -30,7 +30,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/testinterface-interface#testinterfaceproperty-propertysignature">testInterfaceProperty</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testinterface-interface#testinterfaceproperty-propertysignature">testInterfaceProperty</a></td>
               <td><code>Alpha</code></td>
               <td><span>boolean</span></td>
               <td>Test interface property</td>
@@ -51,7 +51,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-a/testnamespace-namespace/testinterface-interface#testinterfacemethod-methodsignature">testInterfaceMethod()</a></td>
+              <td><a href="/test-suite-a/testnamespace-namespace/testinterface-interface#testinterfacemethod-methodsignature">testInterfaceMethod()</a></td>
               <td><code>Alpha</code></td>
               <td><span>void</span></td>
               <td>Test interface method</td>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestSubNamespace</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="./test-suite-a/testnamespace-namespace/testsubnamespace-namespace/">TestSubNamespace</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/">TestSubNamespace</a></p>
       </section>
       <section>
         <p>Test sub-namespace</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testtypealias-typealias.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testtypealias-typealias.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TestTypeAlias</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="./test-suite-a/testnamespace-namespace/testtypealias-typealias">TestTypeAlias</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testnamespace-namespace/">TestNamespace</a> > <a href="/test-suite-a/testnamespace-namespace/testtypealias-typealias">TestTypeAlias</a></p>
       </section>
       <section>
         <p>Test Type-Alias</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/typealias-typealias.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/typealias-typealias.html
@@ -7,7 +7,7 @@
     <section>
       <h1>TypeAlias</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-a/">test-suite-a</a> > <a href="./test-suite-a/typealias-typealias">TypeAlias</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/typealias-typealias">TypeAlias</a></p>
       </section>
       <section>
         <p>Test Type-Alias</p>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-b/foo-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-b/foo-interface.html
@@ -7,7 +7,7 @@
     <section>
       <h1>Foo</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-b/">test-suite-b</a> > <a href="./test-suite-b/foo-interface">Foo</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-b/">test-suite-b</a> > <a href="/test-suite-b/foo-interface">Foo</a></p>
       </section>
       <section>
         <p>Bar</p>
@@ -27,8 +27,8 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-b/foo-interface#bar-propertysignature">bar</a></td>
-              <td><span><a href="./test-suite-a/testenum-enum">TestEnum</a></span></td>
+              <td><a href="/test-suite-b/foo-interface#bar-propertysignature">bar</a></td>
+              <td><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></td>
               <td>Test Enum</td>
             </tr>
           </tbody>
@@ -43,7 +43,7 @@
           </section>
           <section>
             <h4 id="bar-signature">Signature</h4><code>bar: TestEnum;</code>
-            <p><span><span><b>Type: </b></span><span><a href="./test-suite-a/testenum-enum">TestEnum</a></span></span></p>
+            <p><span><span><b>Type: </b></span><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></span></p>
           </section>
           <section>
             <h4 id="bar-remarks">Remarks</h4>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-b/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-b/index.html
@@ -7,7 +7,7 @@
     <section>
       <h1>test-suite-b</h1>
       <section>
-        <p><a href="./">Packages</a> > <a href="./test-suite-b/">test-suite-b</a></p>
+        <p><a href="/">Packages</a> > <a href="/test-suite-b/">test-suite-b</a></p>
       </section>
       <section>
         <h2>Interfaces</h2>
@@ -20,7 +20,7 @@
           </thead>
           <tbody>
             <tr>
-              <td><a href="./test-suite-b/foo-interface">Foo</a></td>
+              <td><a href="/test-suite-b/foo-interface">Foo</a></td>
               <td>Bar</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/index.md
@@ -4,5 +4,5 @@
 
 | Package | Description |
 | --- | --- |
-| [test-suite-a](./test-suite-a/) | Test package |
-| [test-suite-b](./test-suite-b/) |  |
+| [test-suite-a](/test-suite-a/) | Test package |
+| [test-suite-b](/test-suite-b/) |  |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
@@ -1,6 +1,6 @@
 # test-suite-a
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/)
 
 Test package
 
@@ -22,9 +22,9 @@ And an ordered list for good measure!
 
 Also, here is a link test, including a bad link, because we should have some reasonable support if this happens:
 
-- Good link (no alias): [TestClass](./test-suite-a/testclass-class)
+- Good link (no alias): [TestClass](/test-suite-a/testclass-class)
 
-- Good link (with alias): [function alias text](./test-suite-a/#testfunction-function)
+- Good link (with alias): [function alias text](/test-suite-a/#testfunction-function)
 
 - Bad link (no alias): _InvalidItem_
 
@@ -42,54 +42,54 @@ const foo = bar;
 
 | Interface | Description |
 | --- | --- |
-| [TestEmptyInterface](./test-suite-a/testemptyinterface-interface) | An empty interface |
-| [TestInterface](./test-suite-a/testinterface-interface) | Test interface |
-| [TestInterfaceExtendingOtherInterfaces](./test-suite-a/testinterfaceextendingotherinterfaces-interface) | Test interface that extends other interfaces |
-| [TestInterfaceWithIndexSignature](./test-suite-a/testinterfacewithindexsignature-interface) | An interface with an index signature. |
-| [TestInterfaceWithTypeParameter](./test-suite-a/testinterfacewithtypeparameter-interface) | Test interface with generic type parameter |
+| [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) | An empty interface |
+| [TestInterface](/test-suite-a/testinterface-interface) | Test interface |
+| [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface) | Test interface that extends other interfaces |
+| [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface) | An interface with an index signature. |
+| [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface) | Test interface with generic type parameter |
 
 ## Classes
 
 | Class | Description |
 | --- | --- |
-| [TestAbstractClass](./test-suite-a/testabstractclass-class) | A test abstract class. |
-| [TestClass](./test-suite-a/testclass-class) | Test class |
+| [TestAbstractClass](/test-suite-a/testabstractclass-class) | A test abstract class. |
+| [TestClass](/test-suite-a/testclass-class) | Test class |
 
 ## Enumerations
 
 | Enum | Description |
 | --- | --- |
-| [TestEnum](./test-suite-a/testenum-enum) | Test Enum |
+| [TestEnum](/test-suite-a/testenum-enum) | Test Enum |
 
 ## Types
 
 | TypeAlias | Description |
 | --- | --- |
-| [TestMappedType](./test-suite-a/testmappedtype-typealias) | Test Mapped Type, using [TestEnum](./test-suite-a/testenum-enum) |
-| [TypeAlias](./test-suite-a/typealias-typealias) | Test Type-Alias |
+| [TestMappedType](/test-suite-a/testmappedtype-typealias) | Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum) |
+| [TypeAlias](/test-suite-a/typealias-typealias) | Test Type-Alias |
 
 ## Functions
 
 | Function | Alerts | Return Type | Description |
 | --- | --- | --- | --- |
-| [testFunction(testParameter, testOptionalParameter)](./test-suite-a/#testfunction-function) | `Alpha` | TTypeParameter | Test function |
-| [testFunctionReturningInlineType()](./test-suite-a/#testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](./test-suite-a/testenum-enum); } | Test function that returns an inline type |
-| [testFunctionReturningIntersectionType()](./test-suite-a/#testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](./test-suite-a/testemptyinterface-interface) &amp; [TestInterfaceWithTypeParameter](./test-suite-a/testinterfacewithtypeparameter-interface)&lt;number&gt; | Test function that returns an inline type |
-| [testFunctionReturningUnionType()](./test-suite-a/#testfunctionreturninguniontype-function) |  | string \| [TestInterface](./test-suite-a/testinterface-interface) | Test function that returns an inline type |
+| [testFunction(testParameter, testOptionalParameter)](/test-suite-a/#testfunction-function) | `Alpha` | TTypeParameter | Test function |
+| [testFunctionReturningInlineType()](/test-suite-a/#testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum); } | Test function that returns an inline type |
+| [testFunctionReturningIntersectionType()](/test-suite-a/#testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) &amp; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)&lt;number&gt; | Test function that returns an inline type |
+| [testFunctionReturningUnionType()](/test-suite-a/#testfunctionreturninguniontype-function) |  | string \| [TestInterface](/test-suite-a/testinterface-interface) | Test function that returns an inline type |
 
 ## Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
 | --- | --- | --- | --- | --- |
-| [testConst](./test-suite-a/#testconst-variable) | `Beta` | `readonly` |  | Test Constant |
-| [testConstWithEmptyDeprecatedBlock](./test-suite-a/#testconstwithemptydeprecatedblock-variable) | `Deprecated` | `readonly` | string | I have a `@deprecated` tag with an empty comment block. |
+| [testConst](/test-suite-a/#testconst-variable) | `Beta` | `readonly` |  | Test Constant |
+| [testConstWithEmptyDeprecatedBlock](/test-suite-a/#testconstwithemptydeprecatedblock-variable) | `Deprecated` | `readonly` | string | I have a `@deprecated` tag with an empty comment block. |
 
 ## Namespaces
 
 | Namespace | Description |
 | --- | --- |
-| [TestModule](./test-suite-a/testmodule-namespace/) |  |
-| [TestNamespace](./test-suite-a/testnamespace-namespace/) | Test Namespace |
+| [TestModule](/test-suite-a/testmodule-namespace/) |  |
+| [TestNamespace](/test-suite-a/testnamespace-namespace/) | Test Namespace |
 
 ## Function Details
 
@@ -109,11 +109,11 @@ export declare function testFunction<TTypeParameter extends TestInterface = Test
 
 | Parameter | Constraint | Default | Description |
 | --- | --- | --- | --- |
-| TTypeParameter | [TestInterface](./test-suite-a/testinterface-interface) | [TestInterface](./test-suite-a/testinterface-interface) | A test type parameter |
+| TTypeParameter | [TestInterface](/test-suite-a/testinterface-interface) | [TestInterface](/test-suite-a/testinterface-interface) | A test type parameter |
 
 #### Remarks {#testfunction-remarks}
 
-This is a test [link](./test-suite-a/testinterface-interface) to another API member
+This is a test [link](/test-suite-a/testinterface-interface) to another API member
 
 #### Parameters {#testfunction-parameters}
 
@@ -149,7 +149,7 @@ export declare function testFunctionReturningInlineType(): {
 
 An inline type
 
-**Return type:** {     foo: number;     bar: [TestEnum](./test-suite-a/testenum-enum); }
+**Return type:** {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum); }
 
 ### testFunctionReturningIntersectionType {#testfunctionreturningintersectiontype-function}
 
@@ -157,7 +157,7 @@ Test function that returns an inline type
 
 **WARNING: This API is deprecated and will be removed in a future release.**
 
-_This is a test deprecation notice. Here is a_ [_link_](./test-suite-a/#testfunctionreturninguniontype-function)<!-- --> _to something else!_
+_This is a test deprecation notice. Here is a_ [_link_](/test-suite-a/#testfunctionreturninguniontype-function)<!-- --> _to something else!_
 
 #### Signature {#testfunctionreturningintersectiontype-signature}
 
@@ -169,7 +169,7 @@ export declare function testFunctionReturningIntersectionType(): TestEmptyInterf
 
 an intersection type
 
-**Return type:** [TestEmptyInterface](./test-suite-a/testemptyinterface-interface) &amp; [TestInterfaceWithTypeParameter](./test-suite-a/testinterfacewithtypeparameter-interface)&lt;number&gt;
+**Return type:** [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) &amp; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)&lt;number&gt;
 
 ### testFunctionReturningUnionType {#testfunctionreturninguniontype-function}
 
@@ -185,7 +185,7 @@ export declare function testFunctionReturningUnionType(): string | TestInterface
 
 A union type
 
-**Return type:** string \| [TestInterface](./test-suite-a/testinterface-interface)
+**Return type:** string \| [TestInterface](/test-suite-a/testinterface-interface)
 
 ## Variable Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testabstractclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testabstractclass-class.md
@@ -1,6 +1,6 @@
 # TestAbstractClass
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestAbstractClass](./test-suite-a/testabstractclass-class)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestAbstractClass](/test-suite-a/testabstractclass-class)
 
 A test abstract class.
 
@@ -14,22 +14,22 @@ export declare abstract class TestAbstractClass
 
 | Constructor | Description |
 | --- | --- |
-| [(constructor)(privateProperty, protectedProperty)](./test-suite-a/testabstractclass-class#_constructor_-constructor) | This is a _{@customTag constructor}_. |
+| [(constructor)(privateProperty, protectedProperty)](/test-suite-a/testabstractclass-class#_constructor_-constructor) | This is a _{@customTag constructor}_. |
 
 ## Properties
 
 | Property | Modifiers | Type | Description |
 | --- | --- | --- | --- |
-| [abstractPropertyGetter](./test-suite-a/testabstractclass-class#abstractpropertygetter-property) | `readonly` | [TestMappedType](./test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
-| [protectedProperty](./test-suite-a/testabstractclass-class#protectedproperty-property) | `readonly` | [TestEnum](./test-suite-a/testenum-enum) | A test protected property. |
+| [abstractPropertyGetter](/test-suite-a/testabstractclass-class#abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
+| [protectedProperty](/test-suite-a/testabstractclass-class#protectedproperty-property) | `readonly` | [TestEnum](/test-suite-a/testenum-enum) | A test protected property. |
 
 ## Methods
 
 | Method | Modifiers | Return Type | Description |
 | --- | --- | --- | --- |
-| [publicAbstractMethod()](./test-suite-a/testabstractclass-class#publicabstractmethod-method) |  | void | A test public abstract method. |
-| [sealedMethod()](./test-suite-a/testabstractclass-class#sealedmethod-method) | `sealed` | string | A test `@sealed` method. |
-| [virtualMethod()](./test-suite-a/testabstractclass-class#virtualmethod-method) | `virtual` | number | A test `@virtual` method. |
+| [publicAbstractMethod()](/test-suite-a/testabstractclass-class#publicabstractmethod-method) |  | void | A test public abstract method. |
+| [sealedMethod()](/test-suite-a/testabstractclass-class#sealedmethod-method) | `sealed` | string | A test `@sealed` method. |
+| [virtualMethod()](/test-suite-a/testabstractclass-class#virtualmethod-method) | `virtual` | number | A test `@virtual` method. |
 
 ## Constructor Details
 
@@ -48,7 +48,7 @@ protected constructor(privateProperty: number, protectedProperty: TestEnum);
 | Parameter | Type | Description |
 | --- | --- | --- |
 | privateProperty | number |  |
-| protectedProperty | [TestEnum](./test-suite-a/testenum-enum) |  |
+| protectedProperty | [TestEnum](/test-suite-a/testenum-enum) |  |
 
 ## Property Details
 
@@ -62,7 +62,7 @@ A test abstract getter property.
 abstract get abstractPropertyGetter(): TestMappedType;
 ```
 
-**Type:** [TestMappedType](./test-suite-a/testmappedtype-typealias)
+**Type:** [TestMappedType](/test-suite-a/testmappedtype-typealias)
 
 ### protectedProperty {#protectedproperty-property}
 
@@ -74,7 +74,7 @@ A test protected property.
 protected readonly protectedProperty: TestEnum;
 ```
 
-**Type:** [TestEnum](./test-suite-a/testenum-enum)
+**Type:** [TestEnum](/test-suite-a/testenum-enum)
 
 ## Method Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
@@ -1,6 +1,6 @@
 # TestClass
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestClass](./test-suite-a/testclass-class)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestClass](/test-suite-a/testclass-class)
 
 Test class
 
@@ -10,7 +10,7 @@ Test class
 export declare class TestClass<TTypeParameterA, TTypeParameterB> extends TestAbstractClass
 ```
 
-**Extends:** [TestAbstractClass](./test-suite-a/testabstractclass-class)
+**Extends:** [TestAbstractClass](/test-suite-a/testabstractclass-class)
 
 ### Type Parameters
 
@@ -27,41 +27,41 @@ Here are some remarks about the class
 
 | Constructor | Description |
 | --- | --- |
-| [(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)](./test-suite-a/testclass-class#_constructor_-constructor) | Test class constructor |
+| [(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)](/test-suite-a/testclass-class#_constructor_-constructor) | Test class constructor |
 
 ## Static Properties
 
 | Property | Type | Description |
 | --- | --- | --- |
-| [testClassStaticProperty](./test-suite-a/testclass-class#testclassstaticproperty-property) | (foo: number) =&gt; string | Test static class property |
+| [testClassStaticProperty](/test-suite-a/testclass-class#testclassstaticproperty-property) | (foo: number) =&gt; string | Test static class property |
 
 ## Static Methods
 
 | Method | Return Type | Description |
 | --- | --- | --- |
-| [testClassStaticMethod(foo)](./test-suite-a/testclass-class#testclassstaticmethod-method) | string | Test class static method |
+| [testClassStaticMethod(foo)](/test-suite-a/testclass-class#testclassstaticmethod-method) | string | Test class static method |
 
 ## Events
 
 | Property | Modifiers | Type | Description |
 | --- | --- | --- | --- |
-| [testClassEventProperty](./test-suite-a/testclass-class#testclasseventproperty-property) | `readonly` | () =&gt; void | Test class event property |
+| [testClassEventProperty](/test-suite-a/testclass-class#testclasseventproperty-property) | `readonly` | () =&gt; void | Test class event property |
 
 ## Properties
 
 | Property | Modifiers | Type | Description |
 | --- | --- | --- | --- |
-| [abstractPropertyGetter](./test-suite-a/testclass-class#abstractpropertygetter-property) | `readonly` | [TestMappedType](./test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
-| [testClassGetterProperty](./test-suite-a/testclass-class#testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
-| [testClassProperty](./test-suite-a/testclass-class#testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
+| [abstractPropertyGetter](/test-suite-a/testclass-class#abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
+| [testClassGetterProperty](/test-suite-a/testclass-class#testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
+| [testClassProperty](/test-suite-a/testclass-class#testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
 
 ## Methods
 
 | Method | Modifiers | Return Type | Description |
 | --- | --- | --- | --- |
-| [publicAbstractMethod()](./test-suite-a/testclass-class#publicabstractmethod-method) |  | void | A test public abstract method. |
-| [testClassMethod(input)](./test-suite-a/testclass-class#testclassmethod-method) | `sealed` | TTypeParameterA | Test class method |
-| [virtualMethod()](./test-suite-a/testclass-class#virtualmethod-method) |  | number | Overrides [virtualMethod()](./test-suite-a/testabstractclass-class#virtualmethod-method). |
+| [publicAbstractMethod()](/test-suite-a/testclass-class#publicabstractmethod-method) |  | void | A test public abstract method. |
+| [testClassMethod(input)](/test-suite-a/testclass-class#testclassmethod-method) | `sealed` | TTypeParameterA | Test class method |
+| [virtualMethod()](/test-suite-a/testclass-class#virtualmethod-method) |  | number | Overrides [virtualMethod()](/test-suite-a/testabstractclass-class#virtualmethod-method). |
 
 ## Constructor Details
 
@@ -83,10 +83,10 @@ Here are some remarks about the constructor
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| privateProperty | number | See [TestAbstractClass](./test-suite-a/testabstractclass-class)'s constructor. |
-| protectedProperty | [TestEnum](./test-suite-a/testenum-enum) | <p>Some notes about the parameter.</p><p>See <a href="./test-suite-a/testabstractclass-class#protectedproperty-property">protectedProperty</a>.</p> |
-| testClassProperty | TTypeParameterB | See [testClassProperty](./test-suite-a/testclass-class#testclassproperty-property). |
-| testClassEventProperty | () =&gt; void | See [testClassEventProperty](./test-suite-a/testclass-class#testclasseventproperty-property). |
+| privateProperty | number | See [TestAbstractClass](/test-suite-a/testabstractclass-class)'s constructor. |
+| protectedProperty | [TestEnum](/test-suite-a/testenum-enum) | <p>Some notes about the parameter.</p><p>See <a href="/test-suite-a/testabstractclass-class#protectedproperty-property">protectedProperty</a>.</p> |
+| testClassProperty | TTypeParameterB | See [testClassProperty](/test-suite-a/testclass-class#testclassproperty-property). |
+| testClassEventProperty | () =&gt; void | See [testClassEventProperty](/test-suite-a/testclass-class#testclasseventproperty-property). |
 
 ## Event Details
 
@@ -118,7 +118,7 @@ A test abstract getter property.
 get abstractPropertyGetter(): TestMappedType;
 ```
 
-**Type:** [TestMappedType](./test-suite-a/testmappedtype-typealias)
+**Type:** [TestMappedType](/test-suite-a/testmappedtype-typealias)
 
 ### testClassGetterProperty {#testclassgetterproperty-property}
 
@@ -233,7 +233,7 @@ static testClassStaticMethod(foo: number): string;
 
 ### virtualMethod {#virtualmethod-method}
 
-Overrides [virtualMethod()](./test-suite-a/testabstractclass-class#virtualmethod-method).
+Overrides [virtualMethod()](/test-suite-a/testabstractclass-class#virtualmethod-method).
 
 #### Signature {#virtualmethod-signature}
 
@@ -248,4 +248,4 @@ protected virtualMethod(): number;
 
 ## See Also {#testclass-see-also}
 
-[TestAbstractClass](./test-suite-a/testabstractclass-class)
+[TestAbstractClass](/test-suite-a/testabstractclass-class)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testemptyinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testemptyinterface-interface.md
@@ -1,6 +1,6 @@
 # TestEmptyInterface
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestEmptyInterface](./test-suite-a/testemptyinterface-interface)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestEmptyInterface](/test-suite-a/testemptyinterface-interface)
 
 An empty interface
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testenum-enum.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testenum-enum.md
@@ -1,6 +1,6 @@
 # TestEnum
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestEnum](./test-suite-a/testenum-enum)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestEnum](/test-suite-a/testenum-enum)
 
 Test Enum
 
@@ -36,9 +36,9 @@ const bar = TestEnum.TestEnumValue2
 
 | Flag | Description |
 | --- | --- |
-| [TestEnumValue1](./test-suite-a/testenum-enum#testenumvalue1-enummember) | Test enum value 1 (string) |
-| [TestEnumValue2](./test-suite-a/testenum-enum#testenumvalue2-enummember) | Test enum value 2 (number) |
-| [TestEnumValue3](./test-suite-a/testenum-enum#testenumvalue3-enummember) | Test enum value 3 (default) |
+| [TestEnumValue1](/test-suite-a/testenum-enum#testenumvalue1-enummember) | Test enum value 1 (string) |
+| [TestEnumValue2](/test-suite-a/testenum-enum#testenumvalue2-enummember) | Test enum value 2 (number) |
+| [TestEnumValue3](/test-suite-a/testenum-enum#testenumvalue3-enummember) | Test enum value 3 (default) |
 
 ### TestEnumValue1 {#testenumvalue1-enummember}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
@@ -1,6 +1,6 @@
 # TestInterface
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestInterface](./test-suite-a/testinterface-interface)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterface](/test-suite-a/testinterface-interface)
 
 Test interface
 
@@ -18,36 +18,36 @@ Here are some remarks about the interface
 
 | ConstructSignature | Return Type | Description |
 | --- | --- | --- |
-| [new (): TestInterface](./test-suite-a/testinterface-interface#_new_-constructsignature) | [TestInterface](./test-suite-a/testinterface-interface) | Test construct signature. |
+| [new (): TestInterface](/test-suite-a/testinterface-interface#_new_-constructsignature) | [TestInterface](/test-suite-a/testinterface-interface) | Test construct signature. |
 
 ## Events
 
 | Property | Modifiers | Type | Description |
 | --- | --- | --- | --- |
-| [testClassEventProperty](./test-suite-a/testinterface-interface#testclasseventproperty-propertysignature) | `readonly` | () =&gt; void | Test interface event property |
+| [testClassEventProperty](/test-suite-a/testinterface-interface#testclasseventproperty-propertysignature) | `readonly` | () =&gt; void | Test interface event property |
 
 ## Properties
 
 | Property | Modifiers | Default Value | Type | Description |
 | --- | --- | --- | --- | --- |
-| [getterProperty](./test-suite-a/testinterface-interface#getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
-| [propertyWithBadInheritDocTarget](./test-suite-a/testinterface-interface#propertywithbadinheritdoctarget-propertysignature) |  |  | boolean |  |
-| [setterProperty](./test-suite-a/testinterface-interface#setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
-| [testInterfaceProperty](./test-suite-a/testinterface-interface#testinterfaceproperty-propertysignature) |  |  | number | Test interface property |
-| [testOptionalInterfaceProperty](./test-suite-a/testinterface-interface#testoptionalinterfaceproperty-propertysignature) | `optional` | 0 | number | Test optional property |
+| [getterProperty](/test-suite-a/testinterface-interface#getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
+| [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface#propertywithbadinheritdoctarget-propertysignature) |  |  | boolean |  |
+| [setterProperty](/test-suite-a/testinterface-interface#setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
+| [testInterfaceProperty](/test-suite-a/testinterface-interface#testinterfaceproperty-propertysignature) |  |  | number | Test interface property |
+| [testOptionalInterfaceProperty](/test-suite-a/testinterface-interface#testoptionalinterfaceproperty-propertysignature) | `optional` | 0 | number | Test optional property |
 
 ## Methods
 
 | Method | Return Type | Description |
 | --- | --- | --- |
-| [testInterfaceMethod()](./test-suite-a/testinterface-interface#testinterfacemethod-methodsignature) | void | Test interface method |
+| [testInterfaceMethod()](/test-suite-a/testinterface-interface#testinterfacemethod-methodsignature) | void | Test interface method |
 
 ## Call Signatures
 
 | CallSignature | Description |
 | --- | --- |
-| [(event: 'testCallSignature', listener: (input: unknown) =&gt; void): any](./test-suite-a/testinterface-interface#_call_-callsignature) | Test interface event call signature |
-| [(event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number](./test-suite-a/testinterface-interface#_call__1-callsignature) | Another example call signature |
+| [(event: 'testCallSignature', listener: (input: unknown) =&gt; void): any](/test-suite-a/testinterface-interface#_call_-callsignature) | Test interface event call signature |
+| [(event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number](/test-suite-a/testinterface-interface#_call__1-callsignature) | Another example call signature |
 
 ## Construct Signature Details
 
@@ -63,7 +63,7 @@ new (): TestInterface;
 
 #### Returns {#\_new\_-returns}
 
-**Return type:** [TestInterface](./test-suite-a/testinterface-interface)
+**Return type:** [TestInterface](/test-suite-a/testinterface-interface)
 
 ## Event Details
 
@@ -196,10 +196,10 @@ Here are some remarks about the event call signature
 
 ## See Also {#testinterface-see-also}
 
-[testInterfaceMethod()](./test-suite-a/testinterface-interface#testinterfacemethod-methodsignature)
+[testInterfaceMethod()](/test-suite-a/testinterface-interface#testinterfacemethod-methodsignature)
 
-[testInterfaceProperty](./test-suite-a/testinterface-interface#testinterfaceproperty-propertysignature)
+[testInterfaceProperty](/test-suite-a/testinterface-interface#testinterfaceproperty-propertysignature)
 
-[testOptionalInterfaceProperty](./test-suite-a/testinterface-interface#testoptionalinterfaceproperty-propertysignature)
+[testOptionalInterfaceProperty](/test-suite-a/testinterface-interface#testoptionalinterfaceproperty-propertysignature)
 
-[testClassEventProperty](./test-suite-a/testinterface-interface#testclasseventproperty-propertysignature)
+[testClassEventProperty](/test-suite-a/testinterface-interface#testclasseventproperty-propertysignature)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.md
@@ -1,6 +1,6 @@
 # TestInterfaceExtendingOtherInterfaces
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestInterfaceExtendingOtherInterfaces](./test-suite-a/testinterfaceextendingotherinterfaces-interface)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface)
 
 Test interface that extends other interfaces
 
@@ -10,7 +10,7 @@ Test interface that extends other interfaces
 export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter<number>
 ```
 
-**Extends:** [TestInterface](./test-suite-a/testinterface-interface), [TestMappedType](./test-suite-a/testmappedtype-typealias), [TestInterfaceWithTypeParameter](./test-suite-a/testinterfacewithtypeparameter-interface)&lt;number&gt;
+**Extends:** [TestInterface](/test-suite-a/testinterface-interface), [TestMappedType](/test-suite-a/testmappedtype-typealias), [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)&lt;number&gt;
 
 ## Remarks {#testinterfaceextendingotherinterfaces-remarks}
 
@@ -20,7 +20,7 @@ Here are some remarks about the interface
 
 | Method | Return Type | Description |
 | --- | --- | --- |
-| [testMethod(input)](./test-suite-a/testinterfaceextendingotherinterfaces-interface#testmethod-methodsignature) | number | Test interface method accepting a string and returning a number. |
+| [testMethod(input)](/test-suite-a/testinterfaceextendingotherinterfaces-interface#testmethod-methodsignature) | number | Test interface method accepting a string and returning a number. |
 
 ## Method Details
 
@@ -52,8 +52,8 @@ A number
 
 ## See Also {#testinterfaceextendingotherinterfaces-see-also}
 
-- [TestInterface](./test-suite-a/testinterface-interface)
+- [TestInterface](/test-suite-a/testinterface-interface)
 
-- [TestInterfaceWithTypeParameter](./test-suite-a/testinterfacewithtypeparameter-interface)
+- [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)
 
-- [TestMappedType](./test-suite-a/testmappedtype-typealias)
+- [TestMappedType](/test-suite-a/testmappedtype-typealias)

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithindexsignature-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithindexsignature-interface.md
@@ -1,6 +1,6 @@
 # TestInterfaceWithIndexSignature
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestInterfaceWithIndexSignature](./test-suite-a/testinterfacewithindexsignature-interface)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface)
 
 An interface with an index signature.
 
@@ -14,7 +14,7 @@ export interface TestInterfaceWithIndexSignature
 
 | IndexSignature | Description |
 | --- | --- |
-| [\[foo: number\]: { bar: string; }](./test-suite-a/testinterfacewithindexsignature-interface#_indexer_-indexsignature) | Test index signature. |
+| [\[foo: number\]: { bar: string; }](/test-suite-a/testinterfacewithindexsignature-interface#_indexer_-indexsignature) | Test index signature. |
 
 ## Index Signature Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithtypeparameter-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithtypeparameter-interface.md
@@ -1,6 +1,6 @@
 # TestInterfaceWithTypeParameter
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestInterfaceWithTypeParameter](./test-suite-a/testinterfacewithtypeparameter-interface)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)
 
 Test interface with generic type parameter
 
@@ -24,7 +24,7 @@ Here are some remarks about the interface
 
 | Property | Type | Description |
 | --- | --- | --- |
-| [testProperty](./test-suite-a/testinterfacewithtypeparameter-interface#testproperty-propertysignature) | T | A test interface property using generic type parameter |
+| [testProperty](/test-suite-a/testinterfacewithtypeparameter-interface#testproperty-propertysignature) | T | A test interface property using generic type parameter |
 
 ## Property Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testmappedtype-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testmappedtype-typealias.md
@@ -1,8 +1,8 @@
 # TestMappedType
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestMappedType](./test-suite-a/testmappedtype-typealias)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestMappedType](/test-suite-a/testmappedtype-typealias)
 
-Test Mapped Type, using [TestEnum](./test-suite-a/testenum-enum)
+Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum)
 
 ## Signature {#testmappedtype-signature}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testmodule-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testmodule-namespace/index.md
@@ -1,12 +1,12 @@
 # TestModule
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestModule](./test-suite-a/testmodule-namespace/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestModule](/test-suite-a/testmodule-namespace/)
 
 ## Variables
 
 | Variable | Modifiers | Type | Description |
 | --- | --- | --- | --- |
-| [foo](./test-suite-a/testmodule-namespace/#foo-variable) | `readonly` |  | Test constant in module. |
+| [foo](/test-suite-a/testmodule-namespace/#foo-variable) | `readonly` |  | Test constant in module. |
 
 ## Variable Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.md
@@ -1,6 +1,6 @@
 # TestNamespace
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestNamespace](./test-suite-a/testnamespace-namespace/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/)
 
 Test Namespace
 
@@ -38,43 +38,43 @@ const foo = {
 
 | Interface | Alerts | Description |
 | --- | --- | --- |
-| [TestInterface](./test-suite-a/testnamespace-namespace/testinterface-interface) | `Alpha` | Test interface |
+| [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface) | `Alpha` | Test interface |
 
 ## Classes
 
 | Class | Description |
 | --- | --- |
-| [TestClass](./test-suite-a/testnamespace-namespace/testclass-class) | Test class |
+| [TestClass](/test-suite-a/testnamespace-namespace/testclass-class) | Test class |
 
 ## Enumerations
 
 | Enum | Description |
 | --- | --- |
-| [TestEnum](./test-suite-a/testnamespace-namespace/testenum-enum) | Test Enum |
+| [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum) | Test Enum |
 
 ## Types
 
 | TypeAlias | Description |
 | --- | --- |
-| [TestTypeAlias](./test-suite-a/testnamespace-namespace/testtypealias-typealias) | Test Type-Alias |
+| [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias) | Test Type-Alias |
 
 ## Functions
 
 | Function | Return Type | Description |
 | --- | --- | --- |
-| [testFunction(testParameter)](./test-suite-a/testnamespace-namespace/#testfunction-function) | number | Test function |
+| [testFunction(testParameter)](/test-suite-a/testnamespace-namespace/#testfunction-function) | number | Test function |
 
 ## Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
 | --- | --- | --- | --- | --- |
-| [TestConst](./test-suite-a/testnamespace-namespace/#testconst-variable) | `Beta` | `readonly` |  | Test Constant |
+| [TestConst](/test-suite-a/testnamespace-namespace/#testconst-variable) | `Beta` | `readonly` |  | Test Constant |
 
 ## Namespaces
 
 | Namespace | Description |
 | --- | --- |
-| [TestSubNamespace](./test-suite-a/testnamespace-namespace/testsubnamespace-namespace/) | Test sub-namespace |
+| [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/) | Test sub-namespace |
 
 ## Function Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testclass-class.md
@@ -1,6 +1,6 @@
 # TestClass
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestNamespace](./test-suite-a/testnamespace-namespace/) &gt; [TestClass](./test-suite-a/testnamespace-namespace/testclass-class)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestClass](/test-suite-a/testnamespace-namespace/testclass-class)
 
 Test class
 
@@ -14,19 +14,19 @@ class TestClass
 
 | Constructor | Description |
 | --- | --- |
-| [(constructor)(testClassProperty)](./test-suite-a/testnamespace-namespace/testclass-class#_constructor_-constructor) | Test class constructor |
+| [(constructor)(testClassProperty)](/test-suite-a/testnamespace-namespace/testclass-class#_constructor_-constructor) | Test class constructor |
 
 ## Properties
 
 | Property | Modifiers | Type | Description |
 | --- | --- | --- | --- |
-| [testClassProperty](./test-suite-a/testnamespace-namespace/testclass-class#testclassproperty-property) | `readonly` | string | Test interface property |
+| [testClassProperty](/test-suite-a/testnamespace-namespace/testclass-class#testclassproperty-property) | `readonly` | string | Test interface property |
 
 ## Methods
 
 | Method | Return Type | Description |
 | --- | --- | --- |
-| [testClassMethod(testParameter)](./test-suite-a/testnamespace-namespace/testclass-class#testclassmethod-method) | Promise&lt;string&gt; | Test class method |
+| [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class#testclassmethod-method) | Promise&lt;string&gt; | Test class method |
 
 ## Constructor Details
 
@@ -44,7 +44,7 @@ constructor(testClassProperty: string);
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| testClassProperty | string | See [testClassProperty](./test-suite-a/testclass-class#testclassproperty-property) |
+| testClassProperty | string | See [testClassProperty](/test-suite-a/testclass-class#testclassproperty-property) |
 
 ## Property Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testenum-enum.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testenum-enum.md
@@ -1,6 +1,6 @@
 # TestEnum
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestNamespace](./test-suite-a/testnamespace-namespace/) &gt; [TestEnum](./test-suite-a/testnamespace-namespace/testenum-enum)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum)
 
 Test Enum
 
@@ -14,8 +14,8 @@ enum TestEnum
 
 | Flag | Description |
 | --- | --- |
-| [TestEnumValue1](./test-suite-a/testnamespace-namespace/testenum-enum#testenumvalue1-enummember) | Test enum value 1 |
-| [TestEnumValue2](./test-suite-a/testnamespace-namespace/testenum-enum#testenumvalue2-enummember) | Test enum value 2 |
+| [TestEnumValue1](/test-suite-a/testnamespace-namespace/testenum-enum#testenumvalue1-enummember) | Test enum value 1 |
+| [TestEnumValue2](/test-suite-a/testnamespace-namespace/testenum-enum#testenumvalue2-enummember) | Test enum value 2 |
 
 ### TestEnumValue1 {#testenumvalue1-enummember}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testinterface-interface.md
@@ -1,6 +1,6 @@
 # TestInterface
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestNamespace](./test-suite-a/testnamespace-namespace/) &gt; [TestInterface](./test-suite-a/testnamespace-namespace/testinterface-interface)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface)
 
 Test interface
 
@@ -12,19 +12,19 @@ Test interface
 interface TestInterface extends TestInterfaceWithTypeParameter<TestEnum>
 ```
 
-**Extends:** [TestInterfaceWithTypeParameter](./test-suite-a/testinterfacewithtypeparameter-interface)&lt;[TestEnum](./test-suite-a/testnamespace-namespace/testenum-enum)&gt;
+**Extends:** [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)&lt;[TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum)&gt;
 
 ## Properties
 
 | Property | Alerts | Type | Description |
 | --- | --- | --- | --- |
-| [testInterfaceProperty](./test-suite-a/testnamespace-namespace/testinterface-interface#testinterfaceproperty-propertysignature) | `Alpha` | boolean | Test interface property |
+| [testInterfaceProperty](/test-suite-a/testnamespace-namespace/testinterface-interface#testinterfaceproperty-propertysignature) | `Alpha` | boolean | Test interface property |
 
 ## Methods
 
 | Method | Alerts | Return Type | Description |
 | --- | --- | --- | --- |
-| [testInterfaceMethod()](./test-suite-a/testnamespace-namespace/testinterface-interface#testinterfacemethod-methodsignature) | `Alpha` | void | Test interface method |
+| [testInterfaceMethod()](/test-suite-a/testnamespace-namespace/testinterface-interface#testinterfacemethod-methodsignature) | `Alpha` | void | Test interface method |
 
 ## Property Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.md
@@ -1,6 +1,6 @@
 # TestSubNamespace
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestNamespace](./test-suite-a/testnamespace-namespace/) &gt; [TestSubNamespace](./test-suite-a/testnamespace-namespace/testsubnamespace-namespace/)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/)
 
 Test sub-namespace
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testtypealias-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testtypealias-typealias.md
@@ -1,6 +1,6 @@
 # TestTypeAlias
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TestNamespace](./test-suite-a/testnamespace-namespace/) &gt; [TestTypeAlias](./test-suite-a/testnamespace-namespace/testtypealias-typealias)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TestNamespace](/test-suite-a/testnamespace-namespace/) &gt; [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias)
 
 Test Type-Alias
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/typealias-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/typealias-typealias.md
@@ -1,6 +1,6 @@
 # TypeAlias
 
-[Packages](./) &gt; [test-suite-a](./test-suite-a/) &gt; [TypeAlias](./test-suite-a/typealias-typealias)
+[Packages](/) &gt; [test-suite-a](/test-suite-a/) &gt; [TypeAlias](/test-suite-a/typealias-typealias)
 
 Test Type-Alias
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-b/foo-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-b/foo-interface.md
@@ -1,6 +1,6 @@
 # Foo
 
-[Packages](./) &gt; [test-suite-b](./test-suite-b/) &gt; [Foo](./test-suite-b/foo-interface)
+[Packages](/) &gt; [test-suite-b](/test-suite-b/) &gt; [Foo](/test-suite-b/foo-interface)
 
 Bar
 
@@ -14,7 +14,7 @@ export interface Foo
 
 | Property | Type | Description |
 | --- | --- | --- |
-| [bar](./test-suite-b/foo-interface#bar-propertysignature) | [TestEnum](./test-suite-a/testenum-enum) | Test Enum |
+| [bar](/test-suite-b/foo-interface#bar-propertysignature) | [TestEnum](/test-suite-a/testenum-enum) | Test Enum |
 
 ## Property Details
 
@@ -28,7 +28,7 @@ Test Enum
 bar: TestEnum;
 ```
 
-**Type:** [TestEnum](./test-suite-a/testenum-enum)
+**Type:** [TestEnum](/test-suite-a/testenum-enum)
 
 #### Remarks {#bar-remarks}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-b/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-b/index.md
@@ -1,9 +1,9 @@
 # test-suite-b
 
-[Packages](./) &gt; [test-suite-b](./test-suite-b/)
+[Packages](/) &gt; [test-suite-b](/test-suite-b/)
 
 ## Interfaces
 
 | Interface | Description |
 | --- | --- |
-| [Foo](./test-suite-b/foo-interface) | Bar |
+| [Foo](/test-suite-b/foo-interface) | Bar |


### PR DESCRIPTION
While "" and "." for are potentially comparable for a URI root (system dependent), the leading "." makes routes look like relative file paths, which is misleading. Update documentation and tests to use "" instead of ".".
