### PR TITLE
perf(merge-tree): Avoid calling blockUpdate on insertingWalk with no changes

### DIFF
--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -1145,7 +1145,7 @@ describe("Matrix1", () => {
 				runGCTests(GCSharedMatrixProvider);
 			});
 
-			describe.only("inserting and deleting many cells", () => {
+			describe("inserting and deleting many cells", () => {
 				it("is connected", () => {
 					const matrix = createConnectedMatrix(
 						"foo",
@@ -1153,7 +1153,7 @@ describe("Matrix1", () => {
 						isSetCellPolicyFWW,
 					);
 
-					for (let i = 0; i < 5000; i++) {
+					for (let i = 0; i < 10_000; i++) {
 						matrix.insertCols(0, 1);
 						matrix.insertRows(0, 1);
 						matrix.removeCols(0, 1);
@@ -1167,7 +1167,7 @@ describe("Matrix1", () => {
 						matrix.switchSetCellPolicy();
 					}
 
-					for (let i = 0; i <= 5000; i++) {
+					for (let i = 0; i <= 10_000; i++) {
 						matrix.insertCols(0, 1);
 						matrix.insertRows(0, 1);
 						matrix.removeCols(0, 1);

--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -1145,7 +1145,7 @@ describe("Matrix1", () => {
 				runGCTests(GCSharedMatrixProvider);
 			});
 
-			describe("inserting and deleting many cells", () => {
+			describe.only("inserting and deleting many cells", () => {
 				it("is connected", () => {
 					const matrix = createConnectedMatrix(
 						"foo",

--- a/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -348,6 +348,8 @@ describe("MergeTree.insertingWalk", () => {
 		assert.deepStrictEqual(segments, ["G", "F", "E", "(D)", "(C)", "(B)", "(A)", "x", "0"]);
 	});
 
+	// Inserting walk previously unnecessarily called `blockUpdate` for blocks even when no segment changes happened (e.g.
+	// we called `ensureIntervalBoundary` but there was already a segment boundary at the position we wanted to ensure had one).
 	it("avoids calling blockUpdate excessively", () => {
 		let seq = 1;
 		const mergeTree = new MergeTree();


### PR DESCRIPTION
## Description

Refactors `insertingWalk` to pay attention to whether it ended up changing segments. This allows us to remove the recursive block length update in cases where we didn't change anything. I did a small amount of opportunistic refactoring in nearby areas (mostly the entrypoint to `insertingWalk`).

This should be a marginal performance gain for some scenarios, see [context here](https://github.com/microsoft/FluidFramework/pull/24047#discussion_r1999795385), which allows restoring a matrix test to its previous values (changed in #24047) without risk of timeout.