### PR TITLE
Interval Collection: Remove unneeded internal generics

### DIFF
--- a/packages/dds/sequence/src/IntervalCollectionValues.ts
+++ b/packages/dds/sequence/src/IntervalCollectionValues.ts
@@ -16,7 +16,7 @@ import {
 	ISerializableIntervalCollection,
 	ISerializedIntervalCollection,
 } from "./intervalCollectionMapInterfaces.js";
-import { type ISerializableInterval, IntervalOpType } from "./intervals/index.js";
+import { IntervalOpType } from "./intervals/index.js";
 
 /**
  * A local value to be stored in a container type DDS.
@@ -44,7 +44,7 @@ export interface ILocalIntervalCollection {
 	): ISerializedIntervalCollection;
 }
 
-export function makeSerializable<T extends ISerializableInterval>(
+export function makeSerializable(
 	localValue: ILocalIntervalCollection,
 	serializer: IFluidSerializer,
 	bind: IFluidHandle,
@@ -59,9 +59,7 @@ export function makeSerializable<T extends ISerializableInterval>(
 /**
  * Manages a contained value type.
  */
-export class IntervalCollectionTypeLocalValue<T extends ISerializableInterval>
-	implements ILocalIntervalCollection
-{
+export class IntervalCollectionTypeLocalValue implements ILocalIntervalCollection {
 	/**
 	 * Create a new ValueTypeLocalValue.
 	 * @param value - The instance of the value type stored within
@@ -69,7 +67,7 @@ export class IntervalCollectionTypeLocalValue<T extends ISerializableInterval>
 	 */
 	constructor(
 		public readonly value: IntervalCollection,
-		private readonly valueType: IIntervalCollectionType<T>,
+		private readonly valueType: IIntervalCollectionType,
 	) {}
 
 	/**
@@ -100,7 +98,7 @@ export class IntervalCollectionTypeLocalValue<T extends ISerializableInterval>
 	 * @param opName - The name of the operation that needs processing
 	 * @returns The object which can process the given op
 	 */
-	public getOpHandler(opName: IntervalOpType): IIntervalCollectionOperation<T> {
+	public getOpHandler(opName: IntervalOpType): IIntervalCollectionOperation {
 		const handler = this.valueType.ops.get(opName);
 		if (!handler) {
 			throw new Error("Unknown type message");

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -49,7 +49,7 @@ import {
 	type IEndpointIndex,
 	type IIdIntervalIndex,
 	type IntervalIndex,
-	type IOverlappingIntervalsIndex,
+	type ISequenceOverlappingIntervalsIndex,
 	type SequenceIntervalIndex,
 } from "./intervalIndex/index.js";
 import {
@@ -167,7 +167,7 @@ export function computeStickinessFromSide(
 
 export class LocalIntervalCollection {
 	private static readonly legacyIdPrefix = "legacy";
-	public readonly overlappingIntervalsIndex: IOverlappingIntervalsIndex<SequenceInterval>;
+	public readonly overlappingIntervalsIndex: ISequenceOverlappingIntervalsIndex;
 	public readonly idIntervalIndex: IIdIntervalIndex;
 	public readonly endIntervalIndex: IEndpointIndex;
 	private readonly indexes: Set<SequenceIntervalIndex>;
@@ -175,7 +175,7 @@ export class LocalIntervalCollection {
 	constructor(
 		private readonly client: Client,
 		private readonly label: string,
-		private readonly helpers: IIntervalHelpers<SequenceInterval>,
+		private readonly helpers: IIntervalHelpers,
 		private readonly options: Partial<SequenceOptions>,
 		/** Callback invoked each time one of the endpoints of an interval slides. */
 		private readonly onPositionChange?: (
@@ -237,11 +237,11 @@ export class LocalIntervalCollection {
 		}
 	}
 
-	public appendIndex(index: IntervalIndex<SequenceInterval>) {
+	public appendIndex(index: SequenceIntervalIndex) {
 		this.indexes.add(index);
 	}
 
-	public removeIndex(index: IntervalIndex<SequenceInterval>): boolean {
+	public removeIndex(index: SequenceIntervalIndex): boolean {
 		return this.indexes.delete(index);
 	}
 
@@ -408,9 +408,7 @@ export class LocalIntervalCollection {
 	}
 }
 
-class SequenceIntervalCollectionFactory
-	implements IIntervalCollectionFactory<SequenceInterval>
-{
+class SequenceIntervalCollectionFactory implements IIntervalCollectionFactory {
 	public load(
 		emitter: IValueOpEmitter,
 		raw: ISerializedInterval[] | ISerializedIntervalCollectionV2 = [],
@@ -426,38 +424,29 @@ class SequenceIntervalCollectionFactory
 	}
 }
 
-export class SequenceIntervalCollectionValueType
-	implements IIntervalCollectionType<SequenceInterval>
-{
+export class SequenceIntervalCollectionValueType implements IIntervalCollectionType {
 	public static Name = "sharedStringIntervalCollection";
 
 	public get name(): string {
 		return SequenceIntervalCollectionValueType.Name;
 	}
 
-	public get factory(): IIntervalCollectionFactory<SequenceInterval> {
+	public get factory(): IIntervalCollectionFactory {
 		return SequenceIntervalCollectionValueType._factory;
 	}
 
-	public get ops(): Map<IntervalOpType, IIntervalCollectionOperation<SequenceInterval>> {
+	public get ops(): Map<IntervalOpType, IIntervalCollectionOperation> {
 		return SequenceIntervalCollectionValueType._ops;
 	}
 
-	private static readonly _factory: IIntervalCollectionFactory<SequenceInterval> =
+	private static readonly _factory: IIntervalCollectionFactory =
 		new SequenceIntervalCollectionFactory();
 
-	private static readonly _ops = makeOpsMap<SequenceInterval>();
+	private static readonly _ops = makeOpsMap();
 }
 
-export function makeOpsMap<T extends ISerializableInterval>(): Map<
-	IntervalOpType,
-	IIntervalCollectionOperation<T>
-> {
-	const rebase: IIntervalCollectionOperation<T>["rebase"] = (
-		collection,
-		op,
-		localOpMetadata,
-	) => {
+export function makeOpsMap(): Map<IntervalOpType, IIntervalCollectionOperation> {
+	const rebase: IIntervalCollectionOperation["rebase"] = (collection, op, localOpMetadata) => {
 		const { localSeq } = localOpMetadata;
 		const rebasedValue = collection.rebaseLocalInterval(op.opName, op.value, localSeq);
 		if (rebasedValue === undefined) {
@@ -467,7 +456,7 @@ export function makeOpsMap<T extends ISerializableInterval>(): Map<
 		return { rebasedOp, rebasedLocalOpMetadata: localOpMetadata };
 	};
 
-	return new Map<IntervalOpType, IIntervalCollectionOperation<T>>([
+	return new Map<IntervalOpType, IIntervalCollectionOperation>([
 		[
 			IntervalOpType.ADD,
 			{
@@ -1187,7 +1176,7 @@ export class IntervalCollection
 	}
 
 	constructor(
-		private readonly helpers: IIntervalHelpers<SequenceInterval>,
+		private readonly helpers: IIntervalHelpers,
 		private readonly requiresClient: boolean,
 		private readonly emitter: IValueOpEmitter,
 		serializedIntervals: ISerializedInterval[] | ISerializedIntervalCollectionV2,
@@ -1409,9 +1398,7 @@ export class IntervalCollection
 	/**
 	 * {@inheritdoc IIntervalCollection.getIntervalById}
 	 */
-	public getIntervalById(
-		id: string,
-	): ISerializableIntervalPrivate<SequenceInterval> | undefined {
+	public getIntervalById(id: string): ISerializableIntervalPrivate | undefined {
 		if (!this.localCollection) {
 			throw new LoggingError("attach must be called before accessing intervals");
 		}
@@ -1725,8 +1712,7 @@ export class IntervalCollection
 		// strip it out of the properties here.
 		const { [reservedIntervalIdKey]: id, ...newProps } = serializedInterval.properties ?? {};
 		assert(id !== undefined, 0x3fe /* id must exist on the interval */);
-		const interval: ISerializableIntervalPrivate<SequenceInterval> | undefined =
-			this.getIntervalById(id);
+		const interval: ISerializableIntervalPrivate | undefined = this.getIntervalById(id);
 		if (!interval) {
 			// The interval has been removed locally; no-op.
 			return;

--- a/packages/dds/sequence/src/intervalCollectionMap.ts
+++ b/packages/dds/sequence/src/intervalCollectionMap.ts
@@ -30,11 +30,7 @@ import {
 	IValueOpEmitter,
 	SequenceOptions,
 } from "./intervalCollectionMapInterfaces.js";
-import {
-	type ISerializableInterval,
-	IntervalDeltaOpType,
-	SerializedIntervalDelta,
-} from "./intervals/index.js";
+import { IntervalDeltaOpType, SerializedIntervalDelta } from "./intervals/index.js";
 
 function isMapOperation(op: unknown): op is IMapOperation {
 	return typeof op === "object" && op !== null && "type" in op && op.type === "act";
@@ -74,7 +70,7 @@ export interface IMapDataObjectSerializable {
  * Creation of values is implicit on access (either via `get` or a remote op application referring to
  * a collection that wasn't previously known)
  */
-export class IntervalCollectionMap<T extends ISerializableInterval> {
+export class IntervalCollectionMap {
 	/**
 	 * The number of key/value pairs stored in the map.
 	 */
@@ -120,7 +116,7 @@ export class IntervalCollectionMap<T extends ISerializableInterval> {
 	/**
 	 * The in-memory data the map is storing.
 	 */
-	private readonly data = new Map<string, IntervalCollectionTypeLocalValue<T>>();
+	private readonly data = new Map<string, IntervalCollectionTypeLocalValue>();
 
 	/**
 	 * Create a new default map.
@@ -137,7 +133,7 @@ export class IntervalCollectionMap<T extends ISerializableInterval> {
 			op: IMapOperation,
 			localOpMetadata: IMapMessageLocalMetadata,
 		) => void,
-		private readonly type: IIntervalCollectionType<T>,
+		private readonly type: IIntervalCollectionType,
 		private readonly options?: Partial<SequenceOptions>,
 		public readonly eventEmitter = new TypedEventEmitter<ISharedDefaultMapEvents>(),
 	) {}
@@ -316,7 +312,7 @@ export class IntervalCollectionMap<T extends ISerializableInterval> {
 	 * @param key - The key being initialized
 	 * @param local - Whether the message originated from the local client
 	 */
-	private createCore(key: string, local: boolean): IntervalCollectionTypeLocalValue<T> {
+	private createCore(key: string, local: boolean): IntervalCollectionTypeLocalValue {
 		const localValue = new IntervalCollectionTypeLocalValue(
 			this.type.factory.load(this.makeMapValueOpEmitter(key), undefined, this.options),
 			this.type,
@@ -341,7 +337,7 @@ export class IntervalCollectionMap<T extends ISerializableInterval> {
 	private makeLocal(
 		key: string,
 		serializable: ISerializableIntervalCollection,
-	): IntervalCollectionTypeLocalValue<T> {
+	): IntervalCollectionTypeLocalValue {
 		assert(
 			serializable.type !== ValueType[ValueType.Plain] &&
 				serializable.type !== ValueType[ValueType.Shared],

--- a/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
+++ b/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
@@ -10,7 +10,6 @@ import { ISharedObjectEvents } from "@fluidframework/shared-object-base/internal
 
 import type { IntervalCollection } from "./intervalCollection.js";
 import {
-	type ISerializableInterval,
 	ISerializedInterval,
 	IntervalDeltaOpType,
 	IntervalOpType,
@@ -92,7 +91,7 @@ export interface SequenceOptions
  * @legacy
  * @alpha
  */
-export interface IIntervalCollectionFactory<T extends ISerializableInterval> {
+export interface IIntervalCollectionFactory {
 	/**
 	 * Create a new value type.  Used both in creation of new value types, as well as in loading existing ones
 	 * from remote.
@@ -120,7 +119,7 @@ export interface IIntervalCollectionFactory<T extends ISerializableInterval> {
  * @legacy
  * @alpha
  */
-export interface IIntervalCollectionOperation<T extends ISerializableInterval> {
+export interface IIntervalCollectionOperation {
 	/**
 	 * Performs the actual processing on the incoming operation.
 	 * @param value - The current value stored at the given key, which should be the value type
@@ -160,7 +159,7 @@ export interface IIntervalCollectionOperation<T extends ISerializableInterval> {
 /**
  * Defines a value type that can be registered on a container type.
  */
-export interface IIntervalCollectionType<T extends ISerializableInterval> {
+export interface IIntervalCollectionType {
 	/**
 	 * Name of the value type.
 	 */
@@ -169,12 +168,12 @@ export interface IIntervalCollectionType<T extends ISerializableInterval> {
 	/**
 	 * Factory method used to convert to/from a JSON form of the type.
 	 */
-	factory: IIntervalCollectionFactory<T>;
+	factory: IIntervalCollectionFactory;
 
 	/**
 	 * Operations that can be applied to the value type.
 	 */
-	ops: Map<IntervalOpType, IIntervalCollectionOperation<T>>;
+	ops: Map<IntervalOpType, IIntervalCollectionOperation>;
 }
 
 export interface ISharedDefaultMapEvents extends ISharedObjectEvents {

--- a/packages/dds/sequence/src/intervalIndex/endpointIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/endpointIndex.ts
@@ -39,7 +39,7 @@ export class EndpointIndex implements IEndpointIndex {
 
 	constructor(
 		private readonly client: Client,
-		private readonly helpers: IIntervalHelpers<SequenceInterval>,
+		private readonly helpers: IIntervalHelpers,
 	) {
 		this.endIntervalTree = new RedBlackTree<SequenceInterval, SequenceInterval>((a, b) =>
 			a.compareEnd(b),

--- a/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
@@ -72,9 +72,9 @@ export interface ISequenceOverlappingIntervalsIndex extends SequenceIntervalInde
 export class OverlappingIntervalsIndex implements ISequenceOverlappingIntervalsIndex {
 	protected readonly intervalTree = new IntervalTree<SequenceInterval>();
 	protected readonly client: Client;
-	protected readonly helpers: IIntervalHelpers<SequenceInterval>;
+	protected readonly helpers: IIntervalHelpers;
 
-	constructor(client: Client, helpers: IIntervalHelpers<SequenceInterval>) {
+	constructor(client: Client, helpers: IIntervalHelpers) {
 		this.client = client;
 		this.helpers = helpers;
 	}

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -7,15 +7,15 @@
 
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
-	// eslint-disable-next-line import/no-deprecated
 	Client,
-	// eslint-disable-next-line import/no-deprecated
 	PropertiesManager,
 	PropertySet,
 	SlidingPreference,
 	SequencePlace,
 	Side,
 } from "@fluidframework/merge-tree/internal";
+
+import type { SequenceInterval } from "./sequenceInterval.js";
 
 /**
  * Basic interval abstraction
@@ -172,7 +172,7 @@ export interface ISerializableInterval extends IInterval {
 	getIntervalId(): string;
 }
 
-export type ISerializableIntervalPrivate<T extends ISerializableInterval> = T & {
+export type ISerializableIntervalPrivate = SequenceInterval & {
 	propertyManager?: PropertiesManager;
 };
 
@@ -220,7 +220,7 @@ export type CompressedSerializedInterval =
  * @deprecated The methods within have substitutions
  * @internal
  */
-export interface IIntervalHelpers<TInterval extends ISerializableInterval> {
+export interface IIntervalHelpers<TInterval extends ISerializableInterval = SequenceInterval> {
 	/**
 	 *
 	 * @param label - label of the interval collection this interval is being added to. This parameter is
@@ -240,7 +240,6 @@ export interface IIntervalHelpers<TInterval extends ISerializableInterval> {
 		label: string,
 		start: SequencePlace | undefined,
 		end: SequencePlace | undefined,
-		// eslint-disable-next-line import/no-deprecated
 		client: Client | undefined,
 		intervalType: IntervalType,
 		op?: ISequencedDocumentMessage,

--- a/packages/dds/sequence/src/intervals/sequenceInterval.ts
+++ b/packages/dds/sequence/src/intervals/sequenceInterval.ts
@@ -682,6 +682,6 @@ export function createSequenceInterval(
  * @deprecated The methods within have substitutions
  * @internal
  */
-export const sequenceIntervalHelpers: IIntervalHelpers<SequenceInterval> = {
+export const sequenceIntervalHelpers: IIntervalHelpers = {
 	create: createSequenceInterval,
 };

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -79,7 +79,6 @@ import {
 	IValueChanged,
 	type SequenceOptions,
 } from "./intervalCollectionMapInterfaces.js";
-import { SequenceInterval } from "./intervals/index.js";
 import {
 	SequenceDeltaEvent,
 	SequenceDeltaEventClass,
@@ -492,7 +491,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 
 	protected client: Client;
 	private messagesSinceMSNChange: ISequencedDocumentMessage[] = [];
-	private readonly intervalCollections: IntervalCollectionMap<SequenceInterval>;
+	private readonly intervalCollections: IntervalCollectionMap;
 	constructor(
 		dataStoreRuntime: IFluidDataStoreRuntime,
 		public id: string,

--- a/packages/dds/sequence/src/test/intervalCollection.perf.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.perf.spec.ts
@@ -8,10 +8,9 @@ import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/in
 
 import { type ISequenceIntervalCollection } from "../intervalCollection.js";
 import {
-	IOverlappingIntervalsIndex,
 	createOverlappingIntervalsIndex,
+	type ISequenceOverlappingIntervalsIndex,
 } from "../intervalIndex/index.js";
-import { SequenceInterval } from "../intervals/index.js";
 import { SharedString, SharedStringFactory } from "../sequenceFactory.js";
 
 /**
@@ -34,7 +33,7 @@ function runFindOverlappingIntervalsBenchmark({
 }) {
 	let sharedString: SharedString;
 	let intervalCollection: ISequenceIntervalCollection;
-	let overlappingIntervalsIndex: IOverlappingIntervalsIndex<SequenceInterval>;
+	let overlappingIntervalsIndex: ISequenceOverlappingIntervalsIndex;
 
 	const setupSharedString = () => {
 		sharedString = new SharedStringFactory().create(new MockFluidDataStoreRuntime(), "id");

--- a/packages/dds/sequence/src/test/v1IntervalCollectionHelpers.ts
+++ b/packages/dds/sequence/src/test/v1IntervalCollectionHelpers.ts
@@ -28,7 +28,6 @@ import {
 	IIntervalHelpers,
 	ISerializedInterval,
 	IntervalOpType,
-	SequenceInterval,
 	createSequenceInterval,
 } from "../intervals/index.js";
 import { pkgVersion } from "../packageVersion.js";
@@ -45,14 +44,12 @@ export class V1IntervalCollection extends IntervalCollection {
 	casted = this as unknown as IntervalCollectionInternals;
 }
 
-class V1SequenceIntervalCollectionFactory
-	implements IIntervalCollectionFactory<SequenceInterval>
-{
+class V1SequenceIntervalCollectionFactory implements IIntervalCollectionFactory {
 	public load(
 		emitter: IValueOpEmitter,
 		raw: ISerializedInterval[] | ISerializedIntervalCollectionV2 = [],
 	): V1IntervalCollection {
-		const helpers: IIntervalHelpers<SequenceInterval> = {
+		const helpers: IIntervalHelpers = {
 			create: createSequenceInterval,
 		};
 		return new V1IntervalCollection(helpers, true, emitter, raw, {});
@@ -66,31 +63,29 @@ class V1SequenceIntervalCollectionFactory
 	}
 }
 
-export class V1SequenceIntervalCollectionValueType
-	implements IIntervalCollectionType<SequenceInterval>
-{
+export class V1SequenceIntervalCollectionValueType implements IIntervalCollectionType {
 	public static Name = "sharedStringIntervalCollection";
 
 	public get name(): string {
 		return V1SequenceIntervalCollectionValueType.Name;
 	}
 
-	public get factory(): IIntervalCollectionFactory<SequenceInterval> {
+	public get factory(): IIntervalCollectionFactory {
 		return V1SequenceIntervalCollectionValueType._factory;
 	}
 
-	public get ops(): Map<IntervalOpType, IIntervalCollectionOperation<SequenceInterval>> {
+	public get ops(): Map<IntervalOpType, IIntervalCollectionOperation> {
 		return V1SequenceIntervalCollectionValueType._ops;
 	}
 
-	private static readonly _factory: IIntervalCollectionFactory<SequenceInterval> =
+	private static readonly _factory: IIntervalCollectionFactory =
 		new V1SequenceIntervalCollectionFactory();
 
-	private static readonly _ops = makeOpsMap<SequenceInterval>();
+	private static readonly _ops = makeOpsMap();
 }
 
 interface SharedStringInternals {
-	intervalCollections: IntervalCollectionMap<SequenceInterval>;
+	intervalCollections: IntervalCollectionMap;
 }
 
 export class SharedStringWithV1IntervalCollection extends SharedStringClass {


### PR DESCRIPTION
This is just refactoring to remove unneeded generics which are only used internally. this makes further refactoring easier, and make the code easier to read and understand.