### PR TITLE
Added HTTP metrics logging in restWrapper 

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -21,6 +21,7 @@ import {
 	getBooleanFromConfig,
 	verifyToken,
 	verifyStorageToken,
+	logHttpMetrics,
 } from "@fluidframework/server-services-utils";
 import { validateRequestParams, handleResponse } from "@fluidframework/server-services";
 import {
@@ -384,6 +385,8 @@ const uploadBlob = async (
 			getGlobalTelemetryContext().getProperties().correlationId ??
 			uuid() /* getCorrelationId */,
 		() => getGlobalTelemetryContext().getProperties() /* getTelemetryContextProperties */,
+		undefined /* refreshTokenIfNeeded */,
+		logHttpMetrics /* logHttpMetrics */,
 	);
 	return restWrapper.post(uri, blobData, undefined, {
 		"Content-Type": "application/json",

--- a/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
+++ b/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
@@ -52,6 +52,9 @@ export const canWrite: (scopes: string[]) => boolean;
 // @internal (undocumented)
 export const choose: () => string;
 
+// @internal (undocumented)
+export function convertAxiosErrorToNetorkError(error: AxiosError): NetworkError;
+
 // @internal
 export function convertFirstSummaryWholeSummaryTreeToSummaryTree(wholeSummaryTree: IWholeSummaryTree, unreferenced?: true | undefined): ISummaryTree;
 

--- a/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
+++ b/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
@@ -246,6 +246,8 @@ export interface IBasicRestWrapperMetricProps {
     // (undocumented)
     status: number | string;
     // (undocumented)
+    timoutInMs: number | string;
+    // (undocumented)
     url: string;
 }
 

--- a/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
+++ b/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import * as api from '@fluidframework/protocol-definitions';
+import { AxiosError } from 'axios';
 import { AxiosInstance } from 'axios';
 import { AxiosRequestConfig } from 'axios';
 import { ICreateTreeEntry } from '@fluidframework/gitresources';
@@ -25,7 +26,7 @@ import { SummaryObject } from '@fluidframework/protocol-definitions';
 
 // @internal (undocumented)
 export class BasicRestWrapper extends RestWrapper {
-    constructor(baseurl?: string, defaultQueryString?: Record<string, string | number | boolean>, maxBodyLength?: number, maxContentLength?: number, defaultHeaders?: RawAxiosRequestHeaders, axios?: AxiosInstance, refreshDefaultQueryString?: (() => Record<string, string | number | boolean>) | undefined, refreshDefaultHeaders?: (() => RawAxiosRequestHeaders) | undefined, getCorrelationId?: (() => string | undefined) | undefined, getTelemetryContextProperties?: (() => Record<string, string | number | boolean> | undefined) | undefined, refreshTokenIfNeeded?: ((authorizationHeader: RawAxiosRequestHeaders) => Promise<RawAxiosRequestHeaders | undefined>) | undefined);
+    constructor(baseurl?: string, defaultQueryString?: Record<string, string | number | boolean>, maxBodyLength?: number, maxContentLength?: number, defaultHeaders?: RawAxiosRequestHeaders, axios?: AxiosInstance, refreshDefaultQueryString?: (() => Record<string, string | number | boolean>) | undefined, refreshDefaultHeaders?: (() => RawAxiosRequestHeaders) | undefined, getCorrelationId?: (() => string | undefined) | undefined, getTelemetryContextProperties?: (() => Record<string, string | number | boolean> | undefined) | undefined, refreshTokenIfNeeded?: ((authorizationHeader: RawAxiosRequestHeaders) => Promise<RawAxiosRequestHeaders | undefined>) | undefined, logHttpMetrics?: ((requestProps: IBasicRestWrapperMetricProps) => void) | undefined);
     // (undocumented)
     protected request<T>(requestConfig: AxiosRequestConfig, statusCode: number, canRetry?: boolean): Promise<T>;
 }
@@ -227,6 +228,22 @@ export interface IAlfredTenant {
     id: string;
     // (undocumented)
     key: string;
+}
+
+// @internal (undocumented)
+export interface IBasicRestWrapperMetricProps {
+    // (undocumented)
+    axiosError: AxiosError<any>;
+    // (undocumented)
+    correlationId: string;
+    // (undocumented)
+    durationInMs: number;
+    // (undocumented)
+    method: string;
+    // (undocumented)
+    status: number | string;
+    // (undocumented)
+    url: string;
 }
 
 // @internal

--- a/server/routerlicious/packages/services-client/src/error.ts
+++ b/server/routerlicious/packages/services-client/src/error.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import type { AxiosError } from "axios";
+
 /**
  * Represents the internal error code in NetworkError
  * @internal
@@ -299,4 +301,25 @@ export function throwFluidServiceNetworkError(
 ): never {
 	const networkError = createFluidServiceNetworkError(statusCode, errorData);
 	throw networkError;
+}
+
+/**
+ * @internal
+ */
+export function convertAxiosErrorToNetorkError(error: AxiosError) {
+	const { response, request } = error ?? {};
+	if (response === undefined) {
+		if (request !== undefined) {
+			// Request was made but no response was received.
+			return new NetworkError(
+				502,
+				`Network Error: ${error?.message ?? "No response received."}`,
+			);
+		}
+	}
+	if (response !== undefined) {
+		// response.data can have potential sensitive information, so we do not return that.
+		return new NetworkError(response.status, response.statusText);
+	}
+	return new NetworkError(500, "Unknown error.");
 }

--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -28,6 +28,7 @@ export {
 	isNetworkError,
 	NetworkError,
 	throwFluidServiceNetworkError,
+	convertAxiosErrorToNetorkError,
 } from "./error";
 export { choose, getRandomName } from "./generateNames";
 export { GitManager } from "./gitManager";

--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -41,7 +41,7 @@ export {
 export { IAlfredTenant, ISession } from "./interfaces";
 export { promiseTimeout } from "./promiseTimeout";
 export { RestLessClient, RestLessFieldNames } from "./restLessClient";
-export { BasicRestWrapper, RestWrapper } from "./restWrapper";
+export { BasicRestWrapper, RestWrapper, IBasicRestWrapperMetricProps } from "./restWrapper";
 export { defaultHash, getNextHash } from "./rollingHash";
 export {
 	canRead,

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -194,9 +194,10 @@ export class BasicRestWrapper extends RestWrapper {
 		canRetry = true,
 	): Promise<T> {
 		const options = { ...requestConfig };
+		const correlationId = this.getCorrelationId?.() ?? uuid();
 		options.headers = this.generateHeaders(
 			options.headers,
-			this.getCorrelationId?.() ?? uuid(),
+			correlationId,
 			this.getTelemetryContextProperties?.(),
 		);
 
@@ -266,6 +267,7 @@ export class BasicRestWrapper extends RestWrapper {
 
 						this.request<T>(retryConfig, statusCode, false).then(resolve).catch(reject);
 					} else {
+						axiosError = error;
 						const errorSourceMessage = `[${error?.config?.method ?? ""}] request to [${
 							error?.config?.baseURL ?? options.baseURL ?? ""
 						}] failed with [${error.response?.status}] status code`;

--- a/server/routerlicious/packages/services-client/src/restWrapper.ts
+++ b/server/routerlicious/packages/services-client/src/restWrapper.ts
@@ -27,6 +27,7 @@ export interface IBasicRestWrapperMetricProps {
 	url: string;
 	correlationId: string;
 	durationInMs: number;
+	timoutInMs: number | string;
 }
 
 /**
@@ -325,6 +326,7 @@ export class BasicRestWrapper extends RestWrapper {
 							url: options.url ?? "URL_UNAVAILABLE",
 							correlationId,
 							durationInMs: performance.now() - startTime,
+							timoutInMs: options.timeout ?? "TIMEOUT_UNAVAILABLE",
 						};
 						this.logHttpMetrics(requestProps);
 					}

--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -72,4 +72,5 @@ export enum LumberEventName {
 	LivenessProbe = "LivenessProbe",
 	ReadinessProbe = "ReadinessProbe",
 	CircuitBreaker = "CircuitBreaker",
+	RestWrapper = "RestWrapper",
 }

--- a/server/routerlicious/packages/services-utils/src/httpRequestMetricsLogger.ts
+++ b/server/routerlicious/packages/services-utils/src/httpRequestMetricsLogger.ts
@@ -4,18 +4,16 @@
  */
 
 import type { IBasicRestWrapperMetricProps } from "@fluidframework/server-services-client";
-import {
-	CommonProperties,
-	LumberEventName,
-	Lumberjack,
-} from "@fluidframework/server-services-telemetry";
+import { LumberEventName, Lumberjack } from "@fluidframework/server-services-telemetry";
 
 export const logHttpMetrics = (requestProps: IBasicRestWrapperMetricProps) => {
-	const properties = {
-		...requestProps,
-		[CommonProperties.telemetryGroupName]: "http_requests",
-	};
-	const httpMetric = Lumberjack.newLumberMetric(LumberEventName.RestWrapper, properties);
+	if (requestProps.axiosError) {
+		if (requestProps.axiosError.config) {
+			// Since we send requests to riddler with the token in the body this would potentially log the token unless we redact it
+			requestProps.axiosError.config.data = "FLUID_REDACTED";
+		}
+	}
+	const httpMetric = Lumberjack.newLumberMetric(LumberEventName.RestWrapper, requestProps);
 	if (requestProps.axiosError) {
 		httpMetric.error("HttpRequest failed");
 	} else {

--- a/server/routerlicious/packages/services-utils/src/httpRequestMetricsLogger.ts
+++ b/server/routerlicious/packages/services-utils/src/httpRequestMetricsLogger.ts
@@ -1,0 +1,19 @@
+import type { IBasicRestWrapperMetricProps } from "@fluidframework/server-services-client";
+import {
+	CommonProperties,
+	LumberEventName,
+	Lumberjack,
+} from "@fluidframework/server-services-telemetry";
+
+export const logHttpMetrics = (requestProps: IBasicRestWrapperMetricProps) => {
+	const properties = {
+		...requestProps,
+		[CommonProperties.telemetryGroupName]: "http_requests",
+	};
+	const httpMetric = Lumberjack.newLumberMetric(LumberEventName.RestWrapper, properties);
+	if (requestProps.axiosError) {
+		httpMetric.error("HttpRequest failed");
+	} else {
+		httpMetric.success("HttpRequest completed");
+	}
+};

--- a/server/routerlicious/packages/services-utils/src/httpRequestMetricsLogger.ts
+++ b/server/routerlicious/packages/services-utils/src/httpRequestMetricsLogger.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import type { IBasicRestWrapperMetricProps } from "@fluidframework/server-services-client";
 import {
 	CommonProperties,

--- a/server/routerlicious/packages/services-utils/src/httpRequestMetricsLogger.ts
+++ b/server/routerlicious/packages/services-utils/src/httpRequestMetricsLogger.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import type { IBasicRestWrapperMetricProps } from "@fluidframework/server-services-client";
+import {
+	convertAxiosErrorToNetorkError,
+	type IBasicRestWrapperMetricProps,
+} from "@fluidframework/server-services-client";
 import { LumberEventName, Lumberjack } from "@fluidframework/server-services-telemetry";
 
 export const logHttpMetrics = (requestProps: IBasicRestWrapperMetricProps) => {
@@ -14,11 +17,8 @@ export const logHttpMetrics = (requestProps: IBasicRestWrapperMetricProps) => {
 	);
 	httpMetric.setProperty("successful", axiosError ? false : true);
 	if (axiosError) {
-		if (axiosError.config) {
-			// Since we send requests to riddler with the token in the body this would potentially log the token unless we redact it
-			axiosError.config.data = "FLUID_REDACTED";
-		}
-		httpMetric.error("HttpRequest failed", axiosError);
+		const networkError = convertAxiosErrorToNetorkError(axiosError);
+		httpMetric.error("HttpRequest failed", networkError);
 	} else {
 		httpMetric.success("HttpRequest completed");
 	}

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -66,3 +66,4 @@ export {
 } from "./redisClientConnectionManager";
 export { ITenantKeyGenerator, TenantKeyGenerator } from "./tenantKeyGenerator";
 export { ResponseSizeMiddleware } from "./responseSizeMiddleware";
+export { logHttpMetrics } from "./httpRequestMetricsLogger";

--- a/server/routerlicious/packages/services/src/deltaManager.ts
+++ b/server/routerlicious/packages/services/src/deltaManager.ts
@@ -9,6 +9,7 @@ import { BasicRestWrapper } from "@fluidframework/server-services-client";
 import { IDeltaService, type ITenantManager } from "@fluidframework/server-services-core";
 import { getGlobalTelemetryContext } from "@fluidframework/server-services-telemetry";
 import { getRefreshTokenIfNeededCallback, TenantManager } from "./tenant";
+import { logHttpMetrics } from "@fluidframework/server-services-utils";
 
 /**
  * Manager to fetch deltas from Alfred using the internal URL.
@@ -116,6 +117,7 @@ export class DeltaManager implements IDeltaService {
 			() => getGlobalTelemetryContext().getProperties().correlationId /* getCorrelationId */,
 			() => getGlobalTelemetryContext().getProperties() /* getTelemetryContextProperties */,
 			refreshTokenIfNeeded,
+			logHttpMetrics,
 		);
 		return restWrapper;
 	}

--- a/server/routerlicious/packages/services/src/documentManager.ts
+++ b/server/routerlicious/packages/services/src/documentManager.ts
@@ -18,6 +18,7 @@ import {
 	getGlobalTelemetryContext,
 } from "@fluidframework/server-services-telemetry";
 import { getRefreshTokenIfNeededCallback } from "./tenant";
+import { logHttpMetrics } from "@fluidframework/server-services-utils";
 
 /**
  * Manager to fetch document from Alfred using the internal URL.
@@ -150,6 +151,7 @@ export class DocumentManager implements IDocumentManager {
 			() => getGlobalTelemetryContext().getProperties().correlationId /* getCorrelationId */,
 			() => getGlobalTelemetryContext().getProperties() /* getTelemetryContextProperties */,
 			refreshTokenIfNeeded /* refreshTokenIfNeeded */,
+			logHttpMetrics,
 		);
 		return restWrapper;
 	}

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -15,7 +15,11 @@ import {
 } from "@fluidframework/server-services-client";
 import * as core from "@fluidframework/server-services-core";
 import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
-import { extractTokenFromHeader, getValidAccessToken } from "@fluidframework/server-services-utils";
+import {
+	extractTokenFromHeader,
+	getValidAccessToken,
+	logHttpMetrics,
+} from "@fluidframework/server-services-utils";
 import {
 	CommonProperties,
 	getLumberBaseProperties,
@@ -113,6 +117,8 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			undefined /* refreshDefaultHeaders */,
 			() => getGlobalTelemetryContext().getProperties().correlationId,
 			() => getGlobalTelemetryContext().getProperties(),
+			undefined /* refreshTokenIfNeeded */,
+			logHttpMetrics,
 		);
 		const result = await restWrapper.post<core.ITenantConfig & { key: string }>(
 			`${this.endpoint}/api/tenants/${encodeURIComponent(tenantId || "")}`,
@@ -231,6 +237,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			() => getGlobalTelemetryContext().getProperties().correlationId,
 			() => getGlobalTelemetryContext().getProperties(),
 			refreshTokenIfNeeded,
+			logHttpMetrics,
 		);
 		const historian = new Historian(baseUrl, true, false, tenantRestWrapper);
 		const gitManager = new GitManager(historian);
@@ -250,6 +257,8 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			undefined /* refreshDefaultHeaders */,
 			() => getGlobalTelemetryContext().getProperties().correlationId,
 			() => getGlobalTelemetryContext().getProperties(),
+			undefined /* refreshTokenIfNeeded */,
+			logHttpMetrics,
 		);
 		await restWrapper.post(
 			`${this.endpoint}/api/tenants/${encodeURIComponent(tenantId)}/validate`,
@@ -269,6 +278,8 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			undefined /* refreshDefaultHeaders */,
 			() => getGlobalTelemetryContext().getProperties().correlationId,
 			() => getGlobalTelemetryContext().getProperties(),
+			undefined /* refreshTokenIfNeeded */,
+			logHttpMetrics,
 		);
 		const result = await restWrapper.get<core.ITenantKeys>(
 			`${this.endpoint}/api/tenants/${encodeURIComponent(tenantId)}/keys`,
@@ -298,6 +309,8 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			undefined /* refreshDefaultHeaders */,
 			() => getGlobalTelemetryContext().getProperties().correlationId,
 			() => getGlobalTelemetryContext().getProperties(),
+			undefined /* refreshTokenIfNeeded */,
+			logHttpMetrics,
 		);
 		const result = await restWrapper.post<core.IFluidAccessToken>(
 			`${this.endpoint}/api/tenants/${encodeURIComponent(tenantId)}/accesstoken`,
@@ -337,6 +350,8 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			undefined /* refreshDefaultHeaders */,
 			() => getGlobalTelemetryContext().getProperties().correlationId,
 			() => getGlobalTelemetryContext().getProperties(),
+			undefined /* refreshTokenIfNeeded */,
+			logHttpMetrics,
 		);
 		return restWrapper.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`, {
 			includeDisabledTenant,


### PR DESCRIPTION
## Description

Added telemetry for internal micro-service HTTP requests in `restWrapper`. This allows to better track internal API calls.