### PR TITLE
improvement(docs): Don't generate import instructions for API items that cannot be directly imported

### DIFF
--- a/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
+++ b/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
@@ -173,10 +173,10 @@ export function layoutContent(apiItem, itemSpecificContent, config) {
 	const isDocumentItem = ["Document", "Folder"].includes(config.hierarchy[apiItem.kind].kind);
 
 	// Whether or not this item can be imported by the end user.
-	// For example, a function or interface belonging to a package's exports can be directly imported by the end user.
+	// For example, a function or interface belonging to a package's exports (entry-point) can be directly imported by the end user.
 	// Whereas, the method of an interface cannot.
 	// For such members where the end-user can't directly import, we won't display import instructions.
-	const isImportable = apiItem.parent?.kind === ApiItemKind.Package;
+	const isImportable = apiItem.parent?.kind === ApiItemKind.EntryPoint;
 
 	const sections = [];
 

--- a/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
+++ b/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
@@ -157,6 +157,11 @@ export function layoutContent(apiItem, itemSpecificContent, config) {
 		throw new Error("Invalid API item kind.");
 	}
 
+	// Whether or not this item is being transformed into its own document (vs being transformed into a subsection
+	// of some parent document).
+	// TODO: it would probably be better to have the library pass this information in, rather than re-deriving it here.
+	const isDocumentItem = ["Document", "Folder"].includes(config.hierarchy[apiItem.kind].kind);
+
 	const sections = [];
 
 	// Render summary comment (if any)
@@ -229,7 +234,7 @@ export function layoutContent(apiItem, itemSpecificContent, config) {
 
 	// Add heading to top of section only if this is being rendered to a parent item.
 	// Document items have their headings handled specially.
-	return ["Document", "Folder"].includes(config.hierarchy[apiItem.kind].kind)
+	return isDocumentItem
 		? sections
 		: [
 				new SectionNode(

--- a/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
+++ b/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
@@ -76,7 +76,7 @@ function createImportNotice(apiItem) {
 		);
 	}
 
-	if (ApiItemUtilities.hasModifierTag(apiItem, "@legacy")) {
+	if (ApiItemUtilities.ancestryHasModifierTag(apiItem, "@legacy")) {
 		return createImportAdmonition(
 			"legacy",
 			"This API is provided for existing users, but is not recommended for new users.",

--- a/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
+++ b/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
@@ -86,7 +86,7 @@ function createSupportNotice(apiItem, isImportable) {
 		);
 	}
 
-	if (ApiItemUtilities.ancestryHasModifierTag(apiItem, "@legacy")) {
+	if (ApiItemUtilities.hasModifierTag(apiItem, "@legacy")) {
 		return createAdmonition(
 			"legacy",
 			"This API is provided for existing users, but is not recommended for new users.",


### PR DESCRIPTION
Interface members and such cannot be directly imported by the end-user. Yet we were displaying import instructions for such members for `@alpha`/`@beta`/`@legacy` members. This change omits those notices from items that are not directly exported by the package, and therefore cannot be directly imported.

Example (interface member) before:
![image](https://github.com/user-attachments/assets/6b34d229-6de4-4a66-a01a-fabb18007648)

Example after:
![image](https://github.com/user-attachments/assets/d2896c75-dd32-4da3-8405-1d1e1398b303)