### PR TITLE
Fix color contrast of text in code blocks

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -23,7 +23,7 @@
 	// Workaround for <https://github.com/easyops-cn/docusaurus-search-local/issues/336>
 	--ifm-navbar-search-input-icon: url("@site/static/assets/search-icon-light.svg");
 
-	//Text color for classes in code blocks
+	//Text color for classes in code blocks. Ref: https://prismjs.com/tokens.html
 	--ifm-attr-name-color: #345094;
 }
 

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -22,6 +22,9 @@
 
 	// Workaround for <https://github.com/easyops-cn/docusaurus-search-local/issues/336>
 	--ifm-navbar-search-input-icon: url("@site/static/assets/search-icon-light.svg");
+
+	//Text color for classes in code blocks
+	--ifm-attr-name-color: #345094;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -41,4 +44,11 @@
 
 	// Workaround for <https://github.com/easyops-cn/docusaurus-search-local/issues/336>
 	--ifm-navbar-search-input-icon: url("@site/static/assets/search-icon-dark.svg");
+
+	//Text color for classes in code blocks
+	--ifm-attr-name-color: #00b3e6;
+}
+
+.token.attr-name {
+	color: var(--ifm-attr-name-color) !important;
 }


### PR DESCRIPTION
## Description

This PR updates the color of the text in code blocks to improve the contrast ratio with the background, addressing accessibility issues.
#### Before
<img width="717" alt="Screenshot 2025-02-07 at 11 35 12 AM" src="https://github.com/user-attachments/assets/2cae0786-b2e4-4027-9e8e-69b2202692f7" />

#### After
<img width="748" alt="Screenshot 2025-02-07 at 11 36 17 AM" src="https://github.com/user-attachments/assets/26f035e0-ba18-4e9f-92c6-c2ceb2d33079" />

