### PR TITLE
improvement(client-azure-client): deprecate legacy exports

### DIFF
--- a/.changeset/quick-chairs-smile.md
+++ b/.changeset/quick-chairs-smile.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/azure-client": minor
+---
+---
+"section": deprecation
+---
+
+[Deprecate azure-client re-exported legacy APIs](https://github.com/microsoft/FluidFramework/issues/23702) including `ITokenClaims` and `ScopeType`. See [issue #23702](https://github.com/microsoft/FluidFramework/issues/23702) for details and alternatives.

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.alpha.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.alpha.api.md
@@ -82,7 +82,8 @@ export { ITelemetryBaseEvent }
 
 export { ITelemetryBaseLogger }
 
-export { ITokenClaims }
+// @alpha @deprecated
+export type ITokenClaims = ITokenClaims_2;
 
 export { ITokenProvider }
 
@@ -90,6 +91,10 @@ export { ITokenResponse }
 
 export { IUser }
 
-export { ScopeType }
+// @alpha @deprecated
+export const ScopeType: typeof ScopeType_2;
+
+// @alpha @deprecated
+export type ScopeType = ScopeType_2;
 
 ```

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
@@ -82,14 +82,10 @@ export { ITelemetryBaseEvent }
 
 export { ITelemetryBaseLogger }
 
-export { ITokenClaims }
-
 export { ITokenProvider }
 
 export { ITokenResponse }
 
 export { IUser }
-
-export { ScopeType }
 
 ```

--- a/packages/service-clients/azure-client/src/index.ts
+++ b/packages/service-clients/azure-client/src/index.ts
@@ -27,8 +27,8 @@ export type {
 export type { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
 export type { IUser } from "@fluidframework/driver-definitions";
 import {
-	type ITokenClaims as ITokenClaims2,
-	ScopeType as ScopeType2,
+	type ITokenClaims as ITokenClaimsBase,
+	ScopeType as ScopeTypeBase,
 } from "@fluidframework/driver-definitions/internal";
 
 /**
@@ -37,7 +37,7 @@ import {
  * @alpha
  * @deprecated Consider importing from `@fluidframework/driver-definitions/legacy` - to be removed in 2.40
  */
-export type ITokenClaims = ITokenClaims2;
+export type ITokenClaims = ITokenClaimsBase;
 
 /**
  * {@inheritdoc @fluidframework/driver-definitions/legacy#ScopeType}
@@ -45,14 +45,14 @@ export type ITokenClaims = ITokenClaims2;
  * @alpha
  * @deprecated Use ScopeType from \@fluidframework/driver-definitions/legacy - to be removed in 2.40
  */
-export const ScopeType = ScopeType2;
+export const ScopeType = ScopeTypeBase;
 /**
  * {@inheritdoc @fluidframework/driver-definitions/legacy#ScopeType}
  * @legacy
  * @alpha
  * @deprecated Use ScopeType from \@fluidframework/driver-definitions/legacy - to be removed in 2.40
  */
-export type ScopeType = ScopeType2;
+export type ScopeType = ScopeTypeBase;
 
 // Re-export so developers can build loggers without pulling in core-interfaces
 export type {

--- a/packages/service-clients/azure-client/src/index.ts
+++ b/packages/service-clients/azure-client/src/index.ts
@@ -26,7 +26,33 @@ export type {
 
 export type { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
 export type { IUser } from "@fluidframework/driver-definitions";
-export { type ITokenClaims, ScopeType } from "@fluidframework/driver-definitions/internal";
+import {
+	type ITokenClaims as ITokenClaims2,
+	ScopeType as ScopeType2,
+} from "@fluidframework/driver-definitions/internal";
+
+/**
+ * {@inheritdoc @fluidframework/driver-definitions/legacy#ITokenClaims}
+ * @legacy
+ * @alpha
+ * @deprecated Consider importing from `@fluidframework/driver-definitions/legacy` - to be removed in 2.40
+ */
+export type ITokenClaims = ITokenClaims2;
+
+/**
+ * {@inheritdoc @fluidframework/driver-definitions/legacy#ScopeType}
+ * @legacy
+ * @alpha
+ * @deprecated Use ScopeType from \@fluidframework/driver-definitions/legacy - to be removed in 2.40
+ */
+export const ScopeType = ScopeType2;
+/**
+ * {@inheritdoc @fluidframework/driver-definitions/legacy#ScopeType}
+ * @legacy
+ * @alpha
+ * @deprecated Use ScopeType from \@fluidframework/driver-definitions/legacy - to be removed in 2.40
+ */
+export type ScopeType = ScopeType2;
 
 // Re-export so developers can build loggers without pulling in core-interfaces
 export type {

--- a/packages/service-clients/end-to-end-tests/azure-client/.eslintrc.cjs
+++ b/packages/service-clients/end-to-end-tests/azure-client/.eslintrc.cjs
@@ -10,6 +10,16 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
 		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 	},
+	overrides: [
+		{
+			// Rules only for test files
+			files: ["*.spec.ts", "*.test.ts", "**/test/**"],
+			rules: {
+				// Some deprecated APIs are permissible in tests; use `warn` to keep them visible
+				"import/no-deprecated": "warn",
+			},
+		},
+	],
 	parserOptions: {
 		project: ["./src/test/tsconfig.json"],
 	},

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureClientFactory.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureClientFactory.ts
@@ -9,7 +9,6 @@ import {
 	AzureRemoteConnectionConfig,
 	ITelemetryBaseLogger,
 } from "@fluidframework/azure-client";
-import { type ScopeType } from "@fluidframework/azure-client/internal";
 import {
 	AzureClient as AzureClientLegacy,
 	AzureLocalConnectionConfig as AzureLocalConnectionConfigLegacy,
@@ -17,6 +16,7 @@ import {
 	ITelemetryBaseLogger as ITelemetryBaseLoggerLegacy,
 } from "@fluidframework/azure-client-legacy";
 import { IConfigProviderBase } from "@fluidframework/core-interfaces";
+import { ScopeType } from "@fluidframework/driver-definitions/internal";
 import {
 	MockLogger,
 	createChildLogger,
@@ -27,6 +27,9 @@ import { default as Axios, AxiosResponse, type AxiosRequestConfig } from "axios"
 import { v4 as uuid } from "uuid";
 
 import { createAzureTokenProvider } from "./AzureTokenFactory.js";
+
+// eslint-disable-next-line unicorn/prefer-export-from
+export { ScopeType };
 
 /**
  * This function will determine if local or remote mode is required (based on FLUID_CLIENT), and return a new

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureTokenFactory.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureTokenFactory.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITokenProvider } from "@fluidframework/azure-client";
-import { type ScopeType } from "@fluidframework/azure-client/internal";
+import type { ScopeType } from "@fluidframework/driver-definitions/internal";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils/internal";
 
 export function createAzureTokenProvider(

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/audience.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "node:assert";
 
 import { AzureClient, type AzureContainerServices } from "@fluidframework/azure-client";
-import { ScopeType } from "@fluidframework/azure-client/internal";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
 import { ContainerSchema, type IFluidContainer } from "@fluidframework/fluid-static";
@@ -18,6 +17,7 @@ import {
 	createAzureClient,
 	createContainerFromPayload,
 	getContainerIdFromPayloadResponse,
+	ScopeType,
 } from "./AzureClientFactory.js";
 import * as ephemeralSummaryTrees from "./ephemeralSummaryTrees.js";
 import { configProvider, waitForMember, getTestMatrix } from "./utils.js";

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/signals.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/signals.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "node:assert";
 
 import { AzureClient, type AzureContainerServices } from "@fluidframework/azure-client";
-import { type AzureUser, ScopeType } from "@fluidframework/azure-client/internal";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
 import { type ContainerSchema, type IFluidContainer } from "@fluidframework/fluid-static";
@@ -17,10 +16,16 @@ import {
 	createAzureClient,
 	createContainerFromPayload,
 	getContainerIdFromPayloadResponse,
+	ScopeType,
 } from "./AzureClientFactory.js";
 import { SignalerTestDataObject } from "./TestDataObject.js";
 import * as ephemeralSummaryTrees from "./ephemeralSummaryTrees.js";
 import { configProvider, getTestMatrix } from "./utils.js";
+
+interface UserIdAndName {
+	readonly id: string;
+	readonly name: string;
+}
 
 async function createSignalListenerPromise<T>(
 	signaler: SignalerTestDataObject,
@@ -54,18 +59,18 @@ for (const testOpts of testMatrix) {
 		const connectedContainers: IFluidContainer[] = [];
 		const connectTimeoutMs = 10_000;
 		const isEphemeral: boolean = testOpts.options.isEphemeral;
-		const user1: AzureUser = {
+		const user1 = {
 			id: "test-user-id-1",
 			name: "test-user-name-2",
-		};
-		const user2: AzureUser = {
+		} as const satisfies UserIdAndName;
+		const user2 = {
 			id: "test-user-id-1",
 			name: "test-user-name-2",
-		};
-		const user3: AzureUser = {
+		} as const satisfies UserIdAndName;
+		const user3 = {
 			id: "test-user-id-1",
 			name: "test-user-name-2",
-		};
+		} as const satisfies UserIdAndName;
 
 		afterEach(async () => {
 			for (const container of connectedContainers) {
@@ -77,7 +82,7 @@ for (const testOpts of testMatrix) {
 
 		const getOrCreateSignalerContainer = async (
 			id: string | undefined,
-			user: AzureUser,
+			user: UserIdAndName,
 			config?: ReturnType<typeof configProvider>,
 			scopes?: ScopeType[],
 		): Promise<{


### PR DESCRIPTION
and replace internal uses.

Note: legacy.public API appears changed, but that is because current FF configuration for api-extractor (without `bundlePackages`) doesn't have direct re-exports correctly reported. (This is largely moot as all legacy.* exports are exposed from the same /legacy path.)

Clean up `AzureUser` use in end to end tests where test data type is not really `AzureUser`, but an object with `id` and `name`.