### PR TITLE
Reduce calls from Deli to Historian

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -68,6 +68,7 @@ export class DeliLambdaFactory
 		private readonly reverseProducer: IProducer,
 		private readonly serviceConfiguration: IServiceConfiguration,
 		private readonly clusterDrainingChecker?: IClusterDrainingChecker | undefined,
+		private readonly ephemeralDocumentTTLSec?: number,
 	) {
 		super();
 	}
@@ -227,14 +228,27 @@ export class DeliLambdaFactory
 				) {
 					if (document?.isEphemeralContainer) {
 						if (this.serviceConfiguration.deli.enableEphemeralContainerSummaryCleanup) {
-							// Call to historian to delete summaries
-							await requestWithRetry(
-								async () => gitManager.deleteSummary(false),
-								"deliLambda_onClose" /* callName */,
-								baseLumberjackProperties /* telemetryProperties */,
-								undefined /* shouldRetry */, // The default retry function will ensure NetworkErrors are retried only if canRetry is true and isFatal is false
-								3 /* maxRetries */,
-							);
+							if (this.isEphemeralDocumentWithinTtl(document)) {
+								// Call to historian to delete summaries
+								await requestWithRetry(
+									async () => gitManager.deleteSummary(false),
+									"deliLambda_onClose" /* callName */,
+									baseLumberjackProperties /* telemetryProperties */,
+									undefined /* shouldRetry */, // The default retry function will ensure NetworkErrors are retried only if canRetry is true and isFatal is false
+									3 /* maxRetries */,
+								);
+							} else {
+								Lumberjack.info(
+									"Ephemeral container TTL has expired, not calling deleteSummary",
+									{
+										...baseLumberjackProperties,
+										documentCreationTime: document.createTime,
+										documentExpirationTime:
+											document.createTime +
+											(this.ephemeralDocumentTTLSec ?? 0) * 1000,
+									},
+								);
+							}
 						}
 
 						// Delete the document metadata, soft or hard depending on the configuration
@@ -386,6 +400,19 @@ export class DeliLambdaFactory
 			signalProducerClosedP,
 			reverseProducerClosedP,
 		]);
+	}
+
+	private isEphemeralDocumentWithinTtl(document: IDocument): boolean {
+		if (this.ephemeralDocumentTTLSec === undefined) {
+			// If we do not have a TTL value available, then we assume that the document is within TTL
+			// to keep the behavior consistent with the existing implementation.
+			return true;
+		}
+
+		const currentTime = Date.now();
+		const documentExpirationTime = document.createTime + this.ephemeralDocumentTTLSec * 1000;
+
+		return currentTime <= documentExpirationTime;
 	}
 
 	// Fetches last durable deli state from summary. Returns undefined if not present.

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -232,7 +232,7 @@ export class DeliLambdaFactory
 								async () => gitManager.deleteSummary(false),
 								"deliLambda_onClose" /* callName */,
 								baseLumberjackProperties /* telemetryProperties */,
-								(error) => true /* shouldRetry */,
+								undefined /* shouldRetry */, // The default retry function will ensure NetworkErrors are retried only if canRetry is true and isFatal is false
 								3 /* maxRetries */,
 							);
 						}

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -65,6 +65,9 @@ export async function deliCreate(
 	const internalHistorianUrl = config.get("worker:internalBlobStorageUrl");
 	const tenantManager = new services.TenantManager(authEndpoint, internalHistorianUrl);
 	const globalDbEnabled = config.get("mongo:globalDbEnabled") as boolean;
+	const ephemeralDocumentTTLSec = config.get("storage:ephemeralDocumentTTLSec") as
+		| number
+		| undefined;
 	// Database connection for global db if enabled
 	const factory = await services.getDbFactory(config);
 
@@ -218,6 +221,7 @@ export async function deliCreate(
 		reverseProducer,
 		serviceConfiguration,
 		customizations?.clusterDrainingChecker,
+		ephemeralDocumentTTLSec,
 	);
 
 	deliLambdaFactory.on("dispose", () => {


### PR DESCRIPTION
## Description

After document inactivity or a fatal error, Deli will attempt to clean up ECs by calling `deleteSummary` in Historian. In this PR there are two changes to reduce the number of calls from Deli to Historian:

1) If the current time > the EC TTL + doc.createTime, then we can assume that the container no longer exists on RedisFs and we need not invoke `deleteSummary` explicitly.
2) If the current time <= the EC TTL + doc.createTime, then we ask Historian to delete the EC summary. However, we let `requestWithRetry` handle the logic to retry NetworkErrors. This will reduce calls to Historian which continously result in a 404.

## Breaking Changes

The existing functionality of Deli does not differ. Hence, there are no breaking changes.
