### PR TITLE
Use Maps instead of records, and document property vs stored keys

### DIFF
--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -194,6 +194,7 @@ export {
 	type SimpleMapNodeSchema,
 	type SimpleArrayNodeSchema,
 	type SimpleObjectNodeSchema,
+	type SimpleObjectFieldSchema,
 	normalizeAllowedTypes,
 	getSimpleSchema,
 	type ReadonlyArrayNode,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -813,7 +813,7 @@ function exportSimpleNodeSchemaStored(schema: TreeNodeStoredSchema): SimpleNodeS
 		return { kind: NodeKind.Array, allowedTypes: arrayTypes };
 	}
 	if (schema instanceof ObjectNodeStoredSchema) {
-		const fields: Map<FieldKey, SimpleObjectFieldSchema> = new Map();
+		const fields = new Map<FieldKey, SimpleObjectFieldSchema>();
 		for (const [storedKey, field] of schema.objectNodeFields) {
 			fields.set(storedKey, { ...exportSimpleFieldSchemaStored(field), storedKey });
 		}

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -35,6 +35,7 @@ import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitio
 
 import { type ICodecOptions, noopValidator } from "../codec/index.js";
 import {
+	type FieldKey,
 	type GraphCommit,
 	type IEditableForest,
 	type ITreeCursor,
@@ -93,6 +94,7 @@ import {
 	type CustomTreeNode,
 	type CustomTreeValue,
 	type ITreeAlpha,
+	type SimpleObjectFieldSchema,
 } from "../simple-tree/index.js";
 
 import { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
@@ -811,9 +813,9 @@ function exportSimpleNodeSchemaStored(schema: TreeNodeStoredSchema): SimpleNodeS
 		return { kind: NodeKind.Array, allowedTypes: arrayTypes };
 	}
 	if (schema instanceof ObjectNodeStoredSchema) {
-		const fields: Record<string, SimpleFieldSchema> = {};
-		for (const [key, field] of schema.objectNodeFields) {
-			fields[key] = exportSimpleFieldSchemaStored(field);
+		const fields: Map<FieldKey, SimpleObjectFieldSchema> = new Map();
+		for (const [storedKey, field] of schema.objectNodeFields) {
+			fields.set(storedKey, { ...exportSimpleFieldSchemaStored(field), storedKey });
 		}
 		return { kind: NodeKind.Object, fields };
 	}

--- a/packages/dds/tree/src/simple-tree/api/getJsonSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/getJsonSchema.ts
@@ -60,6 +60,16 @@ const jsonSchemaCache = new WeakMap<TreeNodeSchema, JsonTreeSchema>();
  * @privateRemarks In the future, we may wish to move this to a more discoverable API location.
  * For now, while still an experimental API, it is surfaced as a free function.
  *
+ * TODO:
+ * This API should allow generating JSON schema for the whole matrix of combinations:
+ *
+ * 1. VerboseTree and ConciseTree
+ * 2. With and without requiring values with defaults (for insertion vs reading)
+ * 3. Using stored keys and property keys
+ *
+ * Thus current API seems to give ConciseTree with property keys and ignoring default values.
+ *
+ *
  * @alpha
  */
 export function getJsonSchema(schema: ImplicitFieldSchema): JsonTreeSchema {

--- a/packages/dds/tree/src/simple-tree/api/getJsonSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/getJsonSchema.ts
@@ -67,7 +67,7 @@ const jsonSchemaCache = new WeakMap<TreeNodeSchema, JsonTreeSchema>();
  * 2. With and without requiring values with defaults (for insertion vs reading)
  * 3. Using stored keys and property keys
  *
- * Thus current API seems to give ConciseTree with property keys and ignoring default values.
+ * This current API seems to give ConciseTree with property keys and ignoring default values.
  *
  *
  * @alpha

--- a/packages/dds/tree/src/simple-tree/api/index.ts
+++ b/packages/dds/tree/src/simple-tree/api/index.ts
@@ -45,6 +45,7 @@ export type {
 	SimpleArrayNodeSchema,
 	SimpleObjectNodeSchema,
 	SimpleNodeSchemaBase,
+	SimpleObjectFieldSchema,
 } from "./simpleSchema.js";
 export {
 	type JsonSchemaId,

--- a/packages/dds/tree/src/simple-tree/api/schemaFromSimple.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFromSimple.ts
@@ -48,7 +48,7 @@ function generateNode(id: string, schema: SimpleNodeSchema, context: Context): T
 	switch (schema.kind) {
 		case NodeKind.Object: {
 			const fields: Record<string, FieldSchema> = {};
-			for (const [key, field] of Object.entries(schema.fields)) {
+			for (const [key, field] of schema.fields) {
 				fields[key] = generateFieldSchema(field, context);
 			}
 			return factory.object(id, fields);

--- a/packages/dds/tree/src/simple-tree/api/simpleSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleSchema.ts
@@ -46,7 +46,7 @@ export interface SimpleObjectNodeSchema extends SimpleNodeSchemaBase<NodeKind.Ob
 	 * @remarks
 	 * The keys are the property keys if known, otherwise they are the stored keys.
 	 * @privateRemarks
-	 * TODO: Provide and link and way to translate between the stored keys and the property keys.
+	 * TODO: Provide and link a way to translate between the stored keys and the property keys.
 	 * TODO: Consider adding `storedKeysToFields` or something similar to reduce confusion,
 	 * especially if/when TreeNodeSchema for objects implement this and likely provide more maps.
 	 */

--- a/packages/dds/tree/src/simple-tree/api/simpleSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleSchema.ts
@@ -44,12 +44,30 @@ export interface SimpleObjectNodeSchema extends SimpleNodeSchemaBase<NodeKind.Ob
 	/**
 	 * Schemas for each of the object's fields, keyed off of schema's keys.
 	 * @remarks
-	 * Depending on how this schema was exported, the string keys may be either the property keys or the stored keys.
+	 * The keys are the property keys if known, otherwise they are the stored keys.
 	 * @privateRemarks
-	 * TODO: if these are supposed to be JSON compatible,
-	 * then using a record here makes sense, but if not, this should use a map, and the allowedTypes sets elsewhere should be arrays for JSON compatibility.
+	 * TODO: Provide and link and way to translate between the stored keys and the property keys.
+	 * TODO: Consider adding `storedKeysToFields` or something similar to reduce confusion,
+	 * especially if/when TreeNodeSchema for objects implement this and likely provide more maps.
 	 */
-	readonly fields: Record<string, SimpleFieldSchema>;
+	readonly fields: ReadonlyMap<string, SimpleObjectFieldSchema>;
+}
+
+/**
+ * A {@link SimpleNodeSchema} for an object node.
+ * @remarks
+ * The only other case fields are uses in the root schema.
+ *
+ * @internal
+ * @sealed
+ */
+export interface SimpleObjectFieldSchema extends SimpleFieldSchema {
+	/**
+	 * The stored key of the field.
+	 * @remarks
+	 * See {@link FieldProps.key} for more information.
+	 */
+	readonly storedKey: string;
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/api/simpleSchemaToJsonSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleSchemaToJsonSchema.ts
@@ -138,10 +138,10 @@ function convertLeafNodeSchema(schema: SimpleLeafNodeSchema): JsonLeafNodeSchema
 	};
 }
 
-function convertObjectNodeSchema(schema: SimpleObjectNodeSchema): JsonObjectNodeSchema {
+export function convertObjectNodeSchema(schema: SimpleObjectNodeSchema): JsonObjectNodeSchema {
 	const properties: Record<string, JsonFieldSchema> = {};
 	const required: string[] = [];
-	for (const [key, fieldSchema] of Object.entries(schema.fields)) {
+	for (const [key, fieldSchema] of schema.fields) {
 		const allowedTypes: JsonSchemaRef[] = [];
 		for (const allowedType of fieldSchema.allowedTypes) {
 			allowedTypes.push(createSchemaRef(allowedType));

--- a/packages/dds/tree/src/simple-tree/api/viewSchemaToSimpleSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/viewSchemaToSimpleSchema.ts
@@ -5,6 +5,7 @@
 
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
+	getStoredKey,
 	normalizeFieldSchema,
 	type FieldSchema,
 	type ImplicitAllowedTypes,
@@ -16,6 +17,7 @@ import type {
 	SimpleLeafNodeSchema,
 	SimpleMapNodeSchema,
 	SimpleNodeSchema,
+	SimpleObjectFieldSchema,
 	SimpleObjectNodeSchema,
 	SimpleTreeSchema,
 } from "./simpleSchema.js";
@@ -116,9 +118,12 @@ function mapSchemaToSimpleSchema(schema: TreeNodeSchema): SimpleMapNodeSchema {
 }
 
 function objectSchemaToSimpleSchema(schema: ObjectNodeSchema): SimpleObjectNodeSchema {
-	const fields: Record<string, SimpleFieldSchema> = {};
-	for (const [key, field] of schema.fields) {
-		fields[key] = fieldSchemaToSimpleSchema(field);
+	const fields: Map<string, SimpleObjectFieldSchema> = new Map();
+	for (const [propertyKey, field] of schema.fields) {
+		fields.set(propertyKey, {
+			...fieldSchemaToSimpleSchema(field),
+			storedKey: getStoredKey(propertyKey, field),
+		});
 	}
 
 	const output: Mutable<SimpleObjectNodeSchema> = {

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -65,6 +65,7 @@ export {
 	type SimpleMapNodeSchema,
 	type SimpleArrayNodeSchema,
 	type SimpleObjectNodeSchema,
+	type SimpleObjectFieldSchema,
 	type JsonSchemaId,
 	type JsonSchemaType,
 	type JsonObjectNodeSchema,

--- a/packages/dds/tree/src/test/simple-tree/api/getSimpleSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/getSimpleSchema.spec.ts
@@ -166,16 +166,24 @@ describe("getSimpleSchema", () => {
 					"test.object",
 					{
 						kind: NodeKind.Object,
-						fields: {
-							foo: {
-								kind: FieldKind.Optional,
-								allowedTypes: new Set(["com.fluidframework.leaf.number"]),
-							},
-							bar: {
-								kind: FieldKind.Required,
-								allowedTypes: new Set(["com.fluidframework.leaf.string"]),
-							},
-						},
+						fields: new Map([
+							[
+								"foo",
+								{
+									kind: FieldKind.Optional,
+									allowedTypes: new Set(["com.fluidframework.leaf.number"]),
+									storedKey: "foo",
+								},
+							],
+							[
+								"bar",
+								{
+									kind: FieldKind.Required,
+									allowedTypes: new Set(["com.fluidframework.leaf.string"]),
+									storedKey: "bar",
+								},
+							],
+						]),
 					},
 				],
 				[
@@ -213,12 +221,16 @@ describe("getSimpleSchema", () => {
 					"test.object",
 					{
 						kind: NodeKind.Object,
-						fields: {
-							id: {
-								kind: FieldKind.Identifier,
-								allowedTypes: new Set(["com.fluidframework.leaf.string"]),
-							},
-						},
+						fields: new Map([
+							[
+								"id",
+								{
+									kind: FieldKind.Identifier,
+									allowedTypes: new Set(["com.fluidframework.leaf.string"]),
+									storedKey: "id",
+								},
+							],
+						]),
 					},
 				],
 				[
@@ -249,15 +261,19 @@ describe("getSimpleSchema", () => {
 					"test.object",
 					{
 						kind: NodeKind.Object,
-						fields: {
-							foo: {
-								kind: FieldKind.Required,
-								allowedTypes: new Set([
-									"com.fluidframework.leaf.number",
-									"com.fluidframework.leaf.string",
-								]),
-							},
-						},
+						fields: new Map([
+							[
+								"foo",
+								{
+									kind: FieldKind.Required,
+									allowedTypes: new Set([
+										"com.fluidframework.leaf.number",
+										"com.fluidframework.leaf.string",
+									]),
+									storedKey: "foo",
+								},
+							],
+						]),
 					},
 				],
 				[
@@ -295,15 +311,19 @@ describe("getSimpleSchema", () => {
 					"test.recursive-object",
 					{
 						kind: NodeKind.Object,
-						fields: {
-							foo: {
-								kind: FieldKind.Optional,
-								allowedTypes: new Set([
-									"com.fluidframework.leaf.string",
-									"test.recursive-object",
-								]),
-							},
-						},
+						fields: new Map([
+							[
+								"foo",
+								{
+									kind: FieldKind.Optional,
+									allowedTypes: new Set([
+										"com.fluidframework.leaf.string",
+										"test.recursive-object",
+									]),
+									storedKey: "foo",
+								},
+							],
+						]),
 					},
 				],
 				[

--- a/packages/framework/ai-collab/src/explicit-strategy/typeGeneration.ts
+++ b/packages/framework/ai-collab/src/explicit-strategy/typeGeneration.ts
@@ -231,7 +231,7 @@ function getOrCreateType(
 		const nodeSchema = definitionMap.get(definition) ?? fail("Unexpected definition");
 		switch (nodeSchema.kind) {
 			case NodeKind.Object: {
-				for (const [key, field] of Object.entries(nodeSchema.fields)) {
+				for (const [key, field] of nodeSchema.fields) {
 					// TODO: Remove when AI better
 					if (
 						Array.from(
@@ -248,7 +248,7 @@ function getOrCreateType(
 				}
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 				const properties = Object.fromEntries(
-					Object.entries(nodeSchema.fields)
+					[...nodeSchema.fields]
 						.map(([key, field]) => {
 							return [
 								key,

--- a/packages/tools/devtools/devtools-core/src/data-visualization/SharedTreeVisualizer.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/SharedTreeVisualizer.ts
@@ -221,7 +221,7 @@ async function visualizeObjectNode(
 	visualizeChildData: VisualizeChildData,
 ): Promise<VisualSharedTreeNode> {
 	const objectNodeSchemaProperties: Record<string, FieldSchemaProperties> = {};
-	for (const [fieldKey, treeFieldSimpleSchema] of Object.entries(schema.fields)) {
+	for (const [fieldKey, treeFieldSimpleSchema] of schema.fields) {
 		objectNodeSchemaProperties[fieldKey] = {
 			allowedTypes: treeFieldSimpleSchema.allowedTypes,
 			isRequired: treeFieldSimpleSchema.kind === FieldKind.Required ? true : false,


### PR DESCRIPTION
## Description

Use Maps instead of records for SimpleObjectNodeSchema.fields.
Better document its use of property vs stored keys.
Add storedKey property via SimpleObjectFieldSchema to allow access to the stored keys.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


