### PR TITLE
Fix and rename logic around obliteratePrecedingInsertion

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -593,6 +593,8 @@ export class MergeTree {
 	public mergeTreeDeltaCallback?: MergeTreeDeltaCallback;
 	public mergeTreeMaintenanceCallback?: MergeTreeMaintenanceCallback;
 
+	// TODO:AB#29553: This property doesn't seem to be adequately round-tripped through summarization.
+	// Specifically, it seems like we drop information about obliterates within the collab window for at least V1 summaries.
 	private readonly obliterates = new Obliterates(this);
 
 	public constructor(public options?: IMergeTreeOptionsInternal) {
@@ -1635,31 +1637,35 @@ export class MergeTree {
 				}
 			}
 
-			if (oldest && newest?.clientId !== clientId) {
-				const moveInfo: IMoveInfo = {
-					movedClientIds,
-					movedSeq: oldest.seq,
-					movedSeqs,
-					localMovedSeq: oldest.localSeq,
-					wasMovedOnInsert: oldest.seq !== UnassignedSequenceNumber,
-				};
+			if (oldest) {
+				newSegment.obliteratePrecedingInsertion = newest;
+				// See doc comment on obliteratePrecedingInsertion for more details: if the newest obliterate was performed
+				// by the same client that's inserting this segment, we let them insert into this range and therefore don't
+				// mark it obliterated.
+				if (newest?.clientId !== clientId) {
+					const moveInfo: IMoveInfo = {
+						movedClientIds,
+						movedSeq: oldest.seq,
+						movedSeqs,
+						localMovedSeq: oldest.localSeq,
+						wasMovedOnInsert: oldest.seq !== UnassignedSequenceNumber,
+					};
 
-				overwriteInfo(newSegment, moveInfo);
+					overwriteInfo(newSegment, moveInfo);
 
-				if (moveInfo.localMovedSeq !== undefined) {
-					assert(
-						oldest.segmentGroup !== undefined,
-						0x86c /* expected segment group to exist */,
-					);
+					if (moveInfo.localMovedSeq !== undefined) {
+						assert(
+							oldest.segmentGroup !== undefined,
+							0x86c /* expected segment group to exist */,
+						);
 
-					this.addToPendingList(newSegment, oldest.segmentGroup);
+						this.addToPendingList(newSegment, oldest.segmentGroup);
+					}
+
+					if (newSegment.parent) {
+						this.blockUpdatePathLengths(newSegment.parent, seq, clientId);
+					}
 				}
-
-				if (newSegment.parent) {
-					this.blockUpdatePathLengths(newSegment.parent, seq, clientId);
-				}
-			} else if (oldest && newest?.clientId === clientId) {
-				newSegment.prevObliterateByInserter = newest;
 			}
 
 			saveIfLocal(newSegment);
@@ -1682,8 +1688,8 @@ export class MergeTree {
 			segment.segmentGroups.copyTo(next.segmentGroups);
 		}
 
-		if (segment.prevObliterateByInserter) {
-			next.prevObliterateByInserter = segment.prevObliterateByInserter;
+		if (segment.obliteratePrecedingInsertion) {
+			next.obliteratePrecedingInsertion = segment.obliteratePrecedingInsertion;
 		}
 		copyPropertiesAndManager(segment, next);
 		if (segment.localRefs) {
@@ -2058,7 +2064,16 @@ export class MergeTree {
 			}
 			const existingMoveInfo = toMoveInfo(segment);
 
-			if (segment.prevObliterateByInserter?.seq === UnassignedSequenceNumber) {
+			// The "last-to-obliterate-gets-to-insert" policy described by the doc comment on `obliteratePrecedingInsertion`
+			// is mostly handled by logic at insertion time, but we need a small bit of handling here.
+			// Specifically, we want to avoid marking a local-only segment as obliterated when we know one of our own local obliterates
+			// will win against the obliterate we're processing, hence the early exit.
+			if (
+				segment.seq === UnassignedSequenceNumber &&
+				segment.obliteratePrecedingInsertion !== undefined &&
+				segment.obliteratePrecedingInsertion.seq === UnassignedSequenceNumber &&
+				seq !== UnassignedSequenceNumber
+			) {
 				// We chose to not obliterate this segment because we are aware of an unacked local obliteration.
 				// The local obliterate has not been sequenced yet, so it is still the newest obliterate we are aware of.
 				// Other clients will also choose not to obliterate this segment because the most recent obliteration has the same clientId
@@ -2067,8 +2082,8 @@ export class MergeTree {
 
 			const wasMovedOnInsert =
 				clientId !== segment.clientId &&
-				segment.seq !== undefined &&
 				seq !== UnassignedSequenceNumber &&
+				segment.seq !== undefined &&
 				(refSeq < segment.seq || segment.seq === UnassignedSequenceNumber);
 
 			if (existingMoveInfo === undefined) {

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2070,8 +2070,7 @@ export class MergeTree {
 			// will win against the obliterate we're processing, hence the early exit.
 			if (
 				segment.seq === UnassignedSequenceNumber &&
-				segment.obliteratePrecedingInsertion !== undefined &&
-				segment.obliteratePrecedingInsertion.seq === UnassignedSequenceNumber &&
+				segment.obliteratePrecedingInsertion?.seq === UnassignedSequenceNumber &&
 				seq !== UnassignedSequenceNumber
 			) {
 				// We chose to not obliterate this segment because we are aware of an unacked local obliteration.

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -73,11 +73,22 @@ export interface ISegmentPrivate extends ISegmentInternal {
 	segmentGroups?: SegmentGroupCollection;
 	propertyManager?: PropertiesManager;
 	/**
-	 * If a segment is inserted into an obliterated range,
-	 * but the newest obliteration of that range was by the inserting client,
-	 * then the segment is not obliterated because it is aware of the latest obliteration.
+	 * Populated iff this segment was inserted into a range affected by concurrent obliterates at the time of its insertion.
+	 * Contains information about the 'most recent' (i.e. 'winning' in the sense below) obliterate.
+	 *
+	 * BEWARE: We have opted for a certain form of last-write wins (LWW) semantics for obliterates:
+	 * the client which last obliterated a range is considered to have "won ownership" of that range and may insert into it
+	 * without that insertion being obliterated by other clients' concurrent obliterates.
+	 *
+	 * Therefore, this field can be populated even if the segment has not been obliterated (i.e. is still visible).
+	 * This happens precisely when the segment was inserted by the same client that 'won' the obliterate (in a scenario where
+	 * a client first issues a sided obliterate impacting a range, then inserts into that range before the server has acked the obliterate).
+	 *
+	 * See the test case "obliterate with mismatched final states" for an example of such a scenario.
+	 *
+	 * TODO:AB#29553: This property is not persisted in the summary, but it should be.
 	 */
-	prevObliterateByInserter?: ObliterateInfo;
+	obliteratePrecedingInsertion?: ObliterateInfo;
 }
 /**
  * Segment leafs are segments that have both IMergeNodeInfo and IInsertionInfo. This means they

--- a/packages/dds/merge-tree/src/segmentInfos.ts
+++ b/packages/dds/merge-tree/src/segmentInfos.ts
@@ -310,6 +310,9 @@ export interface IMoveInfo {
 	 * If a segment is moved on insertion, its length is only ever visible to
 	 * the client that inserted the segment. This is relevant in partial length
 	 * calculations
+	 *
+	 * @privateRemarks
+	 * TODO:AB#29553: This property is not persisted in the summary, but it should be.
 	 */
 	wasMovedOnInsert: boolean;
 }

--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -140,7 +140,7 @@ export class SnapshotLoader {
 					movedClientIds: spec.movedClientIds.map((id) =>
 						this.client.getOrAddShortClientId(id),
 					),
-					// BUG? This isn't persisted
+					// TODO:AB#29553: This property should be derived from segment data, not hard-coded.
 					wasMovedOnInsert: false,
 				});
 			}

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -1015,8 +1015,8 @@ describe("client.applyMsg", () => {
 
 			logger.validate({ baseText: "BBBBBB B" });
 		});
-		// TODO: see AB#29398
-		it.skip("obliterate with mismatched final states", () => {
+
+		it("obliterate with mismatched final states", () => {
 			const clients = createClientsAtInitialState(
 				{
 					initialState: "0{zzzzzzz}123{yyyyyy}45",


### PR DESCRIPTION
## Description

This fixes some incorrect handling having to do with the segment data previously called `prevObliterateByInserter`, which allows the unit test added in #23743 to be unskipped.

It also does some minor cleanup in the area:

- Tagged a number of places with [AB#29553](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/29553) where it looks like we're not correctly roundtripping data through summaries. This might end up not causing any issues since the V1 snapshot format is where things would be most incorrect, but more investigation is needed.
- Renamed `prevObliterateByInserter` to `obliteratePrecedingInsertion` and added some hopefully more clear doc comments on its purpose. Also populated it whenever there were concurrent obliterates to consider at insertion time rather than only conditionally, since it seems like the "winning obliterate on insertion" is a useful piece of information to have

[AB#29398](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/29398)