### PR TITLE
Enable no-unchecked-record-access for test-end-to-end-tests

### DIFF
--- a/packages/test/test-end-to-end-tests/.eslintrc.cjs
+++ b/packages/test/test-end-to-end-tests/.eslintrc.cjs
@@ -14,7 +14,6 @@ module.exports = {
 	rules: {
 		"prefer-arrow-callback": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
-		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 
 		// This library is used in the browser, so we don't want dependencies on most node libraries.
 		"import/no-nodejs-modules": ["error"],


### PR DESCRIPTION
### ESLint Configuration Changes:
* Changed the rule for `@fluid-internal/fluid/no-unchecked-record-access` from "warn" to "error" in the `.eslintrc.cjs` file by removing the line