### PR TITLE
Fix Timeout Utils Memory Leak

### DIFF
--- a/packages/test/test-utils/src/timeoutUtils.ts
+++ b/packages/test/test-utils/src/timeoutUtils.ts
@@ -17,7 +17,6 @@ class TestTimeout {
 	private timeout: number = 0;
 	private timer: NodeJS.Timeout | undefined;
 	private readonly deferred: Deferred<void>;
-	private rejected = false;
 
 	private static instance: TestTimeout = new TestTimeout();
 	public static reset(runnable: Mocha.Runnable) {
@@ -26,11 +25,8 @@ class TestTimeout {
 	}
 
 	public static clear() {
-		if (TestTimeout.instance.rejected) {
-			TestTimeout.instance = new TestTimeout();
-		} else {
-			TestTimeout.instance.clearTimer();
-		}
+		TestTimeout.instance.clearTimer();
+		TestTimeout.instance = new TestTimeout();
 	}
 
 	public static getInstance() {
@@ -67,7 +63,6 @@ class TestTimeout {
 		// Set up timer to reject near the test timeout.
 		this.timer = setTimeout(() => {
 			this.deferred.reject(this);
-			this.rejected = true;
 		}, this.timeout);
 	}
 	private clearTimer() {


### PR DESCRIPTION
By reusing the same deferred promise, it was leading to promise chains connected to the promise which would only be garbage collected on promise failure, which only happens rarely as it leads to test failures. This was causing gigabytes of memory to be leaked as those chained promise and their references were essentially pinned in memory. This was leading to out memory issues in the most degenerate case like when running a test in a loop to reproduce failure.