### PR TITLE
Run copy results  after tests failures

### DIFF
--- a/packages/tools/devtools/devtools-view/src/test/DynamicComposedChart.test.tsx
+++ b/packages/tools/devtools/devtools-view/src/test/DynamicComposedChart.test.tsx
@@ -75,7 +75,7 @@ describe("DynamicComposedChart component test", () => {
 	test("renders without crashing with data", () => {
 		render(<DynamicComposedChart dataSets={testDataSets} />);
 		const dynamicComposedChartElement = screen.findByTestId("test-dynamic-composed-chart");
-		expect(dynamicComposedChartElement).not.toBeNull();
+		expect(dynamicComposedChartElement).toBeNull();
 		expect(dynamicComposedChartElement).toBeDefined();
 	});
 

--- a/packages/tools/devtools/devtools-view/src/test/DynamicComposedChart.test.tsx
+++ b/packages/tools/devtools/devtools-view/src/test/DynamicComposedChart.test.tsx
@@ -75,7 +75,7 @@ describe("DynamicComposedChart component test", () => {
 	test("renders without crashing with data", () => {
 		render(<DynamicComposedChart dataSets={testDataSets} />);
 		const dynamicComposedChartElement = screen.findByTestId("test-dynamic-composed-chart");
-		expect(dynamicComposedChartElement).toBeNull();
+		expect(dynamicComposedChartElement).not.toBeNull();
 		expect(dynamicComposedChartElement).toBeDefined();
 	});
 

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -596,7 +596,8 @@ extends:
               # Set variable startTest if everything is good so far and we'll start running tests,
               # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
               - script: |
-                  echo "##vso[task.setvariable variable=startTest]true"
+                  echo "##vso[task.setvariable variable=startTest;isOutput=true]true"
+                name: SetStartTestCoverage
                 displayName: Start Test
 
               - ${{ each test in parameters.coverageTests }}:
@@ -608,7 +609,7 @@ extends:
 
               - task: Npm@1
                 displayName: 'npm run test:copyresults'
-                condition: eq(variables['startTest'], 'true')
+                condition: and(succeededOrFailed(), eq(variables['SetStartTestCoverage.startTest'], 'true'))
                 inputs:
                   command: custom
                   workingDir: '${{ parameters.buildDirectory }}'
@@ -750,7 +751,8 @@ extends:
                 # Set variable startTest if everything is good so far and we'll start running tests,
                 # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
                 - script: |
-                    echo "##vso[task.setvariable variable=startTest]true"
+                    echo "##vso[task.setvariable variable=startTest;isOutput=true]true"
+                  name: SetStartTest
                   displayName: Start Test
 
                 - template: /tools/pipelines/templates/include-test-task.yml@self
@@ -761,6 +763,7 @@ extends:
 
                 - task: Npm@1
                   displayName: 'npm run test:copyresults'
+                  condition: and(succeededOrFailed(), eq(variables['SetStartTest.startTest'], 'true'))
                   inputs:
                     command: custom
                     workingDir: '${{ parameters.buildDirectory }}'

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -607,7 +607,7 @@ extends:
                     taskTestStep: '${{ test.name }}'
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testCoverage: '${{ parameters.testCoverage }}'
-                    startTest: eq($[variables['setStartTestCoverage.startTest']], 'true')
+                    startTest: $[eq(variables['setStartTestCoverage.startTest'], 'true')]
 
               - task: Npm@1
                 displayName: 'npm run test:copyresults'
@@ -763,7 +763,7 @@ extends:
                     taskTestStep: '${{ test.name }}'
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testCoverage: 'false'
-                    startTest: eq($[variables['setStartTest.startTest']], 'true')
+                    startTest: $[eq(variables['setStartTest.startTest'], 'true')]
 
                 - task: Npm@1
                   displayName: 'npm run test:copyresults'

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -597,7 +597,7 @@ extends:
               # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
               - script: |
                   echo "##vso[task.setvariable variable=startTest;isOutput=true]true"
-                name: SetStartTestCoverage
+                name: setStartTestCoverage
                 displayName: Start Test
                 condition: succeeded()
 
@@ -607,7 +607,7 @@ extends:
                     taskTestStep: '${{ test.name }}'
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testCoverage: '${{ parameters.testCoverage }}'
-                    startTest: $[variables['SetStartTestCoverage.startTest']]
+                    startTest: eq($[variables['setStartTestCoverage.startTest']], 'true')
 
               - task: Npm@1
                 displayName: 'npm run test:copyresults'
@@ -754,7 +754,7 @@ extends:
                 # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
                 - script: |
                     echo "##vso[task.setvariable variable=startTest;isOutput=true]true"
-                  name: SetStartTest
+                  name: setStartTest
                   displayName: Start Test
                   condition: succeeded()
 
@@ -763,7 +763,7 @@ extends:
                     taskTestStep: '${{ test.name }}'
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testCoverage: 'false'
-                    startTest: $[variables['SetStartTest.startTest']]
+                    startTest: eq($[variables['setStartTest.startTest']], 'true')
 
                 - task: Npm@1
                   displayName: 'npm run test:copyresults'

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -596,10 +596,8 @@ extends:
               # Set variable startTest if everything is good so far and we'll start running tests,
               # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
               - script: |
-                  echo "##vso[task.setvariable variable=startTestCoverage;isOutput=true]true"
-                name: setStartTestCoverage
+                  echo "##vso[task.setvariable variable=startTestCoverage]true"
                 displayName: Start Test
-                condition: succeeded()
 
               - ${{ each test in parameters.coverageTests }}:
                 - template: /tools/pipelines/templates/include-test-task.yml@self
@@ -610,7 +608,7 @@ extends:
 
               - task: Npm@1
                 displayName: 'npm run test:copyresults'
-                condition: and(succeededOrFailed(), eq(variables['SetStartTestCoverage.startTest'], 'true'))
+                condition: and(succeededOrFailed(), eq(variables['startTestCoverage'], 'true'))
                 inputs:
                   command: custom
                   workingDir: '${{ parameters.buildDirectory }}'
@@ -622,7 +620,7 @@ extends:
               # A quick fix to patch the file with sed. (See https://github.com/bcoe/c8/issues/302)
               - task: Bash@3
                 displayName: Check for nyc/report directory
-                condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+                condition: and(succeededOrFailed(), eq(variables['startTestCoverage'], 'true'))
                 inputs:
                   targetType: 'inline'
                   workingDirectory: '${{ parameters.buildDirectory }}'
@@ -752,10 +750,8 @@ extends:
                 # Set variable startTest if everything is good so far and we'll start running tests,
                 # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
                 - script: |
-                    echo "##vso[task.setvariable variable=startTest;isOutput=true]true"
-                  name: setStartTest
+                    echo "##vso[task.setvariable variable=startTest]true"
                   displayName: Start Test
-                  condition: succeeded()
 
                 - template: /tools/pipelines/templates/include-test-task.yml@self
                   parameters:
@@ -765,7 +761,7 @@ extends:
 
                 - task: Npm@1
                   displayName: 'npm run test:copyresults'
-                  condition: and(succeededOrFailed(), eq(variables['SetStartTest.startTest'], 'true'))
+                  condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
                   inputs:
                     command: custom
                     workingDir: '${{ parameters.buildDirectory }}'

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -608,7 +608,7 @@ extends:
 
               - task: Npm@1
                 displayName: 'npm run test:copyresults'
-                condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+                condition: eq(variables['startTest'], 'true')
                 inputs:
                   command: custom
                   workingDir: '${{ parameters.buildDirectory }}'

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -599,6 +599,7 @@ extends:
                   echo "##vso[task.setvariable variable=startTest;isOutput=true]true"
                 name: SetStartTestCoverage
                 displayName: Start Test
+                condition: succeeded()
 
               - ${{ each test in parameters.coverageTests }}:
                 - template: /tools/pipelines/templates/include-test-task.yml@self
@@ -606,6 +607,7 @@ extends:
                     taskTestStep: '${{ test.name }}'
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testCoverage: '${{ parameters.testCoverage }}'
+                    startTest: $[variables['SetStartTestCoverage.startTest']]
 
               - task: Npm@1
                 displayName: 'npm run test:copyresults'
@@ -754,12 +756,14 @@ extends:
                     echo "##vso[task.setvariable variable=startTest;isOutput=true]true"
                   name: SetStartTest
                   displayName: Start Test
+                  condition: succeeded()
 
                 - template: /tools/pipelines/templates/include-test-task.yml@self
                   parameters:
                     taskTestStep: '${{ test.name }}'
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testCoverage: 'false'
+                    startTest: $[variables['SetStartTest.startTest']]
 
                 - task: Npm@1
                   displayName: 'npm run test:copyresults'

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -596,7 +596,7 @@ extends:
               # Set variable startTest if everything is good so far and we'll start running tests,
               # so that the steps to process/upload test coverage results only run if we got to the point of actually running tests.
               - script: |
-                  echo "##vso[task.setvariable variable=startTest;isOutput=true]true"
+                  echo "##vso[task.setvariable variable=startTestCoverage;isOutput=true]true"
                 name: setStartTestCoverage
                 displayName: Start Test
                 condition: succeeded()
@@ -607,7 +607,6 @@ extends:
                     taskTestStep: '${{ test.name }}'
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testCoverage: '${{ parameters.testCoverage }}'
-                    startTest: $[eq(variables['setStartTestCoverage.startTest'], 'true')]
 
               - task: Npm@1
                 displayName: 'npm run test:copyresults'
@@ -763,7 +762,6 @@ extends:
                     taskTestStep: '${{ test.name }}'
                     buildDirectory: '${{ parameters.buildDirectory }}'
                     testCoverage: 'false'
-                    startTest: $[eq(variables['setStartTest.startTest'], 'true')]
 
                 - task: Npm@1
                   displayName: 'npm run test:copyresults'

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -360,7 +360,7 @@ extends:
                               parameters.testCoverage,
                               ne(variables['Build.Reason'], 'PullRequest')
                             )}}
-                          startTest: eq($[variables['setStartTest.startTest']], 'true')
+                          startTest: $[eq(variables['setStartTest.startTest'], 'true')]
 
                   - ${{ if contains(convertToJson(parameters.taskTest), 'tinylicious') }}:
                     - task: Bash@3

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -347,6 +347,8 @@ extends:
                   - script: |
                       echo "##vso[task.setvariable variable=startTest]true"
                     displayName: Start Test
+                    name: setStartTest
+                    condition: succeeded()
 
                   - ${{ each taskTestStep in parameters.taskTest }}:
                       - template: /tools/pipelines/templates/include-test-task.yml@self
@@ -358,6 +360,7 @@ extends:
                               parameters.testCoverage,
                               ne(variables['Build.Reason'], 'PullRequest')
                             )}}
+                          startTest: $[variables['setStartTest.startTest']]
 
                   - ${{ if contains(convertToJson(parameters.taskTest), 'tinylicious') }}:
                     - task: Bash@3

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -360,7 +360,7 @@ extends:
                               parameters.testCoverage,
                               ne(variables['Build.Reason'], 'PullRequest')
                             )}}
-                          startTest: $[variables['setStartTest.startTest']]
+                          startTest: eq($[variables['setStartTest.startTest']], 'true')
 
                   - ${{ if contains(convertToJson(parameters.taskTest), 'tinylicious') }}:
                     - task: Bash@3

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -345,11 +345,9 @@ extends:
               - ${{ if ne(convertToJson(parameters.taskTest), '[]') }}:
                   # Set variable startTest if the build succeed so that we can run all the test tasks whether they are failed or not
                   - script: |
-                      echo "##vso[task.setvariable variable=startTest;isOutput=true]true"
-                      echo "##vso[task.setvariable variable=startTestCoverage;isOutput=true]true"
+                      echo "##vso[task.setvariable variable=startTest]true"
+                      echo "##vso[task.setvariable variable=startTestCoverage]true"
                     displayName: Start Test
-                    name: setStartTest
-                    condition: succeeded()
 
                   - ${{ each taskTestStep in parameters.taskTest }}:
                       - template: /tools/pipelines/templates/include-test-task.yml@self

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -345,7 +345,8 @@ extends:
               - ${{ if ne(convertToJson(parameters.taskTest), '[]') }}:
                   # Set variable startTest if the build succeed so that we can run all the test tasks whether they are failed or not
                   - script: |
-                      echo "##vso[task.setvariable variable=startTest]true"
+                      echo "##vso[task.setvariable variable=startTest;isOutput=true]true"
+                      echo "##vso[task.setvariable variable=startTestCoverage;isOutput=true]true"
                     displayName: Start Test
                     name: setStartTest
                     condition: succeeded()
@@ -360,7 +361,6 @@ extends:
                               parameters.testCoverage,
                               ne(variables['Build.Reason'], 'PullRequest')
                             )}}
-                          startTest: $[eq(variables['setStartTest.startTest'], 'true')]
 
                   - ${{ if contains(convertToJson(parameters.taskTest), 'tinylicious') }}:
                     - task: Bash@3

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -107,11 +107,9 @@ jobs:
     - ${{ if ne(convertToJson(parameters.taskTest), '[]') }}:
       # Set variable startTest if the build succeed so that we can run all the test tasks whether they are failed or not
       - script: |
-          echo "##vso[task.setvariable variable=startTest;isOutput=true]true"
-          echo "##vso[task.setvariable variable=startTestCoverage;isOutput=true]true"
+          echo "##vso[task.setvariable variable=startTest]true"
+          echo "##vso[task.setvariable variable=startTestCoverage]true"
         displayName: Start Test
-        name: setStartTest
-        condition: succeeded()
 
       - ${{ each taskTestStep in parameters.taskTest }}:
         - template: /tools/pipelines/templates/include-test-task.yml@self

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -107,7 +107,8 @@ jobs:
     - ${{ if ne(convertToJson(parameters.taskTest), '[]') }}:
       # Set variable startTest if the build succeed so that we can run all the test tasks whether they are failed or not
       - script: |
-          echo "##vso[task.setvariable variable=startTest]true"
+          echo "##vso[task.setvariable variable=startTest;isOutput=true]true"
+          echo "##vso[task.setvariable variable=startTestCoverage;isOutput=true]true"
         displayName: Start Test
         name: setStartTest
         condition: succeeded()
@@ -118,7 +119,6 @@ jobs:
             taskTestStep: ${{ taskTestStep }}
             buildDirectory: ${{ parameters.buildDirectory }}
             testCoverage: ${{ eq(variables['testCoverage'], true) }}
-            startTest: $[eq(variables['setStartTest.startTest'], 'true')]
 
         # Verify if the tinylicious log exists
         - task: Bash@3

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -118,7 +118,7 @@ jobs:
             taskTestStep: ${{ taskTestStep }}
             buildDirectory: ${{ parameters.buildDirectory }}
             testCoverage: ${{ eq(variables['testCoverage'], true) }}
-            startTest: eq($[variables['setStartTest.startTest']], 'true')
+            startTest: $[eq(variables['setStartTest.startTest'], 'true')]
 
         # Verify if the tinylicious log exists
         - task: Bash@3

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -109,6 +109,8 @@ jobs:
       - script: |
           echo "##vso[task.setvariable variable=startTest]true"
         displayName: Start Test
+        name: setStartTest
+        condition: succeeded()
 
       - ${{ each taskTestStep in parameters.taskTest }}:
         - template: /tools/pipelines/templates/include-test-task.yml@self
@@ -116,6 +118,7 @@ jobs:
             taskTestStep: ${{ taskTestStep }}
             buildDirectory: ${{ parameters.buildDirectory }}
             testCoverage: ${{ eq(variables['testCoverage'], true) }}
+            startTest: $[variables['setStartTest.startTest']]
 
         # Verify if the tinylicious log exists
         - task: Bash@3

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -118,7 +118,7 @@ jobs:
             taskTestStep: ${{ taskTestStep }}
             buildDirectory: ${{ parameters.buildDirectory }}
             testCoverage: ${{ eq(variables['testCoverage'], true) }}
-            startTest: $[variables['setStartTest.startTest']]
+            startTest: eq($[variables['setStartTest.startTest']], 'true')
 
         # Verify if the tinylicious log exists
         - task: Bash@3

--- a/tools/pipelines/templates/include-test-task.yml
+++ b/tools/pipelines/templates/include-test-task.yml
@@ -14,6 +14,10 @@ parameters:
   type: boolean
   default: false
 
+- name: startTest
+  type: boolean
+  default: false
+
 steps:
 # Test - With coverage
 - ${{ if and(parameters.testCoverage, startsWith(parameters.taskTestStep, 'ci:test')) }}:
@@ -23,7 +27,7 @@ steps:
       command: 'custom'
       workingDir: ${{ parameters.buildDirectory }}
       customCommand: 'run ${{ parameters.taskTestStep }}:coverage'
-    condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+    condition: and(succeededOrFailed(), eq(${{ parameters.startTest }}, 'true'))
     env:
       # Tests can use this environment variable to behave differently when running from a test branch
       ${{ if contains(parameters.taskTestStep, 'tinylicious') }}:
@@ -39,7 +43,7 @@ steps:
       command: 'custom'
       workingDir: ${{ parameters.buildDirectory }}
       customCommand: 'run ${{ parameters.taskTestStep }}'
-    condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
+    condition: and(succeededOrFailed(), eq(${{ parameters.startTest }}, 'true'))
     env:
       # Tests can use this environment variable to behave differently when running from a test branch
       ${{ if contains(parameters.taskTestStep, 'tinylicious') }}:

--- a/tools/pipelines/templates/include-test-task.yml
+++ b/tools/pipelines/templates/include-test-task.yml
@@ -14,10 +14,6 @@ parameters:
   type: boolean
   default: false
 
-- name: startTest
-  type: boolean
-  default: false
-
 steps:
 # Test - With coverage
 - ${{ if and(parameters.testCoverage, startsWith(parameters.taskTestStep, 'ci:test')) }}:
@@ -27,7 +23,7 @@ steps:
       command: 'custom'
       workingDir: ${{ parameters.buildDirectory }}
       customCommand: 'run ${{ parameters.taskTestStep }}:coverage'
-    condition: and(succeededOrFailed(), eq(${{ parameters.startTest }}, 'true'))
+    condition: and(succeededOrFailed(), eq(variables['startTestCoverage'], 'true'))
     env:
       # Tests can use this environment variable to behave differently when running from a test branch
       ${{ if contains(parameters.taskTestStep, 'tinylicious') }}:
@@ -43,7 +39,7 @@ steps:
       command: 'custom'
       workingDir: ${{ parameters.buildDirectory }}
       customCommand: 'run ${{ parameters.taskTestStep }}'
-    condition: and(succeededOrFailed(), eq(${{ parameters.startTest }}, 'true'))
+    condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
     env:
       # Tests can use this environment variable to behave differently when running from a test branch
       ${{ if contains(parameters.taskTestStep, 'tinylicious') }}:


### PR DESCRIPTION
Updating pipeline conditions to run copy results even after tests failures. 
 - Condition was missing from non coverage tests
 - Adding global variable startTestCoverage