### PR TITLE
Added support to log reason for getDeltas API call

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/deltas.ts
@@ -158,6 +158,7 @@ export function create(
 
 			const tenantId = request.params.tenantId || appTenants[0].id;
 			const caller = request.query.caller?.toString();
+			const fetchReason = request.query.fetchReason?.toString();
 
 			// Query for the deltas and return a filtered version of just the operations field
 			const deltasP = deltaService.getDeltas(
@@ -167,6 +168,7 @@ export function create(
 				from,
 				to,
 				caller,
+				fetchReason,
 			);
 
 			handleResponse(deltasP, response, undefined, 500);

--- a/server/routerlicious/packages/services-core/src/delta.ts
+++ b/server/routerlicious/packages/services-core/src/delta.ts
@@ -16,6 +16,7 @@ export interface IDeltaService {
 		from?: number,
 		to?: number,
 		caller?: string,
+		fetchReason?: string,
 	): Promise<ISequencedDocumentMessage[]>;
 
 	getDeltasFromStorage(


### PR DESCRIPTION
## Description

This is the OSS change to support logging the reason for getDeltas API call. This follows the client side change in https://github.com/microsoft/FluidFramework/pull/22821/files. AFR would need to consume this change for the logging to be functional.
