### PR TITLE
Enable no-unchecked-record-access for test-service-load

### DIFF
--- a/packages/test/test-service-load/.eslintrc.cjs
+++ b/packages/test/test-service-load/.eslintrc.cjs
@@ -13,6 +13,5 @@ module.exports = {
 	},
 	rules: {
 		"import/no-nodejs-modules": "off",
-		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 	},
 };


### PR DESCRIPTION
### ESLint Configuration Changes:
* Changed the rule for `@fluid-internal/fluid/no-unchecked-record-access` from "warn" to "error" in the `.eslintrc.cjs` file by removing the line