### PR TITLE
Add Patch and Mutable mapped types

### DIFF
--- a/packages/common/client-utils/src/indexBrowser.ts
+++ b/packages/common/client-utils/src/indexBrowser.ts
@@ -26,6 +26,7 @@ export {
 	TypedEventEmitter,
 	type TypedEventTransform,
 } from "./typedEventEmitter.js";
+export { type Patch } from "./typeUtils.js";
 
 export { createEmitter } from "./events/index.js";
 

--- a/packages/common/client-utils/src/indexNode.ts
+++ b/packages/common/client-utils/src/indexNode.ts
@@ -26,6 +26,7 @@ export {
 	TypedEventEmitter,
 	type TypedEventTransform,
 } from "./typedEventEmitter.js";
+export { type Patch } from "./typeUtils.js";
 
 export { createEmitter } from "./events/index.js";
 

--- a/packages/common/client-utils/src/test/types/typeUtils.spec.ts
+++ b/packages/common/client-utils/src/test/types/typeUtils.spec.ts
@@ -1,0 +1,56 @@
+/* eslint-disable no-void */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+//* Remove
+
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { Mutable, Patch } from "../../typeUtils.js";
+
+interface AllReadonly {
+	readonly one: string;
+	readonly two: number;
+}
+
+interface AllMutable {
+	one: string;
+	two: number;
+}
+
+const x: AllReadonly = { one: "hello", two: 42 };
+
+// Now mutable! (no keys specified)
+(x as Mutable<AllReadonly>).one = "goodbye";
+(x as Mutable<AllReadonly>).two = 42;
+// Specifying keys works (without affecting the other props)
+(x as Mutable<AllReadonly, "one">).one = "goodbye";
+void (x as Mutable<AllReadonly, "one">).two;
+// @ts-expect-error - Cannot assign to 'two' because it is still a read-only property.
+(x as Mutable<AllReadonly, "one">).two = 43;
+
+// @ts-expect-error - Cannot assign to 'two' because it is now a read-only property.
+(x as Patch<AllMutable, { readonly two: number }>).two = "hello";
+// @ts-expect-error - Cannot assign 43 to 'two' because it doesn't match the Patched type
+(x as Patch<AllReadonly, { two: 42 }>).two = 43;
+
+class WithPrivate {
+	private readonly foo: string = "FOO";
+	public bar: number = 42;
+}
+const withPrivate = new WithPrivate();
+
+// Useful for accessing private properties for testing
+(withPrivate as unknown as Patch<WithPrivate, { foo: string }>).foo = "BAR";
+
+interface CurrentVersion {
+	foo: string;
+	bar: number;
+}
+
+type EarlierVersion = Patch<CurrentVersion, { bar?: undefined }>;
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- Seems to be a bug in eslint
+type VersionForRead = CurrentVersion | EarlierVersion;
+
+const input: VersionForRead = { foo: "hello" };

--- a/packages/common/client-utils/src/test/types/typeUtils.spec.ts
+++ b/packages/common/client-utils/src/test/types/typeUtils.spec.ts
@@ -37,7 +37,7 @@ void (x as Mutable<AllReadonly, "one">).two;
 
 class WithPrivate {
 	private readonly foo: string = "FOO";
-	public bar: number = 42;
+	public bar: number = this.foo.length;
 }
 const withPrivate = new WithPrivate();
 

--- a/packages/common/client-utils/src/typeUtils.ts
+++ b/packages/common/client-utils/src/typeUtils.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Replaces the properties of T with the properties of U.
+ *
+ * For example, it's useful for overriding properties of a class (or exposing private properties) for testing
+ *
+ * @internal
+ */
+export type Patch<T, U> = Omit<T, keyof U> & U;
+
+/**
+ * Makes properties K in T mutable (not readonly).
+ * If K is not provided, all properties are made mutable.
+ */
+export type Mutable<T, K extends keyof T = keyof T> = Patch<
+	T,
+	{
+		-readonly [P in K]: T[P];
+	}
+>;

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opSplitter.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opSplitter.spec.ts
@@ -122,8 +122,11 @@ describe("OpSplitter", () => {
 		assert.equal(opSplitter.chunks.size, 0);
 	});
 
-	it("Reconstruct original chunked op with initial chunks", () => {
-		const op = generateChunkableOp(chunkSizeInBytes * 3);
+	//* ONLY
+	//* ONLY
+	//* ONLY
+	it.only("Reconstruct original chunked op with initial chunks", () => {
+		const op = generateChunkableOp(chunkSizeInBytes * 1000);
 		const chunks = wrapChunkedOps(splitOp(op, chunkSizeInBytes), "testClient");
 		const opSplitter = new OpSplitter(
 			[],

--- a/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
@@ -24,7 +24,7 @@ import {
 	getContainerEntryPointBackCompat,
 } from "@fluidframework/test-utils/internal";
 
-const versionWithChunking = "0.56.0";
+const versionWithChunking = "2.0.0";
 
 describeInstallVersions(
 	{
@@ -91,19 +91,24 @@ describeInstallVersions(
 	const generateStringOfSize = (sizeInBytes: number): string =>
 		new Array(sizeInBytes + 1).join("0");
 
+	//* ONLY
+	//* ONLY
+	//* ONLY
+	//* ONLY
+	//* ONLY
 	// To be fixed in AB#6302 (the "old" container above is actually just an old runtime with the current version of loader/container)
-	it.skip("If an old container sends chunked ops, a new container is able to process them successfully", async () => {
+	it.only("If an old container sends chunked ops, a new container is able to process them successfully", async () => {
 		await setupContainers();
 		const regularMessageSizeInBytes = 15 * 1024;
 		// Ops larger than 16k will end up chunked in older versions of fluid
-		const chunkableMessageSizeInBytes = 300 * 1024;
+		const chunkableMessageSizeInBytes = 3000 * 1024;
 		const regularValue = generateStringOfSize(regularMessageSizeInBytes);
 		const chunkableValue = generateStringOfSize(chunkableMessageSizeInBytes);
-		oldMap.set("key0", regularValue);
-		oldMap.set("key1", chunkableValue);
-		oldMap.set("key2", chunkableValue);
-		oldMap.set("key3", regularValue);
-		oldMap.set("key4", regularValue);
+		newMap.set("key0", regularValue);
+		newMap.set("key1", chunkableValue);
+		newMap.set("key2", chunkableValue);
+		newMap.set("key3", regularValue);
+		newMap.set("key4", regularValue);
 
 		await provider.ensureSynchronized();
 		assert.strictEqual(newMap.get("key0"), regularValue, "Wrong value found in the new map");


### PR DESCRIPTION
## Description

Over the years I've added multiple definitions of the type `Patch` and `Mutable` (or inlined them) throughout the code, enough that I think it's useful to include them as utility types.

`Patch` lets you change the type of a subset of a type's properties (useful for exposing privates for testing, or building back-compat types from the current type)

`Mutable` lets you remove the `readonly` flag from a subset of a type's properties (useful for fiddling with objects, again for testing and back-compat purposes).
 
## Reviewer Guidance

TODO:
- [ ] start using the new utilities where one-offs exist now
- [ ] Deal with the weird lint errors (currently suppressed)