### PR TITLE
Disable "Conflicting ops" E2E test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -571,7 +571,8 @@ describeCompat("SharedInterval", "NoCompat", (getTestObjectProvider, apis) => {
 			}
 		});
 
-		it("Conflicting ops", async () => {
+		// ! Disabled due to flakiness (see AB#29397)
+		it.skip("Conflicting ops", async () => {
 			const stringId = "stringKey";
 			const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
 			const testContainerConfig: ITestContainerConfig = {


### PR DESCRIPTION
We've seen this test fail a couple of times during OCE rotation against the local service. I'm disabling the test for now to reduce noise.

[AB#29397](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/29397)