### PR TITLE
LocalServerStress: Reenable skipped tests

### DIFF
--- a/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
@@ -12,26 +12,22 @@ import {
 	LocalServerStressModel,
 } from "../localServerStressHarness";
 
-for (let i = 0; i < 200; i++) {
-	describe.only("Local Server Stress", () => {
-		const model: LocalServerStressModel<StressOperations> = {
-			workloadName: `default_${i}`,
-			generatorFactory: () => takeAsync(100, makeGenerator()),
-			reducer,
-			validateConsistency: validateConsistencyOfAllDDS,
-		};
+describe("Local Server Stress", () => {
+	const model: LocalServerStressModel<StressOperations> = {
+		workloadName: "default",
+		generatorFactory: () => takeAsync(100, makeGenerator()),
+		reducer,
+		validateConsistency: validateConsistencyOfAllDDS,
+	};
 
-		createLocalServerStressSuite(model, {
-			defaultTestCount: 100,
-			skipMinimization: true,
-			// Uncomment to replay a particular seed.
-			// replay: 93,
-			// only: [28],
-			saveFailures,
-			// saveSuccesses,
-			// TODO (AB#33713): we've seen seeds 43 and 44 fail in the pipeline with errors that might
-			// represent bugs in the underlying DDSes. Skipping for now.
-			skip: [28],
-		});
+	createLocalServerStressSuite(model, {
+		defaultTestCount: 100,
+		// skipMinimization: true,
+		// Uncomment to replay a particular seed.
+		// replay: 93,
+		// only: [28],
+		saveFailures,
+		// saveSuccesses,
+		skip: [28],
 	});
-}
+});

--- a/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
@@ -12,24 +12,26 @@ import {
 	LocalServerStressModel,
 } from "../localServerStressHarness";
 
-describe("Local Server Stress", () => {
-	const model: LocalServerStressModel<StressOperations> = {
-		workloadName: "default",
-		generatorFactory: () => takeAsync(100, makeGenerator()),
-		reducer,
-		validateConsistency: validateConsistencyOfAllDDS,
-	};
+for (let i = 0; i < 200; i++) {
+	describe.only("Local Server Stress", () => {
+		const model: LocalServerStressModel<StressOperations> = {
+			workloadName: `default_${i}`,
+			generatorFactory: () => takeAsync(100, makeGenerator()),
+			reducer,
+			validateConsistency: validateConsistencyOfAllDDS,
+		};
 
-	createLocalServerStressSuite(model, {
-		defaultTestCount: 100,
-		// skipMinimization: true,
-		// Uncomment to replay a particular seed.
-		// replay: 93,
-		// only: [28],
-		saveFailures,
-		// saveSuccesses,
-		// TODO (AB#33713): we've seen seeds 43 and 44 fail in the pipeline with errors that might
-		// represent bugs in the underlying DDSes. Skipping for now.
-		skip: [28, 43, 44],
+		createLocalServerStressSuite(model, {
+			defaultTestCount: 100,
+			skipMinimization: true,
+			// Uncomment to replay a particular seed.
+			// replay: 93,
+			// only: [28],
+			saveFailures,
+			// saveSuccesses,
+			// TODO (AB#33713): we've seen seeds 43 and 44 fail in the pipeline with errors that might
+			// represent bugs in the underlying DDSes. Skipping for now.
+			skip: [28],
+		});
 	});
-});
+}


### PR DESCRIPTION
I believe the non-deterministic failures seen by a few seeds in this test was fixed by recent improvement to the synchronization logic, that was [previously buggy](https://github.com/microsoft/FluidFramework/pull/24105/files#r2006610929). Failed synchronization would account for the behavior seen in the test. Before the update it was possible reproduce the issue in the gate and locally by running repeated iterations of the test. I found it would hit locally within about 150 iterations. I've run about 5000 iterations locally, and 400 in the gate, and have not seen the issue reproduce

[AB#33713](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/33713)