### PR TITLE
Enable no-unchecked-record-access for container loader

### DIFF
--- a/packages/loader/container-loader/.eslintrc.cjs
+++ b/packages/loader/container-loader/.eslintrc.cjs
@@ -8,9 +8,6 @@ module.exports = {
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
-	rules: {
-		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
-	},
 	overrides: [
 		{
 			// Rules only for test files


### PR DESCRIPTION
### ESLint Configuration Changes:
* Changed the rule for `@fluid-internal/fluid/no-unchecked-record-access` from "warn" to "error" in the `.eslintrc.cjs` file by removing the line