### PR TITLE
build(server): Ignore changesets in prettier config

### DIFF
--- a/server/routerlicious/.changeset/polite-brooms-grab.md
+++ b/server/routerlicious/.changeset/polite-brooms-grab.md
@@ -2,11 +2,8 @@
 "@fluidframework/server-routerlicious-base": major
 "@fluidframework/server-services-shared": major
 ---
-
 ---
-
-## "section": fix
-
+"section": fix
 ---
 
 Surface internal error codes correctly

--- a/server/routerlicious/.prettierignore
+++ b/server/routerlicious/.prettierignore
@@ -98,3 +98,6 @@ tools/markdown-magic/test/include.md
 
 # These files are auto-generated according to the comments in the files
 **/charts/**/Chart.yaml
+
+# Ignore changeset files since their metadata formatting is corrupted by prettier
+.changeset/**


### PR DESCRIPTION
Prettier reformats our second metadata section in the changeset files as a header, which breaks downstream tools that read changesets. Those files are now properly excluded from prettier.