### PR TITLE
Improve presence-tracker test reliability

### DIFF
--- a/examples/apps/presence-tracker/tests/presenceTracker.test.ts
+++ b/examples/apps/presence-tracker/tests/presenceTracker.test.ts
@@ -21,20 +21,25 @@ const initializeBrowser = async () => {
 	return browser;
 };
 
+/**
+ * @param page The page to load the presence tracker app on.
+ */
+const loadPresenceTrackerApp = async (page: Page) => {
+	await page.goto(globals.PATH, { waitUntil: "load" });
+	// eslint-disable-next-line @typescript-eslint/dot-notation, @typescript-eslint/no-unsafe-return
+	await page.waitForFunction(() => window["fluidStarted"]);
+};
+
 // Most tests are passing when tinylicious is running. Those that aren't are individually skipped.
 describe("presence-tracker", () => {
 	beforeAll(async () => {
-		// Wait for the page to load first before running any tests
-		// so this time isn't attributed to the first test
-		await page.goto(globals.PATH, { waitUntil: "load", timeout: 0 });
-		// eslint-disable-next-line @typescript-eslint/dot-notation, @typescript-eslint/no-unsafe-return
-		await page.waitForFunction(() => window["fluidStarted"]);
+		// Wait for the page to load first before running any tests giving a more generous timeout
+		// so this time isn't attributed to the first test.
+		await loadPresenceTrackerApp(page);
 	}, 45000);
 
 	beforeEach(async () => {
-		await page.goto(globals.PATH, { waitUntil: "load" });
-		// eslint-disable-next-line @typescript-eslint/dot-notation, @typescript-eslint/no-unsafe-return
-		await page.waitForFunction(() => window["fluidStarted"]);
+		await loadPresenceTrackerApp(page);
 	});
 
 	describe("Single client", () => {
@@ -89,13 +94,11 @@ describe("presence-tracker", () => {
 			// Create a second browser instance.
 			browser2 = await initializeBrowser();
 			page2 = await browser2.newPage();
+			await loadPresenceTrackerApp(page2);
 		}, 45000);
 
 		beforeEach(async () => {
-			// Navigate to the URL/session created by the first browser.
-			await page2.goto(page.url(), { waitUntil: "load" });
-			// eslint-disable-next-line @typescript-eslint/dot-notation, @typescript-eslint/no-unsafe-return
-			await page2.waitForFunction(() => window["fluidStarted"]);
+			await loadPresenceTrackerApp(page2);
 		});
 
 		afterAll(async () => {

--- a/examples/apps/presence-tracker/tests/presenceTracker.test.ts
+++ b/examples/apps/presence-tracker/tests/presenceTracker.test.ts
@@ -24,8 +24,8 @@ const initializeBrowser = async () => {
 /**
  * @param page The page to load the presence tracker app on.
  */
-const loadPresenceTrackerApp = async (page: Page) => {
-	await page.goto(globals.PATH, { waitUntil: "load" });
+const loadPresenceTrackerApp = async (page: Page, url: string) => {
+	await page.goto(url, { waitUntil: "load" });
 	// eslint-disable-next-line @typescript-eslint/dot-notation, @typescript-eslint/no-unsafe-return
 	await page.waitForFunction(() => window["fluidStarted"]);
 };
@@ -35,11 +35,11 @@ describe("presence-tracker", () => {
 	beforeAll(async () => {
 		// Wait for the page to load first before running any tests giving a more generous timeout
 		// so this time isn't attributed to the first test.
-		await loadPresenceTrackerApp(page);
+		await loadPresenceTrackerApp(page, globals.PATH);
 	}, 45000);
 
 	beforeEach(async () => {
-		await loadPresenceTrackerApp(page);
+		await loadPresenceTrackerApp(page, globals.PATH);
 	});
 
 	describe("Single client", () => {
@@ -94,11 +94,11 @@ describe("presence-tracker", () => {
 			// Create a second browser instance.
 			browser2 = await initializeBrowser();
 			page2 = await browser2.newPage();
-			await loadPresenceTrackerApp(page2);
+			await loadPresenceTrackerApp(page2, page.url());
 		}, 45000);
 
 		beforeEach(async () => {
-			await loadPresenceTrackerApp(page2);
+			await loadPresenceTrackerApp(page2, page.url());
 		});
 
 		afterAll(async () => {


### PR DESCRIPTION
## Description

For the two-client tests (recently added), adds an attempt to load the presence tracker app in the newer browser as part of the 45s `beforeAll` timeout. This matches the one-client tests more closely, which already ensure the page loads once successfully within 45s before beginning the test suite.

We saw this test suite fail on the subsequent `beforeEach` hook due to a 5s timeout, which is somewhat plausible if the browser startup wasn't fresh and/or page cache isn't shared with the first browser.
