### PR TITLE
improvement(container-loader): change Object.keys to Object.entries

### DIFF
--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -145,10 +145,7 @@ function convertSummaryToSnapshotAndBlobs(summary: ISummaryTree): SnapshotWithBl
 		unreferenced: summary.unreferenced,
 		groupId: summary.groupId,
 	};
-	const keys = Object.keys(summary.tree);
-	for (const key of keys) {
-		const summaryObject = summary.tree[key];
-
+	for (const [key, summaryObject] of Object.entries(summary.tree)) {
 		switch (summaryObject.type) {
 			case SummaryType.Tree: {
 				const innerSnapshot = convertSummaryToSnapshotAndBlobs(summaryObject);
@@ -280,7 +277,7 @@ export const combineSnapshotTreeAndSnapshotBlobs = (
 
 	// Process blobs in the current level
 	for (const [, id] of Object.entries(baseSnapshot.blobs)) {
-		if (snapshotBlobs[id]) {
+		if (snapshotBlobs[id] !== undefined) {
 			blobsContents[id] = stringToBuffer(snapshotBlobs[id], "utf8");
 		}
 	}


### PR DESCRIPTION
Prepare for enabling no-unchecked-record-access / noUncheckedIndexedAccess in container-loader by switching Object.keys to Object.entries. Full type safety will require additional changes in a future PR.