### PR TITLE
(gc) Rename garbagecollection.md to README.md and update it

### DIFF
--- a/packages/runtime/container-runtime/src/gc/README.md
+++ b/packages/runtime/container-runtime/src/gc/README.md
@@ -18,7 +18,7 @@ These sections speak of a "referenced DDS" which refers to a DDS that is created
 
 There are 2 ways to reference a data store:
 
--   Store the data stores's handle (see [IFluidHandle](../../../../../packages/common/core-interfaces/src/handles.ts)) in a referenced DDS that supports handle in its data.
+-   Store the data store's handle (see [IFluidHandle](../../../../../packages/common/core-interfaces/src/handles.ts)) in a referenced DDS that supports handles in its data.
 For example, a data store's handle can be stored in a referenced `SharedMap` DDS.
 
     Storing a handle of any of a data store's DDS will also mark the data store as referenced.

--- a/packages/runtime/container-runtime/src/gc/README.md
+++ b/packages/runtime/container-runtime/src/gc/README.md
@@ -18,7 +18,7 @@ These sections speak of a "referenced DDS" which refers to a DDS that is created
 
 There are 2 ways to reference a data store:
 
--   Store the data store's handle (see [IFluidHandle](../../../../../packages/common/core-interfaces/src/handles.ts)) in a referenced DDS that supports handles in its data.
+-   Store the data store's handle (see [IFluidHandle](../../../../../packages/common/core-interfaces/src/handles.ts)) in a referenced DDS that supports handle in its data.
 For example, a data store's handle can be stored in a referenced `SharedMap` DDS.
 
     Storing a handle of any of a data store's DDS will also mark the data store as referenced.


### PR DESCRIPTION
Renamed the `garbagecollection.md` doc to `README.md` so that it is displayed when navigating to the `gc` folder in github.
Added a note about "auto recovery", removed the `More Advanced Configuration` section as the correspnding doc doesn't exist anymore and did some re-structuring of the initial couple of sections.