### PR TITLE
ci: Add missing retries to dependency install steps

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -176,6 +176,7 @@ stages:
 
         - task: Bash@3
           displayName: Install dependencies
+          retryCountOnTaskFailure: 4
           inputs:
             targetType: 'inline'
             workingDirectory: $(Build.SourcesDirectory)/docs
@@ -299,6 +300,7 @@ stages:
 
         - task: Bash@3
           displayName: Install dependencies
+          retryCountOnTaskFailure: 4
           inputs:
             targetType: 'inline'
             workingDirectory: $(Build.SourcesDirectory)/docs

--- a/tools/pipelines/deploy-website.yml
+++ b/tools/pipelines/deploy-website.yml
@@ -120,6 +120,7 @@ stages:
 
         - task: Bash@3
           displayName: Install dependencies
+          retryCountOnTaskFailure: 4
           inputs:
             targetType: 'inline'
             workingDirectory: $(Build.SourcesDirectory)/docs
@@ -245,6 +246,7 @@ stages:
 
         - task: Bash@3
           displayName: Install dependencies
+          retryCountOnTaskFailure: 4
           inputs:
             targetType: 'inline'
             workingDirectory: $(Build.SourcesDirectory)/docs

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -291,6 +291,7 @@ extends:
         - ${{ if eq(parameters.setVersion, true) }}:
           - task: Bash@3
             displayName: Install dependencies
+            retryCountOnTaskFailure: 4
             inputs:
               targetType: 'inline'
               workingDirectory: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -21,6 +21,7 @@ steps:
 
   - task: Bash@3
     displayName: Install dependencies
+    retryCountOnTaskFailure: 4
     inputs:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/include-policy-check.yml
+++ b/tools/pipelines/templates/include-policy-check.yml
@@ -41,6 +41,7 @@ stages:
 
     - task: Bash@3
       displayName: Install dependencies
+      retryCountOnTaskFailure: 4
       inputs:
         targetType: 'inline'
         workingDirectory: ${{ parameters.buildDirectory }}


### PR DESCRIPTION
## Description

Adds retries to a few dependency install steps that didn't have it. This is a pattern we already follow in other places. It's especially relevant because in the internal ADO project we use an intermediate feed that mirrors npmjs and there can be some delay until that one sees public packages.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).