### PR TITLE
Disable CodeQL in new test jobs

### DIFF
--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -559,6 +559,9 @@ extends:
               - name: absolutePathToTelemetryGenerator
                 value: $(Build.SourcesDirectory)/tools/telemetry-generator
                 readonly: true
+              # We already run CodeQL in the main build job, so we don't need to run it again here.
+              - name: DisableCodeQL
+                value: true
             steps:
               # Setup
               - checkout: self
@@ -706,6 +709,9 @@ extends:
                 - name: absolutePathToTelemetryGenerator
                   value: $(Build.SourcesDirectory)/tools/telemetry-generator
                   readonly: true
+                # We already run CodeQL in the main build job, so we don't need to run it again here.
+                - name: DisableCodeQL
+                  value: true
               steps:
                 # Setup
                 - checkout: self


### PR DESCRIPTION
We already run CodeQL in the main build job, so we don't need to run it again on test jobs. 