### PR TITLE
Rollback doesn't work if you clear the batch after creating the checkpoint

### DIFF
--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -292,4 +292,23 @@ describe("BatchManager", () => {
 			});
 		}, /Error: Ops generated durning rollback/);
 	});
+
+	it("Popping the batch then rolling is not allowed", () => {
+		const batchManager = new BatchManager(defaultOptions);
+
+		batchManager.push(
+			{ ...smallMessage(), referenceSequenceNumber: 0 },
+			/* reentrant */ false,
+		);
+		const checkpoint = batchManager.checkpoint();
+		batchManager.popBatch();
+
+		// Attempt rollback and generate ops during rollback
+		assert.throws(() => {
+			checkpoint.rollback((message) => {
+				// Generate ops during rollback
+				batchManager.push(smallMessage(), /* reentrant */ false);
+			});
+		}, /Error: Ops generated durning rollback/);
+	});
 });


### PR DESCRIPTION
## Description

Rollback requires that the batch will remain intact between the checkpoint and when rollback is called.  This PR adds a test case to illustrate this, which tries popping the current batch (clearing it) in that window.

Note: `rollback` is intended for use only by ContainerRuntime's `orderSequentially`, and CR already blocks flush (which is how you pop a batch).
