### PR TITLE
fix(merge-tree): Correctly bookkeep insert into local-only obliterate

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2065,14 +2065,10 @@ export class MergeTree {
 
 		const { segment: startSeg } = this.getContainingSegment(start.pos, refSeq, clientId);
 		const { segment: endSeg } = this.getContainingSegment(end.pos, refSeq, clientId);
-		if (!isSegmentLeaf(startSeg) || !isSegmentLeaf(endSeg)) {
-			this.getContainingSegment(start.pos, refSeq, clientId);
-			this.getContainingSegment(end.pos, refSeq, clientId);
-			assert(
-				isSegmentLeaf(startSeg) && isSegmentLeaf(endSeg),
-				0xa3f /* segments cannot be undefined */,
-			);
-		}
+		assert(
+			isSegmentLeaf(startSeg) && isSegmentLeaf(endSeg),
+			0xa3f /* segments cannot be undefined */,
+		);
 
 		obliterate.start = this.createLocalReferencePosition(
 			startSeg,

--- a/packages/dds/merge-tree/src/test/obliterate.concurrent.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.concurrent.spec.ts
@@ -1912,9 +1912,12 @@ for (const incremental of [true, false]) {
 				helper.logger.validate({ baseText: "8m" });
 			});
 
-			// Idea: Client with local changes needs to recognize that other clients will have thought inserted segment was allowed, even
-			// though local client knows it will go away once its changes are applied.
-			it("TODO name", () => {
+			// See 'Local obliterate wins post-insertion of segment previously thought to have won' (below) for a simpler
+			// to understand version of this test. This test is the original partial synchronization fuzz variant which
+			// demonstrated that issue, and has been preserved for now in case it catches additional related problems.
+			// Once fuzz testing more meaninfully leverages ops being sent to different clients at different types (partial
+			// synchronization), it's probably fine to remove this.
+			it("fuzz regression: Local obliterate wins post-insertion of segment previously thought to have won", () => {
 				const helper = new PartialSyncTestHelper();
 
 				helper.insertText("A", 0, "Hx15J");
@@ -1948,6 +1951,45 @@ for (const incremental of [true, false]) {
 				helper.processAllOps();
 
 				helper.logger.validate({ baseText: "hn4qpJ" });
+			});
+
+			// Simpler version of the above test which has the same root cause but reproduces a slightly different failure mode.
+			it("Local obliterate wins post-insertion of segment previously thought to have won", () => {
+				const helper = new PartialSyncTestHelper();
+				helper.insertText("A", 0, "1xx2");
+				helper.processAllOps();
+				// A and B both obliterate the 'xx' segment with an expanding obliterate, then try to insert
+				// into the gap that it leaves.
+				helper.obliterateRange(
+					"A",
+					{ pos: 0, side: Side.After },
+					{ pos: 3, side: Side.Before },
+				);
+				helper.insertText("A", 1, "aaaa");
+				helper.obliterateRange(
+					"B",
+					{ pos: 0, side: Side.After },
+					{ pos: 3, side: Side.Before },
+				);
+				helper.insertText("B", 1, "bbb");
+				helper.advanceClients("A", "B");
+				// Meanwhile, C attempts the same thing without seeing A or B's obliterate & insertions
+				helper.obliterateRange(
+					"C",
+					{ pos: 0, side: Side.After },
+					{ pos: 3, side: Side.Before },
+				);
+				helper.insertText("C", 1, "ccc");
+				// Before seeing C's ops, B attempts to insert more content. Since B hasn't yet seen C's obliterate,
+				// A and B are under the impression that B's obliterate has won and the string contents are '1bbb2'.
+				helper.insertText("B", 5, "B");
+				helper.insertText("A", 5, "A");
+				helper.processAllOps();
+				// By now, all clients realize C actually won the obliterate and should have additionally applied B's
+				// op correctly as it was outside of the obliterated range.
+				// At the time this test was written, client C had trouble recognizing that A and B think that B has won
+				// and merged incorrectly, hitting 'MergeTree insert failed'.
+				helper.logger.validate({ baseText: "1ccc2AB" });
 			});
 		});
 	});

--- a/packages/dds/merge-tree/src/test/obliterate.concurrent.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.concurrent.spec.ts
@@ -1911,6 +1911,44 @@ for (const incremental of [true, false]) {
 
 				helper.logger.validate({ baseText: "8m" });
 			});
+
+			// Idea: Client with local changes needs to recognize that other clients will have thought inserted segment was allowed, even
+			// though local client knows it will go away once its changes are applied.
+			it("TODO name", () => {
+				const helper = new PartialSyncTestHelper();
+
+				helper.insertText("A", 0, "Hx15J");
+				helper.processAllOps();
+				helper.insertText("A", 0, "9T");
+				helper.insertText("B", 0, "c8v");
+				helper.advanceClients("A", "C");
+				helper.removeRange("A", 2, 5);
+				helper.removeRange("A", 0, 1);
+				helper.obliterateRange("A", 0, 3);
+				helper.obliterateRange(
+					"C",
+					{ pos: 1, side: Side.After },
+					{ pos: 4, side: Side.Before },
+				);
+				helper.insertText("B", 0, "4qpo");
+				helper.insertText("C", 2, "fP");
+				helper.insertText("A", 0, "hn");
+				helper.advanceClients("A", "C");
+				helper.obliterateRange(
+					"A",
+					{ pos: 5, side: Side.After },
+					{ pos: 9, side: Side.After },
+				);
+				helper.obliterateRange(
+					"B",
+					{ pos: 3, side: Side.Before },
+					{ pos: 9, side: Side.After },
+				);
+				// At the time of the original bug, this would hit 0xa3f.
+				helper.processAllOps();
+
+				helper.logger.validate({ baseText: "hn4qpJ" });
+			});
 		});
 	});
 }

--- a/packages/dds/sequence/src/test/fuzz/sharedString.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/fuzz/sharedString.fuzz.spec.ts
@@ -68,6 +68,8 @@ describe("SharedString fuzz with obliterate", () => {
 			reconnectProbability: 0,
 			// Uncomment this line to replay a specific seed from its failure file:
 			// replay: 0,
+			// TODO:AB#7220: This seed should be enabled. The failure here is unrelated to obliterate.
+			skip: [51],
 		},
 	);
 });

--- a/packages/dds/sequence/src/test/fuzz/sharedString.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/fuzz/sharedString.fuzz.spec.ts
@@ -68,8 +68,6 @@ describe("SharedString fuzz with obliterate", () => {
 			reconnectProbability: 0,
 			// Uncomment this line to replay a specific seed from its failure file:
 			// replay: 0,
-			// TODO:AB#7220: This seed should be enabled. The failure here is unrelated to obliterate.
-			skip: [51],
 		},
 	);
 });


### PR DESCRIPTION
## Description

Resolves some issues in obliterate's insert codepath related to unacked obliterates over the range being inserted into. The gist of the change is that we did not properly bookkeep a scenario where:

- The local client has an outstanding obliterate for a range
- Multiple other clients also obliterated this range and attempted to insert into it

In this case, the local client knows that eventually, the remote clients won't have won the rights to insert into that range (since the local obliterate will remove the segment). However, remote clients won't know this until the local client's obliterate is acked. Therefore if remote clients make subsequent changes without seeing the local client's obliterate, the local client may interpret them incorrectly.

The fix here is to fix the bookkeeping of the inserted segment on the local client in the case above, which can be done by being a bit more thorough on examining any overlapping obliterates (specifically, tracking the newest acked obliterate and oldest unacked obliterate separately from the newest overall). See unit tests for more details.

[AB#31009](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/31009)