### PR TITLE
fix(publish:tarballs): Fix unhandled exception when publish fails

### DIFF
--- a/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
+++ b/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
@@ -238,7 +238,7 @@ function handlePublishError(
 	message: string,
 	stack?: string,
 ): "Error" {
-	log.warning(`Failed to publish ${name}`);
+	log.warning(`Failed to publish '${name}'`);
 	log.verbose(message);
 	if (stack !== undefined) {
 		log.verbose(stack);

--- a/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
+++ b/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
@@ -207,7 +207,7 @@ async function publishTarball(
 		}
 	} catch (error) {
 		// Assume package or version is not published, so just continue and try to publish
-		log.verbose(`Caught error: ${error}`);
+		log.verbose(`Version appears unpublished; expected error: ${error}`);
 	}
 
 	const args = ["publish", tarball.fileName, "--access", "public"];
@@ -216,15 +216,32 @@ async function publishTarball(
 	}
 	const tarballDirectory = path.dirname(tarball.filePath);
 	log.verbose(`Executing publish command in ${tarballDirectory}: pnpm ${args.join(" ")}`);
-	const publishOutput = await execa("npm", args, {
-		cwd: tarballDirectory,
-	});
+	try {
+		const publishOutput = await execa("npm", args, {
+			cwd: tarballDirectory,
+		});
 
-	if (publishOutput.exitCode !== 0) {
-		log.warning(`Failed to publish ${tarball.name}`);
-		log.verbose(publishOutput.stderr);
-		return "Error";
+		if (publishOutput.exitCode !== 0) {
+			return handlePublishError(log, tarball.name, publishOutput.stderr);
+		}
+	} catch (error) {
+		const err = error as Error;
+		return handlePublishError(log, tarball.name, err.message, err.stack);
 	}
 
 	return "SuccessfullyPublished";
+}
+
+function handlePublishError(
+	log: Logger,
+	name: string,
+	message: string,
+	stack?: string,
+): "Error" {
+	log.warning(`Failed to publish ${name}`);
+	log.verbose(message);
+	if (stack !== undefined) {
+		log.verbose(stack);
+	}
+	return "Error";
 }


### PR DESCRIPTION
The publish:tarballs command could encounter an exception when publishing which was unhandled. This caused retry logic to fail to kick in, leading to unpublished packages.

The exception is now caught and handled.