### PR TITLE
refactor(merge-tree): Use perspectives in MergeTreeTextHelper

### DIFF
--- a/packages/dds/merge-tree/src/MergeTreeTextHelper.ts
+++ b/packages/dds/merge-tree/src/MergeTreeTextHelper.ts
@@ -3,12 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { IIntegerRange } from "./client.js";
-import { UniversalSequenceNumber } from "./constants.js";
-import { MergeTree } from "./mergeTree.js";
-import { ISegmentPrivate } from "./mergeTreeNodes.js";
-import { PriorPerspective, type Perspective } from "./perspective.js";
-import { IMergeTreeTextHelper, TextSegment } from "./textSegment.js";
+import type { IIntegerRange } from "./client.js";
+import type { MergeTree } from "./mergeTree.js";
+import type { ISegmentPrivate } from "./mergeTreeNodes.js";
+import type { Perspective } from "./perspective.js";
+import { TextSegment } from "./textSegment.js";
 
 interface ITextAccumulator {
 	textSegment: TextSegment;
@@ -16,20 +15,22 @@ interface ITextAccumulator {
 	parallelArrays?: boolean;
 }
 
+/**
+ * @internal
+ */
+export interface IMergeTreeTextHelper {
+	getText(perspective: Perspective, placeholder: string, start?: number, end?: number): string;
+}
+
 export class MergeTreeTextHelper implements IMergeTreeTextHelper {
 	constructor(private readonly mergeTree: MergeTree) {}
 
 	public getText(
-		refSeq: number,
-		clientId: number,
+		perspective: Perspective,
 		placeholder = "",
 		start?: number,
 		end?: number,
 	): string {
-		const perspective =
-			refSeq === UniversalSequenceNumber || clientId === this.mergeTree.collabWindow.clientId
-				? this.mergeTree.localPerspective
-				: new PriorPerspective(refSeq, clientId);
 		const range = this.getValidRange(start, end, perspective);
 
 		const accum: ITextAccumulator = { textSegment: new TextSegment(""), placeholder };

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -25,7 +25,7 @@ import {
 	UsageError,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { MergeTreeTextHelper } from "./MergeTreeTextHelper.js";
+import { MergeTreeTextHelper, type IMergeTreeTextHelper } from "./MergeTreeTextHelper.js";
 import { DoublyLinkedList, RedBlackTree } from "./collections/index.js";
 import { NonCollabClient, UniversalSequenceNumber } from "./constants.js";
 import { LocalReferencePosition, SlidingPreference } from "./localReference.js";
@@ -99,7 +99,6 @@ import { SnapshotV1 } from "./snapshotV1.js";
 import { SnapshotLegacy } from "./snapshotlegacy.js";
 import type { OperationStamp } from "./stamps.js";
 import * as opstampUtils from "./stamps.js";
-import { IMergeTreeTextHelper } from "./textSegment.js";
 
 type IMergeTreeDeltaRemoteOpArgs = Omit<IMergeTreeDeltaOpArgs, "sequencedMessage"> &
 	Required<Pick<IMergeTreeDeltaOpArgs, "sequencedMessage">>;

--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -131,7 +131,7 @@ export {
 } from "./sequencePlace.js";
 export { SortedSet } from "./sortedSet.js";
 export { SortedSegmentSet, SortedSegmentSetItem } from "./sortedSegmentSet.js";
-export { IJSONTextSegment, IMergeTreeTextHelper, TextSegment } from "./textSegment.js";
+export { IJSONTextSegment, TextSegment } from "./textSegment.js";
 export {
 	appendToMergeTreeDeltaRevertibles,
 	discardMergeTreeDeltaRevertible,
@@ -140,4 +140,6 @@ export {
 	MergeTreeRevertibleDriver,
 	revertMergeTreeDeltaRevertibles,
 } from "./revertibles.js";
-export { OperationStamp } from "./stamps.js";
+export type { OperationStamp } from "./stamps.js";
+export type { Perspective } from "./perspective.js";
+export type { IMergeTreeTextHelper } from "./MergeTreeTextHelper.js";

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -602,9 +602,9 @@ export class MergeTree {
 
 	public readonly attributionPolicy: AttributionPolicy | undefined;
 
-	public localPerspective: Perspective = new LocalDefaultPerspective(
-		this.collabWindow.clientId,
-	);
+	public get localPerspective(): Perspective {
+		return this.collabWindow.localPerspective;
+	}
 
 	/**
 	 * Whether or not all blocks in the mergeTree currently have information about local partial lengths computed.
@@ -737,7 +737,7 @@ export class MergeTree {
 		this.collabWindow.minSeq = minSeq;
 		this.collabWindow.collaborating = true;
 		this.collabWindow.currentSeq = currentSeq;
-		this.localPerspective = new LocalDefaultPerspective(localClientId);
+		this.collabWindow.localPerspective = new LocalDefaultPerspective(localClientId);
 		this.nodeUpdateLengthNewStructure(this.root, true);
 	}
 

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -18,7 +18,7 @@ import { TrackingGroupCollection } from "./mergeTreeTracking.js";
 import { IJSONSegment, IMarkerDef, ReferenceType } from "./ops.js";
 import { computeHierarchicalOrdinal } from "./ordinal.js";
 import type { PartialSequenceLengths } from "./partialLengths.js";
-import { PriorPerspective, type Perspective } from "./perspective.js";
+import { LocalDefaultPerspective, PriorPerspective, type Perspective } from "./perspective.js";
 import { PropertySet, clone, createMap, type MapLike } from "./properties.js";
 import { ReferencePosition } from "./referencePositions.js";
 import { SegmentGroupCollection } from "./segmentGroupCollection.js";
@@ -673,6 +673,8 @@ export class CollaborationWindow {
 	 * from a given (seq, localSeq) perspective.
 	 */
 	localSeq = 0;
+
+	public localPerspective: Perspective = new LocalDefaultPerspective(this.clientId);
 
 	public loadFrom(a: CollaborationWindow): void {
 		this.clientId = a.clientId;

--- a/packages/dds/merge-tree/src/perspective.ts
+++ b/packages/dds/merge-tree/src/perspective.ts
@@ -12,6 +12,7 @@ import type { OperationStamp, RemoveOperationStamp } from "./stamps.js";
  * A perspective which includes some subset of operations known to the local client.
  *
  * This helps the local client reason about the state of other clients when they issued an operation.
+ * @internal
  */
 export interface Perspective {
 	/**

--- a/packages/dds/merge-tree/src/test/beastTest.spec.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.spec.ts
@@ -306,10 +306,7 @@ function checkInsertMergeTree(
 	textSegment: TextSegment,
 	verbose = false,
 ): boolean {
-	let checkText = new MergeTreeTextHelper(mergeTree).getText(
-		UniversalSequenceNumber,
-		LocalClientId,
-	);
+	let checkText = new MergeTreeTextHelper(mergeTree).getText(mergeTree.localPerspective);
 	checkText = editFlat(checkText, pos, 0, textSegment.text);
 	const clockStart = clock();
 	mergeTree.insertSegments(
@@ -320,10 +317,7 @@ function checkInsertMergeTree(
 		undefined,
 	);
 	accumTime += elapsedMicroseconds(clockStart);
-	const updatedText = new MergeTreeTextHelper(mergeTree).getText(
-		UniversalSequenceNumber,
-		LocalClientId,
-	);
+	const updatedText = new MergeTreeTextHelper(mergeTree).getText(mergeTree.localPerspective);
 	const result = checkText === updatedText;
 	if (!result && verbose) {
 		log(`mismatch(o): ${checkText}`);
@@ -339,7 +333,7 @@ function checkMarkRemoveMergeTree(
 	verbose = false,
 ): boolean {
 	const helper = new MergeTreeTextHelper(mergeTree);
-	const origText = helper.getText(UniversalSequenceNumber, LocalClientId);
+	const origText = helper.getText(mergeTree.localPerspective);
 	const checkText = editFlat(origText, start, end - start);
 	const clockStart = clock();
 	mergeTree.markRangeRemoved(
@@ -350,7 +344,7 @@ function checkMarkRemoveMergeTree(
 		{ op: createRemoveRangeOp(start, end) },
 	);
 	accumTime += elapsedMicroseconds(clockStart);
-	const updatedText = helper.getText(UniversalSequenceNumber, LocalClientId);
+	const updatedText = helper.getText(mergeTree.localPerspective);
 	const result = checkText === updatedText;
 	if (!result && verbose) {
 		log(`mismatch(o): ${origText}`);
@@ -381,7 +375,7 @@ export function mergeTreeTest1(): void {
 	mergeTree.mapRange(printTextSegment, localPerspective, undefined);
 	const segoff = mergeTree.getContainingSegment(4, mergeTree.localPerspective);
 	log(mergeTree.getPosition(segoff.segment!, mergeTree.localPerspective));
-	log(new MergeTreeTextHelper(mergeTree).getText(UniversalSequenceNumber, LocalClientId));
+	log(new MergeTreeTextHelper(mergeTree).getText(mergeTree.localPerspective));
 	log(mergeTree.toString());
 	TestPack().firstTest();
 }

--- a/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.insertingWalk.spec.ts
@@ -82,7 +82,7 @@ const treeFactories: ITestTreeFactory[] = [
 			}
 
 			const textHelper = new MergeTreeTextHelper(mergeTree);
-			assert.equal(textHelper.getText(UniversalSequenceNumber, localClientId), initialText);
+			assert.equal(textHelper.getText(mergeTree.localPerspective), initialText);
 
 			const nodes: MergeBlock[] = [mergeTree.root];
 			while (nodes.length > 0) {
@@ -197,7 +197,9 @@ describe("MergeTree.insertingWalk", () => {
 						testData.mergeTree.getLength(testData.mergeTree.localPerspective),
 						testData.initialText.length + 1,
 					);
-					const currentValue = testData.textHelper.getText(testData.refSeq, localClientId);
+					const currentValue = testData.textHelper.getText(
+						testData.mergeTree.localPerspective,
+					);
 					assert.equal(currentValue.length, testData.initialText.length + 1);
 					assert.equal(currentValue, `a${testData.initialText}`);
 				});
@@ -215,7 +217,9 @@ describe("MergeTree.insertingWalk", () => {
 						testData.mergeTree.getLength(testData.mergeTree.localPerspective),
 						testData.initialText.length + 1,
 					);
-					const currentValue = testData.textHelper.getText(testData.refSeq, localClientId);
+					const currentValue = testData.textHelper.getText(
+						testData.mergeTree.localPerspective,
+					);
 					assert.equal(currentValue.length, testData.initialText.length + 1);
 					assert.equal(currentValue, `${testData.initialText}a`);
 				});
@@ -233,7 +237,9 @@ describe("MergeTree.insertingWalk", () => {
 						testData.mergeTree.getLength(testData.mergeTree.localPerspective),
 						testData.initialText.length + 1,
 					);
-					const currentValue = testData.textHelper.getText(testData.refSeq, localClientId);
+					const currentValue = testData.textHelper.getText(
+						testData.mergeTree.localPerspective,
+					);
 					assert.equal(currentValue.length, testData.initialText.length + 1);
 					assert.equal(
 						currentValue,
@@ -273,7 +279,7 @@ describe("MergeTree.insertingWalk", () => {
 		const textHelper = new MergeTreeTextHelper(mergeTree);
 
 		assert.equal(mergeTree.root.childCount, 2);
-		assert.equal(textHelper.getText(0, localClientId), "GFEDCBA0");
+		assert.equal(textHelper.getText(mergeTree.localPerspective), "GFEDCBA0");
 		// Remove "DCBA"
 		mergeTree.markRangeRemoved(
 			3,
@@ -282,7 +288,7 @@ describe("MergeTree.insertingWalk", () => {
 			mergeTree.collabWindow.mintNextLocalOperationStamp(),
 			undefined as never,
 		);
-		assert.equal(textHelper.getText(0, localClientId), "GFE0");
+		assert.equal(textHelper.getText(mergeTree.localPerspective), "GFE0");
 		// Simulate another client inserting concurrently with the above operations. Because
 		// all segments but the 0 are unacked, this insert should place the segment directly
 		// before the 0. Prior to this regression test, an issue with `rightExcursion` in the

--- a/packages/dds/merge-tree/src/textSegment.ts
+++ b/packages/dds/merge-tree/src/textSegment.ts
@@ -104,16 +104,3 @@ export class TextSegment extends BaseSegment {
 		}
 	}
 }
-
-/**
- * @internal
- */
-export interface IMergeTreeTextHelper {
-	getText(
-		refSeq: number,
-		clientId: number,
-		placeholder: string,
-		start?: number,
-		end?: number,
-	): string;
-}

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -245,42 +245,24 @@ export class SharedStringClass
 	 * {@inheritDoc ISharedString.getText}
 	 */
 	public getText(start?: number, end?: number) {
-		const segmentWindow = this.client.getCollabWindow();
-		return this.mergeTreeTextHelper.getText(
-			segmentWindow.currentSeq,
-			segmentWindow.clientId,
-			"",
-			start,
-			end,
-		);
+		const collabWindow = this.client.getCollabWindow();
+		return this.mergeTreeTextHelper.getText(collabWindow.localPerspective, "", start, end);
 	}
 
 	/**
 	 * {@inheritDoc ISharedString.getTextWithPlaceholders}
 	 */
 	public getTextWithPlaceholders(start?: number, end?: number) {
-		const segmentWindow = this.client.getCollabWindow();
-		return this.mergeTreeTextHelper.getText(
-			segmentWindow.currentSeq,
-			segmentWindow.clientId,
-			" ",
-			start,
-			end,
-		);
+		const collabWindow = this.client.getCollabWindow();
+		return this.mergeTreeTextHelper.getText(collabWindow.localPerspective, " ", start, end);
 	}
 
 	/**
 	 * {@inheritDoc ISharedString.getTextRangeWithMarkers}
 	 */
 	public getTextRangeWithMarkers(start: number, end: number) {
-		const segmentWindow = this.client.getCollabWindow();
-		return this.mergeTreeTextHelper.getText(
-			segmentWindow.currentSeq,
-			segmentWindow.clientId,
-			"*",
-			start,
-			end,
-		);
+		const collabWindow = this.client.getCollabWindow();
+		return this.mergeTreeTextHelper.getText(collabWindow.localPerspective, "*", start, end);
 	}
 
 	/**


### PR DESCRIPTION
## Description

Makes `IMergeTreeTextHelper` take in a perspective rather than `refSeq` + `clientId`. To make this usable with the local perspective in `SharedString`, I've also added a `localPerspective` field to the collab window.