### PR TITLE
fix(server): Add necessary additionalContext in docker-compose.dev

### DIFF
--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -137,6 +137,8 @@ services:
     build:
       context: ./historian
       target: runner
+      additional_contexts:
+        root: ..
     expose:
       - "3000"
     environment:
@@ -151,6 +153,8 @@ services:
     build:
       context: ./gitrest
       target: runner
+      additional_contexts:
+        root: ..
     environment:
       - DEBUG=fluid:*
       - NODE_ENV=development


### PR DESCRIPTION
## Description

Currently, if you run `docker compose `-f docker-compose.dev.yml build` from `./server`, the build will fail with errors like `failed to resolve source metadata for docker.io/library/root:latest: pull access denied`. This is because the docker-compose.dev.yml is missing `additionalContext` for Historian and Gitrest to provide the correct "root" context. This is present for all R11s services in the file, but is missing for Historian and Gitrest.
