### PR TITLE
Add a test to make sure we don't delete a private function being accessed by a legacy partner

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3724,6 +3724,12 @@ export class ContainerRuntime
 
 	public readonly getAbsoluteUrl: (relativeUrl: string) => Promise<string | undefined>;
 
+	/**
+	 * Builds the Summary tree including all the channels and the container state.
+	 *
+	 * @remarks - Unfortunately, this function is accessed in a non-typesafe way by a legacy first-party partner,
+	 * so until we can provide a proper API for their scenario, we need to ensure this function doesn't change.
+	 */
 	private async summarizeInternal(
 		fullTree: boolean,
 		trackState: boolean,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -1325,7 +1325,7 @@ describe("Runtime", () => {
 
 			// A legacy partner team overrides the summarizeInternal method to add custom data to the Summary.
 			// Let's make sure we don't break them inadvertently, while we work to move them to a better pattern.
-			it("Preserve known overreach into private member", async () => {
+			it("Ensure private member is stable to support legacy usage", async () => {
 				const containerRuntime_withSummarizeInternal = (await ContainerRuntime.loadRuntime({
 					context: getMockContext() as IContainerContext,
 					registryEntries: [],


### PR DESCRIPTION
## Description

An internal partner team is monkey-patching `ContainerRuntime.summarizeInternal` in order to add custom data to the summary, since we don't provide an API for such capability.

We are discussing whether to add that, but in the meantime, this hack has been shipped and supports a critical feature, so we need to ensure we don't inadvertently break it.

Fixes [AB#28387](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/28387)