### PR TITLE
Enabled rejecting token signing when the tenant does not have private keys

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -82,6 +82,7 @@ export function create(
 			ver,
 			jti,
 			getIncludeDisabledFlag(request),
+			getForceGenerateTokenWithPrivateKeyFlag(request),
 		);
 		handleResponse(accessTokenP, response);
 	});
@@ -208,6 +209,11 @@ export function create(
 	function getIncludeDisabledFlag(request): boolean {
 		const includeDisabledRaw = request.query.includeDisabledTenant as string;
 		return includeDisabledRaw?.toLowerCase() === "true";
+	}
+
+	function getForceGenerateTokenWithPrivateKeyFlag(request): boolean {
+		const forceGenerateTokenWithPrivateKey = request.query.forceGenerateTokenWithPrivateKey as string;
+		return forceGenerateTokenWithPrivateKey?.toLowerCase() === "true";
 	}
 
 	return router;

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -212,7 +212,8 @@ export function create(
 	}
 
 	function getForceGenerateTokenWithPrivateKeyFlag(request): boolean {
-		const forceGenerateTokenWithPrivateKey = request.query.forceGenerateTokenWithPrivateKey as string;
+		const forceGenerateTokenWithPrivateKey = request.query
+			.forceGenerateTokenWithPrivateKey as string;
 		return forceGenerateTokenWithPrivateKey?.toLowerCase() === "true";
 	}
 

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -189,7 +189,10 @@ export class TenantManager {
 				`Tenant ${tenantId} does not have private key access enabled. Cannot sign token with private key.`,
 				lumberProperties,
 			);
-			throw new NetworkError(400, `Tenant ${tenantId} does not have private key access enabled.`);
+			throw new NetworkError(
+				400,
+				`Tenant ${tenantId} does not have private key access enabled.`,
+			);
 		}
 
 		const keys = this.decryptKeys(

--- a/server/routerlicious/packages/routerlicious-base/src/test/riddler/tenantManager.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/riddler/tenantManager.spec.ts
@@ -799,7 +799,7 @@ describe("TenantManager", () => {
 			await assert.doesNotReject(validationPKey1);
 		});
 
-		it("Should throw an error when private keys are not enabled for a tenant and forceGenerateTokenWithPrvateKeys is true", async () => {
+		it("Should throw an error when private keys are not enabled for a tenant and forceGenerateTokenWithPrivateKey is true", async () => {
 			sandbox.stub(tenantRepository, "findOne").resolves(tenantWithoutPrivateKeys);
 			const tokenKey1 = tenantManager.signToken(
 				"cordflasher-dolphin",

--- a/server/routerlicious/packages/routerlicious-base/src/test/riddler/tenantManager.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/riddler/tenantManager.spec.ts
@@ -798,5 +798,26 @@ describe("TenantManager", () => {
 			);
 			await assert.doesNotReject(validationPKey1);
 		});
+
+		it("Should throw an error when private keys are not enabled for a tenant and forceGenerateTokenWithPrvateKeys is true", async () => {
+			sandbox.stub(tenantRepository, "findOne").resolves(tenantWithoutPrivateKeys);
+			const tokenKey1 = tenantManager.signToken(
+				"cordflasher-dolphin",
+				keylessAccessTokenClaims.documentId,
+				keylessAccessTokenClaims.scopes,
+				keylessAccessTokenClaims.user,
+				undefined,
+				keylessAccessTokenClaims.ver,
+				undefined,
+				false,
+				true, /* forceGenerateTokenWithPrivateKey */
+			);
+			await assert.rejects(tokenKey1, (err) => {
+				assert(err instanceof NetworkError);
+				assert.strictEqual(err.code, 400);
+				assert.strictEqual(err.message, `Tenant ${tenantWithoutPrivateKeys._id} does not have private key access enabled.`);
+				return true;
+			})
+		});
 	});
 });

--- a/server/routerlicious/packages/routerlicious-base/src/test/riddler/tenantManager.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/riddler/tenantManager.spec.ts
@@ -810,14 +810,17 @@ describe("TenantManager", () => {
 				keylessAccessTokenClaims.ver,
 				undefined,
 				false,
-				true, /* forceGenerateTokenWithPrivateKey */
+				true /* forceGenerateTokenWithPrivateKey */,
 			);
 			await assert.rejects(tokenKey1, (err) => {
 				assert(err instanceof NetworkError);
 				assert.strictEqual(err.code, 400);
-				assert.strictEqual(err.message, `Tenant ${tenantWithoutPrivateKeys._id} does not have private key access enabled.`);
+				assert.strictEqual(
+					err.message,
+					`Tenant ${tenantWithoutPrivateKeys._id} does not have private key access enabled.`,
+				);
 				return true;
-			})
+			});
 		});
 	});
 });

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -12073,7 +12073,7 @@ snapshots:
       debug: 4.4.0(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.0
+      semver: 7.6.3
       ts-api-utils: 1.0.3(typescript@5.1.6)
     optionalDependencies:
       typescript: 5.1.6
@@ -12104,7 +12104,7 @@ snapshots:
       '@typescript-eslint/types': 6.7.5
       '@typescript-eslint/typescript-estree': 6.7.5(typescript@5.1.6)
       eslint: 8.55.0
-      semver: 7.6.0
+      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
## Description

This PR addresses an edge case needed to support keyless access. Keyless access tokens must only be signed by private keys. The existing implementation prioritizes using private keys to sign the token if they exist, else it falls back to using shared keys. 

However, this would mean that a tenant wanting an access token using the keyless access feature can get one even if private keys are not enabled for the tenant. This PR adds a flag to the URL which allows the calling service to specify whether it wants a token specifically signed using private keys. Hence, if the `forceGenerateTokenWithPrivateKey` is sent as true by the caller but the tenant does not have private keys enabled, we reject the request with an `HTTP 400`.

## Breaking Changes

This does not break any existing functionality as my default the `forceGenerateTokenWithPrivateKey` is false. Which would mean that no calling clients will ask riddler to generate a token explicitly with private tenant keys.

