### PR TITLE
fix(check:policy): Correct calculation of repo root

### DIFF
--- a/build-tools/packages/build-cli/src/commands/check/policy.ts
+++ b/build-tools/packages/build-cli/src/commands/check/policy.ts
@@ -335,7 +335,9 @@ export class CheckPolicy extends BaseCommand<typeof CheckPolicy> {
 		try {
 			await this.routeToHandlers(filePath, commandContext);
 		} catch (error: unknown) {
-			throw new Error(`Error routing ${filePath} to handler: ${error}`);
+			throw new Error(
+				`Error routing ${filePath} to handler: ${error}Stack: ${(error as Error).stack}`,
+			);
 		}
 
 		this.processed++;

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
@@ -5,27 +5,25 @@
 
 /* eslint-disable prefer-object-has-own */
 
-import * as child_process from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import { EOL as newline } from "node:os";
 import path from "node:path";
-import { writeJson } from "fs-extra/esm";
-import JSON5 from "json5";
-import replace from "replace-in-file";
-import sortPackageJson from "sort-package-json";
-
+import { findGitRootSync } from "@fluid-tools/build-infrastructure";
 import {
 	PackageJson,
 	getApiExtractorConfigFilePath,
 	updatePackageJsonFile,
 	updatePackageJsonFileAsync,
 } from "@fluidframework/build-tools";
+import { writeJson } from "fs-extra/esm";
+import JSON5 from "json5";
+import replace from "replace-in-file";
+import sortPackageJson from "sort-package-json";
+import { PackageNamePolicyConfig, ScriptRequirement, getFlubConfig } from "../../config.js";
 import { Repository } from "../git.js";
 import { queryTypesResolutionPathsFromPackageExports } from "../packageExports.js";
 import { Handler, readFile, writeFile } from "./common.js";
-
-import { PackageNamePolicyConfig, ScriptRequirement, getFlubConfig } from "../../config.js";
 
 const require = createRequire(import.meta.url);
 
@@ -360,10 +358,8 @@ async function ensurePrivatePackagesComputed(): Promise<Set<string>> {
 	}
 
 	computedPrivatePackages = new Set();
-	const pathToGitRoot = child_process
-		.execSync("git rev-parse --show-cdup", { encoding: "utf8" })
-		.trim();
-	const repo = new Repository({ baseDir: pathToGitRoot }, "microsoft/FluidFramework");
+	const baseDir = findGitRootSync();
+	const repo = new Repository({ baseDir }, "microsoft/FluidFramework");
 	const packageJsons = await repo.getFiles("**/package.json");
 
 	for (const filePath of packageJsons) {


### PR DESCRIPTION
The npm-private-packages policy was incorrectly calculating the repo root. It was calculating the relative path to the root, then treating that relative path at the full path to the root.

This bug is preventing bumping the client to version 0.52 of build-tools.

The bug was introduced in the refactoring in #22695.