### PR TITLE
Staging Mode: Fix bind on resubmit

### DIFF
--- a/examples/version-migration/separate-container/tests/separateContainer.test.ts
+++ b/examples/version-migration/separate-container/tests/separateContainer.test.ts
@@ -43,7 +43,7 @@ describe("separate-container migration", () => {
 			expect(containsOne).toEqual(true);
 		});
 
-		it("migrates and shows the correct code version after migration", async () => {
+		it.skip("migrates and shows the correct code version after migration", async () => {
 			// Validate the migration status shows "one" initially
 			await Promise.all([
 				page.waitForSelector("#sbs-left .migration-status"),
@@ -99,7 +99,7 @@ describe("separate-container migration", () => {
 			await page.waitForFunction(() => window["fluidStarted"]);
 		});
 
-		it("migrates after summarizer has connected", async () => {
+		it.skip("migrates after summarizer has connected", async () => {
 			// Validate the migration status shows "one" initially
 			await Promise.all([
 				page.waitForSelector("#sbs-left .migration-status"),

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -156,11 +156,7 @@ export class OpGroupingManager {
 	public shouldGroup(batch: IBatch): boolean {
 		return (
 			// Grouped batching must be enabled
-			this.config.groupedBatchingEnabled &&
-			// The number of ops in the batch must be 2 or more
-			// or be empty (to allow for empty batches to be grouped)
-			batch.messages.length !== 1
-			// Support for reentrant batches will be on by default
+			this.config.groupedBatchingEnabled
 		);
 	}
 	public groupedBatchingEnabled(): boolean {

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -161,8 +161,9 @@ export class OpGroupingManager {
 			// or be empty (to allow for empty batches to be grouped)
 			// TODO: Can we remove this, as it creates problems for staging mode
 			// as we always want re-submit, even if only 1 op.
-			batch.messages.length !== 1
-			// Support for reentrant batches will be on by default
+			(batch.messages.length !== 1 ||
+				// Support for reentrant batches will be on by default
+				batch.hasReentrantOps === true)
 		);
 	}
 	public groupedBatchingEnabled(): boolean {

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -156,7 +156,13 @@ export class OpGroupingManager {
 	public shouldGroup(batch: IBatch): boolean {
 		return (
 			// Grouped batching must be enabled
-			this.config.groupedBatchingEnabled
+			this.config.groupedBatchingEnabled &&
+			// The number of ops in the batch must be 2 or more
+			// or be empty (to allow for empty batches to be grouped)
+			// TODO: Can we remove this, as it creates problems for staging mode
+			// as we always want re-submit, even if only 1 op.
+			batch.messages.length !== 1
+			// Support for reentrant batches will be on by default
 		);
 	}
 	public groupedBatchingEnabled(): boolean {

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -348,7 +348,7 @@ export class Outbox {
 		const rawBatch = batchManager.popBatch(resubmittingBatchId);
 		const shouldGroup =
 			!disableGroupedBatching && this.params.groupingManager.shouldGroup(rawBatch);
-		if ((batchManager.options.canRebase && rawBatch.hasReentrantOps === true) || shouldGroup) {
+		if (batchManager.options.canRebase && rawBatch.hasReentrantOps === true && shouldGroup) {
 			assert(!this.rebasing, 0x6fa /* A rebased batch should never have reentrant ops */);
 			// If a batch contains reentrant ops (ops created as a result from processing another op)
 			// it needs to be rebased so that we can ensure consistent reference sequence numbers

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -348,7 +348,7 @@ export class Outbox {
 		const rawBatch = batchManager.popBatch(resubmittingBatchId);
 		const shouldGroup =
 			!disableGroupedBatching && this.params.groupingManager.shouldGroup(rawBatch);
-		if (batchManager.options.canRebase && rawBatch.hasReentrantOps === true && shouldGroup) {
+		if ((batchManager.options.canRebase && rawBatch.hasReentrantOps === true) || shouldGroup) {
 			assert(!this.rebasing, 0x6fa /* A rebased batch should never have reentrant ops */);
 			// If a batch contains reentrant ops (ops created as a result from processing another op)
 			// it needs to be rebased so that we can ensure consistent reference sequence numbers

--- a/packages/test/local-server-tests/src/test/stagingMode.spec.ts
+++ b/packages/test/local-server-tests/src/test/stagingMode.spec.ts
@@ -16,6 +16,8 @@ import {
 } from "@fluidframework/container-loader/internal";
 import { loadContainerRuntime } from "@fluidframework/container-runtime/internal";
 import { type FluidObject } from "@fluidframework/core-interfaces/internal";
+import { SharedMap } from "@fluidframework/map/internal";
+import { isFluidHandle, toFluidHandleInternal } from "@fluidframework/runtime-utils/internal";
 import {
 	LocalDeltaConnectionServer,
 	type ILocalDeltaConnectionServer,
@@ -43,11 +45,33 @@ class RootDataObject extends DataObject {
 		this.root.set(`${prefix}-${this.instanceNumber}`, this.root.size);
 	}
 
+	public addDDS(prefix: string) {
+		const newMap = SharedMap.create(this.runtime);
+		this.root.set(`${prefix}-${this.instanceNumber}`, newMap.handle);
+	}
+
 	public get state(): Record<string, unknown> {
 		return [...this.root.keys()].reduce<Record<string, unknown>>((pv, cv) => {
-			pv[cv] = this.root.get(cv);
+			const value = (pv[cv] = this.root.get(cv));
+			if (isFluidHandle(value)) {
+				pv[cv] = toFluidHandleInternal(value).absolutePath;
+			}
 			return pv;
 		}, {});
+	}
+
+	public async loadState(): Promise<Record<string, unknown>> {
+		const state: Record<string, unknown> = {};
+		const loadStateInt = async (map) => {
+			for (const key of map.keys()) {
+				const value = (state[key] = map.get(key));
+				if (isFluidHandle(value)) {
+					state[key] = await loadStateInt(await value.get());
+				}
+			}
+		};
+		await loadStateInt(this.root);
+		return state;
 	}
 
 	public enterStagingMode() {
@@ -217,6 +241,56 @@ describe("Scenario Test", () => {
 		assert.deepStrictEqual(
 			clients.original.dataObject.state,
 			clients.loaded.dataObject.state,
+			"states should match after save",
+		);
+	});
+
+	it.only("enter staging mode, create dds, and merge", async () => {
+		const deltaConnectionServer = LocalDeltaConnectionServer.create();
+		const clients = await createClients(deltaConnectionServer);
+
+		const branchData = clients.original.dataObject.enterStagingMode();
+		assert.deepStrictEqual(
+			clients.original.dataObject.state,
+			clients.loaded.dataObject.state,
+			"states should match after branch",
+		);
+
+		clients.original.dataObject.addDDS("branch-only");
+		clients.loaded.dataObject.makeEdit("after-branch");
+
+		assert.notDeepStrictEqual(
+			clients.original.dataObject.state,
+			clients.loaded.dataObject.state,
+			"should not match before save",
+		);
+
+		await waitForSave([clients.loaded]);
+
+		// Wait for the mainline changes to propagate
+		//* TODO: Need some of e2e test utils like ContainerLoaderTracker to properly wait here
+		await new Promise<void>((resolve) => setTimeout(resolve, 100));
+
+		assert.notDeepStrictEqual(
+			clients.original.dataObject.state,
+			clients.loaded.dataObject.state,
+			"should not match after save",
+		);
+
+		const branchState = clients.original.dataObject.state;
+		assert.notEqual(
+			Object.keys(branchState).find((k) => k.startsWith("after-branch")),
+			undefined,
+			"Expected mainline change to reach branch",
+		);
+
+		branchData.commitChanges();
+
+		await waitForSave(clients);
+
+		assert.deepStrictEqual(
+			await clients.original.dataObject.loadState(),
+			await clients.loaded.dataObject.loadState(),
 			"states should match after save",
 		);
 	});

--- a/packages/test/local-server-tests/src/test/stagingMode.spec.ts
+++ b/packages/test/local-server-tests/src/test/stagingMode.spec.ts
@@ -245,7 +245,7 @@ describe("Scenario Test", () => {
 		);
 	});
 
-	it.only("enter staging mode, create dds, and merge", async () => {
+	it("enter staging mode, create dds, and merge", async () => {
 		const deltaConnectionServer = LocalDeltaConnectionServer.create();
 		const clients = await createClients(deltaConnectionServer);
 


### PR DESCRIPTION
some dds use the pre-serialized message on resubmit, this change catches that and ensure the real handle is bound before sending the messages. There is definitely a memory leak here in the reject case, which is acceptable for the prototype, but we'll need a more robust solution once we build the real thing.