### PR TITLE
fix(build-tools): Stop spinner before logging more

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -540,8 +540,8 @@ export class BuildGraph {
 
 		const isUpToDate = await this.isUpToDate();
 
-		timer?.time(`Check up to date completed`);
 		spinner.succeed("Tasks loaded.");
+		timer?.time(`Check up to date completed`);
 
 		log(
 			`Start tasks '${chalk.cyanBright(this.buildTaskNames.join("', '"))}' in ${

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -538,6 +538,8 @@ export class BuildGraph {
 		const spinner = new Spinner("Checking incremental build task status...");
 		spinner.start();
 
+		// Note: any console logging done here (e.g. in leafTask.ts' checkIsUpToDate()) runs the risk of getting truncated due to how picospinner works.
+		// Ideally we shouldn't do console logging between starting and stopping a spinner.
 		const isUpToDate = await this.isUpToDate();
 
 		spinner.succeed("Tasks loaded.");


### PR DESCRIPTION
## Description

Makes it so we "complete" `picospinner`'s Spinner before logging anything else to avoid issues with console output getting truncated. Follow-up to https://github.com/microsoft/FluidFramework/pull/23875.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).