### PR TITLE
[Staging Mode] Exiting staging mode - final flush before flipping the bit

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3145,10 +3145,10 @@ export class ContainerRuntime
 		this.outbox.flush();
 
 		const exitStagingMode = (discardOrCommit: () => void) => (): void => {
-			this.stageControls = undefined;
-
 			// Final flush of any last staged changes
 			this.outbox.flush(undefined, true /* staged */);
+
+			this.stageControls = undefined;
 
 			discardOrCommit();
 		};


### PR DESCRIPTION
## Description

The intent of the final flush is that any changes submitted during staging mode should happen in staging mode, then we exit cleanly.