### PR TITLE
bugfix(docs): Added alt text to partners and services for screenreaders

### DIFF
--- a/docs/src/components/home/partnersSection.tsx
+++ b/docs/src/components/home/partnersSection.tsx
@@ -37,6 +37,7 @@ export function PartnersSection(): JSX.Element {
 						title="Autodesk"
 						// bodyText={TODO}
 						learnMoreHref={autodeskLink}
+						learnMoreLinkAltText="Autodesk"
 					/>
 					<PartnerEntry
 						icon={
@@ -48,6 +49,7 @@ export function PartnersSection(): JSX.Element {
 						title="Hexagon"
 						// bodyText={TODO}
 						learnMoreHref={hexagonLink}
+						learnMoreLinkAltText="Hexagon"
 					/>
 					<PartnerEntry
 						icon={
@@ -59,6 +61,7 @@ export function PartnersSection(): JSX.Element {
 						title="Microsoft Loop"
 						// bodyText={TODO}
 						learnMoreHref={loopLink}
+						learnMoreLinkAltText="Microsoft Loop"
 					/>
 					<PartnerEntry
 						icon={
@@ -70,6 +73,7 @@ export function PartnersSection(): JSX.Element {
 						title="Microsoft Teams"
 						// bodyText={TODO}
 						learnMoreHref={teamsLink}
+						learnMoreLinkAltText="Microsoft Teams"
 					/>
 					<PartnerEntry
 						icon={
@@ -81,6 +85,7 @@ export function PartnersSection(): JSX.Element {
 						title="Power Apps"
 						// bodyText={TODO}
 						learnMoreHref={powerAppsLink}
+						learnMoreLinkAltText="Power Apps"
 					/>
 					<PartnerEntry
 						icon={
@@ -92,6 +97,7 @@ export function PartnersSection(): JSX.Element {
 						title="Whiteboard"
 						// bodyText={TODO}
 						learnMoreHref={whiteboardLink}
+						learnMoreLinkAltText="Whiteboard"
 					/>
 				</div>
 			</div>
@@ -104,9 +110,15 @@ interface PartnerEntryProps {
 	title: string;
 	// bodyText: string;
 	learnMoreHref: string;
+	learnMoreLinkAltText: string;
 }
 
-function PartnerEntry({ icon, title, learnMoreHref }: PartnerEntryProps): JSX.Element {
+function PartnerEntry({
+	icon,
+	title,
+	learnMoreHref,
+	learnMoreLinkAltText,
+}: PartnerEntryProps): JSX.Element {
 	return (
 		<div className="ffcom-partner-entry">
 			<div className="ffcom-partner-entry-inner">
@@ -114,7 +126,10 @@ function PartnerEntry({ icon, title, learnMoreHref }: PartnerEntryProps): JSX.El
 					<PartnerEntryIcon icon={icon} />
 					<PartnerEntryLabel title={title} />
 					{/* TODO: restore this once we have body text contents: <PartnerEntryBody bodyText={bodyText} /> */}
-					<PartnerEntryFooter learnMoreHref={learnMoreHref} />
+					<PartnerEntryFooter
+						learnMoreHref={learnMoreHref}
+						learnMoreLinkAltText={learnMoreLinkAltText}
+					/>
 				</div>
 			</div>
 		</div>
@@ -156,9 +171,13 @@ function PartnerEntryLabel({ title }: PartnerEntryLabelProps): React.ReactElemen
 
 interface PartnerEntryFooterProps {
 	learnMoreHref: string;
+	learnMoreLinkAltText: string;
 }
 
-function PartnerEntryFooter({ learnMoreHref }: PartnerEntryFooterProps): React.ReactElement {
+function PartnerEntryFooter({
+	learnMoreHref,
+	learnMoreLinkAltText,
+}: PartnerEntryFooterProps): React.ReactElement {
 	return (
 		<div className="ffcom-partner-entry-learn-more-container ">
 			<div className="ffcom-partner-entry-learn-more-container-inner">
@@ -167,6 +186,7 @@ function PartnerEntryFooter({ learnMoreHref }: PartnerEntryFooterProps): React.R
 					href={learnMoreHref}
 					target="_blank"
 					rel="noreferrer"
+					aria-label={learnMoreLinkAltText}
 				>
 					Learn more
 				</a>

--- a/docs/src/components/home/serviceSection.tsx
+++ b/docs/src/components/home/serviceSection.tsx
@@ -49,6 +49,7 @@ export function ServiceSection(): JSX.Element {
 						title="Azure Fluid Relay"
 						description={afrCardDescription}
 						learnMoreHref="https://azure.microsoft.com/en-us/products/fluid-relay/#overview"
+						learnMoreLinkAltText="Azure Fluid Relay"
 					/>
 					<ServiceSectionCard
 						logoSource="https://storage.fluidframework.com/static/images/website/microsoft-logo.png"
@@ -56,6 +57,7 @@ export function ServiceSection(): JSX.Element {
 						title="SharePoint Embedded"
 						description={speCardDescription}
 						learnMoreHref="https://learn.microsoft.com/en-us/sharepoint/dev/embedded/overview"
+						learnMoreLinkAltText="Sharepoint Embedded"
 					/>
 				</div>
 			</div>
@@ -69,6 +71,7 @@ interface ServiceSectionCardProps {
 	title: string;
 	description: string;
 	learnMoreHref: string;
+	learnMoreLinkAltText: string;
 }
 
 function ServiceSectionCard({
@@ -77,6 +80,7 @@ function ServiceSectionCard({
 	title,
 	description,
 	learnMoreHref,
+	learnMoreLinkAltText,
 }: ServiceSectionCardProps): React.ReactElement {
 	return (
 		<div className="ffcom-service">
@@ -89,6 +93,7 @@ function ServiceSectionCard({
 					href={learnMoreHref}
 					target="_blank"
 					rel="noopener noreferrer"
+					aria-label={learnMoreLinkAltText}
 				>
 					Learn more
 				</a>

--- a/docs/src/components/home/serviceSection.tsx
+++ b/docs/src/components/home/serviceSection.tsx
@@ -57,7 +57,7 @@ export function ServiceSection(): JSX.Element {
 						title="SharePoint Embedded"
 						description={speCardDescription}
 						learnMoreHref="https://learn.microsoft.com/en-us/sharepoint/dev/embedded/overview"
-						learnMoreLinkAltText="Sharepoint Embedded"
+						learnMoreLinkAltText="SharePoint Embedded"
 					/>
 				</div>
 			</div>

--- a/docs/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/docs/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -30,7 +30,6 @@ import React from "react";
  * @returns The main documentation page for this version
  */
 function getVersionMainDoc(version: GlobalVersion): GlobalDoc {
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	return version.docs.find((doc) => doc.id === version.mainDocId);
 }
 


### PR DESCRIPTION
[AB#22713](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/22713)

## Description
This PR updates the alt-text for the `Learn more` links for the partner and service cards on the Fluid Framework website. Initially it said `Learn more` and has now been updated to reflect the appropriate partner or service name.