### PR TITLE
On load SharedTree conversion prototype

### DIFF
--- a/examples/apps/tree-comparison/src/model/appModel.ts
+++ b/examples/apps/tree-comparison/src/model/appModel.ts
@@ -12,6 +12,6 @@ import type { IInventoryList, IInventoryListAppModel } from "../modelInterfaces.
 export class InventoryListAppModel implements IInventoryListAppModel {
 	public constructor(
 		public readonly legacyTreeInventoryList: IInventoryList,
-		public readonly newTreeInventoryList: IInventoryList,
+		// public readonly newTreeInventoryList: IInventoryList,
 	) {}
 }

--- a/examples/apps/tree-comparison/src/model/appModel.ts
+++ b/examples/apps/tree-comparison/src/model/appModel.ts
@@ -10,8 +10,5 @@ import type { IInventoryList, IInventoryListAppModel } from "../modelInterfaces.
  * and the other using new SharedTree.  They function the same and share the same interface.
  */
 export class InventoryListAppModel implements IInventoryListAppModel {
-	public constructor(
-		public readonly legacyTreeInventoryList: IInventoryList,
-		// public readonly newTreeInventoryList: IInventoryList,
-	) {}
+	public constructor(public readonly legacyTreeInventoryList: IInventoryList) {}
 }

--- a/examples/apps/tree-comparison/src/model/containerCode.ts
+++ b/examples/apps/tree-comparison/src/model/containerCode.ts
@@ -13,23 +13,31 @@ import type { IContainerRuntime } from "@fluidframework/container-runtime-defini
 import type { IInventoryList, IInventoryListAppModel } from "../modelInterfaces.js";
 
 import { InventoryListAppModel } from "./appModel.js";
-import { LegacyTreeInventoryListFactory } from "./legacyTreeInventoryList.js";
-import { NewTreeInventoryListFactory } from "./newTreeInventoryList.js";
+import {
+	LegacyTreeInventoryListFactory,
+	LegacyTreeInventoryListFactoryNew,
+} from "./legacyTreeInventoryList.js";
+// import { NewTreeInventoryListFactory } from "./newTreeInventoryList.js";
 
 export const legacyTreeInventoryListId = "legacy-tree-inventory-list";
-export const newTreeInventoryListId = "new-tree-inventory-list";
+// export const newTreeInventoryListId = "new-tree-inventory-list";
 
 /**
  * @internal
  */
 export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeFactory<IInventoryListAppModel> {
-	public constructor() {
+	public constructor(useNew: boolean = false) {
 		super(
 			new Map([
-				LegacyTreeInventoryListFactory.registryEntry,
-				NewTreeInventoryListFactory.registryEntry,
+				useNew
+					? LegacyTreeInventoryListFactoryNew.registryEntry
+					: LegacyTreeInventoryListFactory.registryEntry,
+				// NewTreeInventoryListFactory.registryEntry,
 			]), // registryEntries
-			{ enableRuntimeIdCompressor: "on" },
+			{
+				enableRuntimeIdCompressor: "on",
+				summaryOptions: { summaryConfigOverrides: { state: "disabled" } },
+			},
 		);
 	}
 
@@ -41,10 +49,10 @@ export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeF
 			LegacyTreeInventoryListFactory.type,
 		);
 		await legacyTreeInventoryList.trySetAlias(legacyTreeInventoryListId);
-		const newTreeInventoryList = await runtime.createDataStore(
-			NewTreeInventoryListFactory.type,
-		);
-		await newTreeInventoryList.trySetAlias(newTreeInventoryListId);
+		// const newTreeInventoryList = await runtime.createDataStore(
+		// 	NewTreeInventoryListFactory.type,
+		// );
+		// await newTreeInventoryList.trySetAlias(newTreeInventoryListId);
 	}
 
 	/**
@@ -55,10 +63,10 @@ export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeF
 			runtime,
 			legacyTreeInventoryListId,
 		);
-		const newTreeInventoryList = await getDataStoreEntryPoint<IInventoryList>(
-			runtime,
-			newTreeInventoryListId,
-		);
-		return new InventoryListAppModel(legacyTreeInventoryList, newTreeInventoryList);
+		// const newTreeInventoryList = await getDataStoreEntryPoint<IInventoryList>(
+		// 	runtime,
+		// 	newTreeInventoryListId,
+		// );
+		return new InventoryListAppModel(legacyTreeInventoryList);
 	}
 }

--- a/examples/apps/tree-comparison/src/model/containerCode.ts
+++ b/examples/apps/tree-comparison/src/model/containerCode.ts
@@ -17,10 +17,8 @@ import {
 	LegacyTreeInventoryListFactory,
 	LegacyTreeInventoryListFactoryNew,
 } from "./legacyTreeInventoryList.js";
-// import { NewTreeInventoryListFactory } from "./newTreeInventoryList.js";
 
 export const legacyTreeInventoryListId = "legacy-tree-inventory-list";
-// export const newTreeInventoryListId = "new-tree-inventory-list";
 
 /**
  * @internal
@@ -32,7 +30,6 @@ export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeF
 				useNew
 					? LegacyTreeInventoryListFactoryNew.registryEntry
 					: LegacyTreeInventoryListFactory.registryEntry,
-				// NewTreeInventoryListFactory.registryEntry,
 			]), // registryEntries
 			{
 				enableRuntimeIdCompressor: "on",
@@ -49,10 +46,6 @@ export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeF
 			LegacyTreeInventoryListFactory.type,
 		);
 		await legacyTreeInventoryList.trySetAlias(legacyTreeInventoryListId);
-		// const newTreeInventoryList = await runtime.createDataStore(
-		// 	NewTreeInventoryListFactory.type,
-		// );
-		// await newTreeInventoryList.trySetAlias(newTreeInventoryListId);
 	}
 
 	/**
@@ -63,10 +56,6 @@ export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeF
 			runtime,
 			legacyTreeInventoryListId,
 		);
-		// const newTreeInventoryList = await getDataStoreEntryPoint<IInventoryList>(
-		// 	runtime,
-		// 	newTreeInventoryListId,
-		// );
 		return new InventoryListAppModel(legacyTreeInventoryList);
 	}
 }

--- a/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
+++ b/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
@@ -43,7 +43,7 @@ export class InventorySchema extends builder.object("Contoso:Inventory-1.0.0", {
 
 export const treeConfiguration = new TreeViewConfiguration({ schema: InventorySchema });
 
-const sharedTreeKey = "sharedTree";
+export const sharedTreeKey = "sharedTree";
 
 /**
  * NewTreeInventoryItem is the local object with a friendly interface for the view to use.
@@ -89,6 +89,7 @@ class NewTreeInventoryItem
 }
 
 export class NewTreeInventoryList extends DataObject implements IInventoryList {
+	public isNewTree = true;
 	private _sharedTree: ITree | undefined;
 	private get sharedTree(): ITree {
 		if (this._sharedTree === undefined) {

--- a/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
+++ b/examples/apps/tree-comparison/src/model/newTreeInventoryList.ts
@@ -43,7 +43,7 @@ export class InventorySchema extends builder.object("Contoso:Inventory-1.0.0", {
 
 export const treeConfiguration = new TreeViewConfiguration({ schema: InventorySchema });
 
-export const sharedTreeKey = "sharedTree";
+export const newSharedTreeKey = "sharedTree";
 
 /**
  * NewTreeInventoryItem is the local object with a friendly interface for the view to use.
@@ -140,12 +140,12 @@ export class NewTreeInventoryList extends DataObject implements IInventoryList {
 			}),
 		);
 		view.dispose();
-		this.root.set(sharedTreeKey, this._sharedTree.handle);
+		this.root.set(newSharedTreeKey, this._sharedTree.handle);
 	}
 
 	protected async hasInitialized(): Promise<void> {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		this._sharedTree = await this.root.get<IFluidHandle<ITree>>(sharedTreeKey)!.get();
+		this._sharedTree = await this.root.get<IFluidHandle<ITree>>(newSharedTreeKey)!.get();
 		const view = this.sharedTree.viewWith(treeConfiguration);
 		this._inventoryItemList = view.root.inventoryItemList;
 		// "treeChanged" will fire for any change of any type anywhere in the subtree. In this application we expect

--- a/examples/apps/tree-comparison/src/modelInterfaces.ts
+++ b/examples/apps/tree-comparison/src/modelInterfaces.ts
@@ -18,7 +18,7 @@ export interface IInventoryListAppModel {
 	/**
 	 * An inventory tracker list using the new shared tree.
 	 */
-	readonly newTreeInventoryList: IInventoryList;
+	// readonly newTreeInventoryList: IInventoryList;
 }
 
 export interface IInventoryItemEvents {
@@ -45,4 +45,6 @@ export interface IInventoryList extends EventEmitter {
 	 * TODO: Consider using tiny-typed-emitter if not using DataObject
 	 */
 	on(event: "itemAdded" | "itemDeleted", listener: (item: IInventoryItem) => void): this;
+
+	readonly isNewTree: boolean;
 }

--- a/examples/apps/tree-comparison/src/start.ts
+++ b/examples/apps/tree-comparison/src/start.ts
@@ -36,18 +36,20 @@ const render = (model: IInventoryListAppModel) => {
 };
 
 async function start(): Promise<void> {
-	const modelLoader = new TinyliciousModelLoader<IInventoryListAppModel>(
-		new StaticCodeLoader(new InventoryListContainerRuntimeFactory()),
-	);
-
 	let id: string;
 	let model: IInventoryListAppModel;
 
 	if (location.hash.length === 0) {
+		const modelLoader = new TinyliciousModelLoader<IInventoryListAppModel>(
+			new StaticCodeLoader(new InventoryListContainerRuntimeFactory(false)),
+		);
 		const createResponse = await modelLoader.createDetached("1.0");
 		model = createResponse.model;
 		id = await createResponse.attach();
 	} else {
+		const modelLoader = new TinyliciousModelLoader<IInventoryListAppModel>(
+			new StaticCodeLoader(new InventoryListContainerRuntimeFactory(true)),
+		);
 		id = location.hash.substring(1);
 		model = await modelLoader.loadExisting(id);
 	}

--- a/examples/apps/tree-comparison/src/view/appView.tsx
+++ b/examples/apps/tree-comparison/src/view/appView.tsx
@@ -22,10 +22,10 @@ export const InventoryListAppView: React.FC<IInventoryListAppViewProps> = ({
 }: IInventoryListAppViewProps) => {
 	return (
 		<>
-			<h1>Using legacy SharedTree</h1>
+			{/* <h1>Using legacy SharedTree</h1> */}
 			<InventoryListView inventoryList={model.legacyTreeInventoryList} />
-			<h1>Using new SharedTree</h1>
-			<InventoryListView inventoryList={model.newTreeInventoryList} />
+			{/* <h1>Using new SharedTree</h1>
+			<InventoryListView inventoryList={model.newTreeInventoryList} /> */}
 		</>
 	);
 };

--- a/examples/apps/tree-comparison/src/view/inventoryView.tsx
+++ b/examples/apps/tree-comparison/src/view/inventoryView.tsx
@@ -156,23 +156,26 @@ export const InventoryListView: FC<IInventoryListViewProps> = ({
 	});
 
 	return (
-		<table style={{ margin: "0 auto", textAlign: "left", borderCollapse: "collapse" }}>
-			<thead>
-				<tr>
-					<th>Inventory item</th>
-					<th>Quantity</th>
-				</tr>
-			</thead>
-			<tbody>
-				{inventoryItemViews.length > 0 ? (
-					inventoryItemViews
-				) : (
+		<div>
+			<h1>Using {inventoryList.isNewTree ? "new" : "legacy"} SharedTree</h1>
+			<table style={{ margin: "0 auto", textAlign: "left", borderCollapse: "collapse" }}>
+				<thead>
 					<tr>
-						<td colSpan={2}>No items in inventory</td>
+						<th>Inventory item</th>
+						<th>Quantity</th>
 					</tr>
-				)}
-				<AddItemView addItem={inventoryList.addItem} disabled={disabled} />
-			</tbody>
-		</table>
+				</thead>
+				<tbody>
+					{inventoryItemViews.length > 0 ? (
+						inventoryItemViews
+					) : (
+						<tr>
+							<td colSpan={2}>No items in inventory</td>
+						</tr>
+					)}
+					<AddItemView addItem={inventoryList.addItem} disabled={disabled} />
+				</tbody>
+			</table>
+		</div>
 	);
 };

--- a/packages/framework/aqueduct/api-report/aqueduct.legacy.alpha.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.legacy.alpha.api.md
@@ -58,7 +58,7 @@ export abstract class DataObject<I extends DataObjectTypes = DataObjectTypes> ex
 
 // @alpha
 export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectTypes = DataObjectTypes> extends PureDataObjectFactory<TObj, I> {
-    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory<unknown>[] | undefined, optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeFactory?: typeof FluidDataStoreRuntime);
+    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory<unknown>[] | undefined, optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeFactory?: typeof FluidDataStoreRuntime, convertDataFn?: (runtime: FluidDataStoreRuntime, root: ISharedDirectory) => Promise<void>);
 }
 
 // @alpha
@@ -108,7 +108,9 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 // @alpha
 export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> implements IFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry> {
     constructor(
-    type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[], optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime);
+    type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[], optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime, convertDataFn?: ((runtime: FluidDataStoreRuntime) => Promise<void>) | undefined);
+    // (undocumented)
+    readonly convertDataFn?: ((runtime: FluidDataStoreRuntime) => Promise<void>) | undefined;
     createChildInstance(parentContext: IFluidDataStoreContext, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
     createInstance(runtime: IContainerRuntimeBase, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
     // (undocumented)

--- a/packages/framework/aqueduct/api-report/aqueduct.legacy.alpha.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.legacy.alpha.api.md
@@ -50,6 +50,11 @@ export interface ContainerRuntimeFactoryWithDefaultDataStoreProps {
 }
 
 // @alpha
+export class ConverterDataObjectFactory<TObj extends DataObject<I>, U, I extends DataObjectTypes = DataObjectTypes> extends DataObjectFactory<TObj, I> {
+    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory<unknown>[] | undefined, optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>, isConversionNeeded: (root: ISharedDirectory) => Promise<boolean>, asyncGetDataForConversion: (root: ISharedDirectory) => Promise<U>, convertDataStore: (runtime: FluidDataStoreRuntime, root: ISharedDirectory, data: U) => void, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeFactory?: typeof FluidDataStoreRuntime);
+}
+
+// @alpha
 export abstract class DataObject<I extends DataObjectTypes = DataObjectTypes> extends PureDataObject<I> {
     protected getUninitializedErrorString(item: string): string;
     initializeInternal(existing: boolean): Promise<void>;
@@ -58,7 +63,7 @@ export abstract class DataObject<I extends DataObjectTypes = DataObjectTypes> ex
 
 // @alpha
 export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectTypes = DataObjectTypes> extends PureDataObjectFactory<TObj, I> {
-    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory<unknown>[] | undefined, optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeFactory?: typeof FluidDataStoreRuntime, convertDataFn?: (runtime: FluidDataStoreRuntime, root: ISharedDirectory) => Promise<void>);
+    constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory<unknown>[] | undefined, optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeFactory?: typeof FluidDataStoreRuntime, convertDataStore?: (runtime: FluidDataStoreRuntime) => Promise<void>);
 }
 
 // @alpha
@@ -108,9 +113,9 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 // @alpha
 export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> implements IFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry> {
     constructor(
-    type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[], optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime, convertDataFn?: ((runtime: FluidDataStoreRuntime) => Promise<void>) | undefined);
+    type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[], optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime, convertDataStore?: ((runtime: FluidDataStoreRuntime) => Promise<void>) | undefined);
     // (undocumented)
-    readonly convertDataFn?: ((runtime: FluidDataStoreRuntime) => Promise<void>) | undefined;
+    readonly convertDataStore?: ((runtime: FluidDataStoreRuntime) => Promise<void>) | undefined;
     createChildInstance(parentContext: IFluidDataStoreContext, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
     createInstance(runtime: IContainerRuntimeBase, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
     // (undocumented)

--- a/packages/framework/aqueduct/src/data-object-factories/converterDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/converterDataObjectFactory.ts
@@ -1,0 +1,138 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	DataStoreMessageType,
+	FluidDataStoreRuntime,
+} from "@fluidframework/datastore/internal";
+import type { IChannelFactory } from "@fluidframework/datastore-definitions/internal";
+import type { ISharedDirectory } from "@fluidframework/map/internal";
+import type {
+	IRuntimeMessageCollection,
+	IRuntimeMessagesContent,
+	NamedFluidDataStoreRegistryEntries,
+} from "@fluidframework/runtime-definitions/internal";
+import type { FluidObjectSymbolProvider } from "@fluidframework/synthesize/internal";
+
+import {
+	type DataObject,
+	type DataObjectTypes,
+	type IDataObjectProps,
+	dataObjectRootDirectoryId,
+} from "../data-objects/index.js";
+
+import { DataObjectFactory } from "./dataObjectFactory.js";
+
+/**
+ * TODO
+ * @legacy
+ * @alpha
+ */
+export class ConverterDataObjectFactory<
+	TObj extends DataObject<I>,
+	U,
+	I extends DataObjectTypes = DataObjectTypes,
+> extends DataObjectFactory<TObj, I> {
+	private convertLock = false;
+
+	public constructor(
+		type: string,
+		ctor: new (props: IDataObjectProps<I>) => TObj,
+		sharedObjects: readonly IChannelFactory[] = [],
+		optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>,
+		isConversionNeeded: (root: ISharedDirectory) => Promise<boolean>,
+		asyncGetDataForConversion: (root: ISharedDirectory) => Promise<U>,
+		convertDataStore: (
+			runtime: FluidDataStoreRuntime,
+			root: ISharedDirectory,
+			data: U,
+		) => void,
+		registryEntries?: NamedFluidDataStoreRegistryEntries,
+		runtimeFactory: typeof FluidDataStoreRuntime = FluidDataStoreRuntime,
+	) {
+		const fullConvertDataStore = async (runtime: FluidDataStoreRuntime): Promise<void> => {
+			const root = (await runtime.getChannel(dataObjectRootDirectoryId)) as ISharedDirectory;
+			if (!this.convertLock && (await isConversionNeeded(root))) {
+				this.convertLock = true;
+				const data = await asyncGetDataForConversion(root);
+
+				runtime.maintainOnlyLocal?.(() => {
+					runtime.orderSequentially?.(() => {
+						submitConversionOp(runtime);
+						convertDataStore(runtime, root, data);
+					});
+				});
+				this.convertLock = false;
+			}
+		};
+
+		const submitConversionOp = (runtime: FluidDataStoreRuntime): void => {
+			runtime.submitMessage(DataStoreMessageType.ChannelOp, "conversion", undefined);
+		};
+
+		super(
+			type,
+			ctor,
+			sharedObjects,
+			optionalProviders,
+			registryEntries,
+			class ConverterDataStoreRuntime extends runtimeFactory {
+				private conversionOpSeqNum = -1;
+				private readonly seqNumsToSkip = new Set<number>();
+
+				public processMessages(messageCollection: IRuntimeMessageCollection): void {
+					let contents: IRuntimeMessagesContent[] = [];
+					const sequenceNumber = messageCollection.envelope.sequenceNumber;
+
+					// ! TODO: extra validation if this client submitted "conversion" op but lost the race (close/reload Container if lost the race)
+					if (
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+						messageCollection.envelope.type === DataStoreMessageType.ChannelOp &&
+						messageCollection.messagesContent.some((val) => val.contents === "conversion")
+					) {
+						if (this.conversionOpSeqNum === -1) {
+							// This is the first conversion op we've seen
+							this.conversionOpSeqNum = sequenceNumber;
+						} else {
+							// Skip seqNums that lost the race
+							this.seqNumsToSkip.add(sequenceNumber);
+						}
+					}
+
+					contents = messageCollection.messagesContent.filter(
+						(val) => val.contents !== "conversion",
+					);
+
+					if (this.seqNumsToSkip.has(sequenceNumber) || contents.length === 0) {
+						return;
+					}
+
+					super.processMessages({
+						...messageCollection,
+						messagesContent: contents,
+					});
+				}
+
+				public reSubmit(
+					type2: DataStoreMessageType,
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					content: any,
+					localOpMetadata: unknown,
+				): void {
+					if (
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+						type2 === DataStoreMessageType.ChannelOp &&
+						content === "conversion"
+					) {
+						submitConversionOp(this);
+						return;
+					}
+					super.reSubmit(type2, content, localOpMetadata);
+				}
+			},
+			fullConvertDataStore,
+		);
+	}
+}

--- a/packages/framework/aqueduct/src/data-object-factories/index.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/index.ts
@@ -3,5 +3,6 @@
  * Licensed under the MIT License.
  */
 
+export { ConverterDataObjectFactory } from "./converterDataObjectFactory.js";
 export { DataObjectFactory } from "./dataObjectFactory.js";
 export { PureDataObjectFactory } from "./pureDataObjectFactory.js";

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -154,6 +154,7 @@ export class PureDataObjectFactory<
 		private readonly optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>,
 		registryEntries?: NamedFluidDataStoreRegistryEntries,
 		private readonly runtimeClass: typeof FluidDataStoreRuntime = FluidDataStoreRuntime,
+		public readonly convertDataFn?: (runtime: FluidDataStoreRuntime) => Promise<void>,
 	) {
 		if (this.type === "") {
 			throw new Error("undefined type member");

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -154,7 +154,7 @@ export class PureDataObjectFactory<
 		private readonly optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>,
 		registryEntries?: NamedFluidDataStoreRegistryEntries,
 		private readonly runtimeClass: typeof FluidDataStoreRuntime = FluidDataStoreRuntime,
-		public readonly convertDataFn?: (runtime: FluidDataStoreRuntime) => Promise<void>,
+		public readonly convertDataStore?: (runtime: FluidDataStoreRuntime) => Promise<void>,
 	) {
 		if (this.type === "") {
 			throw new Error("undefined type member");

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -14,6 +14,11 @@ import { PureDataObject } from "./pureDataObject.js";
 import type { DataObjectTypes } from "./types.js";
 
 /**
+ * TODO
+ */
+export const dataObjectRootDirectoryId = "root";
+
+/**
  * DataObject is a base data store that is primed with a root directory. It
  * ensures that it is created and ready before you can access it.
  *
@@ -29,7 +34,7 @@ export abstract class DataObject<
 	I extends DataObjectTypes = DataObjectTypes,
 > extends PureDataObject<I> {
 	private internalRoot: ISharedDirectory | undefined;
-	private readonly rootDirectoryId = "root";
+	private readonly rootDirectoryId = dataObjectRootDirectoryId;
 
 	/**
 	 * The root directory will either be ready or will return an error. If an error is thrown

--- a/packages/framework/aqueduct/src/data-objects/index.ts
+++ b/packages/framework/aqueduct/src/data-objects/index.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License.
  */
 
-export { DataObject, createDataObjectKind } from "./dataObject.js";
+export { DataObject, createDataObjectKind, dataObjectRootDirectoryId } from "./dataObject.js";
 export { PureDataObject } from "./pureDataObject.js";
 export type { DataObjectTypes, IDataObjectProps } from "./types.js";

--- a/packages/framework/aqueduct/src/index.ts
+++ b/packages/framework/aqueduct/src/index.ts
@@ -18,7 +18,11 @@
  * @packageDocumentation
  */
 
-export { DataObjectFactory, PureDataObjectFactory } from "./data-object-factories/index.js";
+export {
+	DataObjectFactory,
+	PureDataObjectFactory,
+	ConverterDataObjectFactory,
+} from "./data-object-factories/index.js";
 export {
 	DataObject,
 	type DataObjectTypes,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3458,8 +3458,7 @@ export class ContainerRuntime
 			this._orderSequentiallyCalls--;
 		}
 
-		// We don't flush on TurnBased since we expect all messages in the same JS turn to be part of the same batch
-		if (this.flushMode !== FlushMode.TurnBased && this._orderSequentiallyCalls === 0) {
+		if (this._orderSequentiallyCalls === 0) {
 			this.flush();
 		}
 		return result;
@@ -3473,6 +3472,14 @@ export class ContainerRuntime
 		} finally {
 			this._maintainOnlyLocalCalls--;
 		}
+	}
+
+	public pauseResubmit(): void {
+		this.pendingStateManager.pauseReplayPendingStates();
+	}
+
+	public resumeResubmit(): void {
+		this.pendingStateManager.resumeReplayPendingStates();
 	}
 
 	/**
@@ -3545,7 +3552,8 @@ export class ContainerRuntime
 			this.connected &&
 			!this.innerDeltaManager.readOnlyInfo.readonly &&
 			!this.imminentClosure &&
-			this._maintainOnlyLocalCalls === 0
+			this._maintainOnlyLocalCalls === 0 &&
+			!this.pendingStateManager.pauseSubmittingOps
 		);
 	}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3465,21 +3465,13 @@ export class ContainerRuntime
 	}
 
 	private _maintainOnlyLocalCalls = 0;
-	public async maintainOnlyLocal(callback: () => Promise<void>): Promise<void> {
+	public maintainOnlyLocal(callback: () => void): void {
 		try {
 			this._maintainOnlyLocalCalls++;
-			await callback();
+			callback();
 		} finally {
 			this._maintainOnlyLocalCalls--;
 		}
-	}
-
-	public pauseResubmit(): void {
-		this.pendingStateManager.pauseReplayPendingStates();
-	}
-
-	public resumeResubmit(): void {
-		this.pendingStateManager.resumeReplayPendingStates();
 	}
 
 	/**
@@ -3552,8 +3544,7 @@ export class ContainerRuntime
 			this.connected &&
 			!this.innerDeltaManager.readOnlyInfo.readonly &&
 			!this.imminentClosure &&
-			this._maintainOnlyLocalCalls === 0 &&
-			!this.pendingStateManager.pauseSubmittingOps
+			this._maintainOnlyLocalCalls === 0
 		);
 	}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3465,6 +3465,16 @@ export class ContainerRuntime
 		return result;
 	}
 
+	private _maintainOnlyLocalCalls = 0;
+	public async maintainOnlyLocal(callback: () => Promise<void>): Promise<void> {
+		try {
+			this._maintainOnlyLocalCalls++;
+			await callback();
+		} finally {
+			this._maintainOnlyLocalCalls--;
+		}
+	}
+
 	/**
 	 * Returns the aliased data store's entryPoint, given the alias.
 	 * @param alias - The alias for the data store.
@@ -3532,7 +3542,10 @@ export class ContainerRuntime
 		// Note that the real (non-proxy) delta manager is needed here to get the readonly info. This is because
 		// container runtime's ability to send ops depend on the actual readonly state of the delta manager.
 		return (
-			this.connected && !this.innerDeltaManager.readOnlyInfo.readonly && !this.imminentClosure
+			this.connected &&
+			!this.innerDeltaManager.readOnlyInfo.readonly &&
+			!this.imminentClosure &&
+			this._maintainOnlyLocalCalls === 0
 		);
 	}
 

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -467,7 +467,7 @@ export abstract class FluidDataStoreContext
 	public async realize(): Promise<IFluidDataStoreChannel> {
 		return this.realizeInternal().then(async (runtime) => {
 			const factory = await this.factoryFromPackagePath();
-			await factory.convertDataFn?.(runtime);
+			await factory.convertDataStore?.(runtime);
 			return runtime;
 		});
 	}

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -464,7 +464,6 @@ export abstract class FluidDataStoreContext
 		);
 	}
 
-
 	public async realize(): Promise<IFluidDataStoreChannel> {
 		return this.realizeInternal().then(async (runtime) => {
 			const factory = await this.factoryFromPackagePath();

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -615,7 +615,7 @@ export class PendingStateManager implements IDisposable {
 	 * states in its queue. This includes triggering resubmission of unacked ops.
 	 * ! Note: successfully resubmitting an op that has been successfully sequenced is not possible due to checks in the ConnectionStateHandler (Loader layer)
 	 */
-	public replayPendingStates(): void {
+	public replayPendingStates(ignoreClientIdCheck: boolean = false): void {
 		assert(
 			this.stateHandler.connected(),
 			0x172 /* "The connection state is not consistent with the runtime" */,
@@ -623,7 +623,7 @@ export class PendingStateManager implements IDisposable {
 
 		// This assert suggests we are about to send same ops twice, which will result in data loss.
 		assert(
-			this.clientIdFromLastReplay !== this.stateHandler.clientId(),
+			this.clientIdFromLastReplay !== this.stateHandler.clientId() || ignoreClientIdCheck,
 			0x173 /* "replayPendingStates called twice for same clientId!" */,
 		);
 		this.clientIdFromLastReplay = this.stateHandler.clientId();
@@ -639,7 +639,7 @@ export class PendingStateManager implements IDisposable {
 		// Process exactly `pendingMessagesCount` items in the queue as it represents the number of messages that were
 		// pending when we connected. This is important because the `reSubmitFn` might add more items in the queue
 		// which must not be replayed.
-		while (remainingPendingMessagesCount > 0) {
+		while (remainingPendingMessagesCount > 0 && !this._replayPaused) {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			let pendingMessage = this.pendingMessages.shift()!;
 			remainingPendingMessagesCount--;
@@ -686,7 +686,7 @@ export class PendingStateManager implements IDisposable {
 			const batch: PendingMessageResubmitData[] = [];
 
 			// check is >= because batch end may be last pending message
-			while (remainingPendingMessagesCount >= 0) {
+			while (remainingPendingMessagesCount >= 0 && !this._replayPaused) {
 				batch.push({
 					content: pendingMessage.content,
 					localOpMetadata: pendingMessage.localOpMetadata,
@@ -710,6 +710,18 @@ export class PendingStateManager implements IDisposable {
 			this.stateHandler.reSubmitBatch(batch, batchId);
 		}
 
+		if (this._replayPaused) {
+			// We pause after "reSubmit" so we can prevent further messages from being sent, but allow that last message to get through
+			this._pauseSendingForRuntime = true;
+			// Move remaining items to the end of the pendingMessages to preserve order
+			while (remainingPendingMessagesCount > 0) {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				this.pendingMessages.push(this.pendingMessages.shift()!);
+				remainingPendingMessagesCount--;
+			}
+			return;
+		}
+
 		// pending ops should no longer depend on previous sequenced local ops after resubmit
 		this.savedOps = [];
 
@@ -723,6 +735,29 @@ export class PendingStateManager implements IDisposable {
 				clientId: this.stateHandler.clientId(),
 			});
 		}
+	}
+
+	private _replayPaused = false;
+	private _pauseSendingForRuntime = false;
+	public get pauseSubmittingOps(): boolean {
+		return this._pauseSendingForRuntime;
+	}
+
+	public pauseReplayPendingStates(): void {
+		this._replayPaused = true;
+	}
+
+	public resumeReplayPendingStates(): void {
+		// ! This needs to be in Promise.resolve since outbox will detect a flush from within processing the "conversion" op
+		// eslint-disable-next-line @typescript-eslint/no-floating-promises
+		Promise.resolve().then(() => {
+			const oldState = this._replayPaused;
+			this._replayPaused = false;
+			this._pauseSendingForRuntime = false;
+			if (oldState) {
+				this.replayPendingStates(true /* ignoreClientIdCheck */);
+			}
+		});
 	}
 }
 

--- a/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
@@ -72,6 +72,10 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     get objectsRoutingContext(): this;
     // (undocumented)
     readonly options: Record<string | number, any>;
+    // (undocumented)
+    orderSequentially?(callback: () => void): void;
+    // (undocumented)
+    pauseResubmit?(): void;
     // @deprecated
     process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     processMessages(messageCollection: IRuntimeMessageCollection): void;
@@ -82,6 +86,8 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // (undocumented)
     resolveHandle(request: IRequest): Promise<IResponse>;
     reSubmit(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;
+    // (undocumented)
+    resumeResubmit?(): void;
     rollback?(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;
     // (undocumented)
     get rootRoutingContext(): this;

--- a/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
@@ -66,7 +66,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // (undocumented)
     get logger(): ITelemetryLoggerExt;
     // (undocumented)
-    maintainOnlyLocal?(callback: () => Promise<void>): Promise<void>;
+    maintainOnlyLocal?(callback: () => void): void;
     makeVisibleAndAttachGraph(): void;
     // (undocumented)
     get objectsRoutingContext(): this;
@@ -74,8 +74,6 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     readonly options: Record<string | number, any>;
     // (undocumented)
     orderSequentially?(callback: () => void): void;
-    // (undocumented)
-    pauseResubmit?(): void;
     // @deprecated
     process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
     processMessages(messageCollection: IRuntimeMessageCollection): void;
@@ -86,8 +84,6 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // (undocumented)
     resolveHandle(request: IRequest): Promise<IResponse>;
     reSubmit(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;
-    // (undocumented)
-    resumeResubmit?(): void;
     rollback?(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;
     // (undocumented)
     get rootRoutingContext(): this;

--- a/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
@@ -65,6 +65,8 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     get isAttached(): boolean;
     // (undocumented)
     get logger(): ITelemetryLoggerExt;
+    // (undocumented)
+    maintainOnlyLocal?(callback: () => Promise<void>): Promise<void>;
     makeVisibleAndAttachGraph(): void;
     // (undocumented)
     get objectsRoutingContext(): this;

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1322,16 +1322,8 @@ export class FluidDataStoreRuntime
 		}
 	}
 
-	public async maintainOnlyLocal?(callback: () => Promise<void>): Promise<void> {
+	public maintainOnlyLocal?(callback: () => void): void {
 		return this.dataStoreContext.containerRuntime.maintainOnlyLocal?.(callback);
-	}
-
-	public pauseResubmit?(): void {
-		return this.dataStoreContext.containerRuntime.pauseResubmit?.();
-	}
-
-	public resumeResubmit?(): void {
-		return this.dataStoreContext.containerRuntime.resumeResubmit?.();
 	}
 
 	public orderSequentially?(callback: () => void): void {

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1325,6 +1325,18 @@ export class FluidDataStoreRuntime
 	public async maintainOnlyLocal?(callback: () => Promise<void>): Promise<void> {
 		return this.dataStoreContext.containerRuntime.maintainOnlyLocal?.(callback);
 	}
+
+	public pauseResubmit?(): void {
+		return this.dataStoreContext.containerRuntime.pauseResubmit?.();
+	}
+
+	public resumeResubmit?(): void {
+		return this.dataStoreContext.containerRuntime.resumeResubmit?.();
+	}
+
+	public orderSequentially?(callback: () => void): void {
+		return this.dataStoreContext.containerRuntime.orderSequentially(callback);
+	}
 }
 
 /**

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1321,6 +1321,10 @@ export class FluidDataStoreRuntime
 				unreachableCase(attachState, "unreached");
 		}
 	}
+
+	public async maintainOnlyLocal?(callback: () => Promise<void>): Promise<void> {
+		return this.dataStoreContext.containerRuntime.maintainOnlyLocal?.(callback);
+	}
 }
 
 /**

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -169,6 +169,8 @@ export const IFluidDataStoreFactory: keyof IProvideFluidDataStoreFactory;
 
 // @alpha
 export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
+    // (undocumented)
+    convertDataFn?(runtime: IFluidDataStoreChannel): Promise<void>;
     createDataStore?(context: IFluidDataStoreContext): {
         readonly runtime: IFluidDataStoreChannel;
     };

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -87,6 +87,10 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
     // (undocumented)
     maintainOnlyLocal?: (callback: () => Promise<void>) => Promise<void>;
     orderSequentially(callback: () => void): void;
+    // (undocumented)
+    pauseResubmit?: () => void;
+    // (undocumented)
+    resumeResubmit?: () => void;
     submitSignal: (type: string, content: unknown, targetClientId?: string) => void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -84,6 +84,8 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
         snapshotTree: ISnapshotTree;
         sequenceNumber: number;
     }>;
+    // (undocumented)
+    maintainOnlyLocal?: (callback: () => Promise<void>) => Promise<void>;
     orderSequentially(callback: () => void): void;
     submitSignal: (type: string, content: unknown, targetClientId?: string) => void;
     // (undocumented)

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -85,12 +85,8 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
         sequenceNumber: number;
     }>;
     // (undocumented)
-    maintainOnlyLocal?: (callback: () => Promise<void>) => Promise<void>;
+    maintainOnlyLocal?: (callback: () => void) => void;
     orderSequentially(callback: () => void): void;
-    // (undocumented)
-    pauseResubmit?: () => void;
-    // (undocumented)
-    resumeResubmit?: () => void;
     submitSignal: (type: string, content: unknown, targetClientId?: string) => void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
@@ -176,7 +172,7 @@ export const IFluidDataStoreFactory: keyof IProvideFluidDataStoreFactory;
 // @alpha
 export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
     // (undocumented)
-    convertDataFn?(runtime: IFluidDataStoreChannel): Promise<void>;
+    convertDataStore?(runtime: IFluidDataStoreChannel): Promise<void>;
     createDataStore?(context: IFluidDataStoreContext): {
         readonly runtime: IFluidDataStoreChannel;
     };

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -210,6 +210,10 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
 
 	maintainOnlyLocal?: (callback: () => Promise<void>) => Promise<void>;
 
+	pauseResubmit?: () => void;
+
+	resumeResubmit?: () => void;
+
 	/**
 	 * Submits a container runtime level signal to be sent to other clients.
 	 * @param type - Type of the signal.

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -208,6 +208,8 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
 	 */
 	orderSequentially(callback: () => void): void;
 
+	maintainOnlyLocal?: (callback: () => Promise<void>) => Promise<void>;
+
 	/**
 	 * Submits a container runtime level signal to be sent to other clients.
 	 * @param type - Type of the signal.

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -208,11 +208,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
 	 */
 	orderSequentially(callback: () => void): void;
 
-	maintainOnlyLocal?: (callback: () => Promise<void>) => Promise<void>;
-
-	pauseResubmit?: () => void;
-
-	resumeResubmit?: () => void;
+	maintainOnlyLocal?: (callback: () => void) => void;
 
 	/**
 	 * Submits a container runtime level signal to be sent to other clients.

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -82,4 +82,6 @@ export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
 	createDataStore?(context: IFluidDataStoreContext): {
 		readonly runtime: IFluidDataStoreChannel;
 	};
+
+	convertDataFn?(runtime: IFluidDataStoreChannel): Promise<void>;
 }

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -83,5 +83,5 @@ export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
 		readonly runtime: IFluidDataStoreChannel;
 	};
 
-	convertDataFn?(runtime: IFluidDataStoreChannel): Promise<void>;
+	convertDataStore?(runtime: IFluidDataStoreChannel): Promise<void>;
 }


### PR DESCRIPTION
With the effort to move Loop to new shared tree, we need a way to convert old documents using legacy shared tree to the new shared tree.

This PR works off the idea to add some "converter" layer just above the DataObjectFactory. This "converter" detects that we loaded the legacy shared tree version of the DDS and do the necessary conversion at load time.

### What was explicitly tested

1. Waiting for trailing ops
2. Waiting for conversion op before doing conversion

### What still needs to be verified/tested

1. Loading from legacy pendingState works as expected

### Future considerations to think about and test

1. Only doing conversion once you see "Switch to write". Not sure how this will work as then component code will still be in a weird state knowing how to display the legacy version before the conversion actually happens. And the conversion would no longer be "on load", it'll be "once we connect in write mode". But, in theory, should work almost exactly the same as the idea this prototype explores.
2. Swapping factory name/type as to try smoothly moving off conversion factory
3. Dropping legacy ops that were sequenced too late
4. Dropping legacy ops that are resubmitted from pending state after observing "conversion" op. Possibly just reload container if this is hit.
5. Race condition between different clients doing conversion
6. Client performing conversion fails to finish and closes in an incomplete state

[AB#31337](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/31337)