### PR TITLE
tree: tests showcasing bug that hits assert 0x778

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -126,7 +126,7 @@ describe("SharedTree", () => {
 			assert.equal(view.root, 10);
 		});
 
-		it.only("initialize-dispose-view with primitive schema", () => {
+		it("initialize-dispose-view with primitive schema", () => {
 			const tree = treeTestFactory();
 			assert.deepEqual(tree.contentSnapshot().schema.rootFieldSchema, storedEmptyFieldSchema);
 
@@ -144,7 +144,8 @@ describe("SharedTree", () => {
 			assert.deepEqual(view2.root, 10);
 		});
 
-		it.only("initialize-dispose-view with object schema", () => {
+		// TODO (AB#31456): Enable this test once the bug is fixed.
+		it.skip("initialize-dispose-view with object schema", () => {
 			const tree = treeTestFactory();
 			assert.deepEqual(tree.contentSnapshot().schema.rootFieldSchema, storedEmptyFieldSchema);
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -126,6 +126,51 @@ describe("SharedTree", () => {
 			assert.equal(view.root, 10);
 		});
 
+		it.only("initialize-dispose-view with primitive schema", () => {
+			const tree = treeTestFactory();
+			assert.deepEqual(tree.contentSnapshot().schema.rootFieldSchema, storedEmptyFieldSchema);
+
+			const config = new TreeViewConfiguration({
+				schema: SchemaFactory.number,
+			});
+
+			const view1 = tree.viewWith(config);
+			view1.initialize(10);
+			assert.deepEqual(view1.root, 10);
+
+			view1.dispose();
+
+			const view2 = tree.viewWith(config);
+			assert.deepEqual(view2.root, 10);
+		});
+
+		it.only("initialize-dispose-view with object schema", () => {
+			const tree = treeTestFactory();
+			assert.deepEqual(tree.contentSnapshot().schema.rootFieldSchema, storedEmptyFieldSchema);
+
+			const factory = new SchemaFactory("my-factory");
+			class MySchema extends factory.object("my-root", {
+				number: factory.number,
+			}) {}
+
+			const config = new TreeViewConfiguration({
+				schema: MySchema,
+			});
+
+			const expectedContents = new MySchema({
+				number: 10,
+			});
+
+			const view1 = tree.viewWith(config);
+			view1.initialize(new MySchema({ number: 10 }));
+			assert.deepEqual(view1.root, expectedContents);
+
+			view1.dispose();
+
+			const view2 = tree.viewWith(config);
+			assert.deepEqual(view2.root, expectedContents); // <-- This throws with assert 0x778
+		});
+
 		it("concurrent initialize", () => {
 			const provider = new TestTreeProviderLite(2);
 			const config = new TreeViewConfiguration({


### PR DESCRIPTION
## Description

Tests that showcase a bug in tree view. When using a "complex schema" (in this case an object, instead of just a primitive) for a tree, the pattern of getting a view, initializing the tree through it, disposing the view, getting a second view, and accessing the tree through it, throws with assert 0x778. Any access to the tree root causes it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
