### PR TITLE
Sequence: Remove deprecated tag in type currently used in Copilot Pages

### DIFF
--- a/.changeset/wild-poems-say.md
+++ b/.changeset/wild-poems-say.md
@@ -13,7 +13,9 @@ This change deprecates the following generic types and provides non-generic alte
 - `IIntervalCollection` is replaced by `ISequenceIntervalCollection`
 - `IIntervalCollectionEvent` is replaced by `ISequenceIntervalCollectionEvents`
 - `IntervalIndex` is replaced by `SequenceIntervalIndex`
-- `IOverlappingIntervalsIndex` is replaced by `ISequenceOverlappingIntervalsIndex`
 - `ISharedIntervalCollection` is deprecated without replacement
 
 These types are no longer required to be generic, and replacing them with non-generic alternatives keeps our typing less complex.
+
+Additionally, `IOverlappingIntervalsIndex` will be deprecated soon, and replaced by the new `ISequenceOverlappingIntervalsIndex`.
+Consumers are encouraged to move `ISequenceOverlappingIntervalsIndex` as soon as possible.

--- a/.changeset/wild-poems-say.md
+++ b/.changeset/wild-poems-say.md
@@ -13,9 +13,7 @@ This change deprecates the following generic types and provides non-generic alte
 - `IIntervalCollection` is replaced by `ISequenceIntervalCollection`
 - `IIntervalCollectionEvent` is replaced by `ISequenceIntervalCollectionEvents`
 - `IntervalIndex` is replaced by `SequenceIntervalIndex`
+- `IOverlappingIntervalsIndex` is replaced by `ISequenceOverlappingIntervalsIndex`
 - `ISharedIntervalCollection` is deprecated without replacement
 
 These types are no longer required to be generic, and replacing them with non-generic alternatives keeps our typing less complex.
-
-Additionally, `IOverlappingIntervalsIndex` will be deprecated soon, and replaced by the new `ISequenceOverlappingIntervalsIndex`.
-Consumers are encouraged to move `ISequenceOverlappingIntervalsIndex` as soon as possible.

--- a/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
+++ b/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
@@ -164,7 +164,7 @@ export enum IntervalType {
     SlideOnRemove = 2,// SlideOnRemove is default behavior - all intervals are SlideOnRemove
 }
 
-// @alpha @deprecated (undocumented)
+// @alpha
 export interface IOverlappingIntervalsIndex<TInterval extends ISerializableInterval> extends IntervalIndex<TInterval> {
     // (undocumented)
     findOverlappingIntervals(start: SequencePlace, end: SequencePlace): TInterval[];

--- a/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
@@ -24,11 +24,13 @@ import { ISharedString } from "../sharedString.js";
 import { IntervalIndex, type SequenceIntervalIndex } from "./intervalIndex.js";
 
 /**
+ * The generic version of this interface is deprecated and will be removed in a future release.
+ * Use {@link ISequenceOverlappingIntervalsIndex} instead.
  * @legacy
  * @alpha
  * @privateremarks
- * TODO AB#34436 - This should be deprecated but we need to wait until the Pages codebase is already using
- * the alternative ({@link ISequenceOverlappingIntervalsIndex}) so the integration pipeline doesn't break.
+ * TODO AB#34436 - Can't add a deprecated tag until the Pages codebase is already using
+ * the alternative so the integration pipeline doesn't break.
  */
 export interface IOverlappingIntervalsIndex<TInterval extends ISerializableInterval>
 	extends IntervalIndex<TInterval> {

--- a/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
@@ -26,7 +26,9 @@ import { IntervalIndex, type SequenceIntervalIndex } from "./intervalIndex.js";
 /**
  * @legacy
  * @alpha
- * @deprecated The generic version of this interface is no longer used and will be removed. Use {@link ISequenceOverlappingIntervalsIndex} instead.
+ * @privateremarks
+ * TODO AB#34436 - This should be deprecated but we need to wait until the Pages codebase is already using
+ * the alternative ({@link ISequenceOverlappingIntervalsIndex}) so the integration pipeline doesn't break.
  */
 export interface IOverlappingIntervalsIndex<TInterval extends ISerializableInterval>
 	extends IntervalIndex<TInterval> {


### PR DESCRIPTION
## Description

Related to https://github.com/microsoft/FluidFramework/pull/24164 because [it broke the FF-CopilotPages integration pipeline](https://github.com/microsoft/FluidFramework/pull/24164#issuecomment-2759756022).

Among the deprecated types I could only find this one in use in the partner repos so only reverted that one.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
