### PR TITLE
build(build-tools): Fix syncpack config to account for new package

### DIFF
--- a/build-tools/syncpack.config.cjs
+++ b/build-tools/syncpack.config.cjs
@@ -101,6 +101,7 @@ module.exports = {
 				"Dependencies on other fluid packages within the workspace should use tilde dependency ranges",
 			dependencies: [
 				"@fluid-tools/build-cli",
+				"@fluid-tools/build-infrastructure",
 				"@fluid-tools/version-tools",
 				"@fluidframework/build-tools",
 				"@fluidframework/bundle-size-tools",


### PR DESCRIPTION
Updates the syncpack config to account for the new package in build-tools. This wasn't caught earlier because syncpack doesn't check workspace ranges.

This change targets the build-tools release branch because this bug blocks release of build-tools. #23829 is the main branch change.