### PR TITLE
Fix an edge case during document lambda resume

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -74,7 +74,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 					headOffset: this.head.offset,
 					tailOffset: this.tail.offset,
 					lastSuccessfulOffset: this.lastSuccessfulOffset,
-				}
+				},
 			);
 		}
 	}

--- a/server/routerlicious/packages/lambdas/src/utils/noOpLambda.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/noOpLambda.ts
@@ -27,6 +27,9 @@ export class NoOpLambda implements IPartitionLambda {
 		// default
 		if (!this.checkpointConfiguration?.enabled) {
 			this.context.checkpoint(message);
+			if (this.context.setLastSuccessfulOffset) {
+				this.context.setLastSuccessfulOffset(message.offset);
+			}
 			return undefined;
 		}
 


### PR DESCRIPTION
## Description

When resuming a document lambda, there is an edge case which causes checkpoint assertion error. That is when the following sequence of events happen:
1. During resume, documentLambda handler calls contextManager.setHead with the resumed offset.
2. The above call sets headPaused = false in the context Manager and resets its head to the resumed offset (offset1).
3. Then documentLambda calls contextManager.createContext for offset1 which creates a new document context with head = offset1, but the tail is set to contextManager's tail which is not yet updated to the resumed offset1. So it holds an invalid value.
4. documentContext.checkpoint is called for offset1 -> Throws assertion error because of inaccurate tail offset.
5. Then documentLambda handler calls contextManager.setTail which updates the contextManager's tail to offset1 and sets tailPaused = false.

This PR fixes step 3, i.e. resets the tail to an initial value in this case because the previous checkpointed offset for a new documentContext is unknown at this point. Also resets the lastSuccessfulOffset.

Additionally, also updated NoOpLambda to call setLastSuccessfulOffset for ephemeral documents.