### PR TITLE
(Op bunching) Removed deprecated process function and related code

### DIFF
--- a/.changeset/three-sheep-stick.md
+++ b/.changeset/three-sheep-stick.md
@@ -1,0 +1,24 @@
+---
+"@fluidframework/container-runtime": minor
+"@fluidframework/datastore": minor
+"@fluidframework/datastore-definitions": minor
+"@fluidframework/runtime-definitions": minor
+"@fluidframework/test-runtime-utils": minor
+---
+---
+"section": legacy
+---
+
+The functions `process` and `processDocumentSchemaOp` have been removed.
+
+`process` has been replaced by `processMessages` from the following:
+- `DocumentsSchemaController`
+- `FluidDataStoreRuntime`
+- `IDeltaHandler`
+- `IFluidDataStoreChannel`
+- `MockFluidDataStoreRuntime`
+- `MockDeltaConnection`
+
+`processDocumentSchemaOp` has been replaced by `processDocumentSchemaMessages` from `DocumentsSchemaController`.
+
+See the [deprecation release note](https://github.com/microsoft/FluidFramework/releases/tag/client_v2.5.0#user-content-the-process-function-on-ifluiddatastorechannel-ideltahandler-mockfluiddatastoreruntime-and-mockdeltaconnection-is-now-deprecated-22840) for more details.

--- a/experimental/dds/tree/src/migration-shim/migrationDeltaHandler.ts
+++ b/experimental/dds/tree/src/migration-shim/migrationDeltaHandler.ts
@@ -6,7 +6,7 @@
 import { assert } from '@fluidframework/core-utils/internal';
 import { type IChannelAttributes, type IDeltaHandler } from '@fluidframework/datastore-definitions/internal';
 import { MessageType, type ISequencedDocumentMessage } from '@fluidframework/driver-definitions/internal';
-import type { IRuntimeMessageCollection } from '@fluidframework/runtime-definitions/internal';
+import type { IRuntimeMessageCollection, IRuntimeMessagesContent } from '@fluidframework/runtime-definitions/internal';
 
 import { type IOpContents, type IShimDeltaHandler } from './types.js';
 import { attributesMatch, isBarrierOp, isStampedOp } from './utils.js';
@@ -81,7 +81,7 @@ export class MigrationShimDeltaHandler implements IShimDeltaHandler {
 		assert(this.isUsingNewV2(), 0x7e5 /* Should be using new handler after swap */);
 	}
 
-	public process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void {
+	private process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void {
 		// This allows us to process the migrate op and prevent the shared object from processing the wrong ops
 		assert(!this.isPreAttachState(), 0x82c /* Can't process ops before attaching tree handler */);
 		if (message.type !== MessageType.Operation) {
@@ -97,8 +97,15 @@ export class MigrationShimDeltaHandler implements IShimDeltaHandler {
 		if (this.shouldDropOp(contents)) {
 			return;
 		}
+		const messagesContent: IRuntimeMessagesContent[] = [
+			{
+				contents,
+				localOpMetadata,
+				clientSequenceNumber: message.clientSequenceNumber,
+			},
+		];
 		// Another thought, flatten the IShimDeltaHandler and the MigrationShim into one class
-		return this.treeDeltaHandler.process(message, local, localOpMetadata);
+		return this.treeDeltaHandler.processMessages({ envelope: message, messagesContent, local });
 	}
 
 	public processMessages(messagesCollection: IRuntimeMessageCollection): void {

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -492,17 +492,6 @@ export abstract class SharedObjectCore<
 		);
 		// attachDeltaHandler is only called after services is assigned
 		this.services.deltaConnection.attach({
-			process: (
-				message: ISequencedDocumentMessage,
-				local: boolean,
-				localOpMetadata: unknown,
-			) => {
-				this.process(
-					{ ...message, contents: parseHandles(message.contents, this.serializer) },
-					local,
-					localOpMetadata,
-				);
-			},
 			processMessages: (messagesCollection: IRuntimeMessageCollection) => {
 				this.processMessages(messagesCollection);
 			},

--- a/packages/framework/attributor/src/runtimeAttributorDataStoreChannel.ts
+++ b/packages/framework/attributor/src/runtimeAttributorDataStoreChannel.ts
@@ -24,6 +24,7 @@ import {
 	VisibilityState,
 	type ISummaryTreeWithStats,
 	type ITelemetryContext,
+	type IRuntimeMessageCollection,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	ITelemetryLoggerExt,
@@ -135,13 +136,9 @@ export class RuntimeAttributorDataStoreChannel
 	}
 
 	/**
-	 * {@inheritdoc IFluidDataStoreChannel.process}
+	 * {@inheritdoc IFluidDataStoreChannel.processMessages}
 	 */
-	public process(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
+	public processMessages(messageCollection: IRuntimeMessageCollection): void {
 		throw new Error("Attributor should not receive messages yet");
 	}
 

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -54,8 +54,6 @@ export class DocumentsSchemaController {
     // (undocumented)
     onDisconnect(): void;
     processDocumentSchemaMessages(contents: IDocumentSchemaChangeMessage[], local: boolean, sequenceNumber: number): boolean;
-    // @deprecated
-    processDocumentSchemaOp(content: IDocumentSchemaChangeMessage, local: boolean, sequenceNumber: number): boolean;
     // (undocumented)
     sessionSchema: IDocumentSchemaCurrent;
     // (undocumented)

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -222,7 +222,14 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_DocumentsSchemaController": {
+				"backCompat": false
+			},
+			"ClassStatics_DocumentsSchemaController": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -860,29 +860,6 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 	}
 
 	/**
-	 * This is still here for back-compat purposes because channel collection implements
-	 * IFluidDataStoreChannel. Once it is removed from the interface, this method can be removed.
-	 * Container runtime calls `processMessages` instead.
-	 */
-	public process(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessages({
-			envelope: message,
-			messagesContent: [
-				{
-					contents: message.contents,
-					localOpMetadata,
-					clientSequenceNumber: message.clientSequenceNumber,
-				},
-			],
-			local,
-		});
-	}
-
-	/**
 	 * Process channel messages. The messages here are contiguous channel type messages in a batch. Bunch
 	 * of contiguous messages for a data store should be sent to it together.
 	 * @param messageCollection - The collection of messages to process.

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -610,30 +610,6 @@ export abstract class FluidDataStoreContext
 	}
 
 	/**
-	 * back-compat ADO 21575: This is temporary and will be removed once the compat requirement across Runtime and
-	 * Datastore boundary is satisfied.
-	 * Process the messages to maintain backwards compatibility. The `processMessages` function is added to
-	 * IFluidDataStoreChannel in 2.5.0. For channels before that, call `process` for each message.
-	 */
-	private processMessagesCompat(
-		channel: IFluidDataStoreChannel,
-		messageCollection: IRuntimeMessageCollection,
-	): void {
-		if (channel.processMessages !== undefined) {
-			channel.processMessages(messageCollection);
-		} else {
-			const { envelope, messagesContent, local } = messageCollection;
-			for (const { contents, localOpMetadata, clientSequenceNumber } of messagesContent) {
-				channel.process(
-					{ ...envelope, contents, clientSequenceNumber },
-					local,
-					localOpMetadata,
-				);
-			}
-		}
-	}
-
-	/**
 	 * Process messages for this data store. The messages here are contiguous messages for this data store in a batch.
 	 * @param messageCollection - The collection of messages to process.
 	 */
@@ -648,7 +624,7 @@ export abstract class FluidDataStoreContext
 
 		if (this.loaded) {
 			assert(this.channel !== undefined, 0xa68 /* Channel is not loaded */);
-			this.processMessagesCompat(this.channel, messageCollection);
+			this.channel.processMessages(messageCollection);
 		} else {
 			assert(!local, 0x142 /* "local store channel is not loaded" */);
 			assert(
@@ -886,7 +862,7 @@ export abstract class FluidDataStoreContext
 		for (const messageCollection of this.pendingMessagesState.messageCollections) {
 			// Only process ops whose seq number is greater than snapshot sequence number from which it loaded.
 			if (messageCollection.envelope.sequenceNumber > baseSequenceNumber) {
-				this.processMessagesCompat(channel, messageCollection);
+				channel.processMessages(messageCollection);
 			}
 		}
 

--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -615,23 +615,6 @@ export class DocumentsSchemaController {
 	}
 
 	/**
-	 * Process document schema change message
-	 * Called by ContainerRuntime whenever it sees document schema messages.
-	 * @param content - content of the message
-	 * @param local - whether op is local
-	 * @param sequenceNumber - sequence number of the op
-	 * @returns - true if schema was accepted, otherwise false (rejected due to failed CAS)
-	 * @deprecated It has been replaced by processDocumentSchemaMessages instead.
-	 */
-	public processDocumentSchemaOp(
-		content: IDocumentSchemaChangeMessage,
-		local: boolean,
-		sequenceNumber: number,
-	): boolean {
-		return this.processDocumentSchemaMessages([content], local, sequenceNumber);
-	}
-
-	/**
 	 * Process document schema change messages
 	 * Called by ContainerRuntime whenever it sees document schema messages.
 	 * @param contents - contents of the messages

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -22,6 +22,7 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * typeValidation.broken:
  * "Class_DocumentsSchemaController": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_DocumentsSchemaController = requireAssignableTo<TypeOnly<current.DocumentsSchemaController>, TypeOnly<old.DocumentsSchemaController>>
 
 /*
@@ -67,6 +68,7 @@ declare type current_as_old_for_Class_SummaryCollection = requireAssignableTo<Ty
  * typeValidation.broken:
  * "ClassStatics_DocumentsSchemaController": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_DocumentsSchemaController = requireAssignableTo<TypeOnly<typeof current.DocumentsSchemaController>, TypeOnly<typeof old.DocumentsSchemaController>>
 
 /*

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.legacy.alpha.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.legacy.alpha.api.md
@@ -58,9 +58,7 @@ export interface IDeltaConnection {
 // @alpha
 export interface IDeltaHandler {
     applyStashedOp(message: any): void;
-    // @deprecated
-    process: (message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown) => void;
-    processMessages?: (messageCollection: IRuntimeMessageCollection) => void;
+    processMessages: (messageCollection: IRuntimeMessageCollection) => void;
     reSubmit(message: any, localOpMetadata: unknown): void;
     rollback?(message: any, localOpMetadata: unknown): void;
     setConnectionState(connected: boolean): void;

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -104,7 +104,12 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IDeltaHandler": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -4,7 +4,6 @@
  */
 
 import type { IFluidLoadable } from "@fluidframework/core-interfaces";
-import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import type {
 	IExperimentalIncrementalSummaryContext,
 	IGarbageCollectionData,
@@ -126,24 +125,10 @@ export interface IChannel extends IFluidLoadable {
  */
 export interface IDeltaHandler {
 	/**
-	 * Processes the op.
-	 * @param message - The message to process
-	 * @param local - Whether the message originated from the local client
-	 * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
-	 * For messages from a remote client, this will be undefined.
-	 * @deprecated - Use processMessages instead to process messages.
-	 */
-	process: (
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	) => void;
-
-	/**
 	 * Process messages for this channel. The messages here are contiguous messages for this channel in a batch.
 	 * @param messageCollection - The collection of messages to process.
 	 */
-	processMessages?: (messageCollection: IRuntimeMessageCollection) => void;
+	processMessages: (messageCollection: IRuntimeMessageCollection) => void;
 
 	/**
 	 * State change events to indicate changes to the delta connection

--- a/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
@@ -130,6 +130,7 @@ declare type current_as_old_for_Interface_IDeltaConnection = requireAssignableTo
  * typeValidation.broken:
  * "Interface_IDeltaHandler": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IDeltaHandler = requireAssignableTo<TypeOnly<old.IDeltaHandler>, TypeOnly<current.IDeltaHandler>>
 
 /*
@@ -139,6 +140,7 @@ declare type old_as_current_for_Interface_IDeltaHandler = requireAssignableTo<Ty
  * typeValidation.broken:
  * "Interface_IDeltaHandler": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IDeltaHandler = requireAssignableTo<TypeOnly<current.IDeltaHandler>, TypeOnly<old.IDeltaHandler>>
 
 /*

--- a/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
@@ -70,7 +70,6 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     get objectsRoutingContext(): this;
     // (undocumented)
     readonly options: Record<string | number, any>;
-    process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     processMessages(messageCollection: IRuntimeMessageCollection): void;
     // (undocumented)
     processSignal(message: IInboundSignalMessage, local: boolean): void;

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -160,7 +160,14 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_FluidDataStoreRuntime": {
+				"backCompat": false
+			},
+			"ClassStatics_FluidDataStoreRuntime": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/datastore/src/channelDeltaConnection.ts
+++ b/packages/runtime/datastore/src/channelDeltaConnection.ts
@@ -8,7 +8,6 @@ import {
 	IDeltaConnection,
 	IDeltaHandler,
 } from "@fluidframework/datastore-definitions/internal";
-import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import type {
 	IRuntimeMessageCollection,
 	IRuntimeMessagesContent,
@@ -100,30 +99,20 @@ export class ChannelDeltaConnection implements IDeltaConnection {
 	}
 
 	public processMessages(messageCollection: IRuntimeMessageCollection): void {
-		const { envelope, messagesContent, local } = messageCollection;
 		// catches as data processing error whether or not they come from async pending queues
 		try {
-			const newMessagesContent = getContentsWithStashedOpHandling(messagesContent);
-			if (this.handler.processMessages !== undefined) {
-				this.handler.processMessages({
-					...messageCollection,
-					messagesContent: newMessagesContent,
-				});
-			} else {
-				for (const { contents, localOpMetadata, clientSequenceNumber } of newMessagesContent) {
-					const compatMessage: ISequencedDocumentMessage = {
-						...envelope,
-						contents,
-						clientSequenceNumber,
-					};
-					this.handler.process(compatMessage, local, localOpMetadata);
-				}
-			}
+			const newMessagesContent = getContentsWithStashedOpHandling(
+				messageCollection.messagesContent,
+			);
+			this.handler.processMessages({
+				...messageCollection,
+				messagesContent: newMessagesContent,
+			});
 		} catch (error) {
 			throw DataProcessingError.wrapIfUnrecognized(
 				error,
 				"channelDeltaConnectionFailedToProcessMessages",
-				envelope,
+				messageCollection.envelope,
 			);
 		}
 	}

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -788,29 +788,6 @@ export class FluidDataStoreRuntime
 		}
 	}
 
-	/**
-	 * back-compat ADO 21575.
-	 * This is still here for back-compat purposes because it exists on IFluidDataStoreChannel. Once it is removed from
-	 * the interface, this method can be removed.
-	 */
-	public process(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	) {
-		this.processMessages({
-			envelope: message,
-			messagesContent: [
-				{
-					contents: message.contents,
-					localOpMetadata,
-					clientSequenceNumber: message.clientSequenceNumber,
-				},
-			],
-			local,
-		});
-	}
-
 	public processSignal(message: IInboundSignalMessage, local: boolean) {
 		this.emit("signal", message, local);
 	}

--- a/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
+++ b/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
@@ -31,6 +31,7 @@ declare type old_as_current_for_Class_FluidDataStoreRuntime = requireAssignableT
  * typeValidation.broken:
  * "Class_FluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_FluidDataStoreRuntime = requireAssignableTo<TypeOnly<current.FluidDataStoreRuntime>, TypeOnly<old.FluidDataStoreRuntime>>
 
 /*
@@ -58,6 +59,7 @@ declare type current_as_old_for_Class_FluidObjectHandle = requireAssignableTo<Ty
  * typeValidation.broken:
  * "ClassStatics_FluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_FluidDataStoreRuntime = requireAssignableTo<TypeOnly<typeof current.FluidDataStoreRuntime>, TypeOnly<typeof old.FluidDataStoreRuntime>>
 
 /*

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -129,9 +129,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
     getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     makeVisibleAndAttachGraph(): void;
-    // @deprecated
-    process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
-    processMessages?(messageCollection: IRuntimeMessageCollection): void;
+    processMessages(messageCollection: IRuntimeMessageCollection): void;
     processSignal(message: IInboundSignalMessage, local: boolean): void;
     // (undocumented)
     request(request: IRequest): Promise<IResponse>;

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -110,7 +110,12 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IFluidDataStoreChannel": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -329,13 +329,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
 	 * Process messages for this channel. The messages here are contiguous messages in a batch.
 	 * @param messageCollection - The collection of messages to process.
 	 */
-	processMessages?(messageCollection: IRuntimeMessageCollection): void;
-
-	/**
-	 * Processes the op.
-	 * @deprecated processMessages should be used instead to process messages for a channel.
-	 */
-	process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
+	processMessages(messageCollection: IRuntimeMessageCollection): void;
 
 	/**
 	 * Processes the signal.

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -184,6 +184,7 @@ declare type current_as_old_for_Interface_IExperimentalIncrementalSummaryContext
  * typeValidation.broken:
  * "Interface_IFluidDataStoreChannel": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IFluidDataStoreChannel = requireAssignableTo<TypeOnly<old.IFluidDataStoreChannel>, TypeOnly<current.IFluidDataStoreChannel>>
 
 /*
@@ -193,6 +194,7 @@ declare type old_as_current_for_Interface_IFluidDataStoreChannel = requireAssign
  * typeValidation.broken:
  * "Interface_IFluidDataStoreChannel": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IFluidDataStoreChannel = requireAssignableTo<TypeOnly<current.IFluidDataStoreChannel>, TypeOnly<old.IFluidDataStoreChannel>>
 
 /*

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -168,8 +168,6 @@ export class MockDeltaConnection implements IDeltaConnection {
     dirty(): void;
     // (undocumented)
     handler: IDeltaHandler | undefined;
-    // @deprecated (undocumented)
-    process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     // (undocumented)
     processMessages(messageCollection: IRuntimeMessageCollection): void;
     // (undocumented)
@@ -443,8 +441,6 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     options: Record<string | number, any>;
     // (undocumented)
     readonly path = "";
-    // @deprecated (undocumented)
-    process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     // (undocumented)
     processMessages(messageCollection: IRuntimeMessageCollection): void;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -157,7 +157,21 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_MockDeltaConnection": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"Class_MockFluidDataStoreRuntime": {
+				"backCompat": false
+			},
+			"ClassStatics_MockDeltaConnection": {
+				"backCompat": false
+			},
+			"ClassStatics_MockFluidDataStoreRuntime": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -59,6 +59,7 @@ import {
 	VisibilityState,
 	type ITelemetryContext,
 	type IRuntimeMessageCollection,
+	type IRuntimeMessagesContent,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	getNormalizedObjectStoragePathParts,
@@ -107,17 +108,6 @@ export class MockDeltaConnection implements IDeltaConnection {
 	public setConnectionState(connected: boolean) {
 		this._connected = connected;
 		this.handler?.setConnectionState(connected);
-	}
-
-	/**
-	 * @deprecated - This has been replaced by processMessages
-	 */
-	public process(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	) {
-		this.handler?.process(message, local, localOpMetadata);
 	}
 
 	public processMessages(messageCollection: IRuntimeMessageCollection) {
@@ -442,7 +432,14 @@ export class MockContainerRuntime extends TypedEventEmitter<IContainerRuntimeEve
 		if (this.isSequencedAllocationMessage(message)) {
 			this.finalizeIdRange(message.contents.contents);
 		} else {
-			this.dataStoreRuntime.process(message, local, localOpMetadata);
+			const messagesContent: IRuntimeMessagesContent[] = [
+				{
+					contents: message.contents,
+					clientSequenceNumber: message.clientSequenceNumber,
+					localOpMetadata,
+				},
+			];
+			this.dataStoreRuntime.processMessages({ envelope: message, local, messagesContent });
 		}
 	}
 
@@ -1001,31 +998,10 @@ export class MockFluidDataStoreRuntime
 		return null;
 	}
 
-	/**
-	 * @deprecated - This has been replaced by processMessages
-	 */
-	public process(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	) {
-		this.deltaConnections.forEach((dc) => {
-			dc.process(message, local, localOpMetadata);
-		});
-	}
-
 	public processMessages(messageCollection: IRuntimeMessageCollection) {
-		for (const {
-			contents,
-			localOpMetadata,
-			clientSequenceNumber,
-		} of messageCollection.messagesContent) {
-			this.process(
-				{ ...messageCollection.envelope, contents, clientSequenceNumber },
-				messageCollection.local,
-				localOpMetadata,
-			);
-		}
+		this.deltaConnections.forEach((dc) => {
+			dc.processMessages(messageCollection);
+		});
 	}
 
 	public processSignal(message: any, local: boolean) {

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -112,6 +112,7 @@ declare type current_as_old_for_Class_MockContainerRuntimeForReconnection = requ
  * typeValidation.broken:
  * "Class_MockDeltaConnection": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockDeltaConnection = requireAssignableTo<TypeOnly<old.MockDeltaConnection>, TypeOnly<current.MockDeltaConnection>>
 
 /*
@@ -121,6 +122,7 @@ declare type old_as_current_for_Class_MockDeltaConnection = requireAssignableTo<
  * typeValidation.broken:
  * "Class_MockDeltaConnection": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_MockDeltaConnection = requireAssignableTo<TypeOnly<current.MockDeltaConnection>, TypeOnly<old.MockDeltaConnection>>
 
 /*
@@ -193,6 +195,7 @@ declare type old_as_current_for_Class_MockFluidDataStoreRuntime = requireAssigna
  * typeValidation.broken:
  * "Class_MockFluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_MockFluidDataStoreRuntime = requireAssignableTo<TypeOnly<current.MockFluidDataStoreRuntime>, TypeOnly<old.MockFluidDataStoreRuntime>>
 
 /*
@@ -337,6 +340,7 @@ declare type current_as_old_for_ClassStatics_MockContainerRuntimeForReconnection
  * typeValidation.broken:
  * "ClassStatics_MockDeltaConnection": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_MockDeltaConnection = requireAssignableTo<TypeOnly<typeof current.MockDeltaConnection>, TypeOnly<typeof old.MockDeltaConnection>>
 
 /*
@@ -373,6 +377,7 @@ declare type current_as_old_for_ClassStatics_MockFluidDataStoreContext = require
  * typeValidation.broken:
  * "ClassStatics_MockFluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_MockFluidDataStoreRuntime = requireAssignableTo<TypeOnly<typeof current.MockFluidDataStoreRuntime>, TypeOnly<typeof old.MockFluidDataStoreRuntime>>
 
 /*

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -167,7 +167,16 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IProvideTestFluidObject": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"Interface_ITestFluidObject": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -76,6 +76,7 @@ declare type current_as_old_for_Interface_IOpProcessingController = requireAssig
  * typeValidation.broken:
  * "Interface_IProvideTestFluidObject": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IProvideTestFluidObject = requireAssignableTo<TypeOnly<old.IProvideTestFluidObject>, TypeOnly<current.IProvideTestFluidObject>>
 
 /*
@@ -85,6 +86,7 @@ declare type old_as_current_for_Interface_IProvideTestFluidObject = requireAssig
  * typeValidation.broken:
  * "Interface_IProvideTestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IProvideTestFluidObject = requireAssignableTo<TypeOnly<current.IProvideTestFluidObject>, TypeOnly<old.IProvideTestFluidObject>>
 
 /*
@@ -94,6 +96,7 @@ declare type current_as_old_for_Interface_IProvideTestFluidObject = requireAssig
  * typeValidation.broken:
  * "Interface_ITestFluidObject": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ITestFluidObject = requireAssignableTo<TypeOnly<old.ITestFluidObject>, TypeOnly<current.ITestFluidObject>>
 
 /*
@@ -103,4 +106,5 @@ declare type old_as_current_for_Interface_ITestFluidObject = requireAssignableTo
  * typeValidation.broken:
  * "Interface_ITestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ITestFluidObject = requireAssignableTo<TypeOnly<current.ITestFluidObject>, TypeOnly<old.ITestFluidObject>>

--- a/packages/tools/replay-tool/src/unknownChannel.ts
+++ b/packages/tools/replay-tool/src/unknownChannel.ts
@@ -16,7 +16,6 @@ import {
 	IChannelServices,
 } from "@fluidframework/datastore-definitions/internal";
 import { SummaryType } from "@fluidframework/driver-definitions";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
 	ITelemetryContext,
 	IGarbageCollectionData,
@@ -32,11 +31,6 @@ class UnknownChannel implements IChannel {
 		services: IChannelServices,
 	) {
 		services.deltaConnection.attach({
-			process: (
-				message: ISequencedDocumentMessage,
-				local: boolean,
-				localOpMetadata: unknown,
-			) => {},
 			processMessages: (messageCollection: IRuntimeMessageCollection) => {},
 			setConnectionState: (connected: boolean) => {},
 			reSubmit: (content: any, localOpMetadata: unknown) => {},


### PR DESCRIPTION
The `process` function and related code has been removed. It has been replaced by `processMessages`.

These were deprecated in 2.5.0 - https://github.com/microsoft/FluidFramework/releases/tag/client_v2.5.0#user-content-the-process-function-on-ifluiddatastorechannel-ideltahandler-mockfluiddatastoreruntime-and-mockdeltaconnection-is-now-deprecated-22840