### PR TITLE
Optimizations for alias tests which are flaky and timeout

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -270,8 +270,9 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 			assert.equal(aliasResult2, "Conflict");
 
 			const container3 = await provider.loadTestContainer(testContainerConfig);
-			await provider.ensureSynchronized();
 			const dataObject3 = await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
+
+			await provider.ensureSynchronized();
 			assert.ok(await getAliasedDataStoreEntryPoint(dataObject3, alias));
 		});
 

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -18,6 +18,7 @@ import {
 	ITestObjectProvider,
 	getContainerEntryPointBackCompat,
 	summarizeNow,
+	timeoutAwait,
 } from "@fluidframework/test-utils/internal";
 
 import { TestPersistedCache } from "../testPersistedCache.js";
@@ -273,7 +274,7 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 			const dataObject3 = await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
 
 			await provider.ensureSynchronized();
-			assert.ok(await getAliasedDataStoreEntryPoint(dataObject3, alias));
+			assert.ok(await timeoutAwait(getAliasedDataStoreEntryPoint(dataObject3, alias)));
 		});
 
 		it("getAliasedDataStoreEntryPoint only returns aliased data stores", async function () {
@@ -352,7 +353,7 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 				const aliasResult3 = await ds3.trySetAlias(alias);
 
 				assert.equal(aliasResult3, "Conflict");
-				assert.ok(await getAliasedDataStoreEntryPoint(dataObject3, alias));
+				assert.ok(timeoutAwait(getAliasedDataStoreEntryPoint(dataObject3, alias)));
 			},
 		);
 	});

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -353,7 +353,7 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 				const aliasResult3 = await ds3.trySetAlias(alias);
 
 				assert.equal(aliasResult3, "Conflict");
-				assert.ok(timeoutAwait(getAliasedDataStoreEntryPoint(dataObject3, alias)));
+				assert.ok(await timeoutAwait(getAliasedDataStoreEntryPoint(dataObject3, alias)));
 			},
 		);
 	});

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -269,8 +269,8 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 			assert.equal(aliasResult1, "Success");
 			assert.equal(aliasResult2, "Conflict");
 
-			await provider.ensureSynchronized();
 			const container3 = await provider.loadTestContainer(testContainerConfig);
+			await provider.ensureSynchronized();
 			const dataObject3 = await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
 			assert.ok(await getAliasedDataStoreEntryPoint(dataObject3, alias));
 		});

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -18,7 +18,6 @@ import {
 	ITestObjectProvider,
 	getContainerEntryPointBackCompat,
 	summarizeNow,
-	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 
 import { TestPersistedCache } from "../testPersistedCache.js";
@@ -44,12 +43,12 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 	let provider: ITestObjectProvider;
 	const testPersistedCache = new TestPersistedCache();
 	beforeEach("getTestObjectProvider", async () => {
-		provider = getTestObjectProvider({ persistedCache: testPersistedCache });
+		provider = getTestObjectProvider({
+			persistedCache: testPersistedCache,
+			syncSummarizer: true,
+		});
 		container1 = await provider.makeTestContainer(testContainerConfig);
 		dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
-		await waitForContainerConnection(container1);
-
-		await provider.ensureSynchronized();
 
 		container2 = await provider.loadTestContainer(testContainerConfig);
 		dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
@@ -273,8 +272,6 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 			await provider.ensureSynchronized();
 			const container3 = await provider.loadTestContainer(testContainerConfig);
 			const dataObject3 = await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
-
-			await provider.ensureSynchronized();
 			assert.ok(await getAliasedDataStoreEntryPoint(dataObject3, alias));
 		});
 
@@ -334,11 +331,10 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 				assert.equal(aliasResult1, "Success");
 				assert.equal(aliasResult2, "Conflict");
 
-				await provider.ensureSynchronized();
-
 				const { summarizer } = await createSummarizer(provider, container1, {
 					fluidDataObjectType: DataObjectFactoryType.Test,
 				});
+				await provider.ensureSynchronized();
 				const { summaryVersion } = await summarizeNow(summarizer);
 
 				// For the ODSP driver, we need to clear the cache to ensure we get the latest snapshot


### PR DESCRIPTION
There are a couple of aliasing end-to-end tests that are flaky and intermittently time out. See [AB#31828](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/31828) and [AB#31831](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/31831). This PR attempts to fix that by optimizing a couple of steps and fixing a bug:
1. In `beforeEach`, the test waits for container connection and calls `provider.ensureSynchronized`. Both of these are not needed so removing them.
2. In `Assign multiple data stores to the same alias, first write wins, different containers`, a `provider.ensureSynchronized` is not needed so removing it.
3. In `Assign multiple data stores to the same alias, first write wins, different containers from snapshot` there is a bug where the test expects the summarizer to summarize the data store that was created and aliased. However, that may not happen because the `provider.ensureSynchronized` is called before the summarizer is created - it should be called after.
Also, the test object provider needs to be created with `syncSummarizer: true` option for it to sync changes to the summarizer client.
4. Changed the awaits in the flaky tests to `timeoutAwait` so it's more debuggable.