### PR TITLE
Remove deprecated summarizeProtocolTree option [breaking]

### DIFF
--- a/.changeset/large-sites-admire.md
+++ b/.changeset/large-sites-admire.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/container-loader": minor
+---
+---
+"section": other
+---
+
+Removed deprecated `ILoaderOptions` exported from container-loader.
+
+Previously `ILoaderOptions` exported from `container-loader` was extending the base `ILoaderOptions` defined in `container-definitions` to add an experimental `summarizeProtocolTree` property which was used to test single-commit summaries. The option is no longer required or in use, so the extended version of `ILoaderOptions` is not needed anymore.

--- a/.changeset/large-sites-admire.md
+++ b/.changeset/large-sites-admire.md
@@ -7,4 +7,4 @@
 
 Removed deprecated `ILoaderOptions` exported from container-loader.
 
-Previously `ILoaderOptions` exported from `container-loader` was extending the base `ILoaderOptions` defined in `container-definitions` to add an experimental `summarizeProtocolTree` property which was used to test single-commit summaries. The option is no longer required or in use, so the extended version of `ILoaderOptions` is not needed anymore.
+Previously `ILoaderOptions` exported from `container-loader` was extending the base `ILoaderOptions` defined in `container-definitions` to add an experimental `summarizeProtocolTree` property which was used to test single-commit summaries. The option is no longer required or in use, so the extended version of `ILoaderOptions` is not needed anymore. Use `@fluidframework/container-definitions#ILoaderOptions` instead.

--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -70,12 +70,6 @@ export interface IFluidModuleWithDetails {
     module: IFluidModule;
 }
 
-// @alpha @deprecated (undocumented)
-export interface ILoaderOptions extends ILoaderOptions_2 {
-    // @deprecated (undocumented)
-    summarizeProtocolTree?: boolean;
-}
-
 // @alpha
 export interface ILoaderProps {
     readonly codeLoader: ICodeDetailsLoader;

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -216,7 +216,12 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_ILoaderOptions": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -18,7 +18,6 @@ export {
 	ICodeDetailsLoader,
 	IDetachedBlobStorage,
 	IFluidModuleWithDetails,
-	ILoaderOptions,
 	ILoaderProps,
 	ILoaderServices,
 	Loader,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -90,7 +90,6 @@ export class RelativeLoader implements ILoader {
 	}
 }
 
-
 /**
  * @deprecated IFluidModuleWithDetails interface is moved to
  * {@link @fluidframework/container-definitions#IFluidModuleWithDetails}

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -9,7 +9,7 @@ import {
 	IFluidModule,
 	IHostLoader,
 	ILoader,
-	ILoaderOptions as ILoaderOptions1,
+	ILoaderOptions,
 	IProvideFluidCodeDetailsComparer,
 	LoaderHeader,
 } from "@fluidframework/container-definitions/internal";
@@ -90,20 +90,6 @@ export class RelativeLoader implements ILoader {
 	}
 }
 
-/**
- * @legacy
- * @alpha
- * @deprecated Use {@link @fluidframework/container-definitions#ILoaderOptions} instead
- */
-export interface ILoaderOptions extends ILoaderOptions1 {
-	/**
-	 *
-	 * @deprecated No longer needed or used (initially introduced to test single-commit summaries).
-	 * Driver layer can enable single-commit summaries via document service policies if needed.
-	 * ADO #9098: To remove declaration and usage from code.
-	 */
-	summarizeProtocolTree?: boolean;
-}
 
 /**
  * @deprecated IFluidModuleWithDetails interface is moved to

--- a/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
+++ b/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
@@ -211,6 +211,7 @@ declare type current_as_old_for_Interface_IFluidModuleWithDetails = requireAssig
  * typeValidation.broken:
  * "Interface_ILoaderOptions": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ILoaderOptions = requireAssignableTo<TypeOnly<old.ILoaderOptions>, TypeOnly<current.ILoaderOptions>>
 
 /*
@@ -220,6 +221,7 @@ declare type old_as_current_for_Interface_ILoaderOptions = requireAssignableTo<T
  * typeValidation.broken:
  * "Interface_ILoaderOptions": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ILoaderOptions = requireAssignableTo<TypeOnly<current.ILoaderOptions>, TypeOnly<old.ILoaderOptions>>
 
 /*


### PR DESCRIPTION
Removed deprecated ILoaderOption = summarizeProtocolTree.

summarizeProtocolTree property in ILoaderOptions (the extended definition in container layer) was added to test single-commit summaries during the initial implementation phase. The flag is no longer required or should be used, so marked it as deprecated. If a driver needs to enable or disable single-commit summaries, it can do so via IDocumentServicePolicies.

[AB#9098](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/9098)
#23320 