### PR TITLE
fix(ci): Fix pipeline that calculates bundle size baselines

### DIFF
--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -24,7 +24,7 @@ extends:
     taskBundleAnalysis: true
     taskPublishBundleSizeArtifacts: true
     taskBuildDocs: false
-    testCoverage: true
+    testCoverage: false
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm
     buildDirectory: .

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -28,7 +28,6 @@ extends:
       - nyc/examples
       - nyc/experimental
       - nyc/packages
-    taskWebpack: true
     taskPack: false
     taskBundleAnalysis: true
     taskPublishBundleSizeArtifacts: true

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -19,15 +19,7 @@ extends:
   parameters:
     publish: false
     taskLint: false
-    taskTest:
-      - ci:test:mocha
-      - ci:test:jest
-      - ci:test:realsvc:local
-      - test:copyresults
-    testResultDirs:
-      - nyc/examples
-      - nyc/experimental
-      - nyc/packages
+    taskTest: [] # No need to run tests in this pipeline
     taskPack: false
     taskBundleAnalysis: true
     taskPublishBundleSizeArtifacts: true

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -28,6 +28,7 @@ extends:
       - nyc/examples
       - nyc/experimental
       - nyc/packages
+    taskWebpack: true
     taskPack: false
     taskBundleAnalysis: true
     taskPublishBundleSizeArtifacts: true

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -14,6 +14,9 @@ trigger:
     - lts
     - release/*
 
+variables:
+  - template: /tools/pipelines/templates/include-vars.yml@self
+
 extends:
   template: /tools/pipelines/templates/build-npm-package.yml@self
   parameters:

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -195,6 +195,7 @@ extends:
     isReleaseGroup: true
     poolBuild: Large-eastus2
     checkoutSubmodules: true
+    taskBundleAnalysis: true
     taskLint: false # Linting is captured by `ci:build` via fluid-build
     taskBuildDocs: true
     publishDocs: true

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -195,7 +195,6 @@ extends:
     isReleaseGroup: true
     poolBuild: Large-eastus2
     checkoutSubmodules: true
-    taskBundleAnalysis: true
     taskLint: false # Linting is captured by `ci:build` via fluid-build
     taskBuildDocs: true
     publishDocs: true

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -40,10 +40,6 @@ parameters:
   default:
   - nyc
 
-- name: taskBundleAnalysis
-  type: boolean
-  default: false
-
 - name: taskPack
   type: boolean
   default: true
@@ -380,67 +376,65 @@ extends:
                   # but as part of 1ES migration that's now part of templateContext.outputs below.
 
               # Collect/publish/run bundle analysis
-              - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
-                  - task: Npm@1
-                    displayName: 'npm run bundle-analysis:collect'
+              - task: Npm@1
+                displayName: 'Calculate bundle sizes'
+                inputs:
+                  command: custom
+                  workingDir: '${{ parameters.buildDirectory }}'
+                  customCommand: 'run bundle-analysis:collect'
+
+              # Copy files so all artifacts we publish end up under the same parent folder.
+              # The sourceFolder should be wherever the 'npm run bundle-analysis:collect' task places its output.
+              - task: CopyFiles@2
+                displayName: Copy bundle size files to artifact staging directory
+                inputs:
+                  sourceFolder: '${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'
+                  targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalysis
+
+              # At this point we want to publish the artifact with the bundle size analysis,
+              # but as part of 1ES migration that's now part of templateContext.outputs below.
+
+              - task: Npm@1
+                displayName: (PR only) Compare bundle sizes against baseline
+                condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+                continueOnError: true
+                env:
+                  ADO_API_TOKEN: $(System.AccessToken)
+                  DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)
+                  TARGET_BRANCH_NAME: '$(targetBranchName)'
+                inputs:
+                  command: custom
+                  workingDir: '${{ parameters.buildDirectory }}'
+                  customCommand: 'run bundle-analysis:run'
+
+              - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
+                  - task: Bash@3
+                    displayName: List report.json
                     inputs:
-                      command: custom
-                      workingDir: '${{ parameters.buildDirectory }}'
-                      customCommand: 'run bundle-analysis:collect'
+                      targetType: inline
+                      workingDirectory: '${{ parameters.buildDirectory }}'
+                      script: |
+                        set -eu -o pipefail
+                        echo "Build Directory is ${{ parameters.buildDirectory }}";
+                        BUNDLE_SIZE_TESTS_DIR="$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests";
+                        echo "Contents of $BUNDLE_SIZE_TESTS_DIR:";
+                        ls -la $BUNDLE_SIZE_TESTS_DIR;
 
-                  # Copy files so all artifacts we publish end up under the same parent folder.
-                  # The sourceFolder should be wherever the 'npm run bundle-analysis:collect' task places its output.
-                  - task: CopyFiles@2
-                    displayName: Copy bundleAnalysis files to artifact staging directory
+                  - template: /tools/pipelines/templates/include-telemetry-setup.yml@self
+                    parameters:
+                      pathForTelemetryGeneratorInstall: $(pathToTelemetryGenerator)
+
+                  - task: Bash@3
+                    displayName: Write bundle sizes measurements to Aria/Kusto
                     inputs:
-                      sourceFolder: '${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'
-                      targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalysis
-
-
-                  # At this point we want to publish the artifact with the bundle size analysis,
-                  # but as part of 1ES migration that's now part of templateContext.outputs below.
-
-                  - task: Npm@1
-                    displayName: run bundle size comparison
-                    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-                    continueOnError: true
-                    env:
-                      ADO_API_TOKEN: $(System.AccessToken)
-                      DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)
-                      TARGET_BRANCH_NAME: '$(targetBranchName)'
-                    inputs:
-                      command: custom
-                      workingDir: '${{ parameters.buildDirectory }}'
-                      customCommand: 'run bundle-analysis:run'
-
-                  - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
-                      - task: Bash@3
-                        displayName: List report.json
-                        inputs:
-                          targetType: inline
-                          workingDirectory: '${{ parameters.buildDirectory }}'
-                          script: |
-                            set -eu -o pipefail
-                            echo "Build Directory is ${{ parameters.buildDirectory }}";
-                            BUNDLE_SIZE_TESTS_DIR="$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests";
-                            echo "Contents of $BUNDLE_SIZE_TESTS_DIR:";
-                            ls -la $BUNDLE_SIZE_TESTS_DIR;
-
-                      - template: /tools/pipelines/templates/include-telemetry-setup.yml@self
-                        parameters:
-                          pathForTelemetryGeneratorInstall: $(pathToTelemetryGenerator)
-
-                      - task: Bash@3
-                        displayName: Write bundle sizes measurements to Aria/Kusto
-                        inputs:
-                          targetType: inline
-                          workingDirectory: $(pathToTelemetryGenerator)
-                          script: |
-                            set -eu -o pipefail
-                            echo "Writing the following performance tests results to Aria/Kusto"
-                            echo "Report Size:"
-                            ls -la '$(Build.SourcesDirectory)/examples/utils/bundle-size-tests/bundleAnalysis/report.json';
-                            npx telemetry-generator --handlerModule "$(pathToTelemetryGeneratorHandlers)/bundleSizeHandler.js" --dir '$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests';
+                      targetType: inline
+                      workingDirectory: $(pathToTelemetryGenerator)
+                      script: |
+                        set -eu -o pipefail
+                        echo "Writing the following performance tests results to Aria/Kusto"
+                        echo "Report Size:"
+                        ls -la '$(Build.SourcesDirectory)/examples/utils/bundle-size-tests/bundleAnalysis/report.json';
+                        npx telemetry-generator --handlerModule "$(pathToTelemetryGeneratorHandlers)/bundleSizeHandler.js" --dir '$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests';
 
               # Docs
               - ${{ if ne(parameters.taskBuildDocs, false) }}:
@@ -526,6 +520,13 @@ extends:
                       artifactName: test-files
                       publishLocation: pipeline
                       sbomEnabled: false
+
+                - output: pipelineArtifact
+                  displayName: Publish Artifacts - bundle-analysis
+                  targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalysis
+                  artifactName: bundleAnalysis
+                  sbomEnabled: false
+                  publishLocation: pipeline
 
                 - ${{ if or(eq(parameters.publishDocs, true), eq(parameters.taskBuildDocs, true)) }}:
                     - output: pipelineArtifact

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -44,6 +44,10 @@ parameters:
   type: boolean
   default: false
 
+- name: taskPublishBundleSizeArtifacts
+  type: boolean
+  default: false
+
 - name: taskPack
   type: boolean
   default: true
@@ -324,14 +328,19 @@ extends:
                   buildDirectory: '${{ parameters.buildDirectory }}'
                   packageManagerInstallCommand: '${{ parameters.packageManagerInstallCommand }}'
 
-              - template: /tools/pipelines/templates/include-set-package-version.yml@self
-                parameters:
-                  buildDirectory: '${{ parameters.buildDirectory }}'
-                  buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
-                  buildToolsVersionToInstall: '${{ parameters.buildToolsVersionToInstall }}'
-                  tagName: '${{ parameters.tagName }}'
-                  interdependencyRange: '${{ parameters.interdependencyRange }}'
-                  packageTypesOverride: '${{ parameters.packageTypesOverride }}'
+              # This check is a workaround. We don't want to set versions for the build-bundle-size-and-code-coverage-artifacts
+              # pipeline because it is special - it runs a client build but doesn't publish anything. Working around this properly is
+              # challenging and would create a much bigger change. Since this is the only pipeline that sets these variables to
+              # true, we use that to determine whether to set versions.
+              - ${{ if eq(parameters.taskPublishBundleSizeArtifacts, false) }}:
+                  - template: /tools/pipelines/templates/include-set-package-version.yml@self
+                    parameters:
+                      buildDirectory: '${{ parameters.buildDirectory }}'
+                      buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
+                      buildToolsVersionToInstall: '${{ parameters.buildToolsVersionToInstall }}'
+                      tagName: '${{ parameters.tagName }}'
+                      interdependencyRange: '${{ parameters.interdependencyRange }}'
+                      packageTypesOverride: '${{ parameters.packageTypesOverride }}'
 
               # Build and Lint
               - template: /tools/pipelines/templates/include-build-lint.yml@self
@@ -527,13 +536,13 @@ extends:
                       sbomEnabled: false
 
                 - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
-                  - output: pipelineArtifact
-                    displayName: Publish Artifacts - bundle-analysis
-                    condition: and( succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(${{ parameters.taskPublishBundleSizeArtifacts }}, true) )
-                    targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalysis
-                    artifactName: bundleAnalysis
-                    sbomEnabled: false
-                    publishLocation: pipeline
+                    - output: pipelineArtifact
+                      displayName: Publish Artifacts - bundle-analysis
+                      condition: and( succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(${{ parameters.taskPublishBundleSizeArtifacts }}, true) )
+                      targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalysis
+                      artifactName: bundleAnalysis
+                      sbomEnabled: false
+                      publishLocation: pipeline
 
                 - ${{ if or(eq(parameters.publishDocs, true), eq(parameters.taskBuildDocs, true)) }}:
                     - output: pipelineArtifact

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -44,10 +44,6 @@ parameters:
   type: boolean
   default: false
 
-- name: taskPublishBundleSizeArtifacts
-  type: boolean
-  default: false
-
 - name: taskPack
   type: boolean
   default: true
@@ -328,19 +324,14 @@ extends:
                   buildDirectory: '${{ parameters.buildDirectory }}'
                   packageManagerInstallCommand: '${{ parameters.packageManagerInstallCommand }}'
 
-              # This check is a workaround. We don't want to set versions for the build-bundle-size-and-code-coverage-artifacts
-              # pipeline because it is special - it runs a client build but doesn't publish anything. Working around this properly is
-              # challenging and would create a much bigger change. Since this is the only pipeline that sets these variables to
-              # true, we use that to determine whether to set versions.
-              - ${{ if eq(parameters.taskPublishBundleSizeArtifacts, false) }}:
-                  - template: /tools/pipelines/templates/include-set-package-version.yml@self
-                    parameters:
-                      buildDirectory: '${{ parameters.buildDirectory }}'
-                      buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
-                      buildToolsVersionToInstall: '${{ parameters.buildToolsVersionToInstall }}'
-                      tagName: '${{ parameters.tagName }}'
-                      interdependencyRange: '${{ parameters.interdependencyRange }}'
-                      packageTypesOverride: '${{ parameters.packageTypesOverride }}'
+              - template: /tools/pipelines/templates/include-set-package-version.yml@self
+                parameters:
+                  buildDirectory: '${{ parameters.buildDirectory }}'
+                  buildNumberInPatch: ${{ parameters.buildNumberInPatch }}
+                  buildToolsVersionToInstall: '${{ parameters.buildToolsVersionToInstall }}'
+                  tagName: '${{ parameters.tagName }}'
+                  interdependencyRange: '${{ parameters.interdependencyRange }}'
+                  packageTypesOverride: '${{ parameters.packageTypesOverride }}'
 
               # Build and Lint
               - template: /tools/pipelines/templates/include-build-lint.yml@self
@@ -535,15 +526,6 @@ extends:
                       artifactName: test-files
                       publishLocation: pipeline
                       sbomEnabled: false
-
-                - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
-                    - output: pipelineArtifact
-                      displayName: Publish Artifacts - bundle-analysis
-                      condition: and( succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(${{ parameters.taskPublishBundleSizeArtifacts }}, true) )
-                      targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalysis
-                      artifactName: bundleAnalysis
-                      sbomEnabled: false
-                      publishLocation: pipeline
 
                 - ${{ if or(eq(parameters.publishDocs, true), eq(parameters.taskBuildDocs, true)) }}:
                     - output: pipelineArtifact

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -40,6 +40,10 @@ parameters:
   default:
   - nyc
 
+- name: taskBundleAnalysis
+  type: boolean
+  default: false
+
 - name: taskPack
   type: boolean
   default: true
@@ -376,65 +380,66 @@ extends:
                   # but as part of 1ES migration that's now part of templateContext.outputs below.
 
               # Collect/publish/run bundle analysis
-              - task: Npm@1
-                displayName: 'Calculate bundle sizes'
-                inputs:
-                  command: custom
-                  workingDir: '${{ parameters.buildDirectory }}'
-                  customCommand: 'run bundle-analysis:collect'
+              - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
+                - task: Npm@1
+                  displayName: 'Calculate bundle sizes'
+                  inputs:
+                    command: custom
+                    workingDir: '${{ parameters.buildDirectory }}'
+                    customCommand: 'run bundle-analysis:collect'
 
-              # Copy files so all artifacts we publish end up under the same parent folder.
-              # The sourceFolder should be wherever the 'npm run bundle-analysis:collect' task places its output.
-              - task: CopyFiles@2
-                displayName: Copy bundle size files to artifact staging directory
-                inputs:
-                  sourceFolder: '${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'
-                  targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalysis
+                # Copy files so all artifacts we publish end up under the same parent folder.
+                # The sourceFolder should be wherever the 'npm run bundle-analysis:collect' task places its output.
+                - task: CopyFiles@2
+                  displayName: Copy bundle size files to artifact staging directory
+                  inputs:
+                    sourceFolder: '${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'
+                    targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalysis
 
-              # At this point we want to publish the artifact with the bundle size analysis,
-              # but as part of 1ES migration that's now part of templateContext.outputs below.
+                # At this point we want to publish the artifact with the bundle size analysis,
+                # but as part of 1ES migration that's now part of templateContext.outputs below.
 
-              - task: Npm@1
-                displayName: (PR only) Compare bundle sizes against baseline
-                condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-                continueOnError: true
-                env:
-                  ADO_API_TOKEN: $(System.AccessToken)
-                  DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)
-                  TARGET_BRANCH_NAME: '$(targetBranchName)'
-                inputs:
-                  command: custom
-                  workingDir: '${{ parameters.buildDirectory }}'
-                  customCommand: 'run bundle-analysis:run'
+                - task: Npm@1
+                  displayName: (PR only) Compare bundle sizes against baseline
+                  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+                  continueOnError: true
+                  env:
+                    ADO_API_TOKEN: $(System.AccessToken)
+                    DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)
+                    TARGET_BRANCH_NAME: '$(targetBranchName)'
+                  inputs:
+                    command: custom
+                    workingDir: '${{ parameters.buildDirectory }}'
+                    customCommand: 'run bundle-analysis:run'
 
-              - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
-                  - task: Bash@3
-                    displayName: List report.json
-                    inputs:
-                      targetType: inline
-                      workingDirectory: '${{ parameters.buildDirectory }}'
-                      script: |
-                        set -eu -o pipefail
-                        echo "Build Directory is ${{ parameters.buildDirectory }}";
-                        BUNDLE_SIZE_TESTS_DIR="$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests";
-                        echo "Contents of $BUNDLE_SIZE_TESTS_DIR:";
-                        ls -la $BUNDLE_SIZE_TESTS_DIR;
+                - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
+                    - task: Bash@3
+                      displayName: List report.json
+                      inputs:
+                        targetType: inline
+                        workingDirectory: '${{ parameters.buildDirectory }}'
+                        script: |
+                          set -eu -o pipefail
+                          echo "Build Directory is ${{ parameters.buildDirectory }}";
+                          BUNDLE_SIZE_TESTS_DIR="$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests";
+                          echo "Contents of $BUNDLE_SIZE_TESTS_DIR:";
+                          ls -la $BUNDLE_SIZE_TESTS_DIR;
 
-                  - template: /tools/pipelines/templates/include-telemetry-setup.yml@self
-                    parameters:
-                      pathForTelemetryGeneratorInstall: $(pathToTelemetryGenerator)
+                    - template: /tools/pipelines/templates/include-telemetry-setup.yml@self
+                      parameters:
+                        pathForTelemetryGeneratorInstall: $(pathToTelemetryGenerator)
 
-                  - task: Bash@3
-                    displayName: Write bundle sizes measurements to Aria/Kusto
-                    inputs:
-                      targetType: inline
-                      workingDirectory: $(pathToTelemetryGenerator)
-                      script: |
-                        set -eu -o pipefail
-                        echo "Writing the following performance tests results to Aria/Kusto"
-                        echo "Report Size:"
-                        ls -la '$(Build.SourcesDirectory)/examples/utils/bundle-size-tests/bundleAnalysis/report.json';
-                        npx telemetry-generator --handlerModule "$(pathToTelemetryGeneratorHandlers)/bundleSizeHandler.js" --dir '$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests';
+                    - task: Bash@3
+                      displayName: Write bundle sizes measurements to Aria/Kusto
+                      inputs:
+                        targetType: inline
+                        workingDirectory: $(pathToTelemetryGenerator)
+                        script: |
+                          set -eu -o pipefail
+                          echo "Writing the following performance tests results to Aria/Kusto"
+                          echo "Report Size:"
+                          ls -la '$(Build.SourcesDirectory)/examples/utils/bundle-size-tests/bundleAnalysis/report.json';
+                          npx telemetry-generator --handlerModule "$(pathToTelemetryGeneratorHandlers)/bundleSizeHandler.js" --dir '$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests';
 
               # Docs
               - ${{ if ne(parameters.taskBuildDocs, false) }}:
@@ -521,12 +526,14 @@ extends:
                       publishLocation: pipeline
                       sbomEnabled: false
 
-                - output: pipelineArtifact
-                  displayName: Publish Artifacts - bundle-analysis
-                  targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalysis
-                  artifactName: bundleAnalysis
-                  sbomEnabled: false
-                  publishLocation: pipeline
+                - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
+                  - output: pipelineArtifact
+                    displayName: Publish Artifacts - bundle-analysis
+                    condition: and( succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(${{ parameters.taskPublishBundleSizeArtifacts }}, true) )
+                    targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalysis
+                    artifactName: bundleAnalysis
+                    sbomEnabled: false
+                    publishLocation: pipeline
 
                 - ${{ if or(eq(parameters.publishDocs, true), eq(parameters.taskBuildDocs, true)) }}:
                     - output: pipelineArtifact

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -381,65 +381,65 @@ extends:
 
               # Collect/publish/run bundle analysis
               - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
-                - task: Npm@1
-                  displayName: 'Calculate bundle sizes'
-                  inputs:
-                    command: custom
-                    workingDir: '${{ parameters.buildDirectory }}'
-                    customCommand: 'run bundle-analysis:collect'
+                  - task: Npm@1
+                    displayName: 'Calculate bundle sizes'
+                    inputs:
+                      command: custom
+                      workingDir: '${{ parameters.buildDirectory }}'
+                      customCommand: 'run bundle-analysis:collect'
 
-                # Copy files so all artifacts we publish end up under the same parent folder.
-                # The sourceFolder should be wherever the 'npm run bundle-analysis:collect' task places its output.
-                - task: CopyFiles@2
-                  displayName: Copy bundle size files to artifact staging directory
-                  inputs:
-                    sourceFolder: '${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'
-                    targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalysis
+                  # Copy files so all artifacts we publish end up under the same parent folder.
+                  # The sourceFolder should be wherever the 'npm run bundle-analysis:collect' task places its output.
+                  - task: CopyFiles@2
+                    displayName: Copy bundle size files to artifact staging directory
+                    inputs:
+                      sourceFolder: '${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'
+                      targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalysis
 
-                # At this point we want to publish the artifact with the bundle size analysis,
-                # but as part of 1ES migration that's now part of templateContext.outputs below.
+                  # At this point we want to publish the artifact with the bundle size analysis,
+                  # but as part of 1ES migration that's now part of templateContext.outputs below.
 
-                - task: Npm@1
-                  displayName: (PR only) Compare bundle sizes against baseline
-                  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-                  continueOnError: true
-                  env:
-                    ADO_API_TOKEN: $(System.AccessToken)
-                    DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)
-                    TARGET_BRANCH_NAME: '$(targetBranchName)'
-                  inputs:
-                    command: custom
-                    workingDir: '${{ parameters.buildDirectory }}'
-                    customCommand: 'run bundle-analysis:run'
+                  - task: Npm@1
+                    displayName: (PR only) Compare bundle sizes against baseline
+                    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+                    continueOnError: true
+                    env:
+                      ADO_API_TOKEN: $(System.AccessToken)
+                      DANGER_GITHUB_API_TOKEN: $(githubPublicRepoSecret)
+                      TARGET_BRANCH_NAME: '$(targetBranchName)'
+                    inputs:
+                      command: custom
+                      workingDir: '${{ parameters.buildDirectory }}'
+                      customCommand: 'run bundle-analysis:run'
 
-                - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
-                    - task: Bash@3
-                      displayName: List report.json
-                      inputs:
-                        targetType: inline
-                        workingDirectory: '${{ parameters.buildDirectory }}'
-                        script: |
-                          set -eu -o pipefail
-                          echo "Build Directory is ${{ parameters.buildDirectory }}";
-                          BUNDLE_SIZE_TESTS_DIR="$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests";
-                          echo "Contents of $BUNDLE_SIZE_TESTS_DIR:";
-                          ls -la $BUNDLE_SIZE_TESTS_DIR;
+                  - ${{ if and(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI')), eq(variables['System.TeamProject'], 'internal')) }}:
+                      - task: Bash@3
+                        displayName: List report.json
+                        inputs:
+                          targetType: inline
+                          workingDirectory: '${{ parameters.buildDirectory }}'
+                          script: |
+                            set -eu -o pipefail
+                            echo "Build Directory is ${{ parameters.buildDirectory }}";
+                            BUNDLE_SIZE_TESTS_DIR="$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests";
+                            echo "Contents of $BUNDLE_SIZE_TESTS_DIR:";
+                            ls -la $BUNDLE_SIZE_TESTS_DIR;
 
-                    - template: /tools/pipelines/templates/include-telemetry-setup.yml@self
-                      parameters:
-                        pathForTelemetryGeneratorInstall: $(pathToTelemetryGenerator)
+                      - template: /tools/pipelines/templates/include-telemetry-setup.yml@self
+                        parameters:
+                          pathForTelemetryGeneratorInstall: $(pathToTelemetryGenerator)
 
-                    - task: Bash@3
-                      displayName: Write bundle sizes measurements to Aria/Kusto
-                      inputs:
-                        targetType: inline
-                        workingDirectory: $(pathToTelemetryGenerator)
-                        script: |
-                          set -eu -o pipefail
-                          echo "Writing the following performance tests results to Aria/Kusto"
-                          echo "Report Size:"
-                          ls -la '$(Build.SourcesDirectory)/examples/utils/bundle-size-tests/bundleAnalysis/report.json';
-                          npx telemetry-generator --handlerModule "$(pathToTelemetryGeneratorHandlers)/bundleSizeHandler.js" --dir '$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests';
+                      - task: Bash@3
+                        displayName: Write bundle sizes measurements to Aria/Kusto
+                        inputs:
+                          targetType: inline
+                          workingDirectory: $(pathToTelemetryGenerator)
+                          script: |
+                            set -eu -o pipefail
+                            echo "Writing the following performance tests results to Aria/Kusto"
+                            echo "Report Size:"
+                            ls -la '$(Build.SourcesDirectory)/examples/utils/bundle-size-tests/bundleAnalysis/report.json';
+                            npx telemetry-generator --handlerModule "$(pathToTelemetryGeneratorHandlers)/bundleSizeHandler.js" --dir '$(Build.ArtifactStagingDirectory)/bundleAnalysis/@fluid-example/bundle-size-tests';
 
               # Docs
               - ${{ if ne(parameters.taskBuildDocs, false) }}:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -474,7 +474,7 @@ extends:
               # Collect/publish/run bundle analysis
               - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
                   - task: Npm@1
-                    displayName: 'npm run bundle-analysis:collect'
+                    displayName: 'Calculate bundle sizes'
                     inputs:
                       command: custom
                       workingDir: '${{ parameters.buildDirectory }}'
@@ -483,17 +483,16 @@ extends:
                   # Copy files so all artifacts we publish end up under the same parent folder.
                   # The sourceFolder should be wherever the 'npm run bundle-analysis:collect' task places its output.
                   - task: CopyFiles@2
-                    displayName: Copy bundleAnalysis files to artifact staging directory
+                    displayName: Copy bundle size files to artifact staging directory
                     inputs:
                       sourceFolder: '${{ parameters.buildDirectory }}/artifacts/bundleAnalysis'
                       targetFolder: $(Build.ArtifactStagingDirectory)/bundleAnalysis
-
 
                   # At this point we want to publish the artifact with the bundle size analysis,
                   # but as part of 1ES migration that's now part of templateContext.outputs below.
 
                   - task: Npm@1
-                    displayName: run bundle size comparison
+                    displayName: (PR only) Compare bundle sizes against baseline
                     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
                     continueOnError: true
                     env:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -234,6 +234,7 @@ extends:
                   targetType: inline
                   workingDirectory: '${{ parameters.buildDirectory }}'
                   script: |
+                    set -eu -o pipefail
                     # Note: deliberately not using `set -eu -o pipefail` because this script leverages the return code of grep
                     # even in an error case
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -234,7 +234,6 @@ extends:
                   targetType: inline
                   workingDirectory: '${{ parameters.buildDirectory }}'
                   script: |
-                    set -eu -o pipefail
                     # Note: deliberately not using `set -eu -o pipefail` because this script leverages the return code of grep
                     # even in an error case
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -11,6 +11,11 @@ parameters:
   type: string
   default: ci:build
 
+# If true, this template will run `npm run webpack` after running the task indicated by the taskBuild parameter
+- name: taskWebpack
+  type: boolean
+  default: false
+
 - name: taskBuildDocs
   type: boolean
   default: true
@@ -347,6 +352,14 @@ extends:
                   taskLint: '${{ parameters.taskLint }}'
                   taskLintName: '${{ parameters.taskLintName }}'
                   buildDirectory: '${{ parameters.buildDirectory }}'
+
+              - ${{ if parameters.taskWebpack }}:
+                - task: Npm@1
+                  displayName: 'npm run webpack'
+                  inputs:
+                    command: custom
+                    workingDir: '${{ parameters.buildDirectory }}'
+                    customCommand: 'run webpack'
 
               # Test
               - ${{ if ne(convertToJson(parameters.taskTest), '[]') }}:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -11,11 +11,6 @@ parameters:
   type: string
   default: ci:build
 
-# If true, this template will run `npm run webpack` after running the task indicated by the taskBuild parameter
-- name: taskWebpack
-  type: boolean
-  default: false
-
 - name: taskBuildDocs
   type: boolean
   default: true
@@ -352,14 +347,6 @@ extends:
                   taskLint: '${{ parameters.taskLint }}'
                   taskLintName: '${{ parameters.taskLintName }}'
                   buildDirectory: '${{ parameters.buildDirectory }}'
-
-              - ${{ if parameters.taskWebpack }}:
-                - task: Npm@1
-                  displayName: 'npm run webpack'
-                  inputs:
-                    command: custom
-                    workingDir: '${{ parameters.buildDirectory }}'
-                    customCommand: 'run webpack'
 
               # Test
               - ${{ if ne(convertToJson(parameters.taskTest), '[]') }}:


### PR DESCRIPTION
## Description

Fixes the pipeline in the public ADO project that calculates bundle size baselines, which [broke](https://dev.azure.com/fluidframework/public/_build?definitionId=48&_a=summary) when we merged https://github.com/microsoft/FluidFramework/pull/24044. The root cause is that a test introduced in that PR depends on webpack having run on the bundle-size-tests package to produce a bundle, which the test then checks. The main `build - client pipeline` happens to run webpack after the build script, but the pipeline that calculates bundle size baselines does not, and thus it started failing.

The way this PR fixes the pipeline is by making it so it *does not run the repo tests*, since it doesn't have any reason to. That's already taken care of by `build - client packages`. That also saves us a lot of runtime for it:

![image](https://github.com/user-attachments/assets/11e5c26d-7b30-4475-94d1-1af7874f9017)

### Side discussion

The PR that introduced the test tried to ensure webpack ran [by declaring fluid-build dependencies](https://github.com/microsoft/FluidFramework/blob/529fae8207ab32e113b8d5b45f0ade4dd01f0313/examples/utils/bundle-size-tests/package.json#L85-L90); but we don't seem to use fluid-build to run tests anywhere, so this didn't have any effect. Do we need to update our test npm scripts so they use fluid-build, like our build ones do? It's not entirely clear to me that we can easily do that.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[Successful run of the pipeline for a test/ branch with these changes](https://dev.azure.com/fluidframework/public/_build/results?buildId=328237&view=results).