### PR TITLE
Enable no-unchecked-record-access for fetch-tool

### DIFF
--- a/packages/tools/fetch-tool/.eslintrc.cjs
+++ b/packages/tools/fetch-tool/.eslintrc.cjs
@@ -11,6 +11,5 @@ module.exports = {
 	rules: {
 		// This library is used in the browser, so we don't want dependencies on most node libraries.
 		"import/no-nodejs-modules": ["error", { allow: ["child_process", "fs", "util"] }],
-		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 	},
 };


### PR DESCRIPTION
### ESLint Configuration Changes:
* Changed the rule for `@fluid-internal/fluid/no-unchecked-record-access` from "warn" to "error" in the `.eslintrc.cjs` file by removing the line

We are enabling the `no-unchecked-record-access` rule over `noUncheckedIndexedAccess` because `fetch-tool` has 37 array related access errors, no other errors other than array access