### PR TITLE
Cleanup fluid build options

### DIFF
--- a/build-tools/packages/build-tools/README.md
+++ b/build-tools/packages/build-tools/README.md
@@ -45,22 +45,24 @@ detection for a range of tools and multiple workspace (a.k.a. release group) in 
 Usage: fluid-build <options> [(<package regexp>|<path>) ...]
     [<package regexp> ...] Regexp to match the package name (default: all packages)
 Options:
-     --all            Operate on all packages/monorepo (default: client monorepo). See also "--server".
-  -c --clean          Same as running build script 'clean' on matched packages (all if package regexp is not specified)
-  -d --dep            Apply actions (clean/force/rebuild) to matched packages and their dependent packages
-     --fix            Auto fix warning from package check if possible
-  -f --force          Force build and ignore dependency check on matched packages (all if package regexp is not specified)
-  -? --help           Print this message
-     --install        Run npm install for all packages/monorepo. This skips a package if node_modules already exists: it can not be used to update in response to changes to the package.json.
-  -r --rebuild        Clean and build on matched packages (all if package regexp is not specified)
-     --reinstall      Same as --uninstall --install.
-  -g --releaseGroup   Release group to operate on
-     --root <path>    Root directory of the Fluid repo (default: env _FLUID_ROOT_ if exist, auto detect otherwise)
-  -t --task <name>    target to execute (default:build)
-     --symlink        Fix symlink between packages within monorepo (isolate mode). This configures the symlinks to only connect within each lerna managed group of packages. This is the configuration tested by CI and should be kept working.
-     --symlink:full   Fix symlink between packages across monorepo (full mode). This symlinks everything in the repo together. CI does not ensure this configuration is functional, so it may or may not work.
-     --uninstall      Clean all node_modules. This errors if some node-nodules folders do not exists: if hitting this limitation you can do an install first to work around it.
-     --vscode         Output error message to work with default problem matcher in vscode
+     --all                  Operate on all packages/monorepo (default: client monorepo). See also "-g" or "--releaseGroup".
+  -c --clean                Same as running build script 'clean' on matched packages (all if package regexp is not specified)
+  -d --dep                  Apply actions (clean/force/rebuild) to matched packages and their dependent packages
+     --fix                  Auto fix warning from package check if possible
+  -f --force                Force build and ignore dependency check on matched packages (all if package regexp is not specified)
+  -? --help                 Print this message
+     --install              Run npm install for all packages/monorepo. This skips a package if node_modules already exists: it can not be used to update in response to changes to the package.json.
+     --workerMemoryLimitMB  Memory limit for worker threads in MB
+  -r --rebuild              Clean and build on matched packages (all if package regexp is not specified)
+     --reinstall            Same as --uninstall --install.
+  -g --releaseGroup         Release group to operate on
+     --root <path>          Root directory of the Fluid repo (default: env _FLUID_ROOT_)
+  -t --task <name>          target to execute (default:build)
+     --symlink              Deprecated. Fix symlink between packages within monorepo (isolate mode). This configures the symlinks to only connect within each lerna managed group of packages. This is the configuration tested by CI and should be kept working.
+     --symlink:full         Deprecated. Fix symlink between packages across monorepo (full mode). This symlinks everything in the repo together. CI does not ensure this configuration is functional, so it may or may not work.
+     --uninstall            Clean all node_modules. This errors if some node-nodules folders do not exists: if hitting this limitation you can do an install first to work around it.
+     --vscode               Output error message to work with default problem matcher in vscode
+     --worker               Reuse worker threads for some tasks, increasing memory use but lowering overhead.
      --defroot <path> Default root directory of the Fluid repo if auto detect failed (default: env _FLUID_DEFAULT_ROOT_)
      --timer          Measure elapsed time of each step
      --logtime        Display the current time on every status message for logging

--- a/build-tools/packages/build-tools/README.md
+++ b/build-tools/packages/build-tools/README.md
@@ -60,7 +60,7 @@ Options:
   -t --task <name>          target to execute (default:build)
      --symlink              Deprecated. Fix symlink between packages within monorepo (isolate mode). This configures the symlinks to only connect within each lerna managed group of packages. This is the configuration tested by CI and should be kept working.
      --symlink:full         Deprecated. Fix symlink between packages across monorepo (full mode). This symlinks everything in the repo together. CI does not ensure this configuration is functional, so it may or may not work.
-     --uninstall            Clean all node_modules. This errors if some node-modules folders do not exists: if hitting this limitation you can do an install first to work around it.
+     --uninstall            Clean all node_modules. This errors if some node_modules folder do not exist. If hitting this limitation, you can do an install first to work around it.
      --vscode               Output error message to work with default problem matcher in vscode
      --worker               Reuse worker threads for some tasks, increasing memory use but lowering overhead.
      --defroot <path> Default root directory of the Fluid repo if auto detect failed (default: env _FLUID_DEFAULT_ROOT_)

--- a/build-tools/packages/build-tools/README.md
+++ b/build-tools/packages/build-tools/README.md
@@ -60,7 +60,7 @@ Options:
   -t --task <name>          target to execute (default:build)
      --symlink              Deprecated. Fix symlink between packages within monorepo (isolate mode). This configures the symlinks to only connect within each lerna managed group of packages. This is the configuration tested by CI and should be kept working.
      --symlink:full         Deprecated. Fix symlink between packages across monorepo (full mode). This symlinks everything in the repo together. CI does not ensure this configuration is functional, so it may or may not work.
-     --uninstall            Clean all node_modules. This errors if some node-nodules folders do not exists: if hitting this limitation you can do an install first to work around it.
+     --uninstall            Clean all node_modules. This errors if some node-modules folders do not exists: if hitting this limitation you can do an install first to work around it.
      --vscode               Output error message to work with default problem matcher in vscode
      --worker               Reuse worker threads for some tasks, increasing memory use but lowering overhead.
      --defroot <path> Default root directory of the Fluid repo if auto detect failed (default: env _FLUID_DEFAULT_ROOT_)

--- a/build-tools/packages/build-tools/src/fluidBuild/options.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/options.ts
@@ -100,7 +100,7 @@ Options:
   -t --task <name>          target to execute (default:build)
      --symlink              Deprecated. Fix symlink between packages within monorepo (isolate mode). This configures the symlinks to only connect within each lerna managed group of packages. This is the configuration tested by CI and should be kept working.
      --symlink:full         Deprecated. Fix symlink between packages across monorepo (full mode). This symlinks everything in the repo together. CI does not ensure this configuration is functional, so it may or may not work.
-     --uninstall            Clean all node_modules. This errors if some node-nodules folders do not exists: if hitting this limitation you can do an install first to work around it.
+     --uninstall            Clean all node_modules. This errors if some node-modules folders do not exists: if hitting this limitation you can do an install first to work around it.
      --vscode               Output error message to work with default problem matcher in vscode
      --worker               Reuse worker threads for some tasks, increasing memory use but lowering overhead.
 ${commonOptionString}

--- a/build-tools/packages/build-tools/src/fluidBuild/options.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/options.ts
@@ -100,7 +100,7 @@ Options:
   -t --task <name>          target to execute (default:build)
      --symlink              Deprecated. Fix symlink between packages within monorepo (isolate mode). This configures the symlinks to only connect within each lerna managed group of packages. This is the configuration tested by CI and should be kept working.
      --symlink:full         Deprecated. Fix symlink between packages across monorepo (full mode). This symlinks everything in the repo together. CI does not ensure this configuration is functional, so it may or may not work.
-     --uninstall            Clean all node_modules. This errors if some node-modules folders do not exists: if hitting this limitation you can do an install first to work around it.
+     --uninstall            Clean all node_modules. This errors if some node_modules folder do not exist. If hitting this limitation, you can do an install first to work around it.
      --vscode               Output error message to work with default problem matcher in vscode
      --worker               Reuse worker threads for some tasks, increasing memory use but lowering overhead.
 ${commonOptionString}

--- a/build-tools/packages/build-tools/src/fluidBuild/options.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/options.ts
@@ -13,7 +13,7 @@ import { IPackageMatchedOptions } from "./fluidRepoBuild";
 import { defaultBuildTaskName, defaultCleanTaskName } from "./fluidTaskDefinitions";
 import { ISymlinkOptions } from "./symlinkUtils";
 
-const { log, warning, errorLog } = defaultLogger;
+const { log, errorLog } = defaultLogger;
 
 interface FastBuildOptions extends IPackageMatchedOptions, ISymlinkOptions {
 	nolint: boolean;
@@ -45,6 +45,10 @@ interface FastBuildOptions extends IPackageMatchedOptions, ISymlinkOptions {
 	concurrency: number;
 	worker: boolean;
 	workerThreads: boolean;
+	/**
+	 * Per worker, in bytes.
+	 * When a worker is finished with a task, if this is exceeded, a new worker is spawned.
+	 */
 	workerMemoryLimit: number;
 }
 
@@ -81,23 +85,24 @@ function printUsage() {
 Usage: fluid-build <options> [(<package regexp>|<path>) ...]
     [<package regexp> ...] Regexp to match the package name (default: all packages)
 Options:
-     --all            Operate on all packages/monorepo (default: client monorepo). See also "-g" or "--releaseGroup".
-  -c --clean          Same as running build script 'clean' on matched packages (all if package regexp is not specified)
-  -d --dep            Apply actions (clean/force/rebuild) to matched packages and their dependent packages
-     --fix            Auto fix warning from package check if possible
-  -f --force          Force build and ignore dependency check on matched packages (all if package regexp is not specified)
-  -? --help           Print this message
-     --install        Run npm install for all packages/monorepo. This skips a package if node_modules already exists: it can not be used to update in response to changes to the package.json.
-  -r --rebuild        Clean and build on matched packages (all if package regexp is not specified)
-     --reinstall      Same as --uninstall --install.
-  -g --releaseGroup   Release group to operate on
-     --root <path>    Root directory of the Fluid repo (default: env _FLUID_ROOT_)
-  -t --task <name>    target to execute (default:build)
-     --symlink        Fix symlink between packages within monorepo (isolate mode). This configures the symlinks to only connect within each lerna managed group of packages. This is the configuration tested by CI and should be kept working.
-     --symlink:full   Fix symlink between packages across monorepo (full mode). This symlinks everything in the repo together. CI does not ensure this configuration is functional, so it may or may not work.
-     --uninstall      Clean all node_modules. This errors if some node-nodules folders do not exists: if hitting this limitation you can do an install first to work around it.
-     --vscode         Output error message to work with default problem matcher in vscode
-     --worker         Reuse worker threads for some tasks, increasing memory use but lowering overhead.
+     --all                  Operate on all packages/monorepo (default: client monorepo). See also "-g" or "--releaseGroup".
+  -c --clean                Same as running build script 'clean' on matched packages (all if package regexp is not specified)
+  -d --dep                  Apply actions (clean/force/rebuild) to matched packages and their dependent packages
+     --fix                  Auto fix warning from package check if possible
+  -f --force                Force build and ignore dependency check on matched packages (all if package regexp is not specified)
+  -? --help                 Print this message
+     --install              Run npm install for all packages/monorepo. This skips a package if node_modules already exists: it can not be used to update in response to changes to the package.json.
+     --workerMemoryLimitMB  Memory limit for worker threads in MB
+  -r --rebuild              Clean and build on matched packages (all if package regexp is not specified)
+     --reinstall            Same as --uninstall --install.
+  -g --releaseGroup         Release group to operate on
+     --root <path>          Root directory of the Fluid repo (default: env _FLUID_ROOT_)
+  -t --task <name>          target to execute (default:build)
+     --symlink              Deprecated. Fix symlink between packages within monorepo (isolate mode). This configures the symlinks to only connect within each lerna managed group of packages. This is the configuration tested by CI and should be kept working.
+     --symlink:full         Deprecated. Fix symlink between packages across monorepo (full mode). This symlinks everything in the repo together. CI does not ensure this configuration is functional, so it may or may not work.
+     --uninstall            Clean all node_modules. This errors if some node-nodules folders do not exists: if hitting this limitation you can do an install first to work around it.
+     --vscode               Output error message to work with default problem matcher in vscode
+     --worker               Reuse worker threads for some tasks, increasing memory use but lowering overhead.
 ${commonOptionString}
 `,
 	);
@@ -303,25 +308,6 @@ export function parseOptions(argv: string[]) {
 			}
 			error = true;
 			break;
-		}
-
-		// Back compat switches
-		if (arg === "--azure") {
-			warning("'--azure' is deprecated.  Use '-g azure' instead");
-			options.releaseGroups.push("azure");
-			continue;
-		}
-
-		if (arg === "--buildTools") {
-			warning("'--buildTools' is deprecated.  Use '-g build-tools' instead");
-			options.releaseGroups.push("build-tools");
-			continue;
-		}
-
-		if (arg === "--server") {
-			warning("'--server' is deprecated.  Use '-g server' instead");
-			options.releaseGroups.push("server");
-			continue;
 		}
 
 		// Package regexp or paths


### PR DESCRIPTION
## Description

Add missing documentation for workerMemoryLimitMB.

Update readme with docs from source (it seemed out of date even before my change).

Remove undocumented deprecated release group specific flags (deprecated 20 months ago).

Mark recent (5 month ago) deprecations as deprecated.

`--depcheck` remains undocumented, but its deprecated so I left it.

## Breaking Changes

Fluid build's --azure --server and --buildTools are no longer supported, and -g or --releaseGroup will need to be used instead.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

