### PR TITLE
improvement(build-tools): Remove duplicate json functions

### DIFF
--- a/build-tools/packages/build-cli/src/commands/modify/lockfile.ts
+++ b/build-tools/packages/build-cli/src/commands/modify/lockfile.ts
@@ -3,10 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { updatePackageJsonFile } from "@fluidframework/build-tools";
+import { updatePackageJsonFile } from "@fluid-tools/build-infrastructure";
 import { Flags } from "@oclif/core";
 import execa from "execa";
-
 import { findPackageOrReleaseGroup, packageOrReleaseGroupArg } from "../../args.js";
 import { BaseCommand } from "../../library/index.js";
 

--- a/build-tools/packages/build-cli/src/commands/release/setPackageTypesField.ts
+++ b/build-tools/packages/build-cli/src/commands/release/setPackageTypesField.ts
@@ -5,7 +5,8 @@
 
 import { strict as assert } from "node:assert";
 import path from "node:path";
-import { Package, PackageJson, updatePackageJsonFile } from "@fluidframework/build-tools";
+import { updatePackageJsonFile } from "@fluid-tools/build-infrastructure";
+import { Package, PackageJson } from "@fluidframework/build-tools";
 import { ExtractorConfig } from "@microsoft/api-extractor";
 import { Flags } from "@oclif/core";
 import { PackageCommand } from "../../BasePackageCommand.js";

--- a/build-tools/packages/build-cli/src/commands/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/typetests.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { Package, updatePackageJsonFile } from "@fluidframework/build-tools";
+import { updatePackageJsonFile } from "@fluid-tools/build-infrastructure";
+import { Package } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
-
 import { PackageCommand } from "../BasePackageCommand.js";
 import type { PackageSelectionDefault } from "../flags.js";
 import {

--- a/build-tools/packages/build-cli/src/library/package.ts
+++ b/build-tools/packages/build-cli/src/library/package.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "node:assert";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { updatePackageJsonFile } from "@fluid-tools/build-infrastructure";
 import {
 	InterdependencyRange,
 	ReleaseVersion,
@@ -28,8 +29,6 @@ import ncu from "npm-check-updates";
 import type { Index } from "npm-check-updates/build/src/types/IndexType.js";
 import type { VersionSpec } from "npm-check-updates/build/src/types/VersionSpec.js";
 import * as semver from "semver";
-
-import { updatePackageJsonFile } from "@fluid-tools/build-infrastructure";
 import type { TsConfigJson } from "type-fest";
 import {
 	AllPackagesSelectionCriteria,

--- a/build-tools/packages/build-cli/src/library/package.ts
+++ b/build-tools/packages/build-cli/src/library/package.ts
@@ -17,13 +17,7 @@ import {
 	isRangeOperator,
 	isWorkspaceRange,
 } from "@fluid-tools/version-tools";
-import {
-	Logger,
-	MonoRepo,
-	Package,
-	type PackageJson,
-	updatePackageJsonFile,
-} from "@fluidframework/build-tools";
+import { Logger, MonoRepo, Package, type PackageJson } from "@fluidframework/build-tools";
 import { PackageName } from "@rushstack/node-core-library";
 import { compareDesc, differenceInBusinessDays } from "date-fns";
 import execa from "execa";
@@ -35,6 +29,7 @@ import type { Index } from "npm-check-updates/build/src/types/IndexType.js";
 import type { VersionSpec } from "npm-check-updates/build/src/types/VersionSpec.js";
 import * as semver from "semver";
 
+import { updatePackageJsonFile } from "@fluid-tools/build-infrastructure";
 import type { TsConfigJson } from "type-fest";
 import {
 	AllPackagesSelectionCriteria,

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
@@ -7,6 +7,10 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import {
+	updatePackageJsonFile,
+	updatePackageJsonFileAsync,
+} from "@fluid-tools/build-infrastructure";
+import {
 	FluidRepo,
 	Package,
 	PackageJson,
@@ -15,8 +19,6 @@ import {
 	getFluidBuildConfig,
 	getTaskDefinitions,
 	normalizeGlobalTaskDefinitions,
-	updatePackageJsonFile,
-	updatePackageJsonFileAsync,
 } from "@fluidframework/build-tools";
 import JSON5 from "json5";
 import * as semver from "semver";

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
@@ -10,22 +10,19 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import { EOL as newline } from "node:os";
 import path from "node:path";
+import {
+	updatePackageJsonFile,
+	updatePackageJsonFileAsync,
+} from "@fluid-tools/build-infrastructure";
+import { PackageJson, getApiExtractorConfigFilePath } from "@fluidframework/build-tools";
 import { writeJson } from "fs-extra/esm";
 import JSON5 from "json5";
 import replace from "replace-in-file";
 import sortPackageJson from "sort-package-json";
-
-import {
-	PackageJson,
-	getApiExtractorConfigFilePath,
-	updatePackageJsonFile,
-	updatePackageJsonFileAsync,
-} from "@fluidframework/build-tools";
+import { PackageNamePolicyConfig, ScriptRequirement, getFlubConfig } from "../../config.js";
 import { Repository } from "../git.js";
 import { queryTypesResolutionPathsFromPackageExports } from "../packageExports.js";
 import { Handler, readFile, writeFile } from "./common.js";
-
-import { PackageNamePolicyConfig, ScriptRequirement, getFlubConfig } from "../../config.js";
 
 const require = createRequire(import.meta.url);
 

--- a/build-tools/packages/build-cli/src/test/dirname.cts
+++ b/build-tools/packages/build-cli/src/test/dirname.cts
@@ -10,5 +10,4 @@
 //   - Export '__dirname' from a .cjs file in the same directory.
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
-// eslint-disable-next-line unicorn/prefer-module -- this is used for ESM/CJS interop
 export const _dirname = __dirname;

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -495,38 +495,6 @@ export class Packages {
 }
 
 /**
- * Reads the contents of package.json, applies a transform function to it, then writes the results back to the source
- * file.
- *
- * @param packagePath - A path to a package.json file or a folder containing one. If the path is a directory, the
- * package.json from that directory will be used.
- * @param packageTransformer - A function that will be executed on the package.json contents before writing it
- * back to the file.
- *
- * @remarks
- *
- * The package.json is always sorted using sort-package-json.
- *
- * @internal
- *
- * @deprecated Should not be used outside the build-tools package.
- */
-export function updatePackageJsonFile(
-	packagePath: string,
-	packageTransformer: (json: PackageJson) => void,
-): void {
-	packagePath = packagePath.endsWith("package.json")
-		? packagePath
-		: path.join(packagePath, "package.json");
-	const [pkgJson, indent] = readPackageJsonAndIndent(packagePath);
-
-	// Transform the package.json
-	packageTransformer(pkgJson);
-
-	writePackageJson(packagePath, pkgJson, indent);
-}
-
-/**
  * Reads a package.json file from a path, detects its indentation, and returns both the JSON as an object and
  * indentation.
  *
@@ -548,49 +516,4 @@ export function readPackageJsonAndIndent(
  */
 function writePackageJson(packagePath: string, pkgJson: PackageJson, indent: string) {
 	return writeJsonSync(packagePath, sortPackageJson(pkgJson), { spaces: indent });
-}
-
-/**
- * Reads the contents of package.json, applies a transform function to it, then writes
- * the results back to the source file.
- *
- * @param packagePath - A path to a package.json file or a folder containing one. If the
- * path is a directory, the package.json from that directory will be used.
- * @param packageTransformer - A function that will be executed on the package.json
- * contents before writing it back to the file.
- *
- * @remarks
- * The package.json is always sorted using sort-package-json.
- *
- * @internal
- *
- * @deprecated Should not be used outside the build-tools package.
- */
-export async function updatePackageJsonFileAsync(
-	packagePath: string,
-	packageTransformer: (json: PackageJson) => Promise<void>,
-): Promise<void> {
-	packagePath = packagePath.endsWith("package.json")
-		? packagePath
-		: path.join(packagePath, "package.json");
-	const [pkgJson, indent] = await readPackageJsonAndIndentAsync(packagePath);
-
-	// Transform the package.json
-	await packageTransformer(pkgJson);
-
-	await writeJson(packagePath, sortPackageJson(pkgJson), { spaces: indent });
-}
-
-/**
- * Reads a package.json file from a path, detects its indentation, and returns both the JSON as an object and
- * indentation.
- */
-async function readPackageJsonAndIndentAsync(
-	pathToJson: string,
-): Promise<[json: PackageJson, indent: string]> {
-	return readFile(pathToJson, { encoding: "utf8" }).then((contents) => {
-		const indentation = detectIndent(contents).indent || "\t";
-		const pkgJson: PackageJson = JSON.parse(contents);
-		return [pkgJson, indentation];
-	});
 }

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -7,7 +7,7 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import * as path from "node:path";
 import { queue } from "async";
 import detectIndent from "detect-indent";
-import { readJsonSync, writeJson, writeJsonSync } from "fs-extra";
+import { readJsonSync, writeJsonSync } from "fs-extra";
 import chalk from "picocolors";
 import sortPackageJson from "sort-package-json";
 
@@ -25,7 +25,6 @@ import {
 	rimrafWithErrorAsync,
 } from "./utils";
 
-import { readFile } from "node:fs/promises";
 import registerDebug from "debug";
 const traceInit = registerDebug("fluid-build:init");
 

--- a/build-tools/packages/build-tools/src/index.ts
+++ b/build-tools/packages/build-tools/src/index.ts
@@ -12,8 +12,6 @@ export { MonoRepo } from "./common/monoRepo";
 export {
 	Package,
 	type PackageJson,
-	updatePackageJsonFile,
-	updatePackageJsonFileAsync,
 } from "./common/npmPackage";
 
 // For repo policy check

--- a/build-tools/packages/build-tools/src/test/npmPackage.test.ts
+++ b/build-tools/packages/build-tools/src/test/npmPackage.test.ts
@@ -6,11 +6,7 @@
 import { strict as assert } from "assert";
 import * as path from "node:path";
 
-import {
-	PackageJson,
-	readPackageJsonAndIndent,
-	updatePackageJsonFile,
-} from "../common/npmPackage";
+import { PackageJson, readPackageJsonAndIndent } from "../common/npmPackage";
 import { testDataPath } from "./init";
 
 /**
@@ -34,24 +30,6 @@ describe("readPackageJsonAndIndent", () => {
 		const testFile = path.resolve(testDataPath, "tabs/_package.json");
 		const [, indent] = readPackageJsonAndIndent(testFile);
 		const expectedIndent = "\t";
-		assert.strictEqual(indent, expectedIndent);
-	});
-});
-
-describe("updatePackageJsonFile", () => {
-	it("outputs file with spaces", () => {
-		const testFile = path.resolve(testDataPath, "spaces/_package.json");
-		const expectedIndent = "  ";
-		updatePackageJsonFile(testFile, testTransformer);
-		const [, indent] = readPackageJsonAndIndent(testFile);
-		assert.strictEqual(indent, expectedIndent);
-	});
-
-	it("outputs file with tabs", () => {
-		const testFile = path.resolve(testDataPath, "tabs/_package.json");
-		const expectedIndent = "\t";
-		updatePackageJsonFile(testFile, testTransformer);
-		const [, indent] = readPackageJsonAndIndent(testFile);
 		assert.strictEqual(indent, expectedIndent);
 	});
 });


### PR DESCRIPTION
Removes the deprecated `updatePackageJsonFile` and `updatePackageJsonFileAsync` functions from the build-tools package and replaces them with the versions in build-infra.