### PR TITLE
Avoid depending on runtime inside of SharedTreeKernel

### DIFF
--- a/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
@@ -5,10 +5,7 @@
 
 import { bufferToString } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils/internal";
-import type {
-	IFluidDataStoreRuntime,
-	IChannelStorageService,
-} from "@fluidframework/datastore-definitions/internal";
+import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import { SummaryType } from "@fluidframework/driver-definitions";
 import type {
 	IExperimentalIncrementalSummaryContext,
@@ -45,7 +42,6 @@ export class SchemaSummarizer implements Summarizable {
 	private schemaIndexLastChangedSeq: number | undefined;
 
 	public constructor(
-		private readonly runtime: IFluidDataStoreRuntime,
 		private readonly schema: MutableTreeStoredSchema,
 		options: ICodecOptions,
 		collabWindow: CollabWindow,


### PR DESCRIPTION
## Description

Use IIDCompressor instead of IFluidDataStoreRuntime in SharedTreeKernel

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


