### PR TITLE
feat(devtools-core): Remove `IFluidLoadble` in FluidObject

### DIFF
--- a/packages/tools/devtools/devtools-test-app/src/FluidObject.ts
+++ b/packages/tools/devtools/devtools-test-app/src/FluidObject.ts
@@ -134,7 +134,7 @@ export class AppData extends DataObject {
 			},
 		});
 
-		this._initialObjects[this.initialObjectsDirKey] = this.root.IFluidLoadable;
+		this._initialObjects[this.initialObjectsDirKey] = this.root;
 	}
 
 	protected async hasInitialized(): Promise<void> {


### PR DESCRIPTION
#### Description

Fix redundant reference to `IFluidLoadable` interface in `FluidObject.ts`. 

The code was redundantly trying to access `IFluidLoadble` as a property on `this.root`, which is invalid since`IFluidLoadble` is an interface type, not a property. The root SharedDirectory object already implements IFluidLoadable, so we can simply use `this.root` directly.
