### PR TITLE
improvement(shared-object-base): use shallowCloneObject helper in FluidSerializer to clean up `no-unsafe-assignment` lint disable

### DIFF
--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -8,7 +8,7 @@ import {
 	IFluidHandleContext,
 	type IFluidHandleInternal,
 } from "@fluidframework/core-interfaces/internal";
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, shallowCloneObject } from "@fluidframework/core-utils/internal";
 import {
 	generateHandleContextPath,
 	isSerializedHandle,
@@ -185,8 +185,7 @@ export class FluidSerializer implements IFluidSerializer {
 				// current property is replaced by the `replaced` value.
 				if (replaced !== value) {
 					// Lazily create a shallow clone of the `input` object if we haven't done so already.
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TODO: not sure if there's a good solution
-					clone = clone ?? (Array.isArray(input) ? [...input] : { ...input });
+					clone = clone ?? shallowCloneObject(input);
 
 					// Overwrite the current property `key` in the clone with the `replaced` value.
 					clone[key] = replaced;

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -185,7 +185,7 @@ export class FluidSerializer implements IFluidSerializer {
 				// current property is replaced by the `replaced` value.
 				if (replaced !== value) {
 					// Lazily create a shallow clone of the `input` object if we haven't done so already.
-					clone = clone ?? shallowCloneObject(input);
+					clone ??= shallowCloneObject(input);
 
 					// Overwrite the current property `key` in the clone with the `replaced` value.
 					clone[key] = replaced;

--- a/packages/dds/shared-object-base/src/test/serializer.spec.ts
+++ b/packages/dds/shared-object-base/src/test/serializer.spec.ts
@@ -60,7 +60,6 @@ describe("FluidSerializer", () => {
 		// Verify that `encode` is a no-op for these simple cases.
 		for (const input of simple) {
 			it(`${printHandle(input)} -> ${JSON.stringify(input)}`, () => {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- test deals with several object shapes
 				const actual = serializer.encode(input, handle);
 				assert.strictEqual(
 					actual,
@@ -68,7 +67,6 @@ describe("FluidSerializer", () => {
 					"encode() on input with no handles must return original input.",
 				);
 
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- test deals with several object shapes
 				const decoded = serializer.decode(actual);
 				assert.strictEqual(
 					decoded,
@@ -120,7 +118,6 @@ describe("FluidSerializer", () => {
 
 		for (const input of tricky) {
 			it(`${printHandle(input)} -> ${JSON.stringify(input)}`, () => {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- test deals with several object shapes
 				const actual = serializer.encode(input, handle);
 				assert.strictEqual(
 					actual,
@@ -128,7 +125,6 @@ describe("FluidSerializer", () => {
 					"encode() on input with no handles must return original input.",
 				);
 
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- test deals with several object shapes
 				const decoded = serializer.decode(actual);
 				assert.strictEqual(
 					decoded,
@@ -177,7 +173,6 @@ describe("FluidSerializer", () => {
 
 		function check(decodedForm, encodedForm): void {
 			it(`${printHandle(decodedForm)} -> ${JSON.stringify(encodedForm)}`, () => {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TODO: update when we can fix the return type of serializer.encode()
 				const replaced = serializer.encode(decodedForm, handle);
 				assert.notStrictEqual(
 					replaced,
@@ -186,11 +181,9 @@ describe("FluidSerializer", () => {
 				);
 				assert.deepStrictEqual(replaced, encodedForm, "encode() must return expected output.");
 
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TODO: update when we can fix the return type of serializer.encode()
 				const replacedTwice = serializer.encode(replaced, handle);
 				assert.deepStrictEqual(replacedTwice, replaced, "encode should be idempotent");
 
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TODO: update when we can fix the return type of serializer.decode()
 				const decodedRoundTrip = serializer.decode(replaced);
 				assert.notStrictEqual(
 					decodedRoundTrip,
@@ -203,7 +196,6 @@ describe("FluidSerializer", () => {
 					"input must round-trip through encode()/decode().",
 				);
 
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TODO: update when we can fix the return type of serializer.decode()
 				const decodedTwice = serializer.decode(decodedRoundTrip);
 				assert.deepStrictEqual(decodedTwice, decodedRoundTrip, "decode should be idempotent");
 
@@ -251,7 +243,6 @@ describe("FluidSerializer", () => {
 			input.h = handle; // eslint-disable-line @typescript-eslint/no-unsafe-member-access
 			input.o1.h = handle; // eslint-disable-line @typescript-eslint/no-unsafe-member-access
 
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TODO: update when we can fix the return type of serializer.encode()
 			const replaced = serializer.encode(input, handle);
 			assert.notStrictEqual(
 				replaced,
@@ -259,7 +250,6 @@ describe("FluidSerializer", () => {
 				"encode() must shallow-clone rather than mutate original object.",
 			);
 
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TODO: update when we can fix the return type of serializer.decode()
 			const decoded = serializer.decode(replaced);
 			assert.notStrictEqual(
 				decoded,


### PR DESCRIPTION
## Description
Follow up to https://github.com/microsoft/FluidFramework/pull/23662: https://github.com/microsoft/FluidFramework/pull/23662#discussion_r1936501729

Reason for `shallowCloneObject`: https://github.com/microsoft/FluidFramework/pull/23662#discussion_r1934391673

This PR also removes several unused `no-unsafe-assignment` lint disables in test file serializer.spec.ts. 