### PR TITLE
(prototype) New interface IAttachableNode for attachGraph and bind

### DIFF
--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -21,11 +21,35 @@ export interface IProvideFluidHandleContext {
 }
 
 /**
+ * A node that may be attached to a graph of nodes, along with other "bound" nodes.
+ *
+ * @legacy
+ * @alpha
+ */
+export interface IAttachableNode {
+	/**
+	 * Flag indicating whether or not the entity is attached.
+	 */
+	readonly isAttached: boolean;
+
+	/**
+	 * Attach this node and any nodes it has previously bound.
+	 */
+	attachGraph(): void;
+
+	/**
+	 * Track a reference from this node to the given node,
+	 * such that when this is attached, the other will be as well.
+	 */
+	bind(node: IAttachableNode): void;
+}
+
+/**
  * Describes a routing context from which other `IFluidHandleContext`s are defined.
  * @legacy
  * @alpha
  */
-export interface IFluidHandleContext extends IProvideFluidHandleContext {
+export interface IFluidHandleContext extends IProvideFluidHandleContext, IAttachableNode {
 	/**
 	 * The absolute path to the handle context from the root.
 	 */
@@ -37,15 +61,6 @@ export interface IFluidHandleContext extends IProvideFluidHandleContext {
 	 */
 	readonly routeContext?: IFluidHandleContext;
 
-	/**
-	 * Flag indicating whether or not the entity has services attached.
-	 */
-	readonly isAttached: boolean;
-
-	/**
-	 * Runs through the graph and attach the bounded handles.
-	 */
-	attachGraph(): void;
 
 	resolveHandle(request: IRequest): Promise<IResponse>;
 }
@@ -82,23 +97,12 @@ export interface IProvideFluidHandle {
 export interface IFluidHandleInternal<
 	// REVIEW: Constrain `T` to something? How do we support dds and datastores safely?
 	out T = unknown, // FluidObject & IFluidLoadable,
-> extends IFluidHandle<T>,
+> extends IFluidHandle<T>, IAttachableNode,
 		IProvideFluidHandle {
 	/**
 	 * The absolute path to the handle context from the root.
 	 */
 	readonly absolutePath: string;
-
-	/**
-	 * Runs through the graph and attach the bounded handles.
-	 */
-	attachGraph(): void;
-
-	/**
-	 * Binds the given handle to this one or attach the given handle if this handle is attached.
-	 * A bound handle will also be attached once this handle is attached.
-	 */
-	bind(handle: IFluidHandleInternal): void;
 }
 
 /**

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -28,6 +28,7 @@ export { IFluidLoadable, IFluidRunnable } from "./fluidLoadable.js";
 export type { IRequest, IRequestHeader, IResponse } from "./fluidRouter.js";
 
 export type {
+	IAttachableNode,
 	IProvideFluidHandleContext,
 	IProvideFluidHandle,
 	IFluidHandleInternal,

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -460,7 +460,7 @@ export abstract class SharedObjectCore<
 		if (this.isAttached()) {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			this.services!.deltaConnection.submit(
-				makeHandlesSerializable(content, this.serializer, this.handle),
+				makeHandlesSerializable(content, this.serializer, this.runtime.channelsRoutingContext),
 				localOpMetadata,
 			);
 		}

--- a/packages/dds/shared-object-base/src/test/utils.ts
+++ b/packages/dds/shared-object-base/src/test/utils.ts
@@ -27,6 +27,10 @@ export class MockHandleContext implements IFluidHandleContext {
 		throw new Error("Method not implemented.");
 	}
 
+	public bind(): void {
+		throw new Error("Method not implemented.");
+	}
+
 	public async resolveHandle(request: IRequest): Promise<IResponse> {
 		return create404Response(request);
 	}

--- a/packages/dds/shared-object-base/src/utils.ts
+++ b/packages/dds/shared-object-base/src/utils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IAttachableNode } from "@fluidframework/core-interfaces/internal";
 import type { IChannel } from "@fluidframework/datastore-definitions/internal";
 import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/internal";
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils/internal";
@@ -23,7 +23,7 @@ import { IFluidSerializer } from "./serializer.js";
 export function serializeHandles(
 	value: unknown,
 	serializer: IFluidSerializer,
-	bind: IFluidHandle,
+	bind: IAttachableNode,
 ): string | undefined {
 	return value === undefined ? value : serializer.stringify(value, bind);
 }
@@ -45,7 +45,7 @@ export function serializeHandles(
 export function makeHandlesSerializable(
 	value: unknown,
 	serializer: IFluidSerializer,
-	bind: IFluidHandle,
+	bind: IAttachableNode,
 ): unknown {
 	return serializer.encode(value, bind);
 }
@@ -89,7 +89,7 @@ export function createSingleBlobSummary(
 export function bindHandles(
 	value: unknown,
 	serializer: IFluidSerializer,
-	bind: IFluidHandle,
+	bind: IAttachableNode,
 ): void {
 	// N.B. AB#7316 this could be made more efficient by writing an ad hoc
 	// implementation that doesn't clone at all. Today the distinction between

--- a/packages/dds/tree/src/test/mockSerializer.ts
+++ b/packages/dds/tree/src/test/mockSerializer.ts
@@ -22,6 +22,10 @@ class MockHandleContext implements IFluidHandleContext {
 		throw new Error("Method not implemented.");
 	}
 
+	public bind(): void {
+		throw new Error("Method not implemented.");
+	}
+
 	public async resolveHandle(request: IRequest) {
 		return create404Response(request);
 	}

--- a/packages/runtime/container-runtime/src/containerHandleContext.ts
+++ b/packages/runtime/container-runtime/src/containerHandleContext.ts
@@ -5,7 +5,8 @@
 
 import { AttachState } from "@fluidframework/container-definitions";
 import { IRequest, IResponse } from "@fluidframework/core-interfaces";
-import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
+import { IFluidHandleContext, type IAttachableNode } from "@fluidframework/core-interfaces/internal";
+import { fail } from "@fluidframework/core-utils/internal";
 import { generateHandleContextPath } from "@fluidframework/runtime-utils/internal";
 
 export interface IContainerHandleContextRuntime {
@@ -34,7 +35,11 @@ export class ContainerFluidHandleContext implements IFluidHandleContext {
 	}
 
 	public attachGraph(): void {
-		throw new Error("can't attach container runtime form within container!");
+		fail("Can't attach container runtime from within container!");
+	}
+
+	public bind(node: IAttachableNode): void {
+		fail("Use alias instead of binding to the ContainerRuntime");
 	}
 
 	public get isAttached(): boolean {

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -13,7 +13,7 @@ import {
 	IResponse,
 } from "@fluidframework/core-interfaces";
 import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
-import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
+import type { IAttachableNode, IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
 import {
 	assert,
 	Deferred,
@@ -192,7 +192,7 @@ export class FluidDataStoreRuntime
 	public visibilityState: VisibilityState;
 	// A list of handles that are bound when the data store is not visible. We have to make them visible when the data
 	// store becomes visible.
-	private readonly pendingHandlesToMakeVisible: Set<IFluidHandleInternal> = new Set();
+	private readonly pendingHandlesToMakeVisible: Set<IAttachableNode> = new Set();
 
 	public readonly id: string;
 
@@ -558,7 +558,7 @@ export class FluidDataStoreRuntime
 			return;
 		}
 
-		this.bind(channel.handle);
+		this.bind(toFluidHandleInternal(channel.handle));
 
 		// If our data store is local then add the channel to the queue
 		if (!this.localChannelContextQueue.has(channel.id)) {
@@ -600,13 +600,13 @@ export class FluidDataStoreRuntime
 		this.makeVisibleAndAttachGraph();
 	}
 
-	public bind(handle: IFluidHandle): void {
+	public bind(node: IAttachableNode): void {
 		// If visible, attach the incoming handle's graph. Else, this will be done when we become visible.
 		if (this.visibilityState !== VisibilityState.NotVisible) {
-			toFluidHandleInternal(handle).attachGraph();
+			node.attachGraph();
 			return;
 		}
-		this.pendingHandlesToMakeVisible.add(toFluidHandleInternal(handle));
+		this.pendingHandlesToMakeVisible.add(node);
 	}
 
 	public setConnectionState(connected: boolean, clientId?: string) {

--- a/packages/runtime/datastore/src/fluidHandle.ts
+++ b/packages/runtime/datastore/src/fluidHandle.ts
@@ -4,7 +4,7 @@
  */
 
 import { FluidObject } from "@fluidframework/core-interfaces";
-import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
+import type { IAttachableNode } from "@fluidframework/core-interfaces/internal";
 import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import {
 	generateHandleContextPath,
@@ -19,8 +19,6 @@ import {
 export class FluidObjectHandle<
 	T extends FluidObject = FluidObject,
 > extends FluidHandleBase<T> {
-	private readonly pendingHandlesToMakeVisible: Set<IFluidHandleInternal> = new Set();
-
 	/**
 	 * {@inheritDoc @fluidframework/core-interfaces#IFluidHandle.absolutePath}
 	 */
@@ -32,30 +30,6 @@ export class FluidObjectHandle<
 	public get isAttached(): boolean {
 		return this.routeContext.isAttached;
 	}
-
-	/**
-	 * Tells whether the object of this handle is visible in the container locally or globally.
-	 */
-	private get visible(): boolean {
-		/**
-		 * If the object of this handle is attached, it is visible in the container. Ideally, checking local visibility
-		 * should be enough for a handle. However, there are scenarios where the object becomes locally visible but the
-		 * handle does not know this - This will happen is attachGraph is never called on the handle. Couple of examples
-		 * where this can happen:
-		 *
-		 * 1. Handles to DDS other than the default handle won't know if the DDS becomes visible after the handle was
-		 * created.
-		 *
-		 * 2. Handles to root data stores will never know that it was visible because the handle will not be stores in
-		 * another DDS and so, attachGraph will never be called on it.
-		 */
-		return this.isAttached || this.locallyVisible;
-	}
-
-	/**
-	 * Tracks whether this handle is locally visible in the container.
-	 */
-	private locallyVisible: boolean = false;
 
 	/**
 	 * Creates a new `FluidObjectHandle`.
@@ -86,27 +60,13 @@ export class FluidObjectHandle<
 	 * {@inheritDoc @fluidframework/core-interfaces#IFluidHandle.attachGraph }
 	 */
 	public attachGraph(): void {
-		if (this.visible) {
-			return;
-		}
-
-		this.locallyVisible = true;
-		this.pendingHandlesToMakeVisible.forEach((handle) => {
-			handle.attachGraph();
-		});
-		this.pendingHandlesToMakeVisible.clear();
 		this.routeContext.attachGraph();
 	}
 
 	/**
 	 * {@inheritDoc @fluidframework/core-interfaces#IFluidHandle.bind}
 	 */
-	public bind(handle: IFluidHandleInternal) {
-		// If this handle is visible, attach the graph of the incoming handle as well.
-		if (this.visible) {
-			handle.attachGraph();
-			return;
-		}
-		this.pendingHandlesToMakeVisible.add(handle);
+	public bind(node: IAttachableNode): void {
+		this.routeContext.bind?.(node);
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -21,6 +21,7 @@ import {
 } from "@fluidframework/core-interfaces";
 import {
 	IFluidHandleContext,
+	type IAttachableNode,
 	type IFluidHandleInternal,
 } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
@@ -957,7 +958,7 @@ export class MockFluidDataStoreRuntime
 		return;
 	}
 
-	public bind(handle: IFluidHandle): void {
+	public bind(node: IAttachableNode): void {
 		return;
 	}
 


### PR DESCRIPTION
## Reviewer Guidance

Prototype / work in progress

## Description

When adding references between objects in the runtime (DDS and DataStores), we build up temporary subgraphs such that a detached subgraph will all attach at the same time.  This logic is duplicated between DataStoreRuntime and FluidObjectHandle.

This PR pulls a new interface out of a combo of `IFluidHandleInternal` and `IFluidHandleContext`:

```
/**
 * A node that may be attached to a graph of nodes, along with other "bound" nodes.
 *
 * @legacy
 * @alpha
 */
export interface IAttachableNode {
	/**
	 * Flag indicating whether or not the entity is attached.
	 */
	readonly isAttached: boolean;

	/**
	 * Attach this node and any nodes it has previously bound.
	 */
	attachGraph(): void;

	/**
	 * Track a reference from this node to the given node,
	 * such that when this is attached, the other will be as well.
	 */
	bind(node: IAttachableNode): void;
}
```

This unifies / clarifies the places where we are doing this kind of bind and/or attach.

## Breaking Changes

Yep...
