### PR TITLE
Add base type check to Tree.is

### DIFF
--- a/.changeset/real-doodles-draw.md
+++ b/.changeset/real-doodles-draw.md
@@ -6,13 +6,12 @@
 "section": tree
 ---
 
-Invalid of schema base classes in `Tree.is` now throw an error instead of returning `false`
-
+Invalid schema base classes in `Tree.is` now throw an error instead of returning `false`
 As documented in [`TreeNodeSchemaClass`](https://fluidframework.com/docs/api/fluid-framework/treenodeschemaclass-typealias#treenodeschemaclass-remarks), there are specific rules around sub-classing schema, mainly that only a single most derived class can be used.
-One place where it was easy to accidentally violate this rule and get hard to debug results was [`Tree.is`](https://fluidframework.com/docs/data-structures/tree/nodes#treeis).
+One place where it was easy to accidentally violate this rule and get hard-to-debug results was [`Tree.is`](https://fluidframework.com/docs/data-structures/tree/nodes#treeis).
 This has been mitigated by adding a check in `Tree.is` which detects this mistake (which used to result in `false` being returned) and instead throws a `UsageError` explaining the situation.
 The error will look something like:
 
 > Two schema classes were used (CustomObjectNode and Derived) which derived from the same SchemaFactory generated class ("com.example.Test"). This is invalid.
 
-For applications wanting to test if a given `TreeNode` is an instance of some schema base class, this can be done using `instancof` which includes base base classes when doing the check.
+For applications wanting to test if a given `TreeNode` is an instance of some schema base class, this can be done using `instanceof` which includes base base classes when doing the check.

--- a/.changeset/real-doodles-draw.md
+++ b/.changeset/real-doodles-draw.md
@@ -1,0 +1,18 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+---
+---
+"section": tree
+---
+
+Invalid of schema base classes in `Tree.is` now throw an error instead of returning `false`
+
+As documented in [`TreeNodeSchemaClass`](https://fluidframework.com/docs/api/fluid-framework/treenodeschemaclass-typealias#treenodeschemaclass-remarks), there are specific rules around sub-classing schema, mainly that only a single most derived class can be used.
+One place where it was easy to accidentally violate this rule and get hard to debug results was [`Tree.is`](https://fluidframework.com/docs/data-structures/tree/nodes#treeis).
+This has been mitigated by adding a check in `Tree.is` which detects this mistake (which used to result in `false` being returned) and instead throws a `UsageError` explaining the situation.
+The error will look something like:
+
+> Two schema classes were used (CustomObjectNode and Derived) which derived from the same SchemaFactory generated class ("com.example.Test"). This is invalid.
+
+For applications wanting to test if a given `TreeNode` is an instance of some schema base class, this can be done using `instancof` which includes base base classes when doing the check.

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -206,7 +206,7 @@ export const treeNodeApi: TreeNodeApi = {
 	): value is TreeNodeFromImplicitAllowedTypes<TSchema> {
 		// This "is" utility would return false if the provided schema is a base type of the actual schema.
 		// This could be confusing, and that case can only be hit when violating the rule that there is a single most derived schema that gets used (See documentation on TreeNodeSchemaClass).
-		// Therefor this uses markSchemaMostDerived to ensure an informative usage error is thrown in the case where a base type is used.
+		// Therefore this uses markSchemaMostDerived to ensure an informative usage error is thrown in the case where a base type is used.
 
 		const actualSchema = tryGetSchema(value);
 		if (actualSchema === undefined) {

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -40,6 +40,7 @@ import {
 } from "../core/index.js";
 import { isObjectNodeSchema } from "../objectNodeTypes.js";
 import { isLazy, type LazyItem } from "../flexList.js";
+import { markSchemaMostDerived } from "./schemaFactory.js";
 
 /**
  * Provides various functions for analyzing {@link TreeNode}s.
@@ -203,6 +204,10 @@ export const treeNodeApi: TreeNodeApi = {
 		value: unknown,
 		schema: TSchema,
 	): value is TreeNodeFromImplicitAllowedTypes<TSchema> {
+		// This "is" utility would return false if the provided schema is a base type of the actual schema.
+		// This could be confusing, and that case can only be hit when violating the rule that there is a single most derived schema that gets used (See documentation on TreeNodeSchemaClass).
+		// Therefor this uses markSchemaMostDerived to ensure an informative usage error is thrown in the case where a base type is used.
+
 		const actualSchema = tryGetSchema(value);
 		if (actualSchema === undefined) {
 			return false;
@@ -210,15 +215,15 @@ export const treeNodeApi: TreeNodeApi = {
 		if (isReadonlyArray<LazyItem<TreeNodeSchema>>(schema)) {
 			for (const singleSchema of schema) {
 				const testSchema = isLazy(singleSchema) ? singleSchema() : singleSchema;
+				markSchemaMostDerived(testSchema);
 				if (testSchema === actualSchema) {
 					return true;
 				}
 			}
 			return false;
 		} else {
-			// Linter is incorrect about this bering unnecessary: it does not compile without the type assertion.
-			// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-			return (schema as TreeNodeSchema) === actualSchema;
+			markSchemaMostDerived(schema);
+			return schema === actualSchema;
 		}
 	},
 	schema(node: TreeNode | TreeLeafValue): TreeNodeSchema {

--- a/packages/dds/tree/src/simple-tree/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/treeNodeValid.ts
@@ -119,6 +119,9 @@ export abstract class TreeNodeValid<TInput> extends TreeNode {
 			return this.constructorCached;
 		}
 
+		// If users trying to diagnose the cause of this error becomes a common issue, more information could be captured.
+		// The call stack to when a schema is first marked most derived could be captured in debug builds and stored in the `MostDerivedData` object:
+		// THis could then be included in there error to aid in debugging this error.
 		throw new UsageError(
 			`Two schema classes were used (${this.name} and ${
 				this.constructorCached.constructor.name

--- a/packages/dds/tree/src/simple-tree/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/treeNodeValid.ts
@@ -121,7 +121,7 @@ export abstract class TreeNodeValid<TInput> extends TreeNode {
 
 		// If users trying to diagnose the cause of this error becomes a common issue, more information could be captured.
 		// The call stack to when a schema is first marked most derived could be captured in debug builds and stored in the `MostDerivedData` object:
-		// THis could then be included in there error to aid in debugging this error.
+		// This could then be included in the error to aid in debugging this error.
 		throw new UsageError(
 			`Two schema classes were used (${this.name} and ${
 				this.constructorCached.constructor.name

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -123,6 +123,17 @@ describe("treeNodeApi", () => {
 			assert(!Tree.is(5, [schema.string]));
 			assert(Tree.is(5, [schema.string, schema.number]));
 		});
+
+		it("errors on base type", () => {
+			const Base = schema.object("Test", {});
+			class Derived extends Base {}
+			assert.throws(
+				() => Tree.is(new Derived({}), Base),
+				validateUsageError(
+					/Two schema classes were used \(CustomObjectNode and Derived\) which derived from the same SchemaFactory generated class \("com.example.Test"\)/,
+				),
+			);
+		});
 	});
 
 	describe("schema", () => {

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -127,8 +127,11 @@ describe("treeNodeApi", () => {
 		it("errors on base type", () => {
 			const Base = schema.object("Test", {});
 			class Derived extends Base {}
+			const node = new Derived({});
+			// Check instancof alternative works:
+			assert(node instanceof Base);
 			assert.throws(
-				() => Tree.is(new Derived({}), Base),
+				() => Tree.is(node, Base),
 				validateUsageError(
 					/Two schema classes were used \(CustomObjectNode and Derived\) which derived from the same SchemaFactory generated class \("com.example.Test"\)/,
 				),


### PR DESCRIPTION
## Description

See changeset

## Breaking Changes

Applications relying on the old behavior were violating the rules documented for TreeNodeSchemaClass, and will now receive detailed UssageErrors. See changeset for details.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

