### PR TITLE
refactor(ci): Upload npm logs in test pipelines

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -403,6 +403,8 @@ stages:
 
         - ${{ parameters.additionalSteps }}
 
+        - template: /tools/pipelines/templates/include-upload-npm-logs.yml@self
+
 - template: /tools/pipelines/templates/include-upload-stage-telemetry.yml@self
   parameters:
     stageId: ${{ parameters.stageId }}

--- a/tools/pipelines/templates/include-upload-npm-logs.yml
+++ b/tools/pipelines/templates/include-upload-npm-logs.yml
@@ -22,11 +22,10 @@ steps:
     workingDirectory: '${{ parameters.npmLogsDirectory }}'
     script: |
       set -eu -o pipefail
-      TARFILE_NAME=npm-logs.tar
+      TARFILE_FULLPATH=$(Agent.TempDirectory)/npm-logs.tar
       # Put all files in a tarball, in case there's more than one
       echo "Adding logs to tarball"
-      tar -cvf $TARFILE_NAME .
-      echo "Listing files in current directory"
-      ls -lA
-      echo "Uploading tarball to logs"
-      echo "##vso[task.uploadfile]$TARFILE_NAME";
+      tar -cvf $TARFILE_FULLPATH .
+      echo "Uploading tarball to pipeline logs"
+      # Note: task.uploadFile requires an absolute path to be provided
+      echo "##vso[task.uploadfile]$TARFILE_FULLPATH";

--- a/tools/pipelines/templates/include-upload-npm-logs.yml
+++ b/tools/pipelines/templates/include-upload-npm-logs.yml
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# Template to upload logs from npm (not pnpm!) invocations during a job run.
+# These can be useful for debugging npm-related issues
+
+parameters:
+  # Path to npm logs directory.
+  # Defaults to the path that npm ends up using in Azure Pipelines if there are no overrides to its config.
+  # Files that include this template generally shouldn't need to change this.
+  - name: npmLogsDirectory
+    type: string
+    default: '/home/cloudtest/.npm/_logs'
+
+steps:
+- task: Bash@3
+  displayName: Upload npm logs
+  condition: succeededOrFailed()
+  continueOnError: true
+  inputs:
+    targetType: 'inline'
+    workingDirectory: '${{ parameters.npmLogsDirectory }}'
+    script: |
+      set -eu -o pipefail
+      TARFILE_NAME=npm-logs.tar
+      # Put all files in a tarball, in case there's more than one
+      tar -cvf $TARFILE_NAME .
+      echo "##vso[task.uploadfile]$TARFILE_NAME";

--- a/tools/pipelines/templates/include-upload-npm-logs.yml
+++ b/tools/pipelines/templates/include-upload-npm-logs.yml
@@ -24,5 +24,9 @@ steps:
       set -eu -o pipefail
       TARFILE_NAME=npm-logs.tar
       # Put all files in a tarball, in case there's more than one
+      echo "Adding logs to tarball"
       tar -cvf $TARFILE_NAME .
+      echo "Listing files in current directory"
+      ls -lA
+      echo "Uploading tarball to logs"
       echo "##vso[task.uploadfile]$TARFILE_NAME";

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -209,6 +209,8 @@ stages:
           artifactName: 'perf-test-outputs_execution-time'
         condition: succeededOrFailed()
 
+      - template: /tools/pipelines/templates/include-upload-npm-logs.yml@self
+
   - template: /tools/pipelines/templates/include-upload-stage-telemetry.yml@self
     parameters:
       stageId: perf_unit_tests_runtime
@@ -336,6 +338,8 @@ stages:
           artifactName: 'perf-test-outputs_memory-usage'
         condition: succeededOrFailed()
 
+      - template: /tools/pipelines/templates/include-upload-npm-logs.yml@self
+
   - template: /tools/pipelines/templates/include-upload-stage-telemetry.yml@self
     parameters:
       stageId: perf_unit_tests_memory
@@ -461,6 +465,8 @@ stages:
           targetPath: '${{ variables.consolidatedTestsOutputFolder }}'
           artifactName: 'perf-test-outputs_custom-data'
         condition: succeededOrFailed()
+
+      - template: /tools/pipelines/templates/include-upload-npm-logs.yml@self
 
   - template: /tools/pipelines/templates/include-upload-stage-telemetry.yml@self
     parameters:
@@ -662,6 +668,8 @@ stages:
               ls -laR ${{ variables.memoryUsageTestOutputFolder }};
               echo "Cleanup  ${{ variables.memoryUsageTestOutputFolder }}"
               rm -rf ${{ variables.memoryUsageTestOutputFolder }};
+
+        - template: /tools/pipelines/templates/include-upload-npm-logs.yml@self
 
     - template: /tools/pipelines/templates/include-upload-stage-telemetry.yml@self
       parameters:


### PR DESCRIPTION
## Description

Adds a new yml template to upload npm (not pnpm!) logs as a tar file in an Azure pipeline run. Updates the perf benchmarks and e2e tests pipelines to leverage it. I only added it to these two for now because those are the ones that run tests with compat for older versions and thus cause `npm install` to be invoked by test-version-utils. I'm trying to double check if npm is doing the default number of retries when it fails to install packages during those installs, and I need the logs for that. (With views towards potentially updating the config those installs use, so transient issues while downloading packages during compat-version installs don't cause hard failures in the pipeline).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[Test run of the perf benchmarks pipeline](https://dev.azure.com/fluidframework/internal/_build/results?buildId=327418&view=logs&j=96c48626-beae-58bd-70f1-ce94e154dbad&t=f03dbe9f-4e12-5f84-e7cd-ee4ae71c8858) (msft internal) confirming everything looks good. Also confirmed the pipeline logs have the tar files.