### PR TITLE
tree(perf): batch child change building in field editors

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -42,7 +42,7 @@ export const noChangeHandler: FieldChangeHandler<0> = {
 		rebase: (change: 0, over: 0) => 0,
 	}),
 	codecsFactory: () => noChangeCodecFamily,
-	editor: { buildChildChange: (index, change) => fail("Child changes not supported") },
+	editor: { buildChildChanges: () => fail("Child changes not supported") },
 	intoDelta: (change, deltaFromChild: ToDelta): FieldChangeDelta => ({}),
 	relevantRemovedRoots: (change): Iterable<DeltaDetachedNodeId> => [],
 	isEmpty: (change: 0) => true,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -201,9 +201,12 @@ export function isolatedFieldChangeRebaser<TChangeset>(data: {
 
 export interface FieldEditor<TChangeset> {
 	/**
-	 * Creates a changeset which represents the given `change` to the child at `childIndex` of this editor's field.
+	 * Creates a changeset which represents the given changes to the children of this editor's field.
+	 * For each element in the given iterable
+	 * - The number represents the index of the child node in the field.
+	 * - The `NodeId` represents the nested changes for that child node.
 	 */
-	buildChildChange(childIndex: number, change: NodeId): TChangeset;
+	buildChildChanges(changes: Iterable<[number, NodeId]>): TChangeset;
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -205,8 +205,9 @@ export interface FieldEditor<TChangeset> {
 	 * For each element in the given iterable
 	 * - The number represents the index of the child node in the field.
 	 * - The `NodeId` represents the nested changes for that child node.
+	 * Note: The indices in the iterable must be ordered from smallest to largest (with no duplicates).
 	 */
-	buildChildChanges(changes: Iterable<[number, NodeId]>): TChangeset;
+	buildChildChanges(changes: Iterable<[index: number, change: NodeId]>): TChangeset;
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -6,12 +6,10 @@
 import {
 	type DeltaDetachedNodeId,
 	type DeltaMark,
-	type RevisionMetadataSource,
 	Multiplicity,
 	type RevisionTag,
 	replaceAtomRevisions,
 } from "../../core/index.js";
-import type { IdAllocator } from "../../util/index.js";
 import { assert } from "@fluidframework/core-utils/internal";
 import type {
 	FieldChangeDelta,
@@ -181,9 +179,6 @@ export const genericFieldKind: FieldKindWithEditor = new FieldKindWithEditor(
 export function convertGenericChange<TChange>(
 	changeset: GenericChangeset,
 	target: FieldChangeHandler<TChange>,
-	composeChild: NodeChangeComposer,
-	genId: IdAllocator,
-	revisionMetadata: RevisionMetadataSource,
 ): TChange {
 	return target.editor.buildChildChanges(changeset.entries());
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -2938,10 +2938,9 @@ function buildModularChangesetFromNode(props: {
 		nodeId = { localId: brand(props.idAllocator.allocate()), revision: props.revision },
 	} = props;
 	setInChangeAtomIdMap(props.nodeChanges, nodeId, props.nodeChange);
-	const fieldChangeset = genericFieldKind.changeHandler.editor.buildChildChange(
-		path.parentIndex,
-		nodeId,
-	);
+	const fieldChangeset = genericFieldKind.changeHandler.editor.buildChildChanges([
+		[path.parentIndex, nodeId],
+	]);
 
 	const fieldChange: FieldChange = {
 		fieldKind: genericFieldKind.identifier,

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -646,12 +646,14 @@ export const optionalFieldEditor: OptionalFieldEditor = {
 	}),
 
 	buildChildChanges: (changes: Iterable<[number, NodeId]>): OptionalChangeset => {
+		const childChanges: ChildChange[] = Array.from(changes).map(([index, childChange]) => {
+			assert(index === 0, 0x404 /* Optional fields only support a single child node */);
+			return ["self", childChange];
+		});
+		assert(childChanges.length <= 1, "Optional fields only support a single child node");
 		return {
 			moves: [],
-			childChanges: Array.from(changes).map(([index, childChange]) => {
-				assert(index === 0, 0x404 /* Optional fields only support a single child node */);
-				return ["self", childChange];
-			}),
+			childChanges,
 		};
 	},
 };

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -648,7 +648,7 @@ export const optionalFieldEditor: OptionalFieldEditor = {
 	buildChildChanges: (changes: Iterable<[number, NodeId]>): OptionalChangeset => {
 		return {
 			moves: [],
-			childChanges: Array.from(changes).map(([index, childChange]) => {
+			childChanges: Array.from(changes, ([index, childChange]) => {
 				assert(index === 0, 0x404 /* Optional fields only support a single child node */);
 				return ["self", childChange];
 			}),

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -645,11 +645,13 @@ export const optionalFieldEditor: OptionalFieldEditor = {
 		},
 	}),
 
-	buildChildChange: (index: number, childChange: NodeId): OptionalChangeset => {
-		assert(index === 0, 0x404 /* Optional fields only support a single child node */);
+	buildChildChanges: (changes: Iterable<[number, NodeId]>): OptionalChangeset => {
 		return {
 			moves: [],
-			childChanges: [["self", childChange]],
+			childChanges: Array.from(changes).map(([index, childChange]) => {
+				assert(index === 0, 0x404 /* Optional fields only support a single child node */);
+				return ["self", childChange];
+			}),
 		};
 	},
 };

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -79,6 +79,7 @@ export const sequenceFieldEditor = {
 		const changeset: Changeset = [];
 		let currentIndex = 0;
 		for (const [index, change] of changes) {
+			assert(index >= currentIndex, "Child changes must be in order.");
 			if (index > currentIndex) {
 				changeset.push({ count: index - currentIndex });
 			}

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -75,8 +75,18 @@ export interface SequenceFieldEditor extends FieldEditor<Changeset> {
 }
 
 export const sequenceFieldEditor = {
-	buildChildChange: (index: number, change: NodeId): Changeset =>
-		markAtIndex(index, { count: 1, changes: change }),
+	buildChildChanges: (changes: Iterable<[number, NodeId]>): Changeset => {
+		const changeset: Changeset = [];
+		let currentIndex = 0;
+		for (const [index, change] of changes) {
+			if (index > currentIndex) {
+				changeset.push({ count: index - currentIndex });
+			}
+			changeset.push({ count: 1, changes: change });
+			currentIndex = index + 1;
+		}
+		return changeset;
+	},
 	insert: (
 		index: number,
 		count: number,

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
@@ -239,8 +239,8 @@ describe("defaultFieldKinds", () => {
 				return arbitraryChildChange;
 			};
 
-			const baseChange = fieldHandler.editor.buildChildChange(0, nodeChange1);
-			const changeToRebase = fieldHandler.editor.buildChildChange(0, nodeChange2);
+			const baseChange = fieldHandler.editor.buildChildChanges([[0, nodeChange1]]);
+			const changeToRebase = fieldHandler.editor.buildChildChanges([[0, nodeChange2]]);
 
 			assert.deepEqual(
 				fieldHandler.rebaser.rebase(

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
@@ -80,7 +80,7 @@ export const valueHandler = {
 		makeCodecFamily([
 			[1, makeValueCodec<TUnsafe<ValueChangeset>, FieldChangeEncodingContext>(Type.Any())],
 		]),
-	editor: { buildChildChange: (index, change) => fail("Child changes not supported") },
+	editor: { buildChildChanges: () => fail("Child changes not supported") },
 
 	intoDelta: (change): FieldChangeDelta => {
 		const delta: Mutable<FieldChangeDelta> = {};

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -231,13 +231,25 @@ describe("GenericField", () => {
 		);
 	});
 
-	it("build child change", () => {
-		const change0 = genericChangeHandler.editor.buildChildChange(0, nodeId1);
-		const change1 = genericChangeHandler.editor.buildChildChange(1, nodeId2);
-		const change2 = genericChangeHandler.editor.buildChildChange(2, nodeId3);
-		assert.deepEqual(change0, newGenericChangeset([[0, nodeId1]]));
-		assert.deepEqual(change1, newGenericChangeset([[1, nodeId2]]));
-		assert.deepEqual(change2, newGenericChangeset([[2, nodeId3]]));
+	it("build empty child change", () => {
+		const change0 = genericChangeHandler.editor.buildChildChanges([]);
+		assert.deepEqual(change0, newGenericChangeset([]));
+	});
+
+	it("build child changes", () => {
+		const change0 = genericChangeHandler.editor.buildChildChanges([
+			[0, nodeId1],
+			[1, nodeId2],
+			[2, nodeId3],
+		]);
+		assert.deepEqual(
+			change0,
+			newGenericChangeset([
+				[0, nodeId1],
+				[1, nodeId2],
+				[2, nodeId3],
+			]),
+		);
 	});
 
 	it("relevantRemovedRoots", () => {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -114,9 +114,10 @@ const singleNodeRebaser: FieldChangeRebaser<SingleNodeChangeset> = {
 };
 
 const singleNodeEditor: FieldEditor<SingleNodeChangeset> = {
-	buildChildChange: (index: number, change: NodeId): SingleNodeChangeset => {
-		assert(index === 0, "This field kind only supports one node in its field");
-		return change;
+	buildChildChanges: (changes: Iterable<[number, NodeId]>): SingleNodeChangeset => {
+		const changesArray = Array.from(changes);
+		assert(changesArray.length <= 1, "This field kind only supports one node in its field");
+		return changesArray[0] === undefined ? undefined : changesArray[0][1];
 	},
 };
 

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangesetUtil.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangesetUtil.ts
@@ -222,7 +222,9 @@ function addNodeToField(
 	nodes.set([nodeId.revision, nodeId.localId], nodeChangeset);
 	nodeToParent.set([nodeId.revision, nodeId.localId], parentId);
 
-	const fieldWithChange = changeHandler.editor.buildChildChange(nodeDescription.index, nodeId);
+	const fieldWithChange = changeHandler.editor.buildChildChanges([
+		[nodeDescription.index, nodeId],
+	]);
 
 	return changeHandler.rebaser.compose(
 		fieldWithChange,

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
@@ -94,7 +94,7 @@ const OptionalChange = {
 	},
 
 	buildChildChange(childChange: NodeId) {
-		return optionalFieldEditor.buildChildChange(0, childChange);
+		return optionalFieldEditor.buildChildChanges([[0, childChange]]);
 	},
 };
 

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -105,7 +105,9 @@ const change2PreChange1: TaggedChange<OptionalChangeset> = tagChangeInline(
 );
 
 const change4: TaggedChange<OptionalChangeset> = tagChangeInline(
-	optionalFieldEditor.buildChildChange(0, TestNodeId.create(nodeId2, TestChange.mint([1], 2))),
+	optionalFieldEditor.buildChildChanges([
+		[0, TestNodeId.create(nodeId2, TestChange.mint([1], 2))],
+	]),
 	mintRevisionTag(),
 );
 
@@ -513,7 +515,7 @@ describe("optionalField", () => {
 			it("can rebase a child change over a remove and revive of target node", () => {
 				const tag1 = mintRevisionTag();
 				const tag2 = mintRevisionTag();
-				const changeToRebase = optionalFieldEditor.buildChildChange(0, nodeId1);
+				const changeToRebase = optionalFieldEditor.buildChildChanges([[0, nodeId1]]);
 				const deletion = tagChange(
 					optionalFieldEditor.clear(false, { localId: brand(1), revision: tag1 }),
 					tag1,
@@ -565,7 +567,7 @@ describe("optionalField", () => {
 			});
 
 			it("can rebase a child change over a reserved detach on empty field", () => {
-				const changeToRebase = optionalFieldEditor.buildChildChange(0, nodeId1);
+				const changeToRebase = optionalFieldEditor.buildChildChanges([[0, nodeId1]]);
 				deepFreeze(changeToRebase);
 				const clear = tagChange(
 					optionalFieldEditor.clear(true, { localId: brand(42), revision: tag }),
@@ -596,7 +598,7 @@ describe("optionalField", () => {
 			});
 
 			it("can rebase a child change over a reserved detach on field with a pinned node", () => {
-				const changeToRebase = optionalFieldEditor.buildChildChange(0, nodeId1);
+				const changeToRebase = optionalFieldEditor.buildChildChanges([[0, nodeId1]]);
 				deepFreeze(changeToRebase);
 				const pin = tagChangeInline(Change.pin(brand(42)), tag);
 
@@ -734,7 +736,7 @@ describe("optionalField", () => {
 		);
 		const childChangeTag = mintRevisionTag();
 		const hasChildChanges = tagChange(
-			optionalFieldEditor.buildChildChange(0, { ...nodeId1, revision: childChangeTag }),
+			optionalFieldEditor.buildChildChanges([[0, { ...nodeId1, revision: childChangeTag }]]),
 			childChangeTag,
 		);
 		const relevantNestedTree = { minor: 4242 };

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
@@ -49,7 +49,7 @@ const change2Inverted = inlineRevision(
 );
 
 const changeWithChildChange = inlineRevision(
-	optionalFieldEditor.buildChildChange(0, nodeChange1),
+	optionalFieldEditor.buildChildChanges([[0, nodeChange1]]),
 	tag1,
 );
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldEditor.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldEditor.test.ts
@@ -8,8 +8,6 @@ import { strict as assert } from "node:assert";
 import type { ChangesetLocalId } from "../../../core/index.js";
 import { SequenceField as SF } from "../../../feature-libraries/index.js";
 import { brand } from "../../../util/index.js";
-import { TestChange } from "../../testChange.js";
-import { TestNodeId } from "../../testNodeId.js";
 import { deepFreeze } from "@fluidframework/test-runtime-utils/internal";
 import { MarkMaker as Mark } from "./testEdits.js";
 import { mintRevisionTag } from "../../utils.js";
@@ -18,11 +16,39 @@ const id: ChangesetLocalId = brand(0);
 
 export function testEditor() {
 	describe("Editor", () => {
-		it("child change", () => {
-			const childChange = TestNodeId.create({ localId: brand(0) }, TestChange.mint([0], 1));
-			deepFreeze(childChange);
-			const actual = SF.sequenceFieldEditor.buildChildChange(42, childChange);
-			const expected: SF.Changeset = [{ count: 42 }, Mark.modify(childChange)];
+		it("empty child changes", () => {
+			assert.deepEqual(SF.sequenceFieldEditor.buildChildChanges([]), []);
+		});
+
+		it("child changes", () => {
+			const childChange1 = {
+				localId: brand<ChangesetLocalId>(0),
+				revision: mintRevisionTag(),
+			};
+			const childChange2 = {
+				localId: brand<ChangesetLocalId>(1),
+				revision: mintRevisionTag(),
+			};
+			const childChange3 = {
+				localId: brand<ChangesetLocalId>(2),
+				revision: mintRevisionTag(),
+			};
+			deepFreeze(childChange1);
+			deepFreeze(childChange2);
+			deepFreeze(childChange3);
+			const actual = SF.sequenceFieldEditor.buildChildChanges([
+				[1, childChange1],
+				[4, childChange2],
+				[10, childChange3],
+			]);
+			const expected: SF.Changeset = [
+				{ count: 1 },
+				Mark.modify(childChange1),
+				{ count: 2 },
+				Mark.modify(childChange2),
+				{ count: 5 },
+				Mark.modify(childChange3),
+			];
 			assert.deepEqual(actual, expected);
 		});
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -38,10 +38,9 @@ export const cases: {
 } = {
 	no_change: [],
 	insert: createInsertChangeset(1, 2, undefined /* revision */, { localId: brand(1) }),
-	modify: SF.sequenceFieldEditor.buildChildChange(
-		0,
-		TestNodeId.create(nodeId1, TestChange.mint([], 1)),
-	),
+	modify: SF.sequenceFieldEditor.buildChildChanges([
+		[0, TestNodeId.create(nodeId1, TestChange.mint([], 1))],
+	]),
 	modify_insert: [
 		createSkipMark(1),
 		createInsertMark(1, brand(1), {
@@ -167,7 +166,7 @@ function createReturnChangeset(
 }
 
 function createModifyChangeset(index: number, change: NodeId): SF.Changeset {
-	return SF.sequenceFieldEditor.buildChildChange(index, change);
+	return SF.sequenceFieldEditor.buildChildChanges([[index, change]]);
 }
 
 function createModifyDetachedChangeset(

--- a/packages/dds/tree/src/util/rangeMap.ts
+++ b/packages/dds/tree/src/util/rangeMap.ts
@@ -61,7 +61,7 @@ export class RangeMap<K, V> {
 	 * Retrieves the values for all keys in the query range.
 	 *
 	 * @param start - The first key in the range being queried
-	 * @param length  - The length of the query range
+	 * @param length - The length of the query range
 	 * @returns A list of entries, each describing the value for some subrange of the query.
 	 * The entries are in the same order as the keys, and there is an entry for every key with a non `undefined` value.
 	 */


### PR DESCRIPTION
## Description

This PR refactors the field editor method for creating child changes to take an iterable of changes to allow batch building. This should asymptotically improve the performance of convertGenericChange in the generic field kind.