### PR TITLE
Cleanup tree's map utils

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -52,7 +52,7 @@ import {
 	idAllocatorFromMaxId,
 	idAllocatorFromState,
 	type RangeQueryResult,
-	getOrAddInMapLazy,
+	getOrCreate,
 	newTupleBTree,
 	mergeTupleBTrees,
 	type TupleBTree,
@@ -1924,7 +1924,7 @@ export function updateRefreshers(
 
 	if (change.builds !== undefined) {
 		for (const [[revision, id], chunk] of change.builds.entries()) {
-			const lengthTree = getOrAddInMapLazy(chunkLengths, revision, () => new BTree());
+			const lengthTree = getOrCreate(chunkLengths, revision, () => new BTree());
 			lengthTree.set(id, chunk.topLevelLength);
 		}
 	}

--- a/packages/dds/tree/src/test/util/nestedMap.spec.ts
+++ b/packages/dds/tree/src/test/util/nestedMap.spec.ts
@@ -80,24 +80,14 @@ describe("NestedMap unit tests", () => {
 		});
 
 		it("Existing value", () => {
-			const nestedMap: NestedMap<string, string, number> = new Map<
-				string,
-				Map<string, number>
-			>();
-			const log: unknown[][] = [];
-			getOrCreateInNestedMap(nestedMap, "Foo", "Bar", (...args: unknown[]) => {
-				log.push(args);
-				return 1;
-			});
-			getOrCreateInNestedMap(nestedMap, "Foo", "Bar", (...args: unknown[]) => {
-				log.push(args);
-				return 2;
-			});
-			assert.equal(nestedMap.get("Foo")?.get("Bar"), 2);
-			assert.deepEqual(log, [
-				["Foo", "Bar"],
-				["Foo", "Bar"],
-			]);
+			const nestedMap: NestedMap<string, string, number> = new Map();
+			const got1 = getOrCreateInNestedMap(nestedMap, "Foo", "Bar", (...args: unknown[]) => 1);
+			const got2 = getOrCreateInNestedMap(nestedMap, "Foo", "Bar", (...args: unknown[]) =>
+				assert.fail("Should not be called"),
+			);
+			assert.equal(got1, 1);
+			assert.equal(got2, 1);
+			assert.equal(nestedMap.get("Foo")?.get("Bar"), 1);
 		});
 	});
 

--- a/packages/dds/tree/src/test/util/nestedMap.spec.ts
+++ b/packages/dds/tree/src/test/util/nestedMap.spec.ts
@@ -16,6 +16,7 @@ import {
 	tryAddToNestedMap,
 	tryGetFromNestedMap,
 	mapNestedMap,
+	getOrCreateInNestedMap,
 } from "../../util/index.js";
 
 describe("NestedMap unit tests", () => {
@@ -60,6 +61,43 @@ describe("NestedMap unit tests", () => {
 			setInNestedMap(nestedMap, "Foo", "Bar", 1);
 			setInNestedMap(nestedMap, "Foo", "Bar", 2);
 			assert.equal(nestedMap.get("Foo")?.get("Bar"), 2);
+		});
+	});
+
+	describe("getOrCreateInNestedMap", () => {
+		it("New value", () => {
+			const nestedMap: NestedMap<string, string, number> = new Map<
+				string,
+				Map<string, number>
+			>();
+			const log: unknown[][] = [];
+			getOrCreateInNestedMap(nestedMap, "Foo", "Bar", (...args: unknown[]) => {
+				log.push(args);
+				return 1;
+			});
+			assert.equal(nestedMap.get("Foo")?.get("Bar"), 1);
+			assert.deepEqual(log, [["Foo", "Bar"]]);
+		});
+
+		it("Existing value", () => {
+			const nestedMap: NestedMap<string, string, number> = new Map<
+				string,
+				Map<string, number>
+			>();
+			const log: unknown[][] = [];
+			getOrCreateInNestedMap(nestedMap, "Foo", "Bar", (...args: unknown[]) => {
+				log.push(args);
+				return 1;
+			});
+			getOrCreateInNestedMap(nestedMap, "Foo", "Bar", (...args: unknown[]) => {
+				log.push(args);
+				return 2;
+			});
+			assert.equal(nestedMap.get("Foo")?.get("Bar"), 2);
+			assert.deepEqual(log, [
+				["Foo", "Bar"],
+				["Foo", "Bar"],
+			]);
 		});
 	});
 

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -19,8 +19,6 @@ export {
 } from "./opaque.js";
 export {
 	deleteFromNestedMap,
-	getOrAddInMap,
-	getOrAddInMapLazy,
 	getOrAddInNestedMap,
 	getOrDefaultInNestedMap,
 	forEachInNestedMap,
@@ -34,6 +32,7 @@ export {
 	mapNestedMap,
 	nestedMapToFlatList,
 	nestedMapFromFlatList,
+	getOrCreateInNestedMap,
 } from "./nestedMap.js";
 export { addToNestedSet, type NestedSet, nestedSetContains } from "./nestedSet.js";
 export { type OffsetList, OffsetListFactory } from "./offsetList.js";
@@ -96,6 +95,7 @@ export {
 	hasSingle,
 	defineLazyCachedProperty,
 	copyPropertyIfDefined as copyProperty,
+	getOrAddInMap,
 } from "./utils.js";
 export { ReferenceCountedBase, type ReferenceCounted } from "./referenceCounting.js";
 

--- a/packages/dds/tree/src/util/nestedMap.ts
+++ b/packages/dds/tree/src/util/nestedMap.ts
@@ -5,7 +5,7 @@
 
 import { oob } from "@fluidframework/core-utils/internal";
 
-import type { MapGetSet } from "./utils.js";
+import { getOrAddInMap, getOrCreate } from "./utils.js";
 
 /**
  * A dictionary whose values are keyed off of two objects (key1, key2).
@@ -87,40 +87,16 @@ export function setInNestedMap<Key1, Key2, Value>(
 }
 
 /**
- * Sets the value at `key` in map to value if not already present.
- * Returns the value at `key` after setting it.
- * This is equivalent to a get or default that adds the default to the map.
+ * {@link getOrCreate} for {@link NestedMap}.
  */
-export function getOrAddInMap<Key, Value>(
-	map: MapGetSet<Key, Value>,
-	key: Key,
-	value: Value,
+export function getOrCreateInNestedMap<Key1, Key2, Value>(
+	map: NestedMap<Key1, Key2, Value>,
+	key1: Key1,
+	key2: Key2,
+	defaultValue: (key1: Key1, key2: Key2) => Value,
 ): Value {
-	const currentValue = map.get(key);
-	if (currentValue !== undefined) {
-		return currentValue;
-	}
-	map.set(key, value);
-	return value;
-}
-
-/**
- * Sets the value at `key` in `map` to `generateValue()` if not already present.
- * Returns the value at `key` after setting it.
- */
-export function getOrAddInMapLazy<Key, Value>(
-	map: MapGetSet<Key, Value>,
-	key: Key,
-	generateValue: () => Value,
-): Value {
-	const currentValue = map.get(key);
-	if (currentValue !== undefined) {
-		return currentValue;
-	}
-
-	const value = generateValue();
-	map.set(key, value);
-	return value;
+	const innerMap = getOrAddInMap(map, key1, new Map<Key2, Value>());
+	return getOrCreate(innerMap, key2, (): Value => defaultValue(key1, key2));
 }
 
 /**

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -178,6 +178,24 @@ export function compareSets<T>({
 }
 
 /**
+ * Sets the value at `key` in map to value if not already present.
+ * Returns the value at `key` after setting it.
+ * This is equivalent to a get or default that adds the default to the map.
+ */
+export function getOrAddInMap<Key, Value>(
+	map: MapGetSet<Key, Value>,
+	key: Key,
+	value: Value,
+): Value {
+	const currentValue = map.get(key);
+	if (currentValue !== undefined) {
+		return currentValue;
+	}
+	map.set(key, value);
+	return value;
+}
+
+/**
  * Retrieve a value from a map with the given key, or create a new entry if the key is not in the map.
  * @param map - The map to query/update
  * @param key - The key to lookup in the map


### PR DESCRIPTION
## Description

Remove duplicate function, and move non nested map helper out of nested map.

Also adds getOrCreateInNestedMap.
## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

