### PR TITLE
improvement(merge-tree): Remove wasMovedOnInsert

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1676,7 +1676,6 @@ export class MergeTree {
 						movedSeq: oldest.seq,
 						movedSeqs,
 						localMovedSeq: oldestUnacked?.localSeq,
-						wasMovedOnInsert: oldest.seq !== UnassignedSequenceNumber,
 					};
 				} else {
 					assert(
@@ -1691,7 +1690,6 @@ export class MergeTree {
 						movedSeq: oldestUnacked.seq,
 						movedSeqs: [oldestUnacked.seq],
 						localMovedSeq: oldestUnacked.localSeq,
-						wasMovedOnInsert: false,
 					};
 				}
 
@@ -2142,8 +2140,6 @@ export class MergeTree {
 					movedSeq: seq,
 					localMovedSeq: localSeq,
 					movedSeqs: [seq],
-					wasMovedOnInsert:
-						segment.seq === UnassignedSequenceNumber && seq !== UnassignedSequenceNumber,
 				});
 
 				const existingRemoval = toRemovalInfo(movedSeg);
@@ -2159,7 +2155,6 @@ export class MergeTree {
 				}
 			} else {
 				if (existingMoveInfo.movedSeq === UnassignedSequenceNumber) {
-					// Should not need explicit set here, but this should be implied:
 					assert(
 						!wasMovedOnInsert(segment),
 						0xab4 /* Local obliterate cannot have removed a segment as soon as it was inserted */,
@@ -2168,7 +2163,7 @@ export class MergeTree {
 						seq !== UnassignedSequenceNumber,
 						0xab5 /* Cannot obliterate the same segment locally twice */,
 					);
-					existingMoveInfo.wasMovedOnInsert = segment.seq === UnassignedSequenceNumber;
+
 					// we moved this locally, but someone else moved it first
 					// so put them at the head of the list
 					// The list isn't ordered, but we keep the first move at the head

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -95,6 +95,7 @@ import {
 	removeRemovalInfo,
 	toMoveInfo,
 	toRemovalInfo,
+	wasMovedOnInsert,
 	type IInsertionInfo,
 	type IMoveInfo,
 	type IRemovalInfo,
@@ -2160,7 +2161,7 @@ export class MergeTree {
 				if (existingMoveInfo.movedSeq === UnassignedSequenceNumber) {
 					// Should not need explicit set here, but this should be implied:
 					assert(
-						!existingMoveInfo.wasMovedOnInsert,
+						!wasMovedOnInsert(segment),
 						0xab4 /* Local obliterate cannot have removed a segment as soon as it was inserted */,
 					);
 					assert(

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -375,7 +375,6 @@ export abstract class BaseSegment implements ISegment {
 			overwriteInfo<IMoveInfo>(seg, {
 				movedSeq: this.movedSeq,
 				movedSeqs: [...this.movedSeqs],
-				wasMovedOnInsert: this.wasMovedOnInsert,
 				movedClientIds: [...this.movedClientIds],
 			});
 		}
@@ -441,7 +440,6 @@ export abstract class BaseSegment implements ISegment {
 				movedSeq: this.movedSeq,
 				movedSeqs: [...this.movedSeqs],
 				localMovedSeq: this.localMovedSeq,
-				wasMovedOnInsert: this.wasMovedOnInsert,
 			});
 		}
 

--- a/packages/dds/merge-tree/src/segmentInfos.ts
+++ b/packages/dds/merge-tree/src/segmentInfos.ts
@@ -297,31 +297,12 @@ export interface IMoveInfo {
 	 * list have all issued concurrent ops to move the segment.
 	 */
 	movedClientIds: number[];
-
-	/**
-	 * If this segment was inserted into a concurrently moved range and
-	 * the move op was sequenced before the insertion op. In this case,
-	 * the segment is visible only to the inserting client
-	 *
-	 * `wasMovedOnInsert` only applies for acked obliterates. That is, if
-	 * a segment inserted by a remote client is moved on insertion by a local
-	 * and unacked obliterate, we do not consider it as having been moved
-	 * on insert
-	 *
-	 * If a segment is moved on insertion, its length is only ever visible to
-	 * the client that inserted the segment. This is relevant in partial length
-	 * calculations
-	 *
-	 * @privateRemarks
-	 * TODO:AB#29553: This property is not persisted in the summary, but it should be.
-	 */
-	wasMovedOnInsert: boolean;
 }
+
 export const toMoveInfo = (segmentLike: unknown): IMoveInfo | undefined =>
 	hasProp(segmentLike, "movedClientIds", "array") &&
 	hasProp(segmentLike, "movedSeq", "number") &&
-	hasProp(segmentLike, "movedSeqs", "array") &&
-	hasProp(segmentLike, "wasMovedOnInsert", "boolean")
+	hasProp(segmentLike, "movedSeqs", "array")
 		? segmentLike
 		: undefined;
 
@@ -335,14 +316,16 @@ export const toMoveInfo = (segmentLike: unknown): IMoveInfo | undefined =>
 export const isMoved = (segmentLike: unknown): segmentLike is IMoveInfo =>
 	toMoveInfo(segmentLike) !== undefined;
 
+/**
+ * Returns whether this segment was marked moved as soon as its insertion was acked.
+ *
+ * This can happen when an an insert occurs concurrent to an obliterate over the range the segment was inserted into,
+ * and the obliterate was sequenced first.
+ *
+ * When this happens, the segment is only ever visible to the client that inserted the segment
+ * (and only until that client has seen the obliterate which removed their segment).
+ */
 export function wasMovedOnInsert(segment: IInsertionInfo & ISegmentPrivate): boolean {
-	const result1 = toMoveInfo(segment)?.wasMovedOnInsert ?? false;
-	const result2 = wasMovedOnInsert2(segment);
-	assert(result1 === result2, 0xaa4 /* must be equal */);
-	return result1;
-}
-
-function wasMovedOnInsert2(segment: IInsertionInfo & ISegmentPrivate): boolean {
 	const moveInfo = toMoveInfo(segment);
 	const movedSeq = moveInfo?.movedSeq;
 	if (movedSeq === undefined || movedSeq === UnassignedSequenceNumber) {

--- a/packages/dds/merge-tree/src/snapshotLoader.ts
+++ b/packages/dds/merge-tree/src/snapshotLoader.ts
@@ -140,8 +140,6 @@ export class SnapshotLoader {
 					movedClientIds: spec.movedClientIds.map((id) =>
 						this.client.getOrAddShortClientId(id),
 					),
-					// TODO:AB#29553: This property should be derived from segment data, not hard-coded.
-					wasMovedOnInsert: false,
 				});
 			}
 

--- a/packages/dds/merge-tree/src/test/obliterate.concurrent.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.concurrent.spec.ts
@@ -1199,7 +1199,7 @@ for (const incremental of [true, false]) {
 			helper.logger.validate();
 		});
 
-		it("wasMovedOnInsert remains after leaf node is split", () => {
+		it("wasMovedOnInsert computation remains accurate after leaf node is split", () => {
 			const helper = new ReconnectTestHelper();
 
 			// CD-B-A


### PR DESCRIPTION
## Description

With the changes in #23859, this field is now redundant with information about when a given segment was inserted & when it was moved. This removes anywhere that sets `wasMovedOnInsert`, and replaces areas that read it with that computation.

For some peace of mind, I ran a build on the [first commit of this PR](https://github.com/microsoft/FluidFramework/pull/23946/commits/2f6470174d8b433a7eb9e7e855d2b2d51ea5fdfa) (which asserts that the old code path matches the new code path wherever `wasMovedOnInsert` was read), and [it passed](https://dev.azure.com/fluidframework/public/_build/results?buildId=324331&view=results).
