### PR TITLE
Allow access to rootChanged via TreeBranchEvents

### DIFF
--- a/.changeset/hungry-insects-push.md
+++ b/.changeset/hungry-insects-push.md
@@ -8,4 +8,4 @@
 
 `TreeBranchEvents` exposes `rootChanged`
 
-`TreeBranchEvents` not includes the `rootChanged` event from `TreeViewEvents`.
+`TreeBranchEvents` now includes the `rootChanged` event from `TreeViewEvents`.

--- a/.changeset/hungry-insects-push.md
+++ b/.changeset/hungry-insects-push.md
@@ -1,0 +1,11 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+---
+---
+"section": tree
+---
+
+`TreeBranchEvents` exposes `rootChanged`
+
+`TreeBranchEvents` not includes the `rootChanged` event from `TreeViewEvents`.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -878,10 +878,9 @@ export interface TreeBranch extends IDisposable {
 }
 
 // @alpha @sealed
-export interface TreeBranchEvents {
+export interface TreeBranchEvents extends Omit<TreeViewEvents, "commitApplied"> {
     changed(data: CommitMetadata, getRevertible?: RevertibleAlphaFactory): void;
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleAlphaFactory): void;
-    schemaChanged(): void;
 }
 
 // @alpha @sealed

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -725,12 +725,7 @@ export interface SchemaCompatibilityStatus {
  * Events for {@link TreeBranch}.
  * @sealed @alpha
  */
-export interface TreeBranchEvents {
-	/**
-	 * The stored schema for the document has changed.
-	 */
-	schemaChanged(): void;
-
+export interface TreeBranchEvents extends Omit<TreeViewEvents, "commitApplied"> {
 	/**
 	 * Fired when a change is made to the branch. Includes data about the change that is made which listeners
 	 * can use to filter on changes they care about (e.g. local vs. remote changes).

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1258,10 +1258,9 @@ export interface TreeBranch extends IDisposable {
 }
 
 // @alpha @sealed
-export interface TreeBranchEvents {
+export interface TreeBranchEvents extends Omit<TreeViewEvents, "commitApplied"> {
     changed(data: CommitMetadata, getRevertible?: RevertibleAlphaFactory): void;
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleAlphaFactory): void;
-    schemaChanged(): void;
 }
 
 // @alpha @sealed


### PR DESCRIPTION
## Description

`TreeBranchEvents` now includes the `rootChanged` event from `TreeViewEvents`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).