### PR TITLE
Local Server Stress: Timeout external promises to ease debugging

### DIFF
--- a/packages/test/local-server-stress-tests/src/ddsOperations.ts
+++ b/packages/test/local-server-stress-tests/src/ddsOperations.ts
@@ -17,6 +17,7 @@ import { toFluidHandleInternal } from "@fluidframework/runtime-utils/internal";
 import { ddsModelMap } from "./ddsModels.js";
 import { LocalServerStressState, Client } from "./localServerStressHarness.js";
 import { makeUnreachableCodePathProxy } from "./utils.js";
+import { timeoutAwait } from "@fluidframework/test-utils";
 
 export interface DDSModelOp {
 	type: "DDSModelOp";
@@ -82,7 +83,9 @@ export const DDSModelOpGenerator: AsyncGenerator<DDSModelOp, LocalServerStressSt
 	const model = ddsModelMap.get(channel.attributes.type);
 	assert(model !== undefined, "must have model");
 
-	const op = await model.generator(await covertLocalServerStateToDdsState(state));
+	const op = await timeoutAwait(
+		model.generator(await covertLocalServerStateToDdsState(state)),
+	);
 
 	return {
 		type: "DDSModelOp",
@@ -115,7 +118,7 @@ export const DDSModelOpReducer: AsyncReducer<DDSModelOp, LocalServerStressState>
 		}
 		return value;
 	});
-	await baseModel.reducer(await covertLocalServerStateToDdsState(state), subOp);
+	await timeoutAwait(baseModel.reducer(await covertLocalServerStateToDdsState(state), subOp));
 };
 
 export const validateConsistencyOfAllDDS = async (clientA: Client, clientB: Client) => {

--- a/packages/test/local-server-stress-tests/src/stressDataObject.ts
+++ b/packages/test/local-server-stress-tests/src/stressDataObject.ts
@@ -65,9 +65,8 @@ export class StressDataObject extends DataObject {
 		"defaultStressDataObject",
 	);
 	protected async getDefaultStressDataObject(): Promise<DefaultStressDataObject> {
-		const defaultDataStore = await timeoutAwait(
-			this.context.containerRuntime.getAliasedDataStoreEntryPoint("default"),
-		);
+		const defaultDataStore =
+			await this.context.containerRuntime.getAliasedDataStoreEntryPoint("default");
 		assert(defaultDataStore !== undefined, "default must exist");
 
 		const maybe: FluidObject<DefaultStressDataObject> | undefined =
@@ -97,7 +96,9 @@ export class StressDataObject extends DataObject {
 			// to get all channel each time, as we have no way to
 			// observer when a channel moves from detached to attached,
 			// especially on remove clients/
-			const channel = await timeoutAwait(this.runtime.getChannel(name)).catch(() => undefined);
+			const channel = await timeoutAwait(this.runtime.getChannel(name), {
+				errorMsg: `Timed out waiting for channel: ${name}`,
+			}).catch(() => undefined);
 			if (channel !== undefined) {
 				channels.push(channel);
 			}
@@ -190,6 +191,9 @@ export class DefaultStressDataObject extends StressDataObject {
 					url,
 					headers: { [RuntimeHeaders.wait]: false },
 				}),
+				{
+					errorMsg: `Timed out waiting for client to resolveHandle: ${url}`,
+				},
 			);
 			if (resp.status === 200) {
 				const maybe: FluidObject<IFluidLoadable & StressDataObject> | undefined = resp.value;

--- a/packages/test/local-server-stress-tests/src/stressDataObject.ts
+++ b/packages/test/local-server-stress-tests/src/stressDataObject.ts
@@ -25,6 +25,7 @@ import { assert, LazyPromise, unreachableCase } from "@fluidframework/core-utils
 import type { IChannel } from "@fluidframework/datastore-definitions/internal";
 import { ISharedMap, SharedMap } from "@fluidframework/map/internal";
 import { toFluidHandleInternal } from "@fluidframework/runtime-utils/internal";
+import { timeoutAwait } from "@fluidframework/test-utils/internal";
 
 import { ddsModelMap } from "./ddsModels.js";
 import { makeUnreachableCodePathProxy } from "./utils.js";
@@ -64,8 +65,9 @@ export class StressDataObject extends DataObject {
 		"defaultStressDataObject",
 	);
 	protected async getDefaultStressDataObject(): Promise<DefaultStressDataObject> {
-		const defaultDataStore =
-			await this.context.containerRuntime.getAliasedDataStoreEntryPoint("default");
+		const defaultDataStore = await timeoutAwait(
+			this.context.containerRuntime.getAliasedDataStoreEntryPoint("default"),
+		);
 		assert(defaultDataStore !== undefined, "default must exist");
 
 		const maybe: FluidObject<DefaultStressDataObject> | undefined =
@@ -95,7 +97,7 @@ export class StressDataObject extends DataObject {
 			// to get all channel each time, as we have no way to
 			// observer when a channel moves from detached to attached,
 			// especially on remove clients/
-			const channel = await this.runtime.getChannel(name).catch(() => undefined);
+			const channel = await timeoutAwait(this.runtime.getChannel(name)).catch(() => undefined);
 			if (channel !== undefined) {
 				channels.push(channel);
 			}
@@ -183,10 +185,12 @@ export class DefaultStressDataObject extends StressDataObject {
 			// Due to the both the above, we need to always try
 			// to resolve each object, and just ignore those which can't
 			// be found.
-			const resp = await containerRuntime.resolveHandle({
-				url,
-				headers: { [RuntimeHeaders.wait]: false },
-			});
+			const resp = await timeoutAwait(
+				containerRuntime.resolveHandle({
+					url,
+					headers: { [RuntimeHeaders.wait]: false },
+				}),
+			);
 			if (resp.status === 200) {
 				const maybe: FluidObject<IFluidLoadable & StressDataObject> | undefined = resp.value;
 				const handle = maybe?.IFluidLoadable?.handle;


### PR DESCRIPTION
This change adds some timeout promises and awaits to help prevent tests hangs. I've only added these in places where the code calls something external, rather than needing to do it everywhere, which makes the code messy. Possible i missed some, but we can add more if we find troublesome call sites in the future.