### PR TITLE
docs: Update API docs links to point to `fluid-framework` where practical, rather than lower-level packages

### DIFF
--- a/docs/docs/build/container-states-events.mdx
+++ b/docs/docs/build/container-states-events.mdx
@@ -99,7 +99,7 @@ But the new container has a different ID from the deleted one and subsequent cli
 
 #### Handling publication status
 
-Your code can test for the publication status with the <ApiLink packageName="fluid-static" apiName="IFluidContainer" apiType="interface" headingId="attachstate-propertysignature">container.AttachState</ApiLink> property which has an <ApiLink packageName="container-definitions" apiName="AttachState" apiType="enum">AttachState</ApiLink> value.
+Your code can test for the publication status with the <ApiLink packageName="fluid-framework" apiName="IFluidContainer" apiType="interface" headingId="attachstate-propertysignature">container.AttachState</ApiLink> property which has an <ApiLink packageName="fluid-framework" apiName="AttachState" apiType="enum">AttachState</ApiLink> value.
 This can be useful if your application will publish the container in some code paths on the creating client, but not others.
 For example, on the creating computer, you don't want to call `container.attach` if it has already been called. In simple cases, you can know at coding time if that has happened, but when the creating client in complex code flows and calls of `container.attach` appear in more than one branch, you may need to test for this possibility. The following is a simple example.
 
@@ -269,7 +269,7 @@ The container transitions to this state automatically when it is fully caught up
 
 There are scenarios in which you need to control the connection status of the container. To assist, the `container` object has the following APIs:
 
--   A <ApiLink packageName="fluid-static" apiName="IFluidContainer" apiType="interface" headingId="connectionstate-propertysignature">container.connectionState</ApiLink> property of type `ConnectionState`. There are four possible values for the property:
+-   A <ApiLink packageName="fluid-framework" apiName="IFluidContainer" apiType="interface" headingId="connectionstate-propertysignature">container.connectionState</ApiLink> property of type `ConnectionState`. There are four possible values for the property:
 
     -   `Disconnected`
     -   `EstablishingConnection`: Your code should treat this state the same as it treats the disconnected state. See [Examples](#examples).

--- a/docs/docs/build/containers.mdx
+++ b/docs/docs/build/containers.mdx
@@ -8,7 +8,7 @@ import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
 The container is the primary unit of encapsulation in the Fluid Framework.
 It enables a group of clients to access the same set of shared objects and co-author changes on those objects.
 It is also a permission boundary ensuring visibility and access only to permitted clients.
-A container is represented by the <ApiLink packageName="fluid-static" apiName="IFluidContainer" apiType="interface">FluidContainer</ApiLink> type and consists of a collection of shared objects and APIs to manage the life cycle of those objects.
+A container is represented by the <ApiLink packageName="fluid-framework" apiName="IFluidContainer" apiType="interface">FluidContainer</ApiLink> type and consists of a collection of shared objects and APIs to manage the life cycle of those objects.
 
 This article explains:
 

--- a/docs/docs/data-structures/tree/index.mdx
+++ b/docs/docs/data-structures/tree/index.mdx
@@ -29,4 +29,4 @@ Provided below are links to more detailed information about `SharedTree` usage a
 
 ## API Documentation
 
-For a comprehensive view of the `SharedTree` package's API documentation, see <PackageLink packageName="tree">the SharedTree API docs</PackageLink>.
+For a comprehensive view of the `SharedTree` package's API documentation, see <PackageLink packageName="fluid-framework">the `fluid-framework` API docs</PackageLink>.

--- a/docs/docs/data-structures/tree/schema-definition.mdx
+++ b/docs/docs/data-structures/tree/schema-definition.mdx
@@ -54,8 +54,9 @@ class Note extends sf.object("Note", {
 
 For the remainder of this article, we use the inline style.
 
-You can add fields, properties, and methods like any TypeScript class including methods that wrap one or more methods in the <PackageLink packageName="tree">SharedTree API docs</PackageLink>.
-For example, the `Note` class can have the following `updateText` method. Since the method writes to shared properties, the changes are reflected on all clients.
+You can add fields, properties, and methods like any TypeScript class.
+For example, the `Note` class can have the following `updateText` method.
+Since the method writes to shared properties, the changes are reflected on all clients.
 
 ```typescript
 public updateText(text: string) {

--- a/docs/docs/start/tree-start.mdx
+++ b/docs/docs/start/tree-start.mdx
@@ -93,7 +93,7 @@ This creates a `TodoList` class that is an object schema with two fields, `title
 
 Schemas can also be defined using plain old JavaScript object (POJO) mode.
 Generally, you should prefer customizable mode.
-See <ApiLink packageName="tree" apiName="SchemaFactory" apiType="class">the API docs</ApiLink> for more info on the differences between the two modes.
+See <ApiLink packageName="fluid-framework" apiName="SchemaFactory" apiType="class">the API docs</ApiLink> for more info on the differences between the two modes.
 
 ## Initializing the Tree
 
@@ -154,7 +154,7 @@ useEffect(() => {
 
 `nodeChanged` fires whenever one or more properties of the specified node change while `treeChanged` also fires whenever any node in its subtree changes.
 
-See <ApiLink packageName="tree" apiName="TreeChangeEvents" apiType="interface">the API</ApiLink> docs for more details.
+See <ApiLink packageName="fluid-framework" apiName="TreeChangeEvents" apiType="interface">the API</ApiLink> docs for more details.
 
 ## Editing Tree Data
 


### PR DESCRIPTION
We point users of our public API to the `fluid-framework` package, rather than lower level packages like `tree` or `fluid-static`. This PR updates some existing API docs links to point to `fluid-framework`.