### PR TITLE
Remove deprecated summarizeProtocolTree option [breaking]

### DIFF
--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -216,7 +216,12 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_ILoaderOptions": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -18,7 +18,6 @@ export {
 	ICodeDetailsLoader,
 	IDetachedBlobStorage,
 	IFluidModuleWithDetails,
-	ILoaderOptions,
 	ILoaderProps,
 	ILoaderServices,
 	Loader,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -9,7 +9,7 @@ import {
 	IFluidModule,
 	IHostLoader,
 	ILoader,
-	ILoaderOptions as ILoaderOptions1,
+	ILoaderOptions,
 	IProvideFluidCodeDetailsComparer,
 	LoaderHeader,
 } from "@fluidframework/container-definitions/internal";
@@ -88,21 +88,6 @@ export class RelativeLoader implements ILoader {
 		}
 		return this.loader.resolve(request);
 	}
-}
-
-/**
- * @legacy
- * @alpha
- * @deprecated Use {@link @fluidframework/container-definitions#ILoaderOptions} instead
- */
-export interface ILoaderOptions extends ILoaderOptions1 {
-	/**
-	 *
-	 * @deprecated No longer needed or used (initially introduced to test single-commit summaries).
-	 * Driver layer can enable single-commit summaries via document service policies if needed.
-	 * ADO #9098: To remove declaration and usage from code.
-	 */
-	summarizeProtocolTree?: boolean;
 }
 
 /**

--- a/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
+++ b/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
@@ -211,6 +211,7 @@ declare type current_as_old_for_Interface_IFluidModuleWithDetails = requireAssig
  * typeValidation.broken:
  * "Interface_ILoaderOptions": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ILoaderOptions = requireAssignableTo<TypeOnly<old.ILoaderOptions>, TypeOnly<current.ILoaderOptions>>
 
 /*
@@ -220,6 +221,7 @@ declare type old_as_current_for_Interface_ILoaderOptions = requireAssignableTo<T
  * typeValidation.broken:
  * "Interface_ILoaderOptions": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ILoaderOptions = requireAssignableTo<TypeOnly<current.ILoaderOptions>, TypeOnly<old.ILoaderOptions>>
 
 /*


### PR DESCRIPTION
Removed deprecated ILoaderOption = summarizeProtocolTree.
-- abandoned