### PR TITLE
Assert when op formats from the future are applied to a map

### DIFF
--- a/.changeset/all-heads-lay.md
+++ b/.changeset/all-heads-lay.md
@@ -15,4 +15,4 @@ This prevents data loss and corruption scenarios like a summary client using old
 
 If updating applications using SharedMap, SharedIntervalCollection and AttributableMap use a newer version which adds Ops types in the future,
 old clients which are old enough to be from before this fix will ignore the new ops instead of erroring.
-Therefor is may be useful to ensure this update is deplored as widely as possible before migrating any top newer versions which add new op formats to these DDSes.
+Therefore it may be useful to ensure this update is deployed as widely as possible before migrating any to newer versions which add new op formats to these DDSes.

--- a/.changeset/all-heads-lay.md
+++ b/.changeset/all-heads-lay.md
@@ -1,0 +1,18 @@
+---
+"@fluid-experimental/attributable-map": minor
+"@fluidframework/map": minor
+"@fluidframework/sequence": minor
+---
+---
+"section": fix
+---
+
+SharedMap, SharedIntervalCollection and AttributableMap now error on unrecognized Ops
+
+To avoid future versions of DDSes with new Op types causing silent data corruption and de-sync between clients,
+DDSes should error when unable to apply an Op.
+This prevents data loss and corruption scenarios like a summary client using old code discarding all ops from newer clients.
+
+If updating applications using SharedMap, SharedIntervalCollection and AttributableMap use a newer version which adds Ops types in the future,
+old clients which are old enough to be from before this fix will ignore the new ops instead of erroring.
+Therefor is may be useful to ensure this update is deplored as widely as possible before migrating any top newer versions which add new op formats to these DDSes.

--- a/experimental/dds/attributable-map/src/map.ts
+++ b/experimental/dds/attributable-map/src/map.ts
@@ -407,7 +407,7 @@ export class AttributableMapClass
 		if (message.type === MessageType.Operation) {
 			assert(
 				this.kernel.tryProcessMessage(message, local, localOpMetadata),
-				"AttributableMap received Invalid op, possibly from a never version",
+				"AttributableMap received invalid/unrecognized op, possibly from a never version",
 			);
 		}
 	}

--- a/experimental/dds/attributable-map/src/map.ts
+++ b/experimental/dds/attributable-map/src/map.ts
@@ -407,7 +407,7 @@ export class AttributableMapClass
 		if (message.type === MessageType.Operation) {
 			assert(
 				this.kernel.tryProcessMessage(message, local, localOpMetadata),
-				"AttributableMap received invalid/unrecognized op, possibly from a never version",
+				"AttributableMap received an unrecognized op, possibly from a newer version",
 			);
 		}
 	}

--- a/experimental/dds/attributable-map/src/map.ts
+++ b/experimental/dds/attributable-map/src/map.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/core-utils/internal";
 import {
 	IChannelAttributes,
 	IChannelFactory,
@@ -404,7 +405,10 @@ export class AttributableMapClass
 		localOpMetadata: unknown,
 	): void {
 		if (message.type === MessageType.Operation) {
-			this.kernel.tryProcessMessage(message, local, localOpMetadata);
+			assert(
+				this.kernel.tryProcessMessage(message, local, localOpMetadata),
+				"AttributableMap received Invalid op, possibly from a never version",
+			);
 		}
 	}
 

--- a/experimental/dds/attributable-map/src/mapKernel.ts
+++ b/experimental/dds/attributable-map/src/mapKernel.ts
@@ -508,7 +508,14 @@ export class AttributableMapKernel {
 	 * @param local - Whether the message originated from the local client
 	 * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
 	 * For messages from a remote client, this will be undefined.
-	 * @returns True if the operation was processed, false otherwise.
+	 * @returns True if the operation was recognized and thus processed, false otherwise.
+	 *
+	 * @remarks
+	 * When this returns false and the caller doesn't handle the op itself, then the op could be from a different version of this code.
+	 * In such a case, not applying the op would result in this client becoming out of sync with clients that do handel the op
+	 * and could result in data corruption or data loss as well.
+	 * Therefor, in such cases the caller should typically throw an error, ensuring that this client treats the situation as data corruption
+	 * (since its data no longer matches what other clients think the data should be) and will avoid overriding document content or misleading the users into thinking their current state is accurate.
 	 */
 	public tryProcessMessage(
 		message: ISequencedDocumentMessage,

--- a/experimental/dds/attributable-map/src/mapKernel.ts
+++ b/experimental/dds/attributable-map/src/mapKernel.ts
@@ -512,9 +512,9 @@ export class AttributableMapKernel {
 	 *
 	 * @remarks
 	 * When this returns false and the caller doesn't handle the op itself, then the op could be from a different version of this code.
-	 * In such a case, not applying the op would result in this client becoming out of sync with clients that do handel the op
+	 * In such a case, not applying the op would result in this client becoming out of sync with clients that do handle the op
 	 * and could result in data corruption or data loss as well.
-	 * Therefor, in such cases the caller should typically throw an error, ensuring that this client treats the situation as data corruption
+	 * Therefore, in such cases the caller should typically throw an error, ensuring that this client treats the situation as data corruption
 	 * (since its data no longer matches what other clients think the data should be) and will avoid overriding document content or misleading the users into thinking their current state is accurate.
 	 */
 	public tryProcessMessage(

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -807,7 +807,7 @@ export class SharedDirectory
 			const handler = this.messageHandlers.get(op.type);
 			assert(
 				handler !== undefined,
-				"Missing message handler for message type: op may be from a newer version",
+				0x00e /* "Missing message handler for message type: op may be from a newer version */,
 			);
 			handler.process(message, op, local, localOpMetadata);
 		}

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -805,7 +805,10 @@ export class SharedDirectory
 		if (message.type === MessageType.Operation) {
 			const op: IDirectoryOperation = message.contents as IDirectoryOperation;
 			const handler = this.messageHandlers.get(op.type);
-			assert(handler !== undefined, 0x00e /* Missing message handler for message type */);
+			assert(
+				handler !== undefined,
+				"Missing message handler for message type: op may be from a newer version",
+			);
 			handler.process(message, op, local, localOpMetadata);
 		}
 	}

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/core-utils/internal";
 import type {
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
@@ -293,7 +294,14 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	): void {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
 		if (message.type === MessageType.Operation) {
-			this.kernel.tryProcessMessage(message.contents as IMapOperation, local, localOpMetadata);
+			assert(
+				this.kernel.tryProcessMessage(
+					message.contents as IMapOperation,
+					local,
+					localOpMetadata,
+				),
+				"Map received Invalid op, possibly from a never version",
+			);
 		}
 	}
 

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -300,7 +300,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 					local,
 					localOpMetadata,
 				),
-				"Map received Invalid op, possibly from a never version",
+				"Map received an unrecognized op, possibly from a newer version",
 			);
 		}
 	}

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -437,11 +437,18 @@ export class MapKernel {
 
 	/**
 	 * Process the given op if a handler is registered.
-	 * @param op - The message to process
+	 * @param message - The message to process
 	 * @param local - Whether the message originated from the local client
 	 * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
 	 * For messages from a remote client, this will be undefined.
-	 * @returns True if the operation was processed, false otherwise.
+	 * @returns True if the operation was recognized and thus processed, false otherwise.
+	 *
+	 * @remarks
+	 * When this returns false and the caller doesn't handle the op itself, then the op could be from a different version of this code.
+	 * In such a case, not applying the op would result in this client becoming out of sync with clients that do handel the op
+	 * and could result in data corruption or data loss as well.
+	 * Therefor, in such cases the caller should typically throw an error, ensuring that this client treats the situation as data corruption
+	 * (since its data no longer matches what other clients think the data should be) and will avoid overriding document content or misleading the users into thinking their current state is accurate.
 	 */
 	public tryProcessMessage(
 		op: IMapOperation,

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -445,9 +445,9 @@ export class MapKernel {
 	 *
 	 * @remarks
 	 * When this returns false and the caller doesn't handle the op itself, then the op could be from a different version of this code.
-	 * In such a case, not applying the op would result in this client becoming out of sync with clients that do handel the op
+	 * In such a case, not applying the op would result in this client becoming out of sync with clients that do handle the op
 	 * and could result in data corruption or data loss as well.
-	 * Therefor, in such cases the caller should typically throw an error, ensuring that this client treats the situation as data corruption
+	 * Therefore, in such cases the caller should typically throw an error, ensuring that this client treats the situation as data corruption
 	 * (since its data no longer matches what other clients think the data should be) and will avoid overriding document content or misleading the users into thinking their current state is accurate.
 	 */
 	public tryProcessMessage(

--- a/packages/dds/sequence/src/intervalCollectionMap.ts
+++ b/packages/dds/sequence/src/intervalCollectionMap.ts
@@ -287,9 +287,9 @@ export class IntervalCollectionMap<T extends ISerializableInterval> {
 	 *
 	 * @remarks
 	 * When this returns false and the caller doesn't handle the op itself, then the op could be from a different version of this code.
-	 * In such a case, not applying the op would result in this client becoming out of sync with clients that do handel the op
+	 * In such a case, not applying the op would result in this client becoming out of sync with clients that do handle the op
 	 * and could result in data corruption or data loss as well.
-	 * Therefor, in such cases the caller should typically throw an error, ensuring that this client treats the situation as data corruption
+	 * Therefore, in such cases the caller should typically throw an error, ensuring that this client treats the situation as data corruption
 	 * (since its data no longer matches what other clients think the data should be) and will avoid overriding document content or misleading the users into thinking their current state is accurate.
 	 */
 	public tryProcessMessage(

--- a/packages/dds/sequence/src/intervalCollectionMap.ts
+++ b/packages/dds/sequence/src/intervalCollectionMap.ts
@@ -283,7 +283,14 @@ export class IntervalCollectionMap<T extends ISerializableInterval> {
 	 * @param local - Whether the message originated from the local client
 	 * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
 	 * For messages from a remote client, this will be undefined.
-	 * @returns True if the operation was processed, false otherwise.
+	 * @returns True if the operation was recognized and thus processed, false otherwise.
+	 *
+	 * @remarks
+	 * When this returns false and the caller doesn't handle the op itself, then the op could be from a different version of this code.
+	 * In such a case, not applying the op would result in this client becoming out of sync with clients that do handel the op
+	 * and could result in data corruption or data loss as well.
+	 * Therefor, in such cases the caller should typically throw an error, ensuring that this client treats the situation as data corruption
+	 * (since its data no longer matches what other clients think the data should be) and will avoid overriding document content or misleading the users into thinking their current state is accurate.
 	 */
 	public tryProcessMessage(
 		op: unknown,

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -4,6 +4,7 @@
  */
 
 import { bufferToString } from "@fluid-internal/client-utils";
+import { assert } from "@fluidframework/core-utils/internal";
 import {
 	IChannelAttributes,
 	IChannelFactory,
@@ -169,11 +170,14 @@ export class SharedIntervalCollection
 		localOpMetadata: unknown,
 	) {
 		if (message.type === MessageType.Operation) {
-			this.intervalCollections.tryProcessMessage(
-				message.contents as IMapOperation,
-				local,
-				message,
-				localOpMetadata,
+			assert(
+				this.intervalCollections.tryProcessMessage(
+					message.contents as IMapOperation,
+					local,
+					message,
+					localOpMetadata,
+				),
+				"SharedIntervalCollection received Invalid op, possibly from a never version",
 			);
 		}
 	}

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -177,7 +177,7 @@ export class SharedIntervalCollection
 					message,
 					localOpMetadata,
 				),
-				"SharedIntervalCollection received Invalid op, possibly from a never version",
+				"SharedIntervalCollection received Invalid op, possibly from a newer version",
 			);
 		}
 	}

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -177,7 +177,7 @@ export class SharedIntervalCollection
 					message,
 					localOpMetadata,
 				),
-				"SharedIntervalCollection received Invalid op, possibly from a newer version",
+				"SharedIntervalCollection received an unrecognized op, possibly from a newer version",
 			);
 		}
 	}


### PR DESCRIPTION
## Description

Update map and map similar DDSes to error on unrecognized ops.

See justification in changeset and comments.

Some options currently under consideration for how to do data migrations off of SharedMap and SharedDirectory might involve adding a new migration op, so having this error handling in place and documented may help with that, not just future other features to theses DDSes.

## Breaking Changes

If there is some op which is actually safe to ignore which is currently being ignored (maybe from an old version?) that will now error.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

