### PR TITLE
Use encode safe characters in encodeCompactIdToString()

### DIFF
--- a/packages/runtime/runtime-utils/src/test/utils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/utils.spec.ts
@@ -23,18 +23,17 @@ describe("Utils", () => {
 	});
 
 	it("encodeCompactIdToString() has base of 64 (sort of)", () => {
-		const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ(abcdefghijklmnopqrstuvwxyz)01234567890";
 		for (let i = 0; i < 64; i++) {
 			const value = encodeCompactIdToString(i);
 			assert(value.length === 1, "length");
-			assert(chars[i] === value, "value");
+			assert(charSetForEncodingIds[i] === value, "value");
 		}
 
 		for (let i = 64; i < 65 * 64 - 1; i++) {
 			const value = encodeCompactIdToString(i);
 			assert(value.length === 2, "length");
-			assert(chars.includes(value[0]), "value");
-			assert(chars.includes(value[1]), "value");
+			assert(charSetForEncodingIds.includes(value[0]), "value");
+			assert(charSetForEncodingIds.includes(value[1]), "value");
 		}
 
 		// This is a bit weird, as it does not work as our intuition suggests.

--- a/packages/runtime/runtime-utils/src/test/utils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/utils.spec.ts
@@ -5,10 +5,17 @@
 
 import { strict as assert } from "assert";
 
-import { encodeCompactIdToString } from "../utils.js";
+import { charSetForEncodingIds, encodeCompactIdToString } from "../utils.js";
 
 describe("Utils", () => {
 	beforeEach(() => {});
+
+	it("charSetForEncodingIds doesn't change with encodeURIComponent", () => {
+		assert(
+			encodeURIComponent(charSetForEncodingIds) === charSetForEncodingIds,
+			`${charSetForEncodingIds} contains invalid character(s) which transforms when used with encodeURIComponent`,
+		);
+	});
 
 	it("encodeCompactIdToString() with strings", () => {
 		assert(encodeCompactIdToString("a-b-c") === "a-b-c", "text");

--- a/packages/runtime/runtime-utils/src/test/utils.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/utils.spec.ts
@@ -16,7 +16,7 @@ describe("Utils", () => {
 	});
 
 	it("encodeCompactIdToString() has base of 64 (sort of)", () => {
-		const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ[abcdefghijklmnopqrstuvwxyz{01234567890";
+		const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ(abcdefghijklmnopqrstuvwxyz)01234567890";
 		for (let i = 0; i < 64; i++) {
 			const value = encodeCompactIdToString(i);
 			assert(value.length === 1, "length");
@@ -50,6 +50,8 @@ describe("Utils", () => {
 
 			// Strong rules:
 			assert(!value.includes("/"), "no slashses");
+			assert(!value.includes("["), "opening square bracket");
+			assert(!value.includes("}"), "closing curly bracket");
 			assert(value.length > 0, "length");
 
 			// Soft rules: these rules can be broken, but they are great to have for efficiency

--- a/packages/runtime/runtime-utils/src/utils.ts
+++ b/packages/runtime/runtime-utils/src/utils.ts
@@ -37,13 +37,13 @@ export async function seqFromTree(
 /**
  * Encode compact ID (returned by IContainerRuntime.generateDocumentUniqueId()) to a compact string representation.
  * While this is the main usage pattern, it works with any non-negative integer or a string.
- * Strings are retured as is, and assumed to be UUIDs, i.e. unique enough to never overlap with
+ * Strings are returned as is, and assumed to be UUIDs, i.e. unique enough to never overlap with
  * numbers encoded as strings by this function. Any other strings are likely to run into collisions and should not be used!
  * This function is useful in places where we serialize resulting ID as string and use them as strings, thus we are not
  * gaining any efficiency from having a number type.
- * We do not provide a decode function, so this API is only useful only result is stored and there is no need to go back to origianl form.
+ * We do not provide a decode function, so this API is only useful only result is stored and there is no need to go back to original form.
  * @param idArg - input - either a non-negative integer or a string. Strings are returned as is, while numbers are encoded in compat form
- * @param prefix - optinal string prefix
+ * @param prefix - optional string prefix
  * @returns A string - representation of an input
  * @internal
  */
@@ -51,6 +51,11 @@ export function encodeCompactIdToString(idArg: number | string, prefix = "") {
 	if (typeof idArg === "string") {
 		return idArg;
 	}
+	// The following character emulates the UTF-16 code sequence from 65 - 123, except for the '[' and '{' positioned at 91 and 123 respectively - which are changed to '(' and ')'.
+	// NOTE: The character set must never be changed - since it could result in collisions with existing ids.
+	// If changing, make sure to choose new characters that have never been
+	// used before, and the characters must not change their encoding with 'encodeURIComponent'.
+	const charSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ(abcdefghijklmnopqrstuvwxyz)0123456789";
 	// WARNING: result of this function are stored in storage!
 	// If you ever need to change this function, you will need to ensure that
 	// for any inputs N1 & N2, old(N1) !== new(N2), where old() - is the old implementation,
@@ -63,9 +68,6 @@ export function encodeCompactIdToString(idArg: number | string, prefix = "") {
 	let id = "";
 	let num = idArg;
 	do {
-		// 48-57 -> 0-9
-		// 65-91 > A-Z[
-		// 97-123 -> a-z}
 		// Here are some examples of the input & output:
 		// 0 -> 'A'
 		// 1 -> 'B'
@@ -74,8 +76,7 @@ export function encodeCompactIdToString(idArg: number | string, prefix = "") {
 		// 10000 -> 'BaQ'
 		// 100000 -> 'XZf'
 		const encode = num % 64;
-		const base = encode < 27 ? 65 : encode < 54 ? 97 - 27 : 48 - 54;
-		id = String.fromCharCode(base + encode) + id;
+		id = charSet[encode] + id;
 		num = Math.floor(num / 64) - 1;
 	} while (num !== -1);
 	return prefix + id;

--- a/packages/runtime/runtime-utils/src/utils.ts
+++ b/packages/runtime/runtime-utils/src/utils.ts
@@ -35,6 +35,17 @@ export async function seqFromTree(
 }
 
 /**
+ * The following characters emulates the UTF-16 code sequence from 65 - 123, except for the `[` and `{`
+ * positioned at 91 and 123 respectively - which are changed to '(' and ')'. Used in the `encodeCompactIdToString` utility below.
+ * NOTE: The character set must never be changed - since it could result in collisions with existing ids.
+ * If changing, make sure to choose new characters that have never been
+ * used before, and the characters must not change their encoding with 'encodeURIComponent'.
+ * @internal
+ */
+export const charSetForEncodingIds =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZ(abcdefghijklmnopqrstuvwxyz)0123456789";
+
+/**
  * Encode compact ID (returned by IContainerRuntime.generateDocumentUniqueId()) to a compact string representation.
  * While this is the main usage pattern, it works with any non-negative integer or a string.
  * Strings are returned as is, and assumed to be UUIDs, i.e. unique enough to never overlap with
@@ -51,11 +62,7 @@ export function encodeCompactIdToString(idArg: number | string, prefix = "") {
 	if (typeof idArg === "string") {
 		return idArg;
 	}
-	// The following character emulates the UTF-16 code sequence from 65 - 123, except for the '[' and '{' positioned at 91 and 123 respectively - which are changed to '(' and ')'.
-	// NOTE: The character set must never be changed - since it could result in collisions with existing ids.
-	// If changing, make sure to choose new characters that have never been
-	// used before, and the characters must not change their encoding with 'encodeURIComponent'.
-	const charSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ(abcdefghijklmnopqrstuvwxyz)0123456789";
+
 	// WARNING: result of this function are stored in storage!
 	// If you ever need to change this function, you will need to ensure that
 	// for any inputs N1 & N2, old(N1) !== new(N2), where old() - is the old implementation,
@@ -76,7 +83,7 @@ export function encodeCompactIdToString(idArg: number | string, prefix = "") {
 		// 10000 -> 'BaQ'
 		// 100000 -> 'XZf'
 		const encode = num % 64;
-		id = charSet[encode] + id;
+		id = charSetForEncodingIds[encode] + id;
 		num = Math.floor(num / 64) - 1;
 	} while (num !== -1);
 	return prefix + id;


### PR DESCRIPTION
`encodeCompactIdToString` utility function converts ids into a more compact representation. 

Earlier the function was mapping the ids to also use '{' and ']' characters. This was problematic, because some old versions of driver and runtime layer encode ids using `encodeURIComponent()`, which transformed these characters to `%5B` and `%7B`, resulting in errors. (One such issue is described in the PR description here https://github.com/microsoft/FluidFramework/pull/24032)

This PR updates the function to only use encode safe characters which do not change with `encodeURIComponent()`.

[AB#32688](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/32688)