### PR TITLE
refactor(examples/external-data):  Replaced node-fetch with native fetch

### DIFF
--- a/examples/external-data/CHANGELOG.md
+++ b/examples/external-data/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @fluid-example/app-integration-external-data
 
+## 2.22.0
+Replaced node-fetch with native fetch for improved compatibility and maintainability.
+
 ## 2.21.0
 
 Dependency updates only.

--- a/examples/external-data/CHANGELOG.md
+++ b/examples/external-data/CHANGELOG.md
@@ -1,8 +1,5 @@
 # @fluid-example/app-integration-external-data
 
-## 2.22.0
-Replaced node-fetch with native fetch for improved compatibility and maintainability.
-
 ## 2.21.0
 
 Dependency updates only.

--- a/examples/external-data/jest.config.cjs
+++ b/examples/external-data/jest.config.cjs
@@ -34,4 +34,5 @@ module.exports = {
 			},
 		],
 	],
+	testTimeout: 10000,
 };

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -91,7 +91,6 @@
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "workspace:~",
 		"@types/lodash.isequal": "^4.5.6",
-		"@types/node-fetch": "^2.6.11",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
 		"@types/valid-url": "^1.0.3",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -74,7 +74,6 @@
 		"css-loader": "^7.1.2",
 		"express": "^4.21.2",
 		"lodash.isequal": "^4.5.0",
-		"node-fetch": "^2.6.9",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"style-loader": "^4.0.0",

--- a/examples/external-data/src/mock-customer-service/service.ts
+++ b/examples/external-data/src/mock-customer-service/service.ts
@@ -7,7 +7,6 @@ import { Server } from "node:http";
 
 import cors from "cors";
 import express from "express";
-import fetch from "node-fetch";
 
 import { ITaskData, assertValidTaskData } from "../model-interface/index.js";
 import { ClientManager } from "../utilities/index.js";

--- a/examples/external-data/src/mock-external-data-service/externalDataSource.ts
+++ b/examples/external-data/src/mock-external-data-service/externalDataSource.ts
@@ -5,7 +5,6 @@
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import type { IEvent } from "@fluidframework/core-interfaces";
-import { Response } from "node-fetch";
 
 import { ITaskData, ITaskListData } from "../model-interface/index.js";
 

--- a/examples/external-data/src/mock-external-data-service/service.ts
+++ b/examples/external-data/src/mock-external-data-service/service.ts
@@ -286,9 +286,9 @@ export async function initializeExternalDataService(props: ServiceProps): Promis
 				.json({ message: "Missing parameter externalTaskListId in request url" });
 		}
 		externalDataSource.fetchData(externalTaskListId).then(
-			(response) => {
-				// eslint-disable-next-line @typescript-eslint/no-base-to-string
-				const responseBody = JSON.parse(response.body.toString()) as Record<
+			async (response) => {
+				const responseText = await response.text();
+				const responseBody = JSON.parse(responseText) as Record<
 					string | number | symbol,
 					unknown
 				>;

--- a/examples/external-data/src/mock-external-data-service/webhook.ts
+++ b/examples/external-data/src/mock-external-data-service/webhook.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import fetch from "node-fetch";
-
 /**
  * Represents a webhook subscriber URL.
  * This is the URL that will be notified of the external data changes monitored by {@link MockWebhook}.

--- a/examples/external-data/tests/customerService.test.ts
+++ b/examples/external-data/tests/customerService.test.ts
@@ -7,7 +7,6 @@ import type { Server } from "node:http";
 
 import cors from "cors";
 import express from "express";
-import fetch, { Response } from "node-fetch";
 
 import { initializeCustomerService } from "../src/mock-customer-service/index.js";
 import { customerServicePort } from "../src/mock-customer-service-interface/index.js";

--- a/examples/external-data/tests/externalDataService.test.ts
+++ b/examples/external-data/tests/externalDataService.test.ts
@@ -7,7 +7,6 @@ import type { Server } from "node:http";
 
 import cors from "cors";
 import express from "express";
-import fetch from "node-fetch";
 import request from "supertest";
 
 import {
@@ -75,11 +74,8 @@ describe("mock-external-data-service", () => {
 
 	async function getCurrentExternalData(): Promise<ITaskData> {
 		const fetchResponse = await externalDataSource!.fetchData(externalTaskListId);
-		// eslint-disable-next-line @typescript-eslint/no-base-to-string
-		const responseBody = JSON.parse(fetchResponse.body.toString()) as Record<
-			string | number | symbol,
-			unknown
-		>;
+		const responseText = await fetchResponse.text();
+		const responseBody = JSON.parse(responseText) as Record<string | number | symbol, unknown>;
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
 		return assertValidTaskData((responseBody as any).taskList);
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4140,9 +4140,6 @@ importers:
       lodash.isequal:
         specifier: ^4.5.0
         version: 4.5.0
-      node-fetch:
-        specifier: ^2.6.9
-        version: 2.7.0(encoding@0.1.13)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -4164,7 +4161,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.51.0
-        version: 0.51.0(@types/node@22.10.1)
+        version: 0.51.0(@types/node@18.19.67)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.3
         version: 5.7.3(eslint@8.55.0)(typescript@5.4.5)
@@ -4224,7 +4221,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.10.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -4257,7 +4254,7 @@ importers:
         version: 5.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -31301,6 +31298,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@fluidframework/server-lambdas@5.0.0':
+    dependencies:
+      '@fluidframework/common-utils': 3.1.0
+      '@fluidframework/gitresources': 5.0.0
+      '@fluidframework/protocol-base': 5.0.0
+      '@fluidframework/protocol-definitions': 3.2.0
+      '@fluidframework/server-lambdas-driver': 5.0.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
+      '@types/semver': 7.5.8
+      assert: 2.1.0
+      async: 3.2.6
+      axios: 1.7.9
+      buffer: 6.0.3
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      json-stringify-safe: 5.0.1
+      lodash: 4.17.21
+      nconf: 0.12.1
+      semver: 7.6.3
+      sha.js: 2.4.11
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/server-lambdas@5.0.0(debug@4.4.0)':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
@@ -35203,6 +35227,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  axios@1.7.9:
+    dependencies:
+      follow-redirects: 1.15.9(debug@4.4.0)
+      form-data: 4.0.1
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axios@1.7.9(debug@4.3.7):
     dependencies:
       follow-redirects: 1.15.9(debug@4.3.7)
@@ -38221,6 +38253,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-proxy-middleware@2.0.7(@types/express@4.17.21):
+    dependencies:
+      '@types/http-proxy': 1.17.15
+      http-proxy: 1.18.1
+      is-glob: 4.0.3
+      is-plain-obj: 3.0.0
+      micromatch: 4.0.8
+    optionalDependencies:
+      '@types/express': 4.17.21
+    transitivePeerDependencies:
+      - debug
+
   http-proxy-middleware@2.0.7(@types/express@4.17.21)(debug@4.4.0):
     dependencies:
       '@types/http-proxy': 1.17.15
@@ -38230,6 +38274,14 @@ snapshots:
       micromatch: 4.0.8
     optionalDependencies:
       '@types/express': 4.17.21
+    transitivePeerDependencies:
+      - debug
+
+  http-proxy@1.18.1:
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.15.9(debug@4.4.0)
+      requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
 
@@ -43506,7 +43558,7 @@ snapshots:
       '@fluidframework/gitresources': 5.0.0
       '@fluidframework/protocol-base': 5.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 5.0.0(debug@4.4.0)
+      '@fluidframework/server-lambdas': 5.0.0
       '@fluidframework/server-local-server': 5.0.0
       '@fluidframework/server-memory-orderer': 5.0.0
       '@fluidframework/server-services-client': 5.0.0
@@ -43516,7 +43568,7 @@ snapshots:
       '@fluidframework/server-services-utils': 5.0.0
       '@fluidframework/server-test-utils': 5.0.0
       agentkeepalive: 4.5.0
-      axios: 1.7.9(debug@4.4.0)
+      axios: 1.7.9
       body-parser: 1.20.3
       charwise: 3.0.1
       compression: 1.7.5
@@ -44211,7 +44263,7 @@ snapshots:
 
   wait-on@8.0.1:
     dependencies:
-      axios: 1.7.9(debug@4.4.0)
+      axios: 1.7.9
       joi: 17.13.3
       lodash: 4.17.21
       minimist: 1.2.8
@@ -44417,7 +44469,7 @@ snapshots:
       express: 4.21.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
-      http-proxy-middleware: 2.0.7(@types/express@4.17.21)(debug@4.4.0)
+      http-proxy-middleware: 2.0.7(@types/express@4.17.21)
       ipaddr.js: 2.2.0
       launch-editor: 2.9.1
       open: 8.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4161,7 +4161,7 @@ importers:
         version: 2.0.3
       '@fluidframework/build-tools':
         specifier: ^0.51.0
-        version: 0.51.0(@types/node@18.19.67)
+        version: 0.51.0(@types/node@22.10.1)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.3
         version: 5.7.3(eslint@8.55.0)(typescript@5.4.5)
@@ -4186,9 +4186,6 @@ importers:
       '@types/lodash.isequal':
         specifier: ^4.5.6
         version: 4.5.8
-      '@types/node-fetch':
-        specifier: ^2.6.11
-        version: 2.6.12
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -4221,7 +4218,7 @@ importers:
         version: 5.6.3(webpack@5.97.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.10.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.4.5))
       jest-environment-puppeteer:
         specifier: ^10.1.3
         version: 10.1.4(typescript@5.4.5)
@@ -4254,7 +4251,7 @@ importers:
         version: 5.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@18.19.67)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.67)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.4.5)))(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.97.1)
@@ -31298,33 +31295,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/server-lambdas@5.0.0':
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
-      '@fluidframework/protocol-base': 5.0.0
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas-driver': 5.0.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      '@types/semver': 7.5.8
-      assert: 2.1.0
-      async: 3.2.6
-      axios: 1.7.9
-      buffer: 6.0.3
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      json-stringify-safe: 5.0.1
-      lodash: 4.17.21
-      nconf: 0.12.1
-      semver: 7.6.3
-      sha.js: 2.4.11
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@fluidframework/server-lambdas@5.0.0(debug@4.4.0)':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
@@ -35227,14 +35197,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.7.9:
-    dependencies:
-      follow-redirects: 1.15.9(debug@4.4.0)
-      form-data: 4.0.1
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.7.9(debug@4.3.7):
     dependencies:
       follow-redirects: 1.15.9(debug@4.3.7)
@@ -38253,18 +38215,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.7(@types/express@4.17.21):
-    dependencies:
-      '@types/http-proxy': 1.17.15
-      http-proxy: 1.18.1
-      is-glob: 4.0.3
-      is-plain-obj: 3.0.0
-      micromatch: 4.0.8
-    optionalDependencies:
-      '@types/express': 4.17.21
-    transitivePeerDependencies:
-      - debug
-
   http-proxy-middleware@2.0.7(@types/express@4.17.21)(debug@4.4.0):
     dependencies:
       '@types/http-proxy': 1.17.15
@@ -38274,14 +38224,6 @@ snapshots:
       micromatch: 4.0.8
     optionalDependencies:
       '@types/express': 4.17.21
-    transitivePeerDependencies:
-      - debug
-
-  http-proxy@1.18.1:
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.15.9(debug@4.4.0)
-      requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
 
@@ -43558,7 +43500,7 @@ snapshots:
       '@fluidframework/gitresources': 5.0.0
       '@fluidframework/protocol-base': 5.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 5.0.0
+      '@fluidframework/server-lambdas': 5.0.0(debug@4.4.0)
       '@fluidframework/server-local-server': 5.0.0
       '@fluidframework/server-memory-orderer': 5.0.0
       '@fluidframework/server-services-client': 5.0.0
@@ -43568,7 +43510,7 @@ snapshots:
       '@fluidframework/server-services-utils': 5.0.0
       '@fluidframework/server-test-utils': 5.0.0
       agentkeepalive: 4.5.0
-      axios: 1.7.9
+      axios: 1.7.9(debug@4.4.0)
       body-parser: 1.20.3
       charwise: 3.0.1
       compression: 1.7.5
@@ -44263,7 +44205,7 @@ snapshots:
 
   wait-on@8.0.1:
     dependencies:
-      axios: 1.7.9
+      axios: 1.7.9(debug@4.4.0)
       joi: 17.13.3
       lodash: 4.17.21
       minimist: 1.2.8
@@ -44469,7 +44411,7 @@ snapshots:
       express: 4.21.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
-      http-proxy-middleware: 2.0.7(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.7(@types/express@4.17.21)(debug@4.4.0)
       ipaddr.js: 2.2.0
       launch-editor: 2.9.1
       open: 8.4.2


### PR DESCRIPTION
[AB#29141](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/29141)
## Description

This PR removes the node-fetch dependency in favour of the native fetch function.

This update causes some tests fail due to timeout, so a timeout of 10s was added to the jest config.

