### PR TITLE
refactor(container-runtime): Move summarizer-related code from containerRuntime.ts

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -19,9 +19,7 @@ import {
 import {
 	IContainerContext,
 	IGetPendingLocalStateProps,
-	ILoader,
 	IRuntime,
-	LoaderHeader,
 	IDeltaManager,
 	IDeltaManagerFull,
 	isIDeltaManagerFull,
@@ -58,7 +56,6 @@ import {
 	SummaryType,
 } from "@fluidframework/driver-definitions";
 import {
-	DriverHeader,
 	FetchSource,
 	IDocumentStorageService,
 	type ISnapshot,
@@ -108,7 +105,6 @@ import {
 	calculateStats,
 	create404Response,
 	exceptionToResponse,
-	responseToException,
 	seqFromTree,
 } from "@fluidframework/runtime-utils/internal";
 import type {
@@ -237,7 +233,6 @@ import {
 	// eslint-disable-next-line import/no-deprecated
 	ISubmitSummaryOptions,
 	ISummarizeResults,
-	ISummarizer,
 	// eslint-disable-next-line import/no-deprecated
 	ISummarizerInternalsProvider,
 	// eslint-disable-next-line import/no-deprecated
@@ -268,6 +263,12 @@ import {
 	wrapSummaryInChannelsTree,
 	// eslint-disable-next-line import/no-deprecated
 	type IDocumentSchemaFeatures,
+	formCreateSummarizerFn,
+	summarizerRequestUrl,
+	validateSummaryHeuristicConfiguration,
+	ISummaryConfiguration,
+	DefaultSummaryConfiguration,
+	isSummariesDisabled,
 } from "./summary/index.js";
 import { Throttler, formExponentialFn } from "./throttler.js";
 
@@ -299,154 +300,6 @@ function getUnknownMessageTypeError(
 		},
 	);
 }
-
-/**
- * @legacy
- * @alpha
- */
-export interface ISummaryBaseConfiguration {
-	/**
-	 * Delay before first attempt to spawn summarizing container.
-	 */
-	initialSummarizerDelayMs: number;
-
-	/**
-	 * Defines the maximum allowed time to wait for a pending summary ack.
-	 * The maximum amount of time client will wait for a summarize is the minimum of
-	 * maxSummarizeAckWaitTime (currently 3 * 60 * 1000) and maxAckWaitTime.
-	 */
-	maxAckWaitTime: number;
-	/**
-	 * Defines the maximum number of Ops in between Summaries that can be
-	 * allowed before forcibly electing a new summarizer client.
-	 */
-	maxOpsSinceLastSummary: number;
-}
-
-/**
- * @legacy
- * @alpha
- */
-export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfiguration {
-	state: "enabled";
-	/**
-	 * Defines the maximum allowed time, since the last received Ack, before running the summary
-	 * with reason maxTime.
-	 * For example, say we receive ops one by one just before the idle time is triggered.
-	 * In this case, we still want to run a summary since it's been a while since the last summary.
-	 */
-	maxTime: number;
-	/**
-	 * Defines the maximum number of Ops, since the last received Ack, that can be allowed
-	 * before running the summary with reason maxOps.
-	 */
-	maxOps: number;
-	/**
-	 * Defines the minimum number of Ops, since the last received Ack, that can be allowed
-	 * before running the last summary.
-	 */
-	minOpsForLastSummaryAttempt: number;
-	/**
-	 * Defines the lower boundary for the allowed time in between summarizations.
-	 * Pairs with maxIdleTime to form a range.
-	 * For example, if we only receive 1 op, we don't want to have the same idle time as say 100 ops.
-	 * Based on the boundaries we set in minIdleTime and maxIdleTime, the idle time will change
-	 * linearly depending on the number of ops we receive.
-	 */
-	minIdleTime: number;
-	/**
-	 * Defines the upper boundary for the allowed time in between summarizations.
-	 * Pairs with minIdleTime to form a range.
-	 * For example, if we only receive 1 op, we don't want to have the same idle time as say 100 ops.
-	 * Based on the boundaries we set in minIdleTime and maxIdleTime, the idle time will change
-	 * linearly depending on the number of ops we receive.
-	 */
-	maxIdleTime: number;
-	/**
-	 * Runtime op weight to use in heuristic summarizing.
-	 * This number is a multiplier on the number of runtime ops we process when running summarize heuristics.
-	 * For example: (multiplier) * (number of runtime ops) = weighted number of runtime ops
-	 */
-	runtimeOpWeight: number;
-	/**
-	 * Non-runtime op weight to use in heuristic summarizing
-	 * This number is a multiplier on the number of non-runtime ops we process when running summarize heuristics.
-	 * For example: (multiplier) * (number of non-runtime ops) = weighted number of non-runtime ops
-	 */
-	nonRuntimeOpWeight: number;
-
-	/**
-	 * Number of ops since last summary needed before a non-runtime op can trigger running summary heuristics.
-	 *
-	 * Note: Any runtime ops sent before the threshold is reached will trigger heuristics normally.
-	 * This threshold ONLY applies to non-runtime ops triggering summaries.
-	 *
-	 * For example: Say the threshold is 20. Sending 19 non-runtime ops will not trigger any heuristic checks.
-	 * Sending the 20th non-runtime op will trigger the heuristic checks for summarizing.
-	 */
-	nonRuntimeHeuristicThreshold?: number;
-}
-
-/**
- * @legacy
- * @alpha
- */
-export interface ISummaryConfigurationDisableSummarizer {
-	state: "disabled";
-}
-
-/**
- * @legacy
- * @alpha
- */
-export interface ISummaryConfigurationDisableHeuristics extends ISummaryBaseConfiguration {
-	state: "disableHeuristics";
-}
-
-/**
- * @legacy
- * @alpha
- */
-export type ISummaryConfiguration =
-	| ISummaryConfigurationDisableSummarizer
-	| ISummaryConfigurationDisableHeuristics
-	| ISummaryConfigurationHeuristics;
-
-export function isSummariesDisabled(
-	config: ISummaryConfiguration,
-): config is ISummaryConfigurationDisableSummarizer {
-	return config.state === "disabled";
-}
-
-/**
- * @legacy
- * @alpha
- */
-export const DefaultSummaryConfiguration: ISummaryConfiguration = {
-	state: "enabled",
-
-	minIdleTime: 0,
-
-	maxIdleTime: 30 * 1000, // 30 secs.
-
-	maxTime: 60 * 1000, // 1 min.
-
-	maxOps: 100, // Summarize if 100 weighted ops received since last snapshot.
-
-	minOpsForLastSummaryAttempt: 10,
-
-	maxAckWaitTime: 3 * 60 * 1000, // 3 mins.
-
-	maxOpsSinceLastSummary: 7000,
-
-	initialSummarizerDelayMs: 5 * 1000, // 5 secs.
-
-	nonRuntimeOpWeight: 0.1,
-
-	runtimeOpWeight: 1,
-
-	nonRuntimeHeuristicThreshold: 20,
-};
 
 /**
  * @legacy
@@ -781,50 +634,6 @@ export const makeLegacySendBatchFn =
 
 		return clientSequenceNumber;
 	};
-
-const summarizerRequestUrl = "_summarizer";
-
-/**
- * Create and retrieve the summmarizer
- */
-async function createSummarizer(loader: ILoader, url: string): Promise<ISummarizer> {
-	const request: IRequest = {
-		headers: {
-			[LoaderHeader.cache]: false,
-			[LoaderHeader.clientDetails]: {
-				capabilities: { interactive: false },
-				type: summarizerClientType,
-			},
-			[DriverHeader.summarizingClient]: true,
-			[LoaderHeader.reconnect]: false,
-		},
-		url,
-	};
-
-	const resolvedContainer = await loader.resolve(request);
-	let fluidObject: FluidObject<ISummarizer> | undefined;
-
-	// Older containers may not have the "getEntryPoint" API
-	// ! This check will need to stay until LTS of loader moves past 2.0.0-internal.7.0.0
-	if (resolvedContainer.getEntryPoint === undefined) {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
-		const response = (await (resolvedContainer as any).request({
-			url: `/${summarizerRequestUrl}`,
-		})) as IResponse;
-		if (response.status !== 200 || response.mimeType !== "fluid/object") {
-			throw responseToException(response, request);
-		}
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		fluidObject = response.value;
-	} else {
-		fluidObject = await resolvedContainer.getEntryPoint();
-	}
-
-	if (fluidObject?.ISummarizer === undefined) {
-		throw new UsageError("Fluid object does not implement ISummarizer");
-	}
-	return fluidObject.ISummarizer;
-}
 
 /**
  * Extract last message from the snapshot metadata.
@@ -1762,7 +1571,7 @@ export class ContainerRuntime
 		this.handleContext = new ContainerFluidHandleContext("", this);
 
 		if (summaryConfiguration.state === "enabled") {
-			this.validateSummaryHeuristicConfiguration(summaryConfiguration);
+			validateSummaryHeuristicConfiguration(summaryConfiguration);
 		}
 
 		this.summariesDisabled = isSummariesDisabled(summaryConfiguration);
@@ -2103,7 +1912,7 @@ export class ContainerRuntime
 					this, // IConnectedState
 					summaryCollection,
 					this.baseLogger,
-					this.formCreateSummarizerFn(loader),
+					formCreateSummarizerFn(loader),
 					new Throttler(
 						60 * 1000, // 60 sec delay window
 						30 * 1000, // 30 sec max delay
@@ -5029,33 +4838,6 @@ export class ContainerRuntime
 			throw new UsageError(`Can't summarize, disableSummaries: ${this.summariesDisabled}`);
 		} else {
 			return this.summaryManager.enqueueSummarize(options);
-		}
-	}
-
-	/**
-	 * Forms a function that will create and retrieve a Summarizer.
-	 */
-	private formCreateSummarizerFn(loader: ILoader) {
-		return async () => {
-			return createSummarizer(loader, `/${summarizerRequestUrl}`);
-		};
-	}
-
-	private validateSummaryHeuristicConfiguration(
-		configuration: ISummaryConfigurationHeuristics,
-	): void {
-		// eslint-disable-next-line no-restricted-syntax
-		for (const prop in configuration) {
-			if (typeof configuration[prop] === "number" && configuration[prop] < 0) {
-				throw new UsageError(
-					`Summary heuristic configuration property "${prop}" cannot be less than 0`,
-				);
-			}
-		}
-		if (configuration.minIdleTime > configuration.maxIdleTime) {
-			throw new UsageError(
-				`"minIdleTime" [${configuration.minIdleTime}] cannot be greater than "maxIdleTime" [${configuration.maxIdleTime}]`,
-			);
 		}
 	}
 

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -5,10 +5,6 @@
 
 export {
 	ISummaryRuntimeOptions,
-	ISummaryBaseConfiguration,
-	ISummaryConfigurationHeuristics,
-	ISummaryConfigurationDisableSummarizer,
-	ISummaryConfigurationDisableHeuristics,
 	IContainerRuntimeOptions,
 	IContainerRuntimeOptionsInternal,
 	loadContainerRuntime,
@@ -18,8 +14,6 @@ export {
 	DeletedResponseHeaderKey,
 	TombstoneResponseHeaderKey,
 	InactiveResponseHeaderKey,
-	ISummaryConfiguration,
-	DefaultSummaryConfiguration,
 	ICompressionRuntimeOptions,
 	CompressionAlgorithms,
 	RuntimeHeaderData,
@@ -106,6 +100,12 @@ export {
 	IFluidDataStoreAttributes1,
 	IFluidDataStoreAttributes2,
 	OmitAttributesVersions,
+	ISummaryBaseConfiguration,
+	ISummaryConfigurationHeuristics,
+	ISummaryConfigurationDisableSummarizer,
+	ISummaryConfigurationDisableHeuristics,
+	ISummaryConfiguration,
+	DefaultSummaryConfiguration,
 } from "./summary/index.js";
 export { IChunkedOp, unpackRuntimeMessage } from "./opLifecycle/index.js";
 export { ChannelCollection } from "./channelCollection.js";

--- a/packages/runtime/container-runtime/src/summary/index.ts
+++ b/packages/runtime/container-runtime/src/summary/index.ts
@@ -20,19 +20,7 @@ export {
 	neverCancelledSummaryToken,
 	RunWhileConnectedCoordinator,
 } from "./runWhileConnectedCoordinator.js";
-export {
-	Summarizer,
-	formCreateSummarizerFn,
-	summarizerRequestUrl,
-	validateSummaryHeuristicConfiguration,
-	DefaultSummaryConfiguration,
-	type ISummaryConfiguration,
-	type ISummaryConfigurationDisableHeuristics,
-	type ISummaryConfigurationDisableSummarizer,
-	type ISummaryConfigurationHeuristics,
-	type ISummaryBaseConfiguration,
-	isSummariesDisabled,
-} from "./summarizer.js";
+export { Summarizer } from "./summarizer.js";
 export {
 	ISummarizerClientElection,
 	ISummarizerClientElectionEvents,
@@ -77,6 +65,11 @@ export {
 	SubmitSummaryFailureData,
 	SummaryStage,
 	IRetriableFailureError,
+	type ISummaryConfiguration,
+	type ISummaryConfigurationDisableHeuristics,
+	type ISummaryConfigurationDisableSummarizer,
+	type ISummaryConfigurationHeuristics,
+	type ISummaryBaseConfiguration,
 } from "./summarizerTypes.js";
 export {
 	IAckedSummary,
@@ -115,6 +108,13 @@ export {
 	IFluidDataStoreAttributes2,
 	OmitAttributesVersions,
 } from "./summaryFormat.js";
+export {
+	formCreateSummarizerFn,
+	validateSummaryHeuristicConfiguration,
+	summarizerRequestUrl,
+	DefaultSummaryConfiguration,
+	isSummariesDisabled,
+} from "./summaryHelpers.js";
 export {
 	IdCompressorMode,
 	IDocumentSchemaCurrent,

--- a/packages/runtime/container-runtime/src/summary/index.ts
+++ b/packages/runtime/container-runtime/src/summary/index.ts
@@ -20,7 +20,19 @@ export {
 	neverCancelledSummaryToken,
 	RunWhileConnectedCoordinator,
 } from "./runWhileConnectedCoordinator.js";
-export { Summarizer } from "./summarizer.js";
+export {
+	Summarizer,
+	formCreateSummarizerFn,
+	summarizerRequestUrl,
+	validateSummaryHeuristicConfiguration,
+	DefaultSummaryConfiguration,
+	type ISummaryConfiguration,
+	type ISummaryConfigurationDisableHeuristics,
+	type ISummaryConfigurationDisableSummarizer,
+	type ISummaryConfigurationHeuristics,
+	type ISummaryBaseConfiguration,
+	isSummariesDisabled,
+} from "./summarizer.js";
 export {
 	ISummarizerClientElection,
 	ISummarizerClientElectionEvents,

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -26,9 +26,9 @@ import {
 	type ITelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { ISummaryConfiguration } from "../containerRuntime.js";
 import { opSize } from "../opProperties.js";
 
+import type { ISummaryConfiguration } from "./summarizer.js";
 import { SummarizeHeuristicRunner } from "./summarizerHeuristics.js";
 import {
 	EnqueueSummarizeResult,

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -28,9 +28,9 @@ import {
 
 import { opSize } from "../opProperties.js";
 
-import type { ISummaryConfiguration } from "./summarizer.js";
 import { SummarizeHeuristicRunner } from "./summarizerHeuristics.js";
-import {
+import type {
+	ISummaryConfiguration,
 	EnqueueSummarizeResult,
 	IEnqueueSummarizeOptions,
 	IOnDemandSummarizeOptions,
@@ -49,7 +49,7 @@ import {
 	// eslint-disable-next-line import/no-deprecated
 	ISummaryCancellationToken,
 	SubmitSummaryResult,
-	type IRetriableFailureError,
+	IRetriableFailureError,
 } from "./summarizerTypes.js";
 import {
 	IAckedSummary,

--- a/packages/runtime/container-runtime/src/summary/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizer.ts
@@ -230,7 +230,7 @@ export class SummarizingWarning
 export const summarizerRequestUrl = "_summarizer";
 
 /**
- * Create and retrieve the summmarizer
+ * Create and retrieve the summarizer
  */
 async function createSummarizer(loader: ILoader, url: string): Promise<ISummarizer> {
 	const request: IRequest = {

--- a/packages/runtime/container-runtime/src/summary/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizer.ts
@@ -4,12 +4,21 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
+import { LoaderHeader } from "@fluidframework/container-definitions/internal";
+import type { ILoader } from "@fluidframework/container-definitions/internal";
 import type {
 	ISummarizerEvents,
 	SummarizerStopReason,
 } from "@fluidframework/container-runtime-definitions/internal";
-import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
+import {
+	IFluidHandleContext,
+	type FluidObject,
+	type IRequest,
+	type IResponse,
+} from "@fluidframework/core-interfaces/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
+import { DriverHeader } from "@fluidframework/driver-definitions/internal";
+import { responseToException } from "@fluidframework/runtime-utils/internal";
 import {
 	IFluidErrorBase,
 	ITelemetryLoggerExt,
@@ -19,11 +28,10 @@ import {
 	wrapErrorAndLog,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { ISummaryConfiguration } from "../containerRuntime.js";
-
 // eslint-disable-next-line import/no-deprecated
 import { ICancellableSummarizerController } from "./runWhileConnectedCoordinator.js";
 import { RunningSummarizer } from "./runningSummarizer.js";
+import { summarizerClientType } from "./summarizerClientElection.js";
 import { SummarizeHeuristicData } from "./summarizerHeuristics.js";
 import {
 	EnqueueSummarizeResult,
@@ -45,6 +53,154 @@ import { SummaryCollection } from "./summaryCollection.js";
 import { SummarizeResultBuilder } from "./summaryGenerator.js";
 
 const summarizingError = "summarizingError";
+
+/**
+ * @legacy
+ * @alpha
+ */
+export interface ISummaryBaseConfiguration {
+	/**
+	 * Delay before first attempt to spawn summarizing container.
+	 */
+	initialSummarizerDelayMs: number;
+
+	/**
+	 * Defines the maximum allowed time to wait for a pending summary ack.
+	 * The maximum amount of time client will wait for a summarize is the minimum of
+	 * maxSummarizeAckWaitTime (currently 3 * 60 * 1000) and maxAckWaitTime.
+	 */
+	maxAckWaitTime: number;
+	/**
+	 * Defines the maximum number of Ops in between Summaries that can be
+	 * allowed before forcibly electing a new summarizer client.
+	 */
+	maxOpsSinceLastSummary: number;
+}
+
+/**
+ * @legacy
+ * @alpha
+ */
+export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfiguration {
+	state: "enabled";
+	/**
+	 * Defines the maximum allowed time, since the last received Ack, before running the summary
+	 * with reason maxTime.
+	 * For example, say we receive ops one by one just before the idle time is triggered.
+	 * In this case, we still want to run a summary since it's been a while since the last summary.
+	 */
+	maxTime: number;
+	/**
+	 * Defines the maximum number of Ops, since the last received Ack, that can be allowed
+	 * before running the summary with reason maxOps.
+	 */
+	maxOps: number;
+	/**
+	 * Defines the minimum number of Ops, since the last received Ack, that can be allowed
+	 * before running the last summary.
+	 */
+	minOpsForLastSummaryAttempt: number;
+	/**
+	 * Defines the lower boundary for the allowed time in between summarizations.
+	 * Pairs with maxIdleTime to form a range.
+	 * For example, if we only receive 1 op, we don't want to have the same idle time as say 100 ops.
+	 * Based on the boundaries we set in minIdleTime and maxIdleTime, the idle time will change
+	 * linearly depending on the number of ops we receive.
+	 */
+	minIdleTime: number;
+	/**
+	 * Defines the upper boundary for the allowed time in between summarizations.
+	 * Pairs with minIdleTime to form a range.
+	 * For example, if we only receive 1 op, we don't want to have the same idle time as say 100 ops.
+	 * Based on the boundaries we set in minIdleTime and maxIdleTime, the idle time will change
+	 * linearly depending on the number of ops we receive.
+	 */
+	maxIdleTime: number;
+	/**
+	 * Runtime op weight to use in heuristic summarizing.
+	 * This number is a multiplier on the number of runtime ops we process when running summarize heuristics.
+	 * For example: (multiplier) * (number of runtime ops) = weighted number of runtime ops
+	 */
+	runtimeOpWeight: number;
+	/**
+	 * Non-runtime op weight to use in heuristic summarizing
+	 * This number is a multiplier on the number of non-runtime ops we process when running summarize heuristics.
+	 * For example: (multiplier) * (number of non-runtime ops) = weighted number of non-runtime ops
+	 */
+	nonRuntimeOpWeight: number;
+
+	/**
+	 * Number of ops since last summary needed before a non-runtime op can trigger running summary heuristics.
+	 *
+	 * Note: Any runtime ops sent before the threshold is reached will trigger heuristics normally.
+	 * This threshold ONLY applies to non-runtime ops triggering summaries.
+	 *
+	 * For example: Say the threshold is 20. Sending 19 non-runtime ops will not trigger any heuristic checks.
+	 * Sending the 20th non-runtime op will trigger the heuristic checks for summarizing.
+	 */
+	nonRuntimeHeuristicThreshold?: number;
+}
+
+/**
+ * @legacy
+ * @alpha
+ */
+export interface ISummaryConfigurationDisableSummarizer {
+	state: "disabled";
+}
+
+/**
+ * @legacy
+ * @alpha
+ */
+export interface ISummaryConfigurationDisableHeuristics extends ISummaryBaseConfiguration {
+	state: "disableHeuristics";
+}
+
+/**
+ * @legacy
+ * @alpha
+ */
+export type ISummaryConfiguration =
+	| ISummaryConfigurationDisableSummarizer
+	| ISummaryConfigurationDisableHeuristics
+	| ISummaryConfigurationHeuristics;
+
+export function isSummariesDisabled(
+	config: ISummaryConfiguration,
+): config is ISummaryConfigurationDisableSummarizer {
+	return config.state === "disabled";
+}
+
+/**
+ * @legacy
+ * @alpha
+ */
+export const DefaultSummaryConfiguration: ISummaryConfiguration = {
+	state: "enabled",
+
+	minIdleTime: 0,
+
+	maxIdleTime: 30 * 1000, // 30 secs.
+
+	maxTime: 60 * 1000, // 1 min.
+
+	maxOps: 100, // Summarize if 100 weighted ops received since last snapshot.
+
+	minOpsForLastSummaryAttempt: 10,
+
+	maxAckWaitTime: 3 * 60 * 1000, // 3 mins.
+
+	maxOpsSinceLastSummary: 7000,
+
+	initialSummarizerDelayMs: 5 * 1000, // 5 secs.
+
+	nonRuntimeOpWeight: 0.1,
+
+	runtimeOpWeight: 1,
+
+	nonRuntimeHeuristicThreshold: 20,
+};
 
 export class SummarizingWarning
 	extends LoggingError
@@ -71,10 +227,80 @@ export class SummarizingWarning
 	}
 }
 
+export const summarizerRequestUrl = "_summarizer";
+
+/**
+ * Create and retrieve the summmarizer
+ */
+async function createSummarizer(loader: ILoader, url: string): Promise<ISummarizer> {
+	const request: IRequest = {
+		headers: {
+			[LoaderHeader.cache]: false,
+			[LoaderHeader.clientDetails]: {
+				capabilities: { interactive: false },
+				type: summarizerClientType,
+			},
+			[DriverHeader.summarizingClient]: true,
+			[LoaderHeader.reconnect]: false,
+		},
+		url,
+	};
+
+	const resolvedContainer = await loader.resolve(request);
+	let fluidObject: FluidObject<ISummarizer> | undefined;
+
+	// Older containers may not have the "getEntryPoint" API
+	// ! This check will need to stay until LTS of loader moves past 2.0.0-internal.7.0.0
+	if (resolvedContainer.getEntryPoint === undefined) {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
+		const response = (await (resolvedContainer as any).request({
+			url: `/${summarizerRequestUrl}`,
+		})) as IResponse;
+		if (response.status !== 200 || response.mimeType !== "fluid/object") {
+			throw responseToException(response, request);
+		}
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		fluidObject = response.value;
+	} else {
+		fluidObject = await resolvedContainer.getEntryPoint();
+	}
+
+	if (fluidObject?.ISummarizer === undefined) {
+		throw new UsageError("Fluid object does not implement ISummarizer");
+	}
+	return fluidObject.ISummarizer;
+}
 export const createSummarizingWarning = (
 	errorMessage: string,
 	logged: boolean,
 ): SummarizingWarning => new SummarizingWarning(errorMessage, logged);
+
+/**
+ * Returns a function that will create and retrieve a Summarizer.
+ */
+export function formCreateSummarizerFn(loader: ILoader): () => Promise<ISummarizer> {
+	return async () => {
+		return createSummarizer(loader, `/${summarizerRequestUrl}`);
+	};
+}
+
+export function validateSummaryHeuristicConfiguration(
+	configuration: ISummaryConfigurationHeuristics,
+): void {
+	// eslint-disable-next-line no-restricted-syntax
+	for (const prop in configuration) {
+		if (typeof configuration[prop] === "number" && configuration[prop] < 0) {
+			throw new UsageError(
+				`Summary heuristic configuration property "${prop}" cannot be less than 0`,
+			);
+		}
+	}
+	if (configuration.minIdleTime > configuration.maxIdleTime) {
+		throw new UsageError(
+			`"minIdleTime" [${configuration.minIdleTime}] cannot be greater than "maxIdleTime" [${configuration.maxIdleTime}]`,
+		);
+	}
+}
 
 /**
  * Summarizer is responsible for coordinating when to generate and send summaries.

--- a/packages/runtime/container-runtime/src/summary/summarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizer.ts
@@ -4,21 +4,12 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { LoaderHeader } from "@fluidframework/container-definitions/internal";
-import type { ILoader } from "@fluidframework/container-definitions/internal";
 import type {
 	ISummarizerEvents,
 	SummarizerStopReason,
 } from "@fluidframework/container-runtime-definitions/internal";
-import {
-	IFluidHandleContext,
-	type FluidObject,
-	type IRequest,
-	type IResponse,
-} from "@fluidframework/core-interfaces/internal";
+import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
-import { DriverHeader } from "@fluidframework/driver-definitions/internal";
-import { responseToException } from "@fluidframework/runtime-utils/internal";
 import {
 	IFluidErrorBase,
 	ITelemetryLoggerExt,
@@ -31,7 +22,6 @@ import {
 // eslint-disable-next-line import/no-deprecated
 import { ICancellableSummarizerController } from "./runWhileConnectedCoordinator.js";
 import { RunningSummarizer } from "./runningSummarizer.js";
-import { summarizerClientType } from "./summarizerClientElection.js";
 import { SummarizeHeuristicData } from "./summarizerHeuristics.js";
 import {
 	EnqueueSummarizeResult,
@@ -48,165 +38,16 @@ import {
 	ISummarizerRuntime,
 	ISummarizingWarning,
 	type IRetriableFailureError,
+	type ISummaryConfiguration,
 } from "./summarizerTypes.js";
 import { SummaryCollection } from "./summaryCollection.js";
 import { SummarizeResultBuilder } from "./summaryGenerator.js";
-
-const summarizingError = "summarizingError";
-
-/**
- * @legacy
- * @alpha
- */
-export interface ISummaryBaseConfiguration {
-	/**
-	 * Delay before first attempt to spawn summarizing container.
-	 */
-	initialSummarizerDelayMs: number;
-
-	/**
-	 * Defines the maximum allowed time to wait for a pending summary ack.
-	 * The maximum amount of time client will wait for a summarize is the minimum of
-	 * maxSummarizeAckWaitTime (currently 3 * 60 * 1000) and maxAckWaitTime.
-	 */
-	maxAckWaitTime: number;
-	/**
-	 * Defines the maximum number of Ops in between Summaries that can be
-	 * allowed before forcibly electing a new summarizer client.
-	 */
-	maxOpsSinceLastSummary: number;
-}
-
-/**
- * @legacy
- * @alpha
- */
-export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfiguration {
-	state: "enabled";
-	/**
-	 * Defines the maximum allowed time, since the last received Ack, before running the summary
-	 * with reason maxTime.
-	 * For example, say we receive ops one by one just before the idle time is triggered.
-	 * In this case, we still want to run a summary since it's been a while since the last summary.
-	 */
-	maxTime: number;
-	/**
-	 * Defines the maximum number of Ops, since the last received Ack, that can be allowed
-	 * before running the summary with reason maxOps.
-	 */
-	maxOps: number;
-	/**
-	 * Defines the minimum number of Ops, since the last received Ack, that can be allowed
-	 * before running the last summary.
-	 */
-	minOpsForLastSummaryAttempt: number;
-	/**
-	 * Defines the lower boundary for the allowed time in between summarizations.
-	 * Pairs with maxIdleTime to form a range.
-	 * For example, if we only receive 1 op, we don't want to have the same idle time as say 100 ops.
-	 * Based on the boundaries we set in minIdleTime and maxIdleTime, the idle time will change
-	 * linearly depending on the number of ops we receive.
-	 */
-	minIdleTime: number;
-	/**
-	 * Defines the upper boundary for the allowed time in between summarizations.
-	 * Pairs with minIdleTime to form a range.
-	 * For example, if we only receive 1 op, we don't want to have the same idle time as say 100 ops.
-	 * Based on the boundaries we set in minIdleTime and maxIdleTime, the idle time will change
-	 * linearly depending on the number of ops we receive.
-	 */
-	maxIdleTime: number;
-	/**
-	 * Runtime op weight to use in heuristic summarizing.
-	 * This number is a multiplier on the number of runtime ops we process when running summarize heuristics.
-	 * For example: (multiplier) * (number of runtime ops) = weighted number of runtime ops
-	 */
-	runtimeOpWeight: number;
-	/**
-	 * Non-runtime op weight to use in heuristic summarizing
-	 * This number is a multiplier on the number of non-runtime ops we process when running summarize heuristics.
-	 * For example: (multiplier) * (number of non-runtime ops) = weighted number of non-runtime ops
-	 */
-	nonRuntimeOpWeight: number;
-
-	/**
-	 * Number of ops since last summary needed before a non-runtime op can trigger running summary heuristics.
-	 *
-	 * Note: Any runtime ops sent before the threshold is reached will trigger heuristics normally.
-	 * This threshold ONLY applies to non-runtime ops triggering summaries.
-	 *
-	 * For example: Say the threshold is 20. Sending 19 non-runtime ops will not trigger any heuristic checks.
-	 * Sending the 20th non-runtime op will trigger the heuristic checks for summarizing.
-	 */
-	nonRuntimeHeuristicThreshold?: number;
-}
-
-/**
- * @legacy
- * @alpha
- */
-export interface ISummaryConfigurationDisableSummarizer {
-	state: "disabled";
-}
-
-/**
- * @legacy
- * @alpha
- */
-export interface ISummaryConfigurationDisableHeuristics extends ISummaryBaseConfiguration {
-	state: "disableHeuristics";
-}
-
-/**
- * @legacy
- * @alpha
- */
-export type ISummaryConfiguration =
-	| ISummaryConfigurationDisableSummarizer
-	| ISummaryConfigurationDisableHeuristics
-	| ISummaryConfigurationHeuristics;
-
-export function isSummariesDisabled(
-	config: ISummaryConfiguration,
-): config is ISummaryConfigurationDisableSummarizer {
-	return config.state === "disabled";
-}
-
-/**
- * @legacy
- * @alpha
- */
-export const DefaultSummaryConfiguration: ISummaryConfiguration = {
-	state: "enabled",
-
-	minIdleTime: 0,
-
-	maxIdleTime: 30 * 1000, // 30 secs.
-
-	maxTime: 60 * 1000, // 1 min.
-
-	maxOps: 100, // Summarize if 100 weighted ops received since last snapshot.
-
-	minOpsForLastSummaryAttempt: 10,
-
-	maxAckWaitTime: 3 * 60 * 1000, // 3 mins.
-
-	maxOpsSinceLastSummary: 7000,
-
-	initialSummarizerDelayMs: 5 * 1000, // 5 secs.
-
-	nonRuntimeOpWeight: 0.1,
-
-	runtimeOpWeight: 1,
-
-	nonRuntimeHeuristicThreshold: 20,
-};
 
 export class SummarizingWarning
 	extends LoggingError
 	implements ISummarizingWarning, IFluidErrorBase
 {
-	readonly errorType = summarizingError;
+	readonly errorType = "summarizingError";
 	readonly canRetry = true;
 
 	constructor(
@@ -227,74 +68,10 @@ export class SummarizingWarning
 	}
 }
 
-export const summarizerRequestUrl = "_summarizer";
-
 export const createSummarizingWarning = (
 	errorMessage: string,
 	logged: boolean,
 ): SummarizingWarning => new SummarizingWarning(errorMessage, logged);
-
-/**
- * Returns a function that will create and retrieve a Summarizer.
- */
-export function formCreateSummarizerFn(loader: ILoader): () => Promise<ISummarizer> {
-	return async () => {
-		const request: IRequest = {
-			headers: {
-				[LoaderHeader.cache]: false,
-				[LoaderHeader.clientDetails]: {
-					capabilities: { interactive: false },
-					type: summarizerClientType,
-				},
-				[DriverHeader.summarizingClient]: true,
-				[LoaderHeader.reconnect]: false,
-			},
-			url: `/${summarizerRequestUrl}`,
-		};
-
-		const resolvedContainer = await loader.resolve(request);
-		let fluidObject: FluidObject<ISummarizer> | undefined;
-
-		// Older containers may not have the "getEntryPoint" API
-		// ! This check will need to stay until LTS of loader moves past 2.0.0-internal.7.0.0
-		if (resolvedContainer.getEntryPoint === undefined) {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
-			const response = (await (resolvedContainer as any).request({
-				url: `/${summarizerRequestUrl}`,
-			})) as IResponse;
-			if (response.status !== 200 || response.mimeType !== "fluid/object") {
-				throw responseToException(response, request);
-			}
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-			fluidObject = response.value;
-		} else {
-			fluidObject = await resolvedContainer.getEntryPoint();
-		}
-
-		if (fluidObject?.ISummarizer === undefined) {
-			throw new UsageError("Fluid object does not implement ISummarizer");
-		}
-		return fluidObject.ISummarizer;
-	};
-}
-
-export function validateSummaryHeuristicConfiguration(
-	configuration: ISummaryConfigurationHeuristics,
-): void {
-	// eslint-disable-next-line no-restricted-syntax
-	for (const prop in configuration) {
-		if (typeof configuration[prop] === "number" && configuration[prop] < 0) {
-			throw new UsageError(
-				`Summary heuristic configuration property "${prop}" cannot be less than 0`,
-			);
-		}
-	}
-	if (configuration.minIdleTime > configuration.maxIdleTime) {
-		throw new UsageError(
-			`"minIdleTime" [${configuration.minIdleTime}] cannot be greater than "maxIdleTime" [${configuration.maxIdleTime}]`,
-		);
-	}
-}
 
 /**
  * Summarizer is responsible for coordinating when to generate and send summaries.

--- a/packages/runtime/container-runtime/src/summary/summarizerHeuristics.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerHeuristics.ts
@@ -6,8 +6,7 @@
 import { Timer } from "@fluidframework/core-utils/internal";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
-import { ISummaryConfigurationHeuristics } from "../containerRuntime.js";
-
+import type { ISummaryConfigurationHeuristics } from "./summarizer.js";
 import {
 	ISummarizeAttempt,
 	ISummarizeHeuristicData,

--- a/packages/runtime/container-runtime/src/summary/summarizerHeuristics.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerHeuristics.ts
@@ -6,7 +6,7 @@
 import { Timer } from "@fluidframework/core-utils/internal";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
-import type { ISummaryConfigurationHeuristics } from "./summarizer.js";
+import type { ISummaryConfigurationHeuristics } from "./summarizerTypes.js";
 import {
 	ISummarizeAttempt,
 	ISummarizeHeuristicData,

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -27,8 +27,7 @@ import {
 	ITelemetryLoggerPropertyBag,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { ISummaryConfigurationHeuristics } from "../containerRuntime.js";
-
+import type { ISummaryConfigurationHeuristics } from "./summarizer.js";
 import {
 	ISummaryAckMessage,
 	ISummaryNackMessage,

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -27,7 +27,6 @@ import {
 	ITelemetryLoggerPropertyBag,
 } from "@fluidframework/telemetry-utils/internal";
 
-import type { ISummaryConfigurationHeuristics } from "./summarizer.js";
 import {
 	ISummaryAckMessage,
 	ISummaryNackMessage,
@@ -772,3 +771,115 @@ export interface ISummarizeRunnerTelemetry extends ITelemetryLoggerPropertyBag {
 	 */
 	summarizerSuccessfulAttempts: () => number;
 }
+
+/**
+ * @legacy
+ * @alpha
+ */
+export interface ISummaryBaseConfiguration {
+	/**
+	 * Delay before first attempt to spawn summarizing container.
+	 */
+	initialSummarizerDelayMs: number;
+
+	/**
+	 * Defines the maximum allowed time to wait for a pending summary ack.
+	 * The maximum amount of time client will wait for a summarize is the minimum of
+	 * maxSummarizeAckWaitTime (currently 3 * 60 * 1000) and maxAckWaitTime.
+	 */
+	maxAckWaitTime: number;
+	/**
+	 * Defines the maximum number of Ops in between Summaries that can be
+	 * allowed before forcibly electing a new summarizer client.
+	 */
+	maxOpsSinceLastSummary: number;
+}
+
+/**
+ * @legacy
+ * @alpha
+ */
+export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfiguration {
+	state: "enabled";
+	/**
+	 * Defines the maximum allowed time, since the last received Ack, before running the summary
+	 * with reason maxTime.
+	 * For example, say we receive ops one by one just before the idle time is triggered.
+	 * In this case, we still want to run a summary since it's been a while since the last summary.
+	 */
+	maxTime: number;
+	/**
+	 * Defines the maximum number of Ops, since the last received Ack, that can be allowed
+	 * before running the summary with reason maxOps.
+	 */
+	maxOps: number;
+	/**
+	 * Defines the minimum number of Ops, since the last received Ack, that can be allowed
+	 * before running the last summary.
+	 */
+	minOpsForLastSummaryAttempt: number;
+	/**
+	 * Defines the lower boundary for the allowed time in between summarizations.
+	 * Pairs with maxIdleTime to form a range.
+	 * For example, if we only receive 1 op, we don't want to have the same idle time as say 100 ops.
+	 * Based on the boundaries we set in minIdleTime and maxIdleTime, the idle time will change
+	 * linearly depending on the number of ops we receive.
+	 */
+	minIdleTime: number;
+	/**
+	 * Defines the upper boundary for the allowed time in between summarizations.
+	 * Pairs with minIdleTime to form a range.
+	 * For example, if we only receive 1 op, we don't want to have the same idle time as say 100 ops.
+	 * Based on the boundaries we set in minIdleTime and maxIdleTime, the idle time will change
+	 * linearly depending on the number of ops we receive.
+	 */
+	maxIdleTime: number;
+	/**
+	 * Runtime op weight to use in heuristic summarizing.
+	 * This number is a multiplier on the number of runtime ops we process when running summarize heuristics.
+	 * For example: (multiplier) * (number of runtime ops) = weighted number of runtime ops
+	 */
+	runtimeOpWeight: number;
+	/**
+	 * Non-runtime op weight to use in heuristic summarizing
+	 * This number is a multiplier on the number of non-runtime ops we process when running summarize heuristics.
+	 * For example: (multiplier) * (number of non-runtime ops) = weighted number of non-runtime ops
+	 */
+	nonRuntimeOpWeight: number;
+
+	/**
+	 * Number of ops since last summary needed before a non-runtime op can trigger running summary heuristics.
+	 *
+	 * Note: Any runtime ops sent before the threshold is reached will trigger heuristics normally.
+	 * This threshold ONLY applies to non-runtime ops triggering summaries.
+	 *
+	 * For example: Say the threshold is 20. Sending 19 non-runtime ops will not trigger any heuristic checks.
+	 * Sending the 20th non-runtime op will trigger the heuristic checks for summarizing.
+	 */
+	nonRuntimeHeuristicThreshold?: number;
+}
+
+/**
+ * @legacy
+ * @alpha
+ */
+export interface ISummaryConfigurationDisableSummarizer {
+	state: "disabled";
+}
+
+/**
+ * @legacy
+ * @alpha
+ */
+export interface ISummaryConfigurationDisableHeuristics extends ISummaryBaseConfiguration {
+	state: "disableHeuristics";
+}
+
+/**
+ * @legacy
+ * @alpha
+ */
+export type ISummaryConfiguration =
+	| ISummaryConfigurationDisableSummarizer
+	| ISummaryConfigurationDisableHeuristics
+	| ISummaryConfigurationHeuristics;

--- a/packages/runtime/container-runtime/src/summary/summaryHelpers.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryHelpers.ts
@@ -1,0 +1,118 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { type ILoader, LoaderHeader } from "@fluidframework/container-definitions/internal";
+import type { FluidObject, IRequest, IResponse } from "@fluidframework/core-interfaces";
+import { DriverHeader } from "@fluidframework/driver-definitions/internal";
+import { responseToException } from "@fluidframework/runtime-utils/internal";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
+
+import { summarizerClientType } from "./summarizerClientElection.js";
+import type {
+	ISummarizer,
+	ISummaryConfiguration,
+	ISummaryConfigurationDisableSummarizer,
+	ISummaryConfigurationHeuristics,
+} from "./summarizerTypes.js";
+
+export const summarizerRequestUrl = "_summarizer";
+
+export function isSummariesDisabled(
+	config: ISummaryConfiguration,
+): config is ISummaryConfigurationDisableSummarizer {
+	return config.state === "disabled";
+}
+
+/**
+ * @legacy
+ * @alpha
+ */
+export const DefaultSummaryConfiguration: ISummaryConfiguration = {
+	state: "enabled",
+
+	minIdleTime: 0,
+
+	maxIdleTime: 30 * 1000, // 30 secs.
+
+	maxTime: 60 * 1000, // 1 min.
+
+	maxOps: 100, // Summarize if 100 weighted ops received since last snapshot.
+
+	minOpsForLastSummaryAttempt: 10,
+
+	maxAckWaitTime: 3 * 60 * 1000, // 3 mins.
+
+	maxOpsSinceLastSummary: 7000,
+
+	initialSummarizerDelayMs: 5 * 1000, // 5 secs.
+
+	nonRuntimeOpWeight: 0.1,
+
+	runtimeOpWeight: 1,
+
+	nonRuntimeHeuristicThreshold: 20,
+};
+
+/**
+ * Returns a function that will create and retrieve a Summarizer.
+ */
+export function formCreateSummarizerFn(loader: ILoader): () => Promise<ISummarizer> {
+	return async () => {
+		const request: IRequest = {
+			headers: {
+				[LoaderHeader.cache]: false,
+				[LoaderHeader.clientDetails]: {
+					capabilities: { interactive: false },
+					type: summarizerClientType,
+				},
+				[DriverHeader.summarizingClient]: true,
+				[LoaderHeader.reconnect]: false,
+			},
+			url: `/${summarizerRequestUrl}`,
+		};
+
+		const resolvedContainer = await loader.resolve(request);
+		let fluidObject: FluidObject<ISummarizer> | undefined;
+
+		// Older containers may not have the "getEntryPoint" API
+		// ! This check will need to stay until LTS of loader moves past 2.0.0-internal.7.0.0
+		if (resolvedContainer.getEntryPoint === undefined) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
+			const response = (await (resolvedContainer as any).request({
+				url: `/${summarizerRequestUrl}`,
+			})) as IResponse;
+			if (response.status !== 200 || response.mimeType !== "fluid/object") {
+				throw responseToException(response, request);
+			}
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			fluidObject = response.value;
+		} else {
+			fluidObject = await resolvedContainer.getEntryPoint();
+		}
+
+		if (fluidObject?.ISummarizer === undefined) {
+			throw new UsageError("Fluid object does not implement ISummarizer");
+		}
+		return fluidObject.ISummarizer;
+	};
+}
+
+export function validateSummaryHeuristicConfiguration(
+	configuration: ISummaryConfigurationHeuristics,
+): void {
+	// eslint-disable-next-line no-restricted-syntax
+	for (const prop in configuration) {
+		if (typeof configuration[prop] === "number" && configuration[prop] < 0) {
+			throw new UsageError(
+				`Summary heuristic configuration property "${prop}" cannot be less than 0`,
+			);
+		}
+	}
+	if (configuration.minIdleTime > configuration.maxIdleTime) {
+		throw new UsageError(
+			`"minIdleTime" [${configuration.minIdleTime}] cannot be greater than "maxIdleTime" [${configuration.maxIdleTime}]`,
+		);
+	}
+}

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -31,7 +31,6 @@ import { MockLogger, mixinMonitoringContext } from "@fluidframework/telemetry-ut
 import { MockDeltaManager } from "@fluidframework/test-runtime-utils/internal";
 import sinon from "sinon";
 
-import { ISummaryConfiguration } from "../../containerRuntime.js";
 import {
 	IGeneratedSummaryStats,
 	ISummarizeHeuristicData,
@@ -44,6 +43,7 @@ import {
 	SummaryCollection,
 	getFailMessage,
 	neverCancelledSummaryToken,
+	type ISummaryConfiguration,
 } from "../../summary/index.js";
 import {
 	defaultMaxAttempts,

--- a/packages/runtime/container-runtime/src/test/summary/summarizerHeuristics.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/summarizerHeuristics.spec.ts
@@ -9,12 +9,10 @@ import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 import sinon from "sinon";
 
 import {
-	ISummaryConfiguration,
-	ISummaryConfigurationHeuristics,
-} from "../../containerRuntime.js";
-import {
 	ISummarizeAttempt,
 	ISummarizeHeuristicData,
+	ISummaryConfiguration,
+	ISummaryConfigurationHeuristics,
 	SummarizeHeuristicData,
 	SummarizeHeuristicRunner,
 	SummarizeReason,

--- a/packages/runtime/container-runtime/src/test/summary/summaryManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/summaryManager.spec.ts
@@ -22,7 +22,6 @@ import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 import { MockDeltaManager } from "@fluidframework/test-runtime-utils/internal";
 import sinon from "sinon";
 
-import { DefaultSummaryConfiguration } from "../../containerRuntime.js";
 import {
 	IConnectedEvents,
 	IConnectedState,
@@ -39,6 +38,7 @@ import {
 	SummaryManager,
 	SummaryManagerState,
 	neverCancelledSummaryToken,
+	DefaultSummaryConfiguration,
 } from "../../summary/index.js";
 
 class MockRuntime {


### PR DESCRIPTION
## Description

Moves code related to the summarizer from `containerRuntime.ts` to files in `src/summary/`. Just trying to make `containerRuntime.ts` a more manageable file.

All the moved code is types or methods/functions that don't depend on the internals of the ContainerRuntime class. The `createSummarizer()` function was inlined in its only call site inside `formCreateSummarizerFn()`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
