### PR TITLE
refactor(tree): move initializeForest to feature-libraries

### DIFF
--- a/packages/dds/tree/src/core/forest/editableForest.ts
+++ b/packages/dds/tree/src/core/forest/editableForest.ts
@@ -3,22 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import type { SessionSpaceCompressedId, IIdCompressor } from "@fluidframework/id-compressor";
-import { assert } from "@fluidframework/core-utils/internal";
-
-import type { RevisionTagCodec } from "../rebase/index.js";
 import type { FieldKey } from "../schema-stored/index.js";
-import {
-	type Anchor,
-	type DeltaRoot,
-	type DeltaVisitor,
-	type DetachedField,
-	type ITreeCursorSynchronous,
-	combineVisitors,
-	deltaForRootInitialization,
-	makeDetachedFieldIndex,
-	visitDelta,
-} from "../tree/index.js";
+import type { Anchor, DeltaVisitor, DetachedField } from "../tree/index.js";
 
 import type { IForestSubscription, ITreeSubscriptionCursor } from "./forest.js";
 
@@ -37,43 +23,6 @@ export interface IEditableForest extends IForestSubscription {
 	 * It is invalid to acquire a visitor without releasing the previous one.
 	 */
 	acquireVisitor(): DeltaVisitor;
-}
-
-/**
- * Initializes the given forest with the given content.
- * @remarks The forest must be empty when this function is called.
- * This does not perform an edit in the typical sense.
- * Instead, it creates a delta expressing a creation and insertion of the `content` under the {@link rootFieldKey}, and then applies the delta to the forest.
- * If `visitAnchors` is enabled, then the delta will also be applied to the forest's {@link AnchorSet} (in which case there must be no existing anchors when this function is called).
- *
- * @remarks
- * This does not perform an edit: it updates the forest content as if there was an edit that did that.
- */
-export function initializeForest(
-	forest: IEditableForest,
-	content: readonly ITreeCursorSynchronous[],
-	revisionTagCodec: RevisionTagCodec,
-	idCompressor: IIdCompressor,
-	visitAnchors = false,
-): void {
-	assert(forest.isEmpty, 0x747 /* forest must be empty */);
-	const delta: DeltaRoot = deltaForRootInitialization(content);
-	let visitor = forest.acquireVisitor();
-	if (visitAnchors) {
-		assert(forest.anchors.isEmpty(), 0x9b7 /* anchor set must be empty */);
-		const anchorVisitor = forest.anchors.acquireVisitor();
-		visitor = combineVisitors([visitor, anchorVisitor]);
-	}
-
-	// any detached trees built here are immediately attached so the revision used here doesn't matter
-	// we use a dummy revision to make correctness checks in the detached field index easier
-	visitDelta(
-		delta,
-		visitor,
-		makeDetachedFieldIndex("init", revisionTagCodec, idCompressor),
-		0 as SessionSpaceCompressedId,
-	);
-	visitor.free();
 }
 
 // TODO: Types below here may be useful for input into edit building APIs, but are no longer used here directly.

--- a/packages/dds/tree/src/core/forest/index.ts
+++ b/packages/dds/tree/src/core/forest/index.ts
@@ -9,7 +9,6 @@ export {
 	type TreeLocation,
 	isFieldLocation,
 	type ForestLocation,
-	initializeForest,
 } from "./editableForest.js";
 export {
 	type IForestSubscription,

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -110,7 +110,6 @@ export {
 	type ForestLocation,
 	type ITreeSubscriptionCursor,
 	ITreeSubscriptionCursorState,
-	initializeForest,
 	type FieldAnchor,
 	moveToDetachedField,
 	type ForestEvents,

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -193,3 +193,5 @@ export {
 	type TreeIndexKey,
 	type TreeIndexNodes,
 } from "./indexing/index.js";
+
+export { initializeForest } from "./initializeForest.js";

--- a/packages/dds/tree/src/feature-libraries/initializeForest.ts
+++ b/packages/dds/tree/src/feature-libraries/initializeForest.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { SessionSpaceCompressedId, IIdCompressor } from "@fluidframework/id-compressor";
+import { assert } from "@fluidframework/core-utils/internal";
+
+import {
+	type DeltaRoot,
+	type IEditableForest,
+	type ITreeCursorSynchronous,
+	type RevisionTagCodec,
+	combineVisitors,
+	deltaForRootInitialization,
+	makeDetachedFieldIndex,
+	visitDelta,
+} from "../core/index.js";
+
+/**
+ * Initializes the given forest with the given content.
+ * @remarks The forest must be empty when this function is called.
+ * This does not perform an edit in the typical sense.
+ * Instead, it creates a delta expressing a creation and insertion of the `content` under the {@link rootFieldKey}, and then applies the delta to the forest.
+ * If `visitAnchors` is enabled, then the delta will also be applied to the forest's {@link AnchorSet} (in which case there must be no existing anchors when this function is called).
+ *
+ * @remarks
+ * This does not perform an edit: it updates the forest content as if there was an edit that did that.
+ */
+export function initializeForest(
+	forest: IEditableForest,
+	content: readonly ITreeCursorSynchronous[],
+	revisionTagCodec: RevisionTagCodec,
+	idCompressor: IIdCompressor,
+	visitAnchors = false,
+): void {
+	assert(forest.isEmpty, 0x747 /* forest must be empty */);
+	const delta: DeltaRoot = deltaForRootInitialization(content);
+	let visitor = forest.acquireVisitor();
+	if (visitAnchors) {
+		assert(forest.anchors.isEmpty(), 0x9b7 /* anchor set must be empty */);
+		const anchorVisitor = forest.anchors.acquireVisitor();
+		visitor = combineVisitors([visitor, anchorVisitor]);
+	}
+
+	// any detached trees built here are immediately attached so the revision used here doesn't matter
+	// we use a dummy revision to make correctness checks in the detached field index easier
+	visitDelta(
+		delta,
+		visitor,
+		makeDetachedFieldIndex("init", revisionTagCodec, idCompressor),
+		0 as SessionSpaceCompressedId,
+	);
+	visitor.free();
+}

--- a/packages/dds/tree/src/shared-tree/independentView.ts
+++ b/packages/dds/tree/src/shared-tree/independentView.ts
@@ -14,7 +14,6 @@ import {
 	type RevisionTag,
 	RevisionTagCodec,
 	TreeStoredSchemaRepository,
-	initializeForest,
 	type ITreeCursorSynchronous,
 	mapCursorField,
 } from "../core/index.js";
@@ -27,6 +26,7 @@ import {
 	chunkTree,
 	defaultChunkPolicy,
 	TreeCompressionStrategy,
+	initializeForest,
 } from "../feature-libraries/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import type { Format } from "../feature-libraries/schema-index/format.js";

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -13,7 +13,6 @@ import {
 	type ITreeCursor,
 	type JsonableTree,
 	TreeStoredSchemaRepository,
-	initializeForest,
 	moveToDetachedField,
 } from "../../../core/index.js";
 import {
@@ -28,6 +27,7 @@ import {
 	cursorForJsonableTreeNode,
 	cursorForMapTreeNode,
 	defaultSchemaPolicy,
+	initializeForest,
 	jsonableTreeFromCursor,
 	mapTreeFromCursor,
 } from "../../../feature-libraries/index.js";

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -13,7 +13,6 @@ import {
 	type TaggedChange,
 	type UpPath,
 	applyDelta,
-	initializeForest,
 	makeDetachedFieldIndex,
 	mapCursorField,
 	moveToDetachedField,
@@ -25,6 +24,7 @@ import {
 	DefaultEditBuilder,
 	buildForest,
 	cursorForJsonableTreeNode,
+	initializeForest,
 	intoDelta,
 	jsonableTreeFromCursor,
 } from "../../../feature-libraries/index.js";

--- a/packages/dds/tree/src/test/feature-libraries/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/objectForest.spec.ts
@@ -7,14 +7,9 @@ import { strict as assert } from "node:assert";
 
 import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
-import {
-	type FieldKey,
-	initializeForest,
-	moveToDetachedField,
-	rootFieldKey,
-} from "../../core/index.js";
+import { type FieldKey, moveToDetachedField, rootFieldKey } from "../../core/index.js";
 import { singleJsonCursor } from "../json/index.js";
-import { cursorForMapTreeNode } from "../../feature-libraries/index.js";
+import { cursorForMapTreeNode, initializeForest } from "../../feature-libraries/index.js";
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 import { buildForest } from "../../feature-libraries/object-forest/index.js";

--- a/packages/dds/tree/src/test/forestTestSuite.ts
+++ b/packages/dds/tree/src/test/forestTestSuite.ts
@@ -25,7 +25,6 @@ import {
 	clonePath,
 	createAnnouncedVisitor,
 	detachedFieldAsKey,
-	initializeForest,
 	mapCursorField,
 	moveToDetachedField,
 	rootFieldKey,
@@ -33,6 +32,7 @@ import {
 import { typeboxValidator } from "../external-utilities/index.js";
 import {
 	cursorForJsonableTreeNode,
+	initializeForest,
 	jsonableTreeFromCursor,
 } from "../feature-libraries/index.js";
 import {

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
@@ -12,7 +12,6 @@ import {
 	type RevisionTag,
 	type TaggedChange,
 	TreeStoredSchemaRepository,
-	initializeForest,
 	mapCursorField,
 	rootFieldKey,
 	tagChange,
@@ -29,6 +28,7 @@ import {
 	type TreeChunk,
 	buildForest,
 	fieldKinds,
+	initializeForest,
 } from "../../feature-libraries/index.js";
 import {
 	type SharedTreeMutableChangeEnricher,

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -4,12 +4,13 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { initializeForest, TreeStoredSchemaRepository } from "../../core/index.js";
+import { TreeStoredSchemaRepository } from "../../core/index.js";
 import {
 	buildForest,
 	cursorForMapTreeNode,
 	defaultSchemaPolicy,
 	getSchemaAndPolicy,
+	initializeForest,
 	MockNodeKeyManager,
 } from "../../feature-libraries/index.js";
 import {

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -78,7 +78,6 @@ import {
 	applyDelta,
 	clonePath,
 	compareUpPaths,
-	initializeForest,
 	makeDetachedFieldIndex,
 	mapCursorField,
 	moveToDetachedField,
@@ -107,6 +106,7 @@ import {
 	MockNodeKeyManager,
 	cursorForMapTreeField,
 	type IDefaultEditBuilder,
+	initializeForest,
 } from "../feature-libraries/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { makeSchemaCodec } from "../feature-libraries/schema-index/codec.js";


### PR DESCRIPTION
## Description

`initializeForest` will soon need to depend on code from feature-libraries (e.g., `chunkTree`). In order for that to be possible we need to move `initializeForest` to feature-libraries

## Breaking Changes

None