### PR TITLE
Leverage 1ES pipeline templates schema for syntax checks in YAML files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,11 @@
 		"fence.json": "jsonc",
 		".git-blame-ignore-revs": "ignore",
 	},
-	"[azure-pipelines].customSchemaFile": "",
+
+	// Leverage the 1ES Pipeline templates schema for syntax check in YAML files if possible.
+	// Only works if signed in to the Azure Pipelines extension with a @microsoft.com account.
+	"azure-pipelines.1ESPipelineTemplatesSchemaFile": true,
+
 	"deno.enable": false,
 	"deno.lint": false,
 	"deno.unstable": false,


### PR DESCRIPTION
## Description

Enables using the schema for 1ES pipeline templates for Microsoft contributors. The setting only works if signed in to the Azure Pipelines extension with a `@microsoft.com` account, and does nothing otherwise.

Also removes the unused (and invalid according to the latest version of the extension) `[azure-pipelines].customSchemaFile` setting.

The new setting removes syntax error warnings and provides IntelliSense for 1ES-specific tasks when working on pipeline definition files:

Before

![image](https://github.com/user-attachments/assets/8f2856e1-e417-4c36-9a30-d1a09c338fa2)

After

![image](https://github.com/user-attachments/assets/257fb0a3-9dac-4f0d-bb18-78a4efb3d99b)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
