### PR TITLE
Begin to introduce new interface IAttachableNode for attachGraph and bind

### DIFF
--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
@@ -42,6 +42,13 @@ export type FluidObjectKeys<T> = keyof FluidObject<T>;
 // @public
 export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> = string extends TProp ? never : number extends TProp ? never : TProp extends keyof Required<T>[TProp] ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] ? TProp : never : never;
 
+// @alpha
+export interface IAttachableNode {
+    attachGraph(): void;
+    bind(node: IAttachableNode): void;
+    readonly isAttached: boolean;
+}
+
 // @public
 export interface IConfigProviderBase {
     getRawConfig(name: string): ConfigTypes;
@@ -253,9 +260,10 @@ export interface IFluidHandle<out T = unknown> {
 export const IFluidHandleContext: keyof IProvideFluidHandleContext;
 
 // @alpha
-export interface IFluidHandleContext extends IProvideFluidHandleContext {
+export interface IFluidHandleContext extends IProvideFluidHandleContext, Partial<IAttachableNode> {
     readonly absolutePath: string;
     attachGraph(): void;
+    bind?: IAttachableNode["bind"];
     readonly isAttached: boolean;
     // (undocumented)
     resolveHandle(request: IRequest): Promise<IResponse>;
@@ -267,10 +275,11 @@ export interface IFluidHandleErased<T> extends ErasedType<readonly ["IFluidHandl
 }
 
 // @alpha
-export interface IFluidHandleInternal<out T = unknown> extends IFluidHandle<T>, IProvideFluidHandle {
+export interface IFluidHandleInternal<out T = unknown> extends IFluidHandle<T>, IAttachableNode, IProvideFluidHandle {
     readonly absolutePath: string;
-    attachGraph(): void;
+    // @deprecated
     bind(handle: IFluidHandleInternal): void;
+    bind(node: IAttachableNode): void;
 }
 
 // @public (undocumented)

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -21,11 +21,37 @@ export interface IProvideFluidHandleContext {
 }
 
 /**
+ * A node that may be attached to a graph of nodes, along with other "bound" nodes.
+ *
+ * @legacy
+ * @alpha
+ */
+export interface IAttachableNode {
+	/**
+	 * Flag indicating whether or not the entity is attached.
+	 */
+	readonly isAttached: boolean;
+
+	/**
+	 * Attach this node and any nodes it has previously bound.
+	 */
+	attachGraph(): void;
+
+	/**
+	 * Track a reference from this node to the given node,
+	 * such that when this is attached, the other will be as well.
+	 */
+	bind(node: IAttachableNode): void;
+}
+
+/**
  * Describes a routing context from which other `IFluidHandleContext`s are defined.
  * @legacy
  * @alpha
  */
-export interface IFluidHandleContext extends IProvideFluidHandleContext {
+export interface IFluidHandleContext
+	extends IProvideFluidHandleContext,
+		Partial<IAttachableNode> {
 	/**
 	 * The absolute path to the handle context from the root.
 	 */
@@ -48,6 +74,11 @@ export interface IFluidHandleContext extends IProvideFluidHandleContext {
 	attachGraph(): void;
 
 	resolveHandle(request: IRequest): Promise<IResponse>;
+
+	/**
+	 * See {@link IAttachableNode.bind}
+	 */
+	bind?: IAttachableNode["bind"];
 }
 
 /**
@@ -83,6 +114,7 @@ export interface IFluidHandleInternal<
 	// REVIEW: Constrain `T` to something? How do we support dds and datastores safely?
 	out T = unknown, // FluidObject & IFluidLoadable,
 > extends IFluidHandle<T>,
+		IAttachableNode,
 		IProvideFluidHandle {
 	/**
 	 * The absolute path to the handle context from the root.
@@ -90,15 +122,17 @@ export interface IFluidHandleInternal<
 	readonly absolutePath: string;
 
 	/**
-	 * Runs through the graph and attach the bounded handles.
-	 */
-	attachGraph(): void;
-
-	/**
 	 * Binds the given handle to this one or attach the given handle if this handle is attached.
 	 * A bound handle will also be attached once this handle is attached.
+	 *
+	 * @deprecated - Use the signature that takes an {@link IAttachableNode} instead.
 	 */
 	bind(handle: IFluidHandleInternal): void;
+	/**
+	 * Track a reference from this node to the given node,
+	 * such that when this is attached, the other will be as well.
+	 */
+	bind(node: IAttachableNode): void;
 }
 
 /**

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -28,6 +28,7 @@ export { IFluidLoadable, IFluidRunnable } from "./fluidLoadable.js";
 export type { IRequest, IRequestHeader, IResponse } from "./fluidRouter.js";
 
 export type {
+	IAttachableNode,
 	IProvideFluidHandleContext,
 	IProvideFluidHandle,
 	IFluidHandleInternal,

--- a/packages/dds/shared-object-base/src/test/utils.ts
+++ b/packages/dds/shared-object-base/src/test/utils.ts
@@ -27,6 +27,10 @@ export class MockHandleContext implements IFluidHandleContext {
 		throw new Error("Method not implemented.");
 	}
 
+	public bind(): void {
+		throw new Error("Method not implemented.");
+	}
+
 	public async resolveHandle(request: IRequest): Promise<IResponse> {
 		return create404Response(request);
 	}

--- a/packages/dds/test-dds-utils/src/ddsFuzzHandle.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHandle.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { type IFluidHandle } from "@fluidframework/core-interfaces";
 import { type IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import {
 	FluidHandleBase,
@@ -41,5 +40,5 @@ export class DDSFuzzHandle extends FluidHandleBase<string> {
 		}
 	}
 
-	public bind(handle: IFluidHandle): void {}
+	public bind(): void {}
 }

--- a/packages/dds/tree/src/test/mockSerializer.ts
+++ b/packages/dds/tree/src/test/mockSerializer.ts
@@ -22,6 +22,10 @@ class MockHandleContext implements IFluidHandleContext {
 		throw new Error("Method not implemented.");
 	}
 
+	public bind(): void {
+		throw new Error("Method not implemented.");
+	}
+
 	public async resolveHandle(request: IRequest) {
 		return create404Response(request);
 	}

--- a/packages/runtime/container-runtime/src/containerHandleContext.ts
+++ b/packages/runtime/container-runtime/src/containerHandleContext.ts
@@ -6,6 +6,7 @@
 import { AttachState } from "@fluidframework/container-definitions";
 import { IRequest, IResponse } from "@fluidframework/core-interfaces";
 import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
+import { fail } from "@fluidframework/core-utils/internal";
 import { generateHandleContextPath } from "@fluidframework/runtime-utils/internal";
 
 export interface IContainerHandleContextRuntime {
@@ -33,12 +34,16 @@ export class ContainerFluidHandleContext implements IFluidHandleContext {
 		this.absolutePath = generateHandleContextPath(path, this.routeContext);
 	}
 
-	public attachGraph(): void {
-		throw new Error("can't attach container runtime form within container!");
-	}
-
 	public get isAttached(): boolean {
 		return this.runtime.attachState !== AttachState.Detached;
+	}
+
+	public attachGraph(): void {
+		fail("Can't attach container runtime from within container!");
+	}
+
+	public bind(): void {
+		fail("Use alias instead of binding to the ContainerRuntime");
 	}
 
 	public async resolveHandle(request: IRequest): Promise<IResponse> {

--- a/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
@@ -24,7 +24,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // (undocumented)
     get attachState(): AttachState;
     // (undocumented)
-    bind(handle: IFluidHandle): void;
+    bind(handle: IFluidHandleInternal): void;
     bindChannel(channel: IChannel): void;
     // (undocumented)
     get channelsRoutingContext(): this;

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -558,7 +558,7 @@ export class FluidDataStoreRuntime
 			return;
 		}
 
-		this.bind(channel.handle);
+		this.bind(toFluidHandleInternal(channel.handle));
 
 		// If our data store is local then add the channel to the queue
 		if (!this.localChannelContextQueue.has(channel.id)) {
@@ -600,7 +600,7 @@ export class FluidDataStoreRuntime
 		this.makeVisibleAndAttachGraph();
 	}
 
-	public bind(handle: IFluidHandle): void {
+	public bind(handle: IFluidHandleInternal): void {
 		// If visible, attach the incoming handle's graph. Else, this will be done when we become visible.
 		if (this.visibilityState !== VisibilityState.NotVisible) {
 			toFluidHandleInternal(handle).attachGraph();

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -388,7 +388,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     // (undocumented)
     get attachState(): AttachState;
     // (undocumented)
-    bind(handle: IFluidHandle): void;
+    bind(): void;
     // (undocumented)
     bindChannel(channel: IChannel): void;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -957,7 +957,7 @@ export class MockFluidDataStoreRuntime
 		return;
 	}
 
-	public bind(handle: IFluidHandle): void {
+	public bind(): void {
 		return;
 	}
 


### PR DESCRIPTION
## Description

_(Related: Breaking prototype PR #24163)_

When adding references between objects in the runtime (DDS and DataStores), we build up temporary subgraphs such that a detached subgraph will all attach at the same time.  This logic is duplicated between DataStoreRuntime and FluidObjectHandle.

This PR pulls a new interface out of a combo of `IFluidHandleInternal` and `IFluidHandleContext`:

```
/**
 * A node that may be attached to a graph of nodes, along with other "bound" nodes.
 *
 * @legacy
 * @alpha
 */
export interface IAttachableNode {
	/**
	 * Flag indicating whether or not the entity is attached.
	 */
	readonly isAttached: boolean;

	/**
	 * Attach this node and any nodes it has previously bound.
	 */
	attachGraph(): void;

	/**
	 * Track a reference from this node to the given node,
	 * such that when this is attached, the other will be as well.
	 */
	bind(node: IAttachableNode): void;
}
```

This unifies / clarifies the places where we are doing this kind of bind and/or attach.

## Breaking Changes

Intending for this to not be breaking.  Need to confirm.

## Reviewer Guidance

_Work in progress_
