### PR TITLE
build(datastore, datastore-definitions, container-runtime-definitions, runtime-definitions): Enable `exactOptionalPropertyTypes`

### DIFF
--- a/packages/runtime/container-runtime-definitions/tsconfig.json
+++ b/packages/runtime/container-runtime-definitions/tsconfig.json
@@ -6,6 +6,5 @@
 		"rootDir": "./src",
 		"outDir": "./lib",
 		"emitDeclarationOnly": true,
-		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/runtime/datastore-definitions/tsconfig.json
+++ b/packages/runtime/datastore-definitions/tsconfig.json
@@ -6,6 +6,5 @@
 		"rootDir": "./src",
 		"outDir": "./lib",
 		"emitDeclarationOnly": true,
-		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/runtime/datastore/tsconfig.json
+++ b/packages/runtime/datastore/tsconfig.json
@@ -5,6 +5,5 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/runtime/runtime-definitions/tsconfig.json
+++ b/packages/runtime/runtime-definitions/tsconfig.json
@@ -5,6 +5,5 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 	},
 }


### PR DESCRIPTION
Enables `exactOptionalPropertyTypes` in the following packages:
- datastore
- datastore-definitions
- container-runtime-definitions
- runtime-definitions

None of the above contained any violations, so no code changes were required.

[AB#8215](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8215)