### PR TITLE
A11y(FF.com): Announce the alt text for the graphics on the Community page

### DIFF
--- a/docs/src/components/community.tsx
+++ b/docs/src/components/community.tsx
@@ -77,7 +77,7 @@ function CommunityLink({
 	return (
 		<div className={clsx("col col--4")}>
 			<div className="text--center">
-				<Icon className={"ffcom-community-link-icon"} role="img" />
+				<Icon className={"ffcom-community-link-icon"} role="img" aria-label={title} />
 			</div>
 			<div className="text--center padding-horiz--md">
 				<Heading as="h3">


### PR DESCRIPTION
## Fix Screen reader is not announcing the alt text for the graphics on the Community page
### How to test
- Enable VoiceOver for mac, cmd + F5, or Narrator for windows
- Open the link [Welcome to the Fluid Community | Fluid Framework](https://fluidframework.com/community)
- Navigate till the graphics of community, ask questions and report issues in scan mode.
- Observe that screen reader is not announcing the alt text for the images.

[AB#26842](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26842)