### PR TITLE
Use waitForFunction to avoid early evaluation

### DIFF
--- a/examples/version-migration/separate-container/tests/separateContainer.test.ts
+++ b/examples/version-migration/separate-container/tests/separateContainer.test.ts
@@ -79,17 +79,15 @@ describe("separate-container migration", () => {
 
 			await migrationP;
 
-			// Validate the migration status shows "two" after the migration
-			const leftContainsTwo = await page.evaluate(() => {
+			// After migration, the view should update.  Wait and confirm the migration status shows "two".
+			await page.waitForFunction(() => {
 				const migrationStatusElements = document.querySelectorAll(".migration-status");
 				return migrationStatusElements[0]?.textContent?.includes("two") === true;
 			});
-			const rightContainsTwo = await page.evaluate(() => {
+			await page.waitForFunction(() => {
 				const migrationStatusElements = document.querySelectorAll(".migration-status");
 				return migrationStatusElements[1]?.textContent?.includes("two") === true;
 			});
-			expect(leftContainsTwo).toEqual(true);
-			expect(rightContainsTwo).toEqual(true);
 		});
 	});
 
@@ -178,17 +176,15 @@ describe("separate-container migration", () => {
 
 			await migrationP;
 
-			// Validate the migration status shows "two" after the migration
-			const leftContainsTwo = await page.evaluate(() => {
+			// After migration, the view should update.  Wait and confirm the migration status shows "two".
+			await page.waitForFunction(() => {
 				const migrationStatusElements = document.querySelectorAll(".migration-status");
 				return migrationStatusElements[0]?.textContent?.includes("two") === true;
 			});
-			const rightContainsTwo = await page.evaluate(() => {
+			await page.waitForFunction(() => {
 				const migrationStatusElements = document.querySelectorAll(".migration-status");
 				return migrationStatusElements[1]?.textContent?.includes("two") === true;
 			});
-			expect(leftContainsTwo).toEqual(true);
-			expect(rightContainsTwo).toEqual(true);
 		});
 	});
 });


### PR DESCRIPTION
Still hitting some occasional failures - I am unable to repro locally (seems maybe rare), but my best guess is that the failing evaluation happens before the view manages to update (when the status is still "one").  Changing to waitForFunction should avoid that possibility.

[AB#32408](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/32408)