### PR TITLE
Add FluidSerializableAsTree domain

### DIFF
--- a/examples/utils/import-testing/src/test/tsconfig.json
+++ b/examples/utils/import-testing/src/test/tsconfig.json
@@ -14,6 +14,9 @@
 		// disable it to prevent that from erroring when combined with "skipLibCheck".
 		// TODO: these errors should be fixed!
 		"exactOptionalPropertyTypes": false,
+		// FixRecursiveArraySchema depends on compilation order dependent behavior in the packages that import the generated d.ts file with libCheck enabled.
+		// Since this package imports such an export, disable incrementality to avoid issues with the build that require clean building in come cases.
+		"incremental": false,
 	},
 	"include": ["./**/*"],
 	"references": [

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -260,3 +260,4 @@ export type { MapNodeInsertableData } from "./simple-tree/index.js";
 export type { JsonCompatible, JsonCompatibleObject } from "./util/index.js";
 
 export { JsonAsTree } from "./jsonDomainSchema.js";
+export { FluidSerializableAsTree } from "./serializableDomainSchema.js";

--- a/packages/dds/tree/src/jsonDomainSchema.ts
+++ b/packages/dds/tree/src/jsonDomainSchema.ts
@@ -16,7 +16,7 @@ const sf = new SchemaFactory("com.fluidframework.json");
 /**
  * Utilities for storing JSON data in {@link TreeNode}s.
  * @remarks
- * Schema which replicates the JSON data model with {@link TreeNode}s.
+ * Schema which replicate the JSON data model with {@link TreeNode}s.
  *
  * This allows JSON to be losslessly round-tripped through a tree with the following limitations:
  *
@@ -116,7 +116,7 @@ export namespace JsonAsTree {
 	 * // Using `importConcise` can work better for JSON data:
 	 * const imported = TreeAlpha.importConcise(JsonAsTree.Array, ["a", 0, [1]]);
 	 * // Node API is like an Array:
-	 * const inner: JsonUnion = imported[2];
+	 * const inner: JsonAsTree.Tree = imported[2];
 	 * assert(Tree.is(inner, JsonAsTree.Array));
 	 * const leaf = inner[0];
 	 * ```

--- a/packages/dds/tree/src/jsonDomainSchema.ts
+++ b/packages/dds/tree/src/jsonDomainSchema.ts
@@ -106,9 +106,9 @@ export namespace JsonAsTree {
 	export const _APIExtractorWorkaroundArrayBase = sf.arrayRecursive("array", Tree);
 
 	/**
-	 * Arbitrary JSON object as a {@link TreeNode}.
+	 * Arbitrary JSON array as a {@link TreeNode}.
 	 * @remarks
-	 * This can be worked around by using {@link TreeAlpha.importConcise}.
+	 * This can be imported using {@link TreeAlpha.importConcise}.
 	 * @example
 	 * ```typescript
 	 * // Due to TypeScript restrictions on recursive types, the constructor can be somewhat limiting.

--- a/packages/dds/tree/src/serializableDomainSchema.ts
+++ b/packages/dds/tree/src/serializableDomainSchema.ts
@@ -108,7 +108,7 @@ export namespace FluidSerializableAsTree {
 	 * // Using `importConcise` can work better for Fluid Serializable data:
 	 * const imported = TreeAlpha.importConcise(FluidSerializableAsTree.Array, ["a", 0, [1]]);
 	 * // Node API is like an Array:
-	 * const inner: JsonUnion = imported[2];
+	 * const inner: FluidSerializableAsTree.Tree = imported[2];
 	 * assert(Tree.is(inner, FluidSerializableAsTree.Array));
 	 * const leaf = inner[0];
 	 * ```

--- a/packages/dds/tree/src/serializableDomainSchema.ts
+++ b/packages/dds/tree/src/serializableDomainSchema.ts
@@ -19,7 +19,7 @@ const sf = new SchemaFactory("com.fluidframework.serializable");
  *
  * Same as {@link JsonAsTree} except allows {@link @fluidframework/core-interfaces#(IFluidHandle:interface)}s.
  * @remarks
- * Schema which replicates the Fluid Serializable data model with {@link TreeNode}s.
+ * Schema which replicate the Fluid Serializable data model with {@link TreeNode}s.
  *
  * Fluid Serializable data can be imported from the {@link FluidSerializableAsTree.Data|Fluid Serializable format} into this format using {@link TreeAlpha.importConcise} with the {@link FluidSerializableAsTree.(Tree:variable)} schema.
  * @internal

--- a/packages/dds/tree/src/serializableDomainSchema.ts
+++ b/packages/dds/tree/src/serializableDomainSchema.ts
@@ -37,7 +37,7 @@ export namespace FluidSerializableAsTree {
 	 * {@link AllowedTypes} for any content allowed in the {@link FluidSerializableAsTree} domain.
 	 * @example
 	 * ```typescript
-	 * const tree = TreeAlpha.importConcise(FluidSerializableAsTree.Union, { example: { nested: true }, value: 5 });
+	 * const tree = TreeAlpha.importConcise(FluidSerializableAsTree.Tree, { example: { nested: true }, value: 5 });
 	 * ```
 	 * @internal
 	 */

--- a/packages/dds/tree/src/serializableDomainSchema.ts
+++ b/packages/dds/tree/src/serializableDomainSchema.ts
@@ -1,0 +1,121 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import {
+	SchemaFactory,
+	type FixRecursiveArraySchema,
+	type TreeNodeFromImplicitAllowedTypes,
+	type ValidateRecursiveSchema,
+} from "./simple-tree/index.js";
+import type { JsonCompatible } from "./util/index.js";
+
+const sf = new SchemaFactory("com.fluidframework.serializable");
+
+/**
+ * Utilities for storing {@link FluidSerializableAsTree.Data|Fluid Serializable data} in {@link TreeNode}s.
+ *
+ * Same as {@link JsonAsTree} except allows {@link @fluidframework/core-interfaces#(IFluidHandle:interface)}s.
+ * @remarks
+ * Schema which replicates the Fluid Serializable data model with {@link TreeNode}s.
+ *
+ * Fluid Serializable data can be imported from the {@link FluidSerializableAsTree.Data|Fluid Serializable format} into this format using {@link TreeAlpha.importConcise} with the {@link FluidSerializableAsTree.(Tree:variable)} schema.
+ * @internal
+ */
+export namespace FluidSerializableAsTree {
+	/**
+	 * Data which can be serialized by Fluid.
+	 * @remarks
+	 * Can be encoded as a {@link FluidSerializableAsTree.(Tree:type)} using {@link TreeAlpha.importConcise}.
+	 * @internal
+	 */
+	export type Data = JsonCompatible<IFluidHandle>;
+
+	/**
+	 * {@link AllowedTypes} for any content allowed in the {@link FluidSerializableAsTree} domain.
+	 * @example
+	 * ```typescript
+	 * const tree = TreeAlpha.importConcise(FluidSerializableAsTree.Union, { example: { nested: true }, value: 5 });
+	 * ```
+	 * @internal
+	 */
+	export const Tree = [
+		() => FluidSerializableObject,
+		() => Array,
+		...SchemaFactory.leaves,
+	] as const;
+
+	/**
+	 * @internal
+	 */
+	export type Tree = TreeNodeFromImplicitAllowedTypes<typeof Tree>;
+
+	/**
+	 * Do not use. Exists only as a workaround for {@link https://github.com/microsoft/TypeScript/issues/59550} and {@link https://github.com/microsoft/rushstack/issues/4429}.
+	 * @system @internal
+	 */
+	export const _APIExtractorWorkaroundObjectBase = sf.mapRecursive("object", Tree);
+
+	/**
+	 * Arbitrary Fluid Serializable object as a {@link TreeNode}.
+	 * @remarks
+	 * API of the tree node is more aligned with an es6 map than a JS object using its properties like a map.
+	 * @example
+	 * ```typescript
+	 * // Due to TypeScript restrictions on recursive types, the constructor and be somewhat limiting.
+	 * const fromArray = new JsonAsTreeObject([["a", 0]]);
+	 * // Using `importConcise` can work better for Fluid Serializable data:
+	 * const imported = TreeAlpha.importConcise(FluidSerializableAsTree.Object, { a: 0 });
+	 * // Node API is like a Map:
+	 * const value = imported.get("a");
+	 * ```
+	 * @privateRemarks
+	 * Due to https://github.com/microsoft/TypeScript/issues/61270 this can't be named `Object`.
+	 * @sealed @internal
+	 */
+	export class FluidSerializableObject extends _APIExtractorWorkaroundObjectBase {}
+	{
+		type _check = ValidateRecursiveSchema<typeof FluidSerializableObject>;
+	}
+
+	/**
+	 * D.ts bug workaround, see {@link FixRecursiveArraySchema}.
+	 * @privateRemarks
+	 * In the past this this had to reference the base type (_APIExtractorWorkaroundArrayBase).
+	 * Testing for this in examples/utils/import-testing now shows it has to reference FluidSerializableAsTree.Array instead.
+	 * @system @internal
+	 */
+	export declare type _RecursiveArrayWorkaroundJsonArray = FixRecursiveArraySchema<
+		typeof Array
+	>;
+
+	/**
+	 * Do not use. Exists only as a workaround for {@link https://github.com/microsoft/TypeScript/issues/59550} and {@link https://github.com/microsoft/rushstack/issues/4429}.
+	 * @system @internal
+	 */
+	export const _APIExtractorWorkaroundArrayBase = sf.arrayRecursive("array", Tree);
+
+	/**
+	 * Arbitrary Fluid Serializable array as a {@link TreeNode}.
+	 * @remarks
+	 * This can be imported using {@link TreeAlpha.importConcise}.
+	 * @example
+	 * ```typescript
+	 * // Due to TypeScript restrictions on recursive types, the constructor can be somewhat limiting.
+	 * const usingConstructor = new FluidSerializableAsTree.Array(["a", 0, new FluidSerializableAsTree.Array([1])]);
+	 * // Using `importConcise` can work better for Fluid Serializable data:
+	 * const imported = TreeAlpha.importConcise(FluidSerializableAsTree.Array, ["a", 0, [1]]);
+	 * // Node API is like an Array:
+	 * const inner: JsonUnion = imported[2];
+	 * assert(Tree.is(inner, FluidSerializableAsTree.Array));
+	 * const leaf = inner[0];
+	 * ```
+	 * @sealed @internal
+	 */
+	export class Array extends _APIExtractorWorkaroundArrayBase {}
+	{
+		type _check = ValidateRecursiveSchema<typeof Array>;
+	}
+}


### PR DESCRIPTION
## Description

Adds a domain (schema and related types), currently internal, for working with Add Fluid Serializable data.

This will be used by the schema for the map adapter to store that that could have been put in a SharedMap value in https://github.com/microsoft/FluidFramework/pull/23729

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

