### PR TITLE
Use apiCounter to count kafka checkpoint failures and restart after a threshold

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -75,7 +75,18 @@ data:
                 {{ toJson . }}{{- if ne $i $lastIndex -}}, {{ end }}
                 {{- end }}
             ],
-            "seekTimeoutAfterPause": {{ .Values.kafka.seekTimeoutAfterPause }}
+            "seekTimeoutAfterPause": {{ .Values.kafka.seekTimeoutAfterPause }},
+            "apiCounterEnabled": {{ .Values.kafka.apiCounterEnabled }},
+            "apiCounterIntervalMS": {{ .Values.kafka.apiCounterIntervalMS }},
+            "apiFailureRateTerminationThreshold": {{ .Values.kafka.apiFailureRateTerminationThreshold }},
+            "apiMinimumCountToEnableTermination": {{ .Values.kafka.apiMinimumCountToEnableTermination }},
+            "consecutiveFailedThresholdForLowerTotalRequests": {{ .Values.kafka.consecutiveFailedThresholdForLowerTotalRequests }},
+            "ignoreAndSkipCheckpointOnKafkaErrorCodes": [
+                {{- $lastIndex := sub (len .Values.kafka.ignoreAndSkipCheckpointOnKafkaErrorCodes) 1}}
+                {{- range $i, $tenant := .Values.kafka.ignoreAndSkipCheckpointOnKafkaErrorCodes }}
+                {{ toJson . }}{{- if ne $i $lastIndex -}}, {{ end }}
+                {{- end }}
+            ]
         },
         "zookeeper": {
             "endpoint": "{{ .Values.zookeeper.url }}"

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -193,6 +193,12 @@ kafka:
   libname: rdkafka
   customRestartOnKafkaErrorCodes: [-195, -192, -187, -185, -181, 14]
   seekTimeoutAfterPause: 1000
+  apiCounterEnabled: false
+  apiCounterIntervalMS: 60000
+  apiFailureRateTerminationThreshold: 2
+  apiMinimumCountToEnableTermination: 20
+  consecutiveFailedThresholdForLowerTotalRequests: 3
+  ignoreAndSkipCheckpointOnKafkaErrorCodes: [-185]
 
 ingress:
   class: nginx-prod

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
@@ -93,10 +93,16 @@ export class CheckpointManager {
 				}
 			})
 			.catch((error) => {
-				if (error.name === "PendingCommitError") {
-					Lumberjack.info(`Skipping checkpoint since ${error.message}`, {
+				if (
+					error.name === "PendingCommitError" ||
+					this.consumer
+						.getIgnoreAndSkipCheckpointOnKafkaErrorCodes?.()
+						?.includes(error.code)
+				) {
+					Lumberjack.info(`Skipping checkpoint for the error`, {
 						queuedMessageOffset: queuedMessage.offset,
 						queuedMessagePartition: queuedMessage.partition,
+						error,
 					});
 					this.checkpointing = false;
 					return;

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -61,7 +61,13 @@
 			"rdkafkaMaxConsumerCommitRetries": 10
 		},
 		"customRestartOnKafkaErrorCodes": [-195, -192, -187, -185, -181, 14],
-		"seekTimeoutAfterPause": 1000
+		"seekTimeoutAfterPause": 1000,
+		"apiCounterEnabled": false,
+		"apiCounterIntervalMS": 60000,
+		"apiFailureRateTerminationThreshold": 2,
+		"apiMinimumCountToEnableTermination": 20,
+		"consecutiveFailedThresholdForLowerTotalRequests": 3,
+		"ignoreAndSkipCheckpointOnKafkaErrorCodes": [-185]
 	},
 	"zookeeper": {
 		"endpoint": "zookeeper:2181"

--- a/server/routerlicious/packages/services-core/src/queue.ts
+++ b/server/routerlicious/packages/services-core/src/queue.ts
@@ -76,6 +76,12 @@ export interface IConsumer {
 	getLatestMessageOffset(partitionId: number): number | undefined;
 
 	/**
+	 * Returns the error codes that should be ignored and the checkpoint should be skipped
+	 * We increment counter for such errors and restart when they reach a threshold
+	 */
+	getIgnoreAndSkipCheckpointOnKafkaErrorCodes?(): number[];
+
+	/**
 	 * Event handlers
 	 */
 	on(

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -32,6 +32,7 @@
 		"@fluidframework/server-services-client": "workspace:~",
 		"@fluidframework/server-services-core": "workspace:~",
 		"@fluidframework/server-services-telemetry": "workspace:~",
+		"@fluidframework/server-services-utils": "workspace:~",
 		"events_pkg": "npm:events@^3.1.0",
 		"nconf": "^0.12.0",
 		"node-rdkafka": "^3.0.1",

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -14,6 +14,7 @@ import {
 	ZookeeperClientConstructor,
 } from "@fluidframework/server-services-core";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { InMemoryApiCounters } from "@fluidframework/server-services-utils";
 import { IKafkaBaseOptions, IKafkaEndpoints, RdkafkaBase } from "./rdkafkaBase";
 
 /**
@@ -58,12 +59,21 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 	private readonly latestOffsets: Map<number, number> = new Map();
 	private readonly paused: Map<number, boolean> = new Map();
 	private readonly pausedOffsets: Map<number, number> = new Map();
+	private readonly apiCounter = new InMemoryApiCounters();
+	private readonly failedApiCounterSuffix = ".Failed";
+	private consecutiveFailedCount = 0;
 
 	constructor(
 		endpoints: IKafkaEndpoints,
 		clientId: string,
 		topic: string,
 		public readonly groupId: string,
+		private readonly apiCounterEnabled: boolean,
+		private readonly apiCounterIntervalMS: number,
+		private readonly apiFailureRateTerminationThreshold: number,
+		private readonly apiMinimumCountToEnableTermination: number,
+		private readonly consecutiveFailedThresholdForLowerTotalRequests: number,
+		private readonly ignoreAndSkipCheckpointOnKafkaErrorCodes: number[],
 		options?: Partial<IKafkaConsumerOptions>,
 	) {
 		super(endpoints, clientId, topic, options);
@@ -87,6 +97,72 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			automaticConsume: options?.automaticConsume ?? true,
 			maxConsumerCommitRetries: options?.maxConsumerCommitRetries ?? 10,
 		};
+		if (this.apiCounterEnabled) {
+			setInterval(() => {
+				if (!this.apiCounter.countersAreActive) {
+					return;
+				}
+				const counters = this.apiCounter.getCounters();
+				this.apiCounter.resetAllCounters();
+				Lumberjack.info(
+					`KafkaConsumer counter for topic ${topic}`, // can be multiple partitions..?
+					counters,
+				);
+				this.terminateBasedOnCounterThreshold(counters);
+			}, this.apiCounterIntervalMS);
+		}
+	}
+
+	private terminateBasedOnCounterThreshold(counters: Record<string, number>): void {
+		if (this.apiFailureRateTerminationThreshold > 1) {
+			return; // If threshold set more than 1, meaning we should never terminate and skip followings.
+		}
+		let totalCount = 0;
+		let totalFailedCount = 0;
+
+		// currently we maintain counters for only `kafkaOffsetCommit` apiName
+		for (const [apiName, apiCounter] of Object.entries(counters)) {
+			totalCount += apiCounter;
+			if (apiName.endsWith(this.failedApiCounterSuffix)) {
+				totalFailedCount += apiCounter;
+			}
+		}
+
+		const failureRate = totalFailedCount / totalCount;
+
+		if (failureRate <= this.apiFailureRateTerminationThreshold) {
+			this.consecutiveFailedCount = 0;
+			return;
+		}
+
+		this.consecutiveFailedCount++;
+		const logProperties = {
+			failureRate,
+			totalCount,
+			totalFailedCount,
+			apiFailureRateTerminationThreshold: this.apiFailureRateTerminationThreshold,
+			apiMinimumCountToEnableTermination: this.apiMinimumCountToEnableTermination,
+			consecutiveFailedCount: this.consecutiveFailedCount,
+			consecutiveFailedThresholdForLowerTotalRequests:
+				this.consecutiveFailedThresholdForLowerTotalRequests,
+		};
+		if (
+			totalCount < this.apiMinimumCountToEnableTermination &&
+			this.consecutiveFailedCount < this.consecutiveFailedThresholdForLowerTotalRequests
+		) {
+			Lumberjack.warning("Total count didn't meet min threshold", logProperties);
+			return;
+		}
+
+		Lumberjack.warning("Failure rate more than threshold, terminating", logProperties);
+		this.error(new Error(`Failure rate more than threshold, terminating`), {
+			restart: true,
+			errorLabel: "rdkafkaConsumer:terminateBasedOnCounterThreshold",
+		});
+	}
+
+	public getIgnoreAndSkipCheckpointOnKafkaErrorCodes(): number[] {
+		return this.apiCounterEnabled ? this.ignoreAndSkipCheckpointOnKafkaErrorCodes : [];
 	}
 
 	/**
@@ -188,11 +264,26 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 						err.code === this.kafka.CODES.ERRORS.ERR_ILLEGAL_GENERATION);
 
 				if (!shouldRetryCommit) {
-					this.error(err, {
-						restart: false,
-						errorLabel: "rdkafkaConsumer:offset.commit",
-					});
+					if (
+						this.apiCounterEnabled &&
+						this.ignoreAndSkipCheckpointOnKafkaErrorCodes.includes(err.code)
+					) {
+						Lumberjack.info("Skipping checkpoint and incrementing api failed counter", {
+							error: err,
+							apiName: "kafkaOffsetCommit",
+						});
+						this.apiCounter.incrementCounter(
+							`kafkaOffsetCommit${this.failedApiCounterSuffix}`,
+						);
+					} else {
+						this.error(err, {
+							restart: false,
+							errorLabel: "rdkafkaConsumer:offset.commit",
+						});
+					}
 				}
+			} else if (this.apiCounterEnabled) {
+				this.apiCounter.incrementCounter("kafkaOffsetCommit");
 			}
 
 			for (const offset of offsets) {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -430,8 +430,8 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			return;
 		}
 
-		if (!reconnecting) { // when closed outside of this class
-			// disable reconnecting
+		if (!reconnecting) {
+			// when closed outside of this class, disable reconnecting
 			this.closed = true;
 			// stop the api counter interval
 			if (this.apiCounterInterval !== undefined) {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -80,6 +80,18 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
 			"kafka:lib:consumerGlobalAdditionalConfig",
 		);
 
+		// apiCounter configuration
+		const apiCounterEnabled = config.get("kafka:apiCounterEnabled") ?? false;
+		const apiCounterIntervalMS = config.get("kafka:apiCounterIntervalMS") ?? 60000;
+		const apiFailureRateTerminationThreshold =
+			config.get("kafka:apiFailureRateTerminationThreshold") ?? 2; // 1 means 100%, 2 means disabled
+		const apiMinimumCountToEnableTermination =
+			config.get("kafka:apiMinimumCountToEnableTermination") ?? 20;
+		const consecutiveFailedThresholdForLowerTotalRequests =
+			config.get("kafka:consecutiveFailedThresholdForLowerTotalRequests") ?? 3;
+		const ignoreAndSkipCheckpointOnKafkaErrorCodes =
+			config.get("kafka:ignoreAndSkipCheckpointOnKafkaErrorCodes") ?? [];
+
 		// Receive topic and group - for now we will assume an entry in config mapping
 		// to the given name. Later though the lambda config will likely be split from the stream config
 		const streamConfig = config.get(`lambdas:${this.name}`);
@@ -109,7 +121,19 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
 			additionalOptions: consumerGlobalAdditionalConfig,
 		};
 
-		const consumer = new RdkafkaConsumer(endpoints, clientId, receiveTopic, groupId, options);
+		const consumer = new RdkafkaConsumer(
+			endpoints,
+			clientId,
+			receiveTopic,
+			groupId,
+			apiCounterEnabled,
+			apiCounterIntervalMS,
+			apiFailureRateTerminationThreshold,
+			apiMinimumCountToEnableTermination,
+			consecutiveFailedThresholdForLowerTotalRequests,
+			ignoreAndSkipCheckpointOnKafkaErrorCodes,
+			options,
+		);
 
 		return new RdkafkaResources(lambdaFactory, consumer, config);
 	}

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -92,6 +92,14 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
 		const ignoreAndSkipCheckpointOnKafkaErrorCodes =
 			config.get("kafka:ignoreAndSkipCheckpointOnKafkaErrorCodes") ?? [];
 
+		const apiCounterConfig = {
+			apiCounterEnabled,
+			apiCounterIntervalMS,
+			apiFailureRateTerminationThreshold,
+			apiMinimumCountToEnableTermination,
+			consecutiveFailedThresholdForLowerTotalRequests,
+		};
+
 		// Receive topic and group - for now we will assume an entry in config mapping
 		// to the given name. Later though the lambda config will likely be split from the stream config
 		const streamConfig = config.get(`lambdas:${this.name}`);
@@ -126,11 +134,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
 			clientId,
 			receiveTopic,
 			groupId,
-			apiCounterEnabled,
-			apiCounterIntervalMS,
-			apiFailureRateTerminationThreshold,
-			apiMinimumCountToEnableTermination,
-			consecutiveFailedThresholdForLowerTotalRequests,
+			apiCounterConfig,
 			ignoreAndSkipCheckpointOnKafkaErrorCodes,
 			options,
 		);

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -1394,6 +1394,9 @@ importers:
       '@fluidframework/server-services-telemetry':
         specifier: workspace:~
         version: link:../services-telemetry
+      '@fluidframework/server-services-utils':
+        specifier: workspace:~
+        version: link:../services-utils
       events_pkg:
         specifier: npm:events@^3.1.0
         version: events@3.3.0


### PR DESCRIPTION
## Description

- Changes to add apiCounter in rdKafkaConsumer to count the number of checkpoint failures and restart after a threshold is reached. This is so that the services dont restart every time there's a kafka timedout failure (which is the top reason for service restarts and is transient).
- Changes are behind the config flag - apiCounterEnabled.
- We will enable it in a few clusters to experiment and fine tune the other config values.