### PR TITLE
Revert "build(server,gitrest,historian): Bump build-tools to 0.54"

### DIFF
--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -11,9 +11,10 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"scripts": {
-		"build": "npm run build:compile && npm run lint",
+		"build": "npm run build:genver && npm run build:compile && npm run lint",
 		"build:compile": "pnpm run -r --stream build:compile",
 		"build:docker": "docker build . --build-context root=../..",
+		"build:genver": "pnpm run -r --no-sort --stream --no-bail build:genver",
 		"ci:eslint": "pnpm run -r --no-sort --stream --no-bail eslint",
 		"clean": "rimraf --glob dist \"**/*.tsbuildinfo\" \"**/*.build.log\"",
 		"format": "npm run prettier:fix",
@@ -45,9 +46,9 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@types/async": "^3.2.9",
 		"@types/cors": "^2.8.4",

--- a/server/gitrest/pnpm-lock.yaml
+++ b/server/gitrest/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
   .:
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.17.7)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.17.7)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.17.7)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.17.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.1.6)
@@ -599,17 +599,13 @@ packages:
   '@fluid-internal/eslint-plugin-fluid@0.1.2':
     resolution: {integrity: sha512-E7LF4ukpCoyZcxpDUQz0edXsKllbh4m8NAdiug6sSI1KIIQFwtq5vvW3kQ0Op5xA9w10T6crfcvmuAzdP84UGg==}
 
-  '@fluid-tools/build-cli@0.54.0':
-    resolution: {integrity: sha512-BB6foF3Ps7R3QXkShpLJw1BRmYVq3vCI/1yVAhQ6WoYZZLj7GDiy1tVE+4pc5mepqyggZZw4OZTTYq9Tq2R5Cg==}
+  '@fluid-tools/build-cli@0.52.0-315632':
+    resolution: {integrity: sha512-mCnlGVEhssycNqW6N0xFjcbGjHsNG2aj+9gPtBdd4L0tWLMJyLag7SRfORdvcAuSUhvhiYbEdSGhwvRzkBl/Rw==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
-  '@fluid-tools/build-infrastructure@0.54.0':
-    resolution: {integrity: sha512-b4Qdh1euIdP4zobVL2iF/rkURJpKo7btNhjElo3wEugO/AH+BWHbXo8hoYPK3xlOjprSCH4Yy6mVLam6OADrGQ==}
-    hasBin: true
-
-  '@fluid-tools/version-tools@0.54.0':
-    resolution: {integrity: sha512-Ahqn/EQ6m1q1sjBNphm1hLdkyo9/owmA36RF9EQzq6g8W0nzrKjot4n61JkBQ9v8JkVXRbpUB8kkvZxOXB4JRw==}
+  '@fluid-tools/version-tools@0.52.0-315632':
+    resolution: {integrity: sha512-GLglzryXTGCiBtxBnXOJcloepJhDFtujzkSqXgOMIHTMU8w+8P5qiLNDOa0N1kQHlb6Wt47sCoHG6Cz+bBQ7+Q==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
@@ -617,13 +613,13 @@ packages:
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
     hasBin: true
 
-  '@fluidframework/build-tools@0.54.0':
-    resolution: {integrity: sha512-A/Ze8bfmvzqgZsh2ZmfVqYeRnl3Eo3EeQnJI7tG2cTnXBvjNA/GobuoM9tZtFyD/vsuy1xp7vz7aYh4gANJz/w==}
+  '@fluidframework/build-tools@0.52.0-315632':
+    resolution: {integrity: sha512-L0mwaMA12xppnng21dp64nCJ6As06XOWsbG+pSi3T1n8RCharRkgUVNH7fGW+OeIUnBDGgqCp/k+I/AKnQfaww==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
-  '@fluidframework/bundle-size-tools@0.54.0':
-    resolution: {integrity: sha512-4QwwcyzwAvZELfR16A0dnxX+BERtsOQlrs2pd7GZONjeNOXGXngnpv1e9i3w9nBbFlMehArxdHlxVS2ecYG3ow==}
+  '@fluidframework/bundle-size-tools@0.52.0-315632':
+    resolution: {integrity: sha512-QHxAJDXqtngI3d1Qfxp+xNvPw2nIwEcT74yLYpNXTYOEyChffHtI6KZ/LpSjiogTeB0YnwR9egK4X2A/57esBQ==}
 
   '@fluidframework/common-definitions@0.20.1':
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
@@ -752,6 +748,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^18.17.1
+
+  '@inquirer/figures@1.0.5':
+    resolution: {integrity: sha512-79hP/VWdZ2UVc9bFGJnoQ/lQMpL74mGgzSYX1xUqCVk7/v73vJCMw1VuyWN1jGkZ9B3z7THAbySqGbCNefcjfA==}
+    engines: {node: '>=18'}
 
   '@inquirer/figures@1.0.9':
     resolution: {integrity: sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==}
@@ -3790,7 +3790,6 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
-    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -4585,10 +4584,6 @@ packages:
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
-
-  picospinner@2.0.0:
-    resolution: {integrity: sha512-bRX16jAx5sDlSAEKJ26hKloGU+w2DIkGw0qeUn87WkT8xircacGumNFHS0d/s51S9QbrtoEFwRSAvIvHNstfjA==}
-    engines: {node: '>=18.0.0'}
 
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -6467,13 +6462,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluid-tools/build-cli@0.54.0(@types/node@18.17.7)(encoding@0.1.13)(typescript@5.1.6)':
+  '@fluid-tools/build-cli@0.52.0-315632(@types/node@18.17.7)(encoding@0.1.13)(typescript@5.1.6)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/build-infrastructure': 0.54.0(@types/node@18.17.7)
-      '@fluid-tools/version-tools': 0.54.0(@types/node@18.17.7)
-      '@fluidframework/build-tools': 0.54.0(@types/node@18.17.7)
-      '@fluidframework/bundle-size-tools': 0.54.0
+      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.17.7)
+      '@fluidframework/build-tools': 0.52.0-315632(@types/node@18.17.7)
+      '@fluidframework/bundle-size-tools': 0.52.0-315632
       '@inquirer/prompts': 7.2.1(@types/node@18.17.7)
       '@microsoft/api-extractor': 7.49.0(@types/node@18.17.7)
       '@oclif/core': 4.2.2
@@ -6546,34 +6540,7 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-infrastructure@0.54.0(@types/node@18.17.7)':
-    dependencies:
-      '@fluid-tools/version-tools': 0.54.0(@types/node@18.17.7)
-      '@manypkg/get-packages': 2.2.2
-      '@oclif/core': 4.2.2
-      cosmiconfig: 8.3.6(typescript@5.4.5)
-      detect-indent: 6.1.0
-      execa: 5.1.1
-      fs-extra: 11.2.0
-      globby: 11.1.0
-      micromatch: 4.0.8
-      oclif: 4.17.10(@types/node@18.17.7)
-      picocolors: 1.1.1
-      read-pkg-up: 7.0.1
-      semver: 7.6.3
-      simple-git: 3.27.0
-      sort-package-json: 1.57.0
-      type-fest: 2.19.0
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - '@types/node'
-      - aws-crt
-      - bufferutil
-      - react-devtools-core
-      - supports-color
-      - utf-8-validate
-
-  '@fluid-tools/version-tools@0.54.0(@types/node@18.17.7)':
+  '@fluid-tools/version-tools@0.52.0-315632(@types/node@18.17.7)':
     dependencies:
       '@oclif/core': 4.2.2
       '@oclif/plugin-autocomplete': 3.2.16
@@ -6591,9 +6558,9 @@ snapshots:
 
   '@fluidframework/build-common@2.0.3': {}
 
-  '@fluidframework/build-tools@0.54.0(@types/node@18.17.7)':
+  '@fluidframework/build-tools@0.52.0-315632(@types/node@18.17.7)':
     dependencies:
-      '@fluid-tools/version-tools': 0.54.0(@types/node@18.17.7)
+      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.17.7)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -6611,7 +6578,6 @@ snapshots:
       multimatch: 5.0.0
       picocolors: 1.1.1
       picomatch: 2.3.1
-      picospinner: 2.0.0
       rimraf: 4.4.1
       semver: 7.6.3
       sort-package-json: 1.57.0
@@ -6627,7 +6593,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/bundle-size-tools@0.54.0':
+  '@fluidframework/bundle-size-tools@0.52.0-315632':
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -7013,7 +6979,7 @@ snapshots:
 
   '@inquirer/core@9.1.0':
     dependencies:
-      '@inquirer/figures': 1.0.9
+      '@inquirer/figures': 1.0.5
       '@inquirer/type': 1.5.3
       '@types/mute-stream': 0.0.4
       '@types/node': 18.17.7
@@ -7040,6 +7006,8 @@ snapshots:
       '@inquirer/type': 3.0.2(@types/node@18.17.7)
       '@types/node': 18.17.7
       yoctocolors-cjs: 2.1.2
+
+  '@inquirer/figures@1.0.5': {}
 
   '@inquirer/figures@1.0.9': {}
 
@@ -11884,8 +11852,6 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
-
-  picospinner@2.0.0: {}
 
   pify@4.0.1: {}
 

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -11,9 +11,10 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"scripts": {
-		"build": "npm run build:compile && npm run lint",
+		"build": "npm run build:genver && npm run build:compile && npm run lint",
 		"build:compile": "pnpm run -r --stream build:compile",
 		"build:docker": "docker build . --build-context root=../..",
+		"build:genver": "pnpm run -r --no-sort --stream --no-bail build:genver",
 		"ci:eslint": "pnpm run -r --no-sort --stream --no-bail eslint",
 		"clean": "rimraf --glob dist \"**/*.tsbuildinfo\" \"**/*.build.log\"",
 		"format": "npm run prettier:fix",
@@ -43,7 +44,7 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -28,7 +28,7 @@
 		"tslint": "tslint \"src/**/*.ts\""
 	},
 	"dependencies": {
-		"@fluidframework/historian-base": "workspace:~",
+		"@fluidframework/historian-base": "^0.0.1",
 		"@fluidframework/server-services-shared": "6.0.0-287165",
 		"@fluidframework/server-services-utils": "6.0.0-287165",
 		"body-parser": "^1.20.3",

--- a/server/historian/pnpm-lock.yaml
+++ b/server/historian/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
   .:
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.3)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.3)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -81,7 +81,7 @@ importers:
   packages/historian:
     dependencies:
       '@fluidframework/historian-base':
-        specifier: workspace:~
+        specifier: ^0.0.1
         version: link:../historian-base
       '@fluidframework/server-services-shared':
         specifier: 6.0.0-287165
@@ -535,22 +535,13 @@ packages:
   '@fluid-internal/eslint-plugin-fluid@0.1.2':
     resolution: {integrity: sha512-E7LF4ukpCoyZcxpDUQz0edXsKllbh4m8NAdiug6sSI1KIIQFwtq5vvW3kQ0Op5xA9w10T6crfcvmuAzdP84UGg==}
 
-  '@fluid-tools/build-cli@0.54.0':
-    resolution: {integrity: sha512-BB6foF3Ps7R3QXkShpLJw1BRmYVq3vCI/1yVAhQ6WoYZZLj7GDiy1tVE+4pc5mepqyggZZw4OZTTYq9Tq2R5Cg==}
+  '@fluid-tools/build-cli@0.52.0-315632':
+    resolution: {integrity: sha512-mCnlGVEhssycNqW6N0xFjcbGjHsNG2aj+9gPtBdd4L0tWLMJyLag7SRfORdvcAuSUhvhiYbEdSGhwvRzkBl/Rw==}
     engines: {node: '>=18.17.1'}
-    hasBin: true
-
-  '@fluid-tools/build-infrastructure@0.54.0':
-    resolution: {integrity: sha512-b4Qdh1euIdP4zobVL2iF/rkURJpKo7btNhjElo3wEugO/AH+BWHbXo8hoYPK3xlOjprSCH4Yy6mVLam6OADrGQ==}
     hasBin: true
 
   '@fluid-tools/version-tools@0.52.0-315632':
     resolution: {integrity: sha512-GLglzryXTGCiBtxBnXOJcloepJhDFtujzkSqXgOMIHTMU8w+8P5qiLNDOa0N1kQHlb6Wt47sCoHG6Cz+bBQ7+Q==}
-    engines: {node: '>=18.17.1'}
-    hasBin: true
-
-  '@fluid-tools/version-tools@0.54.0':
-    resolution: {integrity: sha512-Ahqn/EQ6m1q1sjBNphm1hLdkyo9/owmA36RF9EQzq6g8W0nzrKjot4n61JkBQ9v8JkVXRbpUB8kkvZxOXB4JRw==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
@@ -563,13 +554,8 @@ packages:
     engines: {node: '>=18.17.1'}
     hasBin: true
 
-  '@fluidframework/build-tools@0.54.0':
-    resolution: {integrity: sha512-A/Ze8bfmvzqgZsh2ZmfVqYeRnl3Eo3EeQnJI7tG2cTnXBvjNA/GobuoM9tZtFyD/vsuy1xp7vz7aYh4gANJz/w==}
-    engines: {node: '>=18.17.1'}
-    hasBin: true
-
-  '@fluidframework/bundle-size-tools@0.54.0':
-    resolution: {integrity: sha512-4QwwcyzwAvZELfR16A0dnxX+BERtsOQlrs2pd7GZONjeNOXGXngnpv1e9i3w9nBbFlMehArxdHlxVS2ecYG3ow==}
+  '@fluidframework/bundle-size-tools@0.52.0-315632':
+    resolution: {integrity: sha512-QHxAJDXqtngI3d1Qfxp+xNvPw2nIwEcT74yLYpNXTYOEyChffHtI6KZ/LpSjiogTeB0YnwR9egK4X2A/57esBQ==}
 
   '@fluidframework/common-definitions@0.20.1':
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
@@ -710,6 +696,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^18.17.1
+
+  '@inquirer/figures@1.0.5':
+    resolution: {integrity: sha512-79hP/VWdZ2UVc9bFGJnoQ/lQMpL74mGgzSYX1xUqCVk7/v73vJCMw1VuyWN1jGkZ9B3z7THAbySqGbCNefcjfA==}
+    engines: {node: '>=18'}
 
   '@inquirer/figures@1.0.9':
     resolution: {integrity: sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==}
@@ -4733,10 +4723,6 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
-  picospinner@2.0.0:
-    resolution: {integrity: sha512-bRX16jAx5sDlSAEKJ26hKloGU+w2DIkGw0qeUn87WkT8xircacGumNFHS0d/s51S9QbrtoEFwRSAvIvHNstfjA==}
-    engines: {node: '>=18.0.0'}
-
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -4962,6 +4948,10 @@ packages:
   regexp.prototype.flags@1.5.2:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
+
+  registry-auth-token@5.0.2:
+    resolution: {integrity: sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==}
+    engines: {node: '>=14'}
 
   registry-auth-token@5.0.3:
     resolution: {integrity: sha512-1bpc9IyC+e+CNFRaWyn77tk4xGG4PPUyfakSmA6F6cvUDjrm58dfyJ3II+9yb10EDkHoy1LaPSmHaWLOH3m6HA==}
@@ -6641,13 +6631,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluid-tools/build-cli@0.54.0(@types/node@18.19.3)(encoding@0.1.13)(typescript@5.1.6)':
+  '@fluid-tools/build-cli@0.52.0-315632(@types/node@18.19.3)(encoding@0.1.13)(typescript@5.1.6)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/build-infrastructure': 0.54.0(@types/node@18.19.3)
-      '@fluid-tools/version-tools': 0.54.0(@types/node@18.19.3)
-      '@fluidframework/build-tools': 0.54.0(@types/node@18.19.3)
-      '@fluidframework/bundle-size-tools': 0.54.0
+      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.19.3)
+      '@fluidframework/build-tools': 0.52.0-315632(@types/node@18.19.3)
+      '@fluidframework/bundle-size-tools': 0.52.0-315632
       '@inquirer/prompts': 7.2.3(@types/node@18.19.3)
       '@microsoft/api-extractor': 7.49.1(@types/node@18.19.3)
       '@oclif/core': 4.2.4
@@ -6719,49 +6708,7 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-infrastructure@0.54.0(@types/node@18.19.3)':
-    dependencies:
-      '@fluid-tools/version-tools': 0.54.0(@types/node@18.19.3)
-      '@manypkg/get-packages': 2.2.2
-      '@oclif/core': 4.2.4
-      cosmiconfig: 8.3.6(typescript@5.4.5)
-      detect-indent: 6.1.0
-      execa: 5.1.1
-      fs-extra: 11.2.0
-      globby: 11.1.0
-      micromatch: 4.0.8
-      oclif: 4.17.17(@types/node@18.19.3)
-      picocolors: 1.1.1
-      read-pkg-up: 7.0.1
-      semver: 7.6.3
-      simple-git: 3.27.0
-      sort-package-json: 1.57.0
-      type-fest: 2.19.0
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - react-devtools-core
-      - supports-color
-      - utf-8-validate
-
   '@fluid-tools/version-tools@0.52.0-315632(@types/node@18.19.3)':
-    dependencies:
-      '@oclif/core': 4.2.4
-      '@oclif/plugin-autocomplete': 3.2.18
-      '@oclif/plugin-commands': 4.1.17
-      '@oclif/plugin-help': 6.2.22
-      '@oclif/plugin-not-found': 3.2.37(@types/node@18.19.3)
-      semver: 7.6.3
-      table: 6.9.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - react-devtools-core
-      - supports-color
-      - utf-8-validate
-
-  '@fluid-tools/version-tools@0.54.0(@types/node@18.19.3)':
     dependencies:
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
@@ -6814,43 +6761,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/build-tools@0.54.0(@types/node@18.19.3)':
-    dependencies:
-      '@fluid-tools/version-tools': 0.54.0(@types/node@18.19.3)
-      '@manypkg/get-packages': 2.2.2
-      async: 3.2.6
-      cosmiconfig: 8.3.6(typescript@5.4.5)
-      date-fns: 2.30.0
-      debug: 4.4.0(supports-color@8.1.1)
-      detect-indent: 6.1.0
-      find-up: 7.0.0
-      fs-extra: 11.2.0
-      glob: 7.2.3
-      globby: 11.1.0
-      ignore: 5.3.2
-      json5: 2.2.3
-      lodash: 4.17.21
-      lodash.isequal: 4.5.0
-      multimatch: 5.0.0
-      picocolors: 1.1.1
-      picomatch: 2.3.1
-      picospinner: 2.0.0
-      rimraf: 4.4.1
-      semver: 7.6.3
-      sort-package-json: 1.57.0
-      ts-deepmerge: 7.0.1
-      ts-morph: 22.0.0
-      type-fest: 2.19.0
-      typescript: 5.4.5
-      yaml: 2.7.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - react-devtools-core
-      - supports-color
-      - utf-8-validate
-
-  '@fluidframework/bundle-size-tools@0.54.0':
+  '@fluidframework/bundle-size-tools@0.52.0-315632':
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -7301,7 +7212,7 @@ snapshots:
 
   '@inquirer/core@9.1.0':
     dependencies:
-      '@inquirer/figures': 1.0.9
+      '@inquirer/figures': 1.0.5
       '@inquirer/type': 1.5.3
       '@types/mute-stream': 0.0.4
       '@types/node': 18.19.3
@@ -7328,6 +7239,8 @@ snapshots:
       '@inquirer/type': 3.0.2(@types/node@18.19.3)
       '@types/node': 18.19.3
       yoctocolors-cjs: 2.1.2
+
+  '@inquirer/figures@1.0.5': {}
 
   '@inquirer/figures@1.0.9': {}
 
@@ -7387,7 +7300,7 @@ snapshots:
   '@inquirer/select@2.5.0':
     dependencies:
       '@inquirer/core': 9.1.0
-      '@inquirer/figures': 1.0.9
+      '@inquirer/figures': 1.0.5
       '@inquirer/type': 1.5.3
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
@@ -12283,14 +12196,14 @@ snapshots:
   package-json@10.0.1:
     dependencies:
       ky: 1.7.4
-      registry-auth-token: 5.0.3
+      registry-auth-token: 5.0.2
       registry-url: 6.0.1
       semver: 7.6.3
 
   package-json@8.1.0:
     dependencies:
       got: 12.6.1
-      registry-auth-token: 5.0.3
+      registry-auth-token: 5.0.2
       registry-url: 6.0.1
       semver: 7.6.3
 
@@ -12421,8 +12334,6 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
-
-  picospinner@2.0.0: {}
 
   pify@2.3.0: {}
 
@@ -12668,6 +12579,10 @@ snapshots:
       define-properties: 1.2.1
       es-errors: 1.3.0
       set-function-name: 2.0.2
+
+  registry-auth-token@5.0.2:
+    dependencies:
+      '@pnpm/npm-conf': 2.2.0
 
   registry-auth-token@5.0.3:
     dependencies:

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -93,9 +93,9 @@
 	"devDependencies": {
 		"@changesets/cli": "^2.27.8",
 		"@fluid-private/changelog-generator-wrapper": "file:../../packages/tools/changelog-generator-wrapper",
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@microsoft/api-documenter": "^7.21.6",
 		"@microsoft/api-extractor": "^7.45.1",
 		"c8": "^8.0.1",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -29,9 +29,9 @@
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -32,9 +32,9 @@
 		"@fluidframework/server-services-core": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@5.0.0",
 		"@types/node": "^18.19.39",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -64,9 +64,9 @@
 		"serialize-error": "^8.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -77,9 +77,9 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -71,9 +71,9 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -78,9 +78,9 @@
 		"ws": "^7.5.10"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@5.0.0",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -65,9 +65,9 @@
 		"events_pkg": "npm:events@^3.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -86,9 +86,9 @@
 		"ws": "^7.5.10"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-local-server": "workspace:~",
 		"@fluidframework/server-routerlicious-base-previous": "npm:@fluidframework/server-routerlicious-base@5.0.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -59,9 +59,9 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-local-server": "workspace:~",
 		"@fluidframework/server-routerlicious-previous": "npm:@fluidframework/server-routerlicious@5.0.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -73,9 +73,9 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -44,9 +44,9 @@
 		"nconf": "^0.12.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@5.0.0",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -39,9 +39,9 @@
 		"sillyname": "^0.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -39,9 +39,9 @@
 		"sillyname": "^0.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -32,9 +32,9 @@
 		"zookeeper": "^5.3.2"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -79,9 +79,9 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -59,9 +59,9 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@5.0.0",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -72,9 +72,9 @@
 		"winston-transport": "^4.5.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -77,9 +77,9 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -69,9 +69,9 @@
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.54.0",
+		"@fluid-tools/build-cli": "0.52.0-315632",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.54.0",
+		"@fluidframework/build-tools": "0.52.0-315632",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@5.0.0",
 		"@types/lodash": "^4.14.118",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -27,14 +27,14 @@ importers:
         specifier: file:../../packages/tools/changelog-generator-wrapper
         version: file:../../packages/tools/changelog-generator-wrapper
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@22.10.7)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@22.10.7)
       '@microsoft/api-documenter':
         specifier: ^7.21.6
         version: 7.22.21(@types/node@22.10.7)
@@ -72,14 +72,14 @@ importers:
   packages/gitresources:
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@22.10.7)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@22.10.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -118,14 +118,14 @@ importers:
         version: link:../services-core
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -224,14 +224,14 @@ importers:
         version: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -333,14 +333,14 @@ importers:
         version: 8.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -424,14 +424,14 @@ importers:
         version: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)(webpack-cli@5.1.4)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -563,14 +563,14 @@ importers:
         version: 7.5.10
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -624,14 +624,14 @@ importers:
         version: events@3.3.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -736,14 +736,14 @@ importers:
         version: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -881,14 +881,14 @@ importers:
         version: 7.5.10
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1059,14 +1059,14 @@ importers:
         version: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1165,14 +1165,14 @@ importers:
         version: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1259,14 +1259,14 @@ importers:
         version: 0.12.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1332,14 +1332,14 @@ importers:
         version: 0.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1411,14 +1411,14 @@ importers:
         version: 0.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1472,14 +1472,14 @@ importers:
         version: 5.6.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1599,14 +1599,14 @@ importers:
         version: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1687,14 +1687,14 @@ importers:
         version: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1793,14 +1793,14 @@ importers:
         version: 4.5.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1920,14 +1920,14 @@ importers:
         version: 9.0.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.54.0
-        version: 0.54.0(@types/node@18.19.39)
+        specifier: 0.52.0-315632
+        version: 0.52.0-315632(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -2440,17 +2440,13 @@ packages:
   '@fluid-private/changelog-generator-wrapper@file:../../packages/tools/changelog-generator-wrapper':
     resolution: {directory: ../../packages/tools/changelog-generator-wrapper, type: directory}
 
-  '@fluid-tools/build-cli@0.54.0':
-    resolution: {integrity: sha512-BB6foF3Ps7R3QXkShpLJw1BRmYVq3vCI/1yVAhQ6WoYZZLj7GDiy1tVE+4pc5mepqyggZZw4OZTTYq9Tq2R5Cg==}
+  '@fluid-tools/build-cli@0.52.0-315632':
+    resolution: {integrity: sha512-mCnlGVEhssycNqW6N0xFjcbGjHsNG2aj+9gPtBdd4L0tWLMJyLag7SRfORdvcAuSUhvhiYbEdSGhwvRzkBl/Rw==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
-  '@fluid-tools/build-infrastructure@0.54.0':
-    resolution: {integrity: sha512-b4Qdh1euIdP4zobVL2iF/rkURJpKo7btNhjElo3wEugO/AH+BWHbXo8hoYPK3xlOjprSCH4Yy6mVLam6OADrGQ==}
-    hasBin: true
-
-  '@fluid-tools/version-tools@0.54.0':
-    resolution: {integrity: sha512-Ahqn/EQ6m1q1sjBNphm1hLdkyo9/owmA36RF9EQzq6g8W0nzrKjot4n61JkBQ9v8JkVXRbpUB8kkvZxOXB4JRw==}
+  '@fluid-tools/version-tools@0.52.0-315632':
+    resolution: {integrity: sha512-GLglzryXTGCiBtxBnXOJcloepJhDFtujzkSqXgOMIHTMU8w+8P5qiLNDOa0N1kQHlb6Wt47sCoHG6Cz+bBQ7+Q==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
@@ -2458,13 +2454,13 @@ packages:
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
     hasBin: true
 
-  '@fluidframework/build-tools@0.54.0':
-    resolution: {integrity: sha512-A/Ze8bfmvzqgZsh2ZmfVqYeRnl3Eo3EeQnJI7tG2cTnXBvjNA/GobuoM9tZtFyD/vsuy1xp7vz7aYh4gANJz/w==}
+  '@fluidframework/build-tools@0.52.0-315632':
+    resolution: {integrity: sha512-L0mwaMA12xppnng21dp64nCJ6As06XOWsbG+pSi3T1n8RCharRkgUVNH7fGW+OeIUnBDGgqCp/k+I/AKnQfaww==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
-  '@fluidframework/bundle-size-tools@0.54.0':
-    resolution: {integrity: sha512-4QwwcyzwAvZELfR16A0dnxX+BERtsOQlrs2pd7GZONjeNOXGXngnpv1e9i3w9nBbFlMehArxdHlxVS2ecYG3ow==}
+  '@fluidframework/bundle-size-tools@0.52.0-315632':
+    resolution: {integrity: sha512-QHxAJDXqtngI3d1Qfxp+xNvPw2nIwEcT74yLYpNXTYOEyChffHtI6KZ/LpSjiogTeB0YnwR9egK4X2A/57esBQ==}
 
   '@fluidframework/common-definitions@1.1.0':
     resolution: {integrity: sha512-WQYtG9tkx2j7i1JSXPvwLnQsqCOZAghMj0aGciqjZVNppUly/XBpAjb4V6FEUCEjxCScPKhyE+1rhV1ep52NgA==}
@@ -4124,6 +4120,9 @@ packages:
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
+
+  builtins@5.0.1:
+    resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
 
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -6560,6 +6559,10 @@ packages:
     resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minimatch@9.0.4:
+    resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -7163,10 +7166,6 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
-  picospinner@2.0.0:
-    resolution: {integrity: sha512-bRX16jAx5sDlSAEKJ26hKloGU+w2DIkGw0qeUn87WkT8xircacGumNFHS0d/s51S9QbrtoEFwRSAvIvHNstfjA==}
-    engines: {node: '>=18.0.0'}
-
   pidusage@2.0.21:
     resolution: {integrity: sha512-cv3xAQos+pugVX+BfXpHsbyz/dLzX+lr44zNMsYiGxUw+kV5sgQCIcLd1z+0vq+KyC7dJ+/ts2PsfgWfSC3WXA==}
     engines: {node: '>=8'}
@@ -7492,6 +7491,10 @@ packages:
   regexp.prototype.flags@1.5.2:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
+
+  registry-auth-token@5.0.2:
+    resolution: {integrity: sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==}
+    engines: {node: '>=14'}
 
   registry-auth-token@5.0.3:
     resolution: {integrity: sha512-1bpc9IyC+e+CNFRaWyn77tk4xGG4PPUyfakSmA6F6cvUDjrm58dfyJ3II+9yb10EDkHoy1LaPSmHaWLOH3m6HA==}
@@ -8522,6 +8525,10 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  validate-npm-package-name@5.0.0:
+    resolution: {integrity: sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -9301,7 +9308,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.6.3
+      semver: 7.6.0
 
   '@changesets/assemble-release-plan@6.0.4':
     dependencies:
@@ -9310,7 +9317,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.1
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.6.3
+      semver: 7.6.0
 
   '@changesets/changelog-git@0.2.0':
     dependencies:
@@ -9367,8 +9374,8 @@ snapshots:
     dependencies:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      picocolors: 1.1.1
-      semver: 7.6.3
+      picocolors: 1.1.0
+      semver: 7.6.0
 
   '@changesets/get-release-plan@4.0.4':
     dependencies:
@@ -9391,7 +9398,7 @@ snapshots:
 
   '@changesets/logger@0.1.1':
     dependencies:
-      picocolors: 1.1.1
+      picocolors: 1.1.0
 
   '@changesets/parse@0.4.0':
     dependencies:
@@ -9413,7 +9420,7 @@ snapshots:
       '@changesets/types': 6.0.0
       fs-extra: 7.0.1
       p-filter: 2.1.0
-      picocolors: 1.1.1
+      picocolors: 1.1.0
 
   '@changesets/should-skip-package@0.1.1':
     dependencies:
@@ -9503,13 +9510,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluid-tools/build-cli@0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)':
+  '@fluid-tools/build-cli@0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/build-infrastructure': 0.54.0(@types/node@18.19.39)
-      '@fluid-tools/version-tools': 0.54.0(@types/node@18.19.39)
-      '@fluidframework/build-tools': 0.54.0(@types/node@18.19.39)
-      '@fluidframework/bundle-size-tools': 0.54.0
+      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.19.39)
+      '@fluidframework/build-tools': 0.52.0-315632(@types/node@18.19.39)
+      '@fluidframework/bundle-size-tools': 0.52.0-315632
       '@inquirer/prompts': 7.2.3(@types/node@18.19.39)
       '@microsoft/api-extractor': 7.49.1(@types/node@18.19.39)
       '@oclif/core': 4.2.4
@@ -9581,13 +9587,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-cli@0.54.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)(webpack-cli@5.1.4)':
+  '@fluid-tools/build-cli@0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)(webpack-cli@5.1.4)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/build-infrastructure': 0.54.0(@types/node@18.19.39)
-      '@fluid-tools/version-tools': 0.54.0(@types/node@18.19.39)
-      '@fluidframework/build-tools': 0.54.0(@types/node@18.19.39)
-      '@fluidframework/bundle-size-tools': 0.54.0(webpack-cli@5.1.4)
+      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.19.39)
+      '@fluidframework/build-tools': 0.52.0-315632(@types/node@18.19.39)
+      '@fluidframework/bundle-size-tools': 0.52.0-315632(webpack-cli@5.1.4)
       '@inquirer/prompts': 7.2.3(@types/node@18.19.39)
       '@microsoft/api-extractor': 7.49.1(@types/node@18.19.39)
       '@oclif/core': 4.2.4
@@ -9659,13 +9664,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-cli@0.54.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)':
+  '@fluid-tools/build-cli@0.52.0-315632(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/build-infrastructure': 0.54.0(@types/node@22.10.7)
-      '@fluid-tools/version-tools': 0.54.0(@types/node@22.10.7)
-      '@fluidframework/build-tools': 0.54.0(@types/node@22.10.7)
-      '@fluidframework/bundle-size-tools': 0.54.0
+      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@22.10.7)
+      '@fluidframework/build-tools': 0.52.0-315632(@types/node@22.10.7)
+      '@fluidframework/bundle-size-tools': 0.52.0-315632
       '@inquirer/prompts': 7.2.3(@types/node@22.10.7)
       '@microsoft/api-extractor': 7.49.1(@types/node@22.10.7)
       '@oclif/core': 4.2.4
@@ -9737,59 +9741,7 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-infrastructure@0.54.0(@types/node@18.19.39)':
-    dependencies:
-      '@fluid-tools/version-tools': 0.54.0(@types/node@18.19.39)
-      '@manypkg/get-packages': 2.2.2
-      '@oclif/core': 4.2.4
-      cosmiconfig: 8.3.6(typescript@5.4.5)
-      detect-indent: 6.1.0
-      execa: 5.1.1
-      fs-extra: 11.3.0
-      globby: 11.1.0
-      micromatch: 4.0.8
-      oclif: 4.17.17(@types/node@18.19.39)
-      picocolors: 1.1.1
-      read-pkg-up: 7.0.1
-      semver: 7.6.3
-      simple-git: 3.27.0
-      sort-package-json: 1.57.0
-      type-fest: 2.19.0
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - react-devtools-core
-      - supports-color
-      - utf-8-validate
-
-  '@fluid-tools/build-infrastructure@0.54.0(@types/node@22.10.7)':
-    dependencies:
-      '@fluid-tools/version-tools': 0.54.0(@types/node@22.10.7)
-      '@manypkg/get-packages': 2.2.2
-      '@oclif/core': 4.2.4
-      cosmiconfig: 8.3.6(typescript@5.4.5)
-      detect-indent: 6.1.0
-      execa: 5.1.1
-      fs-extra: 11.3.0
-      globby: 11.1.0
-      micromatch: 4.0.8
-      oclif: 4.17.17(@types/node@22.10.7)
-      picocolors: 1.1.1
-      read-pkg-up: 7.0.1
-      semver: 7.6.3
-      simple-git: 3.27.0
-      sort-package-json: 1.57.0
-      type-fest: 2.19.0
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - react-devtools-core
-      - supports-color
-      - utf-8-validate
-
-  '@fluid-tools/version-tools@0.54.0(@types/node@18.19.39)':
+  '@fluid-tools/version-tools@0.52.0-315632(@types/node@18.19.39)':
     dependencies:
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
@@ -9805,7 +9757,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/version-tools@0.54.0(@types/node@22.10.7)':
+  '@fluid-tools/version-tools@0.52.0-315632(@types/node@22.10.7)':
     dependencies:
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
@@ -9823,9 +9775,9 @@ snapshots:
 
   '@fluidframework/build-common@2.0.3': {}
 
-  '@fluidframework/build-tools@0.54.0(@types/node@18.19.39)':
+  '@fluidframework/build-tools@0.52.0-315632(@types/node@18.19.39)':
     dependencies:
-      '@fluid-tools/version-tools': 0.54.0(@types/node@18.19.39)
+      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.19.39)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -9843,7 +9795,6 @@ snapshots:
       multimatch: 5.0.0
       picocolors: 1.1.1
       picomatch: 2.3.1
-      picospinner: 2.0.0
       rimraf: 4.4.1
       semver: 7.6.3
       sort-package-json: 1.57.0
@@ -9859,9 +9810,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/build-tools@0.54.0(@types/node@22.10.7)':
+  '@fluidframework/build-tools@0.52.0-315632(@types/node@22.10.7)':
     dependencies:
-      '@fluid-tools/version-tools': 0.54.0(@types/node@22.10.7)
+      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@22.10.7)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -9879,7 +9830,6 @@ snapshots:
       multimatch: 5.0.0
       picocolors: 1.1.1
       picomatch: 2.3.1
-      picospinner: 2.0.0
       rimraf: 4.4.1
       semver: 7.6.3
       sort-package-json: 1.57.0
@@ -9895,7 +9845,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/bundle-size-tools@0.54.0':
+  '@fluidframework/bundle-size-tools@0.52.0-315632':
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -9909,7 +9859,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@fluidframework/bundle-size-tools@0.54.0(webpack-cli@5.1.4)':
+  '@fluidframework/bundle-size-tools@0.52.0-315632(webpack-cli@5.1.4)':
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -12740,6 +12690,10 @@ snapshots:
 
   builtin-modules@3.3.0: {}
 
+  builtins@5.0.1:
+    dependencies:
+      semver: 7.6.3
+
   bytes@3.0.0: {}
 
   bytes@3.1.2: {}
@@ -14301,7 +14255,7 @@ snapshots:
       dir-glob: 3.0.1
       fast-glob: 3.3.2
       glob: 7.2.3
-      ignore: 5.3.2
+      ignore: 5.3.0
       merge2: 1.4.1
       slash: 3.0.0
 
@@ -14310,7 +14264,7 @@ snapshots:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.2
+      ignore: 5.3.0
       merge2: 1.4.1
       slash: 3.0.0
 
@@ -15628,6 +15582,10 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
+  minimatch@9.0.4:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
@@ -15958,7 +15916,7 @@ snapshots:
       jsonlines: 0.1.1
       lodash: 4.17.21
       make-fetch-happen: 11.1.1
-      minimatch: 9.0.5
+      minimatch: 9.0.4
       p-map: 4.0.0
       pacote: 15.2.0
       parse-github-url: 1.0.2
@@ -15990,7 +15948,7 @@ snapshots:
       hosted-git-info: 6.1.1
       proc-log: 3.0.0
       semver: 7.6.3
-      validate-npm-package-name: 5.0.1
+      validate-npm-package-name: 5.0.0
 
   npm-packlist@7.0.4:
     dependencies:
@@ -16250,14 +16208,14 @@ snapshots:
   package-json@10.0.1:
     dependencies:
       ky: 1.7.4
-      registry-auth-token: 5.0.3
+      registry-auth-token: 5.0.2
       registry-url: 6.0.1
       semver: 7.6.3
 
   package-json@8.1.1:
     dependencies:
       got: 12.6.1
-      registry-auth-token: 5.0.3
+      registry-auth-token: 5.0.2
       registry-url: 6.0.1
       semver: 7.6.3
 
@@ -16389,8 +16347,6 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
-
-  picospinner@2.0.0: {}
 
   pidusage@2.0.21:
     dependencies:
@@ -16800,6 +16756,10 @@ snapshots:
       define-properties: 1.2.1
       es-errors: 1.3.0
       set-function-name: 2.0.2
+
+  registry-auth-token@5.0.2:
+    dependencies:
+      '@pnpm/npm-conf': 2.2.2
 
   registry-auth-token@5.0.3:
     dependencies:
@@ -17988,6 +17948,10 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  validate-npm-package-name@5.0.0:
+    dependencies:
+      builtins: 5.0.1
 
   validate-npm-package-name@5.0.1: {}
 


### PR DESCRIPTION
Reverts microsoft/FluidFramework#23830

Bump to 0.54 caused call stack exceeded errors when building locally