### PR TITLE
Export Sequence Fuzz Models

### DIFF
--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -52,6 +52,18 @@
 				"types": "./dist/intervalCollection.d.ts",
 				"default": "./dist/intervalCollection.js"
 			}
+		},
+		"./internal/test": {
+			"allow-ff-test-exports": {
+				"import": {
+					"types": "./lib/test/index.d.ts",
+					"default": "./lib/test/index.js"
+				},
+				"require": {
+					"types": "./dist/test/index.d.ts",
+					"default": "./dist/test/index.js"
+				}
+			}
 		}
 	},
 	"main": "lib/index.js",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -84,7 +84,7 @@
 		"build:test": "npm run build:test:esm && npm run build:test:cjs",
 		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
 		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
-		"check:are-the-types-wrong": "attw --pack . --exclude-entrypoints ./internal/test/intervalCollection",
+		"check:are-the-types-wrong": "attw --pack . --exclude-entrypoints ./internal/test/intervalCollection ./internal/test",
 		"check:biome": "biome check .",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
 		"check:exports:bundle-release-tags": "api-extractor run --config api-extractor/api-extractor-lint-bundle.json",

--- a/packages/dds/sequence/src/test/fuzz/fuzzUtils.ts
+++ b/packages/dds/sequence/src/test/fuzz/fuzzUtils.ts
@@ -12,6 +12,7 @@ import {
 	AsyncReducer,
 	combineReducersAsync,
 	createWeightedAsyncGenerator,
+	takeAsync,
 } from "@fluid-private/stochastic-test-utils";
 import {
 	DDSFuzzModel,
@@ -648,3 +649,51 @@ export function makeIntervalOperationGenerator(
 		[changeInterval, usableWeights.changeInterval, all(hasAnInterval, hasNonzeroLength)],
 	]);
 }
+
+export const baseIntervalModel = {
+	...baseModel,
+	generatorFactory: () =>
+		takeAsync(100, makeIntervalOperationGenerator(defaultIntervalOperationGenerationConfig)),
+};
+
+export function makeSharedStringOperationGenerator(
+	optionsParam?: SharedStringOperationGenerationConfig,
+	alwaysLeaveChar: boolean = false,
+): AsyncGenerator<Operation, FuzzTestState> {
+	const {
+		addText,
+		removeRange,
+		annotateRange,
+		annotateAdjustRange,
+		removeRangeLeaveChar,
+		lengthSatisfies,
+		hasNonzeroLength,
+		isShorterThanMaxLength,
+	} = createSharedStringGeneratorOperations(optionsParam);
+
+	const usableWeights =
+		optionsParam?.weights ?? defaultIntervalOperationGenerationConfig.weights;
+	return createWeightedAsyncGenerator<Operation, FuzzTestState>([
+		[addText, usableWeights.addText, isShorterThanMaxLength],
+		[
+			alwaysLeaveChar ? removeRangeLeaveChar : removeRange,
+			usableWeights.removeRange,
+			alwaysLeaveChar
+				? lengthSatisfies((length) => {
+						return length > 1;
+					})
+				: hasNonzeroLength,
+		],
+		[annotateRange, usableWeights.annotateRange, hasNonzeroLength],
+		[annotateAdjustRange, usableWeights.annotateRange, hasNonzeroLength],
+	]);
+}
+
+export const baseSharedStringModel = {
+	...baseModel,
+	generatorFactory: () =>
+		takeAsync(
+			100,
+			makeSharedStringOperationGenerator(defaultIntervalOperationGenerationConfig),
+		),
+};

--- a/packages/dds/sequence/src/test/fuzz/index.ts
+++ b/packages/dds/sequence/src/test/fuzz/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { baseIntervalModel, baseSharedStringModel } from "./fuzzUtils.js";

--- a/packages/dds/sequence/src/test/fuzz/intervalCollection.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/fuzz/intervalCollection.fuzz.spec.ts
@@ -3,22 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { takeAsync } from "@fluid-private/stochastic-test-utils";
 import { createDDSFuzzSuite } from "@fluid-private/test-dds-utils";
 import { FlushMode } from "@fluidframework/runtime-definitions/internal";
 
-import {
-	baseModel,
-	defaultFuzzOptions,
-	defaultIntervalOperationGenerationConfig,
-	makeIntervalOperationGenerator,
-} from "./fuzzUtils.js";
-
-const baseIntervalModel = {
-	...baseModel,
-	generatorFactory: () =>
-		takeAsync(100, makeIntervalOperationGenerator(defaultIntervalOperationGenerationConfig)),
-};
+import { defaultFuzzOptions, baseIntervalModel } from "./fuzzUtils.js";
 
 describe("IntervalCollection fuzz testing", () => {
 	const model = {

--- a/packages/dds/sequence/src/test/index.ts
+++ b/packages/dds/sequence/src/test/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { baseIntervalModel, baseSharedStringModel } from "./fuzz/index.js";

--- a/packages/dds/sequence/src/test/tsconfig.json
+++ b/packages/dds/sequence/src/test/tsconfig.json
@@ -7,6 +7,8 @@
 		"noImplicitAny": false,
 		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
+		"declaration": true,
+		"declarationMap": true,
 	},
 	"include": ["./**/*"],
 	"references": [


### PR DESCRIPTION
This change follows the same pattern used for merge tree to export test only utilities from the sequence package. The utilities that are exported are the base fuzz testing model for sequence and shared intervals. Exporting the base model will allow their reuse in other testing contexts. In order to export these models, they have to be put into another file, fuzzUtils.ts, as exporting from a test file (*.spec.ts) results in the test running in that file re-running where anything is imported from it, which is not something we want.

The in-progress PR shows the expected usages of these imports: https://github.com/microsoft/FluidFramework/pull/23701