### PR TITLE
merge-tree: Add farm tests for zero length obliterate

### DIFF
--- a/packages/dds/merge-tree/src/test/client.obliterateFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.obliterateFarm.spec.ts
@@ -68,7 +68,7 @@ function runObliterateFarmTests(opts: IObliterateFarmConfig, extraSeed?: number)
 				},
 			},
 			{
-				name: "obliterate exact range with zero length",
+				name: "obliterate exact range allowing zero length",
 				config: {
 					...opts,
 					operations: [
@@ -118,7 +118,7 @@ function runObliterateFarmTests(opts: IObliterateFarmConfig, extraSeed?: number)
 // More tests pass, but due to how this farm selects ops, the tests take a while to run, and merge-tree
 // already a test suite on the longer side.
 const describeFuzz = createFuzzDescribe({ defaultTestCount: 1 });
-describeFuzz.only("MergeTree.Client Obliterate", ({ testCount }) => {
+describeFuzz("MergeTree.Client Obliterate", ({ testCount }) => {
 	if (testCount > 1) {
 		doOverRange(
 			{ min: 0, max: testCount - 1 },

--- a/packages/dds/merge-tree/src/test/client.obliterateFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.obliterateFarm.spec.ts
@@ -19,6 +19,7 @@ import {
 	insertAvoidField,
 	insertField,
 	obliterateField,
+	obliterateFieldZeroLength,
 	// removeWithField,
 } from "./obliterateOperations.js";
 import { TestClient } from "./testClient.js";
@@ -66,6 +67,18 @@ function runObliterateFarmTests(opts: IObliterateFarmConfig, extraSeed?: number)
 					// applyOpDuringGeneration: true,
 				},
 			},
+			{
+				name: "obliterate exact range with zero length",
+				config: {
+					...opts,
+					operations: [
+						annotateWithField,
+						insertAvoidField,
+						insertField,
+						obliterateFieldZeroLength,
+					],
+				},
+			},
 		])
 			it(`${name}: ObliterateFarm_${minLength}`, async () => {
 				const random = makeRandom(0xdeadbeef, 0xfeedbed, minLength, extraSeed ?? 0);
@@ -105,7 +118,7 @@ function runObliterateFarmTests(opts: IObliterateFarmConfig, extraSeed?: number)
 // More tests pass, but due to how this farm selects ops, the tests take a while to run, and merge-tree
 // already a test suite on the longer side.
 const describeFuzz = createFuzzDescribe({ defaultTestCount: 1 });
-describeFuzz("MergeTree.Client Obliterate", ({ testCount }) => {
+describeFuzz.only("MergeTree.Client Obliterate", ({ testCount }) => {
 	if (testCount > 1) {
 		doOverRange(
 			{ min: 0, max: testCount - 1 },


### PR DESCRIPTION
Allow obliterate operations with a range of length zero in a separate set of tests to make debugging any issues easier. 

[AB#31182](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/31182)