### PR TITLE
Blob Placeholder: Enable no wait

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -353,6 +353,10 @@ export class BlobManager {
 		return [...this.pendingBlobs.values()].some((e) => e.stashedUpload === true);
 	}
 
+	public hasBlob(blobId: string): boolean {
+		return this.redirectTable.get(blobId) !== undefined;
+	}
+
 	public async getBlob(blobId: string): Promise<ArrayBufferLike> {
 		// Verify that the blob is not deleted, i.e., it has not been garbage collected. If it is, this will throw
 		// an error, failing the call.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -147,6 +147,7 @@ import {
 import {
 	ChannelCollection,
 	getSummaryForDatastores,
+	RuntimeHeaders,
 	wrapContext,
 } from "./channelCollection.js";
 import { ReportOpPerfTelemetry } from "./connectionTelemetry.js";
@@ -2211,7 +2212,15 @@ export class ContainerRuntime
 			}
 
 			if (id === blobManagerBasePath && requestParser.isLeaf(2)) {
+				if (
+					!this.blobManager.hasBlob(requestParser.pathParts[1]) &&
+					requestParser.headers?.[RuntimeHeaders.wait] === false
+				) {
+					return create404Response(request);
+				}
+
 				const blob = await this.blobManager.getBlob(requestParser.pathParts[1]);
+
 				return {
 					status: 200,
 					mimeType: "fluid/object",


### PR DESCRIPTION
This is just for testing purposes. We intentionally make it very hard to observe local object creation, and attach state, in a broad way. Test like the local server stress work around this by storing absolute paths, which allow remote clients to find objects one they are attached but avoid attaching them at that point. Clients walk the list of absolute paths, and find those they can resolve, and then use those in dds operations, this can lead to attach, multiple handles to the same object, and reviving unreferenced objects. 