### PR TITLE
test(client): remove mismatched fluid-framework dep

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,11 +1,19 @@
-// .pnpmfile.cjs is a pnpm hook file that allows modification of package.json content
-// (in memory) of the packages that are being installed.
-// https://pnpm.io/pnpmfile
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
 
-// This implementation is based on https://gist.github.com/dvins/33b8fb52480149d37cdeb98890244c5b.
-// Changes:
-//  - Added support for complete dependency removal (specify null for newVersion)
-//  - Specify remapPeerDependencies for local needs
+/*
+ * .pnpmfile.cjs is a pnpm hook file that allows modification of package.json content
+ * (in memory) of the packages that are being installed.
+ * https://pnpm.io/pnpmfile
+ *
+ * This implementation is based on https://gist.github.com/dvins/33b8fb52480149d37cdeb98890244c5b.
+ * Changes:
+ *  - Added support for complete dependency removal (specify null for newVersion)
+ *  - Apply stylistic and naming preferences and comment cleanup
+ *  - Specify remapPeerDependencies for local needs
+ */
 
 //@ts-check
 
@@ -22,40 +30,47 @@ const remapPeerDependencies = [
 	// It should have been an optional peer dependency. We just remove it.
 	{
 		package: "@fluidframework/azure-client",
-		packageVersion: "1.",
+		packageVersionPrefix: "1.",
 		peerDependency: "fluid-framework",
 		newVersion: null,
 	},
 ];
 
 function overridesPeerDependencies(pkg) {
-	if (pkg.peerDependencies) {
-		remapPeerDependencies.map((dep) => {
-			if (pkg.name === dep.package && pkg.version.startsWith(dep.packageVersion)) {
-				console.log(`  - Checking ${pkg.name}@${pkg.version}`); // , pkg.peerDependencies);
+	if (!pkg.peerDependencies) {
+		return;
+	}
 
-				if (dep.peerDependency in pkg.peerDependencies) {
-					try {
-						console.log(
-							`    - Overriding ${pkg.name}@${pkg.version} peerDependency ${dep.peerDependency}@${pkg.peerDependencies[dep.peerDependency]}`,
-						);
+	const applicableRemapPeerDependencies = remapPeerDependencies.filter(
+		(remap) =>
+			remap.package === pkg.name && pkg.version.startsWith(remap.packageVersionPrefix),
+	);
 
-						// First add a new dependency to the package and then remove the peer dependency, if defined.
-						if (dep.newVersion) {
-							// This approach has the added advantage that scoped overrides should now work, too.
-							pkg.dependencies[dep.peerDependency] = dep.newVersion;
-						}
-						delete pkg.peerDependencies[dep.peerDependency];
+	if (applicableRemapPeerDependencies.length === 0) {
+		return;
+	}
 
-						console.log(
-							`      - Overrode ${pkg.name}@${pkg.version} peerDependency ${dep.peerDependency}@${pkg.dependencies[dep.peerDependency]}`,
-						);
-					} catch (err) {
-						console.error(err);
-					}
-				}
+	console.log(`  - Checking ${pkg.name}@${pkg.version}`);
+	for (const dep of applicableRemapPeerDependencies) {
+		if (dep.peerDependency in pkg.peerDependencies) {
+			console.log(
+				`    - Overriding ${pkg.name}@${pkg.version} peerDependency ${dep.peerDependency}@${pkg.peerDependencies[dep.peerDependency]}`,
+			);
+
+			// First add a new dependency to the package, if defined, and then remove the peer dependency.
+			if (dep.newVersion) {
+				// This approach has the added advantage that scoped overrides should now work, too.
+				pkg.dependencies[dep.peerDependency] = dep.newVersion;
 			}
-		});
+			delete pkg.peerDependencies[dep.peerDependency];
+
+			const newDep = pkg.dependencies[dep.peerDependency];
+			console.log(
+				newDep
+					? `      - Overrode ${pkg.name}@${pkg.version} peerDependency to ${dep.peerDependency}@${newDep} (as full dependency)`
+					: `      - Removed ${pkg.name}@${pkg.version} peerDependency`,
+			);
+		}
 	}
 }
 

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,0 +1,66 @@
+//@ts-check
+
+// Based on https://gist.github.com/dvins/33b8fb52480149d37cdeb98890244c5b
+// Changes:
+//  - Added support for complete dependency removal (specify null for newVersion)
+//  - Specify remapPeerDependencies for local needs
+
+// https://pnpm.io/pnpmfile
+// https://github.com/pnpm/pnpm/issues/4214
+// https://github.com/pnpm/pnpm/issues/5391
+
+const rootPkg = require("./package.json");
+
+console.log(`Checking for package peerDependency overrides`);
+
+const remapPeerDependencies = [
+	// @fluidframework/azure-client 1.x declares a peerDependency on fluid-framework but does not require it.
+	// It should have been an optional peer dependency. We just remove it.
+	{
+		package: "@fluidframework/azure-client",
+		packageVersion: "1.",
+		peerDependency: "fluid-framework",
+		newVersion: null,
+	},
+];
+
+function overridesPeerDependencies(pkg) {
+	if (pkg.peerDependencies) {
+		remapPeerDependencies.map((dep) => {
+			if (pkg.name === dep.package && pkg.version.startsWith(dep.packageVersion)) {
+				console.log(`  - Checking ${pkg.name}@${pkg.version}`); // , pkg.peerDependencies);
+
+				if (dep.peerDependency in pkg.peerDependencies) {
+					try {
+						console.log(
+							`    - Overriding ${pkg.name}@${pkg.version} peerDependency ${dep.peerDependency}@${pkg.peerDependencies[dep.peerDependency]}`,
+						);
+
+						// First add a new dependency to the package and then remove the peer dependency, if defined.
+						if (dep.newVersion) {
+							// This approach has the added advantage that scoped overrides should now work, too.
+							pkg.dependencies[dep.peerDependency] = dep.newVersion;
+						}
+						delete pkg.peerDependencies[dep.peerDependency];
+
+						console.log(
+							`      - Overrode ${pkg.name}@${pkg.version} peerDependency ${dep.peerDependency}@${pkg.dependencies[dep.peerDependency]}`,
+						);
+					} catch (err) {
+						console.error(err);
+					}
+				}
+			}
+		});
+	}
+}
+
+module.exports = {
+	hooks: {
+		readPackage(pkg, _context) {
+			// skipDeps(pkg);
+			overridesPeerDependencies(pkg);
+			return pkg;
+		},
+	},
+};

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,9 +1,13 @@
-//@ts-check
+// .pnpmfile.cjs is a pnpm hook file that allows modification of package.json content
+// (in memory) of the packages that are being installed.
+// https://pnpm.io/pnpmfile
 
-// Based on https://gist.github.com/dvins/33b8fb52480149d37cdeb98890244c5b
+// This implementation is based on https://gist.github.com/dvins/33b8fb52480149d37cdeb98890244c5b.
 // Changes:
 //  - Added support for complete dependency removal (specify null for newVersion)
 //  - Specify remapPeerDependencies for local needs
+
+//@ts-check
 
 // https://pnpm.io/pnpmfile
 // https://github.com/pnpm/pnpm/issues/4214
@@ -58,7 +62,6 @@ function overridesPeerDependencies(pkg) {
 module.exports = {
 	hooks: {
 		readPackage(pkg, _context) {
-			// skipDeps(pkg);
 			overridesPeerDependencies(pkg);
 			return pkg;
 		},

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -21,10 +21,6 @@
 // https://github.com/pnpm/pnpm/issues/4214
 // https://github.com/pnpm/pnpm/issues/5391
 
-const rootPkg = require("./package.json");
-
-console.log(`Checking for package peerDependency overrides`);
-
 const remapPeerDependencies = [
 	// @fluidframework/azure-client 1.x declares a peerDependency on fluid-framework but does not require it.
 	// It should have been an optional peer dependency. We just remove it.
@@ -36,7 +32,16 @@ const remapPeerDependencies = [
 	},
 ];
 
+// Only emit the checking banner once.
+// And only if engaged. Some pnpm uses expect specific output (like `pnpm list`) and may break if anything is emitted.
+let emittedCheckBanner = false;
+
 function overridesPeerDependencies(pkg) {
+	if (!emittedCheckBanner) {
+		console.log(`Checking for package peerDependency overrides`);
+		emittedCheckBanner = true;
+	}
+
 	if (!pkg.peerDependencies) {
 		return;
 	}

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -124,6 +124,7 @@
 		"cross-env": "^7.0.3",
 		"eslint": "~8.55.0",
 		"eslint-config-prettier": "~9.0.0",
+		"fluid-framework": "workspace:~",
 		"mocha": "^10.2.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -124,7 +124,6 @@
 		"cross-env": "^7.0.3",
 		"eslint": "~8.55.0",
 		"eslint-config-prettier": "~9.0.0",
-		"fluid-framework": "workspace:~",
 		"mocha": "^10.2.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -84,7 +84,6 @@
 		"@fluidframework/tree": "workspace:~",
 		"axios": "^1.7.7",
 		"cross-env": "^7.0.3",
-		"fluid-framework": "^1.4.0",
 		"mocha": "^10.2.0",
 		"mocha-multi-reporters": "^1.5.1",
 		"moment": "^2.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13097,6 +13097,9 @@ importers:
       eslint-config-prettier:
         specifier: ~9.0.0
         version: 9.0.0(eslint@8.55.0)
+      fluid-framework:
+        specifier: workspace:~
+        version: link:../../framework/fluid-framework
       mocha:
         specifier: ^10.2.0
         version: 10.8.2
@@ -13190,9 +13193,6 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
-      fluid-framework:
-        specifier: ^1.4.0
-        version: 1.4.0
       mocha:
         specifier: ^10.2.0
         version: 10.8.2
@@ -17905,9 +17905,6 @@ packages:
   '@fluidframework/matrix@2.20.0':
     resolution: {integrity: sha512-N3UqVg0hNtY/dkKdmf3DsWS5GknvquMzbsLAlnSW42SfI8b+I5EYpqLVPzaUv3EMMlPP6B1xNMp3Aq6j5TsOkA==}
 
-  '@fluidframework/merge-tree@1.4.0':
-    resolution: {integrity: sha512-UJq7AfD52bp8ecoJLxArGI8506hTFjkNYLU2TXj08Fn8pi6MYN8WBMrCgAGJ47P7ytP1YfXOOWLzeT2ODuYJYw==}
-
   '@fluidframework/merge-tree@2.20.0':
     resolution: {integrity: sha512-6vdrG/rCCQE33ERfau7v0+Qxd87gBAu8PDsURCFtTewUYxz5B17MikMkpba9l850Uql3wDaLPzQKKDtTt4C6bw==}
 
@@ -17973,9 +17970,6 @@ packages:
 
   '@fluidframework/runtime-utils@2.20.0':
     resolution: {integrity: sha512-QjAR9pwMqwguJ5iz1sLxr3/opfcl31rnVoX0IUkHq9bJcsjNufr+8zmZ89Yvlp0Rr4plsIqsz9Tv2fFPYGwhcg==}
-
-  '@fluidframework/sequence@1.4.0':
-    resolution: {integrity: sha512-KV/BNdALIgKhlivGv7U4NRCRrDWLIgWEVB2Q/oSNdKF5kUgoQnl+iIQLQcpC8dGAB7YQyCHFZVi4glanyEPF5Q==}
 
   '@fluidframework/sequence@2.20.0':
     resolution: {integrity: sha512-37k91G1Yxhh9YCv0KzoLBjdi9YuKiZ4yA8mItAnXg5koS6cHJONB8kCZ7iNWIp+ygeKFavAWxIHlDvadICqZ1g==}
@@ -22409,9 +22403,6 @@ packages:
 
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
-
-  fluid-framework@1.4.0:
-    resolution: {integrity: sha512-Alq2+bwmIrYBZFh/8IynI4mfHvKExLahD1wQ1/4G0PiFYVtI6k2vpRVBofXijTJYq81y3WHN7ytzycW4g/JJrQ==}
 
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
@@ -31001,23 +30992,6 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/merge-tree@1.4.0':
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 0.32.2
-      '@fluidframework/container-definitions': 1.4.0
-      '@fluidframework/container-utils': 1.4.0
-      '@fluidframework/core-interfaces': 1.4.0
-      '@fluidframework/datastore-definitions': 1.4.0
-      '@fluidframework/protocol-definitions': 0.1028.2000
-      '@fluidframework/runtime-definitions': 1.4.0
-      '@fluidframework/runtime-utils': 1.4.0
-      '@fluidframework/shared-object-base': 1.4.0
-      '@fluidframework/telemetry-utils': 1.4.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@fluidframework/merge-tree@2.20.0(debug@4.4.0)':
     dependencies:
       '@fluid-internal/client-utils': 2.20.0
@@ -31276,24 +31250,6 @@ snapshots:
       '@fluidframework/driver-utils': 2.20.0(debug@4.4.0)
       '@fluidframework/runtime-definitions': 2.20.0
       '@fluidframework/telemetry-utils': 2.20.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@fluidframework/sequence@1.4.0':
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-      '@fluidframework/common-utils': 0.32.2
-      '@fluidframework/container-utils': 1.4.0
-      '@fluidframework/core-interfaces': 1.4.0
-      '@fluidframework/datastore-definitions': 1.4.0
-      '@fluidframework/merge-tree': 1.4.0
-      '@fluidframework/protocol-definitions': 0.1028.2000
-      '@fluidframework/runtime-definitions': 1.4.0
-      '@fluidframework/runtime-utils': 1.4.0
-      '@fluidframework/shared-object-base': 1.4.0
-      '@fluidframework/telemetry-utils': 1.4.0
-      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -37609,18 +37565,6 @@ snapshots:
   flatted@2.0.2: {}
 
   flatted@3.3.2: {}
-
-  fluid-framework@1.4.0:
-    dependencies:
-      '@fluidframework/container-definitions': 1.4.0
-      '@fluidframework/container-loader': 1.4.0
-      '@fluidframework/driver-definitions': 1.4.0
-      '@fluidframework/fluid-static': 1.4.0
-      '@fluidframework/map': 1.4.0
-      '@fluidframework/sequence': 1.4.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   fn.name@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,8 @@ overrides:
   oclif>@aws-sdk/client-s3: npm:empty-npm-package@1.0.0
   socket.io-client: ~4.7.5
 
+pnpmfileChecksum: guqkatm7ncczi5qx3haxz4klam
+
 patchedDependencies:
   '@microsoft/api-extractor@7.47.8':
     hash: ldzfpsbo3oeejrejk775zxplmi
@@ -13095,9 +13097,6 @@ importers:
       eslint-config-prettier:
         specifier: ~9.0.0
         version: 9.0.0(eslint@8.55.0)
-      fluid-framework:
-        specifier: workspace:~
-        version: link:../../framework/fluid-framework
       mocha:
         specifier: ^10.2.0
         version: 10.8.2
@@ -13139,7 +13138,7 @@ importers:
         version: link:../../azure-client
       '@fluidframework/azure-client-legacy':
         specifier: npm:@fluidframework/azure-client@^1.2.0
-        version: '@fluidframework/azure-client@1.2.0(encoding@0.1.13)(fluid-framework@1.4.0)'
+        version: '@fluidframework/azure-client@1.2.0(encoding@0.1.13)'
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../../common/container-definitions
@@ -17748,8 +17747,6 @@ packages:
 
   '@fluidframework/azure-client@1.2.0':
     resolution: {integrity: sha512-jpfYF6I1uwwCqOc8X0fOgZz4Lj91QFzKV4S9lM7jSW84GxytlL3nDanj9+EYC+vLn4liRVaOCA3zRwpkDNXRWg==}
-    peerDependencies:
-      fluid-framework: ^1.4.0
 
   '@fluidframework/azure-client@2.20.0':
     resolution: {integrity: sha512-Au4TD+WwRPOSfUaEwhDeW/QroSwFeEIlJm8egoetJmeOT7eJdyFyqbr9ucsLGugBFNUfF1hngfONHk+6gMbCKw==}
@@ -30303,7 +30300,7 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/azure-client@1.2.0(encoding@0.1.13)(fluid-framework@1.4.0)':
+  '@fluidframework/azure-client@1.2.0(encoding@0.1.13)':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
@@ -30319,7 +30316,6 @@ snapshots:
       '@fluidframework/runtime-utils': 1.4.0
       '@fluidframework/server-services-client': 0.1036.5002
       axios: 0.28.1(debug@4.4.0)
-      fluid-framework: 1.4.0
       uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   oclif>@aws-sdk/client-s3: npm:empty-npm-package@1.0.0
   socket.io-client: ~4.7.5
 
-pnpmfileChecksum: xaxghnsubb7ncvlsovpnos2y7e
+pnpmfileChecksum: jsbnis4v7zlhs4t7yscsd3mtxe
 
 patchedDependencies:
   '@microsoft/api-extractor@7.47.8':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   oclif>@aws-sdk/client-s3: npm:empty-npm-package@1.0.0
   socket.io-client: ~4.7.5
 
-pnpmfileChecksum: guqkatm7ncczi5qx3haxz4klam
+pnpmfileChecksum: uo47frx7n4fymuqaeishbzde2m
 
 patchedDependencies:
   '@microsoft/api-extractor@7.47.8':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   oclif>@aws-sdk/client-s3: npm:empty-npm-package@1.0.0
   socket.io-client: ~4.7.5
 
-pnpmfileChecksum: uo47frx7n4fymuqaeishbzde2m
+pnpmfileChecksum: xaxghnsubb7ncvlsovpnos2y7e
 
 patchedDependencies:
   '@microsoft/api-extractor@7.47.8':


### PR DESCRIPTION
azure-client 1.x declares a peerDependency on fluid-framework 1.4.0. This should not be elevated as normal dependency in end-to-end-tests and that dependency is removed. (Note that pnpm will allow local workspace version to satisfy that `^1.4.0` requirement, which is also a concerning pattern.)
Since there is no actual peer requirement (it should have been an optional peer dependency), just remove the peer dependency when resolving dependencies using pnpm hook (`.pnpmfile.cjs`).
Then also remove the end-to-end test dependency that had been added to satisfy the peer dependency. (May come back as `fluid-framework-legacy` in later change.)