### PR TITLE
fix(docs): Don't display `Alpha` alert for `Legacy` API items

### DIFF
--- a/docs/infra/api-markdown-documenter/render-api-documentation.mjs
+++ b/docs/infra/api-markdown-documenter/render-api-documentation.mjs
@@ -128,15 +128,18 @@ export async function renderApiDocumentation(inputDir, outputDir, uriRootDir, ap
 				if (ApiItemUtilities.isDeprecated(apiItem)) {
 					alerts.push("Deprecated");
 				}
+
+				// If an item is `@legacy`, ignore its release tag (we use `@alpha`+`@legacy` to mean something
+				// entirely different from `@alpha`, so displaying the release tag would be misleading).
 				if (ApiItemUtilities.hasModifierTag(apiItem, "@legacy")) {
 					alerts.push("Legacy");
-				}
-
-				const releaseTag = ApiItemUtilities.getEffectiveReleaseLevel(apiItem);
-				if (releaseTag === ReleaseTag.Alpha) {
-					alerts.push("Alpha");
-				} else if (releaseTag === ReleaseTag.Beta) {
-					alerts.push("Beta");
+				} else {
+					const releaseTag = ApiItemUtilities.getEffectiveReleaseLevel(apiItem);
+					if (releaseTag === ReleaseTag.Alpha) {
+						alerts.push("Alpha");
+					} else if (releaseTag === ReleaseTag.Beta) {
+						alerts.push("Beta");
+					}
 				}
 			}
 			return alerts;


### PR DESCRIPTION
We have been displaying dual "Alpha" and "Legacy" alerts for items tagged with both `@alpha` and `@legacy`, but this is incorrect. `@alpha` + `@legacy` should map to _just_ "Legacy". API items' details sections already _only_ displayed legacy API notices for these cases, but table entries displayed both alerts, which was misleading.

Example before:
![image](https://github.com/user-attachments/assets/163a2ea8-35e2-40dc-9d3d-8dd2035b06b5)

Example after:
![image](https://github.com/user-attachments/assets/216b6ef6-946e-4150-9b17-81fbb3e61183)
