### PR TITLE
POC to discuss: Add create/load Container APIs that give you an object before doing full initialization

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -439,21 +439,25 @@ export class Container
 	/**
 	 * Create a new container in a detached state.
 	 */
-	public static async createDetached(
+	public static createDetached(
 		createProps: IContainerCreateProps,
 		codeDetails: IFluidCodeDetails,
-	): Promise<Container> {
+	): { container: Container; initialize: () => Promise<IContainer> } {
 		const container = new Container(createProps);
 
-		return PerformanceEvent.timedExecAsync(
-			container.mc.logger,
-			{ eventName: "CreateDetached" },
-			async (_event) => {
-				await container.createDetached(codeDetails);
-				return container;
-			},
-			{ start: true, end: true, cancel: "generic" },
-		);
+		return {
+			container,
+			initialize: async () =>
+				PerformanceEvent.timedExecAsync(
+					container.mc.logger,
+					{ eventName: "CreateDetached" },
+					async (_event) => {
+						await container.createDetached(codeDetails);
+						return container;
+					},
+					{ start: true, end: true, cancel: "generic" },
+				),
+		};
 	}
 
 	/**

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -3,11 +3,13 @@
  * Licensed under the MIT License.
  */
 
+import type { TypedEventEmitter } from "@fluid-internal/client-utils";
 import {
 	IContainer,
 	ICodeDetailsLoader,
 	IFluidCodeDetails,
 	type IContainerPolicies,
+	type IContainerEvents,
 } from "@fluidframework/container-definitions/internal";
 import {
 	FluidObject,
@@ -143,6 +145,47 @@ export async function createDetachedContainer(
 		canReconnect: createDetachedContainerProps.allowReconnect,
 		clientDetailsOverride: createDetachedContainerProps.clientDetailsOverride,
 	});
+}
+
+/**
+ * Creates a new container using the specified code details but in an unattached state. While unattached, all
+ * updates will only be local until the user explicitly attaches the container to a service provider.
+ * @param createDetachedContainerProps - Services and properties necessary for creating detached container.
+ * @legacy
+ * @alpha
+ */
+//* 3 is better
+// export function createDetachedContainer2(
+// 	createDetachedContainerProps: ICreateDetachedContainerProps,
+// ): { container: IContainer; initialize: () => Promise<void> } {
+// 	const loader = new Loader(createDetachedContainerProps);
+// 	return loader.createDetachedContainer2(createDetachedContainerProps.codeDetails, {
+// 		canReconnect: createDetachedContainerProps.allowReconnect,
+// 		clientDetailsOverride: createDetachedContainerProps.clientDetailsOverride,
+// 	});
+// }
+
+/**
+ * Creates a new container using the specified code details but in an unattached state. While unattached, all
+ * updates will only be local until the user explicitly attaches the container to a service provider.
+ * @param createDetachedContainerProps - Services and properties necessary for creating detached container.
+ * @legacy
+ * @alpha
+ */
+export function createDetachedContainer3(
+	createDetachedContainerProps: ICreateDetachedContainerProps,
+	//* name this type
+): { shell: TypedEventEmitter<IContainerEvents> & { initialize: () => Promise<IContainer> } } {
+	const loader = new Loader(createDetachedContainerProps);
+	const { container, initialize } = loader.createDetachedContainer2(
+		createDetachedContainerProps.codeDetails,
+		{
+			canReconnect: createDetachedContainerProps.allowReconnect,
+			clientDetailsOverride: createDetachedContainerProps.clientDetailsOverride,
+		},
+	);
+	//* Put initialize on Container class but not IContainer interface
+	return { shell: Object.assign(container, { initialize }) };
 }
 
 /**

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -3,13 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import type { TypedEventEmitter } from "@fluid-internal/client-utils";
 import {
 	IContainer,
 	ICodeDetailsLoader,
 	IFluidCodeDetails,
 	type IContainerPolicies,
-	type IContainerEvents,
 } from "@fluidframework/container-definitions/internal";
 import {
 	FluidObject,
@@ -154,38 +152,18 @@ export async function createDetachedContainer(
  * @legacy
  * @alpha
  */
-//* 3 is better
-// export function createDetachedContainer2(
-// 	createDetachedContainerProps: ICreateDetachedContainerProps,
-// ): { container: IContainer; initialize: () => Promise<void> } {
-// 	const loader = new Loader(createDetachedContainerProps);
-// 	return loader.createDetachedContainer2(createDetachedContainerProps.codeDetails, {
-// 		canReconnect: createDetachedContainerProps.allowReconnect,
-// 		clientDetailsOverride: createDetachedContainerProps.clientDetailsOverride,
-// 	});
-// }
-
-/**
- * Creates a new container using the specified code details but in an unattached state. While unattached, all
- * updates will only be local until the user explicitly attaches the container to a service provider.
- * @param createDetachedContainerProps - Services and properties necessary for creating detached container.
- * @legacy
- * @alpha
- */
-export function createDetachedContainer3(
+export function createDetachedContainerUninitialized(
 	createDetachedContainerProps: ICreateDetachedContainerProps,
-	//* name this type
-): { shell: TypedEventEmitter<IContainerEvents> & { initialize: () => Promise<IContainer> } } {
+): IContainer & { initialize: () => Promise<void> } {
 	const loader = new Loader(createDetachedContainerProps);
-	const { container, initialize } = loader.createDetachedContainer2(
+	const container = loader.createDetachedContainerUninitialized(
 		createDetachedContainerProps.codeDetails,
 		{
 			canReconnect: createDetachedContainerProps.allowReconnect,
 			clientDetailsOverride: createDetachedContainerProps.clientDetailsOverride,
 		},
 	);
-	//* Put initialize on Container class but not IContainer interface
-	return { shell: Object.assign(container, { initialize }) };
+	return container;
 }
 
 /**
@@ -219,6 +197,22 @@ export async function loadExistingContainer(
 ): Promise<IContainer> {
 	const loader = new Loader(loadExistingContainerProps);
 	return loader.resolve(
+		loadExistingContainerProps.request,
+		loadExistingContainerProps.pendingLocalState,
+	);
+}
+
+/**
+ * Loads a container with an existing snapshot from the service.
+ * @param loadExistingContainerProps - Services and properties necessary for loading an existing container.
+ * @legacy
+ * @alpha
+ */
+export async function loadExistingContainerUninitialized(
+	loadExistingContainerProps: ILoadExistingContainerProps,
+): Promise<IContainer & { initialize: () => Promise<void> }> {
+	const loader = new Loader(loadExistingContainerProps);
+	return loader.resolveUninitialized(
 		loadExistingContainerProps.request,
 		loadExistingContainerProps.pendingLocalState,
 	);

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -336,6 +336,21 @@ export class Loader implements IHostLoader {
 			clientDetailsOverride?: IClientDetails;
 		},
 	): Promise<IContainer> {
+		const { container, initialize } = this.createDetachedContainer2(
+			codeDetails,
+			createDetachedProps,
+		);
+		//*
+		return initialize().then(() => container);
+	}
+
+	public createDetachedContainer2(
+		codeDetails: IFluidCodeDetails,
+		createDetachedProps?: {
+			canReconnect?: boolean;
+			clientDetailsOverride?: IClientDetails;
+		},
+	): { container: Container; initialize: () => Promise<IContainer> } {
 		return Container.createDetached(
 			{
 				...createDetachedProps,


### PR DESCRIPTION
## Description

When using the existing Container load API, which is async, it's possible to receive a closed Container with no way to know what error closed it (the intention is to throw the error if it closes during load, but it's possible that step is missed due to async model).

This PR demonstrates an alternative API which returns a Container object with a bonus async `initialize` function that must be called before the Container is used. This allows the caller to set up listeners for the "closed" event before doing the actual load step.

## Reviewer Guidance

This is currently a sketch to show the API for design discussion.