### PR TITLE
refactor(server): move canbeCoalescedByService to protocol-base

### DIFF
--- a/server/routerlicious/packages/protocol-base/api-report/protocol-base.api.md
+++ b/server/routerlicious/packages/protocol-base/api-report/protocol-base.api.md
@@ -22,7 +22,7 @@ import { TypedEventEmitter } from '@fluidframework/common-utils';
 // @internal
 export function buildGitTreeHierarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>, removeAppTreePrefix?: boolean): ISnapshotTreeEx;
 
-// @internal (undocumented)
+// @internal
 export function canBeCoalescedByService(message: ISequencedDocumentMessage | IDocumentMessage): boolean;
 
 // @internal

--- a/server/routerlicious/packages/protocol-base/api-report/protocol-base.api.md
+++ b/server/routerlicious/packages/protocol-base/api-report/protocol-base.api.md
@@ -7,6 +7,7 @@
 import * as git from '@fluidframework/gitresources';
 import { ICommittedProposal } from '@fluidframework/protocol-definitions';
 import { IDocumentAttributes } from '@fluidframework/protocol-definitions';
+import { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IProcessMessageResult } from '@fluidframework/protocol-definitions';
 import { IQuorum } from '@fluidframework/protocol-definitions';
 import { IQuorumClients } from '@fluidframework/protocol-definitions';
@@ -20,6 +21,9 @@ import { TypedEventEmitter } from '@fluidframework/common-utils';
 
 // @internal
 export function buildGitTreeHierarchy(flatTree: git.ITree, blobsShaToPathCache?: Map<string, string>, removeAppTreePrefix?: boolean): ISnapshotTreeEx;
+
+// @internal (undocumented)
+export function canBeCoalescedByService(message: ISequencedDocumentMessage | IDocumentMessage): boolean;
 
 // @internal
 export function getGitMode(value: SummaryObject): string;

--- a/server/routerlicious/packages/protocol-base/src/index.ts
+++ b/server/routerlicious/packages/protocol-base/src/index.ts
@@ -4,7 +4,12 @@
  */
 
 export { buildGitTreeHierarchy, getGitMode, getGitType } from "./gitHelper";
-export { IProtocolHandler, IScribeProtocolState, ProtocolOpHandler, canBeCoalescedByService } from "./protocol";
+export {
+	IProtocolHandler,
+	IScribeProtocolState,
+	ProtocolOpHandler,
+	canBeCoalescedByService,
+} from "./protocol";
 export {
 	IQuorumSnapshot,
 	Quorum,

--- a/server/routerlicious/packages/protocol-base/src/index.ts
+++ b/server/routerlicious/packages/protocol-base/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 export { buildGitTreeHierarchy, getGitMode, getGitType } from "./gitHelper";
-export { IProtocolHandler, IScribeProtocolState, ProtocolOpHandler } from "./protocol";
+export { IProtocolHandler, IScribeProtocolState, ProtocolOpHandler, canBeCoalescedByService } from "./protocol";
 export {
 	IQuorumSnapshot,
 	Quorum,

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -7,7 +7,7 @@ import {
 	IDocumentAttributes,
 	IClientJoin,
 	ICommittedProposal,
-    IDocumentMessage,
+	IDocumentMessage,
 	IProcessMessageResult,
 	IProposal,
 	IQuorum,

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -7,6 +7,7 @@ import {
 	IDocumentAttributes,
 	IClientJoin,
 	ICommittedProposal,
+    IDocumentMessage,
 	IProcessMessageResult,
 	IProposal,
 	IQuorum,
@@ -177,4 +178,15 @@ export class ProtocolOpHandler implements IProtocolHandler {
 			...snapshot,
 		};
 	}
+}
+
+/**
+ * @internal
+ */
+export function canBeCoalescedByService(
+	message: ISequencedDocumentMessage | IDocumentMessage,
+): boolean {
+	// This assumes that in the future relay service may implement coalescing of accept messages,
+	// same way it was doing coalescing of immediate noops in the past.
+	return message.type === MessageType.NoOp || message.type === MessageType.Accept;
 }

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -181,6 +181,10 @@ export class ProtocolOpHandler implements IProtocolHandler {
 }
 
 /**
+ * Checks if the message is free to be coalesced by the service.
+ *
+ * @param message - The message to check.
+ * @returns true if the message can be coalesced by the service.
  * @internal
  */
 export function canBeCoalescedByService(


### PR DESCRIPTION
## Description
Second part of [AB#31537](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/31537)

First part: https://github.com/microsoft/FluidFramework/pull/23933

This change addresses an old TODO to move canbeCoalescedByService function from driver-utils (messageRecognition.ts) to protocol-base and updates it's corresponding imports:

```typescript
/**
 * @privateRemarks ADO #1385: To be moved to packages/protocol-base/src/protocol.ts
 * @internal
 */
export function canBeCoalescedByService(
	message: ISequencedDocumentMessage | IDocumentMessage,
): boolean {
	// This assumes that in the future relay service may implement coalescing of accept messages,
	// same way it was doing coalescing of immediate noops in the past.
	return message.type === MessageType.NoOp || message.type === MessageType.Accept;
}
```

## Reviewer Guidance
This first change just moves the function to server. I know that client does not like taking prerelease dependency on server, so i'm assuming that the full change will have to wait unti next full server release(?) Would like feedback here. 
