### PR TITLE
refactor(ci): Disable CodeQL the right way

### DIFF
--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -560,8 +560,9 @@ extends:
                 value: $(Build.SourcesDirectory)/tools/telemetry-generator
                 readonly: true
               # We already run CodeQL in the main build job, so we don't need to run it again here.
-              - name: DisableCodeQL
-                value: true
+              # Note that we need to disable it in the right way for 1ES pipeline templates, vs manual CodeQL tasks.
+              - name: ONEES_ENFORCED_CODEQL_ENABLED
+                value: 'false'
             steps:
               # Setup
               - checkout: self
@@ -710,8 +711,9 @@ extends:
                   value: $(Build.SourcesDirectory)/tools/telemetry-generator
                   readonly: true
                 # We already run CodeQL in the main build job, so we don't need to run it again here.
-                - name: DisableCodeQL
-                  value: true
+                # Note that we need to disable it in the right way for 1ES pipeline templates, vs manual CodeQL tasks.
+                - name: ONEES_ENFORCED_CODEQL_ENABLED
+                  value: 'false'
               steps:
                 # Setup
                 - checkout: self

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -105,3 +105,11 @@ variables:
   readonly: true
 
 - template: /tools/pipelines/templates/include-vars-telemetry-generator.yml@self
+
+# The way 1ES pipeline templates determine the default branch of a repository only works for repos hosted in ADO.
+# For repos hosted in Github, they fail to determine a default branch and set the current branch as default,
+# causing CodeQL tasks to run for all branches.
+# They add a significant amount of time to pipeline runs when they trigger, so we force-disable them for non-main branches.
+- ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - name: ONEES_ENFORCED_CODEQL_ENABLED
+    value: 'false'


### PR DESCRIPTION
## Description

Fixes the way we disable CodeQL for the test jobs in the build - client pipeline, so they actually cause the tasks to not trigger (what we had done applies when the CodeQL tasks are added manually, but when they are added by the 1ES pipeline templates we needed a different approach).

Also, it disables CodeQL tasks for all non-main branches. Turns out that the default logic in 1ES templates for "only run CodeQL for the default branch in the repo" only works for repos hosted in ADO. For us, that resulted in all branches triggering CodeQL tasks, which unnecessarily add a significant amount of time to pipeline runs when they trigger.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
