### PR TITLE
improvement(merge-tree): Avoid computing local partials when using local references

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1084,7 +1084,14 @@ export class MergeTree {
 		if (!this.collabWindow.collaborating || this.collabWindow.clientId === clientId) {
 			if (node.isLeaf()) {
 				return this.localNetLength(node, refSeq, localSeq);
-			} else if (localSeq === undefined) {
+			} else if (
+				localSeq === undefined ||
+				// All changes are visible. Small note on why we allow refSeq >= this.collabWindow.currentSeq rather than just equality:
+				// merge-tree eventing occurs before the collab window is updated to account for whatever op it is processing, and we want
+				// to support resolving positions from within the event handler which account for that op. e.g. undo-redo relies on this
+				// behavior with local references.
+				(localSeq === this.collabWindow.localSeq && refSeq >= this.collabWindow.currentSeq)
+			) {
 				// Local client sees all segments, even when collaborating
 				return node.cachedLength;
 			} else {
@@ -1179,6 +1186,8 @@ export class MergeTree {
 	 */
 	public referencePositionToLocalPosition(
 		refPos: ReferencePosition,
+		// Note: this is not `this.collabWindow.currentSeq` because we want to support resolving local reference positions to positions
+		// from within event handlers, and the collab window's sequence numbers are not updated in time in all of those cases.
 		refSeq = Number.MAX_SAFE_INTEGER,
 		clientId = this.collabWindow.clientId,
 		localSeq: number | undefined = this.collabWindow.localSeq,


### PR DESCRIPTION
## Description

Updates `MergeTree.nodeLength` to use the cached length in more cases. Previously, we always passed `localSeq: undefined` when considering a length perspective that was for the local client but included all local changes. A refactor at some point changed a local reference codepath to explicitly use the current localSeq on the collab window rather than undefined, which causes some unnecessary computation in partial lengths. This updates the logic in `nodeLength` to detect when a perspective still includes all local changes and to just use the cached length if so, which should give a small perf improvement for features that use local references.
 
[AB#31013](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/31013)
