### PR TITLE
Enable no-unchecked-record-access for container runtime

### DIFF
--- a/packages/runtime/container-runtime/.eslintrc.cjs
+++ b/packages/runtime/container-runtime/.eslintrc.cjs
@@ -13,7 +13,6 @@ module.exports = {
 	},
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
-		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 
 		// False positives on non-array `push` methods.
 		// TODO:AB#28686: remove this override once this rule has been disabled in the root config.


### PR DESCRIPTION
### ESLint Configuration Changes:
* Changed the rule for `@fluid-internal/fluid/no-unchecked-record-access` from "warn" to "error" in the `.eslintrc.cjs` file by removing the line