### PR TITLE
fix(tinylicious-driver): Remove port from endpoint if it's 80

### DIFF
--- a/packages/drivers/tinylicious-driver/src/insecureTinyliciousUrlResolver.ts
+++ b/packages/drivers/tinylicious-driver/src/insecureTinyliciousUrlResolver.ts
@@ -32,7 +32,7 @@ export const defaultTinyliciousEndpoint = "http://localhost";
 export class InsecureTinyliciousUrlResolver implements IUrlResolver {
 	private readonly tinyliciousEndpoint: string;
 	public constructor(port = defaultTinyliciousPort, endpoint = defaultTinyliciousEndpoint) {
-		this.tinyliciousEndpoint = `${endpoint}:${port}`;
+		this.tinyliciousEndpoint = `${endpoint}${port === 80 ? "" : `:${port}`}`;
 	}
 
 	public async resolve(request: IRequest): Promise<IResolvedUrl> {


### PR DESCRIPTION
The tinylicious driver's URL resolver generates URLs of the form `http://endpoint:port/x/y`. When the port is 80, though, it is typically omitted by browsers etc. This changes the URL generation to omit the port if it is 80.

Context: I ran into this problem during FHL, but I can't remember the exact circumstances. This seems like a reasonable change regardless.