### PR TITLE
(op bunching) Deprecate process on FluidDataStoreRuntime

### DIFF
--- a/.changeset/tender-rabbits-speak.md
+++ b/.changeset/tender-rabbits-speak.md
@@ -5,6 +5,7 @@
 "section": deprecation
 ---
 
-The function `process` on `FluidDataStoreRuntime` is now deprecated.
+The FluidDataStoreRuntime.process function is now deprecated
 
 A new function `processMessages` has been added in its place which will be called to process multiple messages instead of a single one on the data store runtime. This is part of a feature called "Op bunching" where contiguous ops of a given type and to a given data store / DDS are bunched and sent together for processing.
+Note that `process` may still be called in scenarios where this data store runtime (Datastore layer) is running with an older version of data store context (Runtime layer) in the same client. This is to support Fluid layer compatibility.

--- a/.changeset/tender-rabbits-speak.md
+++ b/.changeset/tender-rabbits-speak.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/datastore": minor
+---
+---
+"section": deprecation
+---
+
+The function `process` on `FluidDataStoreRuntime` is now deprecated.
+
+A new function `processMessages` has been added in its place which will be called to process multiple messages instead of a single one on the data store runtime. This is part of a feature called "Op bunching" where contiguous ops of a given type and to a given data store / DDS are bunched and sent together for processing.

--- a/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
@@ -70,6 +70,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     get objectsRoutingContext(): this;
     // (undocumented)
     readonly options: Record<string | number, any>;
+    // @deprecated
     process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     processMessages(messageCollection: IRuntimeMessageCollection): void;
     // (undocumented)

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -790,7 +790,7 @@ export class FluidDataStoreRuntime
 
 	/**
 	 * back-compat ADO 21575.
-	 * @deprecated processMessages should be used instead to process messages. This is still here for back-compat
+	 * @deprecated {@link FluidDataStoreRuntime.processMessages} should be used instead to process messages. This is still here for back-compat
 	 * because it exists on IFluidDataStoreChannel. Once it is removed from the interface, this method can be removed.
 	 */
 	public process(

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -790,8 +790,8 @@ export class FluidDataStoreRuntime
 
 	/**
 	 * back-compat ADO 21575.
-	 * This is still here for back-compat purposes because it exists on IFluidDataStoreChannel. Once it is removed from
-	 * the interface, this method can be removed.
+	 * @deprecated processMessages should be used instead to process messages. This is still here for back-compat
+	 * because it exists on IFluidDataStoreChannel. Once it is removed from the interface, this method can be removed.
 	 */
 	public process(
 		message: ISequencedDocumentMessage,


### PR DESCRIPTION
Deprecating `process` on `FluidDataStoreRuntime`. It was deprecated on `IFluidDataStoreChannel` (and other places) as part of https://github.com/microsoft/FluidFramework/pull/22840 but missed deprecating it on `FluidDataStoreRuntime`. 