### PR TITLE
BlobManager tweaks

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -198,7 +198,7 @@ export class BlobManager {
 	constructor(props: {
 		readonly routeContext: IFluidHandleContext;
 
-		snapshot: IBlobManagerLoadInfo;
+		blobManagerLoadInfo: IBlobManagerLoadInfo;
 		readonly storage: IDocumentStorageService;
 		/**
 		 * Submit a BlobAttach op. When a blob is uploaded, there is a short grace period before which the blob is
@@ -223,7 +223,7 @@ export class BlobManager {
 	}) {
 		const {
 			routeContext,
-			snapshot,
+			blobManagerLoadInfo,
 			storage,
 			sendBlobAttachOp,
 			blobRequested,
@@ -244,7 +244,11 @@ export class BlobManager {
 			namespace: "BlobManager",
 		});
 
-		this.redirectTable = toRedirectTable(snapshot, this.mc.logger, this.runtime.attachState);
+		this.redirectTable = toRedirectTable(
+			blobManagerLoadInfo,
+			this.mc.logger,
+			this.runtime.attachState,
+		);
 
 		// Begin uploading stashed blobs from previous container instance
 		for (const [localId, entry] of Object.entries(stashedBlobs ?? {})) {

--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -317,7 +317,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 	}
 
 	public get allBlobsAttached(): boolean {
-		for (const [, entry] of this.pendingBlobs) {
+		for (const entry of this.pendingBlobs.values()) {
 			if (entry.attached === false) {
 				return false;
 			}

--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -872,9 +872,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 					}
 					// Wait for all blobs to be attached. This is important, otherwise serialized container
 					// could send the blobAttach op without any op that references the blob, making it useless.
-					await Promise.allSettled(attachBlobsP).catch(() => {
-						return undefined;
-					});
+					await Promise.allSettled(attachBlobsP);
 				}
 
 				for (const [id, entry] of this.pendingBlobs) {

--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -17,7 +17,7 @@ import {
 	IFluidHandleContext,
 	type IFluidHandleInternal,
 } from "@fluidframework/core-interfaces/internal";
-import { assert, Deferred, LazyPromise } from "@fluidframework/core-utils/internal";
+import { assert, Deferred } from "@fluidframework/core-utils/internal";
 import {
 	IDocumentStorageService,
 	ICreateBlobResponse,
@@ -267,13 +267,11 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 			});
 		}
 
-		this.stashedBlobsUploadP = new LazyPromise(async () =>
-			PerformanceEvent.timedExecAsync(
-				this.mc.logger,
-				{ eventName: "BlobUploadProcessStashedChanges", count: this.pendingStashedBlobs.size },
-				async () => Promise.all(this.pendingStashedBlobs.values()),
-				{ start: true, end: true },
-			),
+		this.stashedBlobsUploadP = PerformanceEvent.timedExecAsync(
+			this.mc.logger,
+			{ eventName: "BlobUploadProcessStashedChanges", count: this.pendingStashedBlobs.size },
+			async () => Promise.all(this.pendingStashedBlobs.values()),
+			{ start: true, end: true },
 		).finally(() => {
 			this.pendingStashedBlobs.clear();
 		});

--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -15,6 +15,7 @@ import {
 } from "@fluidframework/container-runtime-definitions/internal";
 import type {
 	IEvent,
+	IEventProvider,
 	IFluidHandleContext,
 	IFluidHandleInternal,
 } from "@fluidframework/core-interfaces/internal";
@@ -147,9 +148,13 @@ const stashedPendingBlobOverrides: Pick<
 
 export const blobManagerBasePath = "_blobs" as const;
 
-export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
+export class BlobManager {
 	private readonly mc: MonitoringContext;
 
+	private readonly publicEvents = new TypedEventEmitter<IBlobManagerEvents>();
+	public get events(): IEventProvider<IBlobManagerEvents> {
+		return this.publicEvents;
+	}
 	private readonly internalEvents = new TypedEventEmitter<IBlobManagerInternalEvents>();
 
 	/**
@@ -216,7 +221,6 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 		stashedBlobs: IPendingBlobs | undefined;
 		readonly localBlobIdGenerator?: (() => string) | undefined;
 	}) {
-		super();
 		const {
 			routeContext,
 			snapshot,
@@ -533,7 +537,7 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 
 	private deletePendingBlob(id: string): void {
 		if (this.pendingBlobs.delete(id) && !this.hasPendingBlobs) {
-			this.emit("noPendingBlobs");
+			this.publicEvents.emit("noPendingBlobs");
 		}
 	}
 

--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -320,7 +320,7 @@ export class BlobManager {
 				}
 			}
 			pendingEntry.opsent = true;
-			return sendBlobAttachOp(localId, blobId);
+			sendBlobAttachOp(localId, blobId);
 		};
 	}
 

--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -928,7 +928,7 @@ const getBlobIdFromGCNodePath = (nodePath: string): string => {
 export const isBlobPath = (path: string): path is `/${typeof blobManagerBasePath}/${string}` =>
 	areBlobPathParts(path.split("/"));
 
-export const areBlobPathParts = (
+const areBlobPathParts = (
 	pathParts: string[],
 ): pathParts is ["", typeof blobManagerBasePath, string] =>
 	pathParts.length === 3 && pathParts[1] === blobManagerBasePath;

--- a/packages/runtime/container-runtime/src/blobManager/blobManagerSnapSum.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManagerSnapSum.ts
@@ -58,21 +58,21 @@ const loadV1 = async (
 };
 
 export const toRedirectTable = (
-	snapshot: IBlobManagerLoadInfo,
+	blobManagerLoadInfo: IBlobManagerLoadInfo,
 	logger: ITelemetryLoggerExt,
 	attachState: AttachState,
 ): Map<string, string | undefined> => {
 	logger.sendTelemetryEvent({
 		eventName: "AttachmentBlobsLoaded",
-		count: snapshot.ids?.length ?? 0,
-		redirectTable: snapshot.redirectTable?.length,
+		count: blobManagerLoadInfo.ids?.length ?? 0,
+		redirectTable: blobManagerLoadInfo.redirectTable?.length,
 	});
-	const redirectTable = new Map<string, string | undefined>(snapshot.redirectTable);
+	const redirectTable = new Map<string, string | undefined>(blobManagerLoadInfo.redirectTable);
 	const detached = attachState !== AttachState.Attached;
-	if (snapshot.ids) {
+	if (blobManagerLoadInfo.ids) {
 		// If we are detached, we don't have storage IDs yet, so set to undefined
 		// Otherwise, set identity (id -> id) entries.
-		for (const entry of snapshot.ids) {
+		for (const entry of blobManagerLoadInfo.ids) {
 			redirectTable.set(entry, detached ? undefined : entry);
 		}
 	}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2218,13 +2218,11 @@ export class ContainerRuntime
 
 			if (id === blobManagerBasePath && requestParser.isLeaf(2)) {
 				const blob = await this.blobManager.getBlob(requestParser.pathParts[1]);
-				return blob
-					? {
-							status: 200,
-							mimeType: "fluid/object",
-							value: blob,
-						}
-					: create404Response(request);
+				return {
+					status: 200,
+					mimeType: "fluid/object",
+					value: blob,
+				};
 			} else if (requestParser.pathParts.length > 0) {
 				return await this.channelCollection.request(request);
 			}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1687,7 +1687,7 @@ export class ContainerRuntime
 		this.blobManager = new BlobManager({
 			routeContext: this.handleContext,
 			snapshot: blobManagerSnapshot,
-			getStorage: () => this.storage,
+			storage: this.storage,
 			sendBlobAttachOp: (localId: string, blobId?: string) => {
 				if (!this.disposed) {
 					this.submit(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -825,7 +825,7 @@ export class ContainerRuntime
 		]);
 
 		// read snapshot blobs needed for BlobManager to load
-		const blobManagerSnapshot = await loadBlobManagerLoadInfo(context);
+		const blobManagerLoadInfo = await loadBlobManagerLoadInfo(context);
 
 		const messageAtLastSummary = lastMessageFromMetadata(metadata);
 
@@ -1002,7 +1002,7 @@ export class ContainerRuntime
 			containerScope,
 			logger,
 			existing,
-			blobManagerSnapshot,
+			blobManagerLoadInfo,
 			context.storage,
 			createIdCompressorFn,
 			documentSchemaController,
@@ -1329,7 +1329,7 @@ export class ContainerRuntime
 		public readonly baseLogger: ITelemetryBaseLogger,
 		existing: boolean,
 
-		blobManagerSnapshot: IBlobManagerLoadInfo,
+		blobManagerLoadInfo: IBlobManagerLoadInfo,
 		private readonly _storage: IDocumentStorageService,
 		private readonly createIdCompressor: () => Promise<IIdCompressor & IIdCompressorCore>,
 
@@ -1686,7 +1686,7 @@ export class ContainerRuntime
 
 		this.blobManager = new BlobManager({
 			routeContext: this.handleContext,
-			snapshot: blobManagerSnapshot,
+			blobManagerLoadInfo,
 			storage: this.storage,
 			sendBlobAttachOp: (localId: string, blobId?: string) => {
 				if (!this.disposed) {

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -86,7 +86,7 @@ export class MockRuntime
 	public readonly clientDetails: IClientDetails = { capabilities: { interactive: true } };
 	constructor(
 		public mc: MonitoringContext,
-		snapshot: IBlobManagerLoadInfo = {},
+		blobManagerLoadInfo: IBlobManagerLoadInfo = {},
 		attached = false,
 		stashed: unknown[] = [[], {}],
 	) {
@@ -96,7 +96,7 @@ export class MockRuntime
 		this.baseLogger = mc.logger;
 		this.blobManager = new BlobManager({
 			routeContext: undefined as unknown as IFluidHandleContext,
-			snapshot,
+			blobManagerLoadInfo,
 			storage: this.getStorage(),
 			sendBlobAttachOp: (localId: string, blobId?: string) =>
 				this.sendBlobAttachOp(localId, blobId),

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -97,7 +97,7 @@ export class MockRuntime
 		this.blobManager = new BlobManager({
 			routeContext: undefined as unknown as IFluidHandleContext,
 			snapshot,
-			getStorage: () => this.getStorage(),
+			storage: this.getStorage(),
 			sendBlobAttachOp: (localId: string, blobId?: string) =>
 				this.sendBlobAttachOp(localId, blobId),
 			blobRequested: () => undefined,

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -373,7 +373,7 @@ describe("BlobManager", () => {
 			assert((runtime.blobManager as any).pendingBlobs.size === 0);
 		};
 
-		runtime.blobManager.on("noPendingBlobs", () => onNoPendingBlobs());
+		runtime.blobManager.events.on("noPendingBlobs", () => onNoPendingBlobs());
 	});
 
 	afterEach(async () => {
@@ -420,7 +420,7 @@ describe("BlobManager", () => {
 		await runtime.attach();
 		await runtime.connect();
 		let count = 0;
-		runtime.blobManager.on("noPendingBlobs", () => count++);
+		runtime.blobManager.events.on("noPendingBlobs", () => count++);
 
 		await createBlob(IsoBuffer.from("blob", "utf8"));
 		await runtime.processAll();

--- a/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
@@ -90,12 +90,11 @@ describe("BlobManager.stashed", () => {
 		const blobManager = createBlobManager({
 			sendBlobAttachOp(_localId, _storageId) {},
 			stashedBlobs: {},
-			getStorage: () =>
-				failProxy<IDocumentStorageService>({
-					createBlob: async () => {
-						return createResponse.promise;
-					},
-				}),
+			storage: failProxy<IDocumentStorageService>({
+				createBlob: async () => {
+					return createResponse.promise;
+				},
+			}),
 		});
 		const blob: ArrayBufferLike = stringToBuffer("content", "utf8");
 		const sameBlobAsStashedP = blobManager.createBlob(blob);
@@ -105,12 +104,11 @@ describe("BlobManager.stashed", () => {
 		const pendingBlobs = await pendingBlobsP;
 		const blobManager2 = createBlobManager({
 			stashedBlobs: pendingBlobs,
-			getStorage: () =>
-				failProxy<IDocumentStorageService>({
-					createBlob: async () => {
-						return createResponse.promise;
-					},
-				}),
+			storage: failProxy<IDocumentStorageService>({
+				createBlob: async () => {
+					return createResponse.promise;
+				},
+			}),
 		});
 		assert.strictEqual(blobManager2.hasPendingStashedUploads(), true);
 	});
@@ -120,12 +118,11 @@ describe("BlobManager.stashed", () => {
 		const blobManager = createBlobManager({
 			sendBlobAttachOp(_localId, _storageId) {},
 			stashedBlobs: {},
-			getStorage: () =>
-				failProxy<IDocumentStorageService>({
-					createBlob: async () => {
-						return createResponse.promise;
-					},
-				}),
+			storage: failProxy<IDocumentStorageService>({
+				createBlob: async () => {
+					return createResponse.promise;
+				},
+			}),
 			localBlobIdGenerator: () => "stubbed-local-id",
 			isBlobDeleted: () => false,
 			blobRequested: () => {},
@@ -140,12 +137,11 @@ describe("BlobManager.stashed", () => {
 		const createResponse2 = new Deferred<ICreateBlobResponse>();
 		const blobManager2 = createBlobManager({
 			stashedBlobs: pendingBlobs,
-			getStorage: () =>
-				failProxy<IDocumentStorageService>({
-					createBlob: async () => {
-						return createResponse2.promise;
-					},
-				}),
+			storage: failProxy<IDocumentStorageService>({
+				createBlob: async () => {
+					return createResponse2.promise;
+				},
+			}),
 			isBlobDeleted: () => false,
 		});
 		assert.strictEqual(blobManager2.hasPendingStashedUploads(), true);
@@ -183,12 +179,11 @@ describe("BlobManager.stashed", () => {
 					blob: "a",
 				},
 			},
-			getStorage: () =>
-				failProxy<IDocumentStorageService>({
-					createBlob: async () => {
-						return createResponse.promise;
-					},
-				}),
+			storage: failProxy<IDocumentStorageService>({
+				createBlob: async () => {
+					return createResponse.promise;
+				},
+			}),
 		});
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		await Promise.race([
@@ -213,12 +208,11 @@ describe("BlobManager.stashed", () => {
 			stashedBlobs: {
 				olderThanTTL,
 			},
-			getStorage: () =>
-				failProxy<IDocumentStorageService>({
-					createBlob: async () => {
-						return createResponse.promise;
-					},
-				}),
+			storage: failProxy<IDocumentStorageService>({
+				createBlob: async () => {
+					return createResponse.promise;
+				},
+			}),
 		});
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		await Promise.race([
@@ -254,12 +248,11 @@ describe("BlobManager.stashed", () => {
 			stashedBlobs: {
 				storageIdWithoutUploadTime,
 			},
-			getStorage: () =>
-				failProxy<IDocumentStorageService>({
-					createBlob: async () => {
-						return createResponse.promise;
-					},
-				}),
+			storage: failProxy<IDocumentStorageService>({
+				createBlob: async () => {
+					return createResponse.promise;
+				},
+			}),
 		});
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		await Promise.race([
@@ -298,13 +291,12 @@ describe("BlobManager.stashed", () => {
 
 		const blobManager = createBlobManager({
 			stashedBlobs,
-			getStorage: () =>
-				failProxy<IDocumentStorageService>({
-					createBlob: async (b) => {
-						await letUploadsComplete.promise;
-						return { id: `id:${bufferToString(b, "utf8")}` };
-					},
-				}),
+			storage: failProxy<IDocumentStorageService>({
+				createBlob: async (b) => {
+					await letUploadsComplete.promise;
+					return { id: `id:${bufferToString(b, "utf8")}` };
+				},
+			}),
 		});
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), true);
 		await Promise.race([

--- a/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
@@ -49,7 +49,7 @@ function createBlobManager(overrides?: Partial<ConstructorParameters<typeof Blob
 			// defaults, these can still be overridden below
 			runtime,
 			routeContext,
-			snapshot: {},
+			blobManagerLoadInfo: {},
 			stashedBlobs: undefined,
 			localBlobIdGenerator: undefined,
 


### PR DESCRIPTION
As I'm ramping up on BlobManager, I've been collecting some tweaks/cleanup into this branch.  Mostly naming changes to help new readers of the code avoid confusion (e.g. "snapshot" not really being a snapshot, trying to disambiguate id into localId vs. storageId), but also a few opportunities to remove no-op or unreachable code, event typing, trimming exports, etc.