### PR TITLE
Scrub non-ASCII characters from unexpectedAckReceived event

### DIFF
--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -134,7 +134,7 @@ function scrubAndStringify(
 	// Scrub the whole object in case there are unexpected keys
 	const scrubbed: Record<string, unknown> = typesOfKeys(message);
 
-	// For these known/expected keys, we can either drill in (for contents)
+	// For these known/expected keys, we can either drill into the object (for contents)
 	// or just use the value as-is (since it's not personal info)
 	scrubbed.contents = message.contents && typesOfKeys(message.contents);
 	scrubbed.type = message.type;
@@ -145,7 +145,7 @@ function scrubAndStringify(
 /**
  * Finds and returns the index where the strings diverge, and the character at that index in each string (or undefined if not applicable)
  */
-export function findFirstCharacterMismatched(
+function findFirstRawCharacterMismatched(
 	a: string,
 	b: string,
 ): [index: number, charA?: string, charB?: string] {
@@ -162,6 +162,22 @@ export function findFirstCharacterMismatched(
 	return a.length === b.length
 		? [-1, undefined, undefined]
 		: [minLength, a[minLength], b[minLength]];
+}
+
+/**
+ * Finds and returns the index where the strings diverge, and the character at that index in each string (or undefined if not applicable)
+ * It scrubs non-ASCII characters since they convey more meaning (privacy consideration)
+ */
+export function findFirstCharacterMismatched(
+	a: string,
+	b: string,
+): [index: number, charA?: string, charB?: string] {
+	const [index, rawCharA, rawCharB] = findFirstRawCharacterMismatched(a, b);
+
+	const charA = (rawCharA?.codePointAt(0) ?? 0) <= 0x7f ? rawCharA : "[non-ASCII]";
+	const charB = (rawCharB?.codePointAt(0) ?? 0) <= 0x7f ? rawCharB : "[non-ASCII]";
+
+	return [index, charA, charB];
 }
 
 function withoutLocalOpMetadata(message: IPendingMessage): IPendingMessage {

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -552,6 +552,7 @@ describe("Pending State Manager", () => {
 			});
 
 			it("findFirstCharacterMismatched", () => {
+				const nonAsciiChar = String.fromCodePoint(0x80);
 				const testCases = [
 					{ input: ["", ""], expected: [-1] },
 					{ input: ["", "b"], expected: [0, undefined, "b"] },
@@ -560,6 +561,7 @@ describe("Pending State Manager", () => {
 					{ input: ["xyz", "xy"], expected: [2, "z", undefined] },
 					{ input: ["xy", "xxx"], expected: [1, "y", "x"] },
 					{ input: ["xyz", "xyz"], expected: [-1] },
+					{ input: ["QQ", `Q${nonAsciiChar}`], expected: [1, "Q", "[non-ASCII]"] },
 				];
 				for (const {
 					input: [a, b],


### PR DESCRIPTION
## Description

This event is to help debug super rare cases where an op contents changes during the roundtrip to the ordering service.  We were logging the first character where the JSON contents diverged, to learn some about these cases. That's not a great practice for non-ASCII where a single character can be a whole word.

We still want to see these characters if they're ASCII, e.g. to know is it JSON structure, or a number, or a letter.  But otherwise we don't need to know anything beyond "not ASCII".