### PR TITLE
Enable no-unchecked-record-access rule for map

### DIFF
--- a/packages/dds/map/.eslintrc.cjs
+++ b/packages/dds/map/.eslintrc.cjs
@@ -13,7 +13,7 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 
 		// TODO: consider re-enabling once we have addressed how this rule conflicts with our error codes.
-		"unicorn/numeric-separators-style": "off"
+		"unicorn/numeric-separators-style": "off",
 	},
 	overrides: [
 		{

--- a/packages/dds/map/.eslintrc.cjs
+++ b/packages/dds/map/.eslintrc.cjs
@@ -13,8 +13,7 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 
 		// TODO: consider re-enabling once we have addressed how this rule conflicts with our error codes.
-		"unicorn/numeric-separators-style": "off",
-		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
+		"unicorn/numeric-separators-style": "off"
 	},
 	overrides: [
 		{

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -104,12 +104,12 @@ function serialize(directory1: ISharedDirectory): string {
 	assert.strictEqual(summaryObjectKeys.length, 1, "summary tree should only have one blob");
 	assert.strictEqual(summaryObjectKeys[0], "header", "summary should have a header blob");
 	assert.strictEqual(
-		summaryTree.tree.header.type,
+		summaryTree.tree.header?.type,
 		SummaryType.Blob,
 		"header is not of SummaryType.Blob",
 	);
 
-	const content = summaryTree.tree.header.content as string;
+	const content = summaryTree.tree.header?.content as string;
 	return JSON.stringify((JSON.parse(content) as IDirectoryNewStorageFormat).content);
 }
 
@@ -1725,15 +1725,15 @@ describe("Directory", () => {
 				const fooSubDirIterator = fooSubDir.entries();
 				const fooSubDirResult1 = fooSubDirIterator.next();
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDirResult1.value[0], "testKey");
+				assert.equal(fooSubDirResult1.value?.[0], "testKey");
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDirResult1.value[1], "testValue");
+				assert.equal(fooSubDirResult1.value?.[1], "testValue");
 				assert.equal(fooSubDirResult1.done, false);
 				const fooSubDirResult2 = fooSubDirIterator.next();
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDirResult2.value[0], "testKey2");
+				assert.equal(fooSubDirResult2.value?.[0], "testKey2");
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDirResult2.value[1], "testValue2");
+				assert.equal(fooSubDirResult2.value?.[1], "testValue2");
 				assert.equal(fooSubDirResult2.done, false);
 				const fooSubDirResult3 = fooSubDirIterator.next();
 				assert.equal(fooSubDirResult3.value, undefined);
@@ -1755,15 +1755,15 @@ describe("Directory", () => {
 				const fooSubDir2Iterator = fooSubDir2.entries();
 				const fooSubDir2Result1 = fooSubDir2Iterator.next();
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDir2Result1.value[0], "testKey");
+				assert.equal(fooSubDir2Result1.value?.[0], "testKey");
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDir2Result1.value[1], "testValue");
+				assert.equal(fooSubDir2Result1.value?.[1], "testValue");
 				assert.equal(fooSubDir2Result1.done, false);
 				const fooSubDir2Result2 = fooSubDir2Iterator.next();
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDir2Result2.value[0], "testKey2");
+				assert.equal(fooSubDir2Result2.value?.[0], "testKey2");
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.equal(fooSubDir2Result2.value[1], "testValue2");
+				assert.equal(fooSubDir2Result2.value?.[1], "testValue2");
 				assert.equal(fooSubDir2Result2.done, false);
 				const fooSubDir2Result3 = fooSubDir2Iterator.next();
 				assert.equal(fooSubDir2Result3.value, undefined);


### PR DESCRIPTION
### ESLint Configuration Changes:
* Changed the rule for `@fluid-internal/fluid/no-unchecked-record-access` from "warn" to "error" in the `.eslintrc.cjs` file by removing the line

### Needs Review:
* Updated test assertions in `directory.spec.ts` to use optional chaining:
  * Changed `value[0]` to `value?.[0]` and `value[1]` to `value?.[1]` in multiple test cases for both `fooSubDir` and `fooSubDir2` iterator results
* Modified `serialize` function to use optional chaining when accessing tree properties:
  * Changed `header.type` to `header?.type` 
  * Changed `header.content` to `header?.content`