### PR TITLE
RiskyDiceRoller

### DIFF
--- a/examples/view-integration/external-views/src/containerCode.ts
+++ b/examples/view-integration/external-views/src/containerCode.ts
@@ -17,7 +17,6 @@ import { DiceRollerFactory } from "./diceRoller.js";
 
 const diceRollerId = "dice-roller";
 const diceRollerRegistryKey = "dice-roller";
-const diceRollerFactory = new DiceRollerFactory();
 
 export class DiceRollerContainerRuntimeFactory implements IRuntimeFactory {
 	public get IRuntimeFactory(): IRuntimeFactory {
@@ -31,6 +30,8 @@ export class DiceRollerContainerRuntimeFactory implements IRuntimeFactory {
 		const provideEntryPoint = async (
 			containerRuntime: IContainerRuntime,
 		): Promise<FluidObject> => getDataStoreEntryPoint(containerRuntime, diceRollerId);
+
+		const diceRollerFactory = new DiceRollerFactory(() => runtime.dispose());
 
 		const runtime = await loadContainerRuntime({
 			context,


### PR DESCRIPTION
Example of allowing the container code author to selectively inject a runtime-level superpower into a datastore that's willing to take it.  dispose() isn't the best example since the container code author probably shouldn't even be calling it anyway, but it's funny :). Imagine I'm calling getAudience() or something instead.

Alternatives might include leaving the factory alone but having the datastore's entryPoint be a creator function, i.e. entryPoint of `{ createRiskyDiceRoller: (disposeContainer: () => void): IDiceRoller }` and then have the container code's entry point complete the creation after `getDataStoreEntryPoint` and before returning its entryPoint.  But here I'm confident that the RiskyDiceRoller won't use before initialize so I just pass it directly.