### PR TITLE
(op bunching) Added logic to process messages in a bunch in SharedObject

### DIFF
--- a/.changeset/itchy-pants-brake.md
+++ b/.changeset/itchy-pants-brake.md
@@ -1,0 +1,14 @@
+---
+"@fluidframework/shared-object-base": minor
+---
+---
+"section": other
+---
+
+Change when the `pre-op` and `op` events on `ISharedObjectEvents` are emitted
+
+Previous behavior - `pre-op` was emitted immediately before an op was processed. Then the op was processed and `op` was emitted immediately after that.
+
+New behavior - `pre-op` will still be emitted before an op is processed and `op` will still be emitted after an op is processed. However, these won't be immediate and other ops in a batch for the shared object may be processed in between.
+
+Note that these events are for internal use only as mentioned in the @remarks section of their definition.

--- a/.changeset/witty-falcons-wonder.md
+++ b/.changeset/witty-falcons-wonder.md
@@ -1,0 +1,12 @@
+---
+"@fluidframework/shared-object-base": minor
+---
+---
+"section": deprecation
+---
+
+The function `processCore` on `SharedObject` and `SharedObjectCore` is now deprecated
+
+A new function `processMessagesCore` has been added in its place which will be called to process multiple messages instead of a single one on the channel. This is part of a feature called "Op bunching" where contiguous ops in a grouped batch are bunched and processed together by the shared object.
+
+Implementations of `SharedObject` and `SharedObjectCore` must now also implement `processMessagesCore`. A basic implementation could be to iterate over the messages content and process them one by one as it happens now. Note that some DDS may be able to optimize processing by processing the messages together.

--- a/.changeset/witty-falcons-wonder.md
+++ b/.changeset/witty-falcons-wonder.md
@@ -5,8 +5,8 @@
 "section": deprecation
 ---
 
-The function `processCore` on `SharedObject` and `SharedObjectCore` is now deprecated
+Deprecate `processCore` on `SharedObject` and `SharedObjectCore` in favor of `processMessagesCore`
 
-A new function `processMessagesCore` has been added in its place which will be called to process multiple messages instead of a single one on the channel. This is part of a feature called "Op bunching" where contiguous ops in a grouped batch are bunched and processed together by the shared object.
+A new function `processMessagesCore` has been added in place of `processCore`, which will be called to process multiple messages instead of a single one on the channel. This is part of a feature called "Op bunching" where contiguous ops in a grouped batch are bunched and processed together by the shared object.
 
-Implementations of `SharedObject` and `SharedObjectCore` must now also implement `processMessagesCore`. A basic implementation could be to iterate over the messages content and process them one by one as it happens now. Note that some DDS may be able to optimize processing by processing the messages together.
+Implementations of `SharedObject` and `SharedObjectCore` must now also implement `processMessagesCore`. A basic implementation could be to iterate over the messages' content and process them one by one as it happens now. Note that some DDS may be able to optimize processing by processing the messages together.

--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
@@ -78,7 +78,9 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     protected newAckBasedPromise<T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: unknown) => void) => void): Promise<T>;
     protected onConnect(): void;
     protected abstract onDisconnect(): void;
+    // @deprecated
     protected abstract processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
+    protected processMessagesCore?(messagesCollection: IRuntimeMessageCollection): void;
     protected reSubmitCore(content: unknown, localOpMetadata: unknown): void;
     protected rollback(content: unknown, localOpMetadata: unknown): void;
     // (undocumented)

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -399,7 +399,7 @@ export abstract class SharedObjectCore<
 	 * Process a 'bunch' of messages for this shared object.
 	 *
 	 * @remarks
-	 * A 'bunch is group of messages that have the following properties:
+	 * A 'bunch' is a group of messages that have the following properties:
 	 * - They are all part of the same grouped batch, which entails:
 	 *   - They are contiguous in sequencing order.
 	 *   - They are all from the same client.

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -386,7 +386,7 @@ export abstract class SharedObjectCore<
 	 * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
 	 * For messages from a remote client, this will be undefined.
 	 *
-	 * @deprecated - Replaced by processMessagesCore.
+	 * @deprecated Replaced by {@link SharedObjectCore.processMessagesCore}.
 	 */
 	protected abstract processCore(
 		message: ISequencedDocumentMessage,
@@ -580,7 +580,7 @@ export abstract class SharedObjectCore<
 	 * @param localOpMetadata - For local client messages, this is the metadata that was submitted with the message.
 	 * For messages from a remote client, this will be undefined.
 	 *
-	 * @deprecated - Replaced by processMessages.
+	 * @deprecated Replaced by {@link SharedObjectCore.processMessages}.
 	 */
 	private process(
 		message: ISequencedDocumentMessage,

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -165,18 +165,14 @@ export abstract class SharedObjectCore<
 		this.processMessagesHelper =
 			this.processMessagesCore === undefined
 				? (messagesCollection: IRuntimeMessageCollection) =>
-						processCoreHelper(messagesCollection, this.processCore.bind(this))
+						processHelper(messagesCollection, this.process.bind(this))
 				: (messagesCollection: IRuntimeMessageCollection) => {
-						// This assert is needed to work around the compilation error that this.processMessagesCore could be undefined.
-						assert(
-							this.processMessagesCore !== undefined,
-							"processMessagesCore should be defined",
-						);
 						processMessagesCoreHelper(
 							messagesCollection,
 							this.opProcessingHelper,
 							this.emitInternal.bind(this),
-							this.processMessagesCore.bind(this),
+							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+							this.processMessagesCore!.bind(this),
 						);
 					};
 	}
@@ -1014,7 +1010,7 @@ function isChannel(loadable: IFluidLoadable): loadable is IChannel {
 }
 
 /**
- * Utility that processes the given messages in the message collection together by calling processMessagesCore.
+ * Utility that processes the given messages in the message collection together by calling `processMessagesCore`.
  * This will be called when {@link SharedObjectCore.processMessagesCore} is defined.
  */
 function processMessagesCoreHelper(
@@ -1060,12 +1056,12 @@ function processMessagesCoreHelper(
 }
 
 /**
- * Utility that processes the given messages in the message collection one by one by calling processCore. This will
+ * Utility that processes the given messages in the message collection one by one by calling `process`. This will
  * be called when {@link SharedObjectCore.processMessagesCore} is not defined.
  */
-function processCoreHelper(
+function processHelper(
 	messagesCollection: IRuntimeMessageCollection,
-	processCore: (
+	process: (
 		message: ISequencedDocumentMessage,
 		local: boolean,
 		localOpMetadata: unknown,
@@ -1073,7 +1069,7 @@ function processCoreHelper(
 ): void {
 	const { envelope, local, messagesContent } = messagesCollection;
 	for (const { contents, localOpMetadata, clientSequenceNumber } of messagesContent) {
-		processCore(
+		process(
 			{
 				...envelope,
 				contents,

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -162,8 +162,10 @@ export abstract class SharedObjectCore<
 		const { opProcessingHelper, callbacksHelper } = this.setUpSampledTelemetryHelpers();
 		this.opProcessingHelper = opProcessingHelper;
 		this.callbacksHelper = callbacksHelper;
+
+		const processMessagesCore = this.processMessagesCore?.bind(this);
 		this.processMessagesHelper =
-			this.processMessagesCore === undefined
+			processMessagesCore === undefined
 				? (messagesCollection: IRuntimeMessageCollection) =>
 						processHelper(messagesCollection, this.process.bind(this))
 				: (messagesCollection: IRuntimeMessageCollection) => {
@@ -171,8 +173,7 @@ export abstract class SharedObjectCore<
 							messagesCollection,
 							this.opProcessingHelper,
 							this.emitInternal.bind(this),
-							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-							this.processMessagesCore!.bind(this),
+							processMessagesCore,
 						);
 					};
 	}


### PR DESCRIPTION
This PR adds support for DDSes to process a 'bunch' of messages. Op bunching was added via the following PRs:
https://github.com/microsoft/FluidFramework/pull/22839, https://github.com/microsoft/FluidFramework/pull/22840 and https://github.com/microsoft/FluidFramework/pull/22841.

Added a `processMessagesCore` function to `SharedObjectCore` that DDSes can override to process a message bunch. This is marked optional today because it's a breaking change. It is similar to the `processCore` function and will replace it eventually. For now, `processCore` has been marked as deprecated.

This change updates the relative ordering of the `pre-op` and `op` events emitted by the shared object. Previously, the `pre-op` event would be emitted before a message was processed and `op` event was emitted immediately afterwards. With this change, the ordering of these events w.r.t. to the message being processed is still the same. However, there may be other ops processed and other event fired in between.
Note that the only guarantee these events provide is that the `pre-op` event is emitted before a message is procesed and the `op` event is processed after. So, this change doesn't break that guarantee.

