### PR TITLE
bugfix(docs): Updated role and added underline to doc links

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -6,7 +6,7 @@
 
 /* You can override the default Infima variables here. */
 :root {
-	--ifm-color-primary: #3900bd;
+	--ifm-color-primary: #558cf4;
 	--ifm-color-primary-dark: #3300aa;
 	--ifm-color-primary-darker: #3000a1;
 	--ifm-color-primary-darkest: #280084;
@@ -52,3 +52,6 @@
 .token.attr-name {
 	color: var(--ifm-attr-name-color) !important;
 }
+.markdown a {
+	text-decoration: underline;
+  }

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -52,6 +52,8 @@
 .token.attr-name {
 	color: var(--ifm-attr-name-color) !important;
 }
+
+// Applies text-decoration to all links in markdown/MDX content
 .markdown a {
 	text-decoration: underline;
 }

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -54,4 +54,4 @@
 }
 .markdown a {
 	text-decoration: underline;
-  }
+}

--- a/docs/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/docs/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -134,7 +134,7 @@ export default function DocsVersionDropdownNavbarItem({
 				to={dropdownTo}
 				items={items}
 				aria-label="Select documentation version"
-				role="combobox"
+				role="menu"
 				aria-haspopup="listbox"
 			/>
 		</div>


### PR DESCRIPTION
## Description

This PR addresses some accessibility violations on the Fluid Framework website:

1. The doc version dropdown had the incorrect role of combobox;  updated to menu
2. The link text styling was too similar to the surrounding text.; updated to have underline.

Note 
As an alternative to text-decoration, I tried experimenting/searching for Fluid brand adjacent colours that would pass WCAG AA standards in light mode but was unable to find a colour that could complement surrounding #1c1e21 text colour and #FFF background colour.