### PR TITLE
refactor(server): add versioning to Historian/Gitrest Routes

### DIFF
--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -137,6 +137,8 @@ services:
     build:
       context: ./historian
       target: runner
+      additional_contexts:
+        root: ..
     expose:
       - "3000"
     environment:
@@ -151,6 +153,8 @@ services:
     build:
       context: ./gitrest
       target: runner
+      additional_contexts:
+        root: ..
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development

--- a/server/gitrest/packages/gitrest-base/src/app.ts
+++ b/server/gitrest/packages/gitrest-base/src/app.ts
@@ -114,6 +114,10 @@ export function create(
 		fileSystemManagerFactories,
 		repositoryManagerFactory,
 	);
+	// TEMP: use bodyParser for v2 routes until implementation changes are made
+	// or body parser is used more specifically
+	v2Router.use(json({ limit: requestSize }));
+	v2Router.use(urlencoded({ limit: requestSize, extended: false }));
 	v2Router.use(v2ApiRoutes.git.refs);
 	v2Router.use(v2ApiRoutes.git.repos);
 	v2Router.use(v2ApiRoutes.repository.commits);

--- a/server/gitrest/packages/gitrest-base/src/app.ts
+++ b/server/gitrest/packages/gitrest-base/src/app.ts
@@ -98,15 +98,15 @@ export function create(
 	// v2 routes do not use bodyParser to avoid loading the entire body into memory
 	v1Router.use(json({ limit: requestSize }));
 	v1Router.use(urlencoded({ limit: requestSize, extended: false }));
-	app.use(v1ApiRoutes.git.blobs);
-	app.use(v1ApiRoutes.git.refs);
-	app.use(v1ApiRoutes.git.repos);
-	app.use(v1ApiRoutes.git.tags);
-	app.use(v1ApiRoutes.git.trees);
-	app.use(v1ApiRoutes.git.commits);
-	app.use(v1ApiRoutes.repository.commits);
-	app.use(v1ApiRoutes.repository.contents);
-	app.use(v1ApiRoutes.summaries);
+	v1Router.use(v1ApiRoutes.git.blobs);
+	v1Router.use(v1ApiRoutes.git.refs);
+	v1Router.use(v1ApiRoutes.git.repos);
+	v1Router.use(v1ApiRoutes.git.tags);
+	v1Router.use(v1ApiRoutes.git.trees);
+	v1Router.use(v1ApiRoutes.git.commits);
+	v1Router.use(v1ApiRoutes.repository.commits);
+	v1Router.use(v1ApiRoutes.repository.contents);
+	v1Router.use(v1ApiRoutes.summaries);
 
 	const v2Router = express.Router();
 	const v2ApiRoutes = routes.createV2(
@@ -114,6 +114,9 @@ export function create(
 		fileSystemManagerFactories,
 		repositoryManagerFactory,
 	);
+	v2Router.use(v2ApiRoutes.git.refs);
+	v2Router.use(v2ApiRoutes.git.repos);
+	v2Router.use(v2ApiRoutes.repository.commits);
 	v2Router.use(v2ApiRoutes.summaries);
 
 	// Split v1 and v2 routes by version param

--- a/server/gitrest/packages/gitrest-base/src/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/index.ts
@@ -5,7 +5,14 @@
 
 export { ExternalStorageManager, IExternalStorageManager } from "./externalStorageManager";
 export { configureGitRestLogging } from "./logger";
-export { create, IRoutes } from "./routes";
+export {
+	createV1 as create,
+	IV1Routes as IRoutes,
+	createV1,
+	IV1Routes,
+	createV2,
+	IV2Routes,
+} from "./routes";
 export { GitrestRunner } from "./runner";
 export { GitrestResources, GitrestResourcesFactory, GitrestRunnerFactory } from "./runnerFactory";
 export {

--- a/server/gitrest/packages/gitrest-base/src/routes/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/index.ts
@@ -3,59 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { Router } from "express";
-import nconf from "nconf";
-import { IFileSystemManagerFactories, IRepositoryManagerFactory } from "../utils";
-/* eslint-disable import/no-internal-modules */
-import * as blobs from "./git/blobs";
-import * as commits from "./git/commits";
-import * as refs from "./git/refs";
-import * as repos from "./git/repos";
-import * as tags from "./git/tags";
-import * as trees from "./git/trees";
-import * as repositoryCommits from "./repository/commits";
-import * as contents from "./repository/contents";
-/* eslint-enable import/no-internal-modules */
-import * as summaries from "./summaries";
+export { IRoutes as IV1Routes, create as createV1 } from "./v1";
 
-export interface IRoutes {
-	git: {
-		blobs: Router;
-		commits: Router;
-		refs: Router;
-		repos: Router;
-		tags: Router;
-		trees: Router;
-	};
-	repository: {
-		commits: Router;
-		contents: Router;
-	};
-	summaries: Router;
-}
+export { IRoutes as IV2Routes, create as createV2 } from "./v2";
 
-export function create(
-	store: nconf.Provider,
-	fileSystemManagerFactories: IFileSystemManagerFactories,
-	repoManagerFactory: IRepositoryManagerFactory,
-): IRoutes {
-	return {
-		git: {
-			blobs: blobs.create(store, fileSystemManagerFactories, repoManagerFactory),
-			commits: commits.create(store, fileSystemManagerFactories, repoManagerFactory),
-			refs: refs.create(store, fileSystemManagerFactories, repoManagerFactory),
-			repos: repos.create(store, repoManagerFactory),
-			tags: tags.create(store, fileSystemManagerFactories, repoManagerFactory),
-			trees: trees.create(store, fileSystemManagerFactories, repoManagerFactory),
-		},
-		repository: {
-			commits: repositoryCommits.create(
-				store,
-				fileSystemManagerFactories,
-				repoManagerFactory,
-			),
-			contents: contents.create(store, fileSystemManagerFactories, repoManagerFactory),
-		},
-		summaries: summaries.create(store, fileSystemManagerFactories, repoManagerFactory),
-	};
-}
+export { ApiVersion, getApiVersion } from "./utils";

--- a/server/gitrest/packages/gitrest-base/src/routes/utils.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/utils.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Request, RequestHandler } from "express";
+
+export enum ApiVersion {
+	V1 = "1.0",
+	V2 = "2.0",
+}
+function isValidApiVersion(version: unknown): version is ApiVersion {
+	return version === ApiVersion.V1 || version === ApiVersion.V2;
+}
+export function getApiVersion(req: Request): ApiVersion {
+	const queryParamApiVersion = req.query["api-version"];
+	if (isValidApiVersion(queryParamApiVersion)) {
+		return queryParamApiVersion;
+	}
+	return ApiVersion.V1;
+}
+/**
+ * Middleware wrapper to restrict middleware use to a specific API version.
+ */
+export function apiVersionRestrictedMiddleware(
+	apiVersion: ApiVersion,
+	restrictedMiddleware: RequestHandler,
+): RequestHandler {
+	return (req: Request, res, next) => {
+		if (getApiVersion(req) === apiVersion) {
+			return restrictedMiddleware(req, res, next);
+		}
+		return next();
+	};
+}

--- a/server/gitrest/packages/gitrest-base/src/routes/v1/git/commits.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v1/git/commits.ts
@@ -3,18 +3,19 @@
  * Licensed under the MIT License.
  */
 
+import { ICreateCommitParams } from "@fluidframework/gitresources";
 import { handleResponse } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import nconf from "nconf";
 import {
 	checkSoftDeleted,
-	getExternalWriterParams,
 	getFilesystemManagerFactory,
+	getRepoManagerFromWriteAPI,
 	getRepoManagerParamsFromRequest,
 	IFileSystemManagerFactories,
 	IRepositoryManagerFactory,
 	logAndThrowApiError,
-} from "../../utils";
+} from "../../../utils";
 
 export function create(
 	store: nconf.Provider,
@@ -24,18 +25,16 @@ export function create(
 	const router: Router = Router();
 	const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
 
-	// https://developer.github.com/v3/repos/commits/
-	// sha
-	// path
-	// author
-	// since
-	// until
+	// * https://developer.github.com/v3/git/commits/
 
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	router.get("/repos/:owner/:repo/commits", async (request, response, next) => {
+	router.post("/repos/:owner/:repo/git/commits", async (request, response, next) => {
 		const repoManagerParams = getRepoManagerParamsFromRequest(request);
-		const resultP = repoManagerFactory
-			.open(repoManagerParams)
+		const resultP = getRepoManagerFromWriteAPI(
+			repoManagerFactory,
+			repoManagerParams,
+			repoPerDocEnabled,
+		)
 			.then(async (repoManager) => {
 				const fileSystemManagerFactory = getFilesystemManagerFactory(
 					fileSystemManagerFactories,
@@ -51,13 +50,37 @@ export function create(
 					repoManagerParams,
 					repoPerDocEnabled,
 				);
-				return repoManager.getCommits(
-					request.query.sha as string,
-					Number(request.query.count as string),
-					getExternalWriterParams(request.query?.config as string),
-				);
+				return repoManager.createCommit(request.body as ICreateCommitParams);
 			})
 			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+
+		handleResponse(resultP, response, undefined, undefined, 201);
+	});
+
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	router.get("/repos/:owner/:repo/git/commits/:sha", async (request, response, next) => {
+		const repoManagerParams = getRepoManagerParamsFromRequest(request);
+		const fileSystemManagerFactory = getFilesystemManagerFactory(
+			fileSystemManagerFactories,
+			repoManagerParams.isEphemeralContainer ?? false,
+		);
+		const resultP = repoManagerFactory
+			.open(repoManagerParams)
+			.then(async (repoManager) => {
+				const fsManager = fileSystemManagerFactory.create({
+					...repoManagerParams.fileSystemManagerParams,
+					rootDir: repoManager.path,
+				});
+				await checkSoftDeleted(
+					fsManager,
+					repoManager.path,
+					repoManagerParams,
+					repoPerDocEnabled,
+				);
+				return repoManager.getCommit(request.params.sha);
+			})
+			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+
 		handleResponse(resultP, response);
 	});
 

--- a/server/gitrest/packages/gitrest-base/src/routes/v1/git/refs.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v1/git/refs.ts
@@ -19,7 +19,7 @@ import {
 	IFileSystemManagerFactories,
 	IRepositoryManagerFactory,
 	logAndThrowApiError,
-} from "../../utils";
+} from "../../../utils";
 
 /**
  * Simple method to convert from a path id to the git reference ID

--- a/server/gitrest/packages/gitrest-base/src/routes/v1/git/repos.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v1/git/repos.ts
@@ -11,7 +11,7 @@ import {
 	getRepoManagerParamsFromRequest,
 	IRepositoryManagerFactory,
 	logAndThrowApiError,
-} from "../../utils";
+} from "../../../utils";
 
 export function create(
 	store: nconf.Provider,

--- a/server/gitrest/packages/gitrest-base/src/routes/v1/git/tags.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v1/git/tags.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ICreateBlobParams } from "@fluidframework/gitresources";
+import { ICreateTagParams } from "@fluidframework/gitresources";
 import { handleResponse } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import nconf from "nconf";
@@ -15,7 +15,7 @@ import {
 	IFileSystemManagerFactories,
 	IRepositoryManagerFactory,
 	logAndThrowApiError,
-} from "../../utils";
+} from "../../../utils";
 
 export function create(
 	store: nconf.Provider,
@@ -24,8 +24,11 @@ export function create(
 ): Router {
 	const router: Router = Router();
 	const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
+
+	// https://developer.github.com/v3/git/tags/
+
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	router.post("/repos/:owner/:repo/git/blobs", async (request, response, next) => {
+	router.post("/repos/:owner/:repo/git/tags", async (request, response, next) => {
 		const repoManagerParams = getRepoManagerParamsFromRequest(request);
 		const resultP = getRepoManagerFromWriteAPI(
 			repoManagerFactory,
@@ -47,18 +50,14 @@ export function create(
 					repoManagerParams,
 					repoPerDocEnabled,
 				);
-				return repoManager.createBlob(request.body as ICreateBlobParams);
+				return repoManager.createTag(request.body as ICreateTagParams);
 			})
 			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
-
 		handleResponse(resultP, response, undefined, undefined, 201);
 	});
 
-	/**
-	 * Retrieves the given blob from the repository
-	 */
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	router.get("/repos/:owner/:repo/git/blobs/:sha", async (request, response, next) => {
+	router.get("/repos/:owner/:repo/git/tags/*", async (request, response, next) => {
 		const repoManagerParams = getRepoManagerParamsFromRequest(request);
 		const resultP = repoManagerFactory
 			.open(repoManagerParams)
@@ -77,10 +76,9 @@ export function create(
 					repoManagerParams,
 					repoPerDocEnabled,
 				);
-				return repoManager.getBlob(request.params.sha);
+				return repoManager.getTag(request.params[0]);
 			})
 			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
-
 		handleResponse(resultP, response);
 	});
 

--- a/server/gitrest/packages/gitrest-base/src/routes/v1/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v1/index.ts
@@ -1,0 +1,61 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Router } from "express";
+import nconf from "nconf";
+import { IFileSystemManagerFactories, IRepositoryManagerFactory } from "../../utils";
+/* eslint-disable import/no-internal-modules */
+import * as blobs from "./git/blobs";
+import * as commits from "./git/commits";
+import * as refs from "./git/refs";
+import * as repos from "./git/repos";
+import * as tags from "./git/tags";
+import * as trees from "./git/trees";
+import * as repositoryCommits from "./repository/commits";
+import * as contents from "./repository/contents";
+/* eslint-enable import/no-internal-modules */
+import * as summaries from "./summaries";
+
+export interface IRoutes {
+	git: {
+		blobs: Router;
+		commits: Router;
+		refs: Router;
+		repos: Router;
+		tags: Router;
+		trees: Router;
+	};
+	repository: {
+		commits: Router;
+		contents: Router;
+	};
+	summaries: Router;
+}
+
+export function create(
+	store: nconf.Provider,
+	fileSystemManagerFactories: IFileSystemManagerFactories,
+	repoManagerFactory: IRepositoryManagerFactory,
+): IRoutes {
+	return {
+		git: {
+			blobs: blobs.create(store, fileSystemManagerFactories, repoManagerFactory),
+			commits: commits.create(store, fileSystemManagerFactories, repoManagerFactory),
+			refs: refs.create(store, fileSystemManagerFactories, repoManagerFactory),
+			repos: repos.create(store, repoManagerFactory),
+			tags: tags.create(store, fileSystemManagerFactories, repoManagerFactory),
+			trees: trees.create(store, fileSystemManagerFactories, repoManagerFactory),
+		},
+		repository: {
+			commits: repositoryCommits.create(
+				store,
+				fileSystemManagerFactories,
+				repoManagerFactory,
+			),
+			contents: contents.create(store, fileSystemManagerFactories, repoManagerFactory),
+		},
+		summaries: summaries.create(store, fileSystemManagerFactories, repoManagerFactory),
+	};
+}

--- a/server/gitrest/packages/gitrest-base/src/routes/v1/repository/commits.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v1/repository/commits.ts
@@ -3,19 +3,18 @@
  * Licensed under the MIT License.
  */
 
-import { ICreateTreeParams } from "@fluidframework/gitresources";
 import { handleResponse } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import nconf from "nconf";
 import {
 	checkSoftDeleted,
+	getExternalWriterParams,
 	getFilesystemManagerFactory,
-	getRepoManagerFromWriteAPI,
 	getRepoManagerParamsFromRequest,
 	IFileSystemManagerFactories,
 	IRepositoryManagerFactory,
 	logAndThrowApiError,
-} from "../../utils";
+} from "../../../utils";
 
 export function create(
 	store: nconf.Provider,
@@ -25,37 +24,15 @@ export function create(
 	const router: Router = Router();
 	const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
 
-	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	router.post("/repos/:owner/:repo/git/trees", async (request, response, next) => {
-		const repoManagerParams = getRepoManagerParamsFromRequest(request);
-		const resultP = getRepoManagerFromWriteAPI(
-			repoManagerFactory,
-			repoManagerParams,
-			repoPerDocEnabled,
-		)
-			.then(async (repoManager) => {
-				const fileSystemManagerFactory = getFilesystemManagerFactory(
-					fileSystemManagerFactories,
-					repoManagerParams.isEphemeralContainer ?? false,
-				);
-				const fsManager = fileSystemManagerFactory.create({
-					...repoManagerParams.fileSystemManagerParams,
-					rootDir: repoManager.path,
-				});
-				await checkSoftDeleted(
-					fsManager,
-					repoManager.path,
-					repoManagerParams,
-					repoPerDocEnabled,
-				);
-				return repoManager.createTree(request.body as ICreateTreeParams);
-			})
-			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
-		handleResponse(resultP, response, undefined, undefined, 201);
-	});
+	// https://developer.github.com/v3/repos/commits/
+	// sha
+	// path
+	// author
+	// since
+	// until
 
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	router.get("/repos/:owner/:repo/git/trees/:sha", async (request, response, next) => {
+	router.get("/repos/:owner/:repo/commits", async (request, response, next) => {
 		const repoManagerParams = getRepoManagerParamsFromRequest(request);
 		const resultP = repoManagerFactory
 			.open(repoManagerParams)
@@ -74,7 +51,11 @@ export function create(
 					repoManagerParams,
 					repoPerDocEnabled,
 				);
-				return repoManager.getTree(request.params.sha, request.query.recursive === "1");
+				return repoManager.getCommits(
+					request.query.sha as string,
+					Number(request.query.count as string),
+					getExternalWriterParams(request.query?.config as string),
+				);
 			})
 			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
 		handleResponse(resultP, response);

--- a/server/gitrest/packages/gitrest-base/src/routes/v1/repository/contents.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v1/repository/contents.ts
@@ -3,19 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { ICreateTagParams } from "@fluidframework/gitresources";
 import { handleResponse } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import nconf from "nconf";
 import {
 	checkSoftDeleted,
 	getFilesystemManagerFactory,
-	getRepoManagerFromWriteAPI,
 	getRepoManagerParamsFromRequest,
 	IFileSystemManagerFactories,
 	IRepositoryManagerFactory,
 	logAndThrowApiError,
-} from "../../utils";
+} from "../../../utils";
 
 export function create(
 	store: nconf.Provider,
@@ -25,39 +23,8 @@ export function create(
 	const router: Router = Router();
 	const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
 
-	// https://developer.github.com/v3/git/tags/
-
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	router.post("/repos/:owner/:repo/git/tags", async (request, response, next) => {
-		const repoManagerParams = getRepoManagerParamsFromRequest(request);
-		const resultP = getRepoManagerFromWriteAPI(
-			repoManagerFactory,
-			repoManagerParams,
-			repoPerDocEnabled,
-		)
-			.then(async (repoManager) => {
-				const fileSystemManagerFactory = getFilesystemManagerFactory(
-					fileSystemManagerFactories,
-					repoManagerParams.isEphemeralContainer ?? false,
-				);
-				const fsManager = fileSystemManagerFactory.create({
-					...repoManagerParams.fileSystemManagerParams,
-					rootDir: repoManager.path,
-				});
-				await checkSoftDeleted(
-					fsManager,
-					repoManager.path,
-					repoManagerParams,
-					repoPerDocEnabled,
-				);
-				return repoManager.createTag(request.body as ICreateTagParams);
-			})
-			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
-		handleResponse(resultP, response, undefined, undefined, 201);
-	});
-
-	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	router.get("/repos/:owner/:repo/git/tags/*", async (request, response, next) => {
+	router.get("/repos/:owner/:repo/contents/*", async (request, response, next) => {
 		const repoManagerParams = getRepoManagerParamsFromRequest(request);
 		const resultP = repoManagerFactory
 			.open(repoManagerParams)
@@ -76,7 +43,7 @@ export function create(
 					repoManagerParams,
 					repoPerDocEnabled,
 				);
-				return repoManager.getTag(request.params[0]);
+				return repoManager.getContent(request.query.ref as string, request.params[0]);
 			})
 			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
 		handleResponse(resultP, response);

--- a/server/gitrest/packages/gitrest-base/src/routes/v1/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v1/summaries.ts
@@ -38,7 +38,7 @@ import {
 	retrieveLatestFullSummaryFromStorage,
 	isFilesystemError,
 	throwFileSystemErrorAsNetworkError,
-} from "../utils";
+} from "../../utils";
 
 function getFullSummaryDirectory(repoManager: IRepositoryManager, documentId: string): string {
 	return `${repoManager.path}/${documentId}`;

--- a/server/gitrest/packages/gitrest-base/src/routes/v2/git/refs.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v2/git/refs.ts
@@ -1,0 +1,186 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	ICreateRefParamsExternal,
+	IPatchRefParamsExternal,
+} from "@fluidframework/server-services-client";
+import { handleResponse } from "@fluidframework/server-services-shared";
+import { Router } from "express";
+import nconf from "nconf";
+import {
+	checkSoftDeleted,
+	getExternalWriterParams,
+	getFilesystemManagerFactory,
+	getRepoManagerFromWriteAPI,
+	getRepoManagerParamsFromRequest,
+	IFileSystemManagerFactories,
+	IRepositoryManagerFactory,
+	logAndThrowApiError,
+} from "../../../utils";
+
+/**
+ * Simple method to convert from a path id to the git reference ID
+ */
+function getRefId(id): string {
+	return `refs/${id}`;
+}
+
+export function create(
+	store: nconf.Provider,
+	fileSystemManagerFactories: IFileSystemManagerFactories,
+	repoManagerFactory: IRepositoryManagerFactory,
+): Router {
+	const router: Router = Router();
+	const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
+
+	// https://developer.github.com/v3/git/refs/
+
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	router.get("/repos/:owner/:repo/git/refs", async (request, response, next) => {
+		const repoManagerParams = getRepoManagerParamsFromRequest(request);
+		const resultP = repoManagerFactory
+			.open(repoManagerParams)
+			.then(async (repoManager) => {
+				const fileSystemManagerFactory = getFilesystemManagerFactory(
+					fileSystemManagerFactories,
+					repoManagerParams.isEphemeralContainer ?? false,
+				);
+				const fsManager = fileSystemManagerFactory.create({
+					...repoManagerParams.fileSystemManagerParams,
+					rootDir: repoManager.path,
+				});
+				await checkSoftDeleted(
+					fsManager,
+					repoManager.path,
+					repoManagerParams,
+					repoPerDocEnabled,
+				);
+				return repoManager.getRefs();
+			})
+			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+		handleResponse(resultP, response);
+	});
+
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	router.get("/repos/:owner/:repo/git/refs/*", async (request, response, next) => {
+		const repoManagerParams = getRepoManagerParamsFromRequest(request);
+		const resultP = repoManagerFactory
+			.open(repoManagerParams)
+			.then(async (repoManager) => {
+				const fileSystemManagerFactory = getFilesystemManagerFactory(
+					fileSystemManagerFactories,
+					repoManagerParams.isEphemeralContainer ?? false,
+				);
+				const fsManager = fileSystemManagerFactory.create({
+					...repoManagerParams.fileSystemManagerParams,
+					rootDir: repoManager.path,
+				});
+				await checkSoftDeleted(
+					fsManager,
+					repoManager.path,
+					repoManagerParams,
+					repoPerDocEnabled,
+				);
+				return repoManager.getRef(
+					getRefId(request.params[0]),
+					getExternalWriterParams(request.query?.config as string),
+				);
+			})
+			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+		handleResponse(resultP, response);
+	});
+
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	router.post("/repos/:owner/:repo/git/refs", async (request, response, next) => {
+		const repoManagerParams = getRepoManagerParamsFromRequest(request);
+		const createRefParams = request.body as ICreateRefParamsExternal;
+		const resultP = getRepoManagerFromWriteAPI(
+			repoManagerFactory,
+			repoManagerParams,
+			repoPerDocEnabled,
+		)
+			.then(async (repoManager) => {
+				const fileSystemManagerFactory = getFilesystemManagerFactory(
+					fileSystemManagerFactories,
+					repoManagerParams.isEphemeralContainer ?? false,
+				);
+				const fsManager = fileSystemManagerFactory.create({
+					...repoManagerParams.fileSystemManagerParams,
+					rootDir: repoManager.path,
+				});
+				await checkSoftDeleted(
+					fsManager,
+					repoManager.path,
+					repoManagerParams,
+					repoPerDocEnabled,
+				);
+				return repoManager.createRef(createRefParams, createRefParams.config);
+			})
+			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+		handleResponse(resultP, response, undefined, undefined, 201);
+	});
+
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	router.patch("/repos/:owner/:repo/git/refs/*", async (request, response, next) => {
+		const repoManagerParams = getRepoManagerParamsFromRequest(request);
+		const patchRefParams = request.body as IPatchRefParamsExternal;
+		const resultP = getRepoManagerFromWriteAPI(
+			repoManagerFactory,
+			repoManagerParams,
+			repoPerDocEnabled,
+		)
+			.then(async (repoManager) => {
+				const fileSystemManagerFactory = getFilesystemManagerFactory(
+					fileSystemManagerFactories,
+					repoManagerParams.isEphemeralContainer ?? false,
+				);
+				const fsManager = fileSystemManagerFactory.create({
+					...repoManagerParams.fileSystemManagerParams,
+					rootDir: repoManager.path,
+				});
+				await checkSoftDeleted(
+					fsManager,
+					repoManager.path,
+					repoManagerParams,
+					repoPerDocEnabled,
+				);
+				return repoManager.patchRef(
+					getRefId(request.params[0]),
+					patchRefParams,
+					patchRefParams.config,
+				);
+			})
+			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+		handleResponse(resultP, response);
+	});
+
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	router.delete("/repos/:owner/:repo/git/refs/*", async (request, response, next) => {
+		const repoManagerParams = getRepoManagerParamsFromRequest(request);
+		const resultP = repoManagerFactory
+			.open(repoManagerParams)
+			.then(async (repoManager) => {
+				const fileSystemManagerFactory = getFilesystemManagerFactory(
+					fileSystemManagerFactories,
+					repoManagerParams.isEphemeralContainer ?? false,
+				);
+				const fsManager = fileSystemManagerFactory.create({
+					...repoManagerParams.fileSystemManagerParams,
+					rootDir: repoManager.path,
+				});
+				await checkSoftDeleted(
+					fsManager,
+					repoManager.path,
+					repoManagerParams,
+					repoPerDocEnabled,
+				);
+				return repoManager.deleteRef(getRefId(request.params[0]));
+			})
+			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+		handleResponse(resultP, response, undefined, undefined, 204);
+	});
+	return router;
+}

--- a/server/gitrest/packages/gitrest-base/src/routes/v2/git/repos.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v2/git/repos.ts
@@ -1,0 +1,93 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ICreateRepoParams } from "@fluidframework/gitresources";
+import { handleResponse } from "@fluidframework/server-services-shared";
+import { Router } from "express";
+import nconf from "nconf";
+import {
+	getRepoManagerParamsFromRequest,
+	IRepositoryManagerFactory,
+	logAndThrowApiError,
+} from "../../../utils";
+
+export function create(
+	store: nconf.Provider,
+	repoManagerFactory: IRepositoryManagerFactory,
+): Router {
+	const router: Router = Router();
+	const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
+
+	/**
+	 * Creates a new git repository
+	 */
+	router.post("/:owner/repos", (request, response, next) => {
+		if (repoPerDocEnabled) {
+			// GitRest now supports an alternative setup called "repo-per-doc model". In that setup,
+			// the idea is that we map Git repositories to Fluid documents - previously, we would map
+			// each repo to a tenantId, and each document would be a branch in that repo. "repo-per-doc"
+			// provides interesting advantages in terms of Git performance, Garbage Collection, etc.
+			// Traditionally, getOrCreateRepository() from services-utils would be used to create Git repos.
+			// Now, repos would be created "just in time" by GitRest Write APIs. To avoid making "repo-per-doc"
+			// a breaking change and to reduce changing components as much as possible, we scoped the change down
+			// to GitRest. In other words, getOrCreateRepository() will temporarily keep calling these "repo" APIs.
+			// But they will be no-op when `repoPerDocEnabled` is true. So in that case, we just reply with a
+			// dummy 201 response.
+			// TODO: remove this repos.ts file once Routerlicious can function without getOrCreateRepository().
+			return response.status(201).send();
+		}
+
+		const createParams = request.body as ICreateRepoParams;
+		if (!createParams?.name) {
+			return response.status(400).json("Invalid repo name");
+		}
+
+		const repoManagerParams = getRepoManagerParamsFromRequest(request);
+		const repoManagerP = repoManagerFactory
+			.create({ ...repoManagerParams, repoName: createParams.name })
+			.then(() => undefined)
+			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+
+		handleResponse(repoManagerP, response, undefined, undefined, 201);
+	});
+
+	/**
+	 * Retrieves an existing get repository
+	 */
+	router.get("/repos/:owner/:repo", (request, response, next) => {
+		const result = { name: request.params.repo };
+
+		if (repoPerDocEnabled) {
+			// GitRest now supports an alternative setup called "repo-per-doc model". In that setup,
+			// the idea is that we map Git repositories to Fluid documents - previously, we would map
+			// each repo to a tenantId, and each document would be a branch in that repo. "repo-per-doc"
+			// provides interesting advantages in terms of Git performance, Garbage Collection, etc.
+			// Traditionally, getOrCreateRepository() from services-utils would be used to create Git repos.
+			// Now, repos would be created "just in time" by GitRest Write APIs. To avoid making "repo-per-doc"
+			// a breaking change and to reduce changing components as much as possible, we scoped the change down
+			// to GitRest. In other words, getOrCreateRepository() will temporarily keep calling these "repo" APIs.
+			// But they will be no-op when `repoPerDocEnabled` is true. So in that case, we just reply with a
+			// dummy 200 response. Please note that the body of the response is semantically inaccurate, though:
+			// In the "repo-per-doc" model, the repo name would be `tenantId/documentId`. Here, we are using the
+			// body from the request sent by getOrCreateRepository(), which maps to `tenantId` only.
+			// getOrCreateRepository() does not have any knowledge about documentId, which means this route
+			// does not either. Since this is just a workaround until GitRest fully uses "repo-per-doc",
+			// it's ok for the repo name in the dummy response to be inaccurate - it's actually never read by
+			// getOrCreateRepository().
+			// TODO: remove this repos.ts file once Routerlicious can function without getOrCreateRepository().
+			return response.status(200).json(result);
+		}
+
+		const repoManagerParams = getRepoManagerParamsFromRequest(request);
+		const repoManagerP = repoManagerFactory
+			.open(repoManagerParams)
+			.then(() => result)
+			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+
+		handleResponse(repoManagerP, response);
+	});
+
+	return router;
+}

--- a/server/gitrest/packages/gitrest-base/src/routes/v2/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v2/index.ts
@@ -6,9 +6,21 @@
 import { Router } from "express";
 import nconf from "nconf";
 import { IFileSystemManagerFactories, IRepositoryManagerFactory } from "../../utils";
+/* eslint-disable import/no-internal-modules */
+import * as refs from "./git/refs";
+import * as repos from "./git/repos";
+import * as repositoryCommits from "./repository/commits";
+/* eslint-enable import/no-internal-modules */
 import * as summaries from "./summaries";
 
 export interface IRoutes {
+	git: {
+		refs: Router;
+		repos: Router;
+	};
+	repository: {
+		commits: Router;
+	};
 	summaries: Router;
 }
 
@@ -18,6 +30,17 @@ export function create(
 	repoManagerFactory: IRepositoryManagerFactory,
 ): IRoutes {
 	return {
+		git: {
+			refs: refs.create(store, fileSystemManagerFactories, repoManagerFactory),
+			repos: repos.create(store, repoManagerFactory),
+		},
+		repository: {
+			commits: repositoryCommits.create(
+				store,
+				fileSystemManagerFactories,
+				repoManagerFactory,
+			),
+		},
 		summaries: summaries.create(store, fileSystemManagerFactories, repoManagerFactory),
 	};
 }

--- a/server/gitrest/packages/gitrest-base/src/routes/v2/index.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v2/index.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Router } from "express";
+import nconf from "nconf";
+import { IFileSystemManagerFactories, IRepositoryManagerFactory } from "../../utils";
+import * as summaries from "./summaries";
+
+export interface IRoutes {
+	summaries: Router;
+}
+
+export function create(
+	store: nconf.Provider,
+	fileSystemManagerFactories: IFileSystemManagerFactories,
+	repoManagerFactory: IRepositoryManagerFactory,
+): IRoutes {
+	return {
+		summaries: summaries.create(store, fileSystemManagerFactories, repoManagerFactory),
+	};
+}

--- a/server/gitrest/packages/gitrest-base/src/routes/v2/repository/commits.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v2/repository/commits.ts
@@ -1,0 +1,65 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { handleResponse } from "@fluidframework/server-services-shared";
+import { Router } from "express";
+import nconf from "nconf";
+import {
+	checkSoftDeleted,
+	getExternalWriterParams,
+	getFilesystemManagerFactory,
+	getRepoManagerParamsFromRequest,
+	IFileSystemManagerFactories,
+	IRepositoryManagerFactory,
+	logAndThrowApiError,
+} from "../../../utils";
+
+export function create(
+	store: nconf.Provider,
+	fileSystemManagerFactories: IFileSystemManagerFactories,
+	repoManagerFactory: IRepositoryManagerFactory,
+): Router {
+	const router: Router = Router();
+	const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
+
+	// https://developer.github.com/v3/repos/commits/
+	// sha
+	// path
+	// author
+	// since
+	// until
+
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	router.get("/repos/:owner/:repo/commits", async (request, response, next) => {
+		const repoManagerParams = getRepoManagerParamsFromRequest(request);
+		const resultP = repoManagerFactory
+			.open(repoManagerParams)
+			.then(async (repoManager) => {
+				const fileSystemManagerFactory = getFilesystemManagerFactory(
+					fileSystemManagerFactories,
+					repoManagerParams.isEphemeralContainer ?? false,
+				);
+				const fsManager = fileSystemManagerFactory.create({
+					...repoManagerParams.fileSystemManagerParams,
+					rootDir: repoManager.path,
+				});
+				await checkSoftDeleted(
+					fsManager,
+					repoManager.path,
+					repoManagerParams,
+					repoPerDocEnabled,
+				);
+				return repoManager.getCommits(
+					request.query.sha as string,
+					Number(request.query.count as string),
+					getExternalWriterParams(request.query?.config as string),
+				);
+			})
+			.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+		handleResponse(resultP, response);
+	});
+
+	return router;
+}

--- a/server/gitrest/packages/gitrest-base/src/routes/v2/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/v2/summaries.ts
@@ -1,0 +1,470 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	isNetworkError,
+	IWholeFlatSummary,
+	IWholeSummaryPayload,
+	IWriteSummaryResponse,
+	NetworkError,
+} from "@fluidframework/server-services-client";
+import { handleResponse } from "@fluidframework/server-services-shared";
+import { getGlobalTelemetryContext, Lumberjack } from "@fluidframework/server-services-telemetry";
+import { Router } from "express";
+import { Provider } from "nconf";
+import {
+	BaseGitRestTelemetryProperties,
+	checkSoftDeleted,
+	Constants,
+	getExternalWriterParams,
+	getFilesystemManagerFactory,
+	getLumberjackBasePropertiesFromRepoManagerParams,
+	getRepoManagerFromWriteAPI,
+	getRepoManagerParamsFromRequest,
+	GitWholeSummaryManager,
+	IExternalWriterConfig,
+	IFileSystemManager,
+	IFileSystemManagerFactories,
+	IRepoManagerParams,
+	IRepositoryManager,
+	IRepositoryManagerFactory,
+	isContainerSummary,
+	isIStorageRoutingId,
+	latestSummarySha,
+	logAndThrowApiError,
+	persistLatestFullSummaryInStorage,
+	retrieveLatestFullSummaryFromStorage,
+	isFilesystemError,
+	throwFileSystemErrorAsNetworkError,
+} from "../../utils";
+
+function getFullSummaryDirectory(repoManager: IRepositoryManager, documentId: string): string {
+	return `${repoManager.path}/${documentId}`;
+}
+
+type WholeSummaryCompatibleRepoManagerParams = IRepoManagerParams &
+	Required<Pick<IRepoManagerParams, "storageRoutingId">>;
+
+function isWholeSummaryCompatibleRepoManagerParams(
+	params: IRepoManagerParams,
+): params is WholeSummaryCompatibleRepoManagerParams {
+	return params.storageRoutingId !== undefined && isIStorageRoutingId(params.storageRoutingId);
+}
+
+async function getSummary(
+	repoManager: IRepositoryManager,
+	fileSystemManager: IFileSystemManager,
+	sha: string,
+	repoManagerParams: WholeSummaryCompatibleRepoManagerParams,
+	externalWriterConfig?: IExternalWriterConfig,
+	persistLatestFullSummary = false,
+	persistLatestFullEphemeralSummary = false,
+	enforceStrictPersistedFullSummaryReads = false,
+): Promise<IWholeFlatSummary> {
+	const lumberjackProperties = {
+		...getLumberjackBasePropertiesFromRepoManagerParams(repoManagerParams),
+		[BaseGitRestTelemetryProperties.sha]: sha,
+	};
+
+	const enablePersistLatestFullSummary = repoManagerParams.isEphemeralContainer
+		? persistLatestFullEphemeralSummary
+		: persistLatestFullSummary;
+	if (enablePersistLatestFullSummary && sha === latestSummarySha) {
+		try {
+			const latestFullSummaryFromStorage = await retrieveLatestFullSummaryFromStorage(
+				fileSystemManager,
+				getFullSummaryDirectory(repoManager, repoManagerParams.storageRoutingId.documentId),
+				lumberjackProperties,
+			);
+			if (latestFullSummaryFromStorage !== undefined) {
+				return latestFullSummaryFromStorage;
+			}
+		} catch (error) {
+			// This read is for optimization purposes, so on failure
+			// we can try to read the summary in typical fashion.
+			Lumberjack.error(
+				"Failed to read latest full summary from storage.",
+				lumberjackProperties,
+				error,
+			);
+			if (enforceStrictPersistedFullSummaryReads) {
+				if (isNetworkError(error)) {
+					throw error;
+				}
+				if (isFilesystemError(error)) {
+					throwFileSystemErrorAsNetworkError(error);
+				}
+			}
+		}
+	}
+
+	// If we get to this point, it's because one of the options below:
+	// 1) we did not want to read the latest full summary from storage
+	// 2) we wanted to read the latest full summary, but it did not exist in the storage
+	// 3) the summary being requestd is not the latest
+	// Therefore, we need to compute the summary from scratch.
+	const wholeSummaryManager = new GitWholeSummaryManager(
+		repoManagerParams.storageRoutingId.documentId,
+		repoManager,
+		lumberjackProperties,
+		externalWriterConfig?.enabled ?? false,
+	);
+	const fullSummary = await wholeSummaryManager.readSummary(sha);
+
+	// Now that we computed the summary from scratch, we can persist it to storage if
+	// the following conditions are met.
+	if (enablePersistLatestFullSummary && sha === latestSummarySha && fullSummary) {
+		// We persist the full summary in a fire-and-forget way because we don't want it
+		// to impact getSummary latency. So upon computing the full summary above, we should
+		// return as soon as possible. Also, we don't care about failures much, since the
+		// next getSummary or a createSummary request may trigger persisting to storage.
+		persistLatestFullSummaryInStorage(
+			fileSystemManager,
+			getFullSummaryDirectory(repoManager, repoManagerParams.storageRoutingId.documentId),
+			fullSummary,
+			lumberjackProperties,
+		).catch((error) => {
+			Lumberjack.error(
+				"Failed to persist latest full summary to storage during getSummary",
+				lumberjackProperties,
+				error,
+			);
+		});
+	}
+
+	return fullSummary;
+}
+
+async function createSummary(
+	repoManager: IRepositoryManager,
+	fileSystemManager: IFileSystemManager,
+	payload: IWholeSummaryPayload,
+	repoManagerParams: WholeSummaryCompatibleRepoManagerParams,
+	externalWriterConfig?: IExternalWriterConfig,
+	isInitialSummary?: boolean,
+	persistLatestFullSummary = false,
+	persistLatestFullEphemeralSummary = false,
+	enableLowIoWrite: "initial" | boolean = false,
+	optimizeForInitialSummary: boolean = false,
+): Promise<IWriteSummaryResponse | IWholeFlatSummary> {
+	const lumberjackProperties = {
+		...getLumberjackBasePropertiesFromRepoManagerParams(repoManagerParams),
+		[BaseGitRestTelemetryProperties.summaryType]: payload?.type,
+	};
+
+	const wholeSummaryManager = new GitWholeSummaryManager(
+		repoManagerParams.storageRoutingId.documentId,
+		repoManager,
+		lumberjackProperties,
+		externalWriterConfig?.enabled ?? false,
+		{
+			enableLowIoWrite,
+			optimizeForInitialSummary,
+		},
+	);
+
+	Lumberjack.info("Creating summary", lumberjackProperties);
+
+	const { isNew, writeSummaryResponse } = await wholeSummaryManager.writeSummary(
+		payload,
+		isInitialSummary,
+	);
+
+	// Waiting to pre-compute and persist latest summary would slow down document creation,
+	// so skip this step if it is a new document.
+	if (isContainerSummary(payload)) {
+		const latestFullSummary =
+			"trees" in writeSummaryResponse && Array.isArray(writeSummaryResponse.trees)
+				? writeSummaryResponse
+				: await wholeSummaryManager.readSummary(writeSummaryResponse.id).catch((error) => {
+						// This read is for Historian caching purposes, so it should be ignored on failure.
+						Lumberjack.error(
+							"Failed to read latest summary after writing container summary",
+							lumberjackProperties,
+							error,
+						);
+						return undefined;
+				  });
+		if (latestFullSummary) {
+			const enablePersistLatestFullSummary = repoManagerParams.isEphemeralContainer
+				? persistLatestFullEphemeralSummary
+				: persistLatestFullSummary;
+			if (enablePersistLatestFullSummary) {
+				// Send latest full summary to storage for faster read access.
+				const persistP = persistLatestFullSummaryInStorage(
+					fileSystemManager,
+					getFullSummaryDirectory(
+						repoManager,
+						repoManagerParams.storageRoutingId.documentId,
+					),
+					latestFullSummary,
+					lumberjackProperties,
+				).catch((error) => {
+					// Persisting latest summary is an optimization, not a requirement, so do not throw on failure.
+					Lumberjack.error(
+						"Failed to persist latest full summary to storage during createSummary",
+						lumberjackProperties,
+						error,
+					);
+				});
+				if (!isNew) {
+					// To avoid any possible race conditions when outside the critical path, we can await the persist operation.
+					// Chances for a race condition are slim and likely inconsequential, but better safe than sorry.
+					await persistP;
+				}
+			}
+			// Return latest full summary to Historian for caching.
+			return latestFullSummary;
+		}
+	}
+
+	return writeSummaryResponse;
+}
+
+async function deleteSummary(
+	repoManager: IRepositoryManager,
+	fileSystemManager: IFileSystemManager,
+	repoManagerParams: WholeSummaryCompatibleRepoManagerParams,
+	softDelete: boolean,
+	repoPerDocEnabled: boolean,
+	externalWriterConfig?: IExternalWriterConfig,
+): Promise<void> {
+	const lumberjackProperties: Record<string, any> = {
+		...getLumberjackBasePropertiesFromRepoManagerParams(repoManagerParams),
+		[BaseGitRestTelemetryProperties.repoPerDocEnabled]: repoPerDocEnabled,
+		[BaseGitRestTelemetryProperties.softDelete]: softDelete,
+	};
+	if (!repoPerDocEnabled) {
+		Lumberjack.error("Repo per doc is not implemented", lumberjackProperties);
+		throw new NetworkError(501, "Not Implemented");
+	}
+
+	const wholeSummaryManager = new GitWholeSummaryManager(
+		repoManagerParams.storageRoutingId.documentId,
+		repoManager,
+		lumberjackProperties,
+		externalWriterConfig?.enabled ?? false,
+	);
+
+	return wholeSummaryManager.deleteSummary(fileSystemManager, softDelete);
+}
+
+export function create(
+	store: Provider,
+	fileSystemManagerFactories: IFileSystemManagerFactories,
+	repoManagerFactory: IRepositoryManagerFactory,
+): Router {
+	const router: Router = Router();
+	const persistLatestFullSummary: boolean = store.get("git:persistLatestFullSummary") ?? false;
+	const persistLatestFullEphemeralSummary: boolean =
+		store.get("git:persistLatestFullEphemeralSummary") ?? false;
+	const enableLowIoWrite: "initial" | boolean = store.get("git:enableLowIoWrite") ?? false;
+	const enableOptimizedInitialSummary: boolean =
+		store.get("git:enableOptimizedInitialSummary") ?? false;
+	const repoPerDocEnabled: boolean = store.get("git:repoPerDocEnabled") ?? false;
+	const enforceStrictPersistedFullSummaryReads: boolean =
+		store.get("git:enforceStrictPersistedFullSummaryReads") ?? false;
+
+	/**
+	 * Retrieves a summary.
+	 * If sha is "latest", returns latest summary for owner/repo.
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	router.get("/repos/:owner/:repo/git/summaries/:sha", async (request, response) => {
+		const repoManagerParams = getRepoManagerParamsFromRequest(request);
+		if (!isWholeSummaryCompatibleRepoManagerParams(repoManagerParams)) {
+			handleResponse(
+				Promise.reject(
+					new NetworkError(400, `Invalid ${Constants.StorageRoutingIdHeader} header`),
+				),
+				response,
+			);
+			return;
+		}
+		const tenantId = repoManagerParams.storageRoutingId.tenantId;
+		const documentId = repoManagerParams.storageRoutingId.documentId;
+		getGlobalTelemetryContext().bindProperties({ tenantId, documentId }, () => {
+			const resultP = repoManagerFactory
+				.open(repoManagerParams)
+				.then(async (repoManager) => {
+					const fileSystemManagerFactory = getFilesystemManagerFactory(
+						fileSystemManagerFactories,
+						repoManagerParams.isEphemeralContainer ?? false,
+					);
+					const fsManager = fileSystemManagerFactory.create({
+						...repoManagerParams.fileSystemManagerParams,
+						rootDir: repoManager.path,
+					});
+					await checkSoftDeleted(
+						fsManager,
+						repoManager.path,
+						repoManagerParams,
+						repoPerDocEnabled,
+					);
+					return getSummary(
+						repoManager,
+						fsManager,
+						request.params.sha,
+						repoManagerParams,
+						getExternalWriterParams(request.query?.config as string | undefined),
+						persistLatestFullSummary,
+						persistLatestFullEphemeralSummary,
+						enforceStrictPersistedFullSummaryReads,
+					);
+				})
+				.catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+			handleResponse(resultP, response);
+		});
+	});
+
+	/**
+	 * Creates a new summary.
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	router.post("/repos/:owner/:repo/git/summaries", async (request, response) => {
+		const repoManagerParams = getRepoManagerParamsFromRequest(request);
+		// request.query type is { [string]: string } but it's actually { [string]: any }
+		// Account for possibilities of undefined, boolean, or string types. A number will be false.
+		const isInitialSummary: boolean | undefined =
+			typeof request.query.initial === "undefined"
+				? undefined
+				: typeof request.query.initial === "boolean"
+				? request.query.initial
+				: request.query.initial === "true";
+
+		const lumberjackProperties = {
+			...getLumberjackBasePropertiesFromRepoManagerParams(repoManagerParams),
+			[BaseGitRestTelemetryProperties.repoPerDocEnabled]: repoPerDocEnabled,
+			[BaseGitRestTelemetryProperties.isInitial]: isInitialSummary,
+		};
+		Lumberjack.info("Received request to create a summary", lumberjackProperties);
+
+		if (!isWholeSummaryCompatibleRepoManagerParams(repoManagerParams)) {
+			handleResponse(
+				Promise.reject(
+					new NetworkError(400, `Invalid ${Constants.StorageRoutingIdHeader} header`),
+				),
+				response,
+			);
+			return;
+		}
+		const tenantId = repoManagerParams.storageRoutingId.tenantId;
+		const documentId = repoManagerParams.storageRoutingId.documentId;
+		const wholeSummaryPayload: IWholeSummaryPayload = request.body;
+		getGlobalTelemetryContext().bindProperties({ tenantId, documentId }, () => {
+			const resultP = (async () => {
+				// There are possible optimizations we can make throughout the summary write process
+				// if we are using repoPerDoc model and it is the first summary for that document.
+				const optimizeForInitialSummary =
+					enableOptimizedInitialSummary && isInitialSummary && repoPerDocEnabled;
+				// If creating a repo per document, we do not need to check for an existing repo on initial summary write.
+				const repoManager = await getRepoManagerFromWriteAPI(
+					repoManagerFactory,
+					repoManagerParams,
+					repoPerDocEnabled,
+					optimizeForInitialSummary,
+				);
+				const fileSystemManagerFactory = getFilesystemManagerFactory(
+					fileSystemManagerFactories,
+					repoManagerParams.isEphemeralContainer ?? false,
+				);
+				const fsManager = fileSystemManagerFactory.create({
+					...repoManagerParams.fileSystemManagerParams,
+					rootDir: repoManager.path,
+				});
+				// A new document cannot already be soft-deleted.
+				if (!optimizeForInitialSummary) {
+					await checkSoftDeleted(
+						fsManager,
+						repoManager.path,
+						repoManagerParams,
+						repoPerDocEnabled,
+					);
+				}
+				return createSummary(
+					repoManager,
+					fsManager,
+					wholeSummaryPayload,
+					repoManagerParams,
+					getExternalWriterParams(request.query?.config as string | undefined),
+					isInitialSummary,
+					persistLatestFullSummary,
+					persistLatestFullEphemeralSummary,
+					enableLowIoWrite,
+					optimizeForInitialSummary,
+				);
+			})().catch((error) => logAndThrowApiError(error, request, repoManagerParams));
+			handleResponse(resultP, response, undefined, undefined, 201);
+		});
+	});
+
+	/**
+	 * Deletes the latest summary for the given document.
+	 * If header Soft-Delete="true", only flags summary as deleted.
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	router.delete("/repos/:owner/:repo/git/summaries", async (request, response) => {
+		const repoManagerParams = getRepoManagerParamsFromRequest(request);
+		if (!isWholeSummaryCompatibleRepoManagerParams(repoManagerParams)) {
+			handleResponse(
+				Promise.reject(
+					new NetworkError(400, `Invalid ${Constants.StorageRoutingIdHeader} header`),
+				),
+				response,
+			);
+			return;
+		}
+		const tenantId = repoManagerParams.storageRoutingId.tenantId;
+		const documentId = repoManagerParams.storageRoutingId.documentId;
+		const softDelete = request.get("Soft-Delete")?.toLowerCase() === "true";
+		getGlobalTelemetryContext().bindProperties({ tenantId, documentId }, () => {
+			const resultP = repoManagerFactory
+				.open(repoManagerParams)
+				.then(async (repoManager) => {
+					const fileSystemManagerFactory = getFilesystemManagerFactory(
+						fileSystemManagerFactories,
+						repoManagerParams.isEphemeralContainer ?? false,
+					);
+					const fsManager = fileSystemManagerFactory.create({
+						...repoManagerParams.fileSystemManagerParams,
+						rootDir: repoManager.path,
+					});
+					return deleteSummary(
+						repoManager,
+						fsManager,
+						repoManagerParams,
+						softDelete,
+						repoPerDocEnabled,
+						getExternalWriterParams(request.query?.config as string | undefined),
+					);
+				})
+				.catch((error) => {
+					if (isNetworkError(error)) {
+						if (error.code === 400 && error.message.startsWith("Repo does not exist")) {
+							// Document is already deleted, so there is nothing to do. This is a deletion success.
+							const lumberjackProperties = {
+								...getLumberjackBasePropertiesFromRepoManagerParams(
+									repoManagerParams,
+								),
+								[BaseGitRestTelemetryProperties.repoPerDocEnabled]:
+									repoPerDocEnabled,
+								[BaseGitRestTelemetryProperties.softDelete]: softDelete,
+							};
+							Lumberjack.info(
+								"Attempted to delete document that was already deleted or did not exist",
+								lumberjackProperties,
+							);
+							return;
+						}
+					}
+
+					logAndThrowApiError(error, request, repoManagerParams);
+				});
+			handleResponse(resultP, response, undefined, undefined, 204);
+		});
+	});
+
+	return router;
+}

--- a/server/historian/packages/historian-base/src/app.ts
+++ b/server/historian/packages/historian-base/src/app.ts
@@ -141,6 +141,12 @@ export function create(
 		ephemeralDocumentTTLSec,
 		simplifiedCustomDataRetriever,
 	);
+	// TEMP: use bodyParser for v2 routes until implementation changes are made
+	// or body parser is used more specifically
+	v2Router.use(json({ limit: requestSize }));
+	v2Router.use(urlencoded({ limit: requestSize, extended: false }));
+	v2Router.use(v2ApiRoutes.git.refs);
+	v2Router.use(v2ApiRoutes.repository.commits);
 	v2Router.use(v2ApiRoutes.summaries);
 
 	// Split v1 and v2 routes by version param

--- a/server/historian/packages/historian-base/src/index.ts
+++ b/server/historian/packages/historian-base/src/index.ts
@@ -5,7 +5,14 @@
 
 export { IHistorianResourcesCustomizations } from "./customizations";
 export { configureHistorianLogging } from "./logger";
-export { create, IRoutes } from "./routes";
+export {
+	createV1,
+	createV1 as create,
+	IV1Routes as IRoutes,
+	IV1Routes,
+	createV2,
+	IV2Routes,
+} from "./routes";
 export { HistorianRunner } from "./runner";
 export {
 	HistorianResources,

--- a/server/historian/packages/historian-base/src/routes/index.ts
+++ b/server/historian/packages/historian-base/src/routes/index.ts
@@ -3,83 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import {
-	IStorageNameRetriever,
-	IThrottler,
-	IRevokedTokenChecker,
-	IDocumentManager,
-} from "@fluidframework/server-services-core";
-import { Router } from "express";
-import * as nconf from "nconf";
-import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../services";
-/* eslint-disable import/no-internal-modules */
-import * as blobs from "./git/blobs";
-import * as commits from "./git/commits";
-import * as refs from "./git/refs";
-import * as tags from "./git/tags";
-import * as trees from "./git/trees";
-import * as repositoryCommits from "./repository/commits";
-import * as contents from "./repository/contents";
-import * as headers from "./repository/headers";
-import * as summaries from "./summaries";
-import { CommonRouteParams } from "./utils";
-/* eslint-enable import/no-internal-modules */
+export { IRoutes as IV1Routes, create as createV1 } from "./v1";
 
-export interface IRoutes {
-	git: {
-		blobs: Router;
-		commits: Router;
-		refs: Router;
-		tags: Router;
-		trees: Router;
-	};
-	repository: {
-		commits: Router;
-		contents: Router;
-		headers: Router;
-	};
-	summaries: Router;
-}
+export { IRoutes as IV2Routes, create as createV2 } from "./v2";
 
-export function create(
-	config: nconf.Provider,
-	tenantService: ITenantService,
-	storageNameRetriever: IStorageNameRetriever | undefined,
-	restTenantThrottlers: Map<string, IThrottler>,
-	restClusterThrottlers: Map<string, IThrottler>,
-	documentManager: IDocumentManager,
-	cache?: ICache,
-	revokedTokenChecker?: IRevokedTokenChecker,
-	denyList?: IDenyList,
-	ephemeralDocumentTTLSec?: number,
-	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
-): IRoutes {
-	const commonRouteParams: CommonRouteParams = [
-		config,
-		tenantService,
-		storageNameRetriever,
-		restTenantThrottlers,
-		restClusterThrottlers,
-		documentManager,
-		cache,
-		revokedTokenChecker,
-		denyList,
-		ephemeralDocumentTTLSec,
-		simplifiedCustomDataRetriever,
-	];
-	return {
-		git: {
-			blobs: blobs.create(...commonRouteParams),
-			commits: commits.create(...commonRouteParams),
-			refs: refs.create(...commonRouteParams),
-			tags: tags.create(...commonRouteParams),
-			trees: trees.create(...commonRouteParams),
-		},
-		repository: {
-			commits: repositoryCommits.create(...commonRouteParams),
-			contents: contents.create(...commonRouteParams),
-			headers: headers.create(...commonRouteParams),
-		},
-		summaries: summaries.create(...commonRouteParams),
-	};
-}
+export { ApiVersion, getApiVersion } from "./utils";

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { RequestHandler } from "express";
+import { Request, RequestHandler } from "express";
 import { decode } from "jsonwebtoken";
 import * as nconf from "nconf";
 import { ITokenClaims } from "@fluidframework/protocol-definitions";
@@ -392,5 +392,34 @@ export function verifyToken(revokedTokenChecker: IRevokedTokenChecker | undefine
 		} catch (error) {
 			return handleResponse(Promise.reject(error), response);
 		}
+	};
+}
+
+export enum ApiVersion {
+	V1 = "1.0",
+	V2 = "2.0",
+}
+function isValidApiVersion(version: unknown): version is ApiVersion {
+	return version === ApiVersion.V1 || version === ApiVersion.V2;
+}
+export function getApiVersion(req: Request): ApiVersion {
+	const queryParamApiVersion = req.query["api-version"];
+	if (isValidApiVersion(queryParamApiVersion)) {
+		return queryParamApiVersion;
+	}
+	return ApiVersion.V1;
+}
+/**
+ * Middleware wrapper to restrict middleware use to a specific API version.
+ */
+export function apiVersionRestrictedMiddleware(
+	apiVersion: ApiVersion,
+	restrictedMiddleware: RequestHandler,
+): RequestHandler {
+	return (req: Request, res, next) => {
+		if (getApiVersion(req) === apiVersion) {
+			return restrictedMiddleware(req, res, next);
+		}
+		return next();
 	};
 }

--- a/server/historian/packages/historian-base/src/routes/v1/git/blobs.ts
+++ b/server/historian/packages/historian-base/src/routes/v1/git/blobs.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ICommit, ICreateCommitParams } from "@fluidframework/gitresources";
+import * as git from "@fluidframework/gitresources";
 import {
 	IStorageNameRetriever,
 	IThrottler,
@@ -15,9 +15,14 @@ import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
-import * as utils from "../utils";
-import { Constants } from "../../utils";
+import {
+	ICache,
+	IDenyList,
+	ITenantService,
+	ISimplifiedCustomDataRetriever,
+} from "../../../services";
+import * as utils from "../../utils";
+import { Constants } from "../../../utils";
 
 export function create(
 	config: nconf.Provider,
@@ -42,11 +47,11 @@ export function create(
 		Constants.generalRestCallThrottleIdPrefix,
 	);
 
-	async function createCommit(
+	async function createBlob(
 		tenantId: string,
 		authorization: string | undefined,
-		params: ICreateCommitParams,
-	): Promise<ICommit> {
+		body: git.ICreateBlobParams,
+	): Promise<git.ICreateBlobResponse> {
 		const service = await utils.createGitService({
 			config,
 			tenantId,
@@ -59,15 +64,15 @@ export function create(
 			ephemeralDocumentTTLSec,
 			simplifiedCustomDataRetriever,
 		});
-		return service.createCommit(params);
+		return service.createBlob(body);
 	}
 
-	async function getCommit(
+	async function getBlob(
 		tenantId: string,
 		authorization: string | undefined,
 		sha: string,
 		useCache: boolean,
-	): Promise<ICommit> {
+	): Promise<git.IBlob> {
 		const service = await utils.createGitService({
 			config,
 			tenantId,
@@ -79,40 +84,96 @@ export function create(
 			denyList,
 			ephemeralDocumentTTLSec,
 		});
-		return service.getCommit(sha, useCache);
+		return service.getBlob(sha, useCache);
 	}
 
+	/**
+	 * Historian https ping endpoint for availability monitoring system
+	 */
+	router.get(
+		"/repos/ping",
+		throttle(restTenantGeneralThrottler, winston, {
+			...tenantThrottleOptions,
+			throttleIdPrefix: "ping",
+		}),
+		// eslint-disable-next-line @typescript-eslint/no-misused-promises
+		async (request, response) => {
+			response.sendStatus(200);
+		},
+	);
+
 	router.post(
-		"/repos/:ignored?/:tenantId/git/commits",
+		"/repos/:ignored?/:tenantId/git/blobs",
 		validateRequestParams("tenantId"),
 		throttle(restTenantGeneralThrottler, winston, tenantThrottleOptions),
 		utils.verifyToken(revokedTokenChecker),
 		(request, response, next) => {
-			const commitP = createCommit(
+			const blobP = createBlob(
 				request.params.tenantId,
 				request.get("Authorization"),
 				request.body,
 			);
-
-			utils.handleResponse(commitP, response, false, undefined, 201);
+			utils.handleResponse(blobP, response, false, 201);
 		},
 	);
 
+	/**
+	 * Retrieves the given blob from the repository
+	 */
 	router.get(
-		"/repos/:ignored?/:tenantId/git/commits/:sha",
+		"/repos/:ignored?/:tenantId/git/blobs/:sha",
 		validateRequestParams("tenantId", "sha"),
 		throttle(restTenantGeneralThrottler, winston, tenantThrottleOptions),
 		utils.verifyToken(revokedTokenChecker),
 		(request, response, next) => {
 			const useCache = !("disableCache" in request.query);
-			const commitP = getCommit(
+			const blobP = getBlob(
+				request.params.tenantId,
+				request.get("Authorization"),
+				request.params.sha,
+				useCache,
+			);
+			utils.handleResponse(blobP, response, useCache);
+		},
+	);
+
+	/**
+	 * Retrieves the given blob as an image
+	 */
+	router.get(
+		"/repos/:ignored?/:tenantId/git/blobs/raw/:sha",
+		validateRequestParams("tenantId", "sha"),
+		throttle(restTenantGeneralThrottler, winston, tenantThrottleOptions),
+		utils.verifyToken(revokedTokenChecker),
+		(request, response, next) => {
+			const useCache = !("disableCache" in request.query);
+
+			const blobP = getBlob(
 				request.params.tenantId,
 				request.get("Authorization"),
 				request.params.sha,
 				useCache,
 			);
 
-			utils.handleResponse(commitP, response, useCache);
+			blobP
+				.then((blob) => {
+					if (useCache) {
+						response.setHeader("Cache-Control", "public, max-age=31536000");
+					}
+					// Make sure the browser will expose specific headers for performance analysis.
+					response.setHeader(
+						"Access-Control-Expose-Headers",
+						"Content-Encoding, Content-Length, Content-Type",
+					);
+					// In order to report W3C timings, Time-Allow-Origin needs to be set.
+					response.setHeader("Timing-Allow-Origin", "*");
+					response
+						.status(200)
+						.write(Buffer.from(blob.content, "base64"), () => response.end());
+				})
+				.catch((error) => {
+					response.status(error?.code ?? 400).json(error?.message ?? error);
+				});
 		},
 	);
 

--- a/server/historian/packages/historian-base/src/routes/v1/git/refs.ts
+++ b/server/historian/packages/historian-base/src/routes/v1/git/refs.ts
@@ -19,9 +19,14 @@ import { validateRequestParams } from "@fluidframework/server-services-shared";
 import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
-import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
-import * as utils from "../utils";
-import { Constants } from "../../utils";
+import {
+	ICache,
+	IDenyList,
+	ITenantService,
+	ISimplifiedCustomDataRetriever,
+} from "../../../services";
+import * as utils from "../../utils";
+import { Constants } from "../../../utils";
 
 export function create(
 	config: nconf.Provider,

--- a/server/historian/packages/historian-base/src/routes/v1/index.ts
+++ b/server/historian/packages/historian-base/src/routes/v1/index.ts
@@ -1,0 +1,85 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	IStorageNameRetriever,
+	IThrottler,
+	IRevokedTokenChecker,
+	IDocumentManager,
+} from "@fluidframework/server-services-core";
+import { Router } from "express";
+import * as nconf from "nconf";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
+/* eslint-disable import/no-internal-modules */
+import * as blobs from "./git/blobs";
+import * as commits from "./git/commits";
+import * as refs from "./git/refs";
+import * as tags from "./git/tags";
+import * as trees from "./git/trees";
+import * as repositoryCommits from "./repository/commits";
+import * as contents from "./repository/contents";
+import * as headers from "./repository/headers";
+import * as summaries from "./summaries";
+import { CommonRouteParams } from "../utils";
+/* eslint-enable import/no-internal-modules */
+
+export interface IRoutes {
+	git: {
+		blobs: Router;
+		commits: Router;
+		refs: Router;
+		tags: Router;
+		trees: Router;
+	};
+	repository: {
+		commits: Router;
+		contents: Router;
+		headers: Router;
+	};
+	summaries: Router;
+}
+
+export function create(
+	config: nconf.Provider,
+	tenantService: ITenantService,
+	storageNameRetriever: IStorageNameRetriever | undefined,
+	restTenantThrottlers: Map<string, IThrottler>,
+	restClusterThrottlers: Map<string, IThrottler>,
+	documentManager: IDocumentManager,
+	cache?: ICache,
+	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
+	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
+): IRoutes {
+	const commonRouteParams: CommonRouteParams = [
+		config,
+		tenantService,
+		storageNameRetriever,
+		restTenantThrottlers,
+		restClusterThrottlers,
+		documentManager,
+		cache,
+		revokedTokenChecker,
+		denyList,
+		ephemeralDocumentTTLSec,
+		simplifiedCustomDataRetriever,
+	];
+	return {
+		git: {
+			blobs: blobs.create(...commonRouteParams),
+			commits: commits.create(...commonRouteParams),
+			refs: refs.create(...commonRouteParams),
+			tags: tags.create(...commonRouteParams),
+			trees: trees.create(...commonRouteParams),
+		},
+		repository: {
+			commits: repositoryCommits.create(...commonRouteParams),
+			contents: contents.create(...commonRouteParams),
+			headers: headers.create(...commonRouteParams),
+		},
+		summaries: summaries.create(...commonRouteParams),
+	};
+}

--- a/server/historian/packages/historian-base/src/routes/v1/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/v1/summaries.ts
@@ -20,9 +20,9 @@ import { Router } from "express";
 import * as nconf from "nconf";
 import winston from "winston";
 import { BaseTelemetryProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
-import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../services";
-import { parseToken, Constants } from "../utils";
-import * as utils from "./utils";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
+import { parseToken, Constants } from "../../utils";
+import * as utils from "../utils";
 
 export function create(
 	config: nconf.Provider,

--- a/server/historian/packages/historian-base/src/routes/v2/git/refs.ts
+++ b/server/historian/packages/historian-base/src/routes/v2/git/refs.ts
@@ -1,0 +1,224 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as git from "@fluidframework/gitresources";
+import {
+	ICreateRefParamsExternal,
+	IPatchRefParamsExternal,
+} from "@fluidframework/server-services-client";
+import {
+	IStorageNameRetriever,
+	IThrottler,
+	IRevokedTokenChecker,
+	IDocumentManager,
+} from "@fluidframework/server-services-core";
+import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
+import { validateRequestParams } from "@fluidframework/server-services-shared";
+import { Router } from "express";
+import * as nconf from "nconf";
+import winston from "winston";
+import {
+	ICache,
+	IDenyList,
+	ITenantService,
+	ISimplifiedCustomDataRetriever,
+} from "../../../services";
+import * as utils from "../../utils";
+import { Constants } from "../../../utils";
+
+export function create(
+	config: nconf.Provider,
+	tenantService: ITenantService,
+	storageNameRetriever: IStorageNameRetriever | undefined,
+	restTenantThrottlers: Map<string, IThrottler>,
+	restClusterThrottlers: Map<string, IThrottler>,
+	documentManager: IDocumentManager,
+	cache?: ICache,
+	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
+	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
+): Router {
+	const router: Router = Router();
+
+	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
+		throttleIdPrefix: (req) => req.params.tenantId,
+		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
+	};
+	const restTenantGeneralThrottler = restTenantThrottlers.get(
+		Constants.generalRestCallThrottleIdPrefix,
+	);
+
+	async function getRefs(
+		tenantId: string,
+		authorization: string | undefined,
+	): Promise<git.IRef[]> {
+		const service = await utils.createGitService({
+			config,
+			tenantId,
+			authorization,
+			tenantService,
+			storageNameRetriever,
+			documentManager,
+			cache,
+			denyList,
+			ephemeralDocumentTTLSec,
+		});
+		return service.getRefs();
+	}
+
+	async function getRef(
+		tenantId: string,
+		authorization: string | undefined,
+		ref: string,
+	): Promise<git.IRef> {
+		const service = await utils.createGitService({
+			config,
+			tenantId,
+			authorization,
+			tenantService,
+			storageNameRetriever,
+			documentManager,
+			cache,
+			denyList,
+			ephemeralDocumentTTLSec,
+		});
+		return service.getRef(ref);
+	}
+
+	async function createRef(
+		tenantId: string,
+		authorization: string | undefined,
+		params: ICreateRefParamsExternal,
+	): Promise<git.IRef> {
+		const service = await utils.createGitService({
+			config,
+			tenantId,
+			authorization,
+			tenantService,
+			storageNameRetriever,
+			documentManager,
+			cache,
+			denyList,
+			ephemeralDocumentTTLSec,
+			simplifiedCustomDataRetriever,
+		});
+		return service.createRef(params);
+	}
+
+	async function updateRef(
+		tenantId: string,
+		authorization: string | undefined,
+		ref: string,
+		params: IPatchRefParamsExternal,
+	): Promise<git.IRef> {
+		const service = await utils.createGitService({
+			config,
+			tenantId,
+			authorization,
+			tenantService,
+			storageNameRetriever,
+			documentManager,
+			cache,
+			denyList,
+			ephemeralDocumentTTLSec,
+			simplifiedCustomDataRetriever,
+		});
+		return service.updateRef(ref, params);
+	}
+
+	async function deleteRef(
+		tenantId: string,
+		authorization: string | undefined,
+		ref: string,
+	): Promise<void> {
+		const service = await utils.createGitService({
+			config,
+			tenantId,
+			authorization,
+			tenantService,
+			storageNameRetriever,
+			documentManager,
+			cache,
+			denyList,
+			ephemeralDocumentTTLSec,
+		});
+		return service.deleteRef(ref);
+	}
+
+	router.get(
+		"/repos/:ignored?/:tenantId/git/refs",
+		validateRequestParams("tenantId"),
+		throttle(restTenantGeneralThrottler, winston, tenantThrottleOptions),
+		utils.verifyToken(revokedTokenChecker),
+		(request, response, next) => {
+			const refsP = getRefs(request.params.tenantId, request.get("Authorization"));
+			utils.handleResponse(refsP, response, false);
+		},
+	);
+
+	router.get(
+		"/repos/:ignored?/:tenantId/git/refs/*",
+		validateRequestParams("tenantId", 0),
+		throttle(restTenantGeneralThrottler, winston, tenantThrottleOptions),
+		utils.verifyToken(revokedTokenChecker),
+		(request, response, next) => {
+			const refP = getRef(
+				request.params.tenantId,
+				request.get("Authorization"),
+				request.params[0],
+			);
+			utils.handleResponse(refP, response, false);
+		},
+	);
+
+	router.post(
+		"/repos/:ignored?/:tenantId/git/refs",
+		validateRequestParams("tenantId"),
+		throttle(restTenantGeneralThrottler, winston, tenantThrottleOptions),
+		utils.verifyToken(revokedTokenChecker),
+		(request, response, next) => {
+			const refP = createRef(
+				request.params.tenantId,
+				request.get("Authorization"),
+				request.body,
+			);
+			utils.handleResponse(refP, response, false, undefined, 201);
+		},
+	);
+
+	router.patch(
+		"/repos/:ignored?/:tenantId/git/refs/*",
+		validateRequestParams("tenantId", 0),
+		throttle(restTenantGeneralThrottler, winston, tenantThrottleOptions),
+		utils.verifyToken(revokedTokenChecker),
+		(request, response, next) => {
+			const refP = updateRef(
+				request.params.tenantId,
+				request.get("Authorization"),
+				request.params[0],
+				request.body,
+			);
+			utils.handleResponse(refP, response, false);
+		},
+	);
+
+	router.delete(
+		"/repos/:ignored?/:tenantId/git/refs/*",
+		validateRequestParams("tenantId", 0),
+		throttle(restTenantGeneralThrottler, winston, tenantThrottleOptions),
+		utils.verifyToken(revokedTokenChecker),
+		(request, response, next) => {
+			const refP = deleteRef(
+				request.params.tenantId,
+				request.get("Authorization"),
+				request.params[0],
+			);
+			utils.handleResponse(refP, response, false, undefined, 204);
+		},
+	);
+
+	return router;
+}

--- a/server/historian/packages/historian-base/src/routes/v2/index.ts
+++ b/server/historian/packages/historian-base/src/routes/v2/index.ts
@@ -12,10 +12,20 @@ import {
 import { Router } from "express";
 import * as nconf from "nconf";
 import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
+/* eslint-disable import/no-internal-modules */
+import * as refs from "./git/refs";
+import * as repositoryCommits from "./repository/commits";
+/* eslint-enable import/no-internal-modules */
 import * as summaries from "./summaries";
 import { CommonRouteParams } from "../utils";
 
 export interface IRoutes {
+	git: {
+		refs: Router;
+	};
+	repository: {
+		commits: Router;
+	};
 	summaries: Router;
 }
 
@@ -46,6 +56,12 @@ export function create(
 		simplifiedCustomDataRetriever,
 	];
 	return {
+		git: {
+			refs: refs.create(...commonRouteParams),
+		},
+		repository: {
+			commits: repositoryCommits.create(...commonRouteParams),
+		},
 		summaries: summaries.create(...commonRouteParams),
 	};
 }

--- a/server/historian/packages/historian-base/src/routes/v2/index.ts
+++ b/server/historian/packages/historian-base/src/routes/v2/index.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	IStorageNameRetriever,
+	IThrottler,
+	IRevokedTokenChecker,
+	IDocumentManager,
+} from "@fluidframework/server-services-core";
+import { Router } from "express";
+import * as nconf from "nconf";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
+import * as summaries from "./summaries";
+import { CommonRouteParams } from "../utils";
+
+export interface IRoutes {
+	summaries: Router;
+}
+
+export function create(
+	config: nconf.Provider,
+	tenantService: ITenantService,
+	storageNameRetriever: IStorageNameRetriever | undefined,
+	restTenantThrottlers: Map<string, IThrottler>,
+	restClusterThrottlers: Map<string, IThrottler>,
+	documentManager: IDocumentManager,
+	cache?: ICache,
+	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
+	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
+): IRoutes {
+	const commonRouteParams: CommonRouteParams = [
+		config,
+		tenantService,
+		storageNameRetriever,
+		restTenantThrottlers,
+		restClusterThrottlers,
+		documentManager,
+		cache,
+		revokedTokenChecker,
+		denyList,
+		ephemeralDocumentTTLSec,
+		simplifiedCustomDataRetriever,
+	];
+	return {
+		summaries: summaries.create(...commonRouteParams),
+	};
+}

--- a/server/historian/packages/historian-base/src/routes/v2/repository/commits.ts
+++ b/server/historian/packages/historian-base/src/routes/v2/repository/commits.ts
@@ -1,0 +1,112 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as git from "@fluidframework/gitresources";
+import {
+	IStorageNameRetriever,
+	IThrottler,
+	IRevokedTokenChecker,
+	IDocumentManager,
+} from "@fluidframework/server-services-core";
+import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
+import {
+	containsPathTraversal,
+	validateRequestParams,
+} from "@fluidframework/server-services-shared";
+import { Router } from "express";
+import * as nconf from "nconf";
+import winston from "winston";
+import {
+	ICache,
+	IDenyList,
+	ITenantService,
+	ISimplifiedCustomDataRetriever,
+} from "../../../services";
+import * as utils from "../../utils";
+import { Constants } from "../../../utils";
+import { NetworkError } from "@fluidframework/server-services-client";
+
+export function create(
+	config: nconf.Provider,
+	tenantService: ITenantService,
+	storageNameRetriever: IStorageNameRetriever | undefined,
+	restTenantThrottlers: Map<string, IThrottler>,
+	restClusterThrottlers: Map<string, IThrottler>,
+	documentManager: IDocumentManager,
+	cache?: ICache,
+	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
+	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
+): Router {
+	const router: Router = Router();
+
+	const tenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
+		throttleIdPrefix: (req) => req.params.tenantId,
+		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
+	};
+	const restTenantGeneralThrottler = restTenantThrottlers.get(
+		Constants.generalRestCallThrottleIdPrefix,
+	);
+
+	async function getCommits(
+		tenantId: string,
+		authorization: string | undefined,
+		sha: string,
+		count: number = 1,
+	): Promise<git.ICommitDetails[]> {
+		if (sha === undefined) {
+			throw new NetworkError(400, "Missing required parameter 'sha'");
+		}
+		const service = await utils.createGitService({
+			config,
+			tenantId,
+			authorization,
+			tenantService,
+			storageNameRetriever,
+			documentManager,
+			cache,
+			denyList,
+			ephemeralDocumentTTLSec,
+		});
+		return service.getCommits(sha, count);
+	}
+
+	router.get(
+		"/repos/:ignored?/:tenantId/commits",
+		validateRequestParams("tenantId"),
+		throttle(restTenantGeneralThrottler, winston, tenantThrottleOptions),
+		utils.verifyToken(revokedTokenChecker),
+		(request, response, next) => {
+			const sha = utils.queryParamToString(request.query.sha);
+			if (sha === undefined) {
+				utils.handleResponse(
+					Promise.reject(new NetworkError(400, "Missing required parameter 'sha'")),
+					response,
+					false,
+				);
+				return;
+			}
+			if (containsPathTraversal(sha)) {
+				utils.handleResponse(
+					Promise.reject(new NetworkError(400, "Invalid sha")),
+					response,
+					false,
+				);
+				return;
+			}
+			const commitsP = getCommits(
+				request.params.tenantId,
+				request.get("Authorization"),
+				sha,
+				utils.queryParamToNumber(request.query.count),
+			);
+
+			utils.handleResponse(commitsP, response, false);
+		},
+	);
+
+	return router;
+}

--- a/server/historian/packages/historian-base/src/routes/v2/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/v2/summaries.ts
@@ -1,0 +1,258 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	IWholeFlatSummary,
+	IWholeSummaryPayload,
+	IWriteSummaryResponse,
+} from "@fluidframework/server-services-client";
+import {
+	IStorageNameRetriever,
+	IThrottler,
+	IRevokedTokenChecker,
+	IDocumentManager,
+} from "@fluidframework/server-services-core";
+import { IThrottleMiddlewareOptions, throttle } from "@fluidframework/server-services-utils";
+import { validateRequestParams } from "@fluidframework/server-services-shared";
+import { Router } from "express";
+import * as nconf from "nconf";
+import winston from "winston";
+import { BaseTelemetryProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
+import { ICache, IDenyList, ITenantService, ISimplifiedCustomDataRetriever } from "../../services";
+import { parseToken, Constants } from "../../utils";
+import * as utils from "../utils";
+
+export function create(
+	config: nconf.Provider,
+	tenantService: ITenantService,
+	storageNameRetriever: IStorageNameRetriever | undefined,
+	restTenantThrottlers: Map<string, IThrottler>,
+	restClusterThrottlers: Map<string, IThrottler>,
+	documentManager: IDocumentManager,
+	cache?: ICache,
+	revokedTokenChecker?: IRevokedTokenChecker,
+	denyList?: IDenyList,
+	ephemeralDocumentTTLSec?: number,
+	simplifiedCustomDataRetriever?: ISimplifiedCustomDataRetriever,
+): Router {
+	const router: Router = Router();
+	const ignoreIsEphemeralFlag: boolean = config.get("ignoreEphemeralFlag") ?? true;
+
+	const tenantGeneralThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
+		throttleIdPrefix: (req) => req.params.tenantId,
+		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
+	};
+	const restTenantGeneralThrottler = restTenantThrottlers.get(
+		Constants.generalRestCallThrottleIdPrefix,
+	);
+
+	// Throttling logic for creating summary to provide per-tenant rate-limiting at the HTTP route level
+	const createSummaryPerTenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
+		throttleIdPrefix: (req) => req.params.tenantId,
+		throttleIdSuffix: Constants.createSummaryThrottleIdPrefix,
+	};
+	const restTenantCreateSummaryThrottler = restTenantThrottlers.get(
+		Constants.createSummaryThrottleIdPrefix,
+	);
+
+	// Throttling logic for getting summary to provide per-tenant rate-limiting at the HTTP route level
+	const getSummaryPerTenantThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
+		throttleIdPrefix: (req) => req.params.tenantId,
+		throttleIdSuffix: Constants.getSummaryThrottleIdPrefix,
+	};
+	const restTenantGetSummaryThrottler = restTenantThrottlers.get(
+		Constants.getSummaryThrottleIdPrefix,
+	);
+
+	// Throttling logic for creating summary to provide per-cluster rate-limiting at the HTTP route level
+	const createSummaryPerClusterThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
+		throttleIdPrefix: Constants.createSummaryThrottleIdPrefix,
+		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
+	};
+	const restClusterCreateSummaryThrottler = restClusterThrottlers.get(
+		Constants.createSummaryThrottleIdPrefix,
+	);
+
+	// Throttling logic for getting summary to provide per-cluster rate-limiting at the HTTP route level
+	const getSummaryPerClusterThrottleOptions: Partial<IThrottleMiddlewareOptions> = {
+		throttleIdPrefix: Constants.getSummaryThrottleIdPrefix,
+		throttleIdSuffix: Constants.historianRestThrottleIdSuffix,
+	};
+	const restClusterGetSummaryThrottler = restClusterThrottlers.get(
+		Constants.getSummaryThrottleIdPrefix,
+	);
+
+	async function getSummary(
+		tenantId: string,
+		authorization: string | undefined,
+		sha: string,
+		useCache: boolean,
+	): Promise<IWholeFlatSummary> {
+		const service = await utils.createGitService({
+			config,
+			tenantId,
+			authorization,
+			tenantService,
+			storageNameRetriever,
+			documentManager,
+			cache,
+			denyList,
+			ephemeralDocumentTTLSec,
+		});
+		return service.getSummary(sha, useCache);
+	}
+
+	async function createSummary(
+		tenantId: string,
+		authorization: string | undefined,
+		params: IWholeSummaryPayload,
+		initial?: boolean,
+		storageName?: string,
+		isEphemeralContainer?: boolean,
+		ignoreEphemeralFlag?: boolean,
+	): Promise<IWriteSummaryResponse> {
+		const service = await utils.createGitService({
+			config,
+			tenantId,
+			authorization,
+			tenantService,
+			storageNameRetriever,
+			documentManager,
+			cache,
+			initialUpload: initial,
+			storageName,
+			isEphemeralContainer,
+			denyList,
+			ephemeralDocumentTTLSec,
+			simplifiedCustomDataRetriever,
+		});
+		return service.createSummary(params, initial);
+	}
+
+	async function deleteSummary(
+		tenantId: string,
+		authorization: string | undefined,
+		softDelete: boolean,
+	): Promise<boolean[]> {
+		const service = await utils.createGitService({
+			config,
+			tenantId,
+			authorization,
+			tenantService,
+			storageNameRetriever,
+			documentManager,
+			cache,
+			allowDisabledTenant: true,
+			denyList,
+			ephemeralDocumentTTLSec,
+		});
+		const deletionPs = [service.deleteSummary(softDelete)];
+		if (!softDelete) {
+			const token = parseToken(tenantId, authorization);
+			if (token) {
+				deletionPs.push(tenantService.deleteFromCache(tenantId, token));
+			}
+		}
+		return Promise.all(deletionPs);
+	}
+
+	router.get(
+		"/repos/:ignored?/:tenantId/git/summaries/:sha",
+		validateRequestParams("tenantId", "sha"),
+		throttle(restClusterGetSummaryThrottler, winston, getSummaryPerClusterThrottleOptions),
+		throttle(restTenantGetSummaryThrottler, winston, getSummaryPerTenantThrottleOptions),
+		utils.verifyToken(revokedTokenChecker),
+		(request, response, next) => {
+			const useCache = !("disableCache" in request.query);
+			const summaryP = getSummary(
+				request.params.tenantId,
+				request.get("Authorization"),
+				request.params.sha,
+				useCache,
+			);
+
+			utils.handleResponse(
+				summaryP,
+				response,
+				// Browser caching for summary data should be disabled for now.
+				false,
+			);
+		},
+	);
+
+	router.post(
+		"/repos/:ignored?/:tenantId/git/summaries",
+		validateRequestParams("tenantId"),
+		throttle(
+			restClusterCreateSummaryThrottler,
+			winston,
+			createSummaryPerClusterThrottleOptions,
+		),
+		throttle(restTenantCreateSummaryThrottler, winston, createSummaryPerTenantThrottleOptions),
+		utils.verifyToken(revokedTokenChecker),
+		(request, response, next) => {
+			// request.query type is { [string]: string } but it's actually { [string]: any }
+			// Account for possibilities of undefined, boolean, or string types. A number will be false.
+			const initial: boolean | undefined =
+				typeof request.query.initial === "undefined"
+					? undefined
+					: typeof request.query.initial === "boolean"
+					? request.query.initial
+					: request.query.initial === "true";
+
+			const isEphemeralFromRequest = request.get(Constants.IsEphemeralContainer);
+
+			// We treat these cases where we did not get the header as non-ephemeral containers
+			const isEphemeral: boolean =
+				isEphemeralFromRequest === undefined ? false : isEphemeralFromRequest === "true";
+
+			// Only the initial post summary has a valid IsEphemeralContainer flag which we store in cache
+			// For the other cases, we set the flag to undefined so that it can fetched from cache/storage
+			const isEphemeralContainer: boolean | undefined = !ignoreIsEphemeralFlag
+				? initial
+					? isEphemeral
+					: undefined
+				: false;
+
+			const lumberjackProperties = {
+				[BaseTelemetryProperties.tenantId]: request.params.tenantId,
+				[Constants.IsEphemeralContainer]: isEphemeralContainer,
+				[Constants.isInitialSummary]: initial,
+			};
+			Lumberjack.info(`Calling createSummary`, lumberjackProperties);
+
+			const summaryP = createSummary(
+				request.params.tenantId,
+				request.get("Authorization"),
+				request.body,
+				initial,
+				request.get("StorageName"),
+				isEphemeralContainer,
+				ignoreIsEphemeralFlag,
+			);
+
+			utils.handleResponse(summaryP, response, false, undefined, 201);
+		},
+	);
+
+	router.delete(
+		"/repos/:ignored?/:tenantId/git/summaries",
+		validateRequestParams("tenantId"),
+		throttle(restTenantGeneralThrottler, winston, tenantGeneralThrottleOptions),
+		utils.verifyToken(revokedTokenChecker),
+		(request, response, next) => {
+			const softDelete = request.get("Soft-Delete")?.toLowerCase() === "true";
+			const summaryP = deleteSummary(
+				request.params.tenantId,
+				request.get("Authorization"),
+				softDelete,
+			);
+
+			utils.handleResponse(summaryP, response, false);
+		},
+	);
+
+	return router;
+}

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -84,7 +84,7 @@ data:
             "enableWholeSummaryUpload": {{ .Values.storage.enableWholeSummaryUpload }},
             "ephemeralDocumentTTLSec": {{ .Values.storage.ephemeralDocumentTTLSec }},
             "storageUrl": "{{ .Values.storage.storageUrl }}",
-            "enableHistorianV2Api": {{ .Values.storage.enableHistorianV2Api }}
+            "historianApiVersion": "{{ .Values.storage.historianApiVersion }}"
         },
         "checkpoints": {
             "localCheckpointEnabled": {{ .Values.checkpoints.localCheckpointEnabled }},

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -83,7 +83,8 @@ data:
         "storage": {
             "enableWholeSummaryUpload": {{ .Values.storage.enableWholeSummaryUpload }},
             "ephemeralDocumentTTLSec": {{ .Values.storage.ephemeralDocumentTTLSec }},
-            "storageUrl": "{{ .Values.storage.storageUrl }}"
+            "storageUrl": "{{ .Values.storage.storageUrl }}",
+            "enableHistorianV2Api": {{ .Values.storage.enableHistorianV2Api }}
         },
         "checkpoints": {
             "localCheckpointEnabled": {{ .Values.checkpoints.localCheckpointEnabled }},

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -69,7 +69,7 @@ nexus:
 storage:
   enableWholeSummaryUpload: false
   ephemeralDocumentTTLSec: 86400
-  enableHistorianV2Api: false
+  historianApiVersion: "1.0"
   storageUrl: storage_url
 
 checkpoints:

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -69,6 +69,7 @@ nexus:
 storage:
   enableWholeSummaryUpload: false
   ephemeralDocumentTTLSec: 86400
+  enableHistorianV2Api: false
   storageUrl: storage_url
 
 checkpoints:

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -320,6 +320,7 @@ export class ScribeLambdaFactory
 			this.enableWholeSummaryUpload,
 			lastSummaryMessages,
 			this.getDeltasViaAlfred,
+			undefined /* maxRetriesOnError */,
 			this.maxLogtailLength,
 		);
 		const checkpointManager = new CheckpointManager(

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -218,7 +218,10 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 		// This.nodeTracker.on("invalidate", (id) => this.emit("invalidate", id));
 
 		const internalHistorianUrl = config.get("worker:internalBlobStorageUrl");
-		const tenantManager = new services.TenantManager(authEndpoint, internalHistorianUrl);
+		const enableHistorianApiV2: boolean = config.get("storage:enableHistorianApiV2") ?? false;
+		const tenantManager = new services.TenantManager(authEndpoint, internalHistorianUrl, {
+			enableHistorianApiV2,
+		});
 
 		// Redis connection for throttling.
 		const redisConfigForThrottling = config.get("redisForThrottling");

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -218,9 +218,9 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 		// This.nodeTracker.on("invalidate", (id) => this.emit("invalidate", id));
 
 		const internalHistorianUrl = config.get("worker:internalBlobStorageUrl");
-		const enableHistorianApiV2: boolean = config.get("storage:enableHistorianApiV2") ?? false;
+		const historianApiVersion: string = config.get("storage:historianApiVersion") ?? "1.0";
 		const tenantManager = new services.TenantManager(authEndpoint, internalHistorianUrl, {
-			enableHistorianApiV2,
+			historianApiVersion,
 		});
 
 		// Redis connection for throttling.

--- a/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
@@ -306,7 +306,10 @@ export class NexusResourcesFactory implements core.IResourcesFactory<NexusResour
 
 		const internalHistorianUrl = config.get("worker:internalBlobStorageUrl");
 		const authEndpoint = config.get("auth:endpoint");
-		const tenantManager = new services.TenantManager(authEndpoint, internalHistorianUrl);
+		const enableHistorianApiV2: boolean = config.get("storage:enableHistorianApiV2") ?? false;
+		const tenantManager = new services.TenantManager(authEndpoint, internalHistorianUrl, {
+			enableHistorianApiV2,
+		});
 
 		// Redis connection for throttling.
 		const redisConfigForThrottling = config.get("redisForThrottling");

--- a/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
@@ -306,9 +306,9 @@ export class NexusResourcesFactory implements core.IResourcesFactory<NexusResour
 
 		const internalHistorianUrl = config.get("worker:internalBlobStorageUrl");
 		const authEndpoint = config.get("auth:endpoint");
-		const enableHistorianApiV2: boolean = config.get("storage:enableHistorianApiV2") ?? false;
+		const historianApiVersion: string = config.get("storage:historianApiVersion") ?? "1.0";
 		const tenantManager = new services.TenantManager(authEndpoint, internalHistorianUrl, {
-			enableHistorianApiV2,
+			historianApiVersion,
 		});
 
 		// Redis connection for throttling.

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -67,9 +67,10 @@
 		"endpoint": "zookeeper:2181"
 	},
 	"storage": {
-		"enableWholeSummaryUpload": false,
+		"enableWholeSummaryUpload": true,
 		"ephemeralDocumentTTLSec": 86400,
-		"storageUrl": "http://gitrest:3000"
+		"storageUrl": "http://gitrest:3000",
+		"enableHistorianV2Api": true
 	},
 	"checkpoints": {
 		"localCheckpointEnabled": true,

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -70,7 +70,7 @@
 		"enableWholeSummaryUpload": true,
 		"ephemeralDocumentTTLSec": 86400,
 		"storageUrl": "http://gitrest:3000",
-		"enableHistorianV2Api": true
+		"historianApiVersion": "2.0"
 	},
 	"checkpoints": {
 		"localCheckpointEnabled": true,

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -63,7 +63,10 @@ export async function deliCreate(
 	// Generate tenant manager which abstracts access to the underlying storage provider
 	const authEndpoint = config.get("auth:endpoint");
 	const internalHistorianUrl = config.get("worker:internalBlobStorageUrl");
-	const tenantManager = new services.TenantManager(authEndpoint, internalHistorianUrl);
+	const enableHistorianApiV2: boolean = config.get("storage:enableHistorianApiV2") ?? false;
+	const tenantManager = new services.TenantManager(authEndpoint, internalHistorianUrl, {
+		enableHistorianApiV2,
+	});
 	const globalDbEnabled = config.get("mongo:globalDbEnabled") as boolean;
 	// Database connection for global db if enabled
 	const factory = await services.getDbFactory(config);

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -63,9 +63,9 @@ export async function deliCreate(
 	// Generate tenant manager which abstracts access to the underlying storage provider
 	const authEndpoint = config.get("auth:endpoint");
 	const internalHistorianUrl = config.get("worker:internalBlobStorageUrl");
-	const enableHistorianApiV2: boolean = config.get("storage:enableHistorianApiV2") ?? false;
+	const historianApiVersion: string = config.get("storage:historianApiVersion") ?? "1.0";
 	const tenantManager = new services.TenantManager(authEndpoint, internalHistorianUrl, {
-		enableHistorianApiV2,
+		historianApiVersion,
 	});
 	const globalDbEnabled = config.get("mongo:globalDbEnabled") as boolean;
 	// Database connection for global db if enabled

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -72,9 +72,9 @@ export async function scribeCreate(
 	// Generate tenant manager which abstracts access to the underlying storage provider
 	const authEndpoint = config.get("auth:endpoint");
 	const internalHistorianUrl = config.get("worker:internalBlobStorageUrl");
-	const enableHistorianApiV2: boolean = config.get("storage:enableHistorianApiV2") ?? false;
+	const historianApiVersion: string = config.get("storage:historianApiVersion") ?? "1.0";
 	const tenantManager = new TenantManager(authEndpoint, internalHistorianUrl, {
-		enableHistorianApiV2,
+		historianApiVersion,
 	});
 
 	const deltaManager = new DeltaManager(authEndpoint, internalAlfredUrl);

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -53,7 +53,6 @@ export async function scribeCreate(
 	const kafkaClientId = config.get("scribe:kafkaClientId");
 	const mongoExpireAfterSeconds = config.get("mongo:expireAfterSeconds") as number;
 	const enableWholeSummaryUpload = config.get("storage:enableWholeSummaryUpload") as boolean;
-	const internalHistorianUrl = config.get("worker:internalBlobStorageUrl");
 	const internalAlfredUrl = config.get("worker:alfredUrl");
 	const getDeltasViaAlfred = config.get("scribe:getDeltasViaAlfred") as boolean;
 	const maxLogtailLength = (config.get("scribe:maxLogtailLength") as number) ?? 2000;
@@ -72,7 +71,11 @@ export async function scribeCreate(
 
 	// Generate tenant manager which abstracts access to the underlying storage provider
 	const authEndpoint = config.get("auth:endpoint");
-	const tenantManager = new TenantManager(authEndpoint, internalHistorianUrl);
+	const internalHistorianUrl = config.get("worker:internalBlobStorageUrl");
+	const enableHistorianApiV2: boolean = config.get("storage:enableHistorianApiV2") ?? false;
+	const tenantManager = new TenantManager(authEndpoint, internalHistorianUrl, {
+		enableHistorianApiV2,
+	});
 
 	const deltaManager = new DeltaManager(authEndpoint, internalAlfredUrl);
 	const factory = await getDbFactory(config);

--- a/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
+++ b/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
@@ -180,7 +180,7 @@ export class Heap<T> {
 
 // @internal
 export class Historian implements IHistorian {
-    constructor(endpoint: string, historianApi: boolean, disableCache: boolean, restWrapper?: RestWrapper, enableHistorianApiV2?: boolean);
+    constructor(endpoint: string, historianApi: boolean, disableCache: boolean, restWrapper?: RestWrapper, historianApiVersion?: string);
     // (undocumented)
     createBlob(blob: resources.ICreateBlobParams): Promise<resources.ICreateBlobResponse>;
     // (undocumented)

--- a/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
+++ b/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
@@ -180,7 +180,7 @@ export class Heap<T> {
 
 // @internal
 export class Historian implements IHistorian {
-    constructor(endpoint: string, historianApi: boolean, disableCache: boolean, restWrapper?: RestWrapper);
+    constructor(endpoint: string, historianApi: boolean, disableCache: boolean, restWrapper?: RestWrapper, enableHistorianApiV2?: boolean);
     // (undocumented)
     createBlob(blob: resources.ICreateBlobParams): Promise<resources.ICreateBlobResponse>;
     // (undocumented)

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -77,7 +77,7 @@ export class Historian implements IHistorian {
 		private readonly historianApi: boolean,
 		disableCache: boolean,
 		restWrapper?: RestWrapper,
-		enableHistorianApiV2 = false,
+		historianApiVersion?: string,
 	) {
 		if (disableCache && this.historianApi) {
 			this.defaultQueryString.disableCache = disableCache;
@@ -86,8 +86,8 @@ export class Historian implements IHistorian {
 			this.cacheBust = disableCache;
 		}
 
-		if (enableHistorianApiV2) {
-			this.defaultQueryString["api-version"] = "2.0";
+		if (historianApiVersion) {
+			this.defaultQueryString["api-version"] = historianApiVersion;
 		}
 
 		this.restWrapper = restWrapper ?? new BasicRestWrapper(this.endpoint);

--- a/server/routerlicious/packages/services-client/src/historian.ts
+++ b/server/routerlicious/packages/services-client/src/historian.ts
@@ -77,12 +77,17 @@ export class Historian implements IHistorian {
 		private readonly historianApi: boolean,
 		disableCache: boolean,
 		restWrapper?: RestWrapper,
+		enableHistorianApiV2 = false,
 	) {
 		if (disableCache && this.historianApi) {
 			this.defaultQueryString.disableCache = disableCache;
 			this.cacheBust = false;
 		} else {
 			this.cacheBust = disableCache;
+		}
+
+		if (enableHistorianApiV2) {
+			this.defaultQueryString["api-version"] = "2.0";
 		}
 
 		this.restWrapper = restWrapper ?? new BasicRestWrapper(this.endpoint);

--- a/server/routerlicious/packages/services/src/deltaManager.ts
+++ b/server/routerlicious/packages/services/src/deltaManager.ts
@@ -12,7 +12,7 @@ import { getRefreshTokenIfNeededCallback, TenantManager } from "./tenant";
 import { logHttpMetrics } from "@fluidframework/server-services-utils";
 
 export interface IDeltaManagerOptions {
-	enableHistorianApiV2?: boolean;
+	historianApiVersion?: string;
 }
 
 /**
@@ -27,7 +27,7 @@ export class DeltaManager implements IDeltaService {
 		options?: IDeltaManagerOptions,
 	) {
 		this.tenantManager = new TenantManager(this.authEndpoint, "", {
-			enableHistorianApiV2: options?.enableHistorianApiV2,
+			historianApiVersion: options?.historianApiVersion,
 		});
 	}
 

--- a/server/routerlicious/packages/services/src/deltaManager.ts
+++ b/server/routerlicious/packages/services/src/deltaManager.ts
@@ -11,6 +11,10 @@ import { getGlobalTelemetryContext } from "@fluidframework/server-services-telem
 import { getRefreshTokenIfNeededCallback, TenantManager } from "./tenant";
 import { logHttpMetrics } from "@fluidframework/server-services-utils";
 
+export interface IDeltaManagerOptions {
+	enableHistorianApiV2?: boolean;
+}
+
 /**
  * Manager to fetch deltas from Alfred using the internal URL.
  * @internal
@@ -20,8 +24,11 @@ export class DeltaManager implements IDeltaService {
 	constructor(
 		private readonly authEndpoint,
 		private readonly internalAlfredUrl: string,
+		options?: IDeltaManagerOptions,
 	) {
-		this.tenantManager = new TenantManager(this.authEndpoint, "");
+		this.tenantManager = new TenantManager(this.authEndpoint, "", {
+			enableHistorianApiV2: options?.enableHistorianApiV2,
+		});
 	}
 
 	public async getDeltas(

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -95,6 +95,10 @@ export class Tenant implements core.ITenant {
 	) {}
 }
 
+export interface ITenantManagerOptions {
+	enableHistorianApiV2?: boolean;
+}
+
 /**
  * Manages a collection of tenants
  * @internal
@@ -103,6 +107,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 	constructor(
 		private readonly endpoint: string,
 		private readonly internalHistorianUrl: string,
+		private readonly options?: ITenantManagerOptions,
 	) {}
 
 	public async createTenant(tenantId?: string): Promise<core.ITenantConfig & { key: string }> {
@@ -198,6 +203,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 					const tenantManager = new TenantManager(
 						this.endpoint,
 						this.internalHistorianUrl,
+						this.options,
 					);
 					const newAccessToken = await getValidAccessToken(
 						currentAccessToken,
@@ -239,7 +245,13 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			refreshTokenIfNeeded,
 			logHttpMetrics,
 		);
-		const historian = new Historian(baseUrl, true, false, tenantRestWrapper);
+		const historian = new Historian(
+			baseUrl,
+			true,
+			false,
+			tenantRestWrapper,
+			this.options?.enableHistorianApiV2,
+		);
 		const gitManager = new GitManager(historian);
 
 		return gitManager;

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -96,7 +96,7 @@ export class Tenant implements core.ITenant {
 }
 
 export interface ITenantManagerOptions {
-	enableHistorianApiV2?: boolean;
+	historianApiVersion?: string;
 }
 
 /**
@@ -250,7 +250,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			true,
 			false,
 			tenantRestWrapper,
-			this.options?.enableHistorianApiV2,
+			this.options?.historianApiVersion,
 		);
 		const gitManager = new GitManager(historian);
 


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> This PR does not change any underlying functionality!

Historian and Gitrest are a critical piece of the R11s infrastructure. This means making changes to the APIs there can have massive impacts on performance and reliability in AFR, both for better and worse.

In an attempt to make upcoming major API implementation changes safer, I am introducing this proposal to add versioning to the Historian and Gitrest APIs.

Primarily, the upcoming change I am worried about is experimentation with changes to how request/response bodies are handled in Historian to improve memory use. There is probably a way to do this without API versioning (via configs/feature flags), and maybe there are better ways to do API versioning than this. Hence, this quick PR that does not change any underlying implementation details to start a discussion.

### TL;DR

Add optional `api-version` query param to Historian & Gitrest routes to route requests to an alternate API implementation.

## Breaking Changes

None. Any new params are optional, and all behavior defaults to API v1.

## Reviewer Guidance

I'm not married to this idea, but I would love input on alternatives. Specifically, if we think API versioning is a good idea, and if not, how to more safely/cleanly add configs for major implementation changes.