### PR TITLE
Disable older version E2E testing against ODSP

### DIFF
--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -262,14 +262,18 @@ export function isCompatVersionBelowMinVersion(minVersion: string, config: Compa
  * ! If a summarizer's version is too old, ODSP will nack the summaries with "Upgrade to a newer version of the Fluid client packages to summarize".
  */
 export function isOdspCompatCompliant(config: CompatConfig): boolean {
-	return (
-		(typeof config.compatVersion !== "string" ||
-			semver.compare(config.compatVersion, baseVersionForMinCompat) >= 0) &&
-		(config.createVersion === undefined ||
-			semver.compare(config.createVersion, baseVersionForMinCompat) >= 0) &&
-		(config.loadVersion === undefined ||
-			semver.compare(config.loadVersion, baseVersionForMinCompat) >= 0)
-	);
+	for (const ltsVersion of defaultCompatVersions.ltsVersions) {
+		if (
+			(typeof config.compatVersion === "string" &&
+				semver.compare(config.compatVersion, ltsVersion) <= 0) ||
+			(config.createVersion !== undefined &&
+				semver.compare(config.createVersion, ltsVersion) <= 0) ||
+			(config.loadVersion !== undefined && semver.compare(config.loadVersion, ltsVersion) <= 0)
+		) {
+			return false;
+		}
+	}
+	return true;
 }
 
 // Helper function for genCrossVersionCompatConfig().

--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -257,6 +257,21 @@ export function isCompatVersionBelowMinVersion(minVersion: string, config: Compa
 	return semver.compare(compatVersion, minReqVersion) < 0;
 }
 
+/**
+ * Returns true if the given compat config is compliant with ODSP's version requirements.
+ * ! If a summarizer's version is too old, ODSP will nack the summaries with "Upgrade to a newer version of the Fluid client packages to summarize".
+ */
+export function isOdspCompatCompliant(config: CompatConfig): boolean {
+	return (
+		(typeof config.compatVersion !== "string" ||
+			semver.compare(config.compatVersion, baseVersionForMinCompat) >= 0) &&
+		(config.createVersion === undefined ||
+			semver.compare(config.createVersion, baseVersionForMinCompat) >= 0) &&
+		(config.loadVersion === undefined ||
+			semver.compare(config.loadVersion, baseVersionForMinCompat) >= 0)
+	);
+}
+
 // Helper function for genCrossVersionCompatConfig().
 function genCompatConfig(createVersion: string, loadVersion: string): CompatConfig {
 	return {

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -18,6 +18,7 @@ import {
 	configList,
 	isCompatVersionBelowMinVersion,
 	mochaGlobalSetup,
+	isOdspCompatCompliant,
 } from "./compatConfig.js";
 import {
 	CompatKind,
@@ -62,6 +63,9 @@ function createCompatSuite(
 		for (const config of configs) {
 			if (minVersion && isCompatVersionBelowMinVersion(minVersion, config)) {
 				// skip current config if compat version is below min version supported for test suite
+				continue;
+			}
+			if (driver === "odsp" && !isOdspCompatCompliant(config)) {
 				continue;
 			}
 			describe(config.name, function () {


### PR DESCRIPTION
ODSP doesn't support older version summaries (dual-commit summaries), so we probably shouldn't be running E2E tests against these older versions when using the ODSP driver.

The `"Upgrade to a newer version of the Fluid client packages to summarize"` summaryNack was seen on some test failures as flaky test items. This error is explicitly hit when the ODSP service sees a dual-commit summary.

Looking at current telemetry, the oldest hit that doesn't use dual-commit summaries was version `"2.0.0-rc.5.0.7"`. Given this, version `"2.0.0"` is a fine cut off since we currently only test back to `N-1`.

Related change in the LTS branch from a year ago: https://github.com/microsoft/FluidFramework/pull/19029

Fixes [AB#28836](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/28836)
Fixes [AB#26375](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26375)
Fixes [AB#26972](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/26972)
Fixes [AB#27856](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/27856)
Fixes [AB#29554](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/29554)
Fixes [AB#29273](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/29273)