### PR TITLE
(tree) In TestTreeProviderLite, provide capability to pause and resume processing of messages

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -52,6 +52,7 @@ import {
 	type ISharedTreeEditor,
 	Tree,
 	ForestTypeOptimized,
+	type ISharedTree,
 } from "../../../shared-tree/index.js";
 import {
 	MockTreeCheckout,
@@ -59,7 +60,6 @@ import {
 	forestWithContent,
 	mintRevisionTag,
 	testIdCompressor,
-	type SharedTreeWithConnectionStateSetter,
 } from "../../utils.js";
 import {
 	cursorFromInsertable,
@@ -402,10 +402,7 @@ describe("End to end chunked encoding", () => {
 				id: "test",
 				idCompressor: testIdCompressor,
 			});
-			const tree = factory.create(
-				runtime,
-				"TestSharedTree",
-			) as SharedTreeWithConnectionStateSetter;
+			const tree = factory.create(runtime, "TestSharedTree") as ISharedTree;
 
 			const stableId = testIdCompressor.decompress(testIdCompressor.generateCompressedId());
 

--- a/packages/dds/tree/src/test/feature-libraries/indexing/treeIndex.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/indexing/treeIndex.spec.ts
@@ -492,13 +492,13 @@ describe("tree indexes", () => {
 				child: new IndexableChild({ childKey: childId }),
 			}),
 		);
-		provider.processMessages();
+		provider.synchronizeMessages();
 		const { index } = createIndex(view);
 		const parent = view.root;
 		const child = parent.child;
 		assert(child !== undefined);
 		parent.child = undefined;
-		provider.processMessages();
+		provider.synchronizeMessages();
 		// check that the detached child still exists on the index
 		assert.deepEqual(Array.from(index.allEntries()), [
 			[parentId, [0]],
@@ -506,7 +506,7 @@ describe("tree indexes", () => {
 		]);
 		// send an edit so that the detached node is garbage collected
 		parent.child = new IndexableChild({ childKey: parentId });
-		provider.processMessages();
+		provider.synchronizeMessages();
 		// check that the detached child is removed from the index
 		assert.deepEqual(Array.from(index.allEntries()), [[parentId, [0, 2]]]);
 	});

--- a/packages/dds/tree/src/test/mocksForOpBunching.ts
+++ b/packages/dds/tree/src/test/mocksForOpBunching.ts
@@ -96,24 +96,31 @@ export class MockContainerRuntimeWithOpBunching extends MockContainerRuntimeForR
 	private pendingMessagesWhenPaused: ISequencedDocumentMessage[] = [];
 
 	/**
-	 * Pause the processing of messages. Messages that are received while paused will be queued. These messages
-	 * will be processed and sent to the data store runtime and DDSes when resumeProcessing is called.
-	 * @remarks The pausing and resuming of processing messages can also be achieved via setting the connected
-	 * state. However, any messages that were submitted while disconnected will go through the resubmit flow first
-	 * and then processed during reconnection which can give different results than pausing and resuming processing.
+	 * Pause the processing of inbound messages. Messages that are received while paused will be queued. These messages
+	 * will be processed and sent to the data store runtime and DDSes when resumeInboundProcessing is called.
+	 * @remarks Pausing and resuming does not affect outbound messages like disconnection and reconnection does. Pausing
+	 * and resuming inbound message processing can also be achieved via setting the connected state. However, any
+	 * outbound messages that were submitted while disconnected will go through the resubmit flow on reconnection which
+	 * can result in changes to the outbound messages such as its referenced sequence number.
+	 * For example, consider the following scenario:
+	 * 1. Client 1 disconnects to stop processing messages.
+	 * 2. Client 1 submits a message when its last processed seq# is 1. The message will have ref seq# 1.
+	 * 3. Client 2 submits a message which gets seq# 2. Client 1 doesn't process the message from client 2 because it's
+	 * not connected.
+	 * 4. Client 1 reconnects. It will process the message from client 2 first and its last processed seq# will be 2.
+	 * 5. Client 1 resubmits its message which will now have ref seq# 2 instead of 1. This is an unintended consequence
+	 * of using connected state which may be fine for some tests but not for others.
 	 */
-	public pauseProcessing() {
+	public pauseInboundProcessing() {
 		this.paused = true;
 	}
 
 	/**
 	 * Resume processing of messages. Messages that were received while paused will now be processed and sent to the
 	 * data store runtime and DDSes.
-	 * @remarks The pausing and resuming of processing messages can also be achieved via setting the connected
-	 * state. However, any messages that were submitted while disconnected will go through the resubmit flow first
-	 * and then processed during reconnection which can give different results than pausing and resuming processing.
+	 * @remarks See pauseInboundProcessing for more details.
 	 */
-	public resumeProcessing() {
+	public resumeInboundProcessing() {
 		if (!this.paused) {
 			return;
 		}

--- a/packages/dds/tree/src/test/mocksForOpBunching.ts
+++ b/packages/dds/tree/src/test/mocksForOpBunching.ts
@@ -96,14 +96,22 @@ export class MockContainerRuntimeWithOpBunching extends MockContainerRuntimeForR
 	private pendingMessagesWhenPaused: ISequencedDocumentMessage[] = [];
 
 	/**
-	 * Pause processing of messages. Messages will be queued up until resumeProcessing is called.
+	 * Pause the processing of messages. Messages that are received while paused will be queued. These messages
+	 * will be processed and sent to the data store runtime and DDSes when resumeProcessing is called.
+	 * @remarks The pausing and resuming of processing messages can also be achieved via setting the connected
+	 * state. However, any messages that were submitted while disconnected will go through the resubmit flow first
+	 * and then processed during reconnection which can give different results than pausing and resuming processing.
 	 */
 	public pauseProcessing() {
 		this.paused = true;
 	}
 
 	/**
-	 * Resume processing of messages. Messages that were queued up while paused will now be processed.
+	 * Resume processing of messages. Messages that were received while paused will now be processed and sent to the
+	 * data store runtime and DDSes.
+	 * @remarks The pausing and resuming of processing messages can also be achieved via setting the connected
+	 * state. However, any messages that were submitted while disconnected will go through the resubmit flow first
+	 * and then processed during reconnection which can give different results than pausing and resuming processing.
 	 */
 	public resumeProcessing() {
 		if (!this.paused) {

--- a/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -294,7 +294,7 @@ describe("SharedTreeCore", () => {
 			}),
 		);
 		view1.initialize(["A", "B"]);
-		provider.processMessages();
+		provider.synchronizeMessages();
 		const view2 = provider.trees[1].viewWith(
 			new TreeViewConfiguration({
 				schema: StringArray,
@@ -315,7 +315,7 @@ describe("SharedTreeCore", () => {
 			return Tree.runTransaction.rollback;
 		});
 
-		provider.processMessages();
+		provider.synchronizeMessages();
 		assert.deepEqual([...root1], ["A", "B"]);
 		assert.deepEqual([...root2], ["A", "B"]);
 
@@ -324,7 +324,7 @@ describe("SharedTreeCore", () => {
 			root1.insertAtEnd("C");
 		});
 
-		provider.processMessages();
+		provider.synchronizeMessages();
 		assert.deepEqual([...root1], ["A", "B", "C"]);
 		assert.deepEqual([...root2], ["A", "B", "C"]);
 	});
@@ -338,7 +338,7 @@ describe("SharedTreeCore", () => {
 			}),
 		);
 		view1.initialize(["A", "B"]);
-		provider.processMessages();
+		provider.synchronizeMessages();
 		const view2 = provider.trees[1].viewWith(
 			new TreeViewConfiguration({
 				schema: StringArray,
@@ -362,7 +362,7 @@ describe("SharedTreeCore", () => {
 		assert.deepEqual([...root1], ["B"]);
 		assert.deepEqual([...root2], ["A", "B"]);
 
-		provider.processMessages();
+		provider.synchronizeMessages();
 
 		assert.deepEqual([...root1], ["B"]);
 		assert.deepEqual([...root2], ["B"]);
@@ -372,7 +372,7 @@ describe("SharedTreeCore", () => {
 			root1.insertAtEnd("C");
 		});
 
-		provider.processMessages();
+		provider.synchronizeMessages();
 		assert.deepEqual([...root2], ["B", "C"]);
 		assert.deepEqual([...root2], ["B", "C"]);
 	});

--- a/packages/dds/tree/src/test/shared-tree/repairData.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/repairData.spec.ts
@@ -29,7 +29,7 @@ describe("Repair Data", () => {
 			// make sure that revertibles are created
 			const { unsubscribe } = createTestUndoRedoStacks(view1.checkout.events);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const view2 = provider.trees[1].kernel.viewWith(
 				new TreeViewConfiguration({
 					schema: StringArray,
@@ -44,7 +44,7 @@ describe("Repair Data", () => {
 			// remove in first tree
 			view1.root.removeRange(0, 2);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const removeSequenceNumber = provider.sequenceNumber;
 			assert.deepEqual([...view1.root], ["C", "D"]);
 			assert.deepEqual([...view2.root], ["C", "D"]);
@@ -78,7 +78,7 @@ describe("Repair Data", () => {
 			);
 			view1.initialize(["A", "B", "C", "D"]);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const view2 = provider.trees[1].kernel.viewWith(
 				new TreeViewConfiguration({
 					schema: StringArray,
@@ -96,7 +96,7 @@ describe("Repair Data", () => {
 			assert.deepEqual([...view2.root], ["A", "B", "D"]);
 
 			// Syncing will cause view2 to rebase its local changes
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			const removeSequenceNumber = provider.sequenceNumber;
 			assert.deepEqual([...view1.root], ["A", "x", "B", "D"]);
@@ -134,7 +134,7 @@ describe("Repair Data", () => {
 
 			// remove in first tree
 			view1.root.removeRange(0, 2);
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const removeSequenceNumber = provider.sequenceNumber;
 
 			assert.deepEqual([...view1.root], ["C", "D"]);
@@ -182,7 +182,7 @@ describe("Repair Data", () => {
 			// remove in first tree
 			view1.root.removeRange(0, 1);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const removeSequenceNumber = provider.sequenceNumber;
 
 			assert.deepEqual([...view1.root], ["B"]);
@@ -231,7 +231,7 @@ describe("Repair Data", () => {
 			assert.equal(anchorA.treeStatus, TreeStatus.Removed);
 			assert.equal(anchorB.treeStatus, TreeStatus.InDocument);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const removeSequenceNumber = provider.sequenceNumber;
 			assert.deepEqual([...view1.root], ["B", "C", "D"]);
 			assert.equal(view1.checkout.getRemovedRoots().length, 1);
@@ -257,7 +257,7 @@ describe("Repair Data", () => {
 			);
 			view1.initialize(["A", "B", "C", "D"]);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const view2 = provider.trees[1].kernel.viewWith(
 				new TreeViewConfiguration({
 					schema: StringArray,
@@ -274,7 +274,7 @@ describe("Repair Data", () => {
 			// remove in first tree
 			view1.root.removeAt(0);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const removeSequenceNumber = provider.sequenceNumber;
 			assert.deepEqual([...view1.root], ["B", "C", "D"]);
 			assert.deepEqual([...view2.root], ["B", "C", "D"]);
@@ -306,7 +306,7 @@ describe("Repair Data", () => {
 			// make sure that revertibles are created
 			const { unsubscribe } = createTestUndoRedoStacks(view1.checkout.events);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const view2 = provider.trees[1].kernel.viewWith(
 				new TreeViewConfiguration({
 					schema: StringArray,
@@ -323,7 +323,7 @@ describe("Repair Data", () => {
 			// remove in first tree
 			view1.root.removeAt(0);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const removeSequenceNumber = provider.sequenceNumber;
 			assert.deepEqual([...view1.root], ["B", "C", "D"]);
 			assert.deepEqual([...view2.root], ["B", "C", "D"]);
@@ -351,7 +351,7 @@ describe("Repair Data", () => {
 });
 
 function advanceCollabWindow(provider: TestTreeProviderLite, removeSequenceNumber: number) {
-	provider.processMessages();
+	provider.synchronizeMessages();
 	while (provider.minimumSequenceNumber <= removeSequenceNumber) {
 		for (const tree of provider.trees) {
 			tree.kernel.getEditor().enterTransaction();
@@ -361,7 +361,7 @@ function advanceCollabWindow(provider: TestTreeProviderLite, removeSequenceNumbe
 				parentIndex: 0,
 			});
 			tree.kernel.getEditor().exitTransaction();
-			provider.processMessages();
+			provider.synchronizeMessages();
 		}
 	}
 }

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -780,7 +780,7 @@ describe("SchematizingSimpleTreeView", () => {
 					content: 42,
 					child: { content: 42 },
 				});
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				// Tree A removes the child node (this will be sequenced before anything else because the provider sequences ops in the order of submission).
 				viewA.root.child = undefined;
@@ -806,7 +806,7 @@ describe("SchematizingSimpleTreeView", () => {
 				assert.equal(viewA.root.content, 42);
 				assert.equal(viewB.root.content, 43);
 				// ...but then is rolled back after sequencing because the child node was removed by Tree A.
-				provider.processMessages();
+				provider.synchronizeMessages();
 				assert.equal(viewB.root.content, 42);
 				assert.equal(viewB.root.content, 42);
 			});

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -521,11 +521,12 @@ describe("SharedTree benchmarks", () => {
 								sendLocalCommits(sender, bunchSize, "s");
 								sender.containerRuntime.flush();
 
-								const before = state.timer.now();
-								// Resume the receiver and process the bunched commits. This should force the local branch
-								// to be rebased over the bunch.
-								// The receiver will not process its local commits since they were never flushed.
+								// Resume the receiver so it can process the bunched commits from the sender.
 								receiver.containerRuntime.resumeInboundProcessing();
+
+								const before = state.timer.now();
+								// Process the bunched commits. This should force the local branch to be rebased over the bunch.
+								// The receiver will not process its local commits since they were never flushed.
 								provider.synchronizeMessages({ flush: false });
 								const after = state.timer.now();
 								duration = state.timer.toSeconds(before, after);

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -461,6 +461,10 @@ describe("SharedTree benchmarks", () => {
 
 		/**
 		 * Helper function to send local commits from a given tree.
+		 * In turn based flush mode, the messages won't be sequenced until flush is called explicitly
+		 * on the tree's container runtime.
+		 * In Immediate flush mode, the messages will be flushed and sequenced immediately. So, this
+		 * function will behave similar to 'sequenceLocalCommits'.
 		 */
 		function sendLocalCommits(tree: ISharedTree, count: number, commitPrefix: string) {
 			for (let iCommit = 0; iCommit < count; iCommit++) {

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -351,7 +351,7 @@ describe("SharedTree benchmarks", () => {
 
 						// Measure
 						const before = state.timer.now();
-						provider.processMessages();
+						provider.synchronizeMessages();
 						const after = state.timer.now();
 						duration = state.timer.toSeconds(before, after);
 						// Collect data
@@ -402,7 +402,7 @@ describe("SharedTree benchmarks", () => {
 							// This block generates commits that are all out of date to the same degree
 							for (let iCommit = 0; iCommit < commitCount; iCommit++) {
 								for (let iPeer = 0; iPeer < peerCount; iPeer++) {
-									provider.processSomeMessages(opsPerCommit);
+									provider.synchronizeMessages({ count: opsPerCommit });
 									const peer = provider.trees[iPeer];
 									insert(peer.kernel.checkout, 0, `p${iPeer}c${iCommit}`);
 								}
@@ -415,7 +415,7 @@ describe("SharedTree benchmarks", () => {
 							for (let iCommit = 0; iCommit < sampleSize; iCommit++) {
 								for (let iPeer = 0; iPeer < peerCount; iPeer++) {
 									const before = state.timer.now();
-									provider.processSomeMessages(opsPerCommit);
+									provider.synchronizeMessages({ count: opsPerCommit });
 									const after = state.timer.now();
 									timeSum += state.timer.toSeconds(before, after);
 									// We still generate commits because it affects local branch rebasing
@@ -455,8 +455,8 @@ describe("SharedTree benchmarks", () => {
 			);
 			const sender = provider.trees[0];
 			const receiver = provider.trees[1];
-			sender.containerRuntime.pauseProcessing();
-			receiver.containerRuntime.pauseProcessing();
+			sender.containerRuntime.pauseInboundProcessing();
+			receiver.containerRuntime.pauseInboundProcessing();
 			return { provider, sender, receiver };
 		}
 
@@ -525,8 +525,8 @@ describe("SharedTree benchmarks", () => {
 								// Resume the receiver and process the bunched commits. This should force the local branch
 								// to be rebased over the bunch.
 								// The receiver will not process its local commits since they were never flushed.
-								receiver.containerRuntime.resumeProcessing();
-								provider.processMessages(false /* flush */);
+								receiver.containerRuntime.resumeInboundProcessing();
+								provider.synchronizeMessages({ flush: false });
 								const after = state.timer.now();
 								duration = state.timer.toSeconds(before, after);
 							} while (state.recordBatch(duration));

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -454,8 +454,8 @@ describe("SharedTree benchmarks", () => {
 			);
 			const sender = provider.trees[0];
 			const receiver = provider.trees[1];
-			provider.pauseProcessing(sender.id);
-			provider.pauseProcessing(receiver.id);
+			provider.pauseProcessing(sender);
+			provider.pauseProcessing(receiver);
 			return { provider, sender, receiver };
 		}
 
@@ -478,14 +478,14 @@ describe("SharedTree benchmarks", () => {
 			provider: TestTreeProviderLite,
 		) {
 			sendLocalCommits(tree, count, commitPrefix);
-			provider.flushMessages(tree.id);
+			provider.flushMessages(tree);
 		}
 
 		/**
 		 * Helper function that processes all sequenced commits on a given tree.
 		 */
 		function receiveSequencedCommits(tree: ISharedTree, provider: TestTreeProviderLite) {
-			provider.resumeProcessing(tree.id);
+			provider.resumeProcessing(tree);
 			provider.processMessages(false /* flush */);
 		}
 
@@ -568,7 +568,7 @@ describe("SharedTree benchmarks", () => {
 							FlushMode.TurnBased,
 						);
 						const tree = provider.trees[0];
-						provider.setConnected(tree.id, true);
+						provider.setConnected(tree, true);
 						const view = provider.trees[0].viewWith(
 							new TreeViewConfiguration({
 								schema: StringArray,

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1384,7 +1384,7 @@ describe("SharedTree", () => {
 					submitter.assertInnerListEquals(initialState);
 					resubmitter.assertInnerListEquals(initialState);
 
-					provider.setConnected(resubmitter.id, false);
+					provider.setConnected(resubmitter, false);
 
 					s2.revert();
 					s1.revert();
@@ -1402,7 +1402,7 @@ describe("SharedTree", () => {
 					}
 					resubmitter.assertOuterListEquals([["a", "s1", "s2"]]);
 
-					provider.setConnected(resubmitter.id, true);
+					provider.setConnected(resubmitter, true);
 					provider.processMessages();
 
 					const finalState = [["a"]];
@@ -1426,7 +1426,7 @@ describe("SharedTree", () => {
 					submitter.assertInnerListEquals(initialState);
 					resubmitter.assertInnerListEquals(initialState);
 
-					provider.setConnected(resubmitter.id, false);
+					provider.setConnected(resubmitter, false);
 
 					if (scenario === "restore and edit") {
 						sRemove.revert();
@@ -1444,7 +1444,7 @@ describe("SharedTree", () => {
 					resubmitter.assertOuterListEquals([]);
 					resubmitter.assertInnerListEquals(["a", "s"]);
 
-					provider.setConnected(resubmitter.id, true);
+					provider.setConnected(resubmitter, true);
 					provider.processMessages();
 
 					const finalState = [["a"]];
@@ -1456,7 +1456,7 @@ describe("SharedTree", () => {
 			it("the restore of a tree edited on a branch", () => {
 				const { provider, submitter, resubmitter } = setupResubmitTest();
 
-				provider.setConnected(resubmitter.id, false);
+				provider.setConnected(resubmitter, false);
 
 				// This is the edit that will be rebased over during the re-submit phase
 				undoableInsertInInnerList(submitter, "s");
@@ -1483,7 +1483,7 @@ describe("SharedTree", () => {
 				rRemove.revert();
 				resubmitter.assertOuterListEquals([["a", "f"]]);
 
-				provider.setConnected(resubmitter.id, true);
+				provider.setConnected(resubmitter, true);
 				provider.processMessages();
 
 				const finalState = [["a", "f", "s"]];
@@ -1838,7 +1838,7 @@ describe("SharedTree", () => {
 
 			provider.processMessages();
 
-			provider.setConnected(tree1.id, false);
+			provider.setConnected(tree1, false);
 
 			view1.root.insertAtEnd("43");
 			view1.dispose();
@@ -1850,7 +1850,7 @@ describe("SharedTree", () => {
 			// TODO:#8915: This should be able to insert the _number_ 44, not the string, but currently cannot - see bug #8915
 			view1Json.root.insertAtEnd("44");
 
-			provider.setConnected(tree1.id, true);
+			provider.setConnected(tree1, true);
 
 			provider.processMessages();
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -183,7 +183,7 @@ describe("SharedTree", () => {
 			view1.initialize("x");
 			view2.initialize("x");
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			assert.equal(view1.root, "x");
 		});
 
@@ -815,7 +815,7 @@ describe("SharedTree", () => {
 		);
 		viewInit.initialize([]);
 		viewInit.dispose();
-		provider.processMessages();
+		provider.synchronizeMessages();
 
 		const [view1, view2] = provider.trees.map((t) =>
 			t.viewWith(new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation })),
@@ -826,14 +826,14 @@ describe("SharedTree", () => {
 			view1.root.insertAtStart("");
 		}
 
-		provider.processMessages();
+		provider.synchronizeMessages();
 
 		// These two edit will have ref numbers that correspond to the last of the above edits
 		view1.root.insertAtStart("");
 		view2.root.insertAtStart("");
 
 		// This synchronization point should ensure that both trees see the edits with the higher ref numbers.
-		provider.processMessages();
+		provider.synchronizeMessages();
 
 		// It's not clear if we'll ever want to expose the EditManager to ISharedTree consumers or
 		// if we'll ever expose some memory stats in which the trunk length would be included.
@@ -930,30 +930,30 @@ describe("SharedTree", () => {
 				}
 			};
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const tree2 = provider.trees[1];
 			const view2 = tree2.viewWith(
 				new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }),
 			);
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			// Insert node
 			view1.root.insertAtStart(value);
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			// Validate insertion
 			assert.deepEqual([...view2.root], [value]);
 
 			// Undo node insertion
 			undoStack.pop()?.revert();
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			assert.deepEqual([...view1.root], []);
 			assert.deepEqual([...view2.root], []);
 
 			// Redo node insertion
 			redoStack.pop()?.revert();
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			assert.deepEqual([...view1.root], [value]);
 			assert.deepEqual([...view2.root], [value]);
@@ -971,30 +971,30 @@ describe("SharedTree", () => {
 			const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(
 				tree1.kernel.checkout.events,
 			);
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const tree2 = provider.trees[1];
 			const view2 = tree2.viewWith(
 				new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }),
 			);
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			// Insert node
 			view1.root.insertAtStart(value);
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			// Validate insertion
 			assert.deepEqual([...view2.root], [value]);
 
 			// Undo node insertion
 			undoStack.pop()?.revert();
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			assert.deepEqual([...view1.root], []);
 			assert.deepEqual([...view2.root], []);
 
 			// Redo node insertion
 			redoStack.pop()?.revert();
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			assert.deepEqual([...view1.root], [value]);
 			assert.deepEqual([...view2.root], [value]);
@@ -1014,20 +1014,20 @@ describe("SharedTree", () => {
 			const { undoStack, redoStack, unsubscribe } = createTestUndoRedoStacks(
 				tree1.kernel.checkout.events,
 			);
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const view2 = provider.trees[1].viewWith(
 				new TreeViewConfiguration({
 					schema: StringArray,
 					enableSchemaValidation,
 				}),
 			);
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			// Insert node
 			view1.root.insertAtStart(value3);
 			view1.root.insertAtStart(value2);
 			view1.root.insertAtStart(value);
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			// Validate insertion
 			assert.deepEqual([...view1.root], [value, value2, value3]);
@@ -1035,28 +1035,28 @@ describe("SharedTree", () => {
 
 			// Undo node insertion
 			undoStack.pop()?.revert();
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			assert.deepEqual([...view1.root], [value2, value3]);
 			assert.deepEqual([...view2.root], [value2, value3]);
 
 			// Undo node insertion
 			undoStack.pop()?.revert();
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			assert.deepEqual([...view1.root], [value3]);
 			assert.deepEqual([...view2.root], [value3]);
 
 			// Undo node insertion
 			undoStack.pop()?.revert();
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			assert.deepEqual([...view1.root], []);
 			assert.deepEqual([...view2.root], []);
 
 			// Redo node insertion
 			redoStack.pop()?.revert();
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			assert.deepEqual([...view1.root], [value3]);
 			assert.deepEqual([...view2.root], [value3]);
@@ -1077,7 +1077,7 @@ describe("SharedTree", () => {
 				unsubscribe: unsubscribe1,
 			} = createTestUndoRedoStacks(tree1.kernel.checkout.events);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const tree2 = provider.trees[1];
 			const view2 = tree2.viewWith(
 				new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }),
@@ -1106,7 +1106,7 @@ describe("SharedTree", () => {
 			assert.deepEqual([...root2], ["A", "B", "C", "y", "D"]);
 
 			// Syncing will cause both trees to rebase their local changes
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			// Undo node insertion on both trees
 			undoStack1.pop()?.revert();
@@ -1115,7 +1115,7 @@ describe("SharedTree", () => {
 			undoStack2.pop()?.revert();
 			assert.deepEqual([...root2], ["A", "x", "B", "C", "D"]);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			validateTreeContent(tree1.kernel.checkout, initialState);
 			validateTreeContent(tree2.kernel.checkout, initialState);
 
@@ -1131,7 +1131,7 @@ describe("SharedTree", () => {
 			redoStack2.pop()?.revert();
 			assert.deepEqual([...root2], ["A", "B", "C", "y", "D"]);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			assert.deepEqual([...view1.root], expectedAfterRedo);
 			assert.deepEqual([...view2.root], expectedAfterRedo);
 			unsubscribe1();
@@ -1154,7 +1154,7 @@ describe("SharedTree", () => {
 				tree1.kernel.checkout.events,
 			);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const tree2 = provider.trees[1];
 			const view2 = tree2.viewWith(
 				new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }),
@@ -1169,7 +1169,7 @@ describe("SharedTree", () => {
 			// remove in first treex
 			root1.removeAt(0);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const removeSequenceNumber = provider.sequenceNumber;
 			assert.deepEqual([...root1], ["B", "C", "D"]);
 			assert.deepEqual([...root2], ["B", "C", "D"]);
@@ -1179,13 +1179,13 @@ describe("SharedTree", () => {
 
 			// send edits to move the collab window up
 			root2.insertAt(3, "y");
-			provider.processMessages();
+			provider.synchronizeMessages();
 			root1.removeAt(3);
-			provider.processMessages();
+			provider.synchronizeMessages();
 			root2.insertAt(3, "y");
-			provider.processMessages();
+			provider.synchronizeMessages();
 			root1.removeAt(3);
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			assert.deepEqual([...root1], ["B", "C", "D"]);
 			assert.deepEqual([...root2], ["B", "C", "D"]);
@@ -1197,14 +1197,14 @@ describe("SharedTree", () => {
 
 			undoStack[0]?.revert();
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			assert.deepEqual([...root1], ["A", "B", "C", "D"]);
 			assert.deepEqual([...root2], ["A", "B", "C", "D"]);
 
 			assert.equal(redoStack.length, 1);
 			redoStack.pop()?.revert();
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 			assert.deepEqual([...root1], ["B", "C", "D"]);
 			assert.deepEqual([...root2], ["B", "C", "D"]);
 
@@ -1230,7 +1230,7 @@ describe("SharedTree", () => {
 
 					// This test does not correctly handle views getting invalidated by schema changes, so avoid concurrent schematize
 					// which causes view invalidation when resolving the merge.
-					provider.processMessages();
+					provider.synchronizeMessages();
 
 					const tree2 = provider.trees[1];
 					const view2 = tree2.viewWith(
@@ -1239,7 +1239,7 @@ describe("SharedTree", () => {
 					const { undoStack: undoStack2, unsubscribe: unsubscribe2 } =
 						createTestUndoRedoStacks(tree2.kernel.checkout.events);
 
-					provider.processMessages();
+					provider.synchronizeMessages();
 
 					// Validate insertion
 					validateTreeContent(tree2.kernel.checkout, {
@@ -1251,13 +1251,13 @@ describe("SharedTree", () => {
 					const outerList = view2.root;
 					const innerList = outerList.at(0) ?? assert.fail();
 					innerList.insertAtEnd("b");
-					provider.processMessages();
+					provider.synchronizeMessages();
 					assert.deepEqual([...(view1.root.at(0) ?? assert.fail())], ["a", "b"]);
 					assert.deepEqual([...innerList], ["a", "b"]);
 
 					// remove subtree
 					view1.root.removeAt(0);
-					provider.processMessages();
+					provider.synchronizeMessages();
 					assert.deepEqual([...view1.root], []);
 					assert.deepEqual([...view2.root], []);
 
@@ -1269,7 +1269,7 @@ describe("SharedTree", () => {
 						undoStack1.pop()?.revert();
 					}
 
-					provider.processMessages();
+					provider.synchronizeMessages();
 					// check the undo happened
 					assert.deepEqual([...(view1.root.at(0) ?? assert.fail())], ["a"]);
 					assert.deepEqual([...(view2.root.at(0) ?? assert.fail())], ["a"]);
@@ -1352,9 +1352,9 @@ describe("SharedTree", () => {
 			} {
 				const provider = new TestTreeProviderLite(2);
 				const submitter = peerFromSharedTree(provider.trees[0]);
-				provider.processMessages();
+				provider.synchronizeMessages();
 				const resubmitter = peerFromSharedTree(provider.trees[1]);
-				provider.processMessages();
+				provider.synchronizeMessages();
 				return { provider, submitter, resubmitter };
 			}
 
@@ -1377,7 +1377,7 @@ describe("SharedTree", () => {
 					const s1 = undoableInsertInInnerList(submitter, "s1");
 					const s2 = undoableInsertInInnerList(submitter, "s2");
 
-					provider.processMessages();
+					provider.synchronizeMessages();
 
 					submitter.assertOuterListEquals([]);
 					resubmitter.assertOuterListEquals([]);
@@ -1392,7 +1392,7 @@ describe("SharedTree", () => {
 					submitter.assertOuterListEquals([]);
 					submitter.assertInnerListEquals(["a", "r"]);
 
-					provider.processMessages();
+					provider.synchronizeMessages();
 
 					if (scenario === "restore and edit") {
 						rRemove.revert();
@@ -1404,7 +1404,7 @@ describe("SharedTree", () => {
 					resubmitter.assertOuterListEquals([["a", "s1", "s2"]]);
 
 					resubmitter.containerRuntime.connected = true;
-					provider.processMessages();
+					provider.synchronizeMessages();
 
 					const finalState = [["a"]];
 					submitter.assertOuterListEquals(finalState);
@@ -1419,7 +1419,7 @@ describe("SharedTree", () => {
 					const sEdit = undoableInsertInInnerList(submitter, "s");
 					const sRemove = undoableRemoveOfOuterList(submitter);
 
-					provider.processMessages();
+					provider.synchronizeMessages();
 
 					submitter.assertOuterListEquals([]);
 					resubmitter.assertOuterListEquals([]);
@@ -1438,7 +1438,7 @@ describe("SharedTree", () => {
 					}
 					submitter.assertOuterListEquals([["a", "r1", "r2"]]);
 
-					provider.processMessages();
+					provider.synchronizeMessages();
 
 					r2.revert();
 					r1.revert();
@@ -1446,7 +1446,7 @@ describe("SharedTree", () => {
 					resubmitter.assertInnerListEquals(["a", "s"]);
 
 					resubmitter.containerRuntime.connected = true;
-					provider.processMessages();
+					provider.synchronizeMessages();
 
 					const finalState = [["a"]];
 					submitter.assertOuterListEquals(finalState);
@@ -1461,7 +1461,7 @@ describe("SharedTree", () => {
 
 				// This is the edit that will be rebased over during the re-submit phase
 				undoableInsertInInnerList(submitter, "s");
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				// fork the tree
 				const branch = resubmitter.checkout.branch();
@@ -1485,7 +1485,7 @@ describe("SharedTree", () => {
 				resubmitter.assertOuterListEquals([["a", "f"]]);
 
 				resubmitter.containerRuntime.connected = true;
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				const finalState = [["a", "f", "s"]];
 				resubmitter.assertOuterListEquals(finalState);
@@ -1503,7 +1503,7 @@ describe("SharedTree", () => {
 				new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }),
 			);
 			view1.initialize(["A", "B", "C", "D"]);
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const tree2 = provider.trees[1];
 			const view2 = tree2.viewWith(
 				new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }),
@@ -1533,7 +1533,7 @@ describe("SharedTree", () => {
 			assert.deepEqual([...root2], ["A", "B", "C", "y", "D", "z"]);
 
 			// Syncing will cause both trees to rebase their local changes
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			assert.equal(undoStack1.length, 1);
 			assert.equal(undoStack2.length, 2);
@@ -1550,7 +1550,7 @@ describe("SharedTree", () => {
 				new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }),
 			);
 			view1.initialize([]);
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const tree2 = provider.trees[1];
 			const view2 = tree2.viewWith(
 				new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }),
@@ -1566,7 +1566,7 @@ describe("SharedTree", () => {
 
 			// Insert node
 			view2.root.insertAtStart(value);
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			// Validate insertion
 			assert.deepEqual([...view1.root], [value]);
@@ -1659,16 +1659,16 @@ describe("SharedTree", () => {
 			new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }),
 		);
 		view1.initialize([]);
-		provider.processMessages();
+		provider.synchronizeMessages();
 		const tree2 = provider.trees[1];
 		let opsReceived = 0;
 		tree2.on("op", () => (opsReceived += 1));
 		Tree.runTransaction(view1, () => {
 			view1.root.insertAtStart("x");
-			provider.processMessages();
+			provider.synchronizeMessages();
 			assert.equal(opsReceived, 0);
 		});
-		provider.processMessages();
+		provider.synchronizeMessages();
 		assert.equal(opsReceived, 1);
 		assert.deepEqual(
 			[
@@ -1687,7 +1687,7 @@ describe("SharedTree", () => {
 			new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }),
 		);
 		view1.initialize([]);
-		provider.processMessages();
+		provider.synchronizeMessages();
 		const tree2 = provider.trees[1];
 		let opsReceived = 0;
 		tree2.on("op", () => (opsReceived += 1));
@@ -1695,7 +1695,7 @@ describe("SharedTree", () => {
 			view1.root.insertAtStart("B");
 			view1.root.insertAtStart("A");
 		});
-		provider.processMessages();
+		provider.synchronizeMessages();
 		assert.equal(opsReceived, 1);
 		assert.deepEqual(
 			[
@@ -1714,7 +1714,7 @@ describe("SharedTree", () => {
 			new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }),
 		);
 		view1.initialize([]);
-		provider.processMessages();
+		provider.synchronizeMessages();
 		const tree2 = provider.trees[1];
 		let opsReceived = 0;
 		tree2.on("op", () => (opsReceived += 1));
@@ -1725,12 +1725,12 @@ describe("SharedTree", () => {
 			Tree.runTransaction(view1, () => {
 				view1.root.insertAtStart("A");
 			});
-			provider.processMessages();
+			provider.synchronizeMessages();
 			assert.equal(opsReceived, 0);
 			assert.deepEqual([...view2.root], []);
 			view1.root.insertAtEnd("B");
 		});
-		provider.processMessages();
+		provider.synchronizeMessages();
 		assert.equal(opsReceived, 1);
 		assert.deepEqual([...view2.root], ["A", "B"]);
 	});
@@ -1796,7 +1796,7 @@ describe("SharedTree", () => {
 				.remove(0, 99),
 		);
 
-		provider.processMessages();
+		provider.synchronizeMessages();
 	});
 
 	describe("Schema changes", () => {
@@ -1837,7 +1837,7 @@ describe("SharedTree", () => {
 			);
 			view1.initialize(["42"]);
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			tree1.containerRuntime.connected = false;
 
@@ -1853,7 +1853,7 @@ describe("SharedTree", () => {
 
 			tree1.containerRuntime.connected = true;
 
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			assert.deepEqual([...view1Json.root].length, 3);
 		});
@@ -2006,7 +2006,7 @@ describe("SharedTree", () => {
 				view2.upgradeSchema();
 				view2.root.foo.insertAtStart(1);
 			});
-			provider.processMessages();
+			provider.synchronizeMessages();
 
 			assert.deepEqual(
 				tree.viewWith(new TreeViewConfiguration({ schema: schema2, enableSchemaValidation }))

--- a/packages/dds/tree/src/test/shared-tree/summary.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/summary.bench.ts
@@ -182,7 +182,7 @@ function getSummaryTree<T extends ImplicitFieldSchema>(
 	const tree = provider.trees[0];
 	const view = tree.kernel.viewWith(new TreeViewConfiguration({ schema: content.schema }));
 	view.initialize(content.initialTree);
-	provider.processMessages();
+	provider.synchronizeMessages();
 	const { summary } = tree.getAttachSummary(true);
 	return summary;
 }

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -515,7 +515,7 @@ describe("sharedTreeView", () => {
 				}),
 			);
 			view1.initialize([]);
-			provider.processMessages();
+			provider.synchronizeMessages();
 			const tree2 = provider.trees[1].kernel.viewWith(
 				new TreeViewConfiguration({
 					schema: sf.array(sf.string),
@@ -527,13 +527,13 @@ describe("sharedTreeView", () => {
 			const view = tree.viewWith(view1.config);
 			// Modify the view, but tree2 should remain unchanged until the edit merges all the way up
 			view.root.insertAtStart("42");
-			provider.processMessages();
+			provider.synchronizeMessages();
 			assert.equal(tree2.root[0], undefined);
 			baseTree.merge(tree);
-			provider.processMessages();
+			provider.synchronizeMessages();
 			assert.equal(tree2.root[0], undefined);
 			branch1.merge(baseTree);
-			provider.processMessages();
+			provider.synchronizeMessages();
 			assert.equal(tree2.root[0], "42");
 		});
 
@@ -549,7 +549,7 @@ describe("sharedTreeView", () => {
 				}),
 			);
 			view1.initialize([]);
-			provider.processMessages();
+			provider.synchronizeMessages();
 			let opsReceived = 0;
 			provider.trees[1].on("op", () => (opsReceived += 1));
 			const baseBranch = branch1.branch();
@@ -559,7 +559,7 @@ describe("sharedTreeView", () => {
 			view.root.insertAtStart("B");
 			baseBranch.merge(tree);
 			branch1.merge(baseBranch);
-			provider.processMessages();
+			provider.synchronizeMessages();
 			assert.equal(opsReceived, 2);
 		});
 
@@ -895,20 +895,20 @@ describe("sharedTreeView", () => {
 
 		view1.initialize(["A", 1, "B", 2]);
 		const storedSchema1 = toStoredSchema(schema1);
-		provider.processMessages();
+		provider.synchronizeMessages();
 
 		const checkout1Revertibles = createTestUndoRedoStacks(view1.checkout.events);
 
 		view1.root.removeAt(0); // Remove "A"
 		view1.root.removeAt(0); // Remove 1
 		checkout1Revertibles.undoStack.pop()?.revert(); // Restore 1
-		provider.processMessages();
+		provider.synchronizeMessages();
 
 		const checkout2Revertibles = createTestUndoRedoStacks(view2.checkout.events);
 		view2.root.removeAt(1); // Remove "B"
 		view2.root.removeAt(1); // Remove 2
 		checkout2Revertibles.undoStack.pop()?.revert(); // Restore 2
-		provider.processMessages();
+		provider.synchronizeMessages();
 
 		expectSchemaEqual(storedSchema1, view1.checkout.storedSchema);
 		expectSchemaEqual(storedSchema1, view2.checkout.storedSchema);
@@ -931,7 +931,7 @@ describe("sharedTreeView", () => {
 		assert.equal(checkout1Revertibles.redoStack.length, 1);
 		assert.deepEqual(provider.trees[0].kernel.checkout.getRemovedRoots().length, 2);
 
-		provider.processMessages();
+		provider.synchronizeMessages();
 
 		assert.equal(checkout2Revertibles.undoStack.length, 1);
 		assert.equal(checkout2Revertibles.redoStack.length, 1);

--- a/packages/dds/tree/src/test/shared-tree/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeNodeApi.spec.ts
@@ -158,7 +158,7 @@ describe("treeApi", () => {
 						content: 42,
 						child: {},
 					});
-					provider.processMessages();
+					provider.synchronizeMessages();
 
 					// Tree A removes the child node (this will be sequenced before anything else because the provider sequences ops in the order of submission).
 					viewA.root.child = undefined;
@@ -176,7 +176,7 @@ describe("treeApi", () => {
 					assert.equal(viewA.root.content, 42);
 					assert.equal(viewB.root.content, 43);
 					// ...but then is rolled back after sequencing because the child node was removed by Tree A.
-					provider.processMessages();
+					provider.synchronizeMessages();
 					assert.equal(viewB.root.content, 42);
 					assert.equal(viewB.root.content, 42);
 				});

--- a/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
@@ -61,7 +61,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 				);
 				view.initialize({});
 
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				await takeSnapshot(provider.trees[0], "final");
 			},
@@ -86,7 +86,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 				);
 				view.initialize(new NodeSchema({ foo: ["a", "b", "c"], bar: ["d", "e", "f"] }));
 				view.root.bar.moveRangeToIndex(1, 1, 3, view.root.foo);
-				provider.processMessages();
+				provider.synchronizeMessages();
 				await takeSnapshot(provider.trees[0], "tree-0-final");
 			},
 		},
@@ -103,17 +103,17 @@ export function generateTestTrees(options: SharedTreeOptions) {
 					}),
 				);
 				view.initialize([]);
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				// Insert node
 				view.root.insertAtStart("42");
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				await takeSnapshot(provider.trees[0], "tree-0-after-insert");
 
 				// Remove node
 				view.root.removeRange(0, 1);
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				await takeSnapshot(provider.trees[0], "tree-0-final");
 				await takeSnapshot(provider.trees[1], "tree-1-final");
@@ -139,7 +139,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 				);
 				view1.initialize(undefined);
 				view1.root = new MapNode([]);
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				const tree2 = provider.trees[1];
 				const view2 = tree2.viewWith(
@@ -160,7 +160,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 
 				view1.root?.set("root 3 child", 44);
 
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				// EditManager snapshot should involve information about rebasing tree1's edits (a transaction with root & child changes)
 				// over tree2's edits (a root change and a child change outside of the transaction).
@@ -180,7 +180,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 						}),
 					);
 					view1.initialize([0, 1, 2, 3]);
-					provider.processMessages();
+					provider.synchronizeMessages();
 					const view2 = provider.trees[1].viewWith(
 						new TreeViewConfiguration({
 							schema: [sf.array(sf.number)],
@@ -193,11 +193,11 @@ export function generateTestTrees(options: SharedTreeOptions) {
 							enableSchemaValidation,
 						}),
 					);
-					provider.processMessages();
+					provider.synchronizeMessages();
 					view1.root.removeAt(index);
 					view2.root.removeAt(index);
 					view3.root.removeAt(index);
-					provider.processMessages();
+					provider.synchronizeMessages();
 					await takeSnapshot(provider.trees[0], `index-${index}`);
 				}
 			},
@@ -215,7 +215,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 					}),
 				);
 				view1.initialize([]);
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				const branch1 = getBranch(tree1);
 				const tree2 = branch1.branch();
@@ -230,7 +230,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 				tree2.rebaseOnto(branch1);
 				branch1.merge(tree2, false);
 
-				provider.processMessages();
+				provider.synchronizeMessages();
 				await takeSnapshot(tree1, "tree2");
 
 				assert.deepEqual(view1.root, ["x", "y", "a", "b", "c"]);
@@ -244,7 +244,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 				tree3.rebaseOnto(branch1);
 				branch1.merge(tree3);
 
-				provider.processMessages();
+				provider.synchronizeMessages();
 				await takeSnapshot(tree1, "tree3");
 			},
 		},
@@ -298,7 +298,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 					}
 
 					view.initialize(generateTreeRecursively(mapKeys, startingHeight, { value: 1 }));
-					provider.processMessages();
+					provider.synchronizeMessages();
 					return tree;
 				}
 
@@ -321,10 +321,10 @@ export function generateTestTrees(options: SharedTreeOptions) {
 					}),
 				);
 				view.initialize({ handleField: undefined });
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				view.root.handleField = tree.handle;
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				await takeSnapshot(tree, "final");
 			},
@@ -347,7 +347,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 					}),
 				);
 				view.initialize(new Array([]));
-				provider.processMessages();
+				provider.synchronizeMessages();
 
 				// We must make this shallow change to the sequence field as part of the same transaction as the
 				// nested change. Otherwise, the nested change will be represented using the generic field kind.
@@ -360,7 +360,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 					innerArray.push(new SequenceMap([]));
 				});
 
-				provider.processMessages();
+				provider.synchronizeMessages();
 				await takeSnapshot(tree, "final");
 			},
 		},
@@ -377,7 +377,7 @@ export function generateTestTrees(options: SharedTreeOptions) {
 					}),
 				);
 				view.initialize(undefined);
-				provider.processMessages();
+				provider.synchronizeMessages();
 				await takeSnapshot(tree, "final");
 			},
 		},

--- a/packages/dds/tree/src/test/snapshots/summary/Compressed/v1/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/summary/Compressed/v1/has-handle-final.json
@@ -76,7 +76,7 @@
                                     0,
                                     {
                                       "type": "__fluid_handle__",
-                                      "url": "/test/TestSharedTree"
+                                      "url": "/test/tree-0"
                                     }
                                   ]
                                 ]
@@ -179,7 +179,7 @@
                         [
                           {
                             "type": "__fluid_handle__",
-                            "url": "/test/TestSharedTree"
+                            "url": "/test/tree-0"
                           }
                         ]
                       ]

--- a/packages/dds/tree/src/test/snapshots/summary/Compressed/v2/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/summary/Compressed/v2/has-handle-final.json
@@ -73,7 +73,7 @@
                                     0,
                                     {
                                       "type": "__fluid_handle__",
-                                      "url": "/test/TestSharedTree"
+                                      "url": "/test/tree-0"
                                     }
                                   ]
                                 ]
@@ -176,7 +176,7 @@
                         [
                           {
                             "type": "__fluid_handle__",
-                            "url": "/test/TestSharedTree"
+                            "url": "/test/tree-0"
                           }
                         ]
                       ]

--- a/packages/dds/tree/src/test/snapshots/summary/Compressed/v3/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/summary/Compressed/v3/has-handle-final.json
@@ -73,7 +73,7 @@
                                     0,
                                     {
                                       "type": "__fluid_handle__",
-                                      "url": "/test/TestSharedTree"
+                                      "url": "/test/tree-0"
                                     }
                                   ]
                                 ]
@@ -176,7 +176,7 @@
                         [
                           {
                             "type": "__fluid_handle__",
-                            "url": "/test/TestSharedTree"
+                            "url": "/test/tree-0"
                           }
                         ]
                       ]

--- a/packages/dds/tree/src/test/snapshots/summary/Uncompressed/v1/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/summary/Uncompressed/v1/has-handle-final.json
@@ -81,7 +81,7 @@
                                       true,
                                       {
                                         "type": "__fluid_handle__",
-                                        "url": "/test/TestSharedTree"
+                                        "url": "/test/tree-0"
                                       },
                                       []
                                     ]
@@ -180,7 +180,7 @@
                               true,
                               {
                                 "type": "__fluid_handle__",
-                                "url": "/test/TestSharedTree"
+                                "url": "/test/tree-0"
                               },
                               []
                             ]

--- a/packages/dds/tree/src/test/snapshots/summary/Uncompressed/v2/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/summary/Uncompressed/v2/has-handle-final.json
@@ -78,7 +78,7 @@
                                       true,
                                       {
                                         "type": "__fluid_handle__",
-                                        "url": "/test/TestSharedTree"
+                                        "url": "/test/tree-0"
                                       },
                                       []
                                     ]
@@ -177,7 +177,7 @@
                               true,
                               {
                                 "type": "__fluid_handle__",
-                                "url": "/test/TestSharedTree"
+                                "url": "/test/tree-0"
                               },
                               []
                             ]

--- a/packages/dds/tree/src/test/snapshots/summary/Uncompressed/v3/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/summary/Uncompressed/v3/has-handle-final.json
@@ -78,7 +78,7 @@
                                       true,
                                       {
                                         "type": "__fluid_handle__",
-                                        "url": "/test/TestSharedTree"
+                                        "url": "/test/tree-0"
                                       },
                                       []
                                     ]
@@ -177,7 +177,7 @@
                               true,
                               {
                                 "type": "__fluid_handle__",
-                                "url": "/test/TestSharedTree"
+                                "url": "/test/tree-0"
                               },
                               []
                             ]

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -450,7 +450,7 @@ export class TestTreeProviderLite {
 	 * that they are sequenced. Then, the runtime processes the messages. Flushing is needed in TurnBased mode only
 	 * where messages are not automatically flushed. In Immediate mode, each message is flushed immediately.
 	 * @param options - The options to use when synchronizing messages.
-	 * - count: The number of messages to synchronize. If not provided, all messages are synchronize.
+	 * - count: The number of messages to synchronize. If not provided, all messages are synchronized.
 	 * - flush: Whether or not to flush the messages before processing them. Defaults to true. In TurnBased mode,
 	 * messages are not automatically flushed so this should either be set to true or the test should manually
 	 * flush the messages before calling this method.

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -375,21 +375,6 @@ export class TestTreeProvider {
 /**
  * A type with subset of functionalities of mock container runtime that can help tests control
  * the processing of messages and the connection state of the runtime.
- *
- * - "connected": Set the connection state of a given tree. Any messages that are submitted while the tree is
- * disconnected will be resubmitted when it reconnects by calling the resubmit function on the tree. Also, the
- * clientId of the runtime changes on reconnection.
- *
- * - "pauseProcessing":  Pauses the processing of messages for a tree. Unlike during reconnection, messages that
- * are submitted while the tree is paused will not be resubmitted when it unpauses.
- *
- * - "resumeProcessing": Resumes the processing of messages for a tree. This will process the messages received while
- * the tree was paused. Note that if the tree is not connected, then messages will not be processed - See "connected"
- * for details. Unlike during reconnection, messages that were submitted while the tree was paused will not be resubmitted
- * when it unpauses.
- *
- * - "flush": To be used in TurnBased mode where messages that are sent are not automatically flushed. It flushes the
- * messages that have been sent by a tree. This will be a no-op if the tree's runtime is not connected.
  */
 export type TreeMockContainerRuntime = Pick<
 	MockContainerRuntimeWithOpBunching,

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -434,11 +434,12 @@ export class TestTreeProviderLite {
 
 	/**
 	 * To be used in TurnBased mode where messages that are sent are not automatically flushed.
-	 * Flush the messages that have sent by a given tree.
-	 * @param treeId - The ID of the tree to flush messages for.
+	 * Flush the messages that have been sent by a given tree.
+	 * @param treeId - The id of the tree to flush messages for.
+	 * @remarks This will be a no-op if the tree's runtime is not connected.
 	 */
-	public flushMessages(treeId: string): void {
-		const containerRuntime = this.containerRuntimeMap.get(treeId);
+	public flushMessages(tree: Pick<ISharedTree, "id">): void {
+		const containerRuntime = this.containerRuntimeMap.get(tree.id);
 		assert(containerRuntime !== undefined, "No tree found to flush messages");
 		containerRuntime.flush();
 	}
@@ -450,7 +451,10 @@ export class TestTreeProviderLite {
 	 * disabled by setting the flush parameter to false. Then it is the responsibility of the test to flush the
 	 * messages before calling this method.
 	 * @param flush - Whether or not to flush the messages before processing them. Defaults to true.
-	 * @remarks Flushing does not preserve the order in which the messages were sent. To do so, tests should
+	 * @remarks
+	 * - Trees whose runtime is paused or not connected will queue these messages and not process them. They
+	 * will process the messages when their runtime is unpaused or connected respectively.
+	 * - Flushing does not preserve the order in which the messages were sent. To do so, tests should
 	 * call flushMessages on individual trees in the order messages were sent.
 	 */
 	public processMessages(flush: boolean = true): void {
@@ -464,6 +468,8 @@ export class TestTreeProviderLite {
 
 	/**
 	 * Process the given count of messages across all trees.
+	 * @remarks trees whose runtime is paused or not connected will queue these messages and not process them. They
+	 * will process the messages when their runtime is unpaused or connected respectively.
 	 */
 	public processSomeMessages(count: number): void {
 		this.runtimeFactory.processSomeMessages(count);
@@ -471,31 +477,31 @@ export class TestTreeProviderLite {
 
 	/**
 	 * Set the connection state of the given tree.
-	 * @param treeId - The ID of the tree to set the connection state for.
+	 * @param tree - The tree to set the connection state for.
 	 */
-	public setConnected(treeId: string, connectionState: boolean): void {
-		const containerRuntime = this.containerRuntimeMap.get(treeId);
+	public setConnected(tree: Pick<ISharedTree, "id">, connectionState: boolean): void {
+		const containerRuntime = this.containerRuntimeMap.get(tree.id);
 		assert(containerRuntime !== undefined, "No tree found to set connection state");
 		containerRuntime.connected = connectionState;
 	}
 
 	/**
 	 * Pauses the processing of messages for the given tree.
-	 * @param treeId - The ID of the tree to pause processing for.
+	 * @param tree - The tree to pause processing for.
 	 */
-	public pauseProcessing(treeId: string): void {
-		const containerRuntime = this.containerRuntimeMap.get(treeId);
+	public pauseProcessing(tree: Pick<ISharedTree, "id">): void {
+		const containerRuntime = this.containerRuntimeMap.get(tree.id);
 		assert(containerRuntime !== undefined, "No tree found to pause processing");
 		containerRuntime.pauseProcessing();
 	}
 
 	/**
 	 * Resumes the processing of messages for the given tree.
-	 * @param treeId - The ID of the tree to resume processing for.
+	 * @param tree - The tree to resume processing for.
 	 * @remarks This will process the messages that were received while the tree was paused.
 	 */
-	public resumeProcessing(treeId: string): void {
-		const containerRuntime = this.containerRuntimeMap.get(treeId);
+	public resumeProcessing(tree: Pick<ISharedTree, "id">): void {
+		const containerRuntime = this.containerRuntimeMap.get(tree.id);
 		assert(containerRuntime !== undefined, "No tree found to resume processing");
 		containerRuntime.resumeProcessing();
 	}

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -150,7 +150,6 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
         minimumSequenceNumber?: number;
         trackRemoteOps?: boolean;
     });
-    // (undocumented)
     get connected(): boolean;
     set connected(connected: boolean);
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
@@ -31,8 +31,8 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
 
 	/**
 	 * Returns the connection state of the container runtime.
-	 * Any messages that are submitted while not connected will be resubmitted when it reconnects via the resubmit flow.
-	 * Any messages received while disconnected will be processed when it reconnects.
+	 * Any messages that are submitted while not connected will be resubmitted via the resubmit flow on reconnection.
+	 * Any messages received while disconnected will be processed on reconnection.
 	 * Also, the clientId of the runtime will change on reconnection.
 	 */
 	public get connected(): boolean {

--- a/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
@@ -33,6 +33,12 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
 		return this._connected;
 	}
 
+	/**
+	 * Sets the connection state of the container runtime.
+	 * Any messages that are submitted while disconnected will be resubmitted when it reconnects via the resubmit flow.
+	 * Any messages received while disconnected will be processed when it reconnects.
+	 * Also, the clientId of the runtime will change on reconnection.
+	 */
 	public set connected(connected: boolean) {
 		this.setConnectedState(connected);
 	}

--- a/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
@@ -29,16 +29,16 @@ export class MockContainerRuntimeForReconnection extends MockContainerRuntime {
 	 */
 	protected readonly pendingRemoteMessages: ISequencedDocumentMessage[] = [];
 
+	/**
+	 * Returns the connection state of the container runtime.
+	 * Any messages that are submitted while not connected will be resubmitted when it reconnects via the resubmit flow.
+	 * Any messages received while disconnected will be processed when it reconnects.
+	 * Also, the clientId of the runtime will change on reconnection.
+	 */
 	public get connected(): boolean {
 		return this._connected;
 	}
 
-	/**
-	 * Sets the connection state of the container runtime.
-	 * Any messages that are submitted while disconnected will be resubmitted when it reconnects via the resubmit flow.
-	 * Any messages received while disconnected will be processed when it reconnects.
-	 * Also, the clientId of the runtime will change on reconnection.
-	 */
 	public set connected(connected: boolean) {
 		this.setConnectedState(connected);
 	}


### PR DESCRIPTION
This change adds the capaibility to pause and resume message processing for a given tree in TestTreeProviderLite. It also adds the capability to flush messages from a given tree. Together, these will allow finer control over tests that use TestTreeProviderLite.
The test also changed the trees to be created with unique ids and as a result some of the snapshots had to be updated.

This change is inspired by this comment https://github.com/microsoft/FluidFramework/pull/24093/files#r2003975305. There are scenarios where a test wants to carefully control which client (tree) sequences or processes its ops and when while other clients don't. This PR updates a benchmark test to create utilities such as `sendLocalCommits`, `sequenceLocalCommits` and `receiveSequencedCommits` with the help of the new capabilities added. This makes it simpler to write these kind of tests and makes them easier to understand. These utilities can be used be the other tests added in this PR https://github.com/microsoft/FluidFramework/pull/24093/files. 

[AB#34266](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/34266)