### PR TITLE
Ensure sharedTreeAttributes can be imported without pulling in lots of other stuff

### DIFF
--- a/.changeset/petite-bags-cheer.md
+++ b/.changeset/petite-bags-cheer.md
@@ -1,0 +1,12 @@
+---
+"@fluidframework/tree": minor
+---
+---
+"section": tree
+---
+
+Improve tree shaking for code which imports `SharedTreeAttributes`
+
+Production Webpack bundles of code importing `SharedTreeAttributes` from `@fluidframework/tree/legacy` should now better prune out the rest of the tree package's code.
+This change reduced the dependency on webpack's [`usedExports`](https://webpack.js.org/configuration/optimization/#optimizationusedexports) when tree shaking in this case.
+Other bundlers will likely be impacted similarly.

--- a/examples/utils/bundle-size-tests/src/sharedTreeAttributes.ts
+++ b/examples/utils/bundle-size-tests/src/sharedTreeAttributes.ts
@@ -1,0 +1,11 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// eslint-disable-next-line import/no-internal-modules
+import { SharedTreeAttributes } from "@fluidframework/tree/legacy";
+
+export function apisToBundle() {
+	return SharedTreeAttributes;
+}

--- a/examples/utils/bundle-size-tests/src/test/checkSizes.spec.ts
+++ b/examples/utils/bundle-size-tests/src/test/checkSizes.spec.ts
@@ -6,7 +6,9 @@
 import { strict as assert } from "node:assert";
 import { readFileSync } from "node:fs";
 
-// Since bundle size reporter is broken, and doesn't block merges, do a sanity check here
+// Since bundle size analysis doesn't block regressions, do a sanity check here.
+// This bundle should remain its current tiny size for the foreseeable future so putting a hard limit on its size should be ok.
+// Additionally, this specific bundling scenario is regressed in the past, so protecting it with a regression test is known to have some value.
 describe("checkSizes", () => {
 	it("sharedTreeAttributes", () => {
 		// This test must be run after webpack.

--- a/examples/utils/bundle-size-tests/src/test/checkSizes.spec.ts
+++ b/examples/utils/bundle-size-tests/src/test/checkSizes.spec.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+
+// Since bundle size reporter is broken, and doesn't block merges, do a sanity check here
+describe("checkSizes", () => {
+	it("sharedTreeAttributes", () => {
+		// This test must be run after webpack.
+		const bundle = readFileSync("./dist/sharedTreeAttributes.js", "utf-8");
+
+		// Make sure it contains something
+		assert(bundle.length > 10);
+		// Make sure does not contain a lot more than just the attributes.
+		assert(bundle.length < 1000);
+	});
+});

--- a/examples/utils/bundle-size-tests/webpack.config.cjs
+++ b/examples/utils/bundle-size-tests/webpack.config.cjs
@@ -82,6 +82,7 @@ module.exports = {
 		odspPrefetchSnapshot: "./src/odspPrefetchSnapshot",
 		sharedString: "./src/sharedString",
 		sharedTree: "./src/sharedTree",
+		sharedTreeAttributes: "./src/sharedTreeAttributes",
 	},
 	mode: "production",
 	module: {

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -401,15 +401,15 @@ export namespace JsonAsTree {
     export class JsonObject extends _APIExtractorWorkaroundObjectBase {
     }
     const _APIExtractorWorkaroundObjectBase: TreeNodeSchemaClass<"com.fluidframework.json.object", NodeKind.Map, TreeMapNodeUnsafe<readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array]> & WithType<"com.fluidframework.json.object", NodeKind.Map, unknown>, {
-        [Symbol.iterator](): Iterator<[string, string | number | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null], any, undefined>;
+        [Symbol.iterator](): Iterator<[string, string | number | JsonObject | Array | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null], any, undefined>;
     } | {
-        readonly [x: string]: string | number | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null;
+        readonly [x: string]: string | number | JsonObject | Array | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null;
     }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined>;
     // (undocumented)
     export type Primitive = TreeNodeFromImplicitAllowedTypes<typeof Primitive>;
     export type _RecursiveArrayWorkaroundJsonArray = FixRecursiveArraySchema<typeof Array>;
     const _APIExtractorWorkaroundArrayBase: TreeNodeSchemaClass<"com.fluidframework.json.array", NodeKind.Array, TreeArrayNodeUnsafe<readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array]> & WithType<"com.fluidframework.json.array", NodeKind.Array, unknown>, {
-        [Symbol.iterator](): Iterator<string | number | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null, any, undefined>;
+        [Symbol.iterator](): Iterator<string | number | JsonObject | Array | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null, any, undefined>;
     }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined>;
     // (undocumented)
     export type Tree = TreeNodeFromImplicitAllowedTypes<typeof Tree>;

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -401,15 +401,15 @@ export namespace JsonAsTree {
     export class JsonObject extends _APIExtractorWorkaroundObjectBase {
     }
     const _APIExtractorWorkaroundObjectBase: TreeNodeSchemaClass<"com.fluidframework.json.object", NodeKind.Map, TreeMapNodeUnsafe<readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array]> & WithType<"com.fluidframework.json.object", NodeKind.Map, unknown>, {
-        [Symbol.iterator](): Iterator<[string, string | number | JsonObject | Array | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null], any, undefined>;
+        [Symbol.iterator](): Iterator<[string, string | number | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null], any, undefined>;
     } | {
-        readonly [x: string]: string | number | JsonObject | Array | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null;
+        readonly [x: string]: string | number | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null;
     }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined>;
     // (undocumented)
     export type Primitive = TreeNodeFromImplicitAllowedTypes<typeof Primitive>;
     export type _RecursiveArrayWorkaroundJsonArray = FixRecursiveArraySchema<typeof Array>;
     const _APIExtractorWorkaroundArrayBase: TreeNodeSchemaClass<"com.fluidframework.json.array", NodeKind.Array, TreeArrayNodeUnsafe<readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array]> & WithType<"com.fluidframework.json.array", NodeKind.Array, unknown>, {
-        [Symbol.iterator](): Iterator<string | number | JsonObject | Array | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null, any, undefined>;
+        [Symbol.iterator](): Iterator<string | number | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null, any, undefined>;
     }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined>;
     // (undocumented)
     export type Tree = TreeNodeFromImplicitAllowedTypes<typeof Tree>;

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -230,9 +230,8 @@ export {
 export {
 	SharedTree,
 	configuredSharedTree,
-	SharedTreeAttributes,
-	SharedTreeFactoryType,
 } from "./treeFactory.js";
+export { SharedTreeAttributes, SharedTreeFactoryType } from "./sharedTreeAttributes.js";
 
 export {
 	type ICodecOptions,

--- a/packages/dds/tree/src/sharedTreeAttributes.ts
+++ b/packages/dds/tree/src/sharedTreeAttributes.ts
@@ -1,0 +1,21 @@
+import type { IChannelAttributes } from "@fluidframework/datastore-definitions/internal";
+import { pkgVersion } from "./packageVersion.js";
+
+/**
+ * {@inheritDoc @fluidframework/shared-object-base#ISharedObjectFactory."type"}
+ * @alpha
+ * @legacy
+ */
+
+export const SharedTreeFactoryType = "https://graph.microsoft.com/types/tree";
+/**
+ * {@inheritDoc @fluidframework/shared-object-base#ISharedObjectFactory.attributes}
+ * @alpha
+ * @legacy
+ */
+
+export const SharedTreeAttributes: IChannelAttributes = {
+	type: SharedTreeFactoryType,
+	snapshotFormatVersion: "0.0.0",
+	packageVersion: pkgVersion,
+};

--- a/packages/dds/tree/src/sharedTreeAttributes.ts
+++ b/packages/dds/tree/src/sharedTreeAttributes.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import type { IChannelAttributes } from "@fluidframework/datastore-definitions/internal";
 import { pkgVersion } from "./packageVersion.js";
 
@@ -6,14 +11,13 @@ import { pkgVersion } from "./packageVersion.js";
  * @alpha
  * @legacy
  */
-
 export const SharedTreeFactoryType = "https://graph.microsoft.com/types/tree";
+
 /**
  * {@inheritDoc @fluidframework/shared-object-base#ISharedObjectFactory.attributes}
  * @alpha
  * @legacy
  */
-
 export const SharedTreeAttributes: IChannelAttributes = {
 	type: SharedTreeFactoryType,
 	snapshotFormatVersion: "0.0.0",

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -22,25 +22,7 @@ import {
 } from "./shared-tree/index.js";
 import type { ITree } from "./simple-tree/index.js";
 
-import { pkgVersion } from "./packageVersion.js";
-
-/**
- * {@inheritDoc @fluidframework/shared-object-base#ISharedObjectFactory."type"}
- * @alpha
- * @legacy
- */
-export const SharedTreeFactoryType = "https://graph.microsoft.com/types/tree";
-
-/**
- * {@inheritDoc @fluidframework/shared-object-base#ISharedObjectFactory.attributes}
- * @alpha
- * @legacy
- */
-export const SharedTreeAttributes: IChannelAttributes = {
-	type: SharedTreeFactoryType,
-	snapshotFormatVersion: "0.0.0",
-	packageVersion: pkgVersion,
-};
+import { SharedTreeFactoryType, SharedTreeAttributes } from "./sharedTreeAttributes.js";
 
 /**
  * A channel factory that creates an {@link ITree}.


### PR DESCRIPTION
## Description

Improve tree shaking for code which imports `SharedTreeAttributes`.

See changeset for details.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

