### PR TITLE
refactor(merge-tree): Simplify direct usages of MergeTree in tests

### DIFF
--- a/packages/dds/merge-tree/src/test/Insertion.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/Insertion.perf.spec.ts
@@ -7,22 +7,18 @@ import { BenchmarkType, benchmark } from "@fluid-tools/benchmark";
 
 import { MergeTree } from "../mergeTree.js";
 import { MergeTreeDeltaType } from "../ops.js";
-
-import { insertText } from "./testUtils.js";
+import { TextSegment } from "../textSegment.js";
 
 function constructTree(numOfSegments: number): MergeTree {
 	const mergeTree = new MergeTree();
 	for (let i = 0; i < numOfSegments; i++) {
-		insertText({
-			mergeTree,
-			pos: 0,
-			refSeq: i,
-			clientId: 0,
-			seq: i,
-			text: "a",
-			props: undefined,
-			opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-		});
+		mergeTree.insertSegments(
+			0,
+			[TextSegment.make("a")],
+			mergeTree.localPerspective,
+			{ seq: i, clientId: 0 },
+			{ op: { type: MergeTreeDeltaType.INSERT } },
+		);
 	}
 	return mergeTree;
 }
@@ -35,16 +31,13 @@ describe("MergeTree insertion", () => {
 		title: "insert into empty tree",
 		benchmarkFn: () => {
 			const emptyTree = new MergeTree();
-			insertText({
-				mergeTree: emptyTree,
-				pos: 0,
-				refSeq: 0,
-				clientId: 0,
-				seq: 0,
-				text: "a",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			emptyTree.insertSegments(
+				0,
+				[TextSegment.make("a")],
+				emptyTree.localPerspective,
+				{ seq: 0, clientId: 0 },
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
 		},
 	});
 
@@ -54,16 +47,13 @@ describe("MergeTree insertion", () => {
 		title: "insert at start of large tree",
 		benchmarkFn: () => {
 			for (let i = TREE_SIZE; i < TREE_SIZE + 25; i++) {
-				insertText({
-					mergeTree: startTree,
-					pos: 0,
-					refSeq: i,
-					clientId: 0,
-					seq: i + 1,
-					text: "a",
-					props: undefined,
-					opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-				});
+				startTree.insertSegments(
+					0,
+					[TextSegment.make("a")],
+					startTree.localPerspective,
+					{ seq: i + 1, clientId: 0 },
+					{ op: { type: MergeTreeDeltaType.INSERT } },
+				);
 			}
 		},
 		beforeEachBatch: () => {
@@ -77,16 +67,13 @@ describe("MergeTree insertion", () => {
 		title: "insert at middle of large tree",
 		benchmarkFn: () => {
 			for (let i = TREE_SIZE; i < TREE_SIZE + 25; i++) {
-				insertText({
-					mergeTree: middleTree,
-					pos: TREE_SIZE / 2,
-					refSeq: i,
-					clientId: 0,
-					seq: i + 1,
-					text: "a",
-					props: undefined,
-					opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-				});
+				middleTree.insertSegments(
+					TREE_SIZE / 2,
+					[TextSegment.make("a")],
+					middleTree.localPerspective,
+					{ seq: i + 1, clientId: 0 },
+					{ op: { type: MergeTreeDeltaType.INSERT } },
+				);
 			}
 		},
 		beforeEachBatch: () => {
@@ -100,16 +87,13 @@ describe("MergeTree insertion", () => {
 		title: "insert at end of large tree",
 		benchmarkFn: () => {
 			for (let i = TREE_SIZE; i < TREE_SIZE + 25; i++) {
-				insertText({
-					mergeTree: endTree,
-					pos: i,
-					refSeq: i,
-					clientId: 0,
-					seq: i + 1,
-					text: "a",
-					props: undefined,
-					opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-				});
+				endTree.insertSegments(
+					i,
+					[TextSegment.make("a")],
+					endTree.localPerspective,
+					{ seq: i + 1, clientId: 0 },
+					{ op: { type: MergeTreeDeltaType.INSERT } },
+				);
 			}
 		},
 		beforeEachBatch: () => {

--- a/packages/dds/merge-tree/src/test/PartialLengths.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/PartialLengths.perf.spec.ts
@@ -7,8 +7,9 @@ import { BenchmarkType, benchmark } from "@fluid-tools/benchmark";
 
 import { MergeTree } from "../mergeTree.js";
 import { MergeTreeDeltaType } from "../ops.js";
-
-import { insertText, markRangeRemoved } from "./testUtils.js";
+import { PriorPerspective } from "../perspective.js";
+import type { OperationStamp } from "../stamps.js";
+import { TextSegment } from "../textSegment.js";
 
 describe("MergeTree partial lengths", () => {
 	const originalIncrementalUpdate: boolean = MergeTree.options.incrementalUpdate;
@@ -24,44 +25,54 @@ describe("MergeTree partial lengths", () => {
 			benchmarkFn: () => {
 				const mergeTree = new MergeTree();
 
+				const clientId = 0;
 				let i = 1;
 				for (; i < 1001; i++) {
-					insertText({
-						mergeTree,
-						pos: 0,
-						refSeq: i,
-						clientId: 0,
+					const stamp: OperationStamp = {
 						seq: i,
-						text: "a",
-						props: undefined,
-						opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-					});
+						clientId,
+					};
+					mergeTree.insertSegments(
+						0,
+						[TextSegment.make("a")],
+						new PriorPerspective(i, clientId),
+						stamp,
+						{
+							op: { type: MergeTreeDeltaType.INSERT },
+						},
+					);
 				}
 
 				for (; i < 2001; i++) {
-					markRangeRemoved({
-						mergeTree,
-						start: i - 1001,
-						end: i - 1000,
-						refSeq: i,
-						clientId: 0,
+					const stamp: OperationStamp = {
 						seq: i,
-						opArgs: { op: { type: MergeTreeDeltaType.REMOVE } },
-						overwrite: false,
-					});
+						clientId,
+					};
+					mergeTree.markRangeRemoved(
+						i - 1001,
+						i - 1000,
+						new PriorPerspective(i, clientId),
+						stamp,
+						{
+							op: { type: MergeTreeDeltaType.REMOVE },
+						},
+					);
 				}
 
 				for (; i < 3001; i++) {
-					insertText({
-						mergeTree,
-						pos: 0,
-						refSeq: i,
-						clientId: 0,
+					const stamp: OperationStamp = {
 						seq: i,
-						text: "a",
-						props: undefined,
-						opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-					});
+						clientId,
+					};
+					mergeTree.insertSegments(
+						0,
+						[TextSegment.make("a")],
+						new PriorPerspective(i, clientId),
+						stamp,
+						{
+							op: { type: MergeTreeDeltaType.INSERT },
+						},
+					);
 				}
 			},
 			after: () => {

--- a/packages/dds/merge-tree/src/test/Removal.perf.spec.ts
+++ b/packages/dds/merge-tree/src/test/Removal.perf.spec.ts
@@ -7,13 +7,13 @@ import { BenchmarkType, benchmark } from "@fluid-tools/benchmark";
 import type { ISummaryTree } from "@fluidframework/driver-definitions";
 
 import { MergeTreeDeltaType } from "../ops.js";
+import { PriorPerspective } from "../perspective.js";
 import {
 	MergeTreeDeltaRevertible,
 	appendToMergeTreeDeltaRevertibles,
 } from "../revertibles.js";
 
 import { TestString, loadSnapshot } from "./snapshot.utils.js";
-import { markRangeRemoved } from "./testUtils.js";
 
 describe("MergeTree remove", () => {
 	let summary: ISummaryTree;
@@ -55,16 +55,15 @@ describe("MergeTree remove", () => {
 		benchmarkFnAsync: async () => {
 			const str = await loadSnapshot(summary);
 
-			markRangeRemoved({
-				mergeTree: str.mergeTree,
-				start: 0,
-				end: 1000,
-				refSeq: 1000,
-				clientId: 0,
-				seq: 1001,
-				opArgs: { op: { type: MergeTreeDeltaType.REMOVE } },
-				overwrite: false,
-			});
+			const refSeq = 1000;
+			const clientId = 0;
+			str.mergeTree.markRangeRemoved(
+				0,
+				1000,
+				new PriorPerspective(refSeq, clientId),
+				{ seq: 1001, clientId },
+				{ op: { type: MergeTreeDeltaType.REMOVE } },
+			);
 		},
 	});
 
@@ -121,16 +120,15 @@ describe("MergeTree remove", () => {
 		benchmarkFnAsync: async () => {
 			const str = await loadSnapshot(summary);
 
-			markRangeRemoved({
-				mergeTree: str.mergeTree,
-				start: 0,
-				end: 1,
-				refSeq: 1000,
-				clientId: 0,
-				seq: 1001,
-				opArgs: { op: { type: MergeTreeDeltaType.REMOVE } },
-				overwrite: false,
-			});
+			const refSeq = 1000;
+			const clientId = 0;
+			str.mergeTree.markRangeRemoved(
+				0,
+				1,
+				new PriorPerspective(refSeq, clientId),
+				{ seq: 1001, clientId },
+				{ op: { type: MergeTreeDeltaType.REMOVE } },
+			);
 		},
 	});
 
@@ -150,16 +148,15 @@ describe("MergeTree remove", () => {
 		benchmarkFnAsync: async () => {
 			const str = await loadSnapshot(summary);
 
-			markRangeRemoved({
-				mergeTree: str.mergeTree,
-				start: 499,
-				end: 501,
-				refSeq: 1000,
-				clientId: 0,
-				seq: 1001,
-				opArgs: { op: { type: MergeTreeDeltaType.REMOVE } },
-				overwrite: false,
-			});
+			const refSeq = 1000;
+			const clientId = 0;
+			str.mergeTree.markRangeRemoved(
+				499,
+				501,
+				new PriorPerspective(refSeq, clientId),
+				{ seq: 1001, clientId },
+				{ op: { type: MergeTreeDeltaType.REMOVE } },
+			);
 		},
 	});
 
@@ -179,16 +176,15 @@ describe("MergeTree remove", () => {
 		benchmarkFnAsync: async () => {
 			const str = await loadSnapshot(summary);
 
-			markRangeRemoved({
-				mergeTree: str.mergeTree,
-				start: 999,
-				end: 1000,
-				refSeq: 1000,
-				clientId: 0,
-				seq: 1001,
-				opArgs: { op: { type: MergeTreeDeltaType.REMOVE } },
-				overwrite: false,
-			});
+			const refSeq = 1000;
+			const clientId = 0;
+			str.mergeTree.markRangeRemoved(
+				999,
+				1000,
+				new PriorPerspective(refSeq, clientId),
+				{ seq: 1001, clientId },
+				{ op: { type: MergeTreeDeltaType.REMOVE } },
+			);
 		},
 	});
 });

--- a/packages/dds/merge-tree/src/test/client.annotateMarker.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.annotateMarker.spec.ts
@@ -5,13 +5,11 @@
 
 import { strict as assert } from "node:assert";
 
-import { UniversalSequenceNumber } from "../constants.js";
 import { Marker, reservedMarkerIdKey, type ISegmentPrivate } from "../mergeTreeNodes.js";
 import { ReferenceType } from "../ops.js";
 import { TextSegment } from "../textSegment.js";
 
 import { TestClient } from "./testClient.js";
-import { insertSegments } from "./testUtils.js";
 
 describe("TestClient", () => {
 	const localUserLongId = "localUser";
@@ -19,15 +17,13 @@ describe("TestClient", () => {
 
 	beforeEach(() => {
 		client = new TestClient();
-		insertSegments({
-			mergeTree: client.mergeTree,
-			pos: 0,
-			segments: [TextSegment.make("")],
-			refSeq: UniversalSequenceNumber,
-			clientId: client.getClientId(),
-			seq: UniversalSequenceNumber,
-			opArgs: undefined,
-		});
+		client.mergeTree.insertSegments(
+			0,
+			[TextSegment.make("")],
+			client.mergeTree.localPerspective,
+			client.mergeTree.collabWindow.mintNextLocalOperationStamp(),
+			undefined,
+		);
 		client.startOrUpdateCollaboration(localUserLongId);
 	});
 

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -7,7 +7,6 @@
 
 import { strict as assert } from "node:assert";
 
-import { UniversalSequenceNumber } from "../constants.js";
 import {
 	ISegmentPrivate,
 	Marker,
@@ -19,7 +18,7 @@ import { TextSegment } from "../textSegment.js";
 
 import { TestClient } from "./testClient.js";
 import { TestClientLogger } from "./testClientLogger.js";
-import { insertSegments, validatePartialLengths } from "./testUtils.js";
+import { validatePartialLengths } from "./testUtils.js";
 
 describe("client.rollback", () => {
 	const localUserLongId = "localUser";
@@ -27,15 +26,13 @@ describe("client.rollback", () => {
 
 	beforeEach(() => {
 		client = new TestClient();
-		insertSegments({
-			mergeTree: client.mergeTree,
-			pos: 0,
-			segments: [TextSegment.make("")],
-			refSeq: UniversalSequenceNumber,
-			clientId: client.getClientId(),
-			seq: UniversalSequenceNumber,
-			opArgs: undefined,
-		});
+		client.mergeTree.insertSegments(
+			0,
+			[TextSegment.make("")],
+			client.mergeTree.localPerspective,
+			client.mergeTree.collabWindow.mintNextLocalOperationStamp(),
+			undefined,
+		);
 		client.startOrUpdateCollaboration(localUserLongId);
 	});
 

--- a/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
@@ -15,7 +15,6 @@ import { TextSegment } from "../textSegment.js";
 
 import { TestClient } from "./testClient.js";
 import { createClientsAtInitialState } from "./testClientLogger.js";
-import { insertSegments } from "./testUtils.js";
 
 describe("TestClient", () => {
 	const localUserLongId = "localUser";
@@ -23,15 +22,13 @@ describe("TestClient", () => {
 
 	beforeEach(() => {
 		client = new TestClient();
-		insertSegments({
-			mergeTree: client.mergeTree,
-			pos: 0,
-			segments: [TextSegment.make("")],
-			refSeq: UniversalSequenceNumber,
-			clientId: client.getClientId(),
-			seq: UniversalSequenceNumber,
-			opArgs: undefined,
-		});
+		client.mergeTree.insertSegments(
+			0,
+			[TextSegment.make("")],
+			client.mergeTree.localPerspective,
+			client.mergeTree.collabWindow.mintNextLocalOperationStamp(),
+			undefined,
+		);
 		client.startOrUpdateCollaboration(localUserLongId);
 	});
 
@@ -626,15 +623,13 @@ describe("TestClient", () => {
 			let client2: TestClient;
 			beforeEach(() => {
 				client2 = new TestClient();
-				insertSegments({
-					mergeTree: client2.mergeTree,
-					pos: 0,
-					segments: [TextSegment.make("")],
-					refSeq: UniversalSequenceNumber,
-					clientId: client2.getClientId(),
-					seq: UniversalSequenceNumber,
-					opArgs: undefined,
-				});
+				client2.mergeTree.insertSegments(
+					0,
+					[TextSegment.make("")],
+					client2.mergeTree.localPerspective,
+					client2.mergeTree.collabWindow.mintNextLocalOperationStamp(),
+					undefined,
+				);
 				client2.startOrUpdateCollaboration(remoteUserLongId);
 			});
 

--- a/packages/dds/merge-tree/src/test/index.ts
+++ b/packages/dds/merge-tree/src/test/index.ts
@@ -14,12 +14,8 @@ export {
 export { checkTextMatchRelative, TestServer } from "./testServer.js";
 export {
 	countOperations,
-	insertMarker,
-	insertSegments,
-	insertText,
 	loadTextFromFile,
 	loadTextFromFileWithMarkers,
-	markRangeRemoved,
 	nodeOrdinalsHaveIntegrity,
 	validatePartialLengths,
 	useStrictPartialLengthChecks,

--- a/packages/dds/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insert.deltaCallback.spec.ts
@@ -5,17 +5,13 @@
 
 import { strict as assert } from "node:assert";
 
-import {
-	LocalClientId,
-	UnassignedSequenceNumber,
-	UniversalSequenceNumber,
-} from "../constants.js";
 import { MergeTree } from "../mergeTree.js";
 import { MergeTreeMaintenanceType } from "../mergeTreeDeltaCallback.js";
+import { Marker } from "../mergeTreeNodes.js";
 import { MergeTreeDeltaType, ReferenceType } from "../ops.js";
 import { TextSegment } from "../textSegment.js";
 
-import { countOperations, insertMarker, insertSegments, insertText } from "./testUtils.js";
+import { countOperations, makeRemoteClient } from "./testUtils.js";
 
 describe("MergeTree", () => {
 	let mergeTree: MergeTree;
@@ -23,15 +19,13 @@ describe("MergeTree", () => {
 	let currentSequenceNumber: number;
 	beforeEach(() => {
 		mergeTree = new MergeTree();
-		insertSegments({
-			mergeTree,
-			pos: 0,
-			segments: [TextSegment.make("hello world!")],
-			refSeq: UniversalSequenceNumber,
-			clientId: LocalClientId,
-			seq: UniversalSequenceNumber,
-			opArgs: undefined,
-		});
+		mergeTree.insertSegments(
+			0,
+			[TextSegment.make("hello world!")],
+			mergeTree.localPerspective,
+			mergeTree.collabWindow.mintNextLocalOperationStamp(),
+			undefined,
+		);
 
 		currentSequenceNumber = 0;
 		mergeTree.startCollaboration(
@@ -49,16 +43,13 @@ describe("MergeTree", () => {
 				eventCalled++;
 			};
 
-			insertText({
-				mergeTree,
-				pos: 0,
-				refSeq: currentSequenceNumber,
-				clientId: localClientId,
-				seq: UnassignedSequenceNumber,
-				text: "more ",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			mergeTree.insertSegments(
+				0,
+				[TextSegment.make("more ")],
+				mergeTree.localPerspective,
+				mergeTree.collabWindow.mintNextLocalOperationStamp(),
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
 
 			assert.equal(eventCalled, 1);
 		});
@@ -71,16 +62,13 @@ describe("MergeTree", () => {
 				eventCalled++;
 			};
 
-			insertText({
-				mergeTree,
-				pos: textLength,
-				refSeq: currentSequenceNumber,
-				clientId: localClientId,
-				seq: UnassignedSequenceNumber,
-				text: "more ",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			mergeTree.insertSegments(
+				textLength,
+				[TextSegment.make("more ")],
+				mergeTree.localPerspective,
+				mergeTree.collabWindow.mintNextLocalOperationStamp(),
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
 
 			assert.equal(eventCalled, 1);
 		});
@@ -88,16 +76,13 @@ describe("MergeTree", () => {
 		it("Insert middle text", () => {
 			const count = countOperations(mergeTree);
 
-			insertText({
-				mergeTree,
-				pos: 4,
-				refSeq: currentSequenceNumber,
-				clientId: localClientId,
-				seq: UnassignedSequenceNumber,
-				text: "more ",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			mergeTree.insertSegments(
+				4,
+				[TextSegment.make("more ")],
+				mergeTree.localPerspective,
+				mergeTree.collabWindow.mintNextLocalOperationStamp(),
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
 
 			assert.deepStrictEqual(count, {
 				[MergeTreeDeltaType.INSERT]: 1,
@@ -106,21 +91,18 @@ describe("MergeTree", () => {
 		});
 
 		it("Insert text remote", () => {
-			const remoteClientId: number = 35;
+			const remoteClient = makeRemoteClient({ clientId: 35 });
 			let remoteSequenceNumber = currentSequenceNumber;
 
 			const count = countOperations(mergeTree);
 
-			insertText({
-				mergeTree,
-				pos: 0,
-				refSeq: currentSequenceNumber,
-				clientId: remoteClientId,
-				seq: ++remoteSequenceNumber,
-				text: "more ",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			mergeTree.insertSegments(
+				0,
+				[TextSegment.make("more ")],
+				remoteClient.perspectiveAt({ refSeq: currentSequenceNumber }),
+				remoteClient.stampAt({ seq: ++remoteSequenceNumber }),
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
 
 			assert.deepStrictEqual(count, {
 				[MergeTreeDeltaType.INSERT]: 1,
@@ -131,16 +113,13 @@ describe("MergeTree", () => {
 		it("Insert marker", () => {
 			const count = countOperations(mergeTree);
 
-			insertMarker({
-				mergeTree,
-				pos: 4,
-				refSeq: currentSequenceNumber,
-				clientId: localClientId,
-				seq: UnassignedSequenceNumber,
-				behaviors: ReferenceType.Simple,
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			mergeTree.insertSegments(
+				4,
+				[Marker.make(ReferenceType.Simple)],
+				mergeTree.localPerspective,
+				mergeTree.collabWindow.mintNextLocalOperationStamp(),
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
 
 			assert.deepStrictEqual(count, {
 				[MergeTreeDeltaType.INSERT]: 1,

--- a/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -8,22 +8,13 @@
 import { strict as assert } from "node:assert";
 
 import { MergeTreeTextHelper } from "../MergeTreeTextHelper.js";
-import {
-	LocalClientId,
-	UnassignedSequenceNumber,
-	UniversalSequenceNumber,
-} from "../constants.js";
+import { UniversalSequenceNumber } from "../constants.js";
 import { MergeTree } from "../mergeTree.js";
 import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
 import { MergeBlock, MaxNodesInBlock, segmentIsRemoved } from "../mergeTreeNodes.js";
 import { TextSegment } from "../textSegment.js";
 
-import {
-	insertSegments,
-	insertText,
-	markRangeRemoved,
-	nodeOrdinalsHaveIntegrity,
-} from "./testUtils.js";
+import { makeRemoteClient, nodeOrdinalsHaveIntegrity } from "./testUtils.js";
 
 interface ITestTreeFactory {
 	readonly create: () => ITestData;
@@ -44,15 +35,14 @@ const treeFactories: ITestTreeFactory[] = [
 		create: (): ITestData => {
 			const initialText = "hello world";
 			const mergeTree = new MergeTree();
-			insertSegments({
-				mergeTree,
-				pos: 0,
-				segments: [TextSegment.make(initialText)],
-				refSeq: UniversalSequenceNumber,
-				clientId: LocalClientId,
-				seq: UniversalSequenceNumber,
-				opArgs: undefined,
-			});
+			mergeTree.insertSegments(
+				0,
+				[TextSegment.make(initialText)],
+				mergeTree.localPerspective,
+				mergeTree.collabWindow.mintNextLocalOperationStamp(),
+				undefined,
+			);
+
 			mergeTree.startCollaboration(
 				localClientId,
 				/* minSeq: */ UniversalSequenceNumber,
@@ -72,27 +62,22 @@ const treeFactories: ITestTreeFactory[] = [
 		create: (): ITestData => {
 			let initialText = "0";
 			const mergeTree = new MergeTree();
-			insertSegments({
-				mergeTree,
-				pos: 0,
-				segments: [TextSegment.make(initialText)],
-				refSeq: UniversalSequenceNumber,
-				clientId: LocalClientId,
-				seq: UniversalSequenceNumber,
-				opArgs: undefined,
-			});
+			mergeTree.insertSegments(
+				0,
+				[TextSegment.make(initialText)],
+				mergeTree.localPerspective,
+				mergeTree.collabWindow.mintNextLocalOperationStamp(),
+				undefined,
+			);
 			for (let i = 1; i < MaxNodesInBlock - 1; i++) {
 				const text = i.toString();
-				insertText({
-					mergeTree,
-					pos: mergeTree.getLength(mergeTree.localPerspective),
-					refSeq: UniversalSequenceNumber,
-					clientId: localClientId,
-					seq: UniversalSequenceNumber,
-					text,
-					props: undefined,
-					opArgs: undefined,
-				});
+				mergeTree.insertSegments(
+					mergeTree.getLength(mergeTree.localPerspective),
+					[TextSegment.make(text)],
+					mergeTree.localPerspective,
+					mergeTree.collabWindow.mintNextLocalOperationStamp(),
+					undefined,
+				);
 				initialText += text;
 			}
 
@@ -128,27 +113,22 @@ const treeFactories: ITestTreeFactory[] = [
 		create: (): ITestData => {
 			let initialText = "0";
 			const mergeTree = new MergeTree();
-			insertSegments({
-				mergeTree,
-				pos: 0,
-				segments: [TextSegment.make(initialText)],
-				refSeq: UniversalSequenceNumber,
-				clientId: LocalClientId,
-				seq: UniversalSequenceNumber,
-				opArgs: undefined,
-			});
+			mergeTree.insertSegments(
+				0,
+				[TextSegment.make(initialText)],
+				mergeTree.localPerspective,
+				mergeTree.collabWindow.mintNextLocalOperationStamp(),
+				undefined,
+			);
 			for (let i = 1; i < MaxNodesInBlock * 4; i++) {
 				const text = i.toString();
-				insertText({
-					mergeTree,
-					pos: mergeTree.getLength(mergeTree.localPerspective),
-					refSeq: UniversalSequenceNumber,
-					clientId: localClientId,
-					seq: UniversalSequenceNumber,
-					text,
-					props: undefined,
-					opArgs: undefined,
-				});
+				mergeTree.insertSegments(
+					mergeTree.getLength(mergeTree.localPerspective),
+					[TextSegment.make(text)],
+					mergeTree.localPerspective,
+					mergeTree.collabWindow.mintNextLocalOperationStamp(),
+					undefined,
+				);
 				initialText += text;
 			}
 
@@ -205,16 +185,13 @@ describe("MergeTree.insertingWalk", () => {
 			});
 			describe("insertText", () => {
 				it("at beginning", () => {
-					insertText({
-						mergeTree: testData.mergeTree,
-						pos: 0,
-						refSeq: testData.refSeq,
-						clientId: localClientId,
-						seq: UnassignedSequenceNumber,
-						text: "a",
-						props: undefined,
-						opArgs: undefined,
-					});
+					testData.mergeTree.insertSegments(
+						0,
+						[TextSegment.make("a")],
+						testData.mergeTree.localPerspective,
+						testData.mergeTree.collabWindow.mintNextLocalOperationStamp(),
+						undefined,
+					);
 
 					assert.equal(
 						testData.mergeTree.getLength(testData.mergeTree.localPerspective),
@@ -226,16 +203,13 @@ describe("MergeTree.insertingWalk", () => {
 				});
 
 				it("at end", () => {
-					insertText({
-						mergeTree: testData.mergeTree,
-						pos: testData.initialText.length,
-						refSeq: testData.refSeq,
-						clientId: localClientId,
-						seq: UnassignedSequenceNumber,
-						text: "a",
-						props: undefined,
-						opArgs: undefined,
-					});
+					testData.mergeTree.insertSegments(
+						testData.initialText.length,
+						[TextSegment.make("a")],
+						testData.mergeTree.localPerspective,
+						testData.mergeTree.collabWindow.mintNextLocalOperationStamp(),
+						undefined,
+					);
 
 					assert.equal(
 						testData.mergeTree.getLength(testData.mergeTree.localPerspective),
@@ -247,16 +221,13 @@ describe("MergeTree.insertingWalk", () => {
 				});
 
 				it("in middle", () => {
-					insertText({
-						mergeTree: testData.mergeTree,
-						pos: testData.middle,
-						refSeq: testData.refSeq,
-						clientId: localClientId,
-						seq: UnassignedSequenceNumber,
-						text: "a",
-						props: undefined,
-						opArgs: undefined,
-					});
+					testData.mergeTree.insertSegments(
+						testData.middle,
+						[TextSegment.make("a")],
+						testData.mergeTree.localPerspective,
+						testData.mergeTree.collabWindow.mintNextLocalOperationStamp(),
+						undefined,
+					);
 
 					assert.equal(
 						testData.mergeTree.getLength(testData.mergeTree.localPerspective),
@@ -279,28 +250,23 @@ describe("MergeTree.insertingWalk", () => {
 		let initialText = "0";
 		let seq = 0;
 		const mergeTree = new MergeTree();
+		mergeTree.insertSegments(
+			0,
+			[TextSegment.make(initialText)],
+			mergeTree.localPerspective,
+			mergeTree.collabWindow.mintNextLocalOperationStamp(),
+			undefined,
+		);
 		mergeTree.startCollaboration(localClientId, 0, seq);
-		insertSegments({
-			mergeTree,
-			pos: 0,
-			segments: [TextSegment.make(initialText)],
-			refSeq: UniversalSequenceNumber,
-			clientId: localClientId,
-			seq: UniversalSequenceNumber,
-			opArgs: undefined,
-		});
 		for (let i = 1; i < MaxNodesInBlock; i++) {
 			const text = String.fromCodePoint(i + 64);
-			insertText({
-				mergeTree,
-				pos: 0,
-				refSeq: UniversalSequenceNumber,
-				clientId: localClientId,
-				seq: UnassignedSequenceNumber,
-				text,
-				props: undefined,
-				opArgs: undefined,
-			});
+			mergeTree.insertSegments(
+				0,
+				[TextSegment.make(text)],
+				mergeTree.localPerspective,
+				mergeTree.collabWindow.mintNextLocalOperationStamp(),
+				undefined,
+			);
 			initialText += text;
 		}
 
@@ -309,29 +275,26 @@ describe("MergeTree.insertingWalk", () => {
 		assert.equal(mergeTree.root.childCount, 2);
 		assert.equal(textHelper.getText(0, localClientId), "GFEDCBA0");
 		// Remove "DCBA"
-		markRangeRemoved({
-			mergeTree,
-			start: 3,
-			end: 7,
-			refSeq: UniversalSequenceNumber,
-			clientId: localClientId,
-			seq: UnassignedSequenceNumber,
-			overwrite: false,
-			opArgs: undefined as never,
-		});
+		mergeTree.markRangeRemoved(
+			3,
+			7,
+			mergeTree.localPerspective,
+			mergeTree.collabWindow.mintNextLocalOperationStamp(),
+			undefined as never,
+		);
 		assert.equal(textHelper.getText(0, localClientId), "GFE0");
 		// Simulate another client inserting concurrently with the above operations. Because
 		// all segments but the 0 are unacked, this insert should place the segment directly
 		// before the 0. Prior to this regression test, an issue with `rightExcursion` in the
 		// merge conflict logic instead caused the segment to be placed before the removed segments.
-		insertText({
-			mergeTree,
-			pos: 0,
-			refSeq: UniversalSequenceNumber,
-			clientId: localClientId + 1,
-			seq: ++seq,
-			text: "x",
-		});
+		const remoteClient = makeRemoteClient({ clientId: localClientId + 1 });
+		mergeTree.insertSegments(
+			0,
+			[TextSegment.make("x")],
+			remoteClient.perspectiveAt({ refSeq: 0 }),
+			remoteClient.stampAt({ seq: ++seq }),
+			undefined,
+		);
 
 		const segments: string[] = [];
 		walkAllChildSegments(mergeTree.root, (seg) => {

--- a/packages/dds/merge-tree/src/test/mergeTree.walk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.walk.spec.ts
@@ -5,15 +5,10 @@
 
 import { strict as assert } from "node:assert";
 
-import { LocalClientId, UniversalSequenceNumber } from "../constants.js";
 import { MergeTree } from "../mergeTree.js";
 import { walkAllChildSegments } from "../mergeTreeNodeWalk.js";
 import { MergeBlock, MaxNodesInBlock } from "../mergeTreeNodes.js";
 import { TextSegment } from "../textSegment.js";
-
-import { insertText } from "./testUtils.js";
-
-const localClientId = 17;
 
 describe("MergeTree walks", () => {
 	let mergeTree: MergeTree;
@@ -24,21 +19,18 @@ describe("MergeTree walks", () => {
 			0,
 			[TextSegment.make(initialText)],
 			mergeTree.localPerspective,
-			{ seq: UniversalSequenceNumber, clientId: LocalClientId },
+			mergeTree.collabWindow.mintNextLocalOperationStamp(),
 			undefined,
 		);
 		for (let i = 1; i < MaxNodesInBlock * MaxNodesInBlock; i++) {
 			const text = i.toString();
-			insertText({
-				mergeTree,
-				pos: mergeTree.getLength(mergeTree.localPerspective),
-				refSeq: UniversalSequenceNumber,
-				clientId: localClientId,
-				seq: UniversalSequenceNumber,
-				text,
-				props: undefined,
-				opArgs: undefined,
-			});
+			mergeTree.insertSegments(
+				mergeTree.getLength(mergeTree.localPerspective),
+				[TextSegment.make(text)],
+				mergeTree.localPerspective,
+				mergeTree.collabWindow.mintNextLocalOperationStamp(),
+				undefined,
+			);
 			initialText += text;
 		}
 	});

--- a/packages/dds/merge-tree/src/test/obliterate.partialLength.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.partialLength.spec.ts
@@ -7,13 +7,10 @@ import { strict as assert } from "node:assert";
 
 import { NonCollabClient } from "../constants.js";
 import { MergeTreeDeltaType } from "../ops.js";
+import { TextSegment } from "../textSegment.js";
 
 import { TestClient } from "./testClient.js";
-import {
-	insertText,
-	useStrictPartialLengthChecks,
-	validatePartialLengths,
-} from "./testUtils.js";
+import { useStrictPartialLengthChecks, validatePartialLengths } from "./testUtils.js";
 
 describe("obliterate partial lengths", () => {
 	let client: TestClient;
@@ -109,16 +106,13 @@ describe("obliterate partial lengths", () => {
 		client.startOrUpdateCollaboration("local");
 
 		for (let i = 0; i < 100; i++) {
-			insertText({
-				mergeTree: client.mergeTree,
-				pos: 0,
-				refSeq: i,
-				clientId: localClientId,
-				seq: i + 1,
-				text: "a",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			client.mergeTree.insertSegments(
+				0,
+				[TextSegment.make("a")],
+				client.mergeTree.localPerspective,
+				{ seq: i + 1, clientId: localClientId },
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
 
 			validatePartialLengths(localClientId, client.mergeTree, [{ seq: i + 1, len: i + 1 }]);
 			validatePartialLengths(remoteClientId, client.mergeTree, [{ seq: i + 1, len: i + 1 }]);

--- a/packages/dds/merge-tree/src/test/obliterate.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.spec.ts
@@ -7,15 +7,16 @@ import { strict as assert } from "node:assert";
 
 import type { ISegmentPrivate, ObliterateInfo } from "../mergeTreeNodes.js";
 import { MergeTreeDeltaType } from "../ops.js";
+import { TextSegment } from "../textSegment.js";
 
 import { TestClient } from "./testClient.js";
-import { insertText, obliterateRange } from "./testUtils.js";
+import { makeRemoteClient } from "./testUtils.js";
 
 describe("obliterate", () => {
 	let client: TestClient;
 	let refSeq: number;
-	const localClientId = 17;
-	const remoteClientId = localClientId + 1;
+	const remoteClient1 = makeRemoteClient({ clientId: 18 });
+	const remoteClient2 = makeRemoteClient({ clientId: 19 });
 
 	beforeEach(() => {
 		client = new TestClient({
@@ -41,116 +42,91 @@ describe("obliterate", () => {
 
 	describe("concurrent obliterate and insert", () => {
 		it("removes text for obliterate then insert", () => {
-			obliterateRange({
-				mergeTree: client.mergeTree,
-				start: 0,
-				end: client.getLength(),
-				refSeq,
-				clientId: remoteClientId,
-				seq: refSeq + 1,
-				opArgs: undefined as never,
-			});
-			insertText({
-				mergeTree: client.mergeTree,
-				pos: 1,
-				refSeq,
-				clientId: remoteClientId + 1,
-				seq: refSeq + 2,
-				text: "more ",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			client.mergeTree.obliterateRange(
+				0,
+				client.getLength(),
+				remoteClient1.perspectiveAt({ refSeq }),
+				remoteClient1.stampAt({ seq: refSeq + 1 }),
+				undefined as never,
+			);
+			client.mergeTree.insertSegments(
+				1,
+				[TextSegment.make("more ")],
+				remoteClient2.perspectiveAt({ refSeq }),
+				remoteClient2.stampAt({ seq: refSeq + 2 }),
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
 			assert.equal(client.getText(), "");
 		});
 		it("removes text for insert then obliterate when deleting entire string", () => {
-			insertText({
-				mergeTree: client.mergeTree,
-				pos: 1,
-				refSeq,
-				clientId: remoteClientId + 1,
-				seq: refSeq + 1,
-				text: "more ",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
-			obliterateRange({
-				mergeTree: client.mergeTree,
-				start: 0,
-				end: "hello world".length,
-				refSeq,
-				clientId: remoteClientId,
-				seq: refSeq + 2,
-				opArgs: undefined as never,
-			});
+			client.mergeTree.insertSegments(
+				1,
+				[TextSegment.make("more ")],
+				remoteClient2.perspectiveAt({ refSeq }),
+				remoteClient2.stampAt({ seq: refSeq + 1 }),
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
+			client.mergeTree.obliterateRange(
+				0,
+				"hello world".length,
+				remoteClient1.perspectiveAt({ refSeq }),
+				remoteClient1.stampAt({ seq: refSeq + 2 }),
+				undefined as never,
+			);
 			assert.equal(client.getText(), "");
 		});
 		it("removes text for insert then obliterate", () => {
-			insertText({
-				mergeTree: client.mergeTree,
-				pos: 5,
-				refSeq,
-				clientId: remoteClientId + 1,
-				seq: refSeq + 1,
-				text: "more ",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
-			obliterateRange({
-				mergeTree: client.mergeTree,
-				start: 1,
-				end: "hello world".length,
-				refSeq,
-				clientId: remoteClientId,
-				seq: refSeq + 2,
-				opArgs: undefined as never,
-			});
+			client.mergeTree.insertSegments(
+				5,
+				[TextSegment.make("more ")],
+				remoteClient2.perspectiveAt({ refSeq }),
+				remoteClient2.stampAt({ seq: refSeq + 1 }),
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
+			client.mergeTree.obliterateRange(
+				1,
+				"hello world".length,
+				remoteClient1.perspectiveAt({ refSeq }),
+				remoteClient1.stampAt({ seq: refSeq + 2 }),
+				undefined as never,
+			);
 			assert.equal(client.getText(), "h");
 		});
 	});
 
 	describe("endpoint behavior", () => {
 		it("does not expand to include text inserted at start", () => {
-			obliterateRange({
-				mergeTree: client.mergeTree,
-				start: 5,
-				end: client.getLength(),
-				refSeq,
-				clientId: remoteClientId,
-				seq: refSeq + 1,
-				opArgs: undefined as never,
-			});
-			insertText({
-				mergeTree: client.mergeTree,
-				pos: 5,
-				refSeq,
-				clientId: remoteClientId + 1,
-				seq: refSeq + 2,
-				text: "XXX",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			client.mergeTree.obliterateRange(
+				5,
+				client.getLength(),
+				remoteClient1.perspectiveAt({ refSeq }),
+				remoteClient1.stampAt({ seq: refSeq + 1 }),
+				undefined as never,
+			);
+			client.mergeTree.insertSegments(
+				5,
+				[TextSegment.make("XXX")],
+				remoteClient2.perspectiveAt({ refSeq }),
+				remoteClient2.stampAt({ seq: refSeq + 2 }),
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
 			assert.equal(client.getText(), "helloXXX");
 		});
 		it("does not expand to include text inserted at end", () => {
-			obliterateRange({
-				mergeTree: client.mergeTree,
-				start: 0,
-				end: "hello".length,
-				refSeq,
-				clientId: remoteClientId,
-				seq: refSeq + 1,
-				opArgs: undefined as never,
-			});
-			insertText({
-				mergeTree: client.mergeTree,
-				pos: 5,
-				refSeq,
-				clientId: remoteClientId + 1,
-				seq: refSeq + 2,
-				text: "XXX",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			client.mergeTree.obliterateRange(
+				0,
+				"hello".length,
+				remoteClient1.perspectiveAt({ refSeq }),
+				remoteClient1.stampAt({ seq: refSeq + 1 }),
+				undefined as never,
+			);
+			client.mergeTree.insertSegments(
+				5,
+				[TextSegment.make("XXX")],
+				remoteClient2.perspectiveAt({ refSeq }),
+				remoteClient2.stampAt({ seq: refSeq + 2 }),
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
 			assert.equal(client.getText(), "XXX world");
 		});
 	});
@@ -158,16 +134,13 @@ describe("obliterate", () => {
 	describe("local obliterate with concurrent inserts", () => {
 		it("removes range when pending local obliterate op", () => {
 			client.obliterateRangeLocal(0, client.getLength());
-			insertText({
-				mergeTree: client.mergeTree,
-				pos: 1,
-				refSeq,
-				clientId: remoteClientId,
-				seq: refSeq + 2,
-				text: "XXX",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			client.mergeTree.insertSegments(
+				1,
+				[TextSegment.make("XXX")],
+				remoteClient1.perspectiveAt({ refSeq }),
+				remoteClient1.stampAt({ seq: refSeq + 1 }),
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
 			assert.equal(client.getText(), "");
 		});
 	});
@@ -182,25 +155,20 @@ describe("obliterate", () => {
 			const startSeg = client.getContainingSegment<ISegmentPrivate>(obliterateStart);
 			const endSeg = client.getContainingSegment<ISegmentPrivate>(obliterateEnd);
 			let seq = refSeq;
-			obliterateRange({
-				mergeTree: client.mergeTree,
-				start: obliterateStart,
-				end: obliterateEnd,
-				refSeq,
-				clientId: remoteClientId,
-				seq: ++seq,
-				opArgs: undefined as never,
-			});
-			insertText({
-				mergeTree: client.mergeTree,
-				pos: 1,
-				refSeq,
-				clientId: remoteClientId + 1,
-				seq: ++seq,
-				text: "more ",
-				props: undefined,
-				opArgs: { op: { type: MergeTreeDeltaType.INSERT } },
-			});
+			client.mergeTree.obliterateRange(
+				obliterateStart,
+				obliterateEnd,
+				remoteClient1.perspectiveAt({ refSeq }),
+				remoteClient1.stampAt({ seq: ++seq }),
+				undefined as never,
+			);
+			client.mergeTree.insertSegments(
+				1,
+				[TextSegment.make("more ")],
+				remoteClient2.perspectiveAt({ refSeq }),
+				remoteClient2.stampAt({ seq: ++seq }),
+				{ op: { type: MergeTreeDeltaType.INSERT } },
+			);
 			assert.equal(client.getText(), "");
 
 			startSeg.segment?.localRefs?.walkReferences((ref) => {


### PR DESCRIPTION
## Description

Removes some test utilities which performed operations on `MergeTree`s, and transitioned tests that used them to instead call merge-tree APIs directly, which should be significantly more readable due to #24047.

This PR should not result in any functional changes to tests.