### PR TITLE
Best effort attempt to upgrade publish docker service to 1es deployment job

### DIFF
--- a/tools/pipelines/templates/include-publish-docker-service-steps.yml
+++ b/tools/pipelines/templates/include-publish-docker-service-steps.yml
@@ -85,5 +85,5 @@ jobs:
     # The `type: releaseJob` value makes this deployment job 1ES compliant.
     # see https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/releasepipelines/releaseworkflows/releasejob?tabs=combined-pipeline for more info.
     type: releaseJob
-    # This stage is only run in a production setting.
+    # This template is only referenced when publishing docker images to the public container registry, so it's always "production"
     isProduction: true

--- a/tools/pipelines/templates/include-publish-docker-service-steps.yml
+++ b/tools/pipelines/templates/include-publish-docker-service-steps.yml
@@ -82,3 +82,8 @@ jobs:
     # specified as a runtime variable (variables from variable groups apparently are never available "statically"
     # at parse/compile time, so can't be used with template-expression syntax ( '${{ }}' )).
     - serviceConnection: $(containerRegistryConnection)
+    # The `type: releaseJob` value makes this deployment job 1ES compliant.
+    # see https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/releasepipelines/releaseworkflows/releasejob?tabs=combined-pipeline for more info.
+    type: releaseJob
+    # This stage is only run in a production setting.
+    isProduction: true


### PR DESCRIPTION

## Description
 
1es pipelines have warnings requiring that all [deployment jobs](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/deployment-jobs?view=azure-devops) transition to release jobs (see [Custom Release Job | 1ES On EngHub](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/releasepipelines/releaseworkflows/releasejob?tabs=combined-pipeline)).

The docker publish pipeline is only run on new releases and is currently not working as expected (Even without these changes).

Given the infrequency of the pipeline running and its existing problems, this PR is a best effort attempt to convert it to a 1ES release job. The changes are simple and straightforward. This pipeline does not seem to violate any of the rules required of a 1ES release job and thus is does not require any modifications.


## Reviewer Guidance
1ES Release Job Requirements: (see links above for more details)
- You have to classify the release job as production or non-production based on whether you deploy to a production or non-production environment (in the case of deploying to Azure, this must match the Azure subscription classification in Service Tree).
- You have to declare all the artifacts required for the release as inputs for the job (this is similar to the concept of outputs in a standard build job).
- You can't build source code in a release job (this is to ensure all artifacts have been binary scanned in a build job output).
- You can't check out repositories. All artifacts must be generated and published from a 1ES PT build job and declared as an input.
- All 1ES PT pipelines must use a [1ES hosted pool](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboardingesteams/overview).
