### PR TITLE
Set maxMessageSize as 900KB in Kafka Op

### DIFF
--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -306,3 +306,12 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
 		partitionActivityCheckInterval: 60 * 1000,
 	},
 };
+
+// Kafka has an internal limit of 1Mb.
+// Runtime has a client-imposed limit of 700kb.
+// Set our enforced limit at 900kb to give space for any
+// mysterious overhead.
+/**
+ * @internal
+ */
+export const MaxKafkaMessageSize = 900 * 1024;

--- a/server/routerlicious/packages/services-core/src/index.ts
+++ b/server/routerlicious/packages/services-core/src/index.ts
@@ -21,6 +21,7 @@ export {
 	IScribeServerConfiguration,
 	IServerConfiguration,
 	IServiceConfiguration,
+	MaxKafkaMessageSize,
 } from "./configuration";
 export {
 	ICheckpointRepository,

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
@@ -45,7 +45,6 @@ export class KafkaNodeProducer implements IProducer {
 	) {
 		clientOptions.clientId = clientId;
 		this.maxBatchSize = maxBatchSize ?? MaxBatchSize;
-		// Kafka has an internal limit of 1Mb. Set the enforced limit as 900kb.
 		this.maxMessageSize = maxMessageSize ?? MaxKafkaMessageSize;
 		this.connect();
 	}

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
@@ -44,7 +44,8 @@ export class KafkaNodeProducer implements IProducer {
 	) {
 		clientOptions.clientId = clientId;
 		this.maxBatchSize = maxBatchSize ?? MaxBatchSize;
-		this.maxMessageSize = maxMessageSize ?? Number.MAX_SAFE_INTEGER;
+		// Kafka has an internal limit of 1Mb. Set the enforced limit as 900kb.
+		this.maxMessageSize = maxMessageSize ?? 900 * 1024;
 		this.connect();
 	}
 

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
@@ -13,6 +13,7 @@ import {
 	IProducer,
 	PendingBoxcar,
 	MaxBatchSize,
+	MaxKafkaMessageSize,
 } from "@fluidframework/server-services-core";
 import { NetworkError } from "@fluidframework/server-services-client";
 import * as kafka from "kafka-node";
@@ -45,7 +46,7 @@ export class KafkaNodeProducer implements IProducer {
 		clientOptions.clientId = clientId;
 		this.maxBatchSize = maxBatchSize ?? MaxBatchSize;
 		// Kafka has an internal limit of 1Mb. Set the enforced limit as 900kb.
-		this.maxMessageSize = maxMessageSize ?? 900 * 1024;
+		this.maxMessageSize = maxMessageSize ?? MaxKafkaMessageSize;
 		this.connect();
 	}
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -11,6 +11,7 @@ import {
 	IProducer,
 	PendingBoxcar,
 	IContextErrorData,
+	MaxKafkaMessageSize,
 } from "@fluidframework/server-services-core";
 import { NetworkError } from "@fluidframework/server-services-client";
 import { Lumberjack, getLumberBaseProperties } from "@fluidframework/server-services-telemetry";
@@ -94,7 +95,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 			enableIdempotence: options?.enableIdempotence ?? false,
 			pollIntervalMs: options?.pollIntervalMs ?? 10,
 			// Kafka has an internal limit of 1Mb. Set the enforced limit as 900kb.
-			maxMessageSize: options?.maxMessageSize ?? 900 * 1024,
+			maxMessageSize: options?.maxMessageSize ?? MaxKafkaMessageSize,
 		};
 	}
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -94,7 +94,6 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 			reconnectOnNonFatalErrors: options?.reconnectOnNonFatalErrors ?? false,
 			enableIdempotence: options?.enableIdempotence ?? false,
 			pollIntervalMs: options?.pollIntervalMs ?? 10,
-			// Kafka has an internal limit of 1Mb. Set the enforced limit as 900kb.
 			maxMessageSize: options?.maxMessageSize ?? MaxKafkaMessageSize,
 		};
 	}

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -93,7 +93,8 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 			reconnectOnNonFatalErrors: options?.reconnectOnNonFatalErrors ?? false,
 			enableIdempotence: options?.enableIdempotence ?? false,
 			pollIntervalMs: options?.pollIntervalMs ?? 10,
-			maxMessageSize: options?.maxMessageSize ?? Number.MAX_SAFE_INTEGER,
+			// Kafka has an internal limit of 1Mb. Set the enforced limit as 900kb.
+			maxMessageSize: options?.maxMessageSize ?? 900 * 1024,
 		};
 	}
 

--- a/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
@@ -11,7 +11,7 @@ import { RdkafkaProducer } from "@fluidframework/server-services-ordering-rdkafk
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 
 // Kafka has an internal limit of 1Mb.
-// Runtime has a client-imposed limit of 768kb.
+// Runtime has a client-imposed limit of 700kb.
 // Set our enforced limit at 900kb to give space for any
 // mysterious overhead.
 const MaxKafkaMessageSize = 900 * 1024;

--- a/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
@@ -5,16 +5,13 @@
 
 import { inspect } from "util";
 import winston from "winston";
-import { IContextErrorData, IProducer } from "@fluidframework/server-services-core";
+import { IContextErrorData, IProducer, MaxKafkaMessageSize } from "@fluidframework/server-services-core";
 import { KafkaNodeProducer } from "@fluidframework/server-services-ordering-kafkanode";
 import { RdkafkaProducer } from "@fluidframework/server-services-ordering-rdkafka";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 
-// Kafka has an internal limit of 1Mb.
-// Runtime has a client-imposed limit of 700kb.
-// Set our enforced limit at 900kb to give space for any
-// mysterious overhead.
-const MaxKafkaMessageSize = 900 * 1024;
+// set the max kafka message size to 900kb
+const maxKafkaMessageSize = MaxKafkaMessageSize;
 
 /**
  * @internal
@@ -42,7 +39,7 @@ export function createProducer(
 			pollIntervalMs,
 			numberOfPartitions,
 			replicationFactor,
-			maxMessageSize: MaxKafkaMessageSize,
+			maxMessageSize: maxKafkaMessageSize,
 			sslCACertFilePath,
 			eventHubConnString,
 			additionalOptions,
@@ -77,7 +74,7 @@ export function createProducer(
 			numberOfPartitions,
 			replicationFactor,
 			maxBatchSize,
-			MaxKafkaMessageSize,
+			maxKafkaMessageSize,
 		);
 		producer.on("error", (error) => {
 			winston.error(error);

--- a/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
@@ -5,7 +5,11 @@
 
 import { inspect } from "util";
 import winston from "winston";
-import { IContextErrorData, IProducer, MaxKafkaMessageSize } from "@fluidframework/server-services-core";
+import {
+	IContextErrorData,
+	IProducer,
+	MaxKafkaMessageSize,
+} from "@fluidframework/server-services-core";
 import { KafkaNodeProducer } from "@fluidframework/server-services-ordering-kafkanode";
 import { RdkafkaProducer } from "@fluidframework/server-services-ordering-rdkafka";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";


### PR DESCRIPTION
Set the maxMessageSize as 900KB in Kafka Op Size Limit. 
