### PR TITLE
Logging more request metrics

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -63,6 +63,7 @@ export function create(
 	// Maximum REST request size
 	const requestSize = config.get("alfred:restJsonSize");
 	const enableLatencyMetric = config.get("alfred:enableLatencyMetric") ?? false;
+	const enableEventLoopLagMetric = config.get("alfred:enableEventLoopLagMetric") ?? false;
 	const httpServerConfig: IHttpServerConfig = config.get("system:httpServer");
 
 	// Express app configuration
@@ -147,6 +148,7 @@ export function create(
 					return additionalProperties;
 				},
 				enableLatencyMetric,
+				enableEventLoopLagMetric,
 			),
 		);
 	} else {

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -123,7 +123,8 @@
 		},
 		"getDeltasRequestMaxOpsRange": 2000,
 		"useNodeCluster": false,
-		"enableLatencyMetric": false
+		"enableLatencyMetric": false,
+		"enableEventLoopLagMetric": false
 	},
 	"riddler": {
 		"useNodeCluster": false

--- a/server/routerlicious/packages/services-telemetry/src/resources.ts
+++ b/server/routerlicious/packages/services-telemetry/src/resources.ts
@@ -71,6 +71,8 @@ export enum HttpProperties {
 	status = "status",
 	url = "url",
 	retryCount = "retryCount",
+	scheme = "scheme",
+	httpVersion = "httpVersion",
 }
 
 /**

--- a/server/routerlicious/packages/services-utils/src/morganLoggerMiddleware.ts
+++ b/server/routerlicious/packages/services-utils/src/morganLoggerMiddleware.ts
@@ -65,9 +65,6 @@ function getEventLoopMetrics(histogram: IntervalHistogram) {
 		max: (histogram.max / 1e6).toFixed(3),
 		min: (histogram.min / 1e6).toFixed(3),
 		mean: (histogram.mean / 1e6).toFixed(3),
-		p50: (histogram.percentile(0.5) / 1e6).toFixed(3),
-		p95: (histogram.percentile(0.95) / 1e6).toFixed(3),
-		p99: (histogram.percentile(0.99) / 1e6).toFixed(3),
 	};
 }
 
@@ -82,7 +79,7 @@ export function jsonMorganLoggerMiddleware(
 		res: express.Response,
 	) => Record<string, any>,
 	enableLatencyMetric: boolean = false,
-	enableEventLoopLagMetric: boolean = false,
+	enableEventLoopLagMetric: boolean = false, // This metric has performance overhead, so it should be enabled with caution.
 ): express.RequestHandler {
 	return (request, response, next): void => {
 		response.locals.clientDisconnected = false;

--- a/server/routerlicious/packages/services-utils/src/morganLoggerMiddleware.ts
+++ b/server/routerlicious/packages/services-utils/src/morganLoggerMiddleware.ts
@@ -60,14 +60,14 @@ interface IResponseLatency {
 	closeTime: number;
 }
 
-function getEventLoopMetrics(historian: IntervalHistogram) {
+function getEventLoopMetrics(histogram: IntervalHistogram) {
 	return {
-		max: (historian.max / 1e6).toFixed(3),
-		min: (historian.min / 1e6).toFixed(3),
-		mean: (historian.mean / 1e6).toFixed(3),
-		p50: (historian.percentile(0.5) / 1e6).toFixed(3),
-		p95: (historian.percentile(0.95) / 1e6).toFixed(3),
-		p99: (historian.percentile(0.99) / 1e6).toFixed(3),
+		max: (histogram.max / 1e6).toFixed(3),
+		min: (histogram.min / 1e6).toFixed(3),
+		mean: (histogram.mean / 1e6).toFixed(3),
+		p50: (histogram.percentile(0.5) / 1e6).toFixed(3),
+		p95: (histogram.percentile(0.95) / 1e6).toFixed(3),
+		p99: (histogram.percentile(0.99) / 1e6).toFixed(3),
 	};
 }
 

--- a/server/routerlicious/packages/services-utils/src/morganLoggerMiddleware.ts
+++ b/server/routerlicious/packages/services-utils/src/morganLoggerMiddleware.ts
@@ -33,6 +33,9 @@ export function alternativeMorganLoggerMiddleware(loggerFormat: string) {
 	return morgan(loggerFormat, { stream });
 }
 
+morgan.token("http-version", (req: express.Request, res: express.Response) => req.httpVersion);
+morgan.token("scheme", (req: express.Request, res: express.Response) => req.protocol);
+
 /**
  * @internal
  */
@@ -146,6 +149,8 @@ export function jsonMorganLoggerMiddleware(
 				[HttpProperties.requestContentLength]: tokens.req(req, res, "content-length"),
 				[HttpProperties.responseContentLength]: tokens.res(req, res, "content-length"),
 				[HttpProperties.responseTime]: tokens["response-time"](req, res),
+				[HttpProperties.httpVersion]: tokens["http-version"](req, res),
+				[HttpProperties.scheme]: tokens.scheme(req, res),
 				[BaseTelemetryProperties.correlationId]: getTelemetryContextPropertiesWithHttpInfo(
 					req,
 					res,


### PR DESCRIPTION
## Description

This PR adds logging of the following HTTP metrics:

1) HTTP version
2) HTTP scheme (HTTP/HTTPS)

It also adds a config to enable logging event loop delays in Alfred. 
