### PR TITLE
build(client-bundle-size-tests): clarify build

### DIFF
--- a/examples/utils/bundle-size-tests/.gitignore
+++ b/examples/utils/bundle-size-tests/.gitignore
@@ -1,3 +1,4 @@
+build
 dist
 node_modules
 lib

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -16,20 +16,22 @@
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
 		"build:esnext": "tsc --project ./tsconfig.json",
-		"build:test": "tsc --project ./src/test/tsconfig.json",
+		"build:test": "npm run build:test:esm",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:biome": "biome check .",
 		"check:format": "npm run check:biome",
-		"clean": "rimraf --glob dist lib bundleAnalysis \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
+		"clean": "rimraf --glob build dist lib bundleAnalysis \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
 		"eslint": "eslint --format stylish src",
 		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
-		"explore:tree": "npm run build && npm run webpack && source-map-explorer ./dist/sharedTree.js --html bundleAnalysis/reportTree.html",
+		"explore:tree": "fluid-build . --task webpack && source-map-explorer ./build/sharedTree.js --html bundleAnalysis/reportTree.html",
 		"format": "npm run format:biome",
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"prepack": "npm run webpack",
 		"test": "npm run test:mocha",
-		"test:mocha": "mocha",
+		"test:mocha": "npm run test:mocha:esm",
+		"test:mocha:esm": "mocha",
 		"webpack": "webpack",
 		"webpack:profile": "npm run webpack"
 	},
@@ -77,23 +79,13 @@
 	],
 	"fluidBuild": {
 		"tasks": {
-			"webpack": {
-				"dependsOn": [
-					"build"
-				]
-			},
-			"test:mocha": {
-				"dependsOn": [
-					"...",
-					"webpack"
-				]
-			},
-			"build:test": {
-				"dependsOn": [
-					"...",
-					"build:esnext"
-				]
-			}
+			"webpack": [
+				"^build:esnext"
+			],
+			"test:mocha:esm": [
+				"...",
+				"webpack"
+			]
 		}
 	},
 	"typeValidation": {

--- a/examples/utils/bundle-size-tests/src/debugAssert.ts
+++ b/examples/utils/bundle-size-tests/src/debugAssert.ts
@@ -6,7 +6,7 @@
 import { debugAssert, assert } from "@fluidframework/core-utils/internal";
 
 // TODO: ideally there would be a unit test which actually checks that this is omitted from production builds.
-// For now it can be manually verified in ../dist/debugAssert.js,
+// For now it can be manually verified in ../build/debugAssert.js,
 // and any regression breaking it will show up as a bundle size regression.
 debugAssert(() => "This should be removed in production");
 assert(true, "This should be kept 1");

--- a/examples/utils/bundle-size-tests/src/test/checkDebugAsserts.spec.ts
+++ b/examples/utils/bundle-size-tests/src/test/checkDebugAsserts.spec.ts
@@ -9,7 +9,7 @@ import { readFileSync } from "node:fs";
 describe("checkDebugAsserts", () => {
 	it("examples", () => {
 		// This file must be run after webpack.
-		const bundle = readFileSync("./dist/debugAssert.js", "utf-8");
+		const bundle = readFileSync("./build/debugAssert.js", "utf-8");
 
 		assert.match(bundle, /kept 1/);
 		assert.match(bundle, /kept 2/);

--- a/examples/utils/bundle-size-tests/src/test/checkSizes.spec.ts
+++ b/examples/utils/bundle-size-tests/src/test/checkSizes.spec.ts
@@ -12,7 +12,7 @@ import { readFileSync } from "node:fs";
 describe("checkSizes", () => {
 	it("sharedTreeAttributes", () => {
 		// This test must be run after webpack.
-		const bundle = readFileSync("./dist/sharedTreeAttributes.js", "utf-8");
+		const bundle = readFileSync("./build/sharedTreeAttributes.js", "utf-8");
 
 		// Make sure it contains something
 		assert(bundle.length > 10);

--- a/examples/utils/bundle-size-tests/webpack.config.cjs
+++ b/examples/utils/bundle-size-tests/webpack.config.cjs
@@ -92,7 +92,7 @@ module.exports = {
 		extensions: [".tsx", ".ts", ".js"],
 	},
 	output: {
-		path: path.resolve(__dirname, "dist"),
+		path: path.resolve(__dirname, "build"),
 		library: "bundle",
 	},
 	node: false,


### PR DESCRIPTION
Make it clear that package is ESM by not using dist folder for webpack. Instead use a `build` output directory.
Additionally clean up the build scripts:
- explicitly add `:esm` versions such that `:esm` qualified commands like `build-and-test:mocha:esm` will pick these up.
- correct and simplify dependencies (webpack does not use the output of `build:esnext`, only required that dependencies have built ESM.)