### PR TITLE
perf(tree): N*log(N) composition of sequence-shaped changesets

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -57,6 +57,7 @@ import {
 	mergeTupleBTrees,
 	type TupleBTree,
 	RangeMap,
+	hasSingle,
 } from "../../util/index.js";
 import {
 	type TreeChunk,
@@ -197,9 +198,8 @@ export class ModularChangeFamily
 		// It benefits from the same principle that makes merge sort faster than insertion sort,
 		// making it O(N*log(N)) instead of O(N²) for N changesets each containing 1 change atom.
 		const balancedCompose = (slice: readonly ModularChangeset[]): ModularChangeset => {
-			if (slice.length === 1) {
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				return slice[0]!;
+			if (hasSingle(slice)) {
+				return slice[0];
 			}
 			const mid = Math.floor(slice.length / 2);
 			const left = balancedCompose(slice.slice(0, mid));

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -57,7 +57,7 @@ import {
 	mergeTupleBTrees,
 	type TupleBTree,
 	RangeMap,
-	hasSingle,
+	balancedReduce,
 } from "../../util/index.js";
 import {
 	type TreeChunk,
@@ -184,29 +184,15 @@ export class ModularChangeFamily
 		const { revInfos, maxId } = getRevInfoFromTaggedChanges(changes);
 		const idState: IdAllocationState = { maxId };
 
-		if (changes.length === 0) {
-			return makeModularChangeset();
-		}
-
-		const innerChanges = changes.map((change) => change.change);
-
-		// Recursively compose the left and right halves of the changeset list before composing their respective compositions.
-		// This leads to the same number of compositions as when composing the changesets in order,
-		// but in scenarios where the changesets grow as they are composed
-		// (e.g., when composing changesets that target different elements of a sequence),
-		// this approach reduces the number of times the individual change atoms within the changesets are processed.
-		// It benefits from the same principle that makes merge sort faster than insertion sort,
-		// making it O(N*log(N)) instead of O(N²) for N changesets each containing 1 change atom.
-		const balancedCompose = (slice: readonly ModularChangeset[]): ModularChangeset => {
-			if (hasSingle(slice)) {
-				return slice[0];
-			}
-			const mid = Math.floor(slice.length / 2);
-			const left = balancedCompose(slice.slice(0, mid));
-			const right = balancedCompose(slice.slice(mid));
+		const pairwiseDelegate = (
+			left: ModularChangeset,
+			right: ModularChangeset,
+		): ModularChangeset => {
 			return this.composePair(left, right, revInfos, idState);
 		};
-		return balancedCompose(innerChanges);
+
+		const innerChanges = changes.map((change) => change.change);
+		return balancedReduce(innerChanges, pairwiseDelegate, makeModularChangeset);
 	}
 
 	private composePair(

--- a/packages/dds/tree/src/test/util/utils.spec.ts
+++ b/packages/dds/tree/src/test/util/utils.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import {
+	balancedReduce,
 	capitalize,
 	copyProperty,
 	defineLazyCachedProperty,
@@ -94,6 +95,66 @@ describe("Utils", () => {
 			const destination = {};
 			copyProperty(source, "a", destination);
 			assert.equal(Reflect.has(destination, "a"), false);
+		});
+	});
+
+	describe("balancedReduce", () => {
+		let delegateCallCount = 0;
+		const concatDelegate = (a: string, b: string) => {
+			delegateCallCount += 1;
+			return a + b;
+		};
+
+		let factoryCallCount = 0;
+		const factory = () => {
+			factoryCallCount += 1;
+			return "factory";
+		};
+
+		beforeEach(() => {
+			factoryCallCount = 0;
+			delegateCallCount = 0;
+		});
+
+		it("uses empty case factory on empty input", () => {
+			const actual = balancedReduce([], concatDelegate, factory);
+			assert.equal(actual, "factory");
+			assert.equal(factoryCallCount, 1);
+			assert.equal(delegateCallCount, 0);
+		});
+
+		it("returns lone element on size 1 input", () => {
+			const actual = balancedReduce(["lone"], concatDelegate, factory);
+			assert.equal(actual, "lone");
+			assert.equal(factoryCallCount, 0);
+			assert.equal(delegateCallCount, 0);
+		});
+
+		it("calls delegate once on size 2 input", () => {
+			const actual = balancedReduce(["A", "B"], concatDelegate, factory);
+			assert.equal(actual, "AB");
+			assert.equal(factoryCallCount, 0);
+			assert.equal(delegateCallCount, 1);
+		});
+
+		it("calls delegate twice on size 3 input", () => {
+			const actual = balancedReduce(["A", "B", "C"], concatDelegate, factory);
+			assert.equal(actual, "ABC");
+			assert.equal(factoryCallCount, 0);
+			assert.equal(delegateCallCount, 2);
+		});
+
+		it("calls delegate with balanced inputs", () => {
+			const delegate = (a: string, b: string) => {
+				delegateCallCount += 1;
+				// Checks that the inputs are balanced.
+				assert(Math.abs(a.length - b.length) <= 1);
+				return a + b;
+			};
+			const actual = balancedReduce(["A", "B", "C", "E", "F", "G", "H"], delegate, factory);
+			assert.equal(actual, "ABCEFGH");
+			assert.equal(factoryCallCount, 0);
+			assert.equal(delegateCallCount, 6);
 		});
 	});
 });

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -56,6 +56,7 @@ export type {
 export { StackyIterator } from "./stackyIterator.js";
 export {
 	asMutable,
+	balancedReduce,
 	clone,
 	compareSets,
 	fail,

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -624,7 +624,7 @@ export function copyPropertyIfDefined<
  *
  * When compared with an approach like reducing all the values left-to-right,
  * this balanced approach is beneficial when the cost of invoking `callbackFn` is proportional to the number reduced values that its parameters collectively represent.
- * For example, if `T` is and array, and `callbackFn` concatenates its inputs,
+ * For example, if `T` is an array, and `callbackFn` concatenates its inputs,
  * then `balancedReduce` will have O(N*log(N)) time complexity instead of `Array.prototype.reduce`'s O(N²).
  * However, if `callbackFn` is O(1) then both `balancedReduce` and `Array.prototype.reduce` will have O(N) complexity.
  *

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -616,3 +616,35 @@ export function copyPropertyIfDefined<
 		}
 	}
 }
+
+/**
+ * Reduces an array of values into a single value.
+ * This is similar to `Array.prototype.reduce`,
+ * except that it recursively reduces the left and right halves of the input before reducing their respective reductions.
+ *
+ * When compared with an approach like reducing all the values left-to-right,
+ * this balanced approach is beneficial when the cost of invoking `callbackFn` is proportional to the number reduced values that its parameters collectively represent.
+ * For example, if `T` is and array, and `callbackFn` concatenates its inputs,
+ * then `balancedReduce` will have O(N*log(N)) time complexity instead of `Array.prototype.reduce`'s O(N²).
+ * However, if `callbackFn` is O(1) then both `balancedReduce` and `Array.prototype.reduce` will have O(N) complexity.
+ *
+ * @param array - The array to reduce.
+ * @param callbackFn - The function to execute for each pairwise reduction.
+ * @param emptyCase - A factory function that provides the value to return if the input array is empty.
+ */
+export function balancedReduce<T>(
+	array: readonly T[],
+	callbackFn: (left: T, right: T) => T,
+	emptyCase: () => T,
+): T {
+	if (hasSingle(array)) {
+		return array[0];
+	}
+	if (!hasSome(array)) {
+		return emptyCase();
+	}
+	const mid = Math.floor(array.length / 2);
+	const left = balancedReduce(array.slice(0, mid), callbackFn, emptyCase);
+	const right = balancedReduce(array.slice(mid), callbackFn, emptyCase);
+	return callbackFn(left, right);
+}


### PR DESCRIPTION
## Description

Uses a more efficient algorithm for composing sequence-shaped changesets (both sequence and generic field kinds).
It benefits from the same principle that makes merge sort faster than insertion sort, making it O(N*log(N)) instead of O(N²) for N changesets each containing 1 change atom.

Times from the included benchmark:
| Scenario                                              | Before PR (ns) | After PR  (ns) | Reduction (%) |
| ----------------------------------------------------- | -------------- | -------------- | ------------- |
| Compose 10 sequence edits into a single transaction   | 2,141,503      | 2,053,101      | 4%            |
| Compose 100 sequence edits into a single transaction  | 28,166,687     | 16,318,033     | 42%           |
| Compose 1000 sequence edits into a single transaction | 1,490,000,000  | 169,982,458    | 89%           |

## Breaking Changes

None