### PR TITLE
fix(build-tools): display BuildGraph errors

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
@@ -85,9 +85,13 @@ async function main() {
 		let buildGraph: BuildGraph;
 		const spinner = new Spinner("Creating build graph...");
 		try {
+			// Warning any text output to terminal before spinner is halted
+			// risks being lost. It is known to drop text that exceeds a single
+			// line or the terminal width.
 			spinner.start();
 			buildGraph = repo.createBuildGraph(options.buildTaskNames);
 		} catch (e: unknown) {
+			spinner.stop();
 			error((e as Error).message);
 			process.exit(-11);
 		}


### PR DESCRIPTION
in whole.

Spinner can cause output to be lost. To ensure complete error content is displayed, stop Spinner before outputting.