### PR TITLE
fix: Make `pnpm i` work in Codespaces again

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,12 @@
 	// Invoke 'nvm' to install our preferred version of node, per the '.nvmrc' file
 	// located at the root of the ${workspaceFolder}.
 	// Also run corepack enable to allow node to download and use the right version of pnpm.
-	"postCreateCommand": ". /usr/local/share/nvm/nvm.sh; nvm install; corepack enable",
+	// `npm i -g corepack@latest;` and  `corepack prepare pnpm@latest --activate;` are necessary to get the latest
+	// version of corepack, which has a fix for https://github.com/nodejs/corepack/issues/612
+	// (related https://github.com/pnpm/pnpm/issues/9029), so it can install pnpm.
+	// Those two can probably go away once the devcontainer is using a version of Node which includes a version corepack
+	// with the fix.
+	"postCreateCommand": ". /usr/local/share/nvm/nvm.sh; nvm install; npm i -g corepack@latest; corepack prepare pnpm@latest --activate; corepack enable",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",


### PR DESCRIPTION
## Description

Makes it so the devContainer (used for Codespaces) runs a few extra commands when it gets created, to address https://github.com/nodejs/corepack/issues/612 / https://github.com/pnpm/pnpm/issues/9029 until we start using a version of Node that includes a fixed corepack.

Currently trying to do `pnpm i` in a fresh Codespaces fails like this:

```console
> pnpm i
/usr/local/share/nvm/versions/node/v18.20.6/lib/node_modules/corepack/dist/lib/corepack.cjs:21535
  if (key == null || signature == null) throw new Error(`Cannot find matching keyid: ${JSON.stringify({ signatures, keys })}`);
                                              ^

Error: Cannot find matching keyid: {"signatures":[{"sig":"MEYCIQDkZyZZmBzkRcQowEEFiEcGp4/xV8GBLXxTEzz9QstrsAIhAPx6tvZixjTub6GPqJa82vcWFhUU39JCtoJvcoRK/K39","keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U"}],"keys":[{"expires":null,"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="}]}
    at verifySignature (/usr/local/share/nvm/versions/node/v18.20.6/lib/node_modules/corepack/dist/lib/corepack.cjs:21535:47)
    at fetchLatestStableVersion (/usr/local/share/nvm/versions/node/v18.20.6/lib/node_modules/corepack/dist/lib/corepack.cjs:21553:5)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async fetchLatestStableVersion2 (/usr/local/share/nvm/versions/node/v18.20.6/lib/node_modules/corepack/dist/lib/corepack.cjs:21672:14)
    at async Engine.getDefaultVersion (/usr/local/share/nvm/versions/node/v18.20.6/lib/node_modules/corepack/dist/lib/corepack.cjs:22292:23)
    at async Engine.executePackageManagerRequest (/usr/local/share/nvm/versions/node/v18.20.6/lib/node_modules/corepack/dist/lib/corepack.cjs:22390:47)
    at async Object.runMain (/usr/local/share/nvm/versions/node/v18.20.6/lib/node_modules/corepack/dist/lib/corepack.cjs:23096:5)

Node.js v18.20.6
```
