### PR TITLE
Benchmarking: Fix units of margin of error on results printout

### DIFF
--- a/tools/benchmark/src/runBenchmark.ts
+++ b/tools/benchmark/src/runBenchmark.ts
@@ -203,9 +203,9 @@ class BenchmarkState<T> implements BenchmarkTimer<T> {
 					rawValue: 1e9 * stats.arithmeticMean,
 					formattedValue: prettyNumber(1e9 * stats.arithmeticMean, 2),
 				},
-				"Margin of Error": {
+				"Margin of Error (ns)": {
 					rawValue: stats.marginOfError,
-					formattedValue: `±${prettyNumber(stats.marginOfError, 2)}%`,
+					formattedValue: `±${prettyNumber(1e9 * stats.marginOfError, 2)}`,
 				},
 				"Relative Margin of Error": {
 					rawValue: stats.marginOfErrorPercent,


### PR DESCRIPTION
## Description

Margin of error prints out as a percentage, instead of time.  This fixes it.

### Before

![image](https://github.com/user-attachments/assets/8d9762c6-acf0-48bd-a718-aa1e2797b981)


### After

![image](https://github.com/user-attachments/assets/55b0e365-daf1-4bc3-a12d-443a4b5a4df6)
