### PR TITLE
build: Add depcheck tasks to some packages

### DIFF
--- a/.depcheckrc.base.cjs
+++ b/.depcheckrc.base.cjs
@@ -7,8 +7,9 @@
 // See https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check
 // @ts-check
 
-// This base depcheck config is shared by all packages in the repo.
 /**
+ * This base depcheck config is shared by all packages in the repo.
+ *
  * @type {import("depcheck").Config}
  */
 const config = {

--- a/.depcheckrc.base.cjs
+++ b/.depcheckrc.base.cjs
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Enable TypeScript type-checking for this file.
+// See https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check
+// @ts-check
+
+// This base depcheck config is shared by all packages in the repo.
+/**
+ * @type {import("depcheck").Config}
+ */
+const config = {
+	ignores: [
+		// The following deps are actually in use, but depcheck reports them unused.
+
+		// These packages are used in the CI pipelines.
+		"mocha-multi-reporters",
+		"moment",
+
+		// The following deps are reported as missing, but they are available.
+
+		// We use a 'hack' to make plugins from the shared eslint config available to our packages, those these deps are not
+		// directly needed in the package.
+		"@typescript-eslint/eslint-plugin",
+		"eslint-config-prettier",
+		"eslint-import-resolver-typescript",
+		"eslint-plugin-tsdoc",
+		"eslint-plugin-unicorn",
+	],
+	ignorePatterns: [],
+};
+
+module.exports = config;

--- a/build-tools/packages/build-cli/.depcheckrc.cjs
+++ b/build-tools/packages/build-cli/.depcheckrc.cjs
@@ -1,0 +1,39 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Enable TypeScript type-checking for this file.
+// See https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check
+// @ts-check
+
+/**
+ * @type {import("depcheck").Config}
+ */
+const config = {
+	ignores: [
+		// The following deps are actually in use, but depcheck reports them unused.
+
+		// Oclif plugins are used dynamically at runtime.
+		"@oclif/plugin-*",
+
+		// Danger is used at runtime in the dangerfile.
+		"danger",
+
+		// Types from this package are used in markdown.ts.
+		"mdast",
+
+		// This is needed by the fluid-build task integration in policy-check.
+		"tslib",
+
+		// We use a 'hack' to make plugins from the shared eslint config available to our packages, those these deps are not
+		// directly needed in the package.
+		"@typescript-eslint/eslint-plugin",
+		"eslint-import-resolver-typescript",
+		"eslint-plugin-tsdoc",
+		"eslint-plugin-unicorn",
+	],
+	ignorePatterns: [],
+};
+
+module.exports = config;

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -165,6 +165,7 @@
 		"chai": "^4.5.0",
 		"chai-arrays": "^2.2.0",
 		"copyfiles": "^2.4.1",
+		"depcheck": "^1.4.7",
 		"eslint": "~8.57.0",
 		"eslint-config-oclif": "^5.2.1",
 		"eslint-config-oclif-typescript": "^3.1.12",

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -56,7 +56,8 @@
 		"postpack": "npm run clean:manifest",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm run test",
-		"test:mocha": "mocha --forbid-only \"lib/test/**/*.test.*js\""
+		"test:mocha": "mocha --forbid-only \"lib/test/**/*.test.*js\"",
+		"check:depcheck": "depcheck"
 	},
 	"c8": {
 		"all": true,
@@ -131,7 +132,6 @@
 		"replace-in-file": "^7.2.0",
 		"resolve.exports": "^2.0.2",
 		"semver": "^7.6.3",
-		"semver-utils": "^1.1.4",
 		"simple-git": "^3.27.0",
 		"sort-json": "^2.0.1",
 		"sort-package-json": "1.57.0",
@@ -144,7 +144,6 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
-		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@oclif/test": "^4.1.0",
 		"@types/async": "^3.2.24",
@@ -159,14 +158,12 @@
 		"@types/prettier": "^2.7.3",
 		"@types/prompts": "^2.4.9",
 		"@types/semver": "^7.5.8",
-		"@types/semver-utils": "^1.1.3",
 		"@types/sort-json": "^2.0.3",
 		"@types/unist": "^3.0.3",
 		"@types/xml2js": "^0.4.14",
 		"c8": "^7.14.0",
 		"chai": "^4.5.0",
 		"chai-arrays": "^2.2.0",
-		"concurrently": "^8.2.2",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.57.0",
 		"eslint-config-oclif": "^5.2.1",

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -42,6 +42,7 @@
 		"build:readme": "oclif readme --version 0.0.0 --multi --no-aliases",
 		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:biome": "biome check .",
+		"check:depcheck": "depcheck",
 		"check:format": "npm run check:biome",
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob dist lib oclif.manifest.json \"**/*.tsbuildinfo\" \"**/*.build.log\" _api-extractor-temp nyc",
@@ -56,8 +57,7 @@
 		"postpack": "npm run clean:manifest",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm run test",
-		"test:mocha": "mocha --forbid-only \"lib/test/**/*.test.*js\"",
-		"check:depcheck": "depcheck"
+		"test:mocha": "mocha --forbid-only \"lib/test/**/*.test.*js\""
 	},
 	"c8": {
 		"all": true,

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -161,6 +161,12 @@ module.exports = {
 
 	multiCommandExecutables: ["oclif", "syncpack"],
 	declarativeTasks: {
+		// Depcheck looks at all files in the package, so we need to include all files in the input and output globs.
+		"depcheck": {
+			inputGlobs: ["*.*", "src/**"],
+			outputGlobs: ["*.*", "src/**"],
+			gitignore: ["input", "output"],
+		},
 		// fluid-build lowercases the executable name, so we need to use buildversion instead of buildVersion.
 		"flub check buildversion": {
 			inputGlobs: [

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -61,7 +61,7 @@ module.exports = {
 			script: false,
 		},
 		"checks": {
-			dependsOn: ["check:format"],
+			dependsOn: ["check:format", "check:depcheck"],
 			script: false,
 		},
 		"checks:fix": {
@@ -129,6 +129,7 @@ module.exports = {
 		},
 		"check:biome": [],
 		"check:prettier": [],
+		"check:depcheck": [],
 		// ADO #7297: Review why the direct dependency on 'build:esm:test' is necessary.
 		//            Should 'compile' be enough?  compile -> build:test -> build:test:esm
 		"eslint": ["compile", "build:test:esm"],

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -529,6 +529,7 @@ module.exports = {
 				["concurrently", "concurrently"],
 				["copyfiles", "copyfiles"],
 				["cross-env", "cross-env"],
+				["depcheck", "depcheck"],
 				["depcruise", "dependency-cruiser"],
 				["eslint", "eslint"],
 				["flub", "@fluid-tools/build-cli"],

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"danger": "^11.3.0",
+		"depcheck": "^1.4.7",
 		"eslint": "~8.55.0",
 		"jest": "^29.6.2",
 		"mocha": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -254,6 +254,12 @@
 			"build:readme": {
 				"dependsOn": []
 			},
+			"check:depcheck": {
+				"dependsOn": [
+					"^check:depcheck"
+				],
+				"script": false
+			},
 			"check:format": {
 				"dependsOn": [
 					"check:format:repo"
@@ -268,7 +274,8 @@
 					"layer-check",
 					"syncpack:deps",
 					"syncpack:versions",
-					"check:versions"
+					"check:versions",
+					"check:depcheck"
 				],
 				"script": false
 			},

--- a/packages/framework/presence/.depcheckrc.cjs
+++ b/packages/framework/presence/.depcheckrc.cjs
@@ -14,26 +14,17 @@ const config = {
 	ignores: [
 		// The following deps are actually in use, but depcheck reports them unused.
 
-		// Oclif plugins are used dynamically at runtime.
-		"@oclif/plugin-*",
-
-		// Danger is used at runtime in the dangerfile.
-		"danger",
-
-		// Types from this package are used in markdown.ts.
-		"mdast",
-
-		// This is needed by the fluid-build task integration in policy-check.
-		"tslib",
+		// This mocha plugin is used in the CI pipelines.
+		"mocha-multi-reporters",
 
 		// The following deps are reported as missing, but they are available.
 
 		// We use a 'hack' to make plugins from the shared eslint config available to our packages, those these deps are not
 		// directly needed in the package.
-		"@typescript-eslint/eslint-plugin",
-		"eslint-import-resolver-typescript",
-		"eslint-plugin-tsdoc",
-		"eslint-plugin-unicorn",
+		"eslint-config-prettier",
+
+		// This reference is flagged because of an unusual import in ./src/datastorePresenceManagerFactory.ts
+		"@fluidframework/presence",
 	],
 	ignorePatterns: [],
 };

--- a/packages/framework/presence/.depcheckrc.cjs
+++ b/packages/framework/presence/.depcheckrc.cjs
@@ -7,26 +7,21 @@
 // See https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check
 // @ts-check
 
+// Import the shared config from the root of the repo.
+const sharedConfig = require("../../../.depcheckrc.base.cjs");
+
 /**
  * @type {import("depcheck").Config}
  */
 const config = {
 	ignores: [
-		// The following deps are actually in use, but depcheck reports them unused.
-
-		// This mocha plugin is used in the CI pipelines.
-		"mocha-multi-reporters",
+		...sharedConfig.ignores,
 
 		// The following deps are reported as missing, but they are available.
-
-		// We use a 'hack' to make plugins from the shared eslint config available to our packages, those these deps are not
-		// directly needed in the package.
-		"eslint-config-prettier",
 
 		// This reference is flagged because of an unusual import in ./src/datastorePresenceManagerFactory.ts
 		"@fluidframework/presence",
 	],
-	ignorePatterns: [],
 };
 
 module.exports = config;

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -87,7 +87,8 @@
 		"tsc:experimental": "fluid-tsc commonjs --project ./tsconfig.cjs.json",
 		"tsc:main": "fluid-tsc commonjs --project ./tsconfig.main.cjs.json && copyfiles -f ./src/cjs/package.json ./dist",
 		"typetests:gen": "flub generate typetests --dir . -v",
-		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize",
+		"check:depcheck": "depcheck"
 	},
 	"c8": {
 		"all": true,
@@ -145,6 +146,7 @@
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
+		"depcheck": "^1.4.7",
 		"eslint": "~8.55.0",
 		"mocha": "^10.2.0",
 		"mocha-multi-reporters": "^1.5.1",

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -63,6 +63,7 @@
 		"build:test:esm:core-interfaces-no-exactOptionalPropertyTypes": "tsc --project ./src/test/core-interfaces/tsconfig.no-exactOptionalPropertyTypes.json",
 		"check:are-the-types-wrong": "attw --pack . --profile node16",
 		"check:biome": "biome check .",
+		"check:depcheck": "depcheck",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
 		"check:exports:bundle-release-tags": "api-extractor run --config api-extractor/api-extractor-lint-bundle.json",
 		"check:exports:cjs:alpha": "api-extractor run --config api-extractor/api-extractor-lint-alpha.cjs.json",
@@ -87,8 +88,7 @@
 		"tsc:experimental": "fluid-tsc commonjs --project ./tsconfig.cjs.json",
 		"tsc:main": "fluid-tsc commonjs --project ./tsconfig.main.cjs.json && copyfiles -f ./src/cjs/package.json ./dist",
 		"typetests:gen": "flub generate typetests --dir . -v",
-		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize",
-		"check:depcheck": "depcheck"
+		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"c8": {
 		"all": true,

--- a/packages/runtime/container-runtime/.depcheckrc.cjs
+++ b/packages/runtime/container-runtime/.depcheckrc.cjs
@@ -13,24 +13,6 @@ const sharedConfig = require("../../../.depcheckrc.base.cjs");
 /**
  * @type {import("depcheck").Config}
  */
-const config = {
-	ignores: [
-		...sharedConfig.ignores,
-
-		// The following deps are actually in use, but depcheck reports them unused.
-
-		// Oclif plugins are used dynamically at runtime.
-		"@oclif/plugin-*",
-
-		// Danger is used at runtime in the dangerfile.
-		"danger",
-
-		// Types from this package are used in markdown.ts.
-		"mdast",
-
-		// This is needed by the fluid-build task integration in policy-check.
-		"tslib",
-	],
-};
+const config = sharedConfig;
 
 module.exports = config;

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -114,6 +114,7 @@
 		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack . --exclude-entrypoints ./internal/test/containerRuntime ./internal/test/deltaScheduler ./internal/test/blobManager ./internal/test/summary ./internal/test/gc",
 		"check:biome": "biome check .",
+		"check:depcheck": "depcheck",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
 		"check:exports:bundle-release-tags": "api-extractor run --config api-extractor/api-extractor-lint-bundle.json",
 		"check:exports:cjs:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.cjs.json",
@@ -183,7 +184,6 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"@tylerbu/sorted-btree-es6": "^1.8.0",
 		"double-ended-queue": "^2.1.0-0",
 		"lz4js": "^0.2.0",
 		"uuid": "^9.0.0"
@@ -212,6 +212,7 @@
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
+		"depcheck": "^1.4.7",
 		"eslint": "~8.55.0",
 		"mocha": "^10.2.0",
 		"mocha-multi-reporters": "^1.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11684,6 +11684,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      depcheck:
+        specifier: ^1.4.7
+        version: 1.4.7
       eslint:
         specifier: ~8.55.0
         version: 8.55.0
@@ -20817,6 +20820,9 @@ packages:
     resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
     engines: {node: '>= 0.4'}
 
+  callsite@1.0.0:
+    resolution: {integrity: sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -21624,6 +21630,11 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
+  depcheck@1.4.7:
+    resolution: {integrity: sha512-1lklS/bV5chOxwNKA/2XUUk/hPORp8zihZsXflr8x0kLwmcZ9Y9BsS6Hs3ssvA+2wUVbG0U2Ciqvm1SokNjPkA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
     engines: {node: '>= 0.6'}
@@ -21640,6 +21651,9 @@ packages:
   deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
+  deps-regex@0.2.0:
+    resolution: {integrity: sha512-PwuBojGMQAYbWkMXOY9Pd/NWCDNHVH12pnS7WHqZkTSeMESe4hwnKKRp0yR87g37113x4JPbo/oIvXY+s/f56Q==}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -21647,6 +21661,10 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  detect-file@1.0.0:
+    resolution: {integrity: sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==}
+    engines: {node: '>=0.10.0'}
 
   detect-indent@5.0.0:
     resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
@@ -22508,6 +22526,10 @@ packages:
   find-yarn-workspace-root@2.0.0:
     resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
 
+  findup-sync@5.0.0:
+    resolution: {integrity: sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==}
+    engines: {node: '>= 10.13.0'}
+
   findup@0.1.5:
     resolution: {integrity: sha512-Udxo3C9A6alt2GZ2MNsgnIvX7De0V3VGxeP/x98NSVgSlizcDHdmJza61LI7zJy4OEtSiJyE72s0/+tBl5/ZxA==}
     engines: {node: '>=0.6'}
@@ -22794,8 +22816,16 @@ packages:
     resolution: {integrity: sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==}
     engines: {node: '>=0.10.0'}
 
+  global-modules@1.0.0:
+    resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
+    engines: {node: '>=0.10.0'}
+
   global-prefix@0.1.5:
     resolution: {integrity: sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==}
+    engines: {node: '>=0.10.0'}
+
+  global-prefix@1.0.2:
+    resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
     engines: {node: '>=0.10.0'}
 
   globals@11.12.0:
@@ -25467,6 +25497,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  please-upgrade-node@3.2.0:
+    resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
+
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -26137,6 +26170,9 @@ packages:
     resolution: {integrity: sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==}
     engines: {node: '>=6'}
 
+  require-package-name@2.0.1:
+    resolution: {integrity: sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==}
+
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
@@ -26152,6 +26188,10 @@ packages:
 
   resolve-dir@0.1.1:
     resolution: {integrity: sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-dir@1.0.1:
+    resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==}
     engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
@@ -35667,6 +35707,8 @@ snapshots:
       get-intrinsic: 1.2.5
       set-function-length: 1.2.2
 
+  callsite@1.0.0: {}
+
   callsites@3.1.0: {}
 
   camel-case@3.0.0:
@@ -36555,6 +36597,34 @@ snapshots:
 
   denque@2.1.0: {}
 
+  depcheck@1.4.7:
+    dependencies:
+      '@babel/parser': 7.26.3
+      '@babel/traverse': 7.26.4
+      '@vue/compiler-sfc': 3.4.38
+      callsite: 1.0.0
+      camelcase: 6.3.0
+      cosmiconfig: 7.1.0
+      debug: 4.4.0(supports-color@8.1.1)
+      deps-regex: 0.2.0
+      findup-sync: 5.0.0
+      ignore: 5.3.2
+      is-core-module: 2.15.1
+      js-yaml: 3.14.1
+      json5: 2.2.3
+      lodash: 4.17.21
+      minimatch: 7.4.6
+      multimatch: 5.0.0
+      please-upgrade-node: 3.2.0
+      readdirp: 3.6.0
+      require-package-name: 2.0.1
+      resolve: 1.22.8
+      resolve-from: 5.0.0
+      semver: 7.6.3
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   depd@1.1.2: {}
 
   depd@2.0.0: {}
@@ -36590,9 +36660,13 @@ snapshots:
 
   deprecation@2.3.1: {}
 
+  deps-regex@0.2.0: {}
+
   dequal@2.0.3: {}
 
   destroy@1.2.0: {}
+
+  detect-file@1.0.0: {}
 
   detect-indent@5.0.0: {}
 
@@ -37654,6 +37728,13 @@ snapshots:
     dependencies:
       micromatch: 4.0.8
 
+  findup-sync@5.0.0:
+    dependencies:
+      detect-file: 1.0.0
+      is-glob: 4.0.3
+      micromatch: 4.0.8
+      resolve-dir: 1.0.1
+
   findup@0.1.5:
     dependencies:
       colors: 0.6.2
@@ -37950,11 +38031,25 @@ snapshots:
       global-prefix: 0.1.5
       is-windows: 0.2.0
 
+  global-modules@1.0.0:
+    dependencies:
+      global-prefix: 1.0.2
+      is-windows: 1.0.2
+      resolve-dir: 1.0.1
+
   global-prefix@0.1.5:
     dependencies:
       homedir-polyfill: 1.0.3
       ini: 1.3.8
       is-windows: 0.2.0
+      which: 1.3.1
+
+  global-prefix@1.0.2:
+    dependencies:
+      expand-tilde: 2.0.2
+      homedir-polyfill: 1.0.3
+      ini: 1.3.8
+      is-windows: 1.0.2
       which: 1.3.1
 
   globals@11.12.0: {}
@@ -41527,6 +41622,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  please-upgrade-node@3.2.0:
+    dependencies:
+      semver-compare: 1.0.0
+
   pluralize@8.0.0: {}
 
   pm2-axon-rpc@0.7.1:
@@ -42422,6 +42521,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  require-package-name@2.0.1: {}
+
   requires-port@1.0.0: {}
 
   resize-observer-polyfill@1.5.1: {}
@@ -42436,6 +42537,11 @@ snapshots:
     dependencies:
       expand-tilde: 1.2.2
       global-modules: 0.2.3
+
+  resolve-dir@1.0.1:
+    dependencies:
+      expand-tilde: 2.0.2
+      global-modules: 1.0.0
 
   resolve-from@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       danger:
         specifier: ^11.3.0
         version: 11.3.1(encoding@0.1.13)
+      depcheck:
+        specifier: ^1.4.7
+        version: 1.4.7
       eslint:
         specifier: ~8.55.0
         version: 8.55.0
@@ -12302,9 +12305,6 @@ importers:
       '@fluidframework/telemetry-utils':
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
-      '@tylerbu/sorted-btree-es6':
-        specifier: ^1.8.0
-        version: 1.8.0
       double-ended-queue:
         specifier: ^2.1.0-0
         version: 2.1.0-0
@@ -12384,6 +12384,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      depcheck:
+        specifier: ^1.4.7
+        version: 1.4.7
       eslint:
         specifier: ~8.55.0
         version: 8.55.0


### PR DESCRIPTION
This change is an alternative to the change explored in #23989.

In https://github.com/microsoft/FluidFramework/pull/22448#issuecomment-2383725483 I outlined three options for inegrating depcheck into our builds. This change explores option 1, while #23989 explores option 2.

This change adds a new `check:depcheck` task to the build, along with a declarative task to support incremental build. There is also a shared base config in the root of the repo. Packages can import this shared config and override/supplement the relevant bits. 

Finally, this change adds depcheck to three packages: presence and container-runtime in the client release group, and build-cli in the build-tools release group. Each package has its own config file and extends the base config.

If we proceed with this approach, we would onboard packages individually by adding the "check:depcheck" script to them.