### PR TITLE
Enable no-unchecked-record-access for driver utils

### DIFF
--- a/packages/tools/devtools/devtools-view/.eslintrc.cjs
+++ b/packages/tools/devtools/devtools-view/.eslintrc.cjs
@@ -18,7 +18,6 @@ module.exports = {
 		// Disabled because they disagrees with React common patterns / best practices.
 		"@typescript-eslint/unbound-method": "off",
 		"unicorn/consistent-function-scoping": "off",
-		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 
 		// Disabled because they conflict with Prettier.
 		"unicorn/no-nested-ternary": "off",


### PR DESCRIPTION
### ESLint Configuration Changes:
* Changed the rule for `@fluid-internal/fluid/no-unchecked-record-access` from "warn" to "error" in the `.eslintrc.cjs` file by removing the line