### PR TITLE
WIP: Moving handle binding up to channel context

### DIFF
--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -459,10 +459,7 @@ export abstract class SharedObjectCore<
 		this.verifyNotClosed();
 		if (this.isAttached()) {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			this.services!.deltaConnection.submit(
-				makeHandlesSerializable(content, this.serializer, this.handle),
-				localOpMetadata,
-			);
+			this.services!.deltaConnection.submit(content, localOpMetadata);
 		}
 	}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -4200,6 +4200,8 @@ export class ContainerRuntime
 				});
 			}
 
+			//* NEXT: Stop stringifying here and throughout op lifecycle,
+			//* so we can keep the viable contents all the way through to resubmit
 			const message: BatchMessage = {
 				contents: serializeOpContents(containerRuntimeMessage),
 				metadata,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -89,6 +89,7 @@ import type {
 	IInboundSignalMessage,
 	IRuntimeMessagesContent,
 	ISummarizerNodeWithGC,
+	IFluidParentContext,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	FlushMode,
@@ -166,6 +167,7 @@ import {
 	IGarbageCollector,
 	gcGenerationOptionName,
 	type GarbageCollectionMessage,
+	type IGarbageCollectionRuntime,
 } from "./gc/index.js";
 import { InboundBatchAggregator } from "./inboundBatchAggregator.js";
 import { RuntimeCompatDetails, validateLoaderCompatibility } from "./layerCompatState.js";
@@ -712,8 +714,10 @@ export class ContainerRuntime
 	implements
 		IContainerRuntime,
 		IRuntime,
+		IGarbageCollectionRuntime,
 		ISummarizerRuntime,
 		ISummarizerInternalsProvider,
+		IFluidParentContext,
 		IProvideFluidHandleContext,
 		IProvideLayerCompatDetails
 {

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -333,6 +333,8 @@ export type GarbageCollectionMessage = ISweepMessage | ITombstoneLoadedMessage;
 
 /**
  * Defines the APIs for the runtime object to be passed to the garbage collector.
+ *
+ * @internal
  */
 export interface IGarbageCollectionRuntime {
 	/**

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -36,6 +36,7 @@ export {
 	IGCMetadata,
 	GCFeatureMatrix,
 	GCVersion,
+	IGarbageCollectionRuntime,
 	IGCRuntimeOptions,
 	IMarkPhaseStats,
 	ISweepPhaseStats,

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -237,6 +237,7 @@ export class RehydratedLocalChannelContext extends LocalChannelContextBase {
 				}
 				return createChannelServiceEndpoints(
 					dataStoreContext.connected,
+					//* TODO: Do the same as in remoteChannelContext (maybe move into createChannelServiceEndpoints?)
 					submitFn,
 					this.dirtyFn,
 					() => this.isGloballyVisible,


### PR DESCRIPTION
## Reviewer Guidance

_Exploratory PR, not ready for review_

## Description

Trying to decouple handle binding and encoding, and move it all out of the DDS layer.

Handle binding seems like it can happen in the channel context, and ideally encoding will happen at the last moment before sending to DeltaManager.

This second part is hard and would go into a separate prerequisite PR.  Currently the ContainerRuntime serializes the content right away.  The compression and chunking code depends on contents being a string to be able to estimate payload sizes, so we may still need to stringify sometimes, but we can hopefully leave the actual message unserialized until the last moment.