### PR TITLE
Update pause/resume logic for doc lambdas

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -130,11 +130,14 @@ export class DocumentContextManager extends EventEmitter {
 
 				// if head goes lower than the current tail, we need to update the tail accordingly since it will be an invalid state
 				if (head.offset < this.tail.offset) {
-					Lumberjack.info("contextManager.setHead: updating tail offset because it is greater than the new head offset", {
-						newHeadOffset: head.offset,
-						currentHeadOffset: this.head.offset,
-						currentTailOffset: this.tail.offset,
-					});
+					Lumberjack.info(
+						"contextManager.setHead: updating tail offset because it is greater than the new head offset",
+						{
+							newHeadOffset: head.offset,
+							currentHeadOffset: this.head.offset,
+							currentTailOffset: this.tail.offset,
+						},
+					);
 					this.tail = head;
 				}
 			}

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -160,8 +160,7 @@ export class DocumentContextManager extends EventEmitter {
 
 	public setTail(tail: IQueuedMessage) {
 		assert(
-			(tail.offset > this.tail.offset || this.tailPaused) &&
-				tail.offset <= this.head.offset,
+			(tail.offset > this.tail.offset || this.tailPaused) && tail.offset <= this.head.offset,
 			`Tail offset ${tail.offset} must be greater than the current tail offset ${this.tail.offset} or tailPaused should be true (${this.tailPaused}), and less than or equal to the head offset ${this.head.offset}.`,
 		);
 

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -88,7 +88,8 @@ export class DocumentContextManager extends EventEmitter {
 					lowestOffset = docContext.lastSuccessfulOffset;
 				}
 			}
-			lowestOffset = (lowestOffset > -1 && lowestOffset < Number.MAX_SAFE_INTEGER) ? lowestOffset : 0;
+			lowestOffset =
+				lowestOffset > -1 && lowestOffset < Number.MAX_SAFE_INTEGER ? lowestOffset : 0;
 			this.headPaused = true;
 			this.tailPaused = true;
 			Lumberjack.info("Emitting pause from contextManager", { lowestOffset, offset, reason });

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -127,6 +127,7 @@ export class DocumentContextManager extends EventEmitter {
 							newHeadOffset: head.offset,
 							currentHeadOffset: this.head.offset,
 							lastCheckpointOffset: this.lastCheckpoint.offset,
+							currentTailOffset: this.tail.offset,
 						},
 					);
 					return false;
@@ -138,6 +139,7 @@ export class DocumentContextManager extends EventEmitter {
 					{
 						newHeadOffset: head.offset,
 						currentHeadOffset: this.head.offset,
+						currentTailOffset: this.tail.offset,
 						headPaused: this.headPaused,
 					},
 				);
@@ -147,6 +149,7 @@ export class DocumentContextManager extends EventEmitter {
 				Lumberjack.info("Setting headPaused to false", {
 					newHeadOffset: head.offset,
 					currentHeadOffset: this.head.offset,
+					currentTailOffset: this.tail.offset,
 				});
 				this.headPaused = false;
 			}
@@ -170,6 +173,7 @@ export class DocumentContextManager extends EventEmitter {
 				{
 					newTailOffset: tail.offset,
 					currentTailOffset: this.tail.offset,
+					currentHeadOffset: this.head.offset,
 					tailPaused: this.tailPaused,
 				},
 			);
@@ -179,6 +183,7 @@ export class DocumentContextManager extends EventEmitter {
 			Lumberjack.info("Setting tailPaused to false", {
 				newTailOffset: tail.offset,
 				currentTailOffset: this.tail.offset,
+				currentHeadOffset: this.head.offset,
 			});
 			this.tailPaused = false;
 		}

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -81,11 +81,11 @@ export class DocumentContextManager extends EventEmitter {
 			this.emit("error", error, errorData);
 		});
 		context.addListener("pause", (offset?: number, reason?: any) => {
-			// Find the lowest offset of all doc contexts' tail (checkpointed offset) and emit pause at that offset to ensure we dont miss any messages during resume (reprocessing)
+			// Find the lowest offset of all doc contexts' lastSuccessfulOffset and emit pause at that offset to ensure we dont miss any messages during resume (reprocessing)
 			let lowestOffset = offset ?? Number.MAX_SAFE_INTEGER;
 			for (const docContext of this.contexts) {
-				if (docContext.tail.offset < lowestOffset) {
-					lowestOffset = docContext.tail.offset;
+				if (docContext.lastSuccessfulOffset < lowestOffset) {
+					lowestOffset = docContext.lastSuccessfulOffset;
 				}
 				// Pause all doc partitions' contexts
 				// Set headPaused=true for all doc partitions, so that we allow their head to move backwards(reprocess some ops) during resume

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -81,7 +81,7 @@ export class DocumentContextManager extends EventEmitter {
 			this.emit("error", error, errorData);
 		});
 		context.addListener("pause", (offset?: number, reason?: any) => {
-			// Find the lowest offset of all contexts' tail (checkpointed offset) and emit pause at that offset to ensure we dont miss any messages
+			// Find the lowest offset of all doc contexts' tail (checkpointed offset) and emit pause at that offset to ensure we dont miss any messages during resume (reprocessing)
 			let lowestOffset = offset ?? Number.MAX_SAFE_INTEGER;
 			for (const docContext of this.contexts) {
 				if (docContext.tail.offset < lowestOffset) {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -58,7 +58,7 @@ export class DocumentContextManager extends EventEmitter {
 			assert(head.offset > this.tail.offset && head.offset <= this.head.offset);
 		} else if (this.headUpdatedAfterResume) {
 			// means that tail is pending to be updated after resume, so it might be having an invalid value currently
-			assert(head.offset <= this.head.offset);
+			assert(head.offset === this.head.offset);
 		}
 
 		// Create the new context and register for listeners on it

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -87,11 +87,8 @@ export class DocumentContextManager extends EventEmitter {
 				if (docContext.lastSuccessfulOffset < lowestOffset) {
 					lowestOffset = docContext.lastSuccessfulOffset;
 				}
-				// Pause all doc partitions' contexts
-				// Set headPaused=true for all doc partitions, so that we allow their head to move backwards(reprocess some ops) during resume
-				docContext.setStateToPause();
 			}
-			lowestOffset = lowestOffset > -1 ? lowestOffset : 0;
+			lowestOffset = (lowestOffset > -1 && lowestOffset < Number.MAX_SAFE_INTEGER) ? lowestOffset : 0;
 			this.headPaused = true;
 			this.tailPaused = true;
 			Lumberjack.info("Emitting pause from contextManager", { lowestOffset, offset, reason });

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -53,7 +53,7 @@ export class DocumentContextManager extends EventEmitter {
 		if (this.headUpdatedAfterResume && this.tailUpdatedAfterResume) {
 			// Contexts should only be created within the processing range of the manager
 			assert(head.offset > this.tail.offset && head.offset <= this.head.offset);
-		} else if (this.headUpdatedAfterResume)	{
+		} else if (this.headUpdatedAfterResume) {
 			assert(head.offset === this.head.offset);
 		}
 

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -91,29 +91,29 @@ export class DocumentContext extends EventEmitter implements IContext {
 
 			// allow moving backwards
 			Lumberjack.info(
-				"Allowing the document context head to move to the specified offset, and setting headUpdatedAfterResume to true",
+				"Allowing the document context head to move backwards to the specified offset",
 				{
 					newHeadOffset: head.offset,
 					currentHeadOffset: this.head.offset,
 					documentId: this.routingKey.documentId,
+					headUpdatedAfterResume: this.headUpdatedAfterResume,
 				},
 			);
-
-			// if (!this.headUpdatedAfterResume) { // TODO do we need to resumeBackToOffset !== undefined check here? i.e. if 2 docs emitted pause, will this be defined for both docs?
-			// 	Lumberjack.info("Setting headUpdatedAfterResume to true", {
-			// 		resumeBackToOffset,
-			// 		newHeadOffset: head.offset,
-			// 		currentHeadOffset: this.head.offset,
-			// 		documentId: this.routingKey.documentId,
-			// 	});
-			this.headUpdatedAfterResume = true;
-			// }
 		}
 
 		// When moving back to a state where head and tail differ we set the tail to be the old head, as in the
 		// constructor, to make tail represent the inclusive top end of the checkpoint range.
 		if (!this.hasPendingWork()) {
 			this.tailInternal = this.getLatestTail();
+		}
+
+		if (!this.headUpdatedAfterResume) {
+			Lumberjack.info("Setting headUpdatedAfterResume to true", {
+				newHeadOffset: head.offset,
+				currentHeadOffset: this.head.offset,
+				documentId: this.routingKey.documentId,
+			});
+			this.headUpdatedAfterResume = true;
 		}
 
 		this.headInternal = head;
@@ -162,7 +162,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 		return this.contextError;
 	}
 
-	public pause(offset: number, reason?: any) {
+	public pause(offset?: number, reason?: any) {
 		this.headUpdatedAfterResume = false; // reset this flag when we pause
 		this.emit("pause", offset, reason);
 	}

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -59,7 +59,8 @@ export class DocumentContext extends EventEmitter implements IContext {
 	}
 
 	/**
-	 * TODO
+	 * Sets the state to pause, i.e. resets the headUpdatedAfterResume flag.
+	 * This allows moving backwards during resume even if the document didnt trigger the pause, but some other document in the same kafka partition did.
 	 */
 	public setStateToPause() {
 		this.headUpdatedAfterResume = false;

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -134,7 +134,10 @@ export class DocumentContext extends EventEmitter implements IContext {
 		const offset = message.offset;
 
 		const contextManagerResumeState = this.getContextManagerResumeState();
-		if (contextManagerResumeState.headUpdatedAfterResume && contextManagerResumeState.tailUpdatedAfterResume) {
+		if (
+			contextManagerResumeState.headUpdatedAfterResume &&
+			contextManagerResumeState.tailUpdatedAfterResume
+		) {
 			assert(
 				offset > this.tail.offset && offset <= this.head.offset,
 				`Checkpoint offset ${offset} must be greater than the current tail offset ${this.tail.offset} and less than or equal to the head offset ${this.head.offset}. Topic ${message.topic}, partition ${message.partition}, tenantId ${this.routingKey.tenantId}, documentId ${this.routingKey.documentId}.`,

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -136,10 +136,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 		const offset = message.offset;
 
 		const contextManagerResumeState = this.getContextManagerResumeState();
-		if (
-			!contextManagerResumeState.headPaused &&
-			!contextManagerResumeState.tailPaused
-		) {
+		if (!contextManagerResumeState.headPaused && !contextManagerResumeState.tailPaused) {
 			assert(
 				offset > this.tail.offset && offset <= this.head.offset,
 				`Checkpoint offset ${offset} must be greater than the current tail offset ${this.tail.offset} and less than or equal to the head offset ${this.head.offset}. Topic ${message.topic}, partition ${message.partition}, tenantId ${this.routingKey.tenantId}, documentId ${this.routingKey.documentId}.`,

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -145,7 +145,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 		} else if (contextManagerResumeState.headUpdatedAfterResume) {
 			// means that tail is pending to be updated after resume, so it might be having an invalid value currently
 			assert(
-				offset <= this.head.offset,
+				offset === this.head.offset,
 				`Checkpoint offset ${offset} must be less than or equal to the head offset ${this.head.offset}. Topic ${message.topic}, partition ${message.partition}, tenantId ${this.routingKey.tenantId}, documentId ${this.routingKey.documentId}.`,
 			);
 		}

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -145,7 +145,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 			// means that tail is pending to be updated after resume, so it might be having an invalid value currently
 			assert(
 				offset === this.head.offset,
-				`Checkpoint offset ${offset} must be less than or equal to the head offset ${this.head.offset}. Topic ${message.topic}, partition ${message.partition}, tenantId ${this.routingKey.tenantId}, documentId ${this.routingKey.documentId}.`,
+				`Checkpoint offset ${offset} must be equal to the head offset ${this.head.offset}. Topic ${message.topic}, partition ${message.partition}, tenantId ${this.routingKey.tenantId}, documentId ${this.routingKey.documentId}.`,
 			);
 		}
 

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -24,6 +24,8 @@ export class DocumentContext extends EventEmitter implements IContext {
 	private headInternal: IQueuedMessage;
 	private tailInternal: IQueuedMessage;
 
+	private lastSuccessfulOffsetInternal: number;
+
 	private closed = false;
 	private contextError = undefined;
 
@@ -48,6 +50,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 		// Tail will be set to the checkpoint offset of the previous head
 		this.headInternal = head;
 		this.tailInternal = this.getLatestTail();
+		this.lastSuccessfulOffsetInternal = this.tailInternal.offset; // will be -1 at creation
 	}
 
 	public get head(): IQueuedMessage {
@@ -58,11 +61,22 @@ export class DocumentContext extends EventEmitter implements IContext {
 		return this.tailInternal;
 	}
 
+	public get lastSuccessfulOffset(): number {
+		return this.lastSuccessfulOffsetInternal;
+	}
+
 	/**
 	 * Returns whether or not there is pending work in flight - i.e. the head and tail are not equal
 	 */
 	public hasPendingWork(): boolean {
 		return this.headInternal !== this.tailInternal;
+	}
+
+	/**
+	 * Sets the last successfully processed offset.
+	 */
+	public setLastSuccessfulOffset(offset: number) {
+		this.lastSuccessfulOffsetInternal = offset;
 	}
 
 	/**

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -80,7 +80,9 @@ export class DocumentContext extends EventEmitter implements IContext {
 	}
 
 	/**
-	 * Sets the state to pause, i.e. headPaused = true.
+	 * Sets the state to pause, i.e. headPaused = true, without emitting the pause event.
+	 * It is different than pause() method which emits the pause event.
+	 * This is used to set the state to pause when another doc in the same kafka partition triggered pause and we want to pause all the docs in that kafka partition.
 	 */
 	public setStateToPause() {
 		this.headPaused = true;

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -37,7 +37,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 		head: IQueuedMessage,
 		public readonly log: ILogger | undefined,
 		private readonly getLatestTail: () => IQueuedMessage,
-		private readonly getContextManagerResumeState: () => {
+		private readonly getContextManagerPauseState: () => {
 			headPaused: boolean;
 			tailPaused: boolean;
 		},
@@ -135,13 +135,13 @@ export class DocumentContext extends EventEmitter implements IContext {
 		// Assert offset is between the current tail and head
 		const offset = message.offset;
 
-		const contextManagerResumeState = this.getContextManagerResumeState();
-		if (!contextManagerResumeState.headPaused && !contextManagerResumeState.tailPaused) {
+		const contextManagerPauseState = this.getContextManagerPauseState();
+		if (!contextManagerPauseState.headPaused && !contextManagerPauseState.tailPaused) {
 			assert(
 				offset > this.tail.offset && offset <= this.head.offset,
 				`Checkpoint offset ${offset} must be greater than the current tail offset ${this.tail.offset} and less than or equal to the head offset ${this.head.offset}. Topic ${message.topic}, partition ${message.partition}, tenantId ${this.routingKey.tenantId}, documentId ${this.routingKey.documentId}.`,
 			);
-		} else if (contextManagerResumeState.tailPaused) {
+		} else if (contextManagerPauseState.tailPaused) {
 			// means that tail is pending to be updated after resume, so it might be having an invalid value currently
 			assert(
 				offset === this.head.offset,

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -83,13 +83,13 @@ export class DocumentContext extends EventEmitter implements IContext {
 
 		// If head is moving backwards
 		if (head.offset <= this.head.offset) {
-			if (head.offset <= this.tailInternal.offset) {
+			if (head.offset <= this.tail.offset) {
 				Lumberjack.info(
-					"Not updating documentContext head since new head's offset is <= last checkpoint offset (tailInternal), returning early",
+					"Not updating documentContext head since new head's offset is <= last checkpoint offset (tail), returning early",
 					{
 						newHeadOffset: head.offset,
 						currentHeadOffset: this.head.offset,
-						tailInternalOffset: this.tailInternal.offset,
+						currentTailOffset: this.tail.offset,
 						documentId: this.routingKey.documentId,
 					},
 				);
@@ -102,8 +102,9 @@ export class DocumentContext extends EventEmitter implements IContext {
 				{
 					newHeadOffset: head.offset,
 					currentHeadOffset: this.head.offset,
-					documentId: this.routingKey.documentId,
+					currentTailOffset: this.tail.offset,
 					headPaused: this.headPaused,
+					documentId: this.routingKey.documentId,
 				},
 			);
 		}
@@ -118,6 +119,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 			Lumberjack.info("Setting headPaused to false", {
 				newHeadOffset: head.offset,
 				currentHeadOffset: this.head.offset,
+				currentTailOffset: this.tail.offset,
 				documentId: this.routingKey.documentId,
 			});
 			this.headPaused = false;

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
@@ -34,11 +34,11 @@ export class DocumentLambda implements IPartitionLambda {
 
 	private activityCheckTimer: NodeJS.Timeout | undefined;
 
-	private reprocessRange: { startOffset: number | undefined; endOffset: number | undefined } = {
-		startOffset: undefined,
-		endOffset: undefined,
-	};
-	private reprocessingOffset: number | undefined;
+	// private reprocessRange: { startOffset: number | undefined; endOffset: number | undefined } = {
+	// 	startOffset: undefined,
+	// 	endOffset: undefined,
+	// };
+	// private reprocessingOffset: number | undefined;
 
 	constructor(
 		private readonly factory: IPartitionLambdaFactory<IPartitionLambdaConfig>,
@@ -52,17 +52,14 @@ export class DocumentLambda implements IPartitionLambda {
 			);
 			context.error(error, errorData);
 		});
-		this.contextManager.on(
-			"pause",
-			(lowestOffset: number, pausedAtOffset: number, reason?: any) => {
-				// Emit pause at the lowest offset out of all document partitions
-				// This is important for ensuring that we don't miss any messages
-				// And store the reprocessRange so that we can allow contextManager to move back to it when it resumes
-				// It will move back to the first offset which was not checkpointed from this range
-				this.storeReprocessRange(lowestOffset, pausedAtOffset);
-				context.pause(lowestOffset, reason);
-			},
-		);
+		this.contextManager.on("pause", (lowestOffset: number, reason?: any) => {
+			// Emit pause at the lowest offset out of all document partitions
+			// This is important for ensuring that we don't miss any messages
+			// And store the reprocessRange so that we can allow contextManager to move back to it when it resumes
+			// It will move back to the first offset which was not checkpointed from this range
+			// this.storeReprocessRange(lowestOffset, pausedAtOffset);
+			context.pause(lowestOffset, reason);
+		});
 		this.contextManager.on("resume", () => {
 			context.resume();
 		});
@@ -76,30 +73,30 @@ export class DocumentLambda implements IPartitionLambda {
 	 * {@inheritDoc IPartitionLambda.handler}
 	 */
 	public handler(message: IQueuedMessage): undefined {
-		this.reprocessingOffset = this.isOffsetWithinReprocessRange(message.offset)
-			? message.offset
-			: undefined;
-		if (!this.contextManager.setHead(message, this.reprocessingOffset)) {
+		// this.reprocessingOffset = this.isOffsetWithinReprocessRange(message.offset)
+		// 	? message.offset
+		// 	: undefined;
+		if (!this.contextManager.setHead(message)) {
 			this.context.log?.warn(
 				"Unexpected head offset. " +
 					`head offset: ${this.contextManager.getHeadOffset()}, message offset: ${
 						message.offset
 					}`,
 			);
-			// update reprocessRange to avoid reprocessing the same message again
-			if (this.reprocessingOffset !== undefined) {
-				this.updateReprocessRange(this.reprocessingOffset);
-			}
+			// // update reprocessRange to avoid reprocessing the same message again
+			// if (this.reprocessingOffset !== undefined) {
+			// 	this.updateReprocessRange(this.reprocessingOffset);
+			// }
 			return undefined;
 		}
 
 		this.handlerCore(message);
-		this.contextManager.setTail(message, this.reprocessingOffset);
+		this.contextManager.setTail(message);
 
-		// update reprocessRange to avoid reprocessing the same message again
-		if (this.reprocessingOffset !== undefined) {
-			this.updateReprocessRange(this.reprocessingOffset);
-		}
+		// // update reprocessRange to avoid reprocessing the same message again
+		// if (this.reprocessingOffset !== undefined) {
+		// 	this.updateReprocessRange(this.reprocessingOffset);
+		// }
 
 		return undefined;
 	}
@@ -131,32 +128,32 @@ export class DocumentLambda implements IPartitionLambda {
 		}
 	}
 
-	private storeReprocessRange(lowestOffset: number, pausedAtoffset: number) {
-		this.reprocessRange = {
-			startOffset: lowestOffset,
-			endOffset: pausedAtoffset,
-		};
-	}
+	// private storeReprocessRange(lowestOffset: number, pausedAtoffset: number) {
+	// 	this.reprocessRange = {
+	// 		startOffset: lowestOffset,
+	// 		endOffset: pausedAtoffset,
+	// 	};
+	// }
 
-	private isOffsetWithinReprocessRange(offset: number) {
-		return (
-			this.reprocessRange.startOffset !== undefined &&
-			this.reprocessRange.endOffset !== undefined &&
-			offset >= this.reprocessRange.startOffset &&
-			offset <= this.reprocessRange.endOffset
-		);
-	}
+	// private isOffsetWithinReprocessRange(offset: number) {
+	// 	return (
+	// 		this.reprocessRange.startOffset !== undefined &&
+	// 		this.reprocessRange.endOffset !== undefined &&
+	// 		offset >= this.reprocessRange.startOffset &&
+	// 		offset <= this.reprocessRange.endOffset
+	// 	);
+	// }
 
-	private updateReprocessRange(reprocessedOffset: number) {
-		this.reprocessRange.startOffset = reprocessedOffset + 1;
-		if (
-			this.reprocessRange.endOffset &&
-			this.reprocessRange.endOffset < this.reprocessRange.startOffset
-		) {
-			// reset since all messages in the reprocess range have been processed
-			this.reprocessRange = { startOffset: undefined, endOffset: undefined };
-		}
-	}
+	// private updateReprocessRange(reprocessedOffset: number) {
+	// 	this.reprocessRange.startOffset = reprocessedOffset + 1;
+	// 	if (
+	// 		this.reprocessRange.endOffset &&
+	// 		this.reprocessRange.endOffset < this.reprocessRange.startOffset
+	// 	) {
+	// 		// reset since all messages in the reprocess range have been processed
+	// 		this.reprocessRange = { startOffset: undefined, endOffset: undefined };
+	// 	}
+	// }
 
 	private handlerCore(message: IQueuedMessage): void {
 		const boxcar = extractBoxcar(message);
@@ -189,7 +186,7 @@ export class DocumentLambda implements IPartitionLambda {
 		} else {
 			// SetHead assumes it will always receive increasing offsets (except reprocessing during pause/resume). So we need to split the creation case
 			// from the update case.
-			if (!document.context.setHead(message, this.reprocessingOffset)) {
+			if (!document.context.setHead(message)) {
 				return; // if head not updated, it means it doesnt need to be processed, return early
 			}
 		}

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -92,7 +92,7 @@ export class DocumentPartition {
 			.catch((error) => {
 				if (
 					(error.name && this.restartOnErrorNames.includes(error.name as string)) ||
-					error.message?.includes("Error while creating circuit breaker")
+					error.shouldRestart
 				) {
 					this.context.error(error, {
 						restart: true,

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -90,7 +90,10 @@ export class DocumentPartition {
 				this.q.resume();
 			})
 			.catch((error) => {
-				if (error.name && this.restartOnErrorNames.includes(error.name as string)) {
+				if (
+					(error.name && this.restartOnErrorNames.includes(error.name as string)) ||
+					error.message?.includes("Error while creating circuit breaker")
+				) {
 					this.context.error(error, {
 						restart: true,
 						tenantId: this.tenantId,
@@ -220,6 +223,9 @@ export class DocumentPartition {
 		if (this.lambda?.pause) {
 			this.lambda.pause(offset);
 		}
+		Lumberjack.info(
+			`TEST!! Doc partition paused, docId: ${this.documentId}, tenantId: ${this.tenantId}`,
+		);
 		Lumberjack.info("Doc partition paused", {
 			...getLumberBaseProperties(this.documentId, this.tenantId),
 			offset,
@@ -240,6 +246,9 @@ export class DocumentPartition {
 		if (this.lambda?.resume) {
 			this.lambda.resume();
 		}
+		Lumberjack.info(
+			`TEST!! Doc partition resumed, docId: ${this.documentId}, tenantId: ${this.tenantId}`,
+		);
 		Lumberjack.info("Doc partition resumed", {
 			...getLumberBaseProperties(this.documentId, this.tenantId),
 		});

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -223,6 +223,12 @@ export class DocumentPartition {
 		if (this.lambda?.pause) {
 			this.lambda.pause(offset);
 		}
+
+		// Its possible that some other doc partition triggered the pause
+		// So we need to make sure to set the paused state for this doc partition's context in case its not already set
+		// This will allow its head to move backwards/reprocess ops as needed during resume
+		this.context.setStateToPause();
+
 		Lumberjack.info("Doc partition paused", {
 			...getLumberBaseProperties(this.documentId, this.tenantId),
 			offset,

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -223,9 +223,6 @@ export class DocumentPartition {
 		if (this.lambda?.pause) {
 			this.lambda.pause(offset);
 		}
-		Lumberjack.info(
-			`TEST!! Doc partition paused, docId: ${this.documentId}, tenantId: ${this.tenantId}`,
-		);
 		Lumberjack.info("Doc partition paused", {
 			...getLumberBaseProperties(this.documentId, this.tenantId),
 			offset,
@@ -246,9 +243,6 @@ export class DocumentPartition {
 		if (this.lambda?.resume) {
 			this.lambda.resume();
 		}
-		Lumberjack.info(
-			`TEST!! Doc partition resumed, docId: ${this.documentId}, tenantId: ${this.tenantId}`,
-		);
 		Lumberjack.info("Doc partition resumed", {
 			...getLumberBaseProperties(this.documentId, this.tenantId),
 		});

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
@@ -49,6 +49,10 @@ export class Context extends EventEmitter implements IContext {
 	 * @param errorData - Additional information about the error
 	 */
 	public error(error: any, errorData: IContextErrorData) {
+		if (this.closed) {
+			Lumberjack.info("Context already closed, not emitting error");
+			return;
+		}
 		Lumberjack.verbose("Emitting error from context");
 		this.emit("error", error, errorData);
 	}

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentContext.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentContext.spec.ts
@@ -34,8 +34,8 @@ describe("document-router", () => {
 				DebugLogger.create("fluid-server:TestDocumentContext"),
 				() => contextTailOffset,
 				() => ({
-					headPaused: true,
-					tailPaused: true,
+					headPaused: false,
+					tailPaused: false,
 				}),
 			);
 		});

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentContext.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentContext.spec.ts
@@ -33,6 +33,10 @@ describe("document-router", () => {
 				offset0,
 				DebugLogger.create("fluid-server:TestDocumentContext"),
 				() => contextTailOffset,
+				() => ({
+					headUpdatedAfterResume: true,
+					tailUpdatedAfterResume: true,
+				}),
 			);
 		});
 

--- a/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentContext.spec.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/document-router/documentContext.spec.ts
@@ -34,8 +34,8 @@ describe("document-router", () => {
 				DebugLogger.create("fluid-server:TestDocumentContext"),
 				() => contextTailOffset,
 				() => ({
-					headUpdatedAfterResume: true,
-					tailUpdatedAfterResume: true,
+					headPaused: true,
+					tailPaused: true,
 				}),
 			);
 		});

--- a/server/routerlicious/packages/services-core/src/lambdas.ts
+++ b/server/routerlicious/packages/services-core/src/lambdas.ts
@@ -106,6 +106,11 @@ export interface IContext {
 	 * Resumes the context
 	 */
 	resume(): void;
+
+	/**
+	 * Sets the last successfully processed offset.
+	 */
+	setLastSuccessfulOffset?(offset: number): void;
 }
 
 /**


### PR DESCRIPTION
## Description

Update pause/resume logic for doc lambdas to make it simpler:
(Previous PR for context: https://github.com/microsoft/FluidFramework/pull/23138)

1. During a pause event, the kafka consumer will be paused at the lowest offset of all doc's lastSuccessfulOffset to ensure no missing messages during resume. Earlier we were using head, but in that case some messages might get lost if they were not completely processed when pausing.
2. Made some updates to account for the use case where there are multiple doc partitions in a single kafka partition and only one of them (or few of them, but not all) triggered pause.
    - In this case, all the doc partitions will be updated to a paused state during pause, so that all of them can be resumed and allowed to reprocess ops during resume.
    - Simplified the resume logic by removing resumeBackToOffset variable and reprocessing range, and the doc partitions will now be resumed from the first offset that is > its tail (checkpointed offset). 
3. Updated the asserts in createContext and checkpointing logic, to account for edge cases where the context manager's head is resumed but tail is still pending to be updated.
4. Improved readability by changing headUpdatedAfterResume and tailUpdatedAfterResume to headPaused and tailPaused to track whether head/tail has been updated after a pause/resume event.
5. Some cleanup and logging udpates.
6. Changes to not emit error from document context if it is already closed.
7. Changes to restart the service if the error.shouldRestart = true in document partition, so that any error in setting up the circuit breaker during lambda.create restarts the service instead of marking the doc as corrupt.

## Reviewer Guidance

I tested with opbackup2 (draft PR: https://msazure.visualstudio.com/One/_git/FRS/pullrequest/11660231) - There are a lot of edge cases with document lambdas, and hence we will enable it slowly in each ring.