### PR TITLE
(test runtime mocks) Add ref seq# to messages in MockContainerRuntime during submit

### DIFF
--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -10,6 +10,8 @@ export interface IInternalMockRuntimeMessage {
     content: any;
     // (undocumented)
     localOpMetadata?: unknown;
+    // (undocumented)
+    referenceSequenceNumber: number;
 }
 
 // @alpha

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -11,7 +11,7 @@ export interface IInternalMockRuntimeMessage {
     // (undocumented)
     localOpMetadata?: unknown;
     // (undocumented)
-    referenceSequenceNumber: number;
+    referenceSequenceNumber?: number;
 }
 
 // @alpha

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -182,6 +182,7 @@ const makeContainerRuntimeOptions = (
 export interface IInternalMockRuntimeMessage {
 	content: any;
 	localOpMetadata?: unknown;
+	referenceSequenceNumber?: number;
 }
 
 /**
@@ -260,6 +261,7 @@ export class MockContainerRuntime extends TypedEventEmitter<IContainerRuntimeEve
 		const message: IInternalMockRuntimeMessage = {
 			content: messageContent,
 			localOpMetadata,
+			referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
 		};
 
 		const isAllocationMessage = this.isAllocationMessage(message.content);
@@ -409,6 +411,7 @@ export class MockContainerRuntime extends TypedEventEmitter<IContainerRuntimeEve
 			};
 			return {
 				content: allocationOp,
+				referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
 			};
 		}
 		return undefined;
@@ -420,7 +423,8 @@ export class MockContainerRuntime extends TypedEventEmitter<IContainerRuntimeEve
 			{
 				clientSequenceNumber,
 				contents: message.content,
-				referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
+				referenceSequenceNumber:
+					message.referenceSequenceNumber ?? this.deltaManager.lastSequenceNumber,
 				type: MessageType.Operation,
 			},
 		]);


### PR DESCRIPTION
In the test runtime mocks, when a message is submitted in turn based flush mode, the message is queued in the outbox until flush is explicitly called. During flush, the message is assigned a reference sequence number and processed. However, this behavior is not correct because of two reason:
1. It doesn't preserve the correct state when the op was submitted. Say the message was submitted when the last sequence number processed was 10. By the time flush is called, 10 more messages have been processed making the last sequence number processed 20. The message will be assinged reference seq# 20 which is not what the state was when the message was submitted.
2. This is not inline with what the real container runtime does. It assigns a reference sequence number during op submit even if it doesn't submit it right away and queues it (say because it is not connected or in read mode). This is the reference sequence number used when the op is finally submitted.

This change adds reference seq# to the message when it's submitted and then adds it to the outbox in turn based flush mode. When this message is finally flushed and processed, this is the reference seq# used.

Note than if the client disconnects and reconnects between submit and flush, the reference seq# will be regenerated - this part has not changed.