### PR TITLE
build(bundle-size-tests): Update fluid build task deps

### DIFF
--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -77,21 +77,11 @@
 	],
 	"fluidBuild": {
 		"tasks": {
-			"webpack": {
-				"dependsOn": [
-					"build"
-				]
-			},
-			"test:mocha": {
-				"dependsOn": [
-					"...",
-					"webpack"
-				]
-			},
 			"build:test": {
 				"dependsOn": [
 					"...",
-					"build:esnext"
+					"build:esnext",
+					"webpack"
 				]
 			}
 		}


### PR DESCRIPTION
## Description

Updating fluid build task dependencies [per Abram's suggestion](https://github.com/microsoft/FluidFramework/pull/24125#pullrequestreview-2710977098) so building the bundle-size-tests package locally results in a state where the tests can actually run and succeed.

The `webpack` task already depends on `build:esnext` in the base fluid build config so the entry here was somewhat redundant, but also it prevented the `build:test -> webpack` dependency because it caused circular task dependencies.

I confirmed this now works locally; after running `pnpm build`, `pnpm test` successfully runs the tests and they pass. Of note, `pnpm build:test` is not enough to make that work because that just runs the `build:test` npm script which does not cause fluid-build to run. On the other hand, the `build` npm script invokes fluid-build and all the dependencies work correctly.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
