### PR TITLE
refactor: move isRuntimeMessage to container-definitions

### DIFF
--- a/packages/common/container-definitions/src/index.ts
+++ b/packages/common/container-definitions/src/index.ts
@@ -66,7 +66,7 @@ export type {
 	IRuntime,
 	IGetPendingLocalStateProps,
 } from "./runtime.js";
-export { AttachState, IRuntimeFactory } from "./runtime.js";
+export { AttachState, IRuntimeFactory, isRuntimeMessage } from "./runtime.js";
 
 export type {
 	/**

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -20,9 +20,9 @@ import type {
 	ISnapshotTree,
 	ISummaryContent,
 	IVersion,
-	MessageType,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
+import { MessageType } from "@fluidframework/driver-definitions/internal";
 
 import type { IAudience } from "./audience.js";
 import type { IDeltaManager } from "./deltas.js";
@@ -293,4 +293,14 @@ export interface IGetPendingLocalStateProps {
 	 * Snapshot sequence number. It will help the runtime to know which ops should still be stashed.
 	 */
 	readonly snapshotSequenceNumber?: number;
+}
+
+/**
+ * Tells if message was sent by container runtime
+ * @returns whether the message is a runtime message
+ * @internal
+ */
+export function isRuntimeMessage(message: { type: string }): boolean {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+	return message.type === MessageType.Operation;
 }

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -6,11 +6,14 @@
 import { fromUtf8ToBase64 } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils/internal";
 import { getW3CData } from "@fluidframework/driver-base/internal";
-import { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
+import {
+	ISnapshot,
+	ISnapshotTree,
+	MessageType,
+} from "@fluidframework/driver-definitions/internal";
 import {
 	DriverErrorTelemetryProps,
 	NonRetryableError,
-	isRuntimeMessage,
 } from "@fluidframework/driver-utils/internal";
 import {
 	fetchIncorrectResponse,
@@ -549,7 +552,7 @@ async function fetchLatestSnapshotCore(
 				fetchSnapshotForLoadingGroup,
 				useLegacyFlowWithoutGroups:
 					useLegacyFlowWithoutGroupsForSnapshotFetch(loadingGroupIds),
-				userOps: snapshot.ops?.filter((op) => isRuntimeMessage(op)).length ?? 0,
+				userOps: snapshot.ops?.filter((op) => op.type === MessageType.Operation).length ?? 0,
 				// Measures time to make fetch call. Should be similar to
 				// fetchStartToResponseEndTime - receiveContentTime, i.e. it looks like it's time till first byte /
 				// end of response headers

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -5,7 +5,11 @@
 
 import { TypedEventEmitter, performanceNow } from "@fluid-internal/client-utils";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
-import { IDeltaQueue, ReadOnlyInfo } from "@fluidframework/container-definitions/internal";
+import {
+	IDeltaQueue,
+	ReadOnlyInfo,
+	isRuntimeMessage,
+} from "@fluidframework/container-definitions/internal";
 import {
 	IDisposable,
 	ITelemetryBaseProperties,
@@ -37,7 +41,6 @@ import {
 	createGenericNetworkError,
 	createWriteError,
 	getRetryDelayFromError,
-	isRuntimeMessage,
 	logNetworkFailure,
 	type GenericNetworkError,
 	type ThrottlingError,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -8,6 +8,7 @@ import {
 	IDeltaManagerEvents,
 	IDeltaManagerFull,
 	IDeltaQueue,
+	isRuntimeMessage,
 	type IDeltaSender,
 	type ReadOnlyInfo,
 } from "@fluidframework/container-definitions/internal";
@@ -30,7 +31,7 @@ import {
 	type IClientDetails,
 	type IClientConfiguration,
 } from "@fluidframework/driver-definitions/internal";
-import { NonRetryableError, isRuntimeMessage } from "@fluidframework/driver-utils/internal";
+import { NonRetryableError } from "@fluidframework/driver-utils/internal";
 import {
 	type ITelemetryErrorEventExt,
 	type ITelemetryGenericEventExt,

--- a/packages/loader/container-loader/src/noopHeuristic.ts
+++ b/packages/loader/container-loader/src/noopHeuristic.ts
@@ -4,10 +4,10 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
+import { isRuntimeMessage } from "@fluidframework/container-definitions/internal";
 import { IEvent } from "@fluidframework/core-interfaces";
 import { assert, Timer } from "@fluidframework/core-utils/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
-import { isRuntimeMessage } from "@fluidframework/driver-utils/internal";
 
 const defaultNoopTimeFrequency = 2000;
 const defaultNoopCountFrequency = 50;

--- a/packages/loader/driver-utils/src/index.ts
+++ b/packages/loader/driver-utils/src/index.ts
@@ -8,10 +8,7 @@ export { BlobTreeEntry, TreeTreeEntry, AttachmentTreeEntry } from "./blob.js";
 export { DocumentStorageServiceProxy } from "./documentStorageServiceProxy.js";
 export { UsageError } from "./error.js";
 export { InsecureUrlResolver } from "./insecureUrlResolver.js";
-export {
-	canBeCoalescedByService,
-	isRuntimeMessage,
-} from "./messageRecognition.js";
+export { canBeCoalescedByService } from "./messageRecognition.js";
 export {
 	AuthorizationError,
 	canRetryOnError,

--- a/packages/loader/driver-utils/src/messageRecognition.ts
+++ b/packages/loader/driver-utils/src/messageRecognition.ts
@@ -10,16 +10,6 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 
 /**
- * Tells if message was sent by container runtime
- * @privateRemarks ADO #1385: To be moved to container-definitions
- * @returns whether the message is a runtime message
- * @internal
- */
-export function isRuntimeMessage(message: { type: string }): boolean {
-	return message.type === MessageType.Operation;
-}
-
-/**
  * @privateRemarks ADO #1385: To be moved to packages/protocol-base/src/protocol.ts
  * @internal
  */

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -4,7 +4,10 @@
  */
 
 import { performanceNow } from "@fluid-internal/client-utils";
-import { IDeltaManagerFull } from "@fluidframework/container-definitions/internal";
+import {
+	IDeltaManagerFull,
+	isRuntimeMessage,
+} from "@fluidframework/container-definitions/internal";
 import { IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions/internal";
 import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { IEventProvider } from "@fluidframework/core-interfaces";
@@ -14,7 +17,6 @@ import {
 	MessageType,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
-import { isRuntimeMessage } from "@fluidframework/driver-utils/internal";
 import {
 	IEventSampler,
 	ITelemetryLoggerExt,

--- a/packages/runtime/container-runtime/src/inboundBatchAggregator.ts
+++ b/packages/runtime/container-runtime/src/inboundBatchAggregator.ts
@@ -4,10 +4,12 @@
  */
 
 import { performanceNow } from "@fluid-internal/client-utils";
-import { IDeltaManagerFull } from "@fluidframework/container-definitions/internal";
+import {
+	IDeltaManagerFull,
+	isRuntimeMessage,
+} from "@fluidframework/container-definitions/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
-import { isRuntimeMessage } from "@fluidframework/driver-utils/internal";
 import {
 	ITelemetryLoggerExt,
 	DataCorruptionError,

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -6,7 +6,10 @@
 import { strict as assert } from "node:assert";
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { IDeltaManager } from "@fluidframework/container-definitions/internal";
+import {
+	IDeltaManager,
+	isRuntimeMessage,
+} from "@fluidframework/container-definitions/internal";
 import {
 	IContainerRuntimeEvents,
 	type ISummarizeEventProps,
@@ -26,7 +29,6 @@ import {
 	MessageType,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
-import { isRuntimeMessage } from "@fluidframework/driver-utils/internal";
 import { MockLogger, mixinMonitoringContext } from "@fluidframework/telemetry-utils/internal";
 import { MockDeltaManager } from "@fluidframework/test-runtime-utils/internal";
 import sinon from "sinon";


### PR DESCRIPTION
## Description

First part of [AB#31537](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/31537)

This change addresses an old TODO to move `isRuntimeMessage` function from driver-utils to container-definitions and updates it's corresponding imports. 

I had to replace the function with an inline implementation in odsp-driver/src/fetchSnapshot.ts since there this driver layer cannot take dependency on container-defintions. 

## Reviewer Guidance

- Was hit with [@typescript-eslint/no-unsafe-enum-comparison](https://typescript-eslint.io/rules/no-unsafe-enum-comparison) when moving to container-definitions. I opted to disable this lint rule for the line as it was previously was not a problem but open to feedback on how this could be addressed (string vs. MessageType). 
- Layer check did not allow odsp-driver to depend on container-defintions. I handled this by doing the comparison inline.