### PR TITLE
Fix test to use createContainerRuntimeFactoryWithDefaultDataStore

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summarization/summaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summaryHandles.spec.ts
@@ -11,6 +11,7 @@ import { IFluidHandle, IRequestHeader } from "@fluidframework/core-interfaces";
 import {
 	ITestFluidObject,
 	ITestObjectProvider,
+	createContainerRuntimeFactoryWithDefaultDataStore,
 	createTestConfigProvider,
 	createSummarizerFromFactory,
 	summarizeNow,
@@ -25,9 +26,9 @@ import {
  *
  * ADO:18003
  */
-describeCompat.skip(
+describeCompat(
 	"Summary handles work as expected",
-	"NoCompat",
+	"FullCompat",
 	(getTestObjectProvider, apis) => {
 		const configProvider = createTestConfigProvider();
 		const {
@@ -36,17 +37,20 @@ describeCompat.skip(
 			dds: { SharedDirectory },
 		} = apis;
 		const defaultFactory = new TestFluidObjectFactory([]);
-		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
-			defaultFactory,
-			registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
-			runtimeOptions: {
-				summaryOptions: {
-					summaryConfigOverrides: {
-						state: "disabled",
+		const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
+			ContainerRuntimeFactoryWithDefaultDataStore,
+			{
+				defaultFactory,
+				registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
+				runtimeOptions: {
+					summaryOptions: {
+						summaryConfigOverrides: {
+							state: "disabled",
+						},
 					},
 				},
-			},
-		});
+			}
+		);
 
 		let provider: ITestObjectProvider;
 
@@ -59,7 +63,8 @@ describeCompat.skip(
 
 		it("A data store id with special character `[` works properly with summary handles", async () => {
 			// Enable short ids for this test to create a data store with special chanracter.
-			configProvider.set("Fluid.Runtime.UseShortIds", true);
+			// configProvider.set("Fluid.Runtime.UseShortIds", true);
+			configProvider.set("Fluid.Container.summarizeProtocolTree2", true);
 			const container = await provider.createDetachedContainer(runtimeFactory, {
 				configProvider,
 			});

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summaryHandles.spec.ts
@@ -49,7 +49,7 @@ describeCompat.skip(
 						},
 					},
 				},
-			}
+			},
 		);
 
 		let provider: ITestObjectProvider;

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summaryHandles.spec.ts
@@ -20,15 +20,15 @@ import {
 /**
  * The test is skipped as we have an existing bug in our code where if the use of short ids for data stores and dds is enabled, the summaries will start failing.
  * Without short ids, the code works because the handle for a tree node is exactly able to point to a path of node in the summary tree, because the ids do not have any special characters which
- * could change with the encodeURIComponent(). Once shortids feature is enabled in container runtime, the ids can have special characters (like '[' ) which can result in a handle containing %5b -
+ * could change with the encodeURIComponent(). Once ShortIds feature is enabled in container runtime, the ids can have special characters (like '[' ) which can result in a handle containing %5b -
  * this will be problematic because when uploading a summary with such handles, the server will try to look for a path with %5b but will not find it, as the path to the tree will still be '['
  * since we removed encoding logic from the driver layer with this PR: https://github.com/microsoft/FluidFramework/pull/21680
  *
  * ADO:18003
  */
-describeCompat(
+describeCompat.skip(
 	"Summary handles work as expected",
-	"FullCompat",
+	"NoCompat",
 	(getTestObjectProvider, apis) => {
 		const configProvider = createTestConfigProvider();
 		const {
@@ -62,8 +62,9 @@ describeCompat(
 		});
 
 		it("A data store id with special character `[` works properly with summary handles", async () => {
-			// Enable short ids for this test to create a data store with special chanracter.
-			// configProvider.set("Fluid.Runtime.UseShortIds", true);
+			// Enable short ids for this test to create a data store with special character.
+			configProvider.set("Fluid.Runtime.UseShortIds", true);
+			// Enable single-commit summaries so that when the test runs with old odsp driver, it doesn't fail with summary nacks.
 			configProvider.set("Fluid.Container.summarizeProtocolTree2", true);
 			const container = await provider.createDetachedContainer(runtimeFactory, {
 				configProvider,


### PR DESCRIPTION
- Renamed `summarizeNode.spec.ts` --> `summaryHandles.spec.ts`
- The test now uses `createContainerRuntimeFactoryWithDefaultDataStore` instead of `new ContainerRuntimeFactoryWithDefaultDataStore` so that it works with older versions of runtime when running in FullCompat mode.
- Spellcheck fixes