### PR TITLE
build(core-utils): Enable `exactOptionalPropertyTypes`

### DIFF
--- a/packages/common/core-utils/tsconfig.json
+++ b/packages/common/core-utils/tsconfig.json
@@ -5,7 +5,6 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 		"noUncheckedIndexedAccess": false,
 	},
 }


### PR DESCRIPTION
The build did not detect any violations, so this is an easy win.

[AB#8215](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8215)