### PR TITLE
[LTS] ci: Add retries to npm install steps in pipelines

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -109,6 +109,7 @@ extends:
         version: 18.17.1
     - task: Npm@1
       displayName: Install npm 6
+      retryCountOnTaskFailure: 4
       inputs:
         command: 'custom'
         customCommand: 'install --global npm@^6'

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -30,6 +30,7 @@ steps:
 
 - task: Npm@1
   displayName: Install npm 6
+  retryCountOnTaskFailure: 4
   inputs:
     command: 'custom'
     customCommand: 'install --global npm@^6'

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -202,6 +202,7 @@ stages:
             version: 18.17.1
         - task: Npm@1
           displayName: Install npm 6
+          retryCountOnTaskFailure: 4
           inputs:
             command: 'custom'
             customCommand: 'install --global npm@^6'

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -58,6 +58,7 @@ jobs:
               version: 18.17.1
           - task: Npm@1
             displayName: Install npm 6
+            retryCountOnTaskFailure: 4
             inputs:
               command: 'custom'
               customCommand: 'install --global npm@^6'

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -134,6 +134,7 @@ jobs:
           version: 18.17.1
       - task: Npm@1
         displayName: Install npm 6
+        retryCountOnTaskFailure: 4
         inputs:
           command: 'custom'
           customCommand: 'install --global npm@^6'
@@ -199,6 +200,7 @@ jobs:
       # Install test and logger package
       - task: Npm@1
         displayName: 'npm install'
+        retryCountOnTaskFailure: 4
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}
@@ -238,6 +240,7 @@ jobs:
           # Install extra dependencies for test files
           - task: Npm@1
             displayName: 'npm install - extra dependencies for test files'
+            retryCountOnTaskFailure: 4
             inputs:
               command: 'custom'
               workingDir: ${{ parameters.testWorkspace }}


### PR DESCRIPTION
## Description

Adds retries for install steps in pipelines to avoid spurious failures due to transient network issues. Only focused on the pipelines we run or might want to run in the LTS branch.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).