### PR TITLE
Exclude .next folder from VSCode search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -110,6 +110,8 @@
 		"**/_api-extractor-temp": true,
 		// exclude built `dist` folders
 		"**/dist/*": true,
+		// exclude built `.next` folders (from NextJS' local dev server)
+		"**/.next/*": true,
 		// exclude built `lib` folders but preserve ./common/lib
 		//   paths with packages container
 		"**/packages/**/lib/*": true,


### PR DESCRIPTION
## Description

The ai-collab example app (examples/apps/ai-collab) uses NextJS. The local dev server workflow for it creates a `.next` folder with build output, that is usually not relevant when we do searches in the codebase. So this PR excludes the folder from the search results.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).