### PR TITLE
minor fixes to consensusOrderedCollection

### DIFF
--- a/packages/dds/ordered-collection/api-report/ordered-collection.legacy.alpha.api.md
+++ b/packages/dds/ordered-collection/api-report/ordered-collection.legacy.alpha.api.md
@@ -29,6 +29,7 @@ export class ConsensusOrderedCollection<T = any> extends SharedObject<IConsensus
     protected release(acquireId: string): void;
     // (undocumented)
     protected releaseCore(acquireId: string): void;
+    size?(): number;
     // (undocumented)
     protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats;
     waitAndAcquire(callback: ConsensusCallback<T>): Promise<void>;
@@ -57,6 +58,7 @@ export enum ConsensusResult {
 export interface IConsensusOrderedCollection<T = any> extends ISharedObject<IConsensusOrderedCollectionEvents<T>> {
     acquire(callback: ConsensusCallback<T>): Promise<boolean>;
     add(value: T): Promise<void>;
+    size?(): number;
     waitAndAcquire(callback: ConsensusCallback<T>): Promise<void>;
 }
 

--- a/packages/dds/ordered-collection/src/interfaces.ts
+++ b/packages/dds/ordered-collection/src/interfaces.ts
@@ -125,6 +125,11 @@ export interface IConsensusOrderedCollection<T = any>
 	acquire(callback: ConsensusCallback<T>): Promise<boolean>;
 
 	/**
+	 * Return the size of the collection
+	 */
+	size?(): number;
+
+	/**
 	 * Wait for a value to be available and remove it from the consensus collection
 	 * Calls callback with retrieved value.
 	 */


### PR DESCRIPTION
Add size per customer request.

Stop sending `value` in add op since it has long been replaced by `deserializedValue` which is needed for GC. [AB#7149](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7149)