### PR TITLE
Remove Tree's unused GC customization

### DIFF
--- a/packages/dds/tree/src/feature-libraries/detachedFieldIndexSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/detachedFieldIndexSummarizer.ts
@@ -6,7 +6,6 @@
 import { bufferToString } from "@fluid-internal/client-utils";
 import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import type {
-	IGarbageCollectionData,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions/internal";
@@ -50,16 +49,6 @@ export class DetachedFieldIndexSummarizer implements Summarizable {
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats> {
 		return this.getAttachSummary(stringify, fullTree, trackState, telemetryContext);
-	}
-
-	public getGCData(fullGC?: boolean): IGarbageCollectionData {
-		// TODO: Properly implement garbage collection. Right now, garbage collection is performed automatically
-		// by the code in SharedObject (from which SharedTreeCore extends). The `runtime.uploadBlob` API delegates
-		// to the `BlobManager`, which automatically populates the summary with ISummaryAttachment entries for each
-		// blob.
-		return {
-			gcNodes: {},
-		};
 	}
 
 	public async load(

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -7,7 +7,6 @@ import { bufferToString } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils/internal";
 import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import type {
-	IGarbageCollectionData,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions/internal";
@@ -112,16 +111,6 @@ export class ForestSummarizer implements Summarizable {
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats> {
 		return createSingleBlobSummary(treeBlobKey, this.getTreeString(stringify));
-	}
-
-	public getGCData(fullGC?: boolean): IGarbageCollectionData {
-		// TODO: Properly implement garbage collection. Right now, garbage collection is performed automatically
-		// by the code in SharedObject (from which SharedTreeCore extends). The `runtime.uploadBlob` API delegates
-		// to the `BlobManager`, which automatically populates the summary with ISummaryAttachment entries for each
-		// blob.
-		return {
-			gcNodes: {},
-		};
 	}
 
 	public async load(

--- a/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
@@ -12,7 +12,6 @@ import type {
 import { SummaryType } from "@fluidframework/driver-definitions";
 import type {
 	IExperimentalIncrementalSummaryContext,
-	IGarbageCollectionData,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions/internal";
@@ -92,16 +91,6 @@ export class SchemaSummarizer implements Summarizable {
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined,
 	): Promise<ISummaryTreeWithStats> {
 		throw new Error("Method not implemented.");
-	}
-
-	public getGCData(fullGC?: boolean): IGarbageCollectionData {
-		// TODO: Properly implement garbage collection. Right now, garbage collection is performed automatically
-		// by the code in SharedObject (from which SharedTreeCore extends). The `runtime.uploadBlob` API delegates
-		// to the `BlobManager`, which automatically populates the summary with ISummaryAttachment entries for each
-		// blob.
-		return {
-			gcNodes: {},
-		};
 	}
 
 	public async load(

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -7,7 +7,6 @@ import { bufferToString } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils/internal";
 import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import type {
-	IGarbageCollectionData,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions/internal";
@@ -76,16 +75,6 @@ export class EditManagerSummarizer<TChangeset> implements Summarizable {
 		const jsonCompatible = this.codec.encode(this.editManager.getSummaryData(), context);
 		const dataString = stringify(jsonCompatible);
 		return createSingleBlobSummary(stringKey, dataString);
-	}
-
-	public getGCData(fullGC?: boolean): IGarbageCollectionData {
-		// TODO: Properly implement garbage collection. Right now, garbage collection is performed automatically
-		// by the code in SharedObject (from which SharedTreeCore extends). The `runtime.uploadBlob` API delegates
-		// to the `BlobManager`, which automatically populates the summary with ISummaryAttachment entries for each
-		// blob.
-		return {
-			gcNodes: {},
-		};
 	}
 
 	public async load(

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -13,7 +13,6 @@ import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import type {
 	IExperimentalIncrementalSummaryContext,
-	IGarbageCollectionData,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions/internal";
@@ -423,24 +422,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		} = this.messageCodec.decode(content, { idCompressor: this.idCompressor });
 		this.editManager.localBranch.apply({ change, revision });
 	}
-
-	public override getGCData(fullGC?: boolean): IGarbageCollectionData {
-		const gcNodes: IGarbageCollectionData["gcNodes"] = super.getGCData(fullGC).gcNodes;
-		for (const s of this.summarizables) {
-			for (const [id, routes] of Object.entries(s.getGCData(fullGC).gcNodes)) {
-				gcNodes[id] ??= [];
-				for (const route of routes) {
-					// Non null asserting here because we are creating an array at gcNodes[id] if it is undefined
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					gcNodes[id]!.push(route);
-				}
-			}
-		}
-
-		return {
-			gcNodes,
-		};
-	}
 }
 
 function isClonableSchemaPolicy(
@@ -481,13 +462,6 @@ export interface Summarizable {
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats>;
-
-	/**
-	 * {@inheritDoc (ISharedObject:interface).getGCData}
-	 */
-	// TODO: Change this interface (and the one in ISharedObject, if necessary) to support "handles within handles".
-	// Consider the case of a document with history; the return value here currently grows unboundedly.
-	getGCData(fullGC?: boolean): IGarbageCollectionData;
 
 	/**
 	 * Allows the component to perform custom loading. The storage service is scoped to this component and therefore

--- a/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -156,16 +156,6 @@ describe("SharedTreeCore", () => {
 				"Expected summary stats to correctly count tree nodes",
 			);
 		});
-
-		it("are asked for GC", () => {
-			const summarizable = new MockSummarizable("summarizable");
-			let requestedGC = false;
-			summarizable.on("gcRequested", () => (requestedGC = true));
-			const summarizables = [summarizable] as const;
-			const tree = createTree(summarizables);
-			tree.getGCData();
-			assert(requestedGC, "Expected SharedTree to ask summarizable for GC");
-		});
 	});
 
 	it("evicts trunk commits behind the minimum sequence number", () => {


### PR DESCRIPTION
## Description

Remove Tree's unused GC customization.
This was inted to be used to support blobs referencing blobs, but this is not planned to be used in the near term, and its likley an alternative approach will be taken if its ever neded.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
