### PR TITLE
fix(build-cli): Only update range for workspace:*|^|~ dependencies

### DIFF
--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -39,9 +39,9 @@ FLAGS
       --[no-]install                   Update lockfiles by running 'npm install' automatically.
       --scheme=<option>                Override the version scheme used by the release group or package.
                                        <options: semver|internal|virtualPatch>
-      --updateAllDeps                  Controls the behavior for updating dependencies in a package. If not passed (the
+      --updateAllDeps                  Controls the behavior for updating dependencies in a package. If "false" (the
                                        default), matching dependencies are only updated if they use the "workspace:"
-                                       protocol. If passed, they are updated regardless of what their version specifier
+                                       protocol. If "true", they are updated regardless of what their version specifier
                                        says. This flag only exists to allow use of the old behavior (by passing
                                        `--updateAllDeps).
 

--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -14,7 +14,7 @@ Bumps the version of a release group or package to the next minor, major, or pat
 USAGE
   $ flub bump PACKAGE_OR_RELEASE_GROUP [-v | --quiet] [-t major|minor|patch | --exact <value>] [--scheme
     semver|internal|virtualPatch | ] [--exactDepType ^|~||workspace:*|workspace:^|workspace:~] [-d
-    ^|~||workspace:*|workspace:^|workspace:~] [--onlyUpdateWorkspaceDeps] [-x | --install | --commit |  |  | ]
+    ^|~||workspace:*|workspace:^|workspace:~] [--updateAllDeps] [-x | --install | --commit |  |  | ]
 
 ARGUMENTS
   PACKAGE_OR_RELEASE_GROUP  The name of a package or a release group.
@@ -37,12 +37,13 @@ FLAGS
                                        dependencies.
                                        <options: ^|~||workspace:*|workspace:^|workspace:~>
       --[no-]install                   Update lockfiles by running 'npm install' automatically.
-      --onlyUpdateWorkspaceDeps        Controls the behavior for updating dependencies in a package. If "true", matching
-                                       dependencies are only updated if they use the "workspace:" protocol will be
-                                       updated. If "false", they are updated regardless of what their version specifier
-                                       says. Only exists to allow use of the old behavior (when the flag is "false").
       --scheme=<option>                Override the version scheme used by the release group or package.
                                        <options: semver|internal|virtualPatch>
+      --updateAllDeps                  Controls the behavior for updating dependencies in a package. If not passed (the
+                                       default), matching dependencies are only updated if they use the "workspace:"
+                                       protocol. If passed, they are updated regardless of what their version specifier
+                                       says. This flag only exists to allow use of the old behavior (by passing
+                                       `--updateAllDeps).
 
 LOGGING FLAGS
   -v, --verbose  Enable verbose logging.

--- a/build-tools/packages/build-cli/docs/bump.md
+++ b/build-tools/packages/build-cli/docs/bump.md
@@ -14,7 +14,7 @@ Bumps the version of a release group or package to the next minor, major, or pat
 USAGE
   $ flub bump PACKAGE_OR_RELEASE_GROUP [-v | --quiet] [-t major|minor|patch | --exact <value>] [--scheme
     semver|internal|virtualPatch | ] [--exactDepType ^|~||workspace:*|workspace:^|workspace:~] [-d
-    ^|~||workspace:*|workspace:^|workspace:~] [-x | --install | --commit |  |  | ]
+    ^|~||workspace:*|workspace:^|workspace:~] [--onlyUpdateWorkspaceDeps] [-x | --install | --commit |  |  | ]
 
 ARGUMENTS
   PACKAGE_OR_RELEASE_GROUP  The name of a package or a release group.
@@ -37,6 +37,10 @@ FLAGS
                                        dependencies.
                                        <options: ^|~||workspace:*|workspace:^|workspace:~>
       --[no-]install                   Update lockfiles by running 'npm install' automatically.
+      --onlyUpdateWorkspaceDeps        Controls the behavior for updating dependencies in a package. If "true", matching
+                                       dependencies are only updated if they use the "workspace:" protocol will be
+                                       updated. If "false", they are updated regardless of what their version specifier
+                                       says. Only exists to allow use of the old behavior (when the flag is "false").
       --scheme=<option>                Override the version scheme used by the release group or package.
                                        <options: semver|internal|virtualPatch>
 

--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -78,10 +78,11 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 				'Controls the type of dependency that is used between packages within the release group. Use "" (the empty string) to indicate exact dependencies. Use the workspace:-prefixed values to set interdependencies using the workspace protocol. The interdependency range will be set to the workspace string specified.',
 			options: [...RangeOperators, ...WorkspaceRanges],
 		}),
-		onlyUpdateWorkspaceDeps: Flags.boolean({
+		updateAllDeps: Flags.boolean({
 			description:
-				'Controls the behavior for updating dependencies in a package. If "true", matching dependencies are only updated if they use the "workspace:" protocol. If "false", they are updated regardless of what their version specifier says. This flag only exists to allow use of the old behavior (by passing `--no-onlyUpdateWorkspaceDeps).',
-			default: true,
+				'Controls the behavior for updating dependencies in a package. If "false" (the default), matching dependencies are only updated if they use the "workspace:" protocol. If "true", they are updated regardless of what their version specifier says. This flag only exists to allow use of the old behavior (by passing `--updateAllDeps).',
+			default: false,
+			env: "FLUB_BUMP_UPDATE_ALL_DEPS",
 		}),
 		commit: checkFlags.commit,
 		install: checkFlags.install,
@@ -252,7 +253,7 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 			newVersion,
 			interdependencyRange,
 			this.logger,
-			flags.onlyUpdateWorkspaceDeps,
+			!flags.updateAllDeps,
 		);
 
 		if (shouldInstall) {

--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -78,6 +78,11 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 				'Controls the type of dependency that is used between packages within the release group. Use "" (the empty string) to indicate exact dependencies. Use the workspace:-prefixed values to set interdependencies using the workspace protocol. The interdependency range will be set to the workspace string specified.',
 			options: [...RangeOperators, ...WorkspaceRanges],
 		}),
+		onlyUpdateWorkspaceDeps: Flags.boolean({
+			description:
+				'Controls the behavior for updating dependencies in a package. If "true", matching dependencies are only updated if they use the "workspace:" protocol will be updated. If "false", they are updated regardless of what their version specifier says. Only exists to allow use of the old behavior (when the flag is "false").',
+			default: true,
+		}),
 		commit: checkFlags.commit,
 		install: checkFlags.install,
 		skipChecks: skipCheckFlag,
@@ -247,6 +252,7 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 			newVersion,
 			interdependencyRange,
 			this.logger,
+			flags.onlyUpdateWorkspaceDeps,
 		);
 
 		if (shouldInstall) {

--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -80,7 +80,7 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 		}),
 		onlyUpdateWorkspaceDeps: Flags.boolean({
 			description:
-				'Controls the behavior for updating dependencies in a package. If "true", matching dependencies are only updated if they use the "workspace:" protocol will be updated. If "false", they are updated regardless of what their version specifier says. Only exists to allow use of the old behavior (when the flag is "false").',
+				'Controls the behavior for updating dependencies in a package. If "true", matching dependencies are only updated if they use the "workspace:" protocol. If "false", they are updated regardless of what their version specifier says. This flag only exists to allow use of the old behavior (by passing `--no-onlyUpdateWorkspaceDeps).',
 			default: true,
 		}),
 		commit: checkFlags.commit,

--- a/build-tools/packages/build-cli/src/library/package.ts
+++ b/build-tools/packages/build-cli/src/library/package.ts
@@ -710,7 +710,7 @@ async function setPackageDependencies(
 
 				// eslint-disable-next-line @typescript-eslint/no-base-to-string
 				newRangeString = dep.range.toString();
-				if (dependencies[name] !== newRangeString) {
+				if (dependencies[name] === "workspace:~") {
 					changed = true;
 					dependencies[name] = newRangeString;
 				}

--- a/build-tools/packages/build-cli/src/library/package.ts
+++ b/build-tools/packages/build-cli/src/library/package.ts
@@ -708,9 +708,8 @@ async function setPackageDependencies(
 					continue;
 				}
 
-				// eslint-disable-next-line @typescript-eslint/no-base-to-string
 				newRangeString = dep.range.toString();
-				if (dependencies[name] === "workspace:~") {
+				if (isWorkspaceRange(dependencies[name])) {
 					changed = true;
 					dependencies[name] = newRangeString;
 				}

--- a/build-tools/packages/build-cli/src/library/package.ts
+++ b/build-tools/packages/build-cli/src/library/package.ts
@@ -611,11 +611,9 @@ export async function setVersion(
 					? translatedVersion.version
 					: getVersionRange(translatedVersion, interdependencyRange);
 		} else {
-			// eslint-disable-next-line @typescript-eslint/no-base-to-string
 			newRange = `${interdependencyRange}${translatedVersion.version}`;
 		}
 	} else {
-		// eslint-disable-next-line @typescript-eslint/no-base-to-string
 		newRange = `${interdependencyRange}${translatedVersion.version}`;
 	}
 
@@ -872,7 +870,6 @@ export async function npmCheckUpdatesHomegrown(
 	}
 
 	const range: InterdependencyRange = prerelease ? newVersion : `^${[...versionSet][0]}`;
-	// eslint-disable-next-line @typescript-eslint/no-base-to-string
 	log?.verbose(`Calculated new range: ${range}`);
 	for (const dep of Object.keys(dependencyVersionMap)) {
 		const pkg = context.fullPackageMap.get(dep);


### PR DESCRIPTION
## Description

Makes it so `flub bump` only updates the range for `workspace:*|^|~` dependencies. The problem is that even when we have dependencies like `"fluid-framework": "^1.4.0"` in and end-to-end tests package, which is supposed to point to FF 1.x, it currently gets replaced with an exact dependency on `X.Y.Z-<buildId>` and this breaks some test pipelines.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I'm not certain this is the right fix, but putting it out for discussion. I confirmed locally that it doesn't override the dependency from the example above.