### PR TITLE
fix(server): Fix builds in response to recent corepack issue

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -43,7 +43,12 @@ ENV PNPM_HOME="/pnpm"
 # Add package dependency's executables to the PATH. We also add global pnpm executables by including $PNPM_HOME,
 # though it's not leveraged currently.
 ENV PATH="$PNPM_HOME:$GITREST_ROOT/node_modules/.bin:$PATH"
-RUN corepack enable
+
+# Note: `corepack prepare pnpm@9.15.3` was added as a temporary workaround in response to https://github.com/nodejs/corepack/issues/612.
+# Using the latest version (automatically) was broken by a key rotation in npm registries + corepack "in the wild"
+# having hardcoded references to the old keys.
+# 9.15.3 was chosen to match the version in package.json.
+RUN corepack enable && corepack prepare pnpm@9.15.3
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files

--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -44,11 +44,10 @@ ENV PNPM_HOME="/pnpm"
 # though it's not leveraged currently.
 ENV PATH="$PNPM_HOME:$GITREST_ROOT/node_modules/.bin:$PATH"
 
-# Note: `npm install -g corepack` and `corepack prepare pnpm@9.15.3` were added as a temporary workaround in response
-# to https://github.com/nodejs/corepack/issues/612.
-# Letting corepack try to get the latest version (automatically) of pnpm was broken by a key rotation in npm
-# registries + corepack "in the wild" having hardcoded references to the old keys.
-# 9.15.3 was chosen to match the version in package.json.
+# Note: `npm install -g corepack` was added as a temporary workaround in response to https://github.com/nodejs/corepack/issues/612.
+# The NPM registry recently rotated some keys but non-latest corepack versions (like those distributed with Node18)
+# have hardcoded references to the old keys and thus fail to install packages that were signed with the new keys.
+# So install the latest corepack globally to work around the problem.
 RUN npm install -g corepack && corepack enable
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we

--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -49,7 +49,7 @@ ENV PATH="$PNPM_HOME:$GITREST_ROOT/node_modules/.bin:$PATH"
 # Letting corepack try to get the latest version (automatically) of pnpm was broken by a key rotation in npm
 # registries + corepack "in the wild" having hardcoded references to the old keys.
 # 9.15.3 was chosen to match the version in package.json.
-RUN npm install -g corepack && corepack enable && corepack prepare pnpm@9.15.3
+RUN npm install -g corepack && corepack enable
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files

--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -44,11 +44,12 @@ ENV PNPM_HOME="/pnpm"
 # though it's not leveraged currently.
 ENV PATH="$PNPM_HOME:$GITREST_ROOT/node_modules/.bin:$PATH"
 
-# Note: `corepack prepare pnpm@9.15.3` was added as a temporary workaround in response to https://github.com/nodejs/corepack/issues/612.
-# Using the latest version (automatically) was broken by a key rotation in npm registries + corepack "in the wild"
-# having hardcoded references to the old keys.
+# Note: `npm install -g corepack` and `corepack prepare pnpm@9.15.3` were added as a temporary workaround in response
+# to https://github.com/nodejs/corepack/issues/612.
+# Letting corepack try to get the latest version (automatically) of pnpm was broken by a key rotation in npm
+# registries + corepack "in the wild" having hardcoded references to the old keys.
 # 9.15.3 was chosen to match the version in package.json.
-RUN corepack enable && corepack prepare pnpm@9.15.3
+RUN npm install -g corepack && corepack enable && corepack prepare pnpm@9.15.3
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -52,7 +52,12 @@ ENV PNPM_HOME="/pnpm"
 # Add package dependency's executables to the PATH. We also add global pnpm executables by including $PNPM_HOME,
 # though it's not leveraged currently.
 ENV PATH="$PNPM_HOME:$HISTORIAN_ROOT/node_modules/.bin:$PATH"
-RUN corepack enable
+
+# Note: `npm install -g corepack` was added as a temporary workaround in response to https://github.com/nodejs/corepack/issues/612.
+# The NPM registry recently rotated some keys but non-latest corepack versions (like those distributed with Node18)
+# have hardcoded references to the old keys and thus fail to install packages that were signed with the new keys.
+# So install the latest corepack globally to work around the problem.
+RUN npm install -g corepack && corepack enable
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -82,7 +82,12 @@ ENV PNPM_HOME="/pnpm"
 # Add package dependency's executables to the PATH. We also add global pnpm executables by including $PNPM_HOME,
 # though it's not leveraged currently.
 ENV PATH="$PNPM_HOME:$ROUTERLICIOUS_ROOT/node_modules/.bin:$PATH"
-RUN corepack enable
+
+# Note: `npm install -g corepack` was added as a temporary workaround in response to https://github.com/nodejs/corepack/issues/612.
+# The NPM registry recently rotated some keys but non-latest corepack versions (like those distributed with Node18)
+# have hardcoded references to the old keys and thus fail to install packages that were signed with the new keys.
+# So install the latest corepack globally to work around the problem.
+RUN npm install -g corepack && corepack enable
 
 # Need to set the --unsafe-perm flag since we are doing the install as root. Consider adding an 'app' account so we
 # can do the install as node but then switch to 'app' to run. As app we won't be able to write to installed files


### PR DESCRIPTION
## Description

Builds of server components, which happen inside Docker containers, were broken by a recent issue with corepack + the npm registry. The registry rotated some keys used for package signing, but corepack versions have hardcoded references to the old keys. The latest pnpm packages are signed with the new keys, so when corepack tries to download them it fails.

This PR fixes the problem by making sure we install the latest (fixed) version of corepack before using it.

See: 

- https://github.com/nodejs/corepack/issues/612
- https://github.com/pnpm/pnpm/issues/9029

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).