### PR TITLE
Relax error validation to support Node versions both before/after 20.18.1

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -1501,8 +1501,10 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 			const summary2 = await summarizeNow(summarizer);
 			assert.throws(
 				() => getGCStateFromSummary(summary2.summaryTree),
+				// Assertion error message text changed in Node 20.18.1 to append the failed comparison info.
+				// This validation can be made more strict again once the repo requires Node >= 20.18.1
 				(e: Error) =>
-					validateAssertionError(e, "getGCStateFromSummary: GC state is not a blob"),
+					validateAssertionError(e, /^getGCStateFromSummary: GC state is not a blob/),
 			);
 			const tombstoneState = getGCTombstoneStateFromSummary(summary2.summaryTree);
 			assert(
@@ -1514,10 +1516,12 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 			const summary3 = await summarizeNow(summarizer);
 			assert.throws(
 				() => getGCTombstoneStateFromSummary(summary3.summaryTree),
+				// Assertion error message text changed in Node 20.18.1 to append the failed comparison info.
+				// This validation can be made more strict again once the repo requires Node >= 20.18.1
 				(e: Error) =>
 					validateAssertionError(
 						e,
-						"getGCTombstoneStateFromSummary: GC data should be a tree",
+						/^getGCTombstoneStateFromSummary: GC data should be a tree/,
 					),
 			);
 		});


### PR DESCRIPTION
See https://github.com/nodejs/node/commit/e1d8b4f038f05275fe2eb3189e79ec41a74c4782 for details