### PR TITLE
Handles: Get rid of incorrect signature of bind(handle: IFluidHandle)

### DIFF
--- a/experimental/dds/tree/src/test/utilities/TestSerializer.ts
+++ b/experimental/dds/tree/src/test/utilities/TestSerializer.ts
@@ -39,7 +39,7 @@ export class TestFluidHandle extends FluidHandleBase<unknown> {
 		throw new Error('Method not implemented.');
 	}
 
-	public bind(handle: IFluidHandle): void {
+	public bind(): void {
 		throw new Error('Method not implemented.');
 	}
 

--- a/packages/dds/test-dds-utils/src/ddsFuzzHandle.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHandle.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { type IFluidHandle } from "@fluidframework/core-interfaces";
 import { type IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import {
 	FluidHandleBase,
@@ -41,5 +40,5 @@ export class DDSFuzzHandle extends FluidHandleBase<string> {
 		}
 	}
 
-	public bind(handle: IFluidHandle): void {}
+	public bind(): void {}
 }

--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -88,7 +88,7 @@ export class BlobHandle extends FluidHandleBase<ArrayBufferLike> {
 		}
 	}
 
-	public bind(handle: IFluidHandleInternal): void {
+	public bind(): void {
 		throw new Error("Cannot bind to blob handle");
 	}
 }

--- a/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
@@ -24,7 +24,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // (undocumented)
     get attachState(): AttachState;
     // (undocumented)
-    bind(handle: IFluidHandle): void;
+    bind(handle: IFluidHandleInternal): void;
     bindChannel(channel: IChannel): void;
     // (undocumented)
     get channelsRoutingContext(): this;

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -560,7 +560,7 @@ export class FluidDataStoreRuntime
 			return;
 		}
 
-		this.bind(channel.handle);
+		this.bind(toFluidHandleInternal(channel.handle));
 
 		// If our data store is local then add the channel to the queue
 		if (!this.localChannelContextQueue.has(channel.id)) {
@@ -602,7 +602,7 @@ export class FluidDataStoreRuntime
 		this.makeVisibleAndAttachGraph();
 	}
 
-	public bind(handle: IFluidHandle): void {
+	public bind(handle: IFluidHandleInternal): void {
 		// If visible, attach the incoming handle's graph. Else, this will be done when we become visible.
 		if (this.visibilityState !== VisibilityState.NotVisible) {
 			toFluidHandleInternal(handle).attachGraph();

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -388,7 +388,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     // (undocumented)
     get attachState(): AttachState;
     // (undocumented)
-    bind(handle: IFluidHandle): void;
+    bind(handle: IFluidHandleInternal): void;
     // (undocumented)
     bindChannel(channel: IChannel): void;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -388,7 +388,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     // (undocumented)
     get attachState(): AttachState;
     // (undocumented)
-    bind(handle: IFluidHandleInternal): void;
+    bind(): void;
     // (undocumented)
     bindChannel(channel: IChannel): void;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -957,7 +957,7 @@ export class MockFluidDataStoreRuntime
 		return;
 	}
 
-	public bind(handle: IFluidHandle): void {
+	public bind(): void {
 		return;
 	}
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { ITestDataObject, describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
-import { IFluidHandle, IRequest, IResponse } from "@fluidframework/core-interfaces";
+import { IRequest, IResponse } from "@fluidframework/core-interfaces";
 import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
 // This test doesn't care to test compat of the Fluid handle implementation, it's just used for convenience

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
@@ -37,7 +37,7 @@ export class TestFluidHandle extends FluidHandleBase<unknown> {
 		throw new Error("Method not implemented.");
 	}
 
-	public bind(handle: IFluidHandle): void {
+	public bind(): void {
 		throw new Error("Method not implemented.");
 	}
 


### PR DESCRIPTION
## Description

The interface `IFluidHandleInternal` specifies that `bind` takes an `IFluidHandleInternal`.  But some implementations have signature that takes `IFluidHandle`. This is about to cause trouble as I am preparing to migrate `bind` to a subset (wider type) of `IFluidHandleInternal`.  (See prototype PR #24163)

## Breaking Changes

Even though some of these types are legacy-alpha, `bind` is only called internally, and the handles we pass are always "internal" handles, so it's not an issue.
