### PR TITLE
fix(server): expose session prune promises

### DIFF
--- a/server/routerlicious/packages/lambdas/src/nexus/connect.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/connect.ts
@@ -312,17 +312,15 @@ function trackCollaborationSession(
 			isWriteClient,
 			isSummarizerClient: isSummarizer(clientDetails.details),
 		};
-		collaborationSessionTracker.startClientSession(
-			sessionClient,
-			{ documentId, tenantId },
-			connectedClients,
-		).catch((error) => {
-			Lumberjack.error(
-				"Failed to update collaboration session tracker for new client",
-				{ tenantId, documentId },
-				error,
-			);
-		});
+		collaborationSessionTracker
+			.startClientSession(sessionClient, { documentId, tenantId }, connectedClients)
+			.catch((error) => {
+				Lumberjack.error(
+					"Failed to update collaboration session tracker for new client",
+					{ tenantId, documentId },
+					error,
+				);
+			});
 	}
 }
 

--- a/server/routerlicious/packages/lambdas/src/nexus/connect.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/connect.ts
@@ -316,7 +316,13 @@ function trackCollaborationSession(
 			sessionClient,
 			{ documentId, tenantId },
 			connectedClients,
-		);
+		).catch((error) => {
+			Lumberjack.error(
+				"Failed to update collaboration session tracker for new client",
+				{ tenantId, documentId },
+				error,
+			);
+		});
 	}
 }
 

--- a/server/routerlicious/packages/lambdas/src/nexus/disconnect.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/disconnect.ts
@@ -127,24 +127,26 @@ function removeClientAndSendNotifications(
 			const client = clientMap.get(clientId);
 			const connectionTimestamp = connectionTimeMap.get(clientId);
 			if (client) {
-				collaborationSessionTracker.endClientSession(
-					{
-						clientId,
-						joinedTime: connectionTimestamp ?? 0,
-						isSummarizerClient: isSummarizer(client.details),
-						isWriteClient: isWriter(client.scopes, client.mode),
-					},
-					{
-						tenantId: room.tenantId,
-						documentId: room.documentId,
-					},
-				).catch((error) => {
-					Lumberjack.error(
-						"Failed to update collaboration session tracker for client disconnection",
-						{ messageMetaData },
-						error,
-					);
-				});
+				collaborationSessionTracker
+					.endClientSession(
+						{
+							clientId,
+							joinedTime: connectionTimestamp ?? 0,
+							isSummarizerClient: isSummarizer(client.details),
+							isWriteClient: isWriter(client.scopes, client.mode),
+						},
+						{
+							tenantId: room.tenantId,
+							documentId: room.documentId,
+						},
+					)
+					.catch((error) => {
+						Lumberjack.error(
+							"Failed to update collaboration session tracker for client disconnection",
+							{ messageMetaData },
+							error,
+						);
+					});
 			}
 		}
 	}

--- a/server/routerlicious/packages/lambdas/src/nexus/disconnect.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/disconnect.ts
@@ -138,7 +138,13 @@ function removeClientAndSendNotifications(
 						tenantId: room.tenantId,
 						documentId: room.documentId,
 					},
-				);
+				).catch((error) => {
+					Lumberjack.error(
+						"Failed to update collaboration session tracker for client disconnection",
+						{ messageMetaData },
+						error,
+					);
+				});
 			}
 		}
 	}

--- a/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
@@ -213,10 +213,15 @@ export class NexusResourcesFactory implements core.IResourcesFactory<NexusResour
 			enableCollaborationSessionPruning === true &&
 			collaborationSessionTracker !== undefined
 		) {
-			const intervalMs = core.DefaultServiceConfiguration.documentLambda.partitionActivityCheckInterval;
+			const intervalMs =
+				core.DefaultServiceConfiguration.documentLambda.partitionActivityCheckInterval;
 			setInterval(() => {
 				collaborationSessionTracker.pruneInactiveSessions().catch((error) => {
-					Lumberjack.error("Failed to prune inactive sessions on an interval", { intervalMs}, error);
+					Lumberjack.error(
+						"Failed to prune inactive sessions on an interval",
+						{ intervalMs },
+						error,
+					);
 				});
 			}, intervalMs);
 		}

--- a/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
@@ -213,9 +213,12 @@ export class NexusResourcesFactory implements core.IResourcesFactory<NexusResour
 			enableCollaborationSessionPruning === true &&
 			collaborationSessionTracker !== undefined
 		) {
+			const intervalMs = core.DefaultServiceConfiguration.documentLambda.partitionActivityCheckInterval;
 			setInterval(() => {
-				collaborationSessionTracker.pruneInactiveSessions();
-			}, core.DefaultServiceConfiguration.documentLambda.partitionActivityCheckInterval);
+				collaborationSessionTracker.pruneInactiveSessions().catch((error) => {
+					Lumberjack.error("Failed to prune inactive sessions on an interval", { intervalMs}, error);
+				});
+			}, intervalMs);
 		}
 
 		const redisClientConnectionManagerForJwtCache =

--- a/server/routerlicious/packages/services-core/src/collabSession.ts
+++ b/server/routerlicious/packages/services-core/src/collabSession.ts
@@ -150,7 +150,7 @@ export interface ICollaborationSessionTracker {
 		client: ICollaborationSessionClient,
 		sessionId: Pick<ICollaborationSession, "tenantId" | "documentId">,
 		knownConnectedClients?: ISignalClient[],
-	): void;
+	): Promise<void>;
 	/**
 	 * End tracking a client session for a document.
 	 *
@@ -168,7 +168,7 @@ export interface ICollaborationSessionTracker {
 		client: ICollaborationSessionClient,
 		sessionId: Pick<ICollaborationSession, "tenantId" | "documentId">,
 		knownConnectedClients?: ISignalClient[],
-	): void;
+	): Promise<void>;
 	/**
 	 * Remove all currently tracked sessions that are no longer active and should have expired based on the session timeout.
 	 *
@@ -176,5 +176,5 @@ export interface ICollaborationSessionTracker {
 	 * This should be called periodically to ensure that sessions are not kept active indefinitely due to the service with the original
 	 * timer shutting down or other errors related to session clean up.
 	 */
-	pruneInactiveSessions(): void;
+	pruneInactiveSessions(): Promise<void>;
 }

--- a/server/routerlicious/packages/services/src/sessionTracker.ts
+++ b/server/routerlicious/packages/services/src/sessionTracker.ts
@@ -59,12 +59,12 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 		private readonly sessionActivityTimeoutMs = 10 * 60 * 1000,
 	) {}
 
-	public startClientSession(
+	public async startClientSession(
 		client: ICollaborationSessionClient,
 		sessionId: Pick<ICollaborationSession, "tenantId" | "documentId">,
 		knownConnectedClients?: ISignalClient[],
-	): void {
-		this.startClientSessionCore(client, sessionId, knownConnectedClients).catch((error) => {
+	): Promise<void> {
+		return this.startClientSessionCore(client, sessionId, knownConnectedClients).catch((error) => {
 			Lumberjack.error(
 				"Failed to start tracking client session",
 				{
@@ -73,6 +73,7 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 				},
 				error,
 			);
+			throw error;
 		});
 	}
 
@@ -115,12 +116,12 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 		});
 	}
 
-	public endClientSession(
+	public async endClientSession(
 		client: ICollaborationSessionClient,
 		sessionId: Pick<ICollaborationSession, "tenantId" | "documentId">,
 		knownConnectedClients?: ISignalClient[],
-	): void {
-		this.endClientSessionCore(client, sessionId, knownConnectedClients).catch((error) => {
+	): Promise<void> {
+		return this.endClientSessionCore(client, sessionId, knownConnectedClients).catch((error) => {
 			Lumberjack.error(
 				"Failed to end tracking client session",
 				{
@@ -129,6 +130,7 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 				},
 				error,
 			);
+			throw error;
 		});
 	}
 
@@ -171,9 +173,10 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 		}
 	}
 
-	public pruneInactiveSessions(): void {
-		this.pruneInactiveSessionsCore().catch((error) => {
+	public async pruneInactiveSessions(): Promise<void> {
+		return this.pruneInactiveSessionsCore().catch((error) => {
 			Lumberjack.error("Failed to prune inactive sessions", undefined, error);
+			throw error;
 		});
 	}
 

--- a/server/routerlicious/packages/services/src/sessionTracker.ts
+++ b/server/routerlicious/packages/services/src/sessionTracker.ts
@@ -64,17 +64,19 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 		sessionId: Pick<ICollaborationSession, "tenantId" | "documentId">,
 		knownConnectedClients?: ISignalClient[],
 	): Promise<void> {
-		return this.startClientSessionCore(client, sessionId, knownConnectedClients).catch((error) => {
-			Lumberjack.error(
-				"Failed to start tracking client session",
-				{
-					...getLumberBaseProperties(sessionId.documentId, sessionId.tenantId),
-					numConnectedClients: knownConnectedClients?.length,
-				},
-				error,
-			);
-			throw error;
-		});
+		return this.startClientSessionCore(client, sessionId, knownConnectedClients).catch(
+			(error) => {
+				Lumberjack.error(
+					"Failed to start tracking client session",
+					{
+						...getLumberBaseProperties(sessionId.documentId, sessionId.tenantId),
+						numConnectedClients: knownConnectedClients?.length,
+					},
+					error,
+				);
+				throw error;
+			},
+		);
 	}
 
 	private async startClientSessionCore(
@@ -121,17 +123,19 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 		sessionId: Pick<ICollaborationSession, "tenantId" | "documentId">,
 		knownConnectedClients?: ISignalClient[],
 	): Promise<void> {
-		return this.endClientSessionCore(client, sessionId, knownConnectedClients).catch((error) => {
-			Lumberjack.error(
-				"Failed to end tracking client session",
-				{
-					...getLumberBaseProperties(sessionId.documentId, sessionId.tenantId),
-					numConnectedClients: knownConnectedClients?.length,
-				},
-				error,
-			);
-			throw error;
-		});
+		return this.endClientSessionCore(client, sessionId, knownConnectedClients).catch(
+			(error) => {
+				Lumberjack.error(
+					"Failed to end tracking client session",
+					{
+						...getLumberBaseProperties(sessionId.documentId, sessionId.tenantId),
+						numConnectedClients: knownConnectedClients?.length,
+					},
+					error,
+				);
+				throw error;
+			},
+		);
 	}
 
 	private async endClientSessionCore(


### PR DESCRIPTION
## Description

Internal AFR session pruning job needs to be able to `await` the Session Prune task. Previously, the task was only exposed as a `void` fire-and-forget call. 

## Breaking Changes

Technically some types are changing, but they are all `@internal` so they will not impact external functionality or APIs