### PR TITLE
Yunho/include tenant id in draining check

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -298,7 +298,7 @@ export class DeliLambdaFactory
 					if (this.clusterDrainingChecker) {
 						try {
 							const isClusterDraining =
-								await this.clusterDrainingChecker.isClusterDraining(undefined, {
+								await this.clusterDrainingChecker.isClusterDraining({
 									tenantId,
 								});
 							if (isClusterDraining) {
@@ -337,12 +337,9 @@ export class DeliLambdaFactory
 			const handler = async (): Promise<void> => {
 				// Set activity timer to reduce session grace period for ephemeral containers if cluster is in draining
 				if (document?.isEphemeralContainer && this.clusterDrainingChecker) {
-					const isClusterDraining = await this.clusterDrainingChecker.isClusterDraining(
-						undefined,
-						{
-							tenantId,
-						},
-					);
+					const isClusterDraining = await this.clusterDrainingChecker.isClusterDraining({
+						tenantId,
+					});
 					if (isClusterDraining) {
 						Lumberjack.info(
 							"Cluster is under draining and NoClient event is received",

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -298,7 +298,9 @@ export class DeliLambdaFactory
 					if (this.clusterDrainingChecker) {
 						try {
 							const isClusterDraining =
-								await this.clusterDrainingChecker.isClusterDraining();
+								await this.clusterDrainingChecker.isClusterDraining(undefined, {
+									tenantId,
+								});
 							if (isClusterDraining) {
 								Lumberjack.info(
 									"Cluster is in draining, set skip session stickiness to be true",
@@ -335,7 +337,12 @@ export class DeliLambdaFactory
 			const handler = async (): Promise<void> => {
 				// Set activity timer to reduce session grace period for ephemeral containers if cluster is in draining
 				if (document?.isEphemeralContainer && this.clusterDrainingChecker) {
-					const isClusterDraining = await this.clusterDrainingChecker.isClusterDraining();
+					const isClusterDraining = await this.clusterDrainingChecker.isClusterDraining(
+						undefined,
+						{
+							tenantId,
+						},
+					);
 					if (isClusterDraining) {
 						Lumberjack.info(
 							"Cluster is under draining and NoClient event is received",

--- a/server/routerlicious/packages/lambdas/src/nexus/connect.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/connect.ts
@@ -406,7 +406,9 @@ async function checkClusterDraining(
 	}
 	let clusterInDraining = false;
 	try {
-		clusterInDraining = await clusterDrainingChecker.isClusterDraining();
+		clusterInDraining = await clusterDrainingChecker.isClusterDraining(undefined, {
+			tenantId: message.tenantId,
+		});
 	} catch (error) {
 		Lumberjack.error(
 			"Failed to get cluster draining status. Will allow requests to proceed.",
@@ -417,7 +419,6 @@ async function checkClusterDraining(
 	}
 
 	if (clusterInDraining) {
-		// TODO: add a new error class
 		Lumberjack.info("Reject connect document request because cluster is draining.", {
 			...properties,
 			tenantId: message.tenantId,

--- a/server/routerlicious/packages/lambdas/src/nexus/connect.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/connect.ts
@@ -406,7 +406,7 @@ async function checkClusterDraining(
 	}
 	let clusterInDraining = false;
 	try {
-		clusterInDraining = await clusterDrainingChecker.isClusterDraining(undefined, {
+		clusterInDraining = await clusterDrainingChecker.isClusterDraining({
 			tenantId: message.tenantId,
 		});
 	} catch (error) {

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -263,7 +263,7 @@ export function create(
 			if (
 				clusterDrainingChecker &&
 				(await clusterDrainingChecker
-					.isClusterDraining(undefined, {
+					.isClusterDraining({
 						tenantId,
 					})
 					.catch((error) => {
@@ -411,7 +411,7 @@ export function create(
 			if (
 				clusterDrainingChecker &&
 				(await clusterDrainingChecker
-					.isClusterDraining(undefined, {
+					.isClusterDraining({
 						tenantId,
 					})
 					.catch((error) => {

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -257,13 +257,19 @@ export function create(
 		}),
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		async (request, response, next) => {
+			// Tenant and document
+			const tenantId = request.params.tenantId;
 			// Reject create document request if cluster is in draining process.
 			if (
 				clusterDrainingChecker &&
-				(await clusterDrainingChecker.isClusterDraining().catch((error) => {
-					Lumberjack.error("Failed to get cluster draining status", undefined, error);
-					return false;
-				}))
+				(await clusterDrainingChecker
+					.isClusterDraining(undefined, {
+						tenantId,
+					})
+					.catch((error) => {
+						Lumberjack.error("Failed to get cluster draining status", undefined, error);
+						return false;
+					}))
 			) {
 				Lumberjack.info("Cluster is in draining process. Reject create document request.");
 				const error = createFluidServiceNetworkError(503, {
@@ -272,8 +278,6 @@ export function create(
 				});
 				return handleResponse(Promise.reject(error), response);
 			}
-			// Tenant and document
-			const tenantId = request.params.tenantId;
 			// If enforcing server generated document id, ignore id parameter
 			const id = enforceServerGeneratedDocumentId
 				? uuid()
@@ -406,10 +410,14 @@ export function create(
 			// Reject get session request on existing, inactive sessions if cluster is in draining process.
 			if (
 				clusterDrainingChecker &&
-				(await clusterDrainingChecker.isClusterDraining().catch((error) => {
-					Lumberjack.error("Failed to get cluster draining status", undefined, error);
-					return false;
-				}))
+				(await clusterDrainingChecker
+					.isClusterDraining(undefined, {
+						tenantId,
+					})
+					.catch((error) => {
+						Lumberjack.error("Failed to get cluster draining status", undefined, error);
+						return false;
+					}))
 			) {
 				Lumberjack.info("Cluster is in draining process. Reject get session request.");
 				connectionTrace?.stampStage("ClusterIsDraining");

--- a/server/routerlicious/packages/services-core/src/clusterDraining.ts
+++ b/server/routerlicious/packages/services-core/src/clusterDraining.ts
@@ -10,10 +10,9 @@
 export interface IClusterDrainingChecker {
 	/**
 	 * Check if cluster is draining
-	 * @param cluster - Optional. By default it is the current cluster name if undefined
 	 * @param options - Optional.
 	 */
-	isClusterDraining(cluster?: string, options?: any): Promise<boolean>;
+	isClusterDraining(options?: any): Promise<boolean>;
 }
 
 /**

--- a/server/routerlicious/packages/services-core/src/clusterDraining.ts
+++ b/server/routerlicious/packages/services-core/src/clusterDraining.ts
@@ -10,9 +10,10 @@
 export interface IClusterDrainingChecker {
 	/**
 	 * Check if cluster is draining
-	 * @param cluster - Optional. Use current cluster name if not provided.
+	 * @param cluster - Optional. By default it is the current cluster name if undefined
+	 * @param options - Optional.
 	 */
-	isClusterDraining(cluster?: string): Promise<boolean>;
+	isClusterDraining(cluster?: string, options?: any): Promise<boolean>;
 }
 
 /**

--- a/server/routerlicious/packages/test-utils/src/testClusterDrainingStatusChecker.ts
+++ b/server/routerlicious/packages/test-utils/src/testClusterDrainingStatusChecker.ts
@@ -8,7 +8,7 @@ import type { IClusterDrainingChecker } from "@fluidframework/server-services-co
 export class TestClusterDrainingStatusChecker implements IClusterDrainingChecker {
 	private clusterDrainingStatus: boolean = false;
 
-	public async isClusterDraining(cluster?: string): Promise<boolean> {
+	public async isClusterDraining(options?: any): Promise<boolean> {
 		return this.clusterDrainingStatus;
 	}
 


### PR DESCRIPTION
Update cluster draining checker to accept an options object. It is helpful when FRS can do customized logic like filter out based on tenant id.