### PR TITLE
Fix Signal Notifications API using @socket.io/redis-emitter to Broadcast Signals

### DIFF
--- a/server/routerlicious/.changeset/sharp-tables-love.md
+++ b/server/routerlicious/.changeset/sharp-tables-love.md
@@ -1,0 +1,17 @@
+---
+"@fluidframework/server-routerlicious-base": major
+---
+
+Fix Signal Notifications API replacing `TypedEventEmitter` with `@socket.io/redis-emitter`.
+
+Some breaking changes were introduced by replacing `TypedEventEmitter` with `@socket.io/redis-emitter` (`RedisEmitter`). All of the changes modfify the signature of existing functions, used to create Alfred instances. The type of `collaborationSessionEventEmitter` was changed from `TypedEventEmitter` to `RedisEmitter`.
+
+Here is a list of the changes:
+
+- Modified type `collaborationSessionEventEmitter` from `TypedEventEmitter` to `RedisEmitter` in Alfred. This parameter was modified in the following functions:
+  - `create` in `server/routerlicious/packages/routerlicious-base/src/alfred/app.ts`
+  - `create` in `server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts`
+  - `create` in `server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts`
+  - `create` in `server/routerlicious/packages/routerlicious-base/src/alfred/routes/index.ts`
+  - `AlfredRunner` constructor in `server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts`
+  - `AlfredResources` constructor in `server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts`

--- a/server/routerlicious/packages/lambdas/src/index.ts
+++ b/server/routerlicious/packages/lambdas/src/index.ts
@@ -41,6 +41,7 @@ export {
 	createRoomJoinMessage,
 	createRoomLeaveMessage,
 	createSessionMetric,
+	createRuntimeMessage,
 	generateClientId,
 	isDocumentSessionValid,
 	isDocumentValid,

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -67,6 +67,7 @@
 		"@fluidframework/server-services-shared": "workspace:~",
 		"@fluidframework/server-services-telemetry": "workspace:~",
 		"@fluidframework/server-services-utils": "workspace:~",
+		"@socket.io/redis-emitter": "^4.1.1",
 		"body-parser": "^1.20.3",
 		"bytes": "^3.0.0",
 		"compression": "^1.7.2",

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -19,14 +19,13 @@ import {
 	IReadinessCheck,
 	type IDenyList,
 } from "@fluidframework/server-services-core";
-import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { ICollaborationSessionEvents } from "@fluidframework/server-lambdas";
 import { json, urlencoded } from "body-parser";
 import compression from "compression";
 import cookieParser from "cookie-parser";
 import express from "express";
 import shajs from "sha.js";
 import { Provider } from "nconf";
+import type { Emitter as RedisEmitter } from "@socket.io/redis-emitter";
 import { DriverVersionHeaderName, IAlfredTenant } from "@fluidframework/server-services-client";
 import {
 	alternativeMorganLoggerMiddleware,
@@ -55,7 +54,7 @@ export function create(
 	startupCheck: IReadinessCheck,
 	tokenRevocationManager?: ITokenRevocationManager,
 	revokedTokenChecker?: IRevokedTokenChecker,
-	collaborationSessionEventEmitter?: TypedEventEmitter<ICollaborationSessionEvents>,
+	collaborationSessionEventEmitter?: RedisEmitter,
 	clusterDrainingChecker?: IClusterDrainingChecker,
 	enableClientIPLogging?: boolean,
 	readinessCheck?: IReadinessCheck,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -3,16 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import { fromUtf8ToBase64, TypedEventEmitter } from "@fluidframework/common-utils";
+import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 import * as git from "@fluidframework/gitresources";
 import { IClient, IClientJoin, ScopeType } from "@fluidframework/protocol-definitions";
 import {
-	IBroadcastSignalEventPayload,
-	ICollaborationSessionEvents,
 	IRoom,
 	IRuntimeSignalEnvelope,
+	createRuntimeMessage,
 } from "@fluidframework/server-lambdas";
-import { BasicRestWrapper } from "@fluidframework/server-services-client";
+import { BasicRestWrapper, NetworkError } from "@fluidframework/server-services-client";
 import * as core from "@fluidframework/server-services-core";
 import {
 	throttle,
@@ -30,11 +29,12 @@ import {
 	getLumberBaseProperties,
 	getGlobalTelemetryContext,
 } from "@fluidframework/server-services-telemetry";
-import { Request, Router } from "express";
+import { Request, Router, Response } from "express";
 import sillyname from "sillyname";
 import { Provider } from "nconf";
 import winston from "winston";
 import { v4 as uuid } from "uuid";
+import type { Emitter as RedisEmitter } from "@socket.io/redis-emitter";
 import { Constants } from "../../../utils";
 import {
 	craftClientJoinMessage,
@@ -53,7 +53,7 @@ export function create(
 	tenantThrottlers: Map<string, core.IThrottler>,
 	jwtTokenCache?: core.ICache,
 	revokedTokenChecker?: core.IRevokedTokenChecker,
-	collaborationSessionEventEmitter?: TypedEventEmitter<ICollaborationSessionEvents>,
+	collaborationSessionEventEmitter?: RedisEmitter,
 	fluidAccessTokenGenerator?: core.IFluidAccessTokenGenerator,
 	denyList?: core.IDenyList,
 ): Router {
@@ -181,33 +181,30 @@ export function create(
 		denyListMiddleware(denyList),
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		async (request, response) => {
-			const tenantId = request.params.tenantId;
-			const documentId = request.params.id;
-			const signalContent = request?.body?.signalContent;
-			if (!isValidSignalEnvelope(signalContent)) {
-				response
-					.status(400)
-					.send(
-						`signalContent should contain 'contents.content' and 'contents.type' keys.`,
-					);
-				return;
-			}
-			if (!collaborationSessionEventEmitter) {
-				response
-					.status(500)
-					.send(`No emitter configured for the broadcast-signal endpoint.`);
-				return;
-			}
-			try {
-				const signalRoom: IRoom = { tenantId, documentId };
-				const payload: IBroadcastSignalEventPayload = { signalRoom, signalContent };
-				collaborationSessionEventEmitter.emit("broadcastSignal", payload);
-				response.status(200).send("OK");
-				return;
-			} catch (error) {
-				response.status(500).send(error);
-				return;
-			}
+			const handleBroadcastSignalP = handleBroadcastSignal(
+				request,
+				response,
+				config,
+				storage,
+				collaborationSessionEventEmitter,
+			);
+			handleResponse(
+				handleBroadcastSignalP,
+				response,
+				undefined,
+				500,
+				200,
+				undefined,
+				(error: any) =>
+					Lumberjack.error(
+						"Error handling broadcast-signal",
+						{
+							tenantId: request.params.tenantId,
+							documentId: request.params.documentId,
+						},
+						error,
+					),
+			);
 		},
 	);
 
@@ -399,3 +396,59 @@ const uploadBlob = async (
 		"Content-Type": "application/json",
 	});
 };
+
+async function handleBroadcastSignal(
+	request: Request,
+	response: Response,
+	config: Provider,
+	storage: core.IDocumentStorage,
+	collaborationSessionEventEmitter?: RedisEmitter,
+): Promise<void> {
+	const tenantId = request.params.tenantId;
+	const documentId = request.params.id;
+	const signalContent = request?.body?.signalContent;
+	if (!isValidSignalEnvelope(signalContent)) {
+		Lumberjack.error(
+			"signalContent should contain 'contents.content' and 'contents.type' key",
+			{ tenantId, documentId },
+		);
+		throw new NetworkError(
+			400,
+			`signalContent should contain 'contents.content' and 'contents.type' keys`,
+		);
+	}
+	if (!collaborationSessionEventEmitter) {
+		Lumberjack.error("No emitter configured for the broadcast-signal endpoint", {
+			tenantId,
+			documentId,
+		});
+		throw new NetworkError(500, `No emitter configured for the broadcast-signal endpoint`);
+	}
+
+	const deltaStreamUrl: string = config.get("worker:deltaStreamUrl");
+	const document = await storage?.getDocument(tenantId, documentId);
+	if (!document?.session?.isSessionActive) {
+		Lumberjack.error("Document not found", { tenantId, documentId });
+		throw new NetworkError(404, "Document not found");
+	}
+	if (!document.session.isSessionAlive) {
+		Lumberjack.warning("Document session not alive", { tenantId, documentId });
+		throw new NetworkError(410, "Document session not alive");
+	}
+	if (document.session.deltaStreamUrl !== deltaStreamUrl) {
+		Lumberjack.info("Redirecting broadcast-signal to correct cluster", {
+			documentUrl: document.session.deltaStreamUrl,
+			currentUrl: deltaStreamUrl,
+			targetUrlAndPath: `${document.session.deltaStreamUrl}${request.originalUrl}`,
+		});
+		response.redirect(`${document.session.deltaStreamUrl}${request.originalUrl}`);
+		return;
+	}
+
+	const signalMessage = createRuntimeMessage(signalContent);
+	const signalRoom: IRoom = { tenantId, documentId };
+	Lumberjack.info("Broadcasting signal to socket", { tenantId, documentId });
+	collaborationSessionEventEmitter.to(getRoomId(signalRoom)).emit("signal", signalMessage);
+}
+
+const getRoomId = (room: IRoom): string => `${room.tenantId}/${room.documentId}`;

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { TypedEventEmitter } from "@fluidframework/common-utils";
 import {
 	ICache,
 	IDeltaService,
@@ -19,10 +18,10 @@ import {
 	IReadinessCheck,
 	type IDenyList,
 } from "@fluidframework/server-services-core";
-import { ICollaborationSessionEvents } from "@fluidframework/server-lambdas";
 import cors from "cors";
 import { Router } from "express";
 import { Provider } from "nconf";
+import type { Emitter as RedisEmitter } from "@socket.io/redis-emitter";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
 import { IDocumentDeleteService } from "../../services";
 import * as api from "./api";
@@ -45,7 +44,7 @@ export function create(
 	startupCheck: IReadinessCheck,
 	tokenRevocationManager?: ITokenRevocationManager,
 	revokedTokenChecker?: IRevokedTokenChecker,
-	collaborationSessionEventEmitter?: TypedEventEmitter<ICollaborationSessionEvents>,
+	collaborationSessionEventEmitter?: RedisEmitter,
 	clusterDrainingChecker?: IClusterDrainingChecker,
 	readinessCheck?: IReadinessCheck,
 	fluidAccessTokenGenerator?: IFluidAccessTokenGenerator,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/index.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { TypedEventEmitter } from "@fluidframework/common-utils";
-import { ICollaborationSessionEvents } from "@fluidframework/server-lambdas";
 import {
 	IDeltaService,
 	IDocumentStorage,
@@ -22,6 +20,7 @@ import {
 } from "@fluidframework/server-services-core";
 import { Router } from "express";
 import { Provider } from "nconf";
+import type { Emitter as RedisEmitter } from "@socket.io/redis-emitter";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
 import { IDocumentDeleteService } from "../services";
 import * as api from "./api";
@@ -45,7 +44,7 @@ export function create(
 	startupCheck: IReadinessCheck,
 	tokenRevocationManager?: ITokenRevocationManager,
 	revokedTokenChecker?: IRevokedTokenChecker,
-	collaborationSessionEventEmitter?: TypedEventEmitter<ICollaborationSessionEvents>,
+	collaborationSessionEventEmitter?: RedisEmitter,
 	clusterDrainingChecker?: IClusterDrainingChecker,
 	readinessCheck?: IReadinessCheck,
 	fluidAccessTokenGenerator?: IFluidAccessTokenGenerator,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -4,7 +4,7 @@
  */
 
 import cluster from "cluster";
-import { Deferred, TypedEventEmitter } from "@fluidframework/common-utils";
+import { Deferred } from "@fluidframework/common-utils";
 import {
 	ICache,
 	IClusterDrainingChecker,
@@ -25,9 +25,9 @@ import {
 } from "@fluidframework/server-services-core";
 import { Provider } from "nconf";
 import * as winston from "winston";
+import type { Emitter as RedisEmitter } from "@socket.io/redis-emitter";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
 import { LumberEventName, Lumberjack } from "@fluidframework/server-services-telemetry";
-import { ICollaborationSessionEvents } from "@fluidframework/server-lambdas";
 import { runnerHttpServerStop } from "@fluidframework/server-services-shared";
 import * as app from "./app";
 import { IDocumentDeleteService } from "./services";
@@ -58,7 +58,7 @@ export class AlfredRunner implements IRunner {
 		private readonly startupCheck: IReadinessCheck,
 		private readonly tokenRevocationManager?: ITokenRevocationManager,
 		private readonly revokedTokenChecker?: IRevokedTokenChecker,
-		private readonly collaborationSessionEventEmitter?: TypedEventEmitter<ICollaborationSessionEvents>,
+		private readonly collaborationSessionEventEmitter?: RedisEmitter,
 		private readonly clusterDrainingChecker?: IClusterDrainingChecker,
 		private readonly enableClientIPLogging?: boolean,
 		private readonly readinessCheck?: IReadinessCheck,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -432,6 +432,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 			undefined /* retryDelays */,
 			redisConfig.enableVerboseErrorLogging,
 		);
+		redisClientConnectionManagers.push(redisClientConnectionManagerForPub);
 
 		const redisEmitter = new RedisEmitter(redisClientConnectionManagerForPub.getRedisClient());
 

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -9,6 +9,7 @@ import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import * as utils from "@fluidframework/server-services-utils";
 import { Provider } from "nconf";
 import * as winston from "winston";
+import { Emitter as RedisEmitter } from "@socket.io/redis-emitter";
 import { IAlfredTenant } from "@fluidframework/server-services-client";
 import { RedisClientConnectionManager } from "@fluidframework/server-services-utils";
 import { Constants } from "../utils";
@@ -50,6 +51,7 @@ export class AlfredResources implements core.IResources {
 		public tokenRevocationManager?: core.ITokenRevocationManager,
 		public revokedTokenChecker?: core.IRevokedTokenChecker,
 		public serviceMessageResourceManager?: core.IServiceMessageResourceManager,
+		public collaborationSessionEventEmitter?: RedisEmitter,
 		public clusterDrainingChecker?: core.IClusterDrainingChecker,
 		public enableClientIPLogging?: boolean,
 		public readinessCheck?: IReadinessCheck,
@@ -422,6 +424,17 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 			documentsDenyListConfig,
 		);
 
+		const redisClientConnectionManagerForPub = new RedisClientConnectionManager(
+			undefined,
+			redisConfig,
+			redisConfig.enableClustering,
+			redisConfig.slotsRefreshTimeout,
+			undefined /* retryDelays */,
+			redisConfig.enableVerboseErrorLogging,
+		);
+
+		const redisEmitter = new RedisEmitter(redisClientConnectionManagerForPub.getRedisClient());
+
 		return new AlfredResources(
 			config,
 			producer,
@@ -443,6 +456,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 			tokenRevocationManager,
 			revokedTokenChecker,
 			serviceMessageResourceManager,
+			redisEmitter,
 			customizations?.clusterDrainingChecker,
 			enableClientIPLogging,
 			customizations?.readinessCheck,
@@ -475,7 +489,7 @@ export class AlfredRunnerFactory implements core.IRunnerFactory<AlfredResources>
 			resources.startupCheck,
 			resources.tokenRevocationManager,
 			resources.revokedTokenChecker,
-			undefined,
+			resources.collaborationSessionEventEmitter,
 			resources.clusterDrainingChecker,
 			resources.enableClientIPLogging,
 			resources.readinessCheck,

--- a/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
@@ -497,8 +497,6 @@ export class NexusResourcesFactory implements core.IResourcesFactory<NexusResour
 			ordererManagerOptions,
 		);
 
-		const collaborationSessionEvents = new TypedEventEmitter<ICollaborationSessionEvents>();
-
 		// This wanst to create stuff
 		const port = utils.normalizePort(process.env.PORT || "3000");
 
@@ -615,7 +613,7 @@ export class NexusResourcesFactory implements core.IResourcesFactory<NexusResour
 			socketTracker,
 			tokenRevocationManager,
 			revokedTokenChecker,
-			collaborationSessionEvents,
+			undefined,
 			serviceMessageResourceManager,
 			customizations?.clusterDrainingChecker,
 			collaborationSessionTracker,

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
@@ -3,9 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { TypedEventEmitter } from "@fluidframework/common-utils";
 import { ScopeType } from "@fluidframework/protocol-definitions";
-import { ICollaborationSessionEvents } from "@fluidframework/server-lambdas";
 import { IAlfredTenant, NetworkError } from "@fluidframework/server-services-client";
 import {
 	IDocument,
@@ -24,6 +22,7 @@ import {
 	TestKafka,
 	TestNotImplementedDocumentRepository,
 	TestProducer,
+	TestRedisClientConnectionManager,
 	TestTenantManager,
 	TestThrottler,
 } from "@fluidframework/server-test-utils";
@@ -32,6 +31,7 @@ import express from "express";
 import nconf from "nconf";
 import Sinon from "sinon";
 import request from "supertest";
+import { Emitter as RedisEmitter } from "@socket.io/redis-emitter";
 import * as alfredApp from "../../alfred/app";
 import { DeltaService, DocumentDeleteService } from "../../alfred/services";
 import { Constants } from "../../utils";
@@ -88,6 +88,13 @@ describe("Routerlicious", () => {
 				tenantId: appTenant1.id,
 				documentId: "doc-1",
 				content: "Hello, World!",
+				session: {
+					ordererUrl: defaultProvider.get("worker:serverUrl"),
+					deltaStreamUrl: defaultProvider.get("worker:deltaStreamUrl"),
+					historianUrl: defaultProvider.get("worker:blobStorageUrl"),
+					isSessionAlive: true,
+					isSessionActive: true,
+				},
 			};
 			const defaultDbFactory = new TestDbFactory({
 				[documentsCollectionName]: [document1],
@@ -141,8 +148,10 @@ describe("Routerlicious", () => {
 			const defaultDeltaService = new DeltaService(deltasCollection, defaultTenantManager);
 			const defaultDocumentRepository = new TestNotImplementedDocumentRepository();
 			const defaultDocumentDeleteService = new DocumentDeleteService();
-			const defaultCollaborationSessionEventEmitter =
-				new TypedEventEmitter<ICollaborationSessionEvents>();
+			const defaultRedisClientConnectionManager = new TestRedisClientConnectionManager();
+			const defaultCollaborationSessionEventEmitter = new RedisEmitter(
+				defaultRedisClientConnectionManager.getRedisClient(),
+			);
 			let app: express.Application;
 			let supertest: request.SuperTest<request.Test>;
 			let testFluidAccessTokenGenerator: TestFluidAccessTokenGenerator;
@@ -265,6 +274,14 @@ describe("Routerlicious", () => {
 						await assertThrottle(
 							`/api/v1/${appTenant1.id}/${document1._id}/blobs`,
 							undefined,
+							undefined,
+							"post",
+						);
+					});
+					it("/api/v1/:tenantId/:id/broadcast-signal", async () => {
+						await assertThrottle(
+							`/api/v1/${appTenant1.id}/${document1._id}/broadcast-signal`,
+							"Bearer 12345", // Dummy bearer token
 							undefined,
 							"post",
 						);
@@ -1060,6 +1077,10 @@ describe("Routerlicious", () => {
 					supertest = request(app);
 				});
 
+				afterEach(() => {
+					Sinon.restore();
+				});
+
 				describe("/api/v1", () => {
 					it("/tenants/:tenantid/accesstoken validate access token exists in response", async () => {
 						const body = {
@@ -1128,6 +1149,141 @@ describe("Routerlicious", () => {
 							.set("Authorization", tenantToken1)
 							.set("Content-Type", "application/json")
 							.expect(400);
+					});
+
+					it("Successful request with redirect", async () => {
+						const body = {
+							signalContent: {
+								contents: {
+									type: "ExternalDataChanged_V1.0.0",
+									content: { taskListId: "task-list-1" },
+								},
+							},
+						};
+						const documentHostedInOtherUrl = {
+							_id: "doc-1",
+							tenantId: appTenant1.id,
+							version: "1.0",
+							documentId: "doc-1",
+							content: "Hello, World!",
+							session: {
+								ordererUrl: defaultProvider.get("worker:serverUrl"),
+								deltaStreamUrl: "http://localhost:3006",
+								historianUrl: defaultProvider.get("worker:blobStorageUrl"),
+								isSessionAlive: true,
+								isSessionActive: true,
+							},
+							createTime: Date.now(),
+							scribe: "",
+							deli: "",
+						};
+
+						Sinon.stub(defaultStorage, "getDocument").returns(
+							Promise.resolve(documentHostedInOtherUrl),
+						);
+
+						await supertest
+							.post(
+								`/api/v1/${appTenant1.id}/${documentHostedInOtherUrl._id}/broadcast-signal`,
+							)
+							.send(body)
+							.set("Authorization", tenantToken1)
+							.set("Content-Type", "application/json")
+							.expect(302);
+					});
+
+					it("Document not found", async () => {
+						const body = {
+							signalContent: {
+								contents: {
+									type: "ExternalDataChanged_V1.0.0",
+									content: { taskListId: "task-list-1" },
+								},
+							},
+						};
+
+						const documentNoActiveSession = {
+							_id: "doc-1",
+							tenantId: appTenant1.id,
+							version: "1.0",
+							documentId: "doc-1",
+							content: "Hello, World!",
+							session: {
+								ordererUrl: defaultProvider.get("worker:serverUrl"),
+								deltaStreamUrl: "http://localhost:3006",
+								historianUrl: defaultProvider.get("worker:blobStorageUrl"),
+								isSessionAlive: false,
+								isSessionActive: false,
+							},
+							createTime: Date.now(),
+							scribe: "",
+							deli: "",
+						};
+
+						Sinon.stub(defaultStorage, "getDocument")
+							.onFirstCall()
+							.returns(Promise.resolve(null))
+							.onSecondCall()
+							.returns(Promise.resolve(documentNoActiveSession));
+
+						await supertest
+							.post(
+								`/api/v1/${appTenant1.id}/${documentNoActiveSession._id}/broadcast-signal`,
+							)
+							.send(body)
+							.set("Authorization", tenantToken1)
+							.set("Content-Type", "application/json")
+							.expect(404);
+
+						await supertest
+							.post(
+								`/api/v1/${appTenant1.id}/${documentNoActiveSession._id}/broadcast-signal`,
+							)
+							.send(body)
+							.set("Authorization", tenantToken1)
+							.set("Content-Type", "application/json")
+							.expect(404);
+					});
+
+					it("Document session not alive", async () => {
+						const body = {
+							signalContent: {
+								contents: {
+									type: "ExternalDataChanged_V1.0.0",
+									content: { taskListId: "task-list-1" },
+								},
+							},
+						};
+						const documentNoSessionAlive = {
+							_id: "doc-1",
+							tenantId: appTenant1.id,
+							version: "1.0",
+							documentId: "doc-1",
+							content: "Hello, World!",
+							session: {
+								ordererUrl: defaultProvider.get("worker:serverUrl"),
+								deltaStreamUrl: "http://localhost:3006",
+								historianUrl: defaultProvider.get("worker:blobStorageUrl"),
+								isSessionAlive: false,
+								isSessionActive: true,
+							},
+							createTime: Date.now(),
+							scribe: "",
+							deli: "",
+						};
+
+						Sinon.stub(defaultStorage, "getDocument").returns(
+							Promise.resolve(documentNoSessionAlive),
+						);
+
+						await supertest
+							.post(
+								`/api/v1/${appTenant1.id}/${documentNoSessionAlive._id}/broadcast-signal`,
+							)
+							.send(body)
+							.set("Authorization", tenantToken1)
+							.set("Content-Type", "application/json")
+							.expect(410);
 					});
 				});
 

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
@@ -1167,8 +1167,8 @@ describe("Routerlicious", () => {
 							documentId: "doc-1",
 							content: "Hello, World!",
 							session: {
-								ordererUrl: defaultProvider.get("worker:serverUrl"),
-								deltaStreamUrl: "http://localhost:3006",
+								ordererUrl: "http://localhost:3006",
+								deltaStreamUrl: defaultProvider.get("worker:deltaStreamUrl"),
 								historianUrl: defaultProvider.get("worker:blobStorageUrl"),
 								isSessionAlive: true,
 								isSessionActive: true,
@@ -1202,7 +1202,7 @@ describe("Routerlicious", () => {
 							},
 						};
 
-						const documentNoActiveSession = {
+						const documentNotFound = {
 							_id: "doc-1",
 							tenantId: appTenant1.id,
 							version: "1.0",
@@ -1210,7 +1210,7 @@ describe("Routerlicious", () => {
 							content: "Hello, World!",
 							session: {
 								ordererUrl: defaultProvider.get("worker:serverUrl"),
-								deltaStreamUrl: "http://localhost:3006",
+								deltaStreamUrl: defaultProvider.get("worker:deltaStreamUrl"),
 								historianUrl: defaultProvider.get("worker:blobStorageUrl"),
 								isSessionAlive: false,
 								isSessionActive: false,
@@ -1224,11 +1224,11 @@ describe("Routerlicious", () => {
 							.onFirstCall()
 							.returns(Promise.resolve(null))
 							.onSecondCall()
-							.returns(Promise.resolve(documentNoActiveSession));
+							.returns(Promise.resolve(documentNotFound));
 
 						await supertest
 							.post(
-								`/api/v1/${appTenant1.id}/${documentNoActiveSession._id}/broadcast-signal`,
+								`/api/v1/${appTenant1.id}/${documentNotFound._id}/broadcast-signal`,
 							)
 							.send(body)
 							.set("Authorization", tenantToken1)
@@ -1237,7 +1237,7 @@ describe("Routerlicious", () => {
 
 						await supertest
 							.post(
-								`/api/v1/${appTenant1.id}/${documentNoActiveSession._id}/broadcast-signal`,
+								`/api/v1/${appTenant1.id}/${documentNotFound._id}/broadcast-signal`,
 							)
 							.send(body)
 							.set("Authorization", tenantToken1)
@@ -1245,7 +1245,7 @@ describe("Routerlicious", () => {
 							.expect(404);
 					});
 
-					it("Document session not alive", async () => {
+					it("Document session not active", async () => {
 						const body = {
 							signalContent: {
 								contents: {
@@ -1254,7 +1254,7 @@ describe("Routerlicious", () => {
 								},
 							},
 						};
-						const documentNoSessionAlive = {
+						const documentNoActiveSession = {
 							_id: "doc-1",
 							tenantId: appTenant1.id,
 							version: "1.0",
@@ -1262,10 +1262,10 @@ describe("Routerlicious", () => {
 							content: "Hello, World!",
 							session: {
 								ordererUrl: defaultProvider.get("worker:serverUrl"),
-								deltaStreamUrl: "http://localhost:3006",
+								deltaStreamUrl: defaultProvider.get("worker:deltaStreamUrl"),
 								historianUrl: defaultProvider.get("worker:blobStorageUrl"),
-								isSessionAlive: false,
-								isSessionActive: true,
+								isSessionAlive: true,
+								isSessionActive: false,
 							},
 							createTime: Date.now(),
 							scribe: "",
@@ -1273,12 +1273,12 @@ describe("Routerlicious", () => {
 						};
 
 						Sinon.stub(defaultStorage, "getDocument").returns(
-							Promise.resolve(documentNoSessionAlive),
+							Promise.resolve(documentNoActiveSession),
 						);
 
 						await supertest
 							.post(
-								`/api/v1/${appTenant1.id}/${documentNoSessionAlive._id}/broadcast-signal`,
+								`/api/v1/${appTenant1.id}/${documentNoActiveSession._id}/broadcast-signal`,
 							)
 							.send(body)
 							.set("Authorization", tenantToken1)

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -828,6 +828,9 @@ importers:
       '@fluidframework/server-services-utils':
         specifier: workspace:~
         version: link:../services-utils
+      '@socket.io/redis-emitter':
+        specifier: ^4.1.1
+        version: 4.1.1
       body-parser:
         specifier: ^1.20.3
         version: 1.20.3


### PR DESCRIPTION
## Description

**TL;DR:** The goal of this PR is to fix the current API responsible for broadcasting signals from Alfred to clients via an HTTP endpoint. Currently, the API in Alfred is broken due to the separation of Alfred and Nexus. The API will now emit signals using `socket.io/redis-emitter` package, to broadcast the signals from Alfred to all connected clients to a document.

The following changes were made in this PR:

1. Replaced the `TypedEventEmitter` with `@socket.io/redis-emitter` for the `broadcast-signal` endpoint in Alfred.
2. Fixed signal emission through this API which was broken when migrating web sockets to Nexus
3. Added new unit tests for the API in Alfred, verifying functionality.

Validated with Clicker on a dev cluster.

## Breaking Changes

- Modified type `collaborationSessionEventEmitter` from `TypedEventEmitter` to `RedisEmitter` in Alfred. This parameter was modified in the following functions:
  - `create` in `server/routerlicious/packages/routerlicious-base/src/alfred/app.ts`
  - `create` in `server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts`
  - `create` in `server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts`
  - `create` in `server/routerlicious/packages/routerlicious-base/src/alfred/routes/index.ts`
  - `AlfredRunner` constructor in `server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts`
  - `AlfredResources` constructor in `server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts`

## Reviewer Guidance

- Not sure if the document validations before emitting the signal are 100% correct or accurate.

## TODOs

- [x] Add breaking changes to the Changesets.
- [x] Verify if FRS breaks and create a draft PR to fix changes.
