### PR TITLE
ci(server): Disable broken SBOM task

### DIFF
--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -148,10 +148,11 @@ extends:
       # Tentative workaround for the occasional Credscan failures
       credscan:
         batchSize: 4
-      # Temporarily disable SBOM task until the 1ES Container Security team addresses the problem
-      sbom:
-        enabled: false
-        justificationForDisabling: "'Container Security - SBOM' task 0.0.29597235 has issues and causes the pipeline to timeout"
+      # For routerlicious, temporarily disable SBOM task until the 1ES Container Security team addresses an outstanding problem
+      ${{ if (eq(parameters.tagName, "server")) }}:
+        sbom:
+          enabled: false
+          justificationForDisabling: "'Container Security - SBOM' task 0.0.29597235 has issues and causes the pipeline to timeout"
     # Skip tagging if Github PR coming from a fork;  This skips Microsoft security checks that won't work on forks.
     settings:
       skipBuildTagsForGitHubPullRequests: true

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -149,7 +149,7 @@ extends:
       credscan:
         batchSize: 4
       # For routerlicious, temporarily disable SBOM task until the 1ES Container Security team addresses an outstanding problem
-      ${{ if (eq(parameters.tagName, "server")) }}:
+      ${{ if eq(parameters.tagName, "server") }}:
         sbom:
           enabled: false
           justificationForDisabling: "'Container Security - SBOM' task 0.0.29597235 has issues and causes the pipeline to timeout"

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -148,6 +148,10 @@ extends:
       # Tentative workaround for the occasional Credscan failures
       credscan:
         batchSize: 4
+      # Temporarily disable SBOM task until the 1ES Container Security team addresses the problem
+      sbom:
+        enabled: false
+        justificationForDisabling: "'Container Security - SBOM' task 0.0.29597235 has issues and causes the pipeline to timeout"
     # Skip tagging if Github PR coming from a fork;  This skips Microsoft security checks that won't work on forks.
     settings:
       skipBuildTagsForGitHubPullRequests: true

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -149,7 +149,7 @@ extends:
       credscan:
         batchSize: 4
       # For routerlicious, temporarily disable SBOM task until the 1ES Container Security team addresses an outstanding problem
-      ${{ if eq(parameters.tagName, "server") }}:
+      ${{ if eq(parameters.tagName, 'server') }}:
         sbom:
           enabled: false
           justificationForDisabling: "'Container Security - SBOM' task 0.0.29597235 has issues and causes the pipeline to timeout"


### PR DESCRIPTION
## Description

A recent version of the "Container Security - SBOM" task introduced an issue that causes the pipeline to timeout. Temporarily disabling it while the owner team fixes it. Before breaking like that, this task already timed out every time, but letting the pipeline continue, so we're not really losing anything by disabling it at the moment.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).