### PR TITLE
(tree) Add changeset to include the performance enhancements in shared tree

### DIFF
--- a/.changeset/purple-ideas-switch.md
+++ b/.changeset/purple-ideas-switch.md
@@ -2,11 +2,16 @@
 "@fluidframework/tree": minor
 ---
 ---
-"section": deprecation
+"section": tree
 ---
 
-The SharedTreeCore.processCore on SharedTreeCore is now deprecated
+Performance enhancements in Shared Tree
 
-A new function `processMessagesCore` has been added in place of `processCore`, which will be called to process multiple messages instead of a single one on the channel. This is part of a feature called "Op bunching" where contiguous ops in a grouped batch are bunched and processed together by the shared object.
-
-Implementations of `SharedTreeCore` must now also implement `processMessagesCore`. For a reference implementation, see `SharedTreeCore.processMessagesCore`.
+- Op bunching - A new feature called "Op bunching" is added to Shared Tree where contiguous ops in a grouped batch are
+bunched and processed together. This improves the performance of processing ops asymptotically - with the increase in
+the number of local ops and incoming ops, the processing time will reduce. For example, with 10 local ops + 10 incoming
+ops, the performance increases by 70%; with 100 local ops + 100 incoming ops, the performance increases by 94%.
+This will help improve performance in the following scenarios:
+- A client makes a large number of changes in a single JS turn. For example, copy pasting large data like a table.
+- A client has a large number of local changes. For example, slow clients whose changes are slow to ack or clients with
+a local branch with large number of changes.

--- a/.changeset/purple-ideas-switch.md
+++ b/.changeset/purple-ideas-switch.md
@@ -8,7 +8,7 @@
 
 Performance enhancements in Shared Tree
 
-- Op bunching - A new feature called "Op bunching" is added to Shared Tree where contiguous ops in a grouped batch are
+Op bunching - A new feature called "Op bunching" is added to Shared Tree where contiguous ops in a grouped batch are
 bunched and processed together. This improves the performance of processing ops asymptotically - with the increase in
 the number of local ops and incoming ops, the processing time will reduce. For example, with 10 local ops + 10 incoming
 ops, the performance increases by 70%; with 100 local ops + 100 incoming ops, the performance increases by 94%.

--- a/.changeset/purple-ideas-switch.md
+++ b/.changeset/purple-ideas-switch.md
@@ -1,5 +1,6 @@
 ---
 "@fluidframework/tree": minor
+"fluid-framework": minor
 ---
 ---
 "section": tree


### PR DESCRIPTION
The op bunching feature (https://github.com/microsoft/FluidFramework/pull/23732) improves the performance of op processing in shared tree. This change adds a changeset to include these performance enhancements that impacts the users so that they are part of release notes.

Note that it repurposes an existing changeset added by https://github.com/microsoft/FluidFramework/pull/23732. The changes in that PR did not require a changeset but once was added incorrectly.