### PR TITLE
test: Allow selecting PPE env for r11s tests

### DIFF
--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -97,7 +97,7 @@ stages:
       artifactBuildId: $(resources.pipeline.client.runID)
       testCommand: test:realsvc:routerlicious:report
       continueOnError: true
-      ${{ if eq(parameters.useR11sPpeEnvironment, 'true') }}:
+      ${{ if eq(parameters.useR11sPpeEnvironment, true) }}:
         r11sSelfSignedCertSecureFile: wu2-ppe-tls-certificate.pem
       ${{ else }}:
         r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -8,6 +8,16 @@ name: $(Build.BuildId)
 trigger: none
 pr: none
 
+parameters:
+# If true, the routerlicious tests will run against the PPE (aka non-prod) environment.
+# This can be useful when we need to make changes to the routerlicious cluster
+# and we can make them in the PPE environment first before making them in the "prod" environment
+# that the tests normally target.
+- name: useR11sPpeEnvironment
+  displayName: Use PPE Routerlicious environment?
+  type: boolean
+  default: false
+
 resources:
   pipelines:
   - pipeline: client   # Name of the pipeline resource
@@ -87,7 +97,10 @@ stages:
       artifactBuildId: $(resources.pipeline.client.runID)
       testCommand: test:realsvc:routerlicious:report
       continueOnError: true
-      r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
+      ${{ if eq(parameters.useR11sPpeEnvironment, 'true') }}:
+        r11sSelfSignedCertSecureFile: wu2-ppe-tls-certificate.pem
+      ${{ else }}:
+        r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
       stageVariables:
         - group: e2e-r11s-lock
       splitTestVariants:
@@ -103,7 +116,10 @@ stages:
       uploadTestPassRateTelemetry: true
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       env:
-        fluid__test__driver__r11s: $(automation-fluid-test-driver-r11s)
+        ${{ if eq(parameters.useR11sPpeEnvironment, 'true') }}:
+          fluid__test__driver__r11s: $(automation-fluid-test-driver-r11s-ppe)
+        ${{ else }}:
+          fluid__test__driver__r11s: $(automation-fluid-test-driver-r11s)
         FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
         FLUID_LOGGER_PROPS: '{ "displayName": "${{variables.pipelineIdentifierForTelemetry}}"}'
 

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -116,7 +116,7 @@ stages:
       uploadTestPassRateTelemetry: true
       pipelineIdentifierForTelemetry: ${{ variables.pipelineIdentifierForTelemetry }}
       env:
-        ${{ if eq(parameters.useR11sPpeEnvironment, 'true') }}:
+        ${{ if eq(parameters.useR11sPpeEnvironment, true) }}:
           fluid__test__driver__r11s: $(automation-fluid-test-driver-r11s-ppe)
         ${{ else }}:
           fluid__test__driver__r11s: $(automation-fluid-test-driver-r11s)


### PR DESCRIPTION
## Description

Add a parameter to the e2e tests pipeline to run against the PPE (aka non-prod) environment of our internal routerlicious deployment.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).