### PR TITLE
Local Server Stress: Allow replay to be array

### DIFF
--- a/packages/test/local-server-stress-tests/src/localServerStressHarness.ts
+++ b/packages/test/local-server-stress-tests/src/localServerStressHarness.ts
@@ -572,10 +572,7 @@ function mixinSynchronization<TOperation extends BaseOperation>(
 				if (client.container.closed || client.container.disposed === true) {
 					throw new Error(`Client ${client.tag} is closed`);
 				}
-				return (
-					client.container.connectionState !== ConnectionState.Disconnected &&
-					!client.entryPoint.inStagingMode()
-				);
+				return client.container.connectionState !== ConnectionState.Disconnected;
 			});
 
 			if (connectedClients.length > 0) {
@@ -899,9 +896,6 @@ async function runTestForSeed<TOperation extends BaseOperation>(
 		if (operation.type === finalSynchronization.type) {
 			const { clients, validationClient } = state;
 			for (const client of clients) {
-				if (client.entryPoint.inStagingMode()) {
-					client.entryPoint.exitStagingMode(true);
-				}
 				if (client.container.connectionState === ConnectionState.Disconnected) {
 					client.container.connect();
 				}

--- a/packages/test/local-server-stress-tests/src/localServerStressHarness.ts
+++ b/packages/test/local-server-stress-tests/src/localServerStressHarness.ts
@@ -280,7 +280,7 @@ export interface LocalServerStressOptions {
 	 * TODO: Improving workflows around fuzz test minimization, regression test generation for a particular seed,
 	 * or more flexibility around replay of test files would be a nice value add to this harness.
 	 */
-	replay?: number;
+	replay?: number | Iterable<number>;
 
 	/**
 	 * Runs only the provided seeds.
@@ -572,7 +572,10 @@ function mixinSynchronization<TOperation extends BaseOperation>(
 				if (client.container.closed || client.container.disposed === true) {
 					throw new Error(`Client ${client.tag} is closed`);
 				}
-				return client.container.connectionState !== ConnectionState.Disconnected;
+				return (
+					client.container.connectionState !== ConnectionState.Disconnected &&
+					!client.entryPoint.inStagingMode()
+				);
 			});
 
 			if (connectedClients.length > 0) {
@@ -896,7 +899,12 @@ async function runTestForSeed<TOperation extends BaseOperation>(
 		if (operation.type === finalSynchronization.type) {
 			const { clients, validationClient } = state;
 			for (const client of clients) {
-				client.container.connect();
+				if (client.entryPoint.inStagingMode()) {
+					client.entryPoint.exitStagingMode(true);
+				}
+				if (client.container.connectionState === ConnectionState.Disconnected) {
+					client.container.connect();
+				}
 			}
 			await synchronizeClients([validationClient, ...clients]);
 			for (const client of clients) {
@@ -1046,6 +1054,7 @@ export function createLocalServerStressSuite<TOperation extends BaseOperation>(
 
 	const only = new Set(options.only);
 	const skip = new Set(options.skip);
+	const replay = options.replay;
 	Object.assign(options, { only, skip });
 	assert(isInternalOptions(options));
 
@@ -1071,25 +1080,27 @@ export function createLocalServerStressSuite<TOperation extends BaseOperation>(
 			runTest(model, options, seed, getSaveInfo(model, options, seed));
 		}
 
-		if (options.replay !== undefined) {
-			const seed = options.replay;
+		if (replay !== undefined) {
 			describe.only(`replay from file`, () => {
-				const saveInfo = getSaveInfo(model, options, seed);
-				assert(
-					saveInfo.saveOnFailure !== false,
-					"Cannot replay a file without a directory to save files in!",
-				);
-				const operations = options.parseOperations(
-					readFileSync(saveInfo.saveOnFailure.path).toString(),
-				);
+				const replaySeeds = typeof replay === "number" ? [replay] : replay;
+				for (const seed of replaySeeds) {
+					const saveInfo = getSaveInfo(model, options, seed);
+					assert(
+						saveInfo.saveOnFailure !== false,
+						"Cannot replay a file without a directory to save files in!",
+					);
+					const operations = options.parseOperations(
+						readFileSync(saveInfo.saveOnFailure.path).toString(),
+					);
 
-				const replayModel = {
-					...model,
-					// We lose some type safety here because the options interface isn't generic
-					generatorFactory: (): AsyncGenerator<TOperation, unknown> =>
-						asyncGeneratorFromArray(operations as TOperation[]),
-				};
-				runTest(replayModel, options, seed, undefined);
+					const replayModel = {
+						...model,
+						// We lose some type safety here because the options interface isn't generic
+						generatorFactory: (): AsyncGenerator<TOperation, unknown> =>
+							asyncGeneratorFromArray(operations as TOperation[]),
+					};
+					runTest(replayModel, { ...options, skipMinimization: true }, seed, undefined);
+				}
 			});
 		}
 	});


### PR DESCRIPTION
This change aligns the replay option with only and skip, so they can now all take an array, which makes moving between while debugging easier. 