### PR TITLE
DDS Fuzz: Make reducers sync for easier re-use

### DIFF
--- a/packages/dds/map/src/test/mocha/fuzzUtils.ts
+++ b/packages/dds/map/src/test/mocha/fuzzUtils.ts
@@ -7,10 +7,9 @@ import { strict as assert } from "node:assert";
 
 import {
 	type AsyncGenerator,
-	type AsyncReducer,
 	type Generator,
+	type Reducer,
 	combineReducers,
-	combineReducersAsync,
 	createWeightedAsyncGenerator,
 	createWeightedGenerator,
 	takeAsync,
@@ -151,7 +150,7 @@ export const baseMapModel: DDSFuzzModel<MapFactory, MapOperation> = {
 	workloadName: "default",
 	factory: new MapFactory(),
 	generatorFactory: () => takeAsync(100, mapMakeGenerator()),
-	reducer: async (state, operation) => mapReducer(state, operation),
+	reducer: (state, operation) => mapReducer(state, operation),
 	validateConsistency: async (a, b) => assertMapsAreEquivalent(a.channel, b.channel),
 };
 
@@ -450,17 +449,17 @@ function logCurrentState(clients: Client<DirectoryFactory>[], loggingInfo: Loggi
  */
 export function makeDirReducer(
 	loggingInfo?: LoggingInfo,
-): AsyncReducer<DirOperation, DirFuzzTestState> {
+): Reducer<DirOperation, DirFuzzTestState> {
 	const withLogging =
-		<T>(baseReducer: AsyncReducer<T, DirFuzzTestState>): AsyncReducer<T, DirFuzzTestState> =>
-		async (state, operation) => {
+		<T>(baseReducer: Reducer<T, DirFuzzTestState>): Reducer<T, DirFuzzTestState> =>
+		(state, operation) => {
 			if (loggingInfo?.printConsoleLogs === true) {
 				logCurrentState(state.clients, loggingInfo);
 				console.log("-".repeat(20));
 				console.log("Next operation:", JSON.stringify(operation, undefined, 4));
 			}
 			try {
-				await baseReducer(state, operation);
+				baseReducer(state, operation);
 			} catch (error) {
 				if (loggingInfo?.printConsoleLogs === true) {
 					logCurrentState(state.clients, loggingInfo);
@@ -470,28 +469,28 @@ export function makeDirReducer(
 			return state;
 		};
 
-	const reducer: AsyncReducer<DirOperation, DirFuzzTestState> = combineReducersAsync({
-		createSubDirectory: async ({ client }, { path, name }) => {
+	const reducer: Reducer<DirOperation, DirFuzzTestState> = combineReducers({
+		createSubDirectory: ({ client }, { path, name }) => {
 			const dir = client.channel.getWorkingDirectory(path);
 			assert(dir);
 			dir.createSubDirectory(name);
 		},
-		deleteSubDirectory: async ({ client }, { path, name }) => {
+		deleteSubDirectory: ({ client }, { path, name }) => {
 			const dir = client.channel.getWorkingDirectory(path);
 			assert(dir);
 			dir.deleteSubDirectory(name);
 		},
-		set: async ({ client }, { path, key, value }) => {
+		set: ({ client }, { path, key, value }) => {
 			const dir = client.channel.getWorkingDirectory(path);
 			assert(dir);
 			dir.set(key, value);
 		},
-		clear: async ({ client }, { path }) => {
+		clear: ({ client }, { path }) => {
 			const dir = client.channel.getWorkingDirectory(path);
 			assert(dir);
 			dir.clear();
 		},
-		delete: async ({ client }, { path, key }) => {
+		delete: ({ client }, { path, key }) => {
 			const dir = client.channel.getWorkingDirectory(path);
 			assert(dir);
 			dir.delete(key);

--- a/packages/dds/matrix/src/test/matrix.fuzz.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.fuzz.spec.ts
@@ -232,7 +232,7 @@ describe("Matrix fuzz tests", function () {
 	const model: Omit<DDSFuzzModel<SharedMatrixFactory, Operation>, "workloadName"> = {
 		factory: SharedMatrix.getFactory(),
 		generatorFactory: () => takeAsync(50, makeGenerator()),
-		reducer: async (state, operation) => reducer(state, operation),
+		reducer: (state, operation) => reducer(state, operation),
 		validateConsistency: async (a, b) => assertMatricesAreEquivalent(a.channel, b.channel),
 		minimizationTransforms: ["count", "start", "row", "col"].map((p) => (op) => {
 			if (p in op && typeof op[p] === "number" && op[p] > 0) {

--- a/packages/dds/task-manager/src/test/taskManager.fuzz.spec.ts
+++ b/packages/dds/task-manager/src/test/taskManager.fuzz.spec.ts
@@ -8,8 +8,8 @@ import * as path from "path";
 
 import {
 	AsyncGenerator as Generator,
-	AsyncReducer as Reducer,
-	combineReducersAsync as combineReducers,
+	Reducer,
+	combineReducers,
 	createWeightedAsyncGenerator as createWeightedGenerator,
 	makeRandom,
 	takeAsync as take,
@@ -171,17 +171,17 @@ function logCurrentState(state: FuzzTestState, loggingInfo: LoggingInfo): void {
 function makeReducer(loggingInfo?: LoggingInfo): Reducer<Operation, FuzzTestState> {
 	const withLogging =
 		<T>(baseReducer: Reducer<T, FuzzTestState>): Reducer<T, FuzzTestState> =>
-		async (state, operation) => {
+		(state, operation) => {
 			if (loggingInfo !== undefined && (operation as any).taskId === loggingInfo.taskId) {
 				logCurrentState(state, loggingInfo);
 				console.log("-".repeat(20));
 				console.log("Next operation:", JSON.stringify(operation, undefined, 4));
 			}
-			await baseReducer(state, operation);
+			baseReducer(state, operation);
 		};
 
 	const reducer = combineReducers<Operation, FuzzTestState>({
-		volunteer: async ({ client }, { taskId }) => {
+		volunteer: ({ client }, { taskId }) => {
 			// Note: this is fire-and-forget as `volunteerForTask` resolves/rejects its returned
 			// promise based on server responses, which will occur on later operations (and
 			// processing those operations will raise the error directly)
@@ -196,13 +196,13 @@ function makeReducer(loggingInfo?: LoggingInfo): Reducer<Operation, FuzzTestStat
 				}
 			});
 		},
-		abandon: async ({ client }, { taskId }) => {
+		abandon: ({ client }, { taskId }) => {
 			client.channel.abandon(taskId);
 		},
-		subscribe: async ({ client }, { taskId }) => {
+		subscribe: ({ client }, { taskId }) => {
 			client.channel.subscribeToTask(taskId);
 		},
-		complete: async ({ client }, { taskId }) => {
+		complete: ({ client }, { taskId }) => {
 			client.channel.complete(taskId);
 		},
 	});

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -267,6 +267,12 @@ export interface DDSFuzzModel<
 }
 
 /**
+ * This model is used within the harness to wrap the provided {@link DDSFuzzModel}.
+ *
+ * This model's reducer differs from the {@link DDSFuzzModel} in that it can be an asynchronous
+ * reducer. This is necessary for the harness to support asynchronous operations
+ * like loading new clients, and doing synchronization.
+ *
  * @internal
  */
 export interface DDSFuzzHarnessModel<
@@ -276,9 +282,6 @@ export interface DDSFuzzHarnessModel<
 > extends Omit<DDSFuzzModel<TChannelFactory, TOperation, TState>, "reducer"> {
 	/**
 	 * Reducer capable of updating the test state according to the operations generated.
-	 * This reducer differs from the {@link DDSFuzzModel} in that it can be an asynchronous
-	 * reducer. This is necessary for the harness to support asynchronous operations
-	 * like loading new clients, and doing synchronization.
 	 */
 	reducer: AsyncReducer<TOperation, TState> | Reducer<TOperation, TState>;
 }

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -276,6 +276,9 @@ export interface DDSFuzzHarnessModel<
 > extends Omit<DDSFuzzModel<TChannelFactory, TOperation, TState>, "reducer"> {
 	/**
 	 * Reducer capable of updating the test state according to the operations generated.
+	 * This reducer differs from the {@link DDSFuzzModel} in that it can be an asynchronous
+	 * reducer. This is necessary for the harness to support asynchronous operations
+	 * like loading new clients, and doing synchronization.
 	 */
 	reducer: AsyncReducer<TOperation, TState> | Reducer<TOperation, TState>;
 }

--- a/packages/dds/test-dds-utils/src/index.ts
+++ b/packages/dds/test-dds-utils/src/index.ts
@@ -10,6 +10,7 @@ export type {
 	ChangeConnectionState,
 	ClientSpec,
 	DDSFuzzModel,
+	DDSFuzzHarnessModel,
 	DDSFuzzSuiteOptions,
 	DDSFuzzTestState,
 	DDSFuzzHarnessEvents,

--- a/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
@@ -24,6 +24,7 @@ import type {
 	ChangeConnectionState,
 	ClientSpec,
 	DDSFuzzHarnessEvents,
+	DDSFuzzHarnessModel,
 	DDSFuzzModel,
 	DDSFuzzSuiteOptions,
 	DDSFuzzTestState,
@@ -64,9 +65,9 @@ function mixinSpying<
 	TOperation extends BaseOperation,
 	TState extends DDSFuzzTestState<TChannelFactory>,
 >(
-	model: DDSFuzzModel<TChannelFactory, TOperation, TState>,
+	model: DDSFuzzHarnessModel<TChannelFactory, TOperation, TState>,
 ): {
-	model: DDSFuzzModel<TChannelFactory, TOperation, TState>;
+	model: DDSFuzzHarnessModel<TChannelFactory, TOperation, TState>;
 	generatedOperations: (TOperation | typeof done)[];
 	processedOperations: TOperation[];
 } {
@@ -208,7 +209,7 @@ describe("DDS Fuzz Harness", () => {
 			it("processes outstanding messages on synchronize ops", async () => {
 				const noValidateModel: Model = {
 					...baseModel,
-					reducer: async ({ clients }, operation) => {
+					reducer: ({ clients }, operation) => {
 						assert(isNoopOp(operation));
 						clients[0].channel.noop();
 					},

--- a/packages/dds/test-dds-utils/src/test/ddsSuiteCases/failure.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsSuiteCases/failure.ts
@@ -15,7 +15,7 @@ const model: DDSFuzzModel<SharedNothingFactory, Operation | ChangeConnectionStat
 	workloadName: "failing configuration",
 	// note: overriding the infinite generator isn't necessary here as the test
 	// should exit immediately.
-	reducer: async () => {
+	reducer: () => {
 		throw new Error("Injected failure");
 	},
 };

--- a/packages/dds/test-dds-utils/src/test/ddsSuiteCases/replay.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsSuiteCases/replay.ts
@@ -27,7 +27,7 @@ const model: DDSFuzzModel<SharedNothingFactory, Operation> = {
 	...baseModel,
 	workloadName: "replay",
 	generatorFactory: () => generatorUnreachable,
-	reducer: async (state, op) => {
+	reducer: (state, op) => {
 		assert.deepEqual(op, expectedOps[currentIndex]);
 		assert.equal(state.client.channel.id, expectedOps[currentIndex].clientId);
 		// Note: the above checks failing if currentIndex goes out of bounds is part of the

--- a/packages/dds/test-dds-utils/src/test/sharedNothing.ts
+++ b/packages/dds/test-dds-utils/src/test/sharedNothing.ts
@@ -120,7 +120,7 @@ export const baseModel: DDSFuzzModel<SharedNothingFactory, Operation | ChangeCon
 		workloadName: "test",
 		factory: new SharedNothingFactory(),
 		generatorFactory: () => noopGenerator,
-		reducer: async (state, op) => {},
+		reducer: (state, op) => {},
 		validateConsistency: () => {},
 		minimizationTransforms: [],
 	};

--- a/packages/dds/tree/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert, fail } from "node:assert";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import {
 	type AsyncGenerator,
-	combineReducersAsync,
+	combineReducers,
 	takeAsync,
 } from "@fluid-private/stochastic-test-utils";
 import {
@@ -50,11 +50,8 @@ interface BranchedTreeFuzzTestState extends FuzzTestState {
 	branch?: FuzzTransactionView;
 }
 
-const fuzzComposedVsIndividualReducer = combineReducersAsync<
-	Operation,
-	BranchedTreeFuzzTestState
->({
-	treeEdit: async (state, { edit }) => {
+const fuzzComposedVsIndividualReducer = combineReducers<Operation, BranchedTreeFuzzTestState>({
+	treeEdit: (state, { edit }) => {
 		switch (edit.type) {
 			case "fieldEdit": {
 				const tree = state.branch;
@@ -67,28 +64,28 @@ const fuzzComposedVsIndividualReducer = combineReducersAsync<
 		}
 		return state;
 	},
-	transactionBoundary: async (state, operation) => {
+	transactionBoundary: (state, operation) => {
 		assert.fail(
 			"Transactions are simulated manually in these tests and should not be generated.",
 		);
 	},
-	undoRedo: async (state, { operation }) => {
+	undoRedo: (state, { operation }) => {
 		const tree = state.main ?? assert.fail();
 		assert(isRevertibleSharedTreeView(tree.checkout));
 		applyUndoRedoEdit(tree.checkout.undoStack, tree.checkout.redoStack, operation);
 		return state;
 	},
-	synchronizeTrees: async (state) => {
+	synchronizeTrees: (state) => {
 		applySynchronizationOp(state);
 		return state;
 	},
-	schemaChange: async (state, operation) => {
+	schemaChange: (state, operation) => {
 		return state;
 	},
-	constraint: async (state, operation) => {
+	constraint: (state, operation) => {
 		applyConstraint(state, operation);
 	},
-	forkMergeOperation: async (state, operation) => {
+	forkMergeOperation: (state, operation) => {
 		return applyForkMergeOperation(state, operation);
 	},
 });

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { type AsyncReducer, combineReducers } from "@fluid-private/stochastic-test-utils";
+import { type Reducer, combineReducers } from "@fluid-private/stochastic-test-utils";
 import type { DDSFuzzTestState, Client } from "@fluid-private/test-dds-utils";
 import { unreachableCase } from "@fluidframework/core-utils/internal";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
@@ -97,7 +97,7 @@ const syncFuzzReducer = combineReducers<Operation, DDSFuzzTestState<TreeFactory>
 		applyForkMergeOperation(state, operation);
 	},
 });
-export const fuzzReducer: AsyncReducer<Operation, DDSFuzzTestState<TreeFactory>> = async (
+export const fuzzReducer: Reducer<Operation, DDSFuzzTestState<TreeFactory>> = (
 	state,
 	operation,
 ) => syncFuzzReducer(state, operation);

--- a/packages/test/local-server-stress-tests/src/ddsOperations.ts
+++ b/packages/test/local-server-stress-tests/src/ddsOperations.ts
@@ -121,9 +121,7 @@ export const DDSModelOpReducer: AsyncReducer<DDSModelOp, LocalServerStressState>
 		}
 		return value;
 	});
-	await timeoutAwait(baseModel.reducer(await covertLocalServerStateToDdsState(state), subOp), {
-		errorMsg: `Timed out waiting for dds reducer: ${state.channel.attributes.type}`,
-	});
+	baseModel.reducer(await covertLocalServerStateToDdsState(state), subOp);
 };
 
 export const validateConsistencyOfAllDDS = async (clientA: Client, clientB: Client) => {


### PR DESCRIPTION
The primary motivation for this change is to add support to the local server stress harness for orderSequentially which will increase coverage for batching and rollback. That will come as a follow up. orderSequentially  can only perform synchronous operations, and so I need the models to be able to reduce synchronously, it is fine for generation to remain async.

This also seems like a reasonable change as dds are generally synchronous in nature. There are some dds like consensus which are not synchronous, but those will be hard to test already given we can't track asynchronous operations across fuzz operations, as operations much be serializable, and the same techniques use to make that work, can make them work with a synchronous reducer.