### PR TITLE
docs(client-presence): fix comment for IPresence.events

### DIFF
--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -163,7 +163,7 @@ export interface PresenceEvents {
  */
 export interface IPresence {
 	/**
-	 * Events for Presence Manager.
+	 * Events for Presence.
 	 */
 	readonly events: Listenable<PresenceEvents>;
 

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -163,7 +163,7 @@ export interface PresenceEvents {
  */
 export interface IPresence {
 	/**
-	 * Events for Notifications manager.
+	 * Events for Presence Manager.
 	 */
 	readonly events: Listenable<PresenceEvents>;
 


### PR DESCRIPTION
## Description
IPresence.events refers to presence events (attendeeJoined, attendeeDisconnected, etc.) rather than Notification Manager events. 