### PR TITLE
(mocks) Update the runtime mocks to correctly support TurnBased flush mode

### DIFF
--- a/packages/dds/matrix/src/test/matrix.applyStashedOp.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.applyStashedOp.spec.ts
@@ -71,10 +71,10 @@ function spyOnContainerRuntimeMessages(runtime: MockContainerRuntimeForReconnect
 	};
 
 	const processedMessages: ISequencedDocumentMessage[] = [];
-	const originalProcess = runtime.process.bind(runtime);
-	runtime.process = (message: ISequencedDocumentMessage): void => {
-		processedMessages.push(message);
-		return originalProcess(message);
+	const originalProcessMessages = runtime.processMessages.bind(runtime);
+	runtime.processMessages = (messages: ISequencedDocumentMessage[]): void => {
+		processedMessages.push(...messages);
+		return originalProcessMessages(messages);
 	};
 
 	return { submittedContent, processedMessages };

--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -122,6 +122,7 @@ describe("Fuzz - Top-Level", () => {
 			rebaseProbability: 0.2,
 			containerRuntimeOptions: {
 				flushMode: FlushMode.TurnBased,
+				flushAutomatically: false,
 				enableGroupedBatching: true,
 			},
 			// AB#7162: see comment above.

--- a/packages/dds/tree/src/test/shared-tree/repairData.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/repairData.spec.ts
@@ -162,7 +162,7 @@ describe("Repair Data", () => {
 				1,
 				undefined /* factory */,
 				undefined /* useDeterministicSessionIds */,
-				FlushMode.TurnBased,
+				{ flushMode: FlushMode.TurnBased },
 			);
 			const tree1 = provider.trees[0];
 			const view1 = tree1.viewWith(

--- a/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "node:assert";
 import type { SessionId } from "@fluidframework/id-compressor";
 import { createAlwaysFinalizedIdCompressor } from "@fluidframework/id-compressor/internal/test-utils";
+import { FlushMode } from "@fluidframework/runtime-definitions/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import { typeboxValidator } from "../../external-utilities/index.js";
@@ -49,7 +50,9 @@ export function generateTestTrees(options: SharedTreeOptions) {
 		{
 			name: "tree-with-identifier-field",
 			runScenario: async (takeSnapshot) => {
-				const provider = new TestTreeProviderLite(2, factory, true);
+				const provider = new TestTreeProviderLite(2, factory, true, {
+					flushMode: FlushMode.Immediate,
+				});
 				const tree1 = provider.trees[0];
 				const sf = new SchemaFactory("com.example");
 				class SchemaWithIdentifier extends sf.object("parent", {
@@ -75,7 +78,9 @@ export function generateTestTrees(options: SharedTreeOptions) {
 					bar: sf.array(sf.string),
 				});
 
-				const provider = new TestTreeProviderLite(2, factory, true);
+				const provider = new TestTreeProviderLite(2, factory, true, {
+					flushMode: FlushMode.Immediate,
+				});
 				const tree = provider.trees[0];
 
 				const view = tree.viewWith(
@@ -94,7 +99,9 @@ export function generateTestTrees(options: SharedTreeOptions) {
 			name: "insert-and-remove",
 			runScenario: async (takeSnapshot) => {
 				const sf = new SchemaFactory("insert-and-remove");
-				const provider = new TestTreeProviderLite(2, factory, true);
+				const provider = new TestTreeProviderLite(2, factory, true, {
+					flushMode: FlushMode.Immediate,
+				});
 				const tree1 = provider.trees[0];
 				const view = tree1.viewWith(
 					new TreeViewConfiguration({
@@ -129,7 +136,9 @@ export function generateTestTrees(options: SharedTreeOptions) {
 				const sf = new SchemaFactory("optional-field-scenarios");
 				const MapNode = sf.map("Map", [sf.string, sf.number]);
 
-				const provider = new TestTreeProviderLite(2, factory, true);
+				const provider = new TestTreeProviderLite(2, factory, true, {
+					flushMode: FlushMode.Immediate,
+				});
 				const tree1 = provider.trees[0];
 				const view1 = tree1.viewWith(
 					new TreeViewConfiguration({
@@ -172,7 +181,9 @@ export function generateTestTrees(options: SharedTreeOptions) {
 			runScenario: async (takeSnapshot) => {
 				for (const index of [0, 1, 2, 3]) {
 					const sf = new SchemaFactory("competing-removes");
-					const provider = new TestTreeProviderLite(3, factory, true);
+					const provider = new TestTreeProviderLite(3, factory, true, {
+						flushMode: FlushMode.Immediate,
+					});
 					const view1 = provider.trees[0].viewWith(
 						new TreeViewConfiguration({
 							schema: [sf.array(sf.number)],
@@ -206,7 +217,9 @@ export function generateTestTrees(options: SharedTreeOptions) {
 			name: "concurrent-inserts",
 			runScenario: async (takeSnapshot) => {
 				const sf = new SchemaFactory("concurrent-inserts");
-				const provider = new TestTreeProviderLite(1, factory, true);
+				const provider = new TestTreeProviderLite(1, factory, true, {
+					flushMode: FlushMode.Immediate,
+				});
 				const tree1 = provider.trees[0];
 				const view1 = tree1.viewWith(
 					new TreeViewConfiguration({
@@ -265,7 +278,9 @@ export function generateTestTrees(options: SharedTreeOptions) {
 						StringArray,
 					]) {}
 
-					const provider = new TestTreeProviderLite(1, new TreeFactory(options), true);
+					const provider = new TestTreeProviderLite(1, new TreeFactory(options), true, {
+						flushMode: FlushMode.Immediate,
+					});
 					const tree = provider.trees[0];
 					const view = tree.viewWith(
 						new TreeViewConfiguration({
@@ -312,7 +327,9 @@ export function generateTestTrees(options: SharedTreeOptions) {
 			name: "has-handle",
 			runScenario: async (takeSnapshot) => {
 				const sf = new SchemaFactory("has-handle");
-				const provider = new TestTreeProviderLite(1, factory, true);
+				const provider = new TestTreeProviderLite(1, factory, true, {
+					flushMode: FlushMode.Immediate,
+				});
 				const tree = provider.trees[0];
 				const view = tree.viewWith(
 					new TreeViewConfiguration({
@@ -338,7 +355,9 @@ export function generateTestTrees(options: SharedTreeOptions) {
 				]) {}
 				class SequenceMap extends sf.mapRecursive("Recursive Map", [() => Array]) {}
 
-				const provider = new TestTreeProviderLite(1, factory, true);
+				const provider = new TestTreeProviderLite(1, factory, true, {
+					flushMode: FlushMode.Immediate,
+				});
 				const tree = provider.trees[0];
 				const view = tree.viewWith(
 					new TreeViewConfiguration({
@@ -368,7 +387,9 @@ export function generateTestTrees(options: SharedTreeOptions) {
 			name: "empty-root",
 			runScenario: async (takeSnapshot) => {
 				const sf = new SchemaFactory("test trees");
-				const provider = new TestTreeProviderLite(1, factory, true);
+				const provider = new TestTreeProviderLite(1, factory, true, {
+					flushMode: FlushMode.Immediate,
+				});
 				const tree = provider.trees[0];
 				const view = tree.viewWith(
 					new TreeViewConfiguration({

--- a/packages/runtime/container-runtime/src/test/fuzz/summarizerFuzzMocks.ts
+++ b/packages/runtime/container-runtime/src/test/fuzz/summarizerFuzzMocks.ts
@@ -63,10 +63,9 @@ export class MockContainerRuntimeFactoryForSummarizer extends MockContainerRunti
 	}
 }
 
-export interface IMockContainerRuntimeForSummarizerOptions
-	extends IMockContainerRuntimeOptions {
+export type IMockContainerRuntimeForSummarizerOptions = IMockContainerRuntimeOptions & {
 	summaryConfiguration?: ISummaryConfiguration;
-}
+};
 
 const DefaultSummaryConfiguration: ISummaryConfiguration = {
 	state: "disableHeuristics",
@@ -91,7 +90,7 @@ export class MockContainerRuntimeForSummarizer
 	constructor(
 		dataStoreRuntime: MockFluidDataStoreRuntime,
 		factory: MockContainerRuntimeFactoryForSummarizer,
-		runtimeOptions: IMockContainerRuntimeForSummarizerOptions = {},
+		runtimeOptions?: IMockContainerRuntimeForSummarizerOptions,
 	) {
 		// trackRemoteOps is needed for replaying all ops on creating new ContainerRuntime
 		super(dataStoreRuntime, factory, runtimeOptions, { trackRemoteOps: true });
@@ -106,7 +105,7 @@ export class MockContainerRuntimeForSummarizer
 
 		const summaryConfiguration: ISummaryConfiguration = {
 			...DefaultSummaryConfiguration,
-			...runtimeOptions.summaryConfiguration,
+			...runtimeOptions?.summaryConfiguration,
 		};
 
 		this.summarizer = new Summarizer(

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -7,16 +7,21 @@
 // @alpha (undocumented)
 export interface IInternalMockRuntimeMessage {
     // (undocumented)
+    clientSequenceNumber: number;
+    // (undocumented)
     content: any;
     // (undocumented)
     localOpMetadata?: unknown;
 }
 
 // @alpha
-export interface IMockContainerRuntimeOptions {
+export type IMockContainerRuntimeOptions = {
+    readonly flushMode: FlushMode.Immediate;
+} | {
+    readonly flushMode: FlushMode.TurnBased;
     readonly enableGroupedBatching?: boolean;
-    readonly flushMode?: FlushMode;
-}
+    readonly flushAutomatically?: boolean;
+};
 
 // @alpha (undocumented)
 export interface IMockContainerRuntimePendingMessage {
@@ -81,8 +86,8 @@ export class MockContainerRuntime extends TypedEventEmitter<IContainerRuntimeEve
     } | undefined;
     // (undocumented)
     protected readonly pendingMessages: IMockContainerRuntimePendingMessage[];
-    // (undocumented)
     process(message: ISequencedDocumentMessage): void;
+    processMessages(messages: ISequencedDocumentMessage[]): void;
     rebase(): void;
     // (undocumented)
     resolveHandle(handle: IFluidHandle): Promise<IResponse>;
@@ -112,6 +117,8 @@ export class MockContainerRuntimeFactory {
     processSomeMessages(count: number): void;
     // (undocumented)
     pushMessage(msg: Partial<ISequencedDocumentMessage>): void;
+    // (undocumented)
+    queueFlush(clientId: string, flush: () => void): void;
     // (undocumented)
     readonly quorum: MockQuorumClients;
     // (undocumented)
@@ -146,9 +153,11 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
     // (undocumented)
     protected readonly factory: MockContainerRuntimeFactoryForReconnection;
     // (undocumented)
+    flush(): void;
+    // (undocumented)
     initializeWithStashedOps(fromContainerRuntime: MockContainerRuntimeForReconnection): Promise<void>;
     // (undocumented)
-    process(message: ISequencedDocumentMessage): void;
+    processMessages(messages: ISequencedDocumentMessage[]): void;
     // (undocumented)
     protected setConnectedState(connected: boolean): void;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -19,8 +19,8 @@ export type IMockContainerRuntimeOptions = {
     readonly flushMode: FlushMode.Immediate;
 } | {
     readonly flushMode: FlushMode.TurnBased;
-    readonly enableGroupedBatching?: boolean;
     readonly flushAutomatically?: boolean;
+    readonly enableGroupedBatching?: boolean;
 };
 
 // @alpha (undocumented)
@@ -117,7 +117,6 @@ export class MockContainerRuntimeFactory {
     processSomeMessages(count: number): void;
     // (undocumented)
     pushMessage(msg: Partial<ISequencedDocumentMessage>): void;
-    // (undocumented)
     queueFlush(clientId: string, flush: () => void): void;
     // (undocumented)
     readonly quorum: MockQuorumClients;

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -86,6 +86,7 @@ export class MockContainerRuntime extends TypedEventEmitter<IContainerRuntimeEve
     } | undefined;
     // (undocumented)
     protected readonly pendingMessages: IMockContainerRuntimePendingMessage[];
+    // (undocumented)
     process(message: ISequencedDocumentMessage): void;
     processMessages(messages: ISequencedDocumentMessage[]): void;
     rebase(): void;

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -157,7 +157,29 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_MockContainerRuntime": {
+				"forwardCompat": false
+			},
+			"Class_MockContainerRuntimeFactory": {
+				"forwardCompat": false
+			},
+			"Class_MockContainerRuntimeFactoryForReconnection": {
+				"forwardCompat": false
+			},
+			"Class_MockContainerRuntimeForReconnection": {
+				"forwardCompat": false
+			},
+			"Class_MockFluidDataStoreRuntime": {
+				"forwardCompat": false
+			},
+			"Interface_IInternalMockRuntimeMessage": {
+				"forwardCompat": false
+			},
+			"Interface_IMockContainerRuntimeOptions": {
+				"forwardCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -40,6 +40,7 @@ declare type current_as_old_for_Class_MockAudience = requireAssignableTo<TypeOnl
  * typeValidation.broken:
  * "Class_MockContainerRuntime": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockContainerRuntime = requireAssignableTo<TypeOnly<old.MockContainerRuntime>, TypeOnly<current.MockContainerRuntime>>
 
 /*
@@ -58,6 +59,7 @@ declare type current_as_old_for_Class_MockContainerRuntime = requireAssignableTo
  * typeValidation.broken:
  * "Class_MockContainerRuntimeFactory": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockContainerRuntimeFactory = requireAssignableTo<TypeOnly<old.MockContainerRuntimeFactory>, TypeOnly<current.MockContainerRuntimeFactory>>
 
 /*
@@ -76,6 +78,7 @@ declare type current_as_old_for_Class_MockContainerRuntimeFactory = requireAssig
  * typeValidation.broken:
  * "Class_MockContainerRuntimeFactoryForReconnection": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockContainerRuntimeFactoryForReconnection = requireAssignableTo<TypeOnly<old.MockContainerRuntimeFactoryForReconnection>, TypeOnly<current.MockContainerRuntimeFactoryForReconnection>>
 
 /*
@@ -94,6 +97,7 @@ declare type current_as_old_for_Class_MockContainerRuntimeFactoryForReconnection
  * typeValidation.broken:
  * "Class_MockContainerRuntimeForReconnection": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockContainerRuntimeForReconnection = requireAssignableTo<TypeOnly<old.MockContainerRuntimeForReconnection>, TypeOnly<current.MockContainerRuntimeForReconnection>>
 
 /*
@@ -184,6 +188,7 @@ declare type current_as_old_for_Class_MockFluidDataStoreContext = requireAssigna
  * typeValidation.broken:
  * "Class_MockFluidDataStoreRuntime": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockFluidDataStoreRuntime = requireAssignableTo<TypeOnly<old.MockFluidDataStoreRuntime>, TypeOnly<current.MockFluidDataStoreRuntime>>
 
 /*
@@ -427,6 +432,7 @@ declare type current_as_old_for_ClassStatics_MockStorage = requireAssignableTo<T
  * typeValidation.broken:
  * "Interface_IInternalMockRuntimeMessage": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IInternalMockRuntimeMessage = requireAssignableTo<TypeOnly<old.IInternalMockRuntimeMessage>, TypeOnly<current.IInternalMockRuntimeMessage>>
 
 /*
@@ -445,6 +451,7 @@ declare type current_as_old_for_Interface_IInternalMockRuntimeMessage = requireA
  * typeValidation.broken:
  * "Interface_IMockContainerRuntimeOptions": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IMockContainerRuntimeOptions = requireAssignableTo<TypeOnly<old.IMockContainerRuntimeOptions>, TypeOnly<current.IMockContainerRuntimeOptions>>
 
 /*


### PR DESCRIPTION
The runtime mocks currently support TurnBased flush mode but it doesn't correctly cover all scenarios. This change updates the following in the mocks:
- Preserve the clientSequenceNumber assigned to the messages during submit so that it doesn't generate new ones during flush. Some tests rely on this to be the case.
- Mock assigning the same sequence number to all messages in a batch by taking the reference sequence number into account.
- Adds a `flushAutomatically` flag in TurnBased flush mode. When this is true, it tries to preserve the order in which messages sent by automatically flushing messages when another client starts sending messages. When this is false, the tests are responsible for flushing the messages manually. Some tests (dds fuzz tests for example) closely control when messages are flushed but most tests do not care about this.
- In TurnBased mode, when process is called on runtime factory, it stores the ops in an array and sends them together to the runtimes for processing. This doesn't do anything special yet but it will be updated to mock op bunching feature in a separate PR.
- Updates the type of `IMockContainerRuntimeOptions` to be stricter.
- In `MockContainerRuntimeForReconnection`, only flush messages if connected. 