### PR TITLE
Not retry on get session

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/test/utils/sessionHelper.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/utils/sessionHelper.spec.ts
@@ -22,7 +22,7 @@ describe("sessionHelper", () => {
 				sinon.createStubInstance<IDocumentRepository>(MongoDocumentRepository);
 		});
 
-		it("should retry on initial failure and succeed on subsequent calls", async () => {
+		it("should retry on transilient replication sync and succeed on subsequent calls", async () => {
 			const ordererUrl = "ordererUrl";
 			const historianUrl = "historianUrl";
 			const deltaStreamUrl = "deltaStreamUrl";
@@ -61,7 +61,7 @@ describe("sessionHelper", () => {
 			assert.ok(session);
 		});
 
-		it("should throw an error if all retries fail", async () => {
+		it("should throw an error if documents not found after retry", async () => {
 			const ordererUrl = "ordererUrl";
 			const historianUrl = "historianUrl";
 			const deltaStreamUrl = "deltaStreamUrl";

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -13,6 +13,7 @@ import {
 } from "@fluidframework/server-services-core";
 import { getLumberBaseProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
 import { StageTrace } from "./trace";
+import { delay } from "@fluidframework/common-utils";
 
 const defaultSessionStickinessDurationMs = 60 * 60 * 1000; // 60 minutes
 
@@ -290,35 +291,29 @@ export async function getSession(
 ): Promise<ISession> {
 	const baseLumberjackProperties = getLumberBaseProperties(documentId, tenantId);
 
-	const document = await runWithRetry(
-		async () =>
-			documentRepository.readOne({ tenantId, documentId }).then((result) => {
-				if (result === null) {
-					throw new NetworkError(
-						404,
-						"Document is deleted and cannot be accessed",
-						false /* canRetry, we should not retry if DB already not in DB! */,
-					);
-				}
-				return result;
-			}),
-		"getDocumentForSession",
-		readDocumentMaxRetries, // maxRetries
-		readDocumentRetryDelay, // retryAfterMs
-		baseLumberjackProperties, // telemetry props
-		undefined,
-		(error) => shouldRetryNetworkError(error),
-	).catch((error) => {
-		if (isNetworkError(error) && error.code === 404) {
-			return undefined;
+	let document: IDocument | null ;
+	try{
+		document = await documentRepository.readOne({ tenantId, documentId });
+		if(document === null) {
+			await delay(readDocumentRetryDelay);
+			document = await documentRepository.readOne({ tenantId, documentId });
 		}
-		connectionTrace?.stampStage("DocumentDBError");
+		if(document === null) {
+			// Retry once in case of DB replication lag should be enough
+			throw new NetworkError(404, "Document is deleted and cannot be accessed");
+		}
+	} catch (error: unknown) {
+		if (isNetworkError(error) && error.code === 404) {
+			connectionTrace?.stampStage("DocumentNotFound");
+		} else {
+			connectionTrace?.stampStage("DocumentDBError");
+		}
 		throw error;
-	});
+	};
 
-	// Check whether document was found in the DB.
-	if (!document || document?.scheduledDeletionTime !== undefined) {
-		connectionTrace?.stampStage("DocumentDoesNotExist");
+	// Check whether document was soft deleted
+	if (document.scheduledDeletionTime !== undefined) {
+		connectionTrace?.stampStage("DocumentSoftDeleted");
 		throw new NetworkError(404, "Document is deleted and cannot be accessed.");
 	}
 	connectionTrace?.stampStage("DocumentExistenceChecked");

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -297,7 +297,7 @@ export async function getSession(
 					throw new NetworkError(
 						404,
 						"Document is deleted and cannot be accessed",
-						true /* canRetry */,
+						false /* canRetry, we should not retry if DB already not in DB! */,
 					);
 				}
 				return result;


### PR DESCRIPTION
GetSession retry for transilent DB replication lag got too agressive. We would see 15 seconds delay if document is EC and got deleted. This change simplify the logic