### PR TITLE
Passing the baseUrl to BasicRestWrapper

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -153,12 +153,12 @@ export function create(
 			// TODO: why is this contacting external blob storage?
 			const externalHistorianUrl = config.get("worker:blobStorageUrl") as string;
 			const requestToken = fromUtf8ToBase64(tenantId);
-			const uri = `${externalHistorianUrl}/repos/${tenantId}/git/blobs?token=${requestToken}`;
+			const uri = `/repos/${tenantId}/git/blobs?token=${requestToken}`;
 			const requestBody: git.ICreateBlobParams = {
 				content: blobData.content,
 				encoding: "base64",
 			};
-			uploadBlob(uri, requestBody)
+			uploadBlob(externalHistorianUrl, uri, requestBody)
 				.then((data: git.ICreateBlobResponse) => {
 					response.status(200).json(data);
 				})
@@ -369,11 +369,12 @@ async function checkDocumentExistence(
 }
 
 const uploadBlob = async (
+	baseUrl: string,
 	uri: string,
 	blobData: git.ICreateBlobParams,
 ): Promise<git.ICreateBlobResponse> => {
 	const restWrapper = new BasicRestWrapper(
-		undefined,
+		baseUrl,
 		undefined,
 		undefined,
 		undefined,

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -107,7 +107,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 
 	public async createTenant(tenantId?: string): Promise<core.ITenantConfig & { key: string }> {
 		const restWrapper = new BasicRestWrapper(
-			undefined /* baseUrl */,
+			this.endpoint /* baseUrl */,
 			undefined /* defaultQueryString */,
 			undefined /* maxBodyLength */,
 			undefined /* maxContentLength */,
@@ -121,7 +121,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			logHttpMetrics,
 		);
 		const result = await restWrapper.post<core.ITenantConfig & { key: string }>(
-			`${this.endpoint}/api/tenants/${encodeURIComponent(tenantId || "")}`,
+			`/api/tenants/${encodeURIComponent(tenantId || "")}`,
 			undefined,
 		);
 		return result;
@@ -247,7 +247,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 
 	public async verifyToken(tenantId: string, token: string): Promise<void> {
 		const restWrapper = new BasicRestWrapper(
-			undefined /* baseUrl */,
+			this.endpoint /* baseUrl */,
 			undefined /* defaultQueryString */,
 			undefined /* maxBodyLength */,
 			undefined /* maxContentLength */,
@@ -260,15 +260,12 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			undefined /* refreshTokenIfNeeded */,
 			logHttpMetrics,
 		);
-		await restWrapper.post(
-			`${this.endpoint}/api/tenants/${encodeURIComponent(tenantId)}/validate`,
-			{ token },
-		);
+		await restWrapper.post(`/api/tenants/${encodeURIComponent(tenantId)}/validate`, { token });
 	}
 
 	public async getKey(tenantId: string, includeDisabledTenant = false): Promise<string> {
 		const restWrapper = new BasicRestWrapper(
-			undefined /* baseUrl */,
+			this.endpoint /* baseUrl */,
 			undefined /* defaultQueryString */,
 			undefined /* maxBodyLength */,
 			undefined /* maxContentLength */,
@@ -282,7 +279,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			logHttpMetrics,
 		);
 		const result = await restWrapper.get<core.ITenantKeys>(
-			`${this.endpoint}/api/tenants/${encodeURIComponent(tenantId)}/keys`,
+			`/api/tenants/${encodeURIComponent(tenantId)}/keys`,
 			{ includeDisabledTenant },
 		);
 		return result.key1;
@@ -299,7 +296,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 		includeDisabledTenant?: boolean,
 	): Promise<string> {
 		const restWrapper = new BasicRestWrapper(
-			undefined /* baseUrl */,
+			this.endpoint /* baseUrl */,
 			undefined /* defaultQueryString */,
 			undefined /* maxBodyLength */,
 			undefined /* maxContentLength */,
@@ -313,7 +310,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			logHttpMetrics,
 		);
 		const result = await restWrapper.post<core.IFluidAccessToken>(
-			`${this.endpoint}/api/tenants/${encodeURIComponent(tenantId)}/accesstoken`,
+			`/api/tenants/${encodeURIComponent(tenantId)}/accesstoken`,
 			{
 				documentId,
 				scopes,
@@ -340,7 +337,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 		includeDisabledTenant = false,
 	): Promise<core.ITenantConfig> {
 		const restWrapper = new BasicRestWrapper(
-			undefined /* baseUrl */,
+			this.endpoint /* baseUrl */,
 			undefined /* defaultQueryString */,
 			undefined /* maxBodyLength */,
 			undefined /* maxContentLength */,
@@ -353,7 +350,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			undefined /* refreshTokenIfNeeded */,
 			logHttpMetrics,
 		);
-		return restWrapper.get<core.ITenantConfig>(`${this.endpoint}/api/tenants/${tenantId}`, {
+		return restWrapper.get<core.ITenantConfig>(`/api/tenants/${tenantId}`, {
 			includeDisabledTenant,
 		});
 	}


### PR DESCRIPTION

## Description

There are cases in `BasicRestWrapper`, where we would pass the baseUrl as `undefined` and instead pass the `baseUrl` + `apiEndpoint` in the request args. However, when we log error telemetry, this approach might cause the telemetry to indicate the request endpoint as "". This PR fixes this bug. It should not have any impact on existing APIs.
