### PR TITLE
Upgrades release/client/2.30 pipeline deployment jobs to be 1ES compliant

### DIFF
--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -123,6 +123,13 @@ resources:
     type: git
     name: 1ESPipelineTemplates/M365GPT
     ref: refs/tags/release
+  # Listing a pipeline as a resource makes its artifacts available for download in any job
+  pipelines:
+    # Access to this pipelines artifacts allows 1ES deployment jobs to install build tools without checking out out a repo.
+    - pipeline: buildTools-resource
+      project: internal
+      source: Build - build-tools
+      branch: main
 extends:
   # The pipeline extends the 1ES pipeline template which will inject different SDL and compliance tasks.
   # Read more: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -147,6 +147,13 @@ resources:
       type: git
       name: 1ESPipelineTemplates/M365GPT
       ref: refs/tags/release
+  # Listing a pipeline as a resource makes its artifacts available for download in any job
+  pipelines:
+    # Access to this pipelines artifacts allows 1ES deployment jobs to install build tools without checking out out a repo.
+    - pipeline: buildTools-resource
+      project: internal
+      source: Build - build-tools
+      branch: main
 
 extends:
   # The pipeline extends the 1ES pipeline template which will inject different SDL and compliance tasks.

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -146,6 +146,13 @@ resources:
       type: git
       name: 1ESPipelineTemplates/M365GPT
       ref: refs/tags/release
+  # Listing a pipeline as a resource makes its artifacts available for download in any job
+  pipelines:
+    # Access to this pipelines artifacts allows 1ES deployment jobs to install build tools without checking out out a repo.
+    - pipeline: buildTools-resource
+      project: internal
+      source: Build - build-tools
+      branch: main
 
 extends:
   # The pipeline extends the 1ES pipeline template which will inject different SDL and compliance tasks.

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -51,21 +51,41 @@ jobs:
   variables:
     version: $[ stageDependencies.build.build.outputs['SetVersion.version']]
     isLatest: $[ stageDependencies.build.build.outputs['SetVersion.isLatest']]
+  templateContext:
+    type: releaseJob
+    # in() returns true if the first parameter is equal to any of the others
+    isProduction: ${{ in(variables['release'], 'release', 'prerelease')  }}
+
+    # This 'inputs' section downloads initial required artifacts/data for this job.
+    inputs:
+      - input: pipelineArtifact
+        pipeline: buildTools-resource
+        artifactName: pack
+        targetPath: $(Pipeline.Workspace)/buildTools-zip
+
+      - input: pipelineArtifact
+        artifactName: pack
+        buildType: current
+        targetPath: $(Pipeline.Workspace)/pack
   strategy:
     runOnce:
         deploy:
           steps:
-          - checkout: self
-            clean: true
-            persistCredentials: true # Necessary for creation of git tags to work
-          - download: current
-            artifact: pack
           - template: /tools/pipelines/templates/include-use-node-version.yml@self
-          - template: /tools/pipelines/templates/include-install-build-tools.yml@self
-            parameters:
-              buildDirectory: ${{ parameters.buildDirectory }}
-              buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
-              pnpmStorePath: ${{ parameters.pnpmStorePath }}
+
+          - task: Bash@3
+            name: InstallBuildToolsFromTarball
+            displayName: Install Fluid Build Tools from artifact tarball
+            inputs:
+              targetType: 'inline'
+              workingDirectory: '$(Pipeline.Workspace)/buildTools-zip/tarballs'
+              script: |
+                set -eu -o pipefail
+                echo "Listing files in directory: $(pwd)"
+                ls -la
+                echo "Attempting install of build tools from build tools pipeline artifact tarball"
+                npm i -g ./*.tgz
+
           - template: /tools/pipelines/templates/include-publish-npm-package-steps.yml@self
             parameters:
               artifactPath: tarballs


### PR DESCRIPTION
## Read THIS FIRST
This change is being ported from main: https://github.com/microsoft/FluidFramework/pull/24026

Below is a repeat of the description from the above linked PR. The goal here is to ensure that if we decide to rerelease this fluid version that our deployment pipeline is 1ES compliant.

## Description
 
1es pipelines have warnings requiring that all [deployment jobs](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/deployment-jobs?view=azure-devops) transition to release jobs (see [Custom Release Job | 1ES On EngHub](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/releasepipelines/releaseworkflows/releasejob?tabs=combined-pipeline)).

The `include-publish-npm-package-deployment.yml` is a template included in many pipelines, including the build client pipeline. This template includes a deployment job that needed to be upgraded to a 1ES compliant.

To that effort, a few changes have been made to pipelines:
1. The FF repo is no longer checked out in `include-publish-npm-package-deployment.yml`. This was necessary to install build tools properly.
1. 'Build - Build tools' is now a specified as a 'pipeline resource' in upstream pipelines such as build-npm-client-package which enables us to selectively download its artifacts in the deployment job within `include-publish-npm-package-deployment.yml`.
1. The original code for installing build tools within `include-publish-npm-package-deployment.yml` using the downloaded FF repo was removed and replaced with a bash script that installs the build tools from the tarball artifact from the 'Build - Build Tools' pipeline.
1. A new template context section was added to  `include-publish-npm-package-deployment.yml` which specifies variables necessary to make is a 1ES deployment job and this also includes a dynamic isProduction variable based on the 'testBuild' parameter from `include-vars.yml` pipeline template
1. `include-publish-npm-package-deployment.yml` uses the new `templateContext` section to download the pipeline artifact from 'Build - Build tools' using the `inputs` parameter rather than a explicitly defined task. This also applies to downloading the `pack` artifact from the build stage of the pipeline


## Reviewer Guidance
1ES Release Job Requirements: (see links above for more details)
- You have to classify the release job as production or non-production based on whether you deploy to a production or non-production environment (in the case of deploying to Azure, this must match the Azure subscription classification in Service Tree).
- You have to declare all the artifacts required for the release as inputs for the job (this is similar to the concept of outputs in a standard build job).
- You can't build source code in a release job (this is to ensure all artifacts have been binary scanned in a build job output).
- You can't check out repositories. All artifacts must be generated and published from a 1ES PT build job and declared as an input.
- All 1ES PT pipelines must use a [1ES hosted pool](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboardingesteams/overview).
