### PR TITLE
feat(server): Add compression middleware to Gitrest

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/app.ts
+++ b/server/gitrest/packages/gitrest-base/src/app.ts
@@ -17,6 +17,7 @@ import {
 	ResponseSizeMiddleware,
 } from "@fluidframework/server-services-utils";
 import { json, urlencoded } from "body-parser";
+import compression from "compression";
 import cors from "cors";
 import express, { Express } from "express";
 import nconf from "nconf";
@@ -84,6 +85,7 @@ export function create(
 	}
 
 	const requestSize = store.get("requestSizeLimit");
+	app.use(compression());
 	app.use(json({ limit: requestSize }));
 	app.use(urlencoded({ limit: requestSize, extended: false }));
 


### PR DESCRIPTION
## Description

In AFR, we have seen internal AKS network hang-ups. Upon investigation, there are 2 internal services that do not use the `compression` middleware. One such service is Gitrest. These services are are consuming orders of magnitude more internal network bandwidth than all the other services combined.

While adding `compression` will slightly increase CPU use, we have not seen any CPU bottlenecks. Hopefully, by compressing the response data from Gitrest, we will lighten the bandwidth pressure.
