### PR TITLE
fix(client-odsp-driver): allow internal webpack path

### DIFF
--- a/packages/drivers/odsp-driver/src/fetch.ts
+++ b/packages/drivers/odsp-driver/src/fetch.ts
@@ -1,0 +1,10 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * @deprecated - Do not use. This is a temporary workaround to allow Pages
+ * webpack replacement to continue functioning without error.
+ */
+export const fetch = globalThis.fetch;


### PR DESCRIPTION
Pages uses webpack to replace fetch. Place dummy in the original location to allow that to continue working until patching can be removed after FF version advance.