### PR TITLE
Set debugAssert enablement to opposite of isInPerformanceTestingMode in tree benchmarks

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -45,6 +45,7 @@ import {
 	StringArray,
 	TestTreeProviderLite,
 	checkoutWithContent,
+	configureBenchmarkHooks,
 	chunkFromJsonTrees,
 	flexTreeViewWithContent,
 	toJsonableTree,
@@ -75,6 +76,7 @@ const factory = new TreeFactory({
 
 // TODO: Once the "BatchTooLarge" error is no longer an issue, extend tests for larger trees.
 describe("SharedTree benchmarks", () => {
+	configureBenchmarkHooks();
 	describe("Direct JS Object", () => {
 		for (const [numberOfNodes, benchmarkType] of nodesCountDeep) {
 			let tree: JSDeepTree;

--- a/packages/dds/tree/src/test/shared-tree/summary.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/summary.bench.ts
@@ -22,7 +22,7 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { TestTreeProviderLite, testIdCompressor } from "../utils.js";
+import { TestTreeProviderLite, configureBenchmarkHooks, testIdCompressor } from "../utils.js";
 import { TreeViewConfiguration, type ImplicitFieldSchema } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import type { TreeSimpleContentTyped } from "../feature-libraries/flex-tree/utils.js";
@@ -51,6 +51,7 @@ const nodesCountDeep: [numberOfNodes: number, minLength: number, maxLength: numb
 ];
 
 describe("Summary benchmarks", () => {
+	configureBenchmarkHooks();
 	// TODO: report these sizes as benchmark output which can be tracked over time.
 	describe("size of", () => {
 		it("an empty tree.", async () => {

--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -18,6 +18,7 @@ import {
 } from "./benchmarkUtilities.js";
 import { SchemaFactory } from "../../simple-tree/index.js";
 import { hydrate, hydrateUnsafe } from "./utils.js";
+import { configureBenchmarkHooks } from "../utils.js";
 
 // number of nodes in test for wide trees
 const nodesCountWide = [
@@ -33,6 +34,7 @@ const nodesCountDeep = [
 ];
 
 describe("SimpleTree benchmarks", () => {
+	configureBenchmarkHooks();
 	describe("Read SimpleTree", () => {
 		const leafValue = 1;
 		for (const [numberOfNodes, benchmarkType] of nodesCountDeep) {

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1336,7 +1336,8 @@ export function moveWithin(
 }
 
 /**
- * Invoke inside a describe block for benchmarks to add hooks that configure things for maximum performance if isInPerformanceTestingMode
+ * Invoke inside a describe block for benchmarks to add hooks that configure things for maximum performance if isInPerformanceTestingMode,
+ * and enable debug asserts otherwise.
  */
 export function configureBenchmarkHooks(): void {
 	let debugBefore: boolean;

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -172,6 +172,8 @@ import {
 	MockContainerRuntimeFactoryWithOpBunching,
 	type MockContainerRuntimeWithOpBunching,
 } from "./mocksForOpBunching.js";
+import { configureDebugAsserts } from "@fluidframework/core-utils/internal";
+import { isInPerformanceTestingMode } from "@fluid-tools/benchmark";
 
 // Testing utilities
 
@@ -1331,6 +1333,19 @@ export function moveWithin(
 	destIndex: number,
 ) {
 	editor.move(field, sourceIndex, count, field, destIndex);
+}
+
+/**
+ * Invoke inside a describe block for benchmarks to add hooks that configure things for maximum performance if isInPerformanceTestingMode
+ */
+export function configureBenchmarkHooks(): void {
+	let debugBefore: boolean;
+	before(() => {
+		debugBefore = configureDebugAsserts(!isInPerformanceTestingMode);
+	});
+	after(() => {
+		assert.equal(configureDebugAsserts(debugBefore), !isInPerformanceTestingMode);
+	});
 }
 
 export function chunkFromJsonTrees(field: JsonCompatible[]): TreeChunk {


### PR DESCRIPTION
## Description

Set debugAssert enablement to opposite of isInPerformanceTestingMode in tree benchmarks.

Note that debugAsserts are currently disabled by default, so this is opting into them for correctness mode of perf tests.
This is designed to still work correctly if/when debug asserts are enabled by default, and/or enabled for all tests.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

