### PR TITLE
ContainerRuntime: Use RunCounter for batches and reentrancy

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3043,7 +3043,7 @@ export class ContainerRuntime
 	private flush(resubmittingBatchId?: BatchId): void {
 		assert(
 			!this.batchRunner.running,
-			0x24c /* "Cannot call `flush()` from `orderSequentially`'s callback" */,
+			0x24c /* "Cannot call `flush()` while manually accumulating a batch (e.g. under orderSequentially) */,
 		);
 
 		this.outbox.flush(resubmittingBatchId);
@@ -4259,7 +4259,7 @@ export class ContainerRuntime
 			default: {
 				assert(
 					this.batchRunner.running,
-					0x587 /* Unreachable unless running under orderSequentially */,
+					0x587 /* Unreachable unless manually accumulating a batch */,
 				);
 				break;
 			}
@@ -4548,7 +4548,7 @@ export class ContainerRuntime
 		this.verifyNotClosed();
 
 		if (this.batchRunner.running) {
-			throw new UsageError("can't get state during orderSequentially");
+			throw new UsageError("can't get state while manually accumulating a batch");
 		}
 		this.imminentClosure ||= props?.notifyImminentClosure ?? false;
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -202,6 +202,7 @@ import {
 	IPendingLocalState,
 	PendingStateManager,
 } from "./pendingStateManager.js";
+import { RunCounter } from "./runCounter.js";
 import { SignalTelemetryManager } from "./signalTelemetryProcessing.js";
 import {
 	DocumentsSchemaController,
@@ -1175,7 +1176,7 @@ export class ContainerRuntime
 
 	private readonly maxConsecutiveReconnects: number;
 
-	private _orderSequentiallyCalls: number = 0;
+	private readonly batchRunner = new RunCounter();
 	private readonly _flushMode: FlushMode;
 	private readonly offlineEnabled: boolean;
 	private flushTaskExists = false;
@@ -1190,7 +1191,7 @@ export class ContainerRuntime
 	 */
 	private delayConnectClientId?: string;
 
-	private ensureNoDataModelChangesCalls = 0;
+	private readonly dataModelChangeRunner = new RunCounter();
 
 	/**
 	 * Invokes the given callback and expects that no ops are submitted
@@ -1201,12 +1202,7 @@ export class ContainerRuntime
 	 * @param callback - the callback to be invoked
 	 */
 	public ensureNoDataModelChanges<T>(callback: () => T): T {
-		this.ensureNoDataModelChangesCalls++;
-		try {
-			return callback();
-		} finally {
-			this.ensureNoDataModelChangesCalls--;
-		}
+		return this.dataModelChangeRunner.run(callback);
 	}
 
 	public get connected(): boolean {
@@ -1743,7 +1739,7 @@ export class ContainerRuntime
 				clientSequenceNumber: this._processedClientSequenceNumber,
 			}),
 			reSubmit: this.reSubmit.bind(this),
-			opReentrancy: () => this.ensureNoDataModelChangesCalls > 0,
+			opReentrancy: () => this.dataModelChangeRunner.running,
 			closeContainer: this.closeFn,
 		});
 
@@ -3046,7 +3042,7 @@ export class ContainerRuntime
 	 */
 	private flush(resubmittingBatchId?: BatchId): void {
 		assert(
-			this._orderSequentiallyCalls === 0,
+			!this.batchRunner.running,
 			0x24c /* "Cannot call `flush()` from `orderSequentially`'s callback" */,
 		);
 
@@ -3060,61 +3056,59 @@ export class ContainerRuntime
 	public orderSequentially<T>(callback: () => T): T {
 		let checkpoint: IBatchCheckpoint | undefined;
 		const checkpointDirtyState = this.dirtyContainer;
-		let result: T;
 		if (this.mc.config.getBoolean("Fluid.ContainerRuntime.EnableRollback")) {
 			// Note: we are not touching any batches other than mainBatch here, for two reasons:
 			// 1. It would not help, as other batches are flushed independently from main batch.
 			// 2. There is no way to undo process of data store creation, blob creation, ID compressor ops, or other things tracked by other batches.
 			checkpoint = this.outbox.getBatchCheckpoints().mainBatch;
 		}
-		try {
-			this._orderSequentiallyCalls++;
-			result = callback();
-		} catch (error) {
-			if (checkpoint) {
-				// This will throw and close the container if rollback fails
-				try {
-					checkpoint.rollback((message: BatchMessage) =>
-						this.rollback(message.contents, message.localOpMetadata),
-					);
-					// reset the dirty state after rollback to what it was before to keep it consistent
-					if (this.dirtyContainer !== checkpointDirtyState) {
-						this.updateDocumentDirtyState(checkpointDirtyState);
+		const result = this.batchRunner.run(() => {
+			try {
+				return callback();
+			} catch (error) {
+				if (checkpoint) {
+					// This will throw and close the container if rollback fails
+					try {
+						checkpoint.rollback((message: BatchMessage) =>
+							this.rollback(message.contents, message.localOpMetadata),
+						);
+						// reset the dirty state after rollback to what it was before to keep it consistent
+						if (this.dirtyContainer !== checkpointDirtyState) {
+							this.updateDocumentDirtyState(checkpointDirtyState);
+						}
+					} catch (error_) {
+						const error2 = wrapError(error_, (message) => {
+							return DataProcessingError.create(
+								`RollbackError: ${message}`,
+								"checkpointRollback",
+								undefined,
+							) as DataProcessingError;
+						});
+						this.closeFn(error2);
+						throw error2;
 					}
-				} catch (error_) {
-					const error2 = wrapError(error_, (message) => {
-						return DataProcessingError.create(
-							`RollbackError: ${message}`,
-							"checkpointRollback",
-							undefined,
-						) as DataProcessingError;
-					});
-					this.closeFn(error2);
-					throw error2;
+				} else {
+					this.closeFn(
+						wrapError(
+							error,
+							(errorMessage) =>
+								new GenericError(
+									`orderSequentially callback exception: ${errorMessage}`,
+									error,
+									{
+										orderSequentiallyCalls: this.batchRunner.runs,
+									},
+								),
+						),
+					);
 				}
-			} else {
-				this.closeFn(
-					wrapError(
-						error,
-						(errorMessage) =>
-							new GenericError(
-								`orderSequentially callback exception: ${errorMessage}`,
-								error,
-								{
-									orderSequentiallyCalls: this._orderSequentiallyCalls,
-								},
-							),
-					),
-				);
-			}
 
-			throw error; // throw the original error for the consumer of the runtime
-		} finally {
-			this._orderSequentiallyCalls--;
-		}
+				throw error; // throw the original error for the consumer of the runtime
+			}
+		});
 
 		// We don't flush on TurnBased since we expect all messages in the same JS turn to be part of the same batch
-		if (this.flushMode !== FlushMode.TurnBased && this._orderSequentiallyCalls === 0) {
+		if (this.flushMode !== FlushMode.TurnBased && !this.batchRunner.running) {
 			this.flush();
 		}
 		return result;
@@ -3195,7 +3189,7 @@ export class ContainerRuntime
 	 * Typically ops are batched and later flushed together, but in some cases we want to flush immediately.
 	 */
 	private currentlyBatching(): boolean {
-		return this.flushMode !== FlushMode.Immediate || this._orderSequentiallyCalls !== 0;
+		return this.flushMode !== FlushMode.Immediate || this.batchRunner.running;
 	}
 
 	private readonly _quorum: IQuorumClients;
@@ -4264,7 +4258,7 @@ export class ContainerRuntime
 
 			default: {
 				assert(
-					this._orderSequentiallyCalls > 0,
+					this.batchRunner.running,
 					0x587 /* Unreachable unless running under orderSequentially */,
 				);
 				break;
@@ -4305,7 +4299,7 @@ export class ContainerRuntime
 	 * for correlation to detect container forking.
 	 */
 	private reSubmitBatch(batch: PendingMessageResubmitData[], batchId: BatchId): void {
-		this.orderSequentially(() => {
+		this.batchRunner.run(() => {
 			for (const message of batch) {
 				this.reSubmit(message);
 			}
@@ -4553,7 +4547,7 @@ export class ContainerRuntime
 	public getPendingLocalState(props?: IGetPendingLocalStateProps): unknown {
 		this.verifyNotClosed();
 
-		if (this._orderSequentiallyCalls !== 0) {
+		if (this.batchRunner.running) {
 			throw new UsageError("can't get state during orderSequentially");
 		}
 		this.imminentClosure ||= props?.notifyImminentClosure ?? false;

--- a/packages/runtime/container-runtime/src/runCounter.ts
+++ b/packages/runtime/container-runtime/src/runCounter.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export class RunCounter {
+	#runs = 0;
+
+	public get running(): boolean {
+		return this.#runs !== 0;
+	}
+
+	public get runs(): number {
+		return this.#runs;
+	}
+
+	public run<T>(act: () => T): T {
+		this.#runs++;
+		try {
+			return act();
+		} finally {
+			this.#runs--;
+		}
+	}
+}

--- a/packages/runtime/container-runtime/src/test/runCounter.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runCounter.spec.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { RunCounter } from "../runCounter.js";
+
+describe("RunCounter", () => {
+	it("should start with zero runs", () => {
+		const runCounter = new RunCounter();
+		assert.strictEqual(runCounter.runs, 0);
+		assert.strictEqual(runCounter.running, false);
+	});
+
+	it("should increment runs when running", () => {
+		const runCounter = new RunCounter();
+		runCounter.run(() => {
+			assert.strictEqual(runCounter.runs, 1);
+			assert.strictEqual(runCounter.running, true);
+		});
+		assert.strictEqual(runCounter.runs, 0);
+		assert.strictEqual(runCounter.running, false);
+	});
+
+	it("should handle nested runs correctly", () => {
+		const runCounter = new RunCounter();
+		runCounter.run(() => {
+			assert.strictEqual(runCounter.runs, 1);
+			runCounter.run(() => {
+				assert.strictEqual(runCounter.runs, 2);
+			});
+			assert.strictEqual(runCounter.runs, 1);
+		});
+		assert.strictEqual(runCounter.runs, 0);
+	});
+
+	it("should return the result of the action", () => {
+		const runCounter = new RunCounter();
+		const result = runCounter.run(() => 42);
+		assert.strictEqual(result, 42);
+	});
+
+	it("should decrement runs even if the action throws", () => {
+		const runCounter = new RunCounter();
+		assert.throws(() => {
+			runCounter.run(() => {
+				throw new Error("test error");
+			});
+		}, /test error/);
+		assert.strictEqual(runCounter.runs, 0);
+		assert.strictEqual(runCounter.running, false);
+	});
+});


### PR DESCRIPTION
Adds a new class called RunCounter which simply counts the number of nested runners it is used over. This pattern is used multiple times in the container runtime, and encapsulating it allows us to remove a number of error prone mutable variable from the ContainerRuntime and replace them with immutable variables. It also reduces some coupling between the different classes of batching, orderSequentially, and resubmit, and makes them explicitly use the  batchRunner, rather than depending on side effects of orderSequentially. This will also allow us to further evolve orderSequentially for things like StagingMode.