### PR TITLE
feat(Loader): Add create/load Container APIs that give you an object before doing full initialization

### DIFF
--- a/.changeset/busy-mangos-ask.md
+++ b/.changeset/busy-mangos-ask.md
@@ -5,7 +5,7 @@
 "section": feature
 ---
 
-IContainer.criticalError added to access which error closed the container
+IContainer.closedWithError added to access which error closed the container
 
 Once the container is closed or disposed with an error, this property will be set to that error.
 

--- a/.changeset/busy-mangos-ask.md
+++ b/.changeset/busy-mangos-ask.md
@@ -1,0 +1,17 @@
+---
+"@fluidframework/container-definitions": minor
+---
+---
+"section": feature
+---
+
+IContainer.criticalError added to access which error closed the container
+
+Once the container is closed or disposed with an error, this property will be set to that error.
+
+Note that this error is also readily available via the "closed" and "disposed" events.
+
+However, there is a race condition during `Container.load` that results in a closed container being returned (as opposed to the error being thrown),
+with no opportunity for the caller to listen to the "closed" event.
+
+This API closes that gap, so after container load fails you always can determine the cause.

--- a/.changeset/busy-mangos-ask.md
+++ b/.changeset/busy-mangos-ask.md
@@ -7,9 +7,10 @@
 
 IContainer.closedWithError added to access which error closed the container
 
-Once the container is closed or disposed with an error, this property will be set to that error.
+Once the container is closed with an error, this property will be set to that error.
+(If the container is disposed with an error _without first being closed_, that error will be reported here)
 
-Note that this error is also readily available via the "closed" and "disposed" events.
+Note that this error is also readily available via the "closed" or "disposed" event.
 
 However, there is a race condition during `Container.load` that results in a closed container being returned (as opposed to the error being thrown),
 with no opportunity for the caller to listen to the "closed" event.

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
@@ -100,10 +100,10 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
     readonly clientId?: string | undefined;
     close(error?: ICriticalContainerError): void;
     readonly closed: boolean;
+    readonly closedWithError?: ICriticalContainerError | undefined;
     connect(): void;
     readonly connectionState: ConnectionState;
     containerMetadata: Record<string, string>;
-    readonly criticalError?: ICriticalContainerError;
     deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     disconnect(): void;
     dispose(error?: ICriticalContainerError): void;

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
@@ -103,6 +103,7 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
     connect(): void;
     readonly connectionState: ConnectionState;
     containerMetadata: Record<string, string>;
+    readonly criticalError?: ICriticalContainerError;
     deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     disconnect(): void;
     dispose(error?: ICriticalContainerError): void;

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -364,24 +364,6 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	 */
 	getContainerPackageInfo?(): IContainerPackageInfo | undefined;
 
-	//* Copilot's opinion :P
-	// readonly status: {
-	// 	readonly connected: boolean;
-	// 	readonly readonly: boolean;
-	// 	readonly dirty: boolean;
-	// 	readonly attached: boolean;
-	// 	readonly version: string | undefined;
-	// 	readonly audience: IAudience;
-	// 	readonly clientId: string | undefined;
-	// 	readonly connectionState: ConnectionState;
-	// 	readonly resolvedUrl: IResolvedUrl | undefined;
-	// 	readonly attachState: AttachState;
-	// 	readonly codeDetails: IFluidCodeDetails | undefined;
-	// 	readonly loadedCodeDetails: IFluidCodeDetails | undefined;
-	// 	readonly packageInfo: IContainerPackageInfo | undefined;
-	// 	readonly containerMetadata: Record<string, string>;
-	// }
-
 	/**
 	 * Returns true if the container has been closed and/or disposed, otherwise false.
 	 */
@@ -391,6 +373,13 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	 * Returns true if the container has been disposed, otherwise false.
 	 */
 	readonly disposed?: boolean;
+
+	/**
+	 * Critical/fatal error that caused the container to close or dispose.
+	 *
+	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
+	 */
+	readonly criticalError?: ICriticalContainerError;
 
 	/**
 	 * Whether or not there are any local changes that have not been saved.

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -364,6 +364,24 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	 */
 	getContainerPackageInfo?(): IContainerPackageInfo | undefined;
 
+	//* Copilot's opinion :P
+	// readonly status: {
+	// 	readonly connected: boolean;
+	// 	readonly readonly: boolean;
+	// 	readonly dirty: boolean;
+	// 	readonly attached: boolean;
+	// 	readonly version: string | undefined;
+	// 	readonly audience: IAudience;
+	// 	readonly clientId: string | undefined;
+	// 	readonly connectionState: ConnectionState;
+	// 	readonly resolvedUrl: IResolvedUrl | undefined;
+	// 	readonly attachState: AttachState;
+	// 	readonly codeDetails: IFluidCodeDetails | undefined;
+	// 	readonly loadedCodeDetails: IFluidCodeDetails | undefined;
+	// 	readonly packageInfo: IContainerPackageInfo | undefined;
+	// 	readonly containerMetadata: Record<string, string>;
+	// }
+
 	/**
 	 * Returns true if the container has been closed and/or disposed, otherwise false.
 	 */

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -377,7 +377,8 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	/**
 	 * The error that caused the container to close or dispose.
 	 *
-	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
+	 * @remarks If the container is closed first and then later disposed,
+	 * this will be the error from the close (even if undefined), not the dispose.
 	 */
 	readonly closedWithError?: ICriticalContainerError | undefined;
 

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -375,11 +375,11 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	readonly disposed?: boolean;
 
 	/**
-	 * Critical/fatal error that caused the container to close or dispose.
+	 * The error that caused the container to close or dispose.
 	 *
 	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
 	 */
-	readonly criticalError?: ICriticalContainerError | undefined;
+	readonly closedWithError?: ICriticalContainerError | undefined;
 
 	/**
 	 * Whether or not there are any local changes that have not been saved.

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -379,7 +379,7 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	 *
 	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
 	 */
-	readonly criticalError?: ICriticalContainerError;
+	readonly criticalError?: ICriticalContainerError | undefined;
 
 	/**
 	 * Whether or not there are any local changes that have not been saved.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -584,11 +584,6 @@ export class Container
 		return this._lifecycleState === "disposing" || this._lifecycleState === "disposed";
 	}
 
-	/**
-	 * The error that caused the container to close or dispose.
-	 *
-	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
-	 */
 	public get closedWithError(): ICriticalContainerError | undefined {
 		return this._closedWithError;
 	}
@@ -1168,6 +1163,10 @@ export class Container
 						// Use error category if there's an error, unless we already closed with an error (i.e. _closedWithError is set)
 						category:
 							error !== undefined && this._closedWithError === undefined ? "error" : "generic",
+						details: {
+							closedWithErrorType: this._closedWithError?.errorType,
+							closedWithErrorMessage: this._closedWithError?.message,
+						},
 					},
 					error,
 				);
@@ -1175,13 +1174,11 @@ export class Container
 				// ! Progressing from "closed" to "disposing" is not allowed
 				if (this._lifecycleState !== "closed") {
 					this._lifecycleState = "disposing";
-				}
 
-				// Corner cases that are expressed imprecisely here:
-				// When disposing with an error after the Container is already closed...
-				// - if we closed with an error, _closedWithError doesn't expose the dispose error.
-				// - if we closed without an error, _closedWithError doesn't distinguish whether this error came from close or dispose.
-				this._closedWithError ??= error;
+					// Only set _closedWithError if we're "disposing and closing" all at once
+					// (disposing from a non-closed state)
+					this._closedWithError = error;
+				}
 
 				this._protocolHandler?.close();
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -590,9 +590,9 @@ export class Container
 	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
 	 */
 	public get closedWithError(): ICriticalContainerError | undefined {
-		return this._criticalError;
+		return this._closedWithError;
 	}
-	private _criticalError?: ICriticalContainerError;
+	private _closedWithError?: ICriticalContainerError;
 
 	private readonly storageAdapter: ContainerStorageAdapter;
 
@@ -1143,7 +1143,7 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "closed";
-			this._criticalError = error;
+			this._closedWithError = error;
 
 			// There is no user for summarizer, so we need to ensure dispose is called
 			if (this.client.details.type === summarizerClientType) {
@@ -1165,9 +1165,9 @@ export class Container
 				this.mc.logger.sendTelemetryEvent(
 					{
 						eventName: "ContainerDispose",
-						// Use error category if there's an error, unless we already closed with an error (i.e. _criticalError is set)
+						// Use error category if there's an error, unless we already closed with an error (i.e. _closedWithError is set)
 						category:
-							error !== undefined && this._criticalError === undefined ? "error" : "generic",
+							error !== undefined && this._closedWithError === undefined ? "error" : "generic",
 					},
 					error,
 				);
@@ -1204,9 +1204,9 @@ export class Container
 			this._lifecycleState = "disposed";
 			// Corner cases that are expressed imprecisely here:
 			// When disposing with an error...
-			// - if we closed with an error, _criticalError doesn't expose the dispose error.
-			// - if we closed without an error, _criticalError doesn't distinguish whether this error came from close or dispose.
-			this._criticalError ??= error;
+			// - if we closed with an error, _closedWithError doesn't expose the dispose error.
+			// - if we closed without an error, _closedWithError doesn't distinguish whether this error came from close or dispose.
+			this._closedWithError ??= error;
 			this._lifecycleEvents.emit("disposed");
 		}
 	}

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -585,11 +585,11 @@ export class Container
 	}
 
 	/**
-	 * Critical/fatal error that caused the container to close or dispose.
+	 * The error that caused the container to close or dispose.
 	 *
 	 * @remarks If the container is closed and then disposed, both with errors given, this will expose the close error only.
 	 */
-	public get criticalError(): ICriticalContainerError | undefined {
+	public get closedWithError(): ICriticalContainerError | undefined {
 		return this._criticalError;
 	}
 	private _criticalError?: ICriticalContainerError;
@@ -1202,12 +1202,11 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "disposed";
-			// Corner cases that are expressed imprecisely here: When disposing with an error...
-			// - If we closed with an error, _criticalError doesn't expose the dispose error.
-			// - If we closed without an error, _criticalError doesn't distinguish whether this error came from close or dispose.
-			if (this._criticalError === undefined) {
-				this._criticalError = error;
-			}
+			// Corner cases that are expressed imprecisely here:
+			// When disposing with an error...
+			// - if we closed with an error, _criticalError doesn't expose the dispose error.
+			// - if we closed without an error, _criticalError doesn't distinguish whether this error came from close or dispose.
+			this._criticalError ??= error;
 			this._lifecycleEvents.emit("disposed");
 		}
 	}

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -584,6 +584,15 @@ export class Container
 		return this._lifecycleState === "disposing" || this._lifecycleState === "disposed";
 	}
 
+	private _closedWithError?: ICriticalContainerError;
+
+	public get closedWithError(): ICriticalContainerError | undefined {
+		if (this.closed) {
+			return this._closedWithError;
+		}
+		return undefined;
+	}
+
 	private readonly storageAdapter: ContainerStorageAdapter;
 
 	private readonly _deltaManager: DeltaManager<ConnectionManager>;
@@ -1133,6 +1142,7 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "closed";
+			this._closedWithError = error;
 
 			// There is no user for summarizer, so we need to ensure dispose is called
 			if (this.client.details.type === summarizerClientType) {
@@ -1190,6 +1200,10 @@ export class Container
 			}
 		} finally {
 			this._lifecycleState = "disposed";
+			//* Double-check this logic
+			if (this._closedWithError === undefined) {
+				this._closedWithError = error;
+			}
 			this._lifecycleEvents.emit("disposed");
 		}
 	}

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -439,21 +439,25 @@ export class Container
 	/**
 	 * Create a new container in a detached state.
 	 */
-	public static async createDetached(
+	public static createDetached(
 		createProps: IContainerCreateProps,
 		codeDetails: IFluidCodeDetails,
-	): Promise<Container> {
+	): { container: Container; initialize: () => Promise<IContainer> } {
 		const container = new Container(createProps);
 
-		return PerformanceEvent.timedExecAsync(
-			container.mc.logger,
-			{ eventName: "CreateDetached" },
-			async (_event) => {
-				await container.createDetached(codeDetails);
-				return container;
-			},
-			{ start: true, end: true, cancel: "generic" },
-		);
+		return {
+			container,
+			initialize: async () =>
+				PerformanceEvent.timedExecAsync(
+					container.mc.logger,
+					{ eventName: "CreateDetached" },
+					async (_event) => {
+						await container.createDetached(codeDetails);
+						return container;
+					},
+					{ start: true, end: true, cancel: "generic" },
+				),
+		};
 	}
 
 	/**

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -3,11 +3,13 @@
  * Licensed under the MIT License.
  */
 
+import type { TypedEventEmitter } from "@fluid-internal/client-utils";
 import {
 	IContainer,
 	ICodeDetailsLoader,
 	IFluidCodeDetails,
 	type IContainerPolicies,
+	type IContainerEvents,
 } from "@fluidframework/container-definitions/internal";
 import {
 	FluidObject,
@@ -143,6 +145,47 @@ export async function createDetachedContainer(
 		canReconnect: createDetachedContainerProps.allowReconnect,
 		clientDetailsOverride: createDetachedContainerProps.clientDetailsOverride,
 	});
+}
+
+/**
+ * Creates a new container using the specified code details but in an unattached state. While unattached, all
+ * updates will only be local until the user explicitly attaches the container to a service provider.
+ * @param createDetachedContainerProps - Services and properties necessary for creating detached container.
+ * @legacy
+ * @alpha
+ */
+//* 3 is better
+// export function createDetachedContainer2(
+// 	createDetachedContainerProps: ICreateDetachedContainerProps,
+// ): { container: IContainer; initialize: () => Promise<void> } {
+// 	const loader = new Loader(createDetachedContainerProps);
+// 	return loader.createDetachedContainer2(createDetachedContainerProps.codeDetails, {
+// 		canReconnect: createDetachedContainerProps.allowReconnect,
+// 		clientDetailsOverride: createDetachedContainerProps.clientDetailsOverride,
+// 	});
+// }
+
+/**
+ * Creates a new container using the specified code details but in an unattached state. While unattached, all
+ * updates will only be local until the user explicitly attaches the container to a service provider.
+ * @param createDetachedContainerProps - Services and properties necessary for creating detached container.
+ * @legacy
+ * @alpha
+ */
+export function createDetachedContainer3(
+	createDetachedContainerProps: ICreateDetachedContainerProps,
+	//* name this type
+): { shell: TypedEventEmitter<IContainerEvents> & { initialize: () => Promise<IContainer> } } {
+	const loader = new Loader(createDetachedContainerProps);
+	const { container, initialize } = loader.createDetachedContainer2(
+		createDetachedContainerProps.codeDetails,
+		{
+			canReconnect: createDetachedContainerProps.allowReconnect,
+			clientDetailsOverride: createDetachedContainerProps.clientDetailsOverride,
+		},
+	);
+	//* Put initialize on Container class but not IContainer interface
+	return { shell: Object.assign(container, { initialize }) };
 }
 
 /**

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -3,13 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import type { TypedEventEmitter } from "@fluid-internal/client-utils";
 import {
 	IContainer,
 	ICodeDetailsLoader,
 	IFluidCodeDetails,
 	type IContainerPolicies,
-	type IContainerEvents,
 } from "@fluidframework/container-definitions/internal";
 import {
 	FluidObject,
@@ -154,38 +152,18 @@ export async function createDetachedContainer(
  * @legacy
  * @alpha
  */
-//* 3 is better
-// export function createDetachedContainer2(
-// 	createDetachedContainerProps: ICreateDetachedContainerProps,
-// ): { container: IContainer; initialize: () => Promise<void> } {
-// 	const loader = new Loader(createDetachedContainerProps);
-// 	return loader.createDetachedContainer2(createDetachedContainerProps.codeDetails, {
-// 		canReconnect: createDetachedContainerProps.allowReconnect,
-// 		clientDetailsOverride: createDetachedContainerProps.clientDetailsOverride,
-// 	});
-// }
-
-/**
- * Creates a new container using the specified code details but in an unattached state. While unattached, all
- * updates will only be local until the user explicitly attaches the container to a service provider.
- * @param createDetachedContainerProps - Services and properties necessary for creating detached container.
- * @legacy
- * @alpha
- */
-export function createDetachedContainer3(
+export function createDetachedContainerUninitialized(
 	createDetachedContainerProps: ICreateDetachedContainerProps,
-	//* name this type
-): { shell: TypedEventEmitter<IContainerEvents> & { initialize: () => Promise<IContainer> } } {
+): IContainer & { initialize: () => Promise<void> } {
 	const loader = new Loader(createDetachedContainerProps);
-	const { container, initialize } = loader.createDetachedContainer2(
+	const container = loader.createDetachedContainerUninitialized(
 		createDetachedContainerProps.codeDetails,
 		{
 			canReconnect: createDetachedContainerProps.allowReconnect,
 			clientDetailsOverride: createDetachedContainerProps.clientDetailsOverride,
 		},
 	);
-	//* Put initialize on Container class but not IContainer interface
-	return { shell: Object.assign(container, { initialize }) };
+	return container;
 }
 
 /**
@@ -219,6 +197,22 @@ export async function loadExistingContainer(
 ): Promise<IContainer> {
 	const loader = new Loader(loadExistingContainerProps);
 	return loader.resolve(
+		loadExistingContainerProps.request,
+		loadExistingContainerProps.pendingLocalState,
+	);
+}
+
+/**
+ * Loads a container with an existing snapshot from the service.
+ * @param loadExistingContainerProps - Services and properties necessary for loading an existing container.
+ * @legacy
+ * @alpha
+ */
+export async function loadExistingContainerUninitialized(
+	loadExistingContainerProps: ILoadExistingContainerProps,
+): Promise<IContainer & { initialize: () => Promise<void> }> {
+	const loader = new Loader(loadExistingContainerProps);
+	return loader.resolveUninitialized(
 		loadExistingContainerProps.request,
 		loadExistingContainerProps.pendingLocalState,
 	);

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -336,6 +336,21 @@ export class Loader implements IHostLoader {
 			clientDetailsOverride?: IClientDetails;
 		},
 	): Promise<IContainer> {
+		const { container, initialize } = this.createDetachedContainer2(
+			codeDetails,
+			createDetachedProps,
+		);
+		//*
+		return initialize().then(() => container);
+	}
+
+	public createDetachedContainer2(
+		codeDetails: IFluidCodeDetails,
+		createDetachedProps?: {
+			canReconnect?: boolean;
+			clientDetailsOverride?: IClientDetails;
+		},
+	): { container: Container; initialize: () => Promise<IContainer> } {
 		return Container.createDetached(
 			{
 				...createDetachedProps,

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -691,7 +691,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 				() => runtimeDispose++,
 			);
 
-			container.dispose(new DataCorruptionError("expected", {}));
+			container.dispose(new DataCorruptionError("dispose error", {}));
 			assert.strictEqual(
 				containerDisposed,
 				1,
@@ -716,6 +716,11 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 				runtimeDispose,
 				1,
 				"IContainerRuntime should send dispose event on container dispose",
+			);
+			assert.strictEqual(
+				container.criticalError?.message,
+				"dispose error",
+				"Expected the error that disposed the container",
 			);
 		},
 	);
@@ -744,13 +749,56 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 				() => runtimeDispose++,
 			);
 
-			container.close(new DataCorruptionError("expected", {}));
-			container.dispose(new DataCorruptionError("expected", {}));
+			container.close(new DataCorruptionError("close error", {}));
+			container.dispose(new DataCorruptionError("dispose error", {}));
 			assert.strictEqual(containerDisposed, 1, "Container should send disposed event");
 			assert.strictEqual(containerClosed, 1, "Container should send closed event");
 			assert.strictEqual(deltaManagerDisposed, 1, "DeltaManager should send disposed event");
 			assert.strictEqual(deltaManagerClosed, 1, "DeltaManager should send closed event");
 			assert.strictEqual(runtimeDispose, 1, "IContainerRuntime should send dispose event");
+			assert.strictEqual(
+				container.criticalError?.message,
+				"close error",
+				"Expected the error that closed the container (not the dispose one)",
+			);
+		},
+	);
+
+	itExpects(
+		"Closing (no error) then disposing (with error) container should set criticalError properly",
+		[
+			{ eventName: "fluid:telemetry:Container:ContainerClose", category: "generic" },
+			{ eventName: "fluid:telemetry:Container:ContainerDispose", category: "error" },
+		],
+		async () => {
+			const container = await createConnectedContainer();
+			container.close();
+			container.dispose(new DataCorruptionError("dispose error", {}));
+
+			assert.strictEqual(
+				container.criticalError?.message,
+				"dispose error",
+				"Expected the error that disposed the container",
+			);
+		},
+	);
+
+	itExpects(
+		"Closing (with error) then disposing (no error) container should set criticalError properly",
+		[
+			{ eventName: "fluid:telemetry:Container:ContainerClose", category: "error" },
+			{ eventName: "fluid:telemetry:Container:ContainerDispose", category: "generic" },
+		],
+		async () => {
+			const container = await createConnectedContainer();
+			container.close(new DataCorruptionError("close error", {}));
+			container.dispose();
+
+			assert.strictEqual(
+				container.criticalError?.message,
+				"close error",
+				"Expected the error that closed the container",
+			);
 		},
 	);
 

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -765,7 +765,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 	);
 
 	itExpects(
-		"Closing (no error) then disposing (with error) container should set closedWithError properly",
+		"Closing (no error) then disposing (with error) container leaves closedWithError unset",
 		[
 			{ eventName: "fluid:telemetry:Container:ContainerClose", category: "generic" },
 			{ eventName: "fluid:telemetry:Container:ContainerDispose", category: "error" },
@@ -776,9 +776,9 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 			container.dispose(new DataCorruptionError("dispose error", {}));
 
 			assert.strictEqual(
-				container.closedWithError?.message,
-				"dispose error",
-				"Expected the error that disposed the container",
+				container.closedWithError,
+				undefined,
+				"Expected undefined since the container was closed without error",
 			);
 		},
 	);

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -718,7 +718,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 				"IContainerRuntime should send dispose event on container dispose",
 			);
 			assert.strictEqual(
-				container.criticalError?.message,
+				container.closedWithError?.message,
 				"dispose error",
 				"Expected the error that disposed the container",
 			);
@@ -757,7 +757,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 			assert.strictEqual(deltaManagerClosed, 1, "DeltaManager should send closed event");
 			assert.strictEqual(runtimeDispose, 1, "IContainerRuntime should send dispose event");
 			assert.strictEqual(
-				container.criticalError?.message,
+				container.closedWithError?.message,
 				"close error",
 				"Expected the error that closed the container (not the dispose one)",
 			);
@@ -765,7 +765,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 	);
 
 	itExpects(
-		"Closing (no error) then disposing (with error) container should set criticalError properly",
+		"Closing (no error) then disposing (with error) container should set closedWithError properly",
 		[
 			{ eventName: "fluid:telemetry:Container:ContainerClose", category: "generic" },
 			{ eventName: "fluid:telemetry:Container:ContainerDispose", category: "error" },
@@ -776,7 +776,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 			container.dispose(new DataCorruptionError("dispose error", {}));
 
 			assert.strictEqual(
-				container.criticalError?.message,
+				container.closedWithError?.message,
 				"dispose error",
 				"Expected the error that disposed the container",
 			);
@@ -784,7 +784,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 	);
 
 	itExpects(
-		"Closing (with error) then disposing (no error) container should set criticalError properly",
+		"Closing (with error) then disposing (no error) container should set closedWithError properly",
 		[
 			{ eventName: "fluid:telemetry:Container:ContainerClose", category: "error" },
 			{ eventName: "fluid:telemetry:Container:ContainerDispose", category: "generic" },
@@ -795,7 +795,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 			container.dispose();
 
 			assert.strictEqual(
-				container.criticalError?.message,
+				container.closedWithError?.message,
 				"close error",
 				"Expected the error that closed the container",
 			);


### PR DESCRIPTION
## Description

When using the existing Container load API, which is async, it's possible to receive a closed Container with no way to know what error closed it (the intention is to throw the error if it closes during load, but it's possible that step is missed due to async model).

This PR demonstrates an alternative API which returns a Container object with a bonus async `initialize` function that must be called before the Container is used. This allows the caller to set up listeners for the "closed" event before doing the actual load step.

## Reviewer Guidance

This is currently a sketch to show the API for design discussion.