### PR TITLE
Dedup tree factories

### DIFF
--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -5,7 +5,7 @@
 
 export {
 	type ISharedTree,
-	SharedTreeFactory,
+	type SharedTreeOptionsInternal,
 	type SharedTreeOptions,
 	SharedTree,
 	getBranch,

--- a/packages/dds/tree/src/shared-tree/publicContracts.ts
+++ b/packages/dds/tree/src/shared-tree/publicContracts.ts
@@ -4,6 +4,7 @@
  */
 
 import type { IChannelAttributes } from "@fluidframework/datastore-definitions/internal";
+import { pkgVersion } from "../packageVersion.js";
 
 /**
  * {@inheritDoc @fluidframework/shared-object-base#ISharedObjectFactory."type"}
@@ -20,5 +21,5 @@ export const SharedTreeFactoryType = "https://graph.microsoft.com/types/tree";
 export const SharedTreeAttributes: IChannelAttributes = {
 	type: SharedTreeFactoryType,
 	snapshotFormatVersion: "0.0.0",
-	packageVersion: "0.0.0",
+	packageVersion: pkgVersion,
 };

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -7,9 +7,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import type { ErasedType, IFluidHandle } from "@fluidframework/core-interfaces/internal";
 import type {
 	IChannelAttributes,
-	IChannelFactory,
 	IFluidDataStoreRuntime,
-	IChannelServices,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
 import type { ISharedObject } from "@fluidframework/shared-object-base/internal";
@@ -84,7 +82,6 @@ import type { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
 import { type TreeCheckout, type BranchableTree, createTreeCheckout } from "./treeCheckout.js";
 import { breakingClass, fail, throwIfBroken } from "../util/index.js";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
-import { SharedTreeAttributes, SharedTreeFactoryType } from "./publicContracts.js";
 
 /**
  * Copy of data from an {@link ISharedTree} at some point in time.
@@ -641,34 +638,6 @@ export const defaultSharedTreeOptions: Required<SharedTreeOptionsInternal> = {
 	formatVersion: SharedTreeFormatVersion.v3,
 	disposeForksAfterTransaction: true,
 };
-
-/**
- * A channel factory that creates {@link ISharedTree}s.
- */
-export class SharedTreeFactory implements IChannelFactory<ISharedTree> {
-	public readonly type: string = SharedTreeFactoryType;
-
-	public readonly attributes: IChannelAttributes = SharedTreeAttributes;
-
-	public constructor(private readonly options: SharedTreeOptionsInternal = {}) {}
-
-	public async load(
-		runtime: IFluidDataStoreRuntime,
-		id: string,
-		services: IChannelServices,
-		channelAttributes: Readonly<IChannelAttributes>,
-	): Promise<SharedTree> {
-		const tree = new SharedTree(id, runtime, channelAttributes, this.options);
-		await tree.load(services);
-		return tree;
-	}
-
-	public create(runtime: IFluidDataStoreRuntime, id: string): SharedTree {
-		const tree = new SharedTree(id, runtime, this.attributes, this.options);
-		tree.initializeLocal();
-		return tree;
-	}
-}
 
 function verboseFromCursor(
 	reader: ITreeCursor,

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -50,7 +50,6 @@ import {
 import {
 	type TreeStoredContent,
 	type ISharedTreeEditor,
-	SharedTreeFactory,
 	Tree,
 	ForestTypeOptimized,
 } from "../../../shared-tree/index.js";
@@ -83,6 +82,7 @@ import { brand } from "../../../util/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { ChunkedForest } from "../../../feature-libraries/chunked-forest/chunkedForest.js";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
+import { TreeFactory } from "../../../treeFactory.js";
 
 const options = {
 	jsonValidator: typeboxValidator,
@@ -395,7 +395,7 @@ describe("End to end chunked encoding", () => {
 		});
 
 		it("Initializing tree creates uniform chunks with encoded identifiers", async () => {
-			const factory = new SharedTreeFactory({
+			const factory = new TreeFactory({
 				jsonValidator: typeboxValidator,
 				forest: ForestTypeOptimized,
 			});

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -24,12 +24,7 @@ import type {
 	TreeNodeSchemaIdentifier,
 } from "../../../core/index.js";
 import { type DownPath, toDownPath } from "../../../feature-libraries/index.js";
-import {
-	Tree,
-	type ISharedTree,
-	type SharedTree,
-	type SharedTreeFactory,
-} from "../../../shared-tree/index.js";
+import { Tree, type ISharedTree, type SharedTree } from "../../../shared-tree/index.js";
 import { fail, getOrCreate, makeArray } from "../../../util/index.js";
 
 import {
@@ -69,6 +64,7 @@ import {
 	type TreeNode,
 	type TreeNodeSchema,
 } from "../../../simple-tree/index.js";
+import type { TreeFactory } from "../../../treeFactory.js";
 
 export type FuzzView = SchematizingSimpleTreeView<typeof fuzzFieldSchema> & {
 	/**
@@ -98,7 +94,7 @@ export type FuzzTransactionView = SchematizingSimpleTreeView<typeof fuzzFieldSch
 	currentSchema: FuzzNodeSchema;
 };
 
-export interface FuzzTestState extends DDSFuzzTestState<SharedTreeFactory> {
+export interface FuzzTestState extends DDSFuzzTestState<TreeFactory> {
 	/**
 	 * Schematized view of clients and their nodeSchemas. Created lazily by viewFromState.
 	 *
@@ -118,7 +114,7 @@ export interface FuzzTestState extends DDSFuzzTestState<SharedTreeFactory> {
 
 export function viewFromState(
 	state: FuzzTestState,
-	client: Client<SharedTreeFactory> = state.client,
+	client: Client<TreeFactory> = state.client,
 ): FuzzView {
 	state.clientViews ??= new Map();
 	const view =
@@ -594,7 +590,7 @@ export const makeConstraintEditGenerator = (
 
 export function makeOpGenerator(
 	weightsArg: Partial<EditGeneratorOpWeights> = defaultEditGeneratorOpWeights,
-): AsyncGenerator<Operation, DDSFuzzTestState<SharedTreeFactory>> {
+): AsyncGenerator<Operation, DDSFuzzTestState<TreeFactory>> {
 	const weights = {
 		...defaultEditGeneratorOpWeights,
 		...weightsArg,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -12,7 +12,7 @@ import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 import type { Revertible } from "../../../core/index.js";
 import type { DownPath } from "../../../feature-libraries/index.js";
-import { Tree, type SharedTreeFactory } from "../../../shared-tree/index.js";
+import { Tree } from "../../../shared-tree/index.js";
 import { fail } from "../../../util/index.js";
 import { validateFuzzTreeConsistency, viewCheckout } from "../../utils.js";
 
@@ -62,8 +62,9 @@ import {
 	type TreeNode,
 	type TreeNodeSchema,
 } from "../../../simple-tree/index.js";
+import type { TreeFactory } from "../../../treeFactory.js";
 
-const syncFuzzReducer = combineReducers<Operation, DDSFuzzTestState<SharedTreeFactory>>({
+const syncFuzzReducer = combineReducers<Operation, DDSFuzzTestState<TreeFactory>>({
 	treeEdit: (state, { edit }) => {
 		switch (edit.type) {
 			case "fieldEdit": {
@@ -92,18 +93,18 @@ const syncFuzzReducer = combineReducers<Operation, DDSFuzzTestState<SharedTreeFa
 		applyConstraint(state, operation);
 	},
 });
-export const fuzzReducer: AsyncReducer<
-	Operation,
-	DDSFuzzTestState<SharedTreeFactory>
-> = async (state, operation) => syncFuzzReducer(state, operation);
+export const fuzzReducer: AsyncReducer<Operation, DDSFuzzTestState<TreeFactory>> = async (
+	state,
+	operation,
+) => syncFuzzReducer(state, operation);
 
-export function checkTreesAreSynchronized(trees: readonly Client<SharedTreeFactory>[]) {
+export function checkTreesAreSynchronized(trees: readonly Client<TreeFactory>[]) {
 	for (const tree of trees) {
 		validateFuzzTreeConsistency(trees[0], tree);
 	}
 }
 
-export function applySynchronizationOp(state: DDSFuzzTestState<SharedTreeFactory>) {
+export function applySynchronizationOp(state: DDSFuzzTestState<TreeFactory>) {
 	state.containerRuntimeFactory.processAllMessages();
 	const connectedClients = state.clients.filter((client) => client.containerRuntime.connected);
 	if (connectedClients.length > 0) {

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -20,7 +20,7 @@ import {
 	TreeCompressionStrategy,
 	jsonableTreeFromCursor,
 } from "../../feature-libraries/index.js";
-import { SharedTreeFactory, type CheckoutFlexTreeView } from "../../shared-tree/index.js";
+import type { CheckoutFlexTreeView } from "../../shared-tree/index.js";
 import {
 	type JSDeepTree,
 	type JSWideTree,
@@ -49,6 +49,7 @@ import {
 } from "../utils.js";
 import { insert } from "../sequenceRootUtils.js";
 import { cursorFromInsertable } from "../../simple-tree/index.js";
+import { TreeFactory } from "../../treeFactory.js";
 
 // number of nodes in test for wide trees
 const nodesCountWide = [
@@ -64,7 +65,7 @@ const nodesCountDeep = [
 ];
 
 // TODO: ADO#7111 Schema should be fixed to enable schema based encoding.
-const factory = new SharedTreeFactory({
+const factory = new TreeFactory({
 	jsonValidator: typeboxValidator,
 	treeEncodeType: TreeCompressionStrategy.Uncompressed,
 });

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -53,7 +53,6 @@ import {
 	getBranch,
 	type ISharedTree,
 	type SharedTree,
-	SharedTreeFactory,
 	Tree,
 	type TreeCheckout,
 } from "../../shared-tree/index.js";
@@ -90,7 +89,7 @@ import {
 	NumberArray,
 	validateViewConsistency,
 } from "../utils.js";
-import { configuredSharedTree } from "../../treeFactory.js";
+import { configuredSharedTree, TreeFactory } from "../../treeFactory.js";
 import type { ISharedObjectKind } from "@fluidframework/shared-object-base/internal";
 import { TestAnchor } from "../testAnchor.js";
 // eslint-disable-next-line import/no-internal-modules
@@ -177,7 +176,7 @@ describe("SharedTree", () => {
 		const provider = await TestTreeProvider.create(
 			2,
 			SummarizeType.disabled,
-			new SharedTreeFactory({
+			new TreeFactory({
 				jsonValidator: typeboxValidator,
 				treeEncodeType: TreeCompressionStrategy.Uncompressed,
 			}),
@@ -546,7 +545,7 @@ describe("SharedTree", () => {
 		// Detached trees are not connected to the sequencing service, but they still "sequence" their edits as if they were totally ordered.
 		// The second tree must take care to avoid sequencing its edits with sequence numbers that the first tree already used.
 		// If it doesn't, the second tree will throw an error when trying to sequence a commit with sequence number that has "gone backwards" and this test will fail.
-		const sharedTreeFactory = new SharedTreeFactory();
+		const sharedTreeFactory = new TreeFactory({});
 		const runtime = new MockFluidDataStoreRuntime({
 			idCompressor: createIdCompressor(),
 			attachState: AttachState.Detached,
@@ -1876,7 +1875,7 @@ describe("SharedTree", () => {
 		it("unspecified ForestType uses ObjectForest", () => {
 			const { trees } = new TestTreeProviderLite(
 				1,
-				new SharedTreeFactory({
+				new TreeFactory({
 					jsonValidator: typeboxValidator,
 				}),
 			);
@@ -1886,7 +1885,7 @@ describe("SharedTree", () => {
 		it("ForestType.Reference uses ObjectForest with additionalAsserts flag set to false", () => {
 			const { trees } = new TestTreeProviderLite(
 				1,
-				new SharedTreeFactory({
+				new TreeFactory({
 					jsonValidator: typeboxValidator,
 					forest: ForestTypeReference,
 				}),
@@ -1899,7 +1898,7 @@ describe("SharedTree", () => {
 		it("ForestType.Optimized uses ChunkedForest", () => {
 			const { trees } = new TestTreeProviderLite(
 				1,
-				new SharedTreeFactory({
+				new TreeFactory({
 					jsonValidator: typeboxValidator,
 					forest: ForestTypeOptimized,
 				}),
@@ -1910,7 +1909,7 @@ describe("SharedTree", () => {
 		it("ForestType.Expensive uses ObjectForest with additionalAsserts flag set to true", () => {
 			const { trees } = new TestTreeProviderLite(
 				1,
-				new SharedTreeFactory({
+				new TreeFactory({
 					jsonValidator: typeboxValidator,
 					forest: ForestTypeExpensiveDebug,
 				}),
@@ -1923,7 +1922,7 @@ describe("SharedTree", () => {
 	describe("Schema based op encoding", () => {
 		// TODO:#8915: This test will fail until bug #8915 is fixed
 		it.skip("uses the correct schema for subsequent edits after schema change.", async () => {
-			const factory = new SharedTreeFactory({
+			const factory = new TreeFactory({
 				jsonValidator: typeboxValidator,
 				treeEncodeType: TreeCompressionStrategy.Compressed,
 			});
@@ -1968,7 +1967,7 @@ describe("SharedTree", () => {
 
 		it("properly encodes ops using specified compression strategy", async () => {
 			// Check that ops are using uncompressed encoding with "Uncompressed" treeEncodeType
-			const factory = new SharedTreeFactory({
+			const factory = new TreeFactory({
 				jsonValidator: typeboxValidator,
 				treeEncodeType: TreeCompressionStrategy.Uncompressed,
 			});
@@ -2011,7 +2010,7 @@ describe("SharedTree", () => {
 			assert.deepEqual(encodedTreeData.data[0][1], expectedUncompressedTreeData);
 
 			// Check that ops are encoded using schema based compression with "Compressed" treeEncodeType
-			const factory2 = new SharedTreeFactory({
+			const factory2 = new TreeFactory({
 				jsonValidator: typeboxValidator,
 				treeEncodeType: TreeCompressionStrategy.Compressed,
 			});
@@ -2043,7 +2042,7 @@ describe("SharedTree", () => {
 
 	describe("Identifiers", () => {
 		it("Can use identifiers and the static Tree Apis", async () => {
-			const factory = new SharedTreeFactory({
+			const factory = new TreeFactory({
 				jsonValidator: typeboxValidator,
 				treeEncodeType: TreeCompressionStrategy.Compressed,
 			});
@@ -2107,7 +2106,7 @@ describe("SharedTree", () => {
 	});
 
 	it("throws an error if attaching during a transaction", () => {
-		const sharedTreeFactory = new SharedTreeFactory();
+		const sharedTreeFactory = new TreeFactory({});
 		const runtime = new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() });
 		const tree = sharedTreeFactory.create(runtime, "tree");
 		const runtimeFactory = new MockContainerRuntimeFactory();

--- a/packages/dds/tree/src/test/shared-tree/summary.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/summary.bench.ts
@@ -22,7 +22,6 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { SharedTreeFactory } from "../../shared-tree/index.js";
 import { TestTreeProviderLite, testIdCompressor } from "../utils.js";
 import { TreeViewConfiguration, type ImplicitFieldSchema } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
@@ -33,6 +32,7 @@ import {
 	makeJsWideTreeWithEndValue,
 	WideRoot,
 } from "../scalableTestTrees.js";
+import { TreeFactory } from "../../treeFactory.js";
 
 // TODO: these tests currently only cover tree content.
 // It might make sense to extend them to cover complex collaboration windows.
@@ -114,7 +114,7 @@ describe("Summary benchmarks", () => {
 			type: BenchmarkType,
 		) {
 			let summaryTree: ITree;
-			const factory = new SharedTreeFactory();
+			const factory = new TreeFactory({});
 			benchmark({
 				title,
 				type,

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -11,7 +11,7 @@ import {
 	rootFieldKey,
 } from "../../core/index.js";
 import { singleJsonCursor } from "../json/index.js";
-import { SharedTreeFactory, type ITreeCheckout } from "../../shared-tree/index.js";
+import type { ITreeCheckout } from "../../shared-tree/index.js";
 import { type JsonCompatible, brand } from "../../util/index.js";
 import {
 	createTestUndoRedoStacks,
@@ -34,6 +34,7 @@ import {
 } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { initialize } from "../../shared-tree/schematizeTree.js";
+import { TreeFactory } from "../../treeFactory.js";
 
 const rootPath: UpPath = {
 	parent: undefined,
@@ -485,7 +486,7 @@ describe("Undo and redo", () => {
 	it("can undo while detached", () => {
 		const sf = new SchemaFactory(undefined);
 		class Schema extends sf.object("Object", { foo: sf.number }) {}
-		const sharedTreeFactory = new SharedTreeFactory();
+		const sharedTreeFactory = new TreeFactory({});
 		const runtime = new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() });
 		const tree = sharedTreeFactory.create(runtime, "tree");
 		const view = tree.viewWith(new TreeViewConfiguration({ schema: Schema }));
@@ -683,7 +684,7 @@ describe("Undo and redo", () => {
  * @param attachTree - whether or not the SharedTree should be attached to the Fluid runtime
  */
 export function createCheckout(json: JsonCompatible[], attachTree: boolean): ITreeCheckout {
-	const sharedTreeFactory = new SharedTreeFactory();
+	const sharedTreeFactory = new TreeFactory({});
 	const runtime = new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() });
 	const tree = sharedTreeFactory.create(runtime, "tree");
 	const runtimeFactory = new MockContainerRuntimeFactory();

--- a/packages/dds/tree/src/test/snapshots/gc.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/gc.spec.ts
@@ -15,12 +15,13 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 
 import { typeboxValidator } from "../../external-utilities/index.js";
-import { type ISharedTree, SharedTree, SharedTreeFactory } from "../../shared-tree/index.js";
+import { type ISharedTree, SharedTree } from "../../shared-tree/index.js";
 import {
 	SchemaFactory,
 	TreeViewConfiguration,
 	type TreeView,
 } from "../../simple-tree/index.js";
+import { TreeFactory } from "../../treeFactory.js";
 
 const builder = new SchemaFactory("test");
 class Bar extends builder.object("bar", {
@@ -39,7 +40,7 @@ function createConnectedTree(
 	const dataStoreRuntime = new MockFluidDataStoreRuntime({
 		idCompressor: createIdCompressor(),
 	});
-	const tree = new SharedTree(id, dataStoreRuntime, new SharedTreeFactory().attributes, {});
+	const tree = new SharedTree(id, dataStoreRuntime, new TreeFactory({}).attributes, {});
 	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
 		deltaConnection: dataStoreRuntime.createDeltaConnection(),
@@ -51,7 +52,7 @@ function createConnectedTree(
 }
 
 function createLocalTree(id: string): ISharedTree {
-	const factory = new SharedTreeFactory({ jsonValidator: typeboxValidator });
+	const factory = new TreeFactory({ jsonValidator: typeboxValidator });
 	return factory.create(
 		new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 		id,

--- a/packages/dds/tree/src/test/snapshots/opFormat.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/opFormat.spec.ts
@@ -14,12 +14,9 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 import { takeJsonSnapshot, useSnapshotDirectory } from "./snapshotTools.js";
 import { SchemaFactory, TreeViewConfiguration } from "../../simple-tree/index.js";
-import {
-	type SharedTree,
-	SharedTreeFactory,
-	SharedTreeFormatVersion,
-} from "../../shared-tree/index.js";
+import { type SharedTree, SharedTreeFormatVersion } from "../../shared-tree/index.js";
 import type { JsonCompatibleReadOnly } from "../../util/index.js";
+import { TreeFactory } from "../../treeFactory.js";
 
 /**
  * This suite provides some e2e snapshot coverage for how SharedTree ops look.
@@ -49,7 +46,7 @@ describe("SharedTree op format snapshots", () => {
 		describe(`using SharedTreeFormatVersion.${versionKey}`, () => {
 			useSnapshotDirectory(`op-format/${versionKey}`);
 			beforeEach(() => {
-				const factory = new SharedTreeFactory({
+				const factory = new TreeFactory({
 					formatVersion:
 						SharedTreeFormatVersion[versionKey as keyof typeof SharedTreeFormatVersion],
 				});

--- a/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
@@ -12,12 +12,12 @@ import { typeboxValidator } from "../../external-utilities/index.js";
 import {
 	getBranch,
 	type ISharedTree,
-	SharedTreeFactory,
 	type SharedTreeOptions,
 	Tree,
 } from "../../shared-tree/index.js";
 import { TestTreeProviderLite, treeTestFactory } from "../utils.js";
 import { SchemaFactory, TreeViewConfiguration } from "../../simple-tree/index.js";
+import { TreeFactory } from "../../treeFactory.js";
 
 // Session ids used for the created trees' IdCompressors must be deterministic.
 // TestTreeProviderLite does this by default.
@@ -37,7 +37,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 		jsonValidator: typeboxValidator,
 		...options,
 	};
-	const factory = new SharedTreeFactory(factoryOptions);
+	const factory = new TreeFactory(factoryOptions);
 	const testTrees: {
 		only?: boolean;
 		skip?: boolean;
@@ -265,7 +265,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 						StringArray,
 					]) {}
 
-					const provider = new TestTreeProviderLite(1, new SharedTreeFactory(options), true);
+					const provider = new TestTreeProviderLite(1, new TreeFactory(options), true);
 					const tree = provider.trees[0];
 					const view = tree.viewWith(
 						new TreeViewConfiguration({

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -118,7 +118,6 @@ import {
 	type ITreeCheckout,
 	SharedTree,
 	type SharedTreeContentSnapshot,
-	SharedTreeFactory,
 	type TreeCheckout,
 	createTreeCheckout,
 	type ISharedTreeEditor,
@@ -159,6 +158,7 @@ import type { TreeSimpleContent } from "./feature-libraries/flex-tree/utils.js";
 import type { Transactor } from "../shared-tree-core/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import type { FieldChangeDelta } from "../feature-libraries/modular-schema/fieldChangeHandler.js";
+import { TreeFactory } from "../treeFactory.js";
 
 // Testing utilities
 
@@ -233,7 +233,7 @@ export class TestTreeProvider {
 	public static async create(
 		trees = 0,
 		summarizeType: SummarizeType = SummarizeType.disabled,
-		factory: SharedTreeFactory = new SharedTreeFactory({ jsonValidator: typeboxValidator }),
+		factory: TreeFactory = new TreeFactory({ jsonValidator: typeboxValidator }),
 	): Promise<ITestTreeProvider> {
 		// The on-demand summarizer shares a container with the first tree, so at least one tree and container must be created right away.
 		assert(
@@ -383,7 +383,7 @@ export class TestTreeProviderLite {
 	 */
 	public constructor(
 		trees = 1,
-		private readonly factory = new SharedTreeFactory({ jsonValidator: typeboxValidator }),
+		private readonly factory = new TreeFactory({ jsonValidator: typeboxValidator }),
 		useDeterministicSessionIds = true,
 	) {
 		assert(trees >= 1, "Must initialize provider with at least one tree");
@@ -512,7 +512,7 @@ export function assertDeltaEqual(a: DeltaRoot, b: DeltaRoot): void {
 /**
  * A test helper that allows custom code to be injected when a tree is created/loaded.
  */
-export class SharedTreeTestFactory extends SharedTreeFactory {
+export class SharedTreeTestFactory extends TreeFactory {
 	/**
 	 * @param onCreate - Called once for each created tree (not called for trees loaded from summaries).
 	 * @param onLoad - Called once for each tree that is loaded from a summary.
@@ -574,8 +574,8 @@ export function validateTreeConsistency(treeA: ISharedTree, treeB: ISharedTree):
 }
 
 export function validateFuzzTreeConsistency(
-	treeA: Client<SharedTreeFactory>,
-	treeB: Client<SharedTreeFactory>,
+	treeA: Client<TreeFactory>,
+	treeB: Client<TreeFactory>,
 ): void {
 	validateSnapshotConsistency(
 		treeA.channel.contentSnapshot(),
@@ -1143,7 +1143,7 @@ const testSessionId = "beefbeef-beef-4000-8000-000000000001" as SessionId;
 /**
  * Simple non-factory based wrapper around `new SharedTree` with test appropriate defaults.
  *
- * See TestTreeProvider, TestTreeProviderLite and SharedTreeFactory for other ways to build trees.
+ * See TestTreeProvider, TestTreeProviderLite and TreeFactory for other ways to build trees.
  *
  * If what is needed is a view, see options to create one without making a SharedTree instance.
  */
@@ -1164,7 +1164,7 @@ export function treeTestFactory(
 				clientId: "test-client",
 				id: "test",
 			}),
-		options.attributes ?? new SharedTreeFactory().attributes,
+		options.attributes ?? new TreeFactory({}).attributes,
 		options.options ?? { jsonValidator: typeboxValidator },
 		options.telemetryContextPrefix,
 	);

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -15,25 +15,25 @@ import {
 	createSharedObjectKind,
 } from "@fluidframework/shared-object-base/internal";
 
-import { pkgVersion } from "./packageVersion.js";
-import { SharedTree as SharedTreeImpl, type SharedTreeOptions } from "./shared-tree/index.js";
+import {
+	SharedTreeAttributes,
+	SharedTreeFactoryType,
+	SharedTree as SharedTreeImpl,
+	type SharedTreeOptions,
+	type SharedTreeOptionsInternal,
+} from "./shared-tree/index.js";
 import type { ITree } from "./simple-tree/index.js";
 
 /**
  * A channel factory that creates an {@link ITree}.
  */
 export class TreeFactory implements IChannelFactory<ITree> {
-	public static readonly Type = "https://graph.microsoft.com/types/tree";
-	public static readonly attributes: IChannelAttributes = {
-		type: this.Type,
-		snapshotFormatVersion: "0.0.0",
-		packageVersion: pkgVersion,
-	};
+	public static Type: string = SharedTreeFactoryType;
+	public readonly type: string = SharedTreeFactoryType;
 
-	public readonly type = TreeFactory.Type;
-	public readonly attributes: IChannelAttributes = TreeFactory.attributes;
+	public readonly attributes: IChannelAttributes = SharedTreeAttributes;
 
-	public constructor(private readonly options: SharedTreeOptions) {}
+	public constructor(private readonly options: SharedTreeOptionsInternal) {}
 
 	public async load(
 		runtime: IFluidDataStoreRuntime,


### PR DESCRIPTION
## Description

Deduplicate the two tree channel factories.

> If there are no breaking changes, delete this section.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
