### PR TITLE
refactor(container-runtime): Improvements around telemetry-processing logic for signals

### DIFF
--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -457,57 +457,6 @@ class OpPerfTelemetry {
 		}
 	}
 }
-export interface IPerfSignalReport {
-	/**
-	 * Identifier to track broadcast signals being submitted in order to
-	 * allow collection of data around the roundtrip of signal messages.
-	 */
-	broadcastSignalSequenceNumber: number;
-
-	/**
-	 * Accumulates the total number of broadcast signals sent during the current signal latency measurement window.
-	 * This value represents the total number of signals sent since the latency measurement began and is used
-	 * logged in telemetry when the latency measurement completes.
-	 */
-	totalSignalsSentInLatencyWindow: number;
-
-	/**
-	 * Counts the number of broadcast signals sent since the last latency measurement was initiated.
-	 * This counter increments with each broadcast signal sent. When a new latency measurement starts,
-	 * this counter is added to `totalSignalsSentInLatencyWindow` and then reset to zero.
-	 */
-	signalsSentSinceLastLatencyMeasurement: number;
-
-	/**
-	 * Number of signals that were expected but not received.
-	 */
-	signalsLost: number;
-
-	/**
-	 * Number of signals received out of order/non-sequentially.
-	 */
-	signalsOutOfOrder: number;
-
-	/**
-	 * Timestamp before submitting the signal we will trace.
-	 */
-	signalTimestamp: number;
-
-	/**
-	 * Signal we will trace for roundtrip latency.
-	 */
-	roundTripSignalSequenceNumber: number | undefined;
-
-	/**
-	 * Next expected signal sequence number to be received.
-	 */
-	trackingSignalSequenceNumber: number | undefined;
-
-	/**
-	 * Inclusive lower bound of signal monitoring window.
-	 */
-	minimumTrackingSignalSequenceNumber: number | undefined;
-}
 
 /**
  * Starts monitoring and generation of telemetry related to op performance.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1681,10 +1681,9 @@ export class ContainerRuntime
 		parentContext.submitSignal = (type: string, content: unknown, targetClientId?: string) => {
 			const envelope1 = content as IEnvelope;
 			const envelope2 = createNewSignalEnvelope(envelope1.address, type, envelope1.contents);
-			this.signalTelemetryManager.applyTrackingToSignalEnvelope(
-				envelope2,
-				targetClientId === undefined,
-			);
+			if (targetClientId === undefined) {
+				this.signalTelemetryManager.applyTrackingToBroadcastSignalEnvelope(envelope2);
+			}
 			this.submitSignalFn(envelope2, targetClientId);
 		};
 
@@ -3301,10 +3300,9 @@ export class ContainerRuntime
 	public submitSignal(type: string, content: unknown, targetClientId?: string): void {
 		this.verifyNotClosed();
 		const envelope = createNewSignalEnvelope(undefined /* address */, type, content);
-		this.signalTelemetryManager.applyTrackingToSignalEnvelope(
-			envelope,
-			targetClientId === undefined,
-		);
+		if (targetClientId === undefined) {
+			this.signalTelemetryManager.applyTrackingToBroadcastSignalEnvelope(envelope);
+		}
 		this.submitSignalFn(envelope, targetClientId);
 	}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1681,7 +1681,10 @@ export class ContainerRuntime
 		parentContext.submitSignal = (type: string, content: unknown, targetClientId?: string) => {
 			const envelope1 = content as IEnvelope;
 			const envelope2 = createNewSignalEnvelope(envelope1.address, type, envelope1.contents);
-			this.signalTelemetryManager.applyTrackingToSignalEnvelope(envelope2, targetClientId === undefined);
+			this.signalTelemetryManager.applyTrackingToSignalEnvelope(
+				envelope2,
+				targetClientId === undefined,
+			);
 			this.submitSignalFn(envelope2, targetClientId);
 		};
 
@@ -3298,7 +3301,10 @@ export class ContainerRuntime
 	public submitSignal(type: string, content: unknown, targetClientId?: string): void {
 		this.verifyNotClosed();
 		const envelope = createNewSignalEnvelope(undefined /* address */, type, content);
-		this.signalTelemetryManager.applyTrackingToSignalEnvelope(envelope, targetClientId === undefined);
+		this.signalTelemetryManager.applyTrackingToSignalEnvelope(
+			envelope,
+			targetClientId === undefined,
+		);
 		this.submitSignalFn(envelope, targetClientId);
 	}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1681,7 +1681,7 @@ export class ContainerRuntime
 		parentContext.submitSignal = (type: string, content: unknown, targetClientId?: string) => {
 			const envelope1 = content as IEnvelope;
 			const envelope2 = createNewSignalEnvelope(envelope1.address, type, envelope1.contents);
-			this.signalTelemetryManager.applyTrackingToSignalEnvelope(envelope2, targetClientId);
+			this.signalTelemetryManager.applyTrackingToSignalEnvelope(envelope2, targetClientId === undefined);
 			this.submitSignalFn(envelope2, targetClientId);
 		};
 
@@ -3052,7 +3052,7 @@ export class ContainerRuntime
 
 		// Only collect signal telemetry for broadcast messages sent by the current client.
 		if (message.clientId === this.clientId) {
-			this.signalTelemetryManager.processSignalForTelemetry(
+			this.signalTelemetryManager.trackReceivedSignal(
 				envelope,
 				this.mc.logger,
 				this.consecutiveReconnects,
@@ -3298,7 +3298,7 @@ export class ContainerRuntime
 	public submitSignal(type: string, content: unknown, targetClientId?: string): void {
 		this.verifyNotClosed();
 		const envelope = createNewSignalEnvelope(undefined /* address */, type, content);
-		this.signalTelemetryManager.applyTrackingToSignalEnvelope(envelope, targetClientId);
+		this.signalTelemetryManager.applyTrackingToSignalEnvelope(envelope, targetClientId === undefined);
 		this.submitSignalFn(envelope, targetClientId);
 	}
 

--- a/packages/runtime/container-runtime/src/signalTelemetryProcessing.ts
+++ b/packages/runtime/container-runtime/src/signalTelemetryProcessing.ts
@@ -13,9 +13,8 @@ const defaultTelemetrySignalSampleCount = 100;
 
 /**
  * Set of stats/values used to keep track of telemetry related to signals.
- * @remarks Exported just for testing purposes, shouldn't be necessary in production code.
  */
-export interface ISignalTelemetryTracking {
+interface ISignalTelemetryTracking {
 	/**
 	 * Accumulates the total number of broadcast signals sent during the current signal latency measurement window.
 	 * This value represents the total number of signals sent since the latency measurement began and is used

--- a/packages/runtime/container-runtime/src/signalTelemetryProcessing.ts
+++ b/packages/runtime/container-runtime/src/signalTelemetryProcessing.ts
@@ -96,7 +96,7 @@ export class SignalTelemetryManager {
 	 * @param logger - The telemetry logger to use for emitting telemetry events.
 	 * @param consecutiveReconnects - The number of consecutive reconnects that have occurred. Only used for logging.
 	 */
-	public processSignalForTelemetry(
+	public trackReceivedSignal(
 		envelope: ISignalEnvelope,
 		logger: ITelemetryLoggerExt,
 		consecutiveReconnects: number,
@@ -184,12 +184,16 @@ export class SignalTelemetryManager {
 		}
 	}
 
+	/**
+	 * Updates tracking state for signals based on the provided signal envelope, and potentially updates the
+	 * envelope with additional information that the signal needs to have stamped on it.
+	 * @param envelope - The signal envelope to process.
+	 * @param isBroadcastSignal - Indicates whether the signal is a broadcast signal.
+	 */
 	public applyTrackingToSignalEnvelope(
 		envelope: ISignalEnvelope,
-		targetClientId?: string,
+		isBroadcastSignal: boolean
 	): void {
-		const isBroadcastSignal = targetClientId === undefined;
-
 		if (isBroadcastSignal) {
 			const clientBroadcastSignalSeqNo = ++this.broadcastSignalSequenceNumber;
 

--- a/packages/runtime/container-runtime/src/signalTelemetryProcessing.ts
+++ b/packages/runtime/container-runtime/src/signalTelemetryProcessing.ts
@@ -11,7 +11,11 @@ import type {
 
 const defaultTelemetrySignalSampleCount = 100;
 
-export interface IPerfSignalReport {
+/**
+ * Set of stats/values used to keep track of telemetry related to signals.
+ * @remarks Exported just for testing purposes, shouldn't be necessary in production code.
+ */
+export interface ISignalTelemetryTracking {
 	/**
 	 * Accumulates the total number of broadcast signals sent during the current signal latency measurement window.
 	 * This value represents the total number of signals sent since the latency measurement began and is used
@@ -59,7 +63,7 @@ export interface IPerfSignalReport {
 }
 
 export class SignalTelemetryManager {
-	private readonly signalTracking: IPerfSignalReport = {
+	private readonly signalTracking: ISignalTelemetryTracking = {
 		totalSignalsSentInLatencyWindow: 0,
 		signalsLost: 0,
 		signalsOutOfOrder: 0,
@@ -192,7 +196,7 @@ export class SignalTelemetryManager {
 	 */
 	public applyTrackingToSignalEnvelope(
 		envelope: ISignalEnvelope,
-		isBroadcastSignal: boolean
+		isBroadcastSignal: boolean,
 	): void {
 		if (isBroadcastSignal) {
 			const clientBroadcastSignalSeqNo = ++this.broadcastSignalSequenceNumber;

--- a/packages/runtime/container-runtime/src/signalTelemetryProcessing.ts
+++ b/packages/runtime/container-runtime/src/signalTelemetryProcessing.ts
@@ -201,10 +201,10 @@ export class SignalTelemetryManager {
 	 * @param envelope - The signal envelope to process.
 	 */
 	public applyTrackingToBroadcastSignalEnvelope(envelope: ISignalEnvelope): void {
-		const clientBroadcastSignalSeqNumber = ++this.broadcastSignalSequenceNumber;
+		const broadcastSignalSequenceNumber = ++this.broadcastSignalSequenceNumber;
 
 		// Stamp with the broadcast signal sequence number.
-		envelope.clientBroadcastSignalSequenceNumber = clientBroadcastSignalSeqNumber;
+		envelope.clientBroadcastSignalSequenceNumber = broadcastSignalSequenceNumber;
 
 		this.signalTracking.signalsSentSinceLastLatencyMeasurement++;
 
@@ -214,17 +214,17 @@ export class SignalTelemetryManager {
 			this.signalTracking.minimumTrackingSignalSequenceNumber === undefined ||
 			this.signalTracking.trackingSignalSequenceNumber === undefined
 		) {
-			this.signalTracking.minimumTrackingSignalSequenceNumber = clientBroadcastSignalSeqNumber;
-			this.signalTracking.trackingSignalSequenceNumber = clientBroadcastSignalSeqNumber;
+			this.signalTracking.minimumTrackingSignalSequenceNumber = broadcastSignalSequenceNumber;
+			this.signalTracking.trackingSignalSequenceNumber = broadcastSignalSequenceNumber;
 		}
 
 		// Start tracking roundtrip for a new signal only if we are not tracking one already (and sampling logic is met)
 		if (
 			this.signalTracking.roundTripSignalSequenceNumber === undefined &&
-			clientBroadcastSignalSeqNumber % defaultTelemetrySignalSampleCount === 1
+			broadcastSignalSequenceNumber % defaultTelemetrySignalSampleCount === 1
 		) {
 			this.signalTracking.signalTimestamp = Date.now();
-			this.signalTracking.roundTripSignalSequenceNumber = clientBroadcastSignalSeqNumber;
+			this.signalTracking.roundTripSignalSequenceNumber = broadcastSignalSequenceNumber;
 			this.signalTracking.totalSignalsSentInLatencyWindow +=
 				this.signalTracking.signalsSentSinceLastLatencyMeasurement;
 			this.signalTracking.signalsSentSinceLastLatencyMeasurement = 0;


### PR DESCRIPTION
## Description

Small follow-up to #23972 . Moves `IPerfSignalReport` from `containerRuntime.ts` to `signalTelemetryProcessing.ts` and renames it to `ISignalTelemetryTracking`; renames a couple of things in the extracted class; and slightly changes the API so signal telemetry processing only needs a boolean instead of doing a comparison itself.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
