### PR TITLE
merge-tree: Reproduce obliterate endpoint expansion bug in unit tests

### DIFF
--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -1039,7 +1039,7 @@ describe("client.applyMsg", () => {
 					b.obliterateRangeLocal({ pos: 1, side: Side.After }, { pos: 9, side: Side.Before }),
 					++seq,
 				),
-				b.makeOpMessage(b.insertTextLocal(2, "66"), ++seq),
+				b.makeOpMessage(b.insertTextLocal(2, "xx"), ++seq),
 				b.makeOpMessage(b.insertTextLocal(8, "BB"), ++seq),
 				b.makeOpMessage(
 					b.obliterateRangeLocal({ pos: 1, side: Side.After }, { pos: 4, side: Side.Before }),

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -1019,7 +1019,7 @@ describe("client.applyMsg", () => {
 		it.skip("obliterate with mismatched final states", () => {
 			const clients = createClientsAtInitialState(
 				{
-					initialState: "B{6666666}BBB{666666}BB",
+					initialState: "0{zzzzzzz}123{yyyyyy}45",
 					options: {
 						mergeTreeEnableObliterate: true,
 						mergeTreeEnableSidedObliterate: true,

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -1015,7 +1015,7 @@ describe("client.applyMsg", () => {
 
 			logger.validate({ baseText: "BBBBBB B" });
 		});
-		it.only("obliterate with mismatched final states", () => {
+		it.skip("obliterate with mismatched final states", () => {
 			const clients = createClientsAtInitialState(
 				{
 					initialState: "B{6666666}BBB{666666}BB",

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -1035,8 +1035,6 @@ describe("client.applyMsg", () => {
 			const b = clients.B;
 
 			ops.push(
-				// no way to know if annotates are regular or adjust
-				b.makeOpMessage(b.annotateRangeLocal(12, 21, { foo: 1 }), ++seq),
 				b.makeOpMessage(
 					b.obliterateRangeLocal({ pos: 1, side: Side.After }, { pos: 9, side: Side.Before }),
 					++seq,
@@ -1055,7 +1053,7 @@ describe("client.applyMsg", () => {
 					c.applyMsg(op);
 				}
 
-			logger.validate({ baseText: "B{66666666}BBBBB{666666}BB" });
+			logger.validate({ baseText: "0{6666666666}123BB{yyyyyy}45" });
 		});
 	});
 

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -1015,6 +1015,7 @@ describe("client.applyMsg", () => {
 
 			logger.validate({ baseText: "BBBBBB B" });
 		});
+		// TODO: see AB#29398
 		it.skip("obliterate with mismatched final states", () => {
 			const clients = createClientsAtInitialState(
 				{


### PR DESCRIPTION
Of the failures discovered in #23614, write the smallest one into a unit test for investigation purposes.  
[AB#29398](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/29398) for investigation tracking