### PR TITLE
Skip test explicitSchemaControl for FRS and ODSP

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
@@ -177,12 +177,9 @@ describeCompat(
 			for (const compression of choices) {
 				for (const chunking of choices) {
 					it(`test explicitSchemaControl = ${explicitSchemaControl}, compression = ${compression}, chunking = ${chunking}`, async function () {
-						// Skip this test for FRS and ODSP as its timing is flaky.
+						// Skip this test for R11s and ODSP as its timing is flaky.
 						// This test is covering client logic and the coverage from other drivers/endpoints is sufficient.
-						if (
-							provider.driver.type === "odsp" ||
-							(provider.driver.type === "r11s" && provider.driver.endpointName === "frs")
-						) {
+						if (provider.driver.type === "odsp" || provider.driver.type === "r11s") {
 							this.skip();
 						}
 						await testSchemaControl(explicitSchemaControl, compression, chunking);

--- a/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
@@ -176,7 +176,15 @@ describeCompat(
 		for (const explicitSchemaControl of choices) {
 			for (const compression of choices) {
 				for (const chunking of choices) {
-					it(`test explicitSchemaControl = ${explicitSchemaControl}, compression = ${compression}, chunking = ${chunking}`, async () => {
+					it(`test explicitSchemaControl = ${explicitSchemaControl}, compression = ${compression}, chunking = ${chunking}`, async function () {
+						// Skip this test for FRS and ODSP as its timing is flaky.
+						// This test is covering client logic and the coverage from other drivers/endpoints is sufficient.
+						if (
+							provider.driver.type === "odsp" ||
+							(provider.driver.type === "r11s" && provider.driver.endpointName === "frs")
+						) {
+							this.skip();
+						}
 						await testSchemaControl(explicitSchemaControl, compression, chunking);
 					});
 				}


### PR DESCRIPTION
Skip this test for FRS and ODSP as its timing is flaky.
This test is covering client logic and the coverage from other drivers/endpoints is sufficient.

Note: For ODSP, the failures in the pipeline were [fixed in version 2.0.0-internal.2.3.0](https://github.com/microsoft/FluidFramework/pull/13360). Porting the fix back to LTS is not worth the effort as of now since we haven't seen the issue in production scenarios.

### Testing data
5/1000 failures for FRS (<1% failure rate)
11/1000 failures for ODSP (~1% failure rate)

**FRS:**
Fixes [AB#21046](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21046)
Fixes [AB#21047](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21047)
Fixes [AB#21048](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21048)
Fixes [AB#21049](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21049)
Fixes [AB#21051](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21051)
Fixes [AB#21055](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21055)
Fixes [AB#21056](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21056)
Fixes [AB#21058](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21058)
Fixes [AB#21059](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21059)
Fixes [AB#21061](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21061)
Fixes [AB#21062](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21062)

**ODSP:**
Fixes [AB#26377](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26377)
Fixes [AB#26378](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26378)
Fixes [AB#26379](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26379)
Fixes [AB#26380](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26380)
Fixes [AB#26973](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26973)
Fixes [AB#26974](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26974)
Fixes [AB#26975](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26975)
Fixes [AB#26976](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26976)
Fixes [AB#27857](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/27857)
Fixes [AB#27858](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/27858)
Fixes [AB#27859](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/27859)
Fixes [AB#27860](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/27860)