### PR TITLE
Checkout same commit for build and tests jobs

### DIFF
--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -231,8 +231,8 @@ extends:
                 submodules: '${{ parameters.checkoutSubmodules }}'
 
               - script: |
-                  echo "commit sha: $(git rev-parse HEAD)"
-                  echo "##vso[task.setvariable variable=COMMIT_SHA;isOutput=true]$(git rev-parse HEAD)"
+                  echo "commit sha: $(Build.SourceVersion)"
+                  echo "##vso[task.setvariable variable=COMMIT_SHA;isOutput=true]$(Build.SourceVersion)"
                 displayName: "Capture Commit SHA"
                 name: setCommitSHA
 
@@ -735,6 +735,8 @@ extends:
                 # Note that we need to disable it in the right way for 1ES pipeline templates, vs manual CodeQL tasks.
                 - name: ONEES_ENFORCED_CODEQL_ENABLED
                   value: 'false'
+                - name: COMMIT_SHA
+                  value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
               steps:
                 # Setup
                 - checkout: self
@@ -743,7 +745,7 @@ extends:
                   submodules: '${{ parameters.checkoutSubmodules }}'
 
                 - script: |
-                    echo $(COMMIT_SHA)
+                    echo "commit: $(COMMIT_SHA)"
                     git fetch origin $(COMMIT_SHA)
                     git checkout $(COMMIT_SHA)
                   displayName: "Checkout build commit"

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -231,6 +231,7 @@ extends:
                 submodules: '${{ parameters.checkoutSubmodules }}'
 
               - script: |
+                  echo "commit sha: $(git rev-parse HEAD)"
                   echo "##vso[task.setvariable variable=COMMIT_SHA;isOutput=true]$(git rev-parse HEAD)"
                 displayName: "Capture Commit SHA"
                 name: setCommitSHA
@@ -574,6 +575,9 @@ extends:
               # Note that we need to disable it in the right way for 1ES pipeline templates, vs manual CodeQL tasks.
               - name: ONEES_ENFORCED_CODEQL_ENABLED
                 value: 'false'
+              - name: COMMIT_SHA
+                value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+
             steps:
               # Setup
               - checkout: self
@@ -582,8 +586,9 @@ extends:
                 submodules: '${{ parameters.checkoutSubmodules }}'
 
               - script: |
-                  git fetch origin $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
-                  git checkout $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+                  echo "commit: $(COMMIT_SHA)"
+                  git fetch origin $(COMMIT_SHA)
+                  git checkout $(COMMIT_SHA)
                 displayName: "Checkout build commit"
 
               - template: /tools/pipelines/templates/include-use-node-version.yml@self
@@ -738,8 +743,9 @@ extends:
                   submodules: '${{ parameters.checkoutSubmodules }}'
 
                 - script: |
-                    git fetch origin $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
-                    git checkout $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+                    echo $(COMMIT_SHA)
+                    git fetch origin $(COMMIT_SHA)
+                    git checkout $(COMMIT_SHA)
                   displayName: "Checkout build commit"
 
                 - template: /tools/pipelines/templates/include-use-node-version.yml@self

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -574,8 +574,6 @@ extends:
               # Note that we need to disable it in the right way for 1ES pipeline templates, vs manual CodeQL tasks.
               - name: ONEES_ENFORCED_CODEQL_ENABLED
                 value: 'false'
-              - name: COMMIT_SHA
-                value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
             steps:
               # Setup
               - checkout: self
@@ -584,9 +582,9 @@ extends:
                 submodules: '${{ parameters.checkoutSubmodules }}'
 
               - script: |
-                  git fetch origin $COMMIT_SHA
-                  git checkout $COMMIT_SHA
-                displayName: "Ensure Same Commit"
+                  git fetch origin $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+                  git checkout $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+                displayName: "Checkout build commit"
 
               - template: /tools/pipelines/templates/include-use-node-version.yml@self
 
@@ -738,6 +736,11 @@ extends:
                   clean: true
                   lfs: '${{ parameters.checkoutSubmodules }}'
                   submodules: '${{ parameters.checkoutSubmodules }}'
+
+                - script: |
+                    git fetch origin $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+                    git checkout $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
+                  displayName: "Checkout build commit"
 
                 - template: /tools/pipelines/templates/include-use-node-version.yml@self
 

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -230,6 +230,11 @@ extends:
                 lfs: '${{ parameters.checkoutSubmodules }}'
                 submodules: '${{ parameters.checkoutSubmodules }}'
 
+              - script: |
+                  echo "##vso[task.setvariable variable=COMMIT_SHA;isOutput=true]$(git rev-parse HEAD)"
+                displayName: "Capture Commit SHA"
+                name: setCommitSHA
+
               - task: Bash@3
                 displayName: Parameters
                 inputs:
@@ -569,12 +574,19 @@ extends:
               # Note that we need to disable it in the right way for 1ES pipeline templates, vs manual CodeQL tasks.
               - name: ONEES_ENFORCED_CODEQL_ENABLED
                 value: 'false'
+              - name: COMMIT_SHA
+                value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
             steps:
               # Setup
               - checkout: self
                 clean: true
                 lfs: '${{ parameters.checkoutSubmodules }}'
                 submodules: '${{ parameters.checkoutSubmodules }}'
+
+              - script: |
+                  git fetch origin $COMMIT_SHA
+                  git checkout $COMMIT_SHA
+                displayName: "Ensure Same Commit"
 
               - template: /tools/pipelines/templates/include-use-node-version.yml@self
 


### PR DESCRIPTION
We use the default checkout pattern for all our jobs. ADO checks out whatever latest state of the repo is at the moment, which could cause one commit being checked out at build job and another one at test jobs if a change is merged after the build checks out and before the test jobs do it. 
This change simply captures the commit at build time to be later used by the test jobs, ensuring same state across jobs.