### PR TITLE
refactor(container-runtime): Add IProtocolOptions and CompatibilityMode to container-runtime

### DIFF
--- a/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
@@ -4,8 +4,9 @@
 
 ```ts
 
-// @public
-export type CompatibilityMode = "1" | "2";
+export { CompatibilityMode }
+
+export { compatibilityModeRuntimeOptions }
 
 // @public
 export type ContainerAttachProps<T = unknown> = T;

--- a/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
@@ -4,8 +4,9 @@
 
 ```ts
 
-// @public
-export type CompatibilityMode = "1" | "2";
+export { CompatibilityMode }
+
+export { compatibilityModeRuntimeOptions }
 
 // @public
 export type ContainerAttachProps<T = unknown> = T;

--- a/packages/framework/fluid-static/api-report/fluid-static.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.public.api.md
@@ -4,8 +4,9 @@
 
 ```ts
 
-// @public
-export type CompatibilityMode = "1" | "2";
+export { CompatibilityMode }
+
+export { compatibilityModeRuntimeOptions }
 
 // @public
 export type ContainerAttachProps<T = unknown> = T;

--- a/packages/framework/fluid-static/src/index.ts
+++ b/packages/framework/fluid-static/src/index.ts
@@ -20,7 +20,6 @@ export {
 export { createDOProviderContainerRuntimeFactory } from "./rootDataObject.js";
 export { createServiceAudience } from "./serviceAudience.js";
 export type {
-	CompatibilityMode,
 	ContainerSchema,
 	ContainerAttachProps,
 	IConnection,
@@ -33,3 +32,8 @@ export type {
 	MemberChangedListener,
 	Myself,
 } from "./types.js";
+
+// Re-export so other packages don't need to pull in container-runtime
+// TODO: Should we re-export?
+export type { CompatibilityMode } from "@fluidframework/container-runtime";
+export { compatibilityModeRuntimeOptions } from "@fluidframework/container-runtime/internal";

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -10,15 +10,15 @@ import {
 	DataObjectFactory,
 } from "@fluidframework/aqueduct/internal";
 import type { IRuntimeFactory } from "@fluidframework/container-definitions/internal";
+import type { CompatibilityMode } from "@fluidframework/container-runtime";
+import { compatibilityModeRuntimeOptions } from "@fluidframework/container-runtime/internal";
 import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import type { FluidObject, IFluidLoadable } from "@fluidframework/core-interfaces";
 import type { IDirectory } from "@fluidframework/map/internal";
 import type { SharedObjectKind } from "@fluidframework/shared-object-base";
 import type { ISharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
-import { compatibilityModeRuntimeOptions } from "./compatibilityConfiguration.js";
 import type {
-	CompatibilityMode,
 	ContainerSchema,
 	IRootDataObject,
 	LoadableObjectKind,

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -9,12 +9,6 @@ import type { SharedObjectKind } from "@fluidframework/shared-object-base";
 import type { ISharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
 /**
- * Valid compatibility modes that may be specified when creating a DOProviderContainerRuntimeFactory.
- * @public
- */
-export type CompatibilityMode = "1" | "2";
-
-/**
  * A mapping of string identifiers to instantiated `DataObject`s or `SharedObject`s.
  * @internal
  */

--- a/packages/runtime/container-runtime/api-report/container-runtime.beta.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.beta.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+// @public
+export type CompatibilityMode = "1" | "2";
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -195,7 +195,6 @@ export interface IContainerRuntimeMetadata extends ICreateContainerMetadata, IGC
 // @alpha
 export interface IContainerRuntimeOptions {
     readonly chunkSizeInBytes?: number;
-    // (undocumented)
     readonly compatibilityMode?: CompatibilityMode;
     readonly compressionOptions?: ICompressionRuntimeOptions;
     // @deprecated
@@ -206,7 +205,6 @@ export interface IContainerRuntimeOptions {
     readonly gcOptions?: IGCRuntimeOptions;
     readonly loadSequenceNumberVerification?: "close" | "log" | "bypass";
     readonly maxBatchSizeInBytes?: number;
-    // (undocumented)
     readonly protocolOptions?: IProtocolOptions;
     // (undocumented)
     readonly summaryOptions?: ISummaryRuntimeOptions;

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -7,6 +7,9 @@
 // @alpha
 export const AllowTombstoneRequestHeaderKey = "allowTombstone";
 
+// @public
+export type CompatibilityMode = "1" | "2";
+
 // @alpha
 export enum CompressionAlgorithms {
     // (undocumented)
@@ -192,6 +195,8 @@ export interface IContainerRuntimeMetadata extends ICreateContainerMetadata, IGC
 // @alpha
 export interface IContainerRuntimeOptions {
     readonly chunkSizeInBytes?: number;
+    // (undocumented)
+    readonly compatibilityMode?: CompatibilityMode;
     readonly compressionOptions?: ICompressionRuntimeOptions;
     // @deprecated
     readonly enableGroupedBatching?: boolean;
@@ -201,6 +206,8 @@ export interface IContainerRuntimeOptions {
     readonly gcOptions?: IGCRuntimeOptions;
     readonly loadSequenceNumberVerification?: "close" | "log" | "bypass";
     readonly maxBatchSizeInBytes?: number;
+    // (undocumented)
+    readonly protocolOptions?: IProtocolOptions;
     // (undocumented)
     readonly summaryOptions?: ISummaryRuntimeOptions;
 }
@@ -352,6 +359,16 @@ export const InactiveResponseHeaderKey = "isInactive";
 export interface IOnDemandSummarizeOptions extends ISummarizeOptions {
     readonly reason: string;
     readonly retryOnFailure?: boolean;
+}
+
+// @alpha
+export interface IProtocolOptions {
+    readonly compressionOptions?: ICompressionRuntimeOptions;
+    readonly enableGCSweep?: true | undefined;
+    // @deprecated
+    readonly enableGroupedBatching?: boolean;
+    readonly enableRuntimeIdCompressor?: IdCompressorMode;
+    readonly explicitSchemaControl?: boolean;
 }
 
 // @alpha @deprecated

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.public.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.public.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+// @public
+export type CompatibilityMode = "1" | "2";
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/runtime/container-runtime/api-report/container-runtime.public.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.public.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+// @public
+export type CompatibilityMode = "1" | "2";
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/runtime/container-runtime/src/compatibilityConfiguration.ts
+++ b/packages/runtime/container-runtime/src/compatibilityConfiguration.ts
@@ -3,17 +3,32 @@
  * Licensed under the MIT License.
  */
 
+import { FlushMode } from "@fluidframework/runtime-definitions/internal";
+
 import {
 	CompressionAlgorithms,
 	type IContainerRuntimeOptionsInternal,
-} from "@fluidframework/container-runtime/internal";
-import { FlushMode } from "@fluidframework/runtime-definitions/internal";
+} from "./containerRuntime.js";
 
-import type { CompatibilityMode } from "./types.js";
+/**
+ * Valid compatibility modes that may be specified when creating a DOProviderContainerRuntimeFactory.
+ * @public
+ */
+export type CompatibilityMode = "1" | "2";
+
+/**
+ * The default compatibility mode is "1".
+ * This is based on our current cross-client compat policy, which states we must support the most recent
+ * adjacent public major version (currently 1.x).
+ * This value will need to be updated if our compat policy changes, or we release a major public version.
+ * @public
+ */
+export const defaultCompatibilityMode: CompatibilityMode = "1";
 
 /**
  * The CompatibilityMode selected determines the set of runtime options to use. In "1" mode we support
  * full interop with true 1.x clients, while in "2" mode we only support interop with 2.x clients.
+ * @internal
  */
 export const compatibilityModeRuntimeOptions: Record<
 	CompatibilityMode,

--- a/packages/runtime/container-runtime/src/compatibilityConfiguration.ts
+++ b/packages/runtime/container-runtime/src/compatibilityConfiguration.ts
@@ -51,6 +51,8 @@ export const compatibilityModeRuntimeOptions: Record<
 		// Explicitly disable running Sweep in compat mode "1". Sweep is supported only in 2.x. So, when 1.x and 2.x
 		// clients are running in parallel, running sweep will fail 1.x clients.
 		gcOptions: { enableGCSweep: undefined },
+
+		disallowedVersions: [],
 	},
 	"2": {
 		// Explicit schema control explicitly makes the container incompatible with 1.x clients, to force their
@@ -62,5 +64,7 @@ export const compatibilityModeRuntimeOptions: Record<
 		// Explicitly disable running Sweep in compat mode "2". Although sweep is supported in 2.x, it is disabled by default.
 		// This setting explicitly disables it to be extra safe.
 		gcOptions: { enableGCSweep: undefined },
+
+		disallowedVersions: ["<2.0"],
 	},
 };

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -546,7 +546,13 @@ export interface IProtocolOptions {
  * @alpha
  */
 export interface IContainerRuntimeOptions {
+	/**
+	 * TODO: TSDoc
+	 */
 	readonly protocolOptions?: IProtocolOptions;
+	/**
+	 * TODO: TSDoc
+	 */
 	readonly compatibilityMode?: CompatibilityMode;
 
 	readonly summaryOptions?: ISummaryRuntimeOptions;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1070,7 +1070,7 @@ export class ContainerRuntime
 		// 1. We check if any of the properties in protocolOptions are also defined in runtimeOptions. If they are not the same, we throw an error.
 		// 2. We set any undefined properties in runtimeOptions to the value in protocolOptions.
 		for (const key of Object.keys(protocolOptions)) {
-			if (key in runtimeOptions && protocolOptions[key] !== undefined) {
+			if (protocolOptions[key] !== undefined) {
 				if (runtimeOptions[key] === undefined) {
 					runtimeOptions[key] = protocolOptions[key] as IContainerRuntimeOptions;
 				} else if (runtimeOptions[key] !== protocolOptions[key]) {

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -24,6 +24,7 @@ export {
 	CompressionAlgorithms,
 	RuntimeHeaderData,
 	disabledCompressionConfig,
+	IProtocolOptions,
 } from "./containerRuntime.js";
 export {
 	ContainerMessageType,
@@ -121,3 +122,7 @@ export {
 	IFluidDataStoreContextEvents,
 } from "./dataStoreContext.js";
 export { DataStoreContexts } from "./dataStoreContexts.js";
+export {
+	CompatibilityMode,
+	compatibilityModeRuntimeOptions,
+} from "./compatibilityConfiguration.js";

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -112,6 +112,8 @@ export function generateRuntimeOptions(
 		enableRuntimeIdCompressor: ["on", undefined, "delayed"],
 		enableGroupedBatching: [true, false],
 		explicitSchemaControl: [true, false],
+		protocolOptions: [undefined, {}], // TODO: This will change in the future
+		compatibilityMode: ["1", "2"],
 	};
 
 	const pairwiseOptions = generatePairwiseOptions<IContainerRuntimeOptionsInternal>(

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -114,6 +114,7 @@ export function generateRuntimeOptions(
 		explicitSchemaControl: [true, false],
 		protocolOptions: [undefined, {}], // TODO: This will change in the future
 		compatibilityMode: ["1", "2"],
+		disallowedVersions: [],
 	};
 
 	const pairwiseOptions = generatePairwiseOptions<IContainerRuntimeOptionsInternal>(


### PR DESCRIPTION
### TODO
1. Add tests to validate properties are applied correctly
1. Fix circular import issue with `CompressionAlgorithms`

## Description

This PR adds `IProtocolOptions` and `CompatibilityMode` (moved from fluid-static) to the container-runtime package.

### IProtocolOptions
The options currently in `IContainerRuntimeOptions` can be categorized into two groups. The first group are options that we provide to customers to customize their FluidFramework experience depending on their needs (i.e. `summaryOptions`). The second group are options where their main function is to to maintain compliance with our cross-client compatibility policy. For example, `enableGroupedBatching`, since batching is a feature we would ideally recommend to all customers but is not compatible with 1.x clients.
`IProtocolOptions` contains the options in the second group. This was done to add clarity for both customers and FF devs on which options are compat-related.

In this PR's implementation, the container runtime accepts inputs from both `IContainerRuntimeOptions` and `IProtocolOptions`. If a property is provided in `IProtocolOptions`, it will overwrite the value in `IContainerRuntimeOptions`. Eventually, we will remove any properties from `IContainerRuntimeOptions` that overlap with `IProtocolOptions`.

### CompatibilityMode
`CompatibilityMode` was added in this PR to lay the groundwork for easy upgrade paths for customers. Additional changes are required, but it will ultimately allow customers to specify the "minimum required version" to collaborate. It will ultimately accomplish the following:
1. Bundle the appropriate configuraitons for collaboration with the "minimum required version".
3. Disallow versions under the "minimum required version" from joining a session. 
By giving customers a "switch" they can flip once they reach saturation on a new version of FF, they will have an easy and clear upgrade path.

Note: Since container-runtime is a depedency of fluid-static, we needed to move `CompatibilityMode` to the container-runtime package to make it accessible within container-runtime.


## Reviewer Guidance
- Some features are currently enabled by default, which based on recent compat policy discussions should likely be disabled by default. See comment below on batching for more details.
- Do we need to stage the removal of `CompatibilityMode` and `compatibilityModeRuntimeOptions` from fluid-static?

## Next Steps

1. Depreacate the properties on `IContainerRuntimeOptions` that overlap with `IProtocolOptions` (and eventually remove).
1. Implement "disallow versions under the \`minimum required version\` from joining a session".


[AB#31227](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/31227)