### PR TITLE
Update circuit breaker shutdown logic to clear the restart timeout + update logs

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scriptorium/lambda.ts
@@ -200,9 +200,17 @@ export class ScriptoriumLambda implements IPartitionLambda {
 				error?.message?.toString()?.indexOf(errorFilter) >= 0 ||
 				error?.stack?.toString()?.indexOf(errorFilter) >= 0
 			) {
+				Lumberjack.info("Error filter checked, opening the circuit breaker", {
+					error,
+					errorFilter: this.circuitBreakerOptions.filterOnErrors,
+				});
 				return false; // circuit breaker will open and pause the lambda
 			}
 		}
+		Lumberjack.info("Error filter checked, not opening the circuit breaker", {
+			error,
+			errorFilter: this.circuitBreakerOptions.filterOnErrors,
+		});
 		return true; // do not open the circuit for other errors, and let scriptorium restart
 	}
 

--- a/server/routerlicious/packages/lambdas/src/test/utils/circuitBreaker.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/utils/circuitBreaker.spec.ts
@@ -208,7 +208,7 @@ describe("Lambda CircuitBreaker", () => {
 		const contextErrorHandler = Sinon.spy((error, errorData) => {
 			assert.strictEqual(error.message, errorResponse);
 			assert.strictEqual(errorData.restart, true);
-		})
+		});
 		testContext.on("error", contextErrorHandler);
 
 		await assert.rejects(circuitBreaker.execute([false]), {
@@ -233,7 +233,7 @@ describe("Lambda CircuitBreaker", () => {
 		const contextErrorHandler = Sinon.spy((error, errorData) => {
 			assert.strictEqual(error.message, errorResponse);
 			assert.strictEqual(errorData.restart, true);
-		})
+		});
 		testContext.on("error", contextErrorHandler);
 
 		await assert.rejects(circuitBreaker.execute([false]), {

--- a/server/routerlicious/packages/lambdas/src/utils/circuitBreaker.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/circuitBreaker.ts
@@ -111,9 +111,9 @@ export class LambdaCircuitBreaker {
 		};
 		if (this.circuitBreakerMetric) {
 			this.circuitBreakerMetric?.setProperties(metricProperties);
-			this.circuitBreakerMetric?.success("Circuit breaker shutdown due to lambda close"); // could be due to rebalancing
+			this.circuitBreakerMetric?.success("Circuit breaker shutdown"); // could be due to rebalancing
 		} else {
-			Lumberjack.info("Circuit breaker shutdown due to lambda close", metricProperties);
+			Lumberjack.info("Circuit breaker shutdown", metricProperties);
 		}
 	}
 


### PR DESCRIPTION
## Description

Update circuit breaker shutdown logic to clear the restart timeout and emit logs.

This is to avoid a situation where the circuit breaker is shutdown (could be due to lambda rebalancing) while it was in open state, but the restart timer continues and restarts the pod unnecessarily. 
