### PR TITLE
Enable gc dedupe tests and delay returning the handle if in Attaching state

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -452,15 +452,7 @@ export class BlobManager {
 		if (this.runtime.attachState === AttachState.Detached) {
 			return this.createBlobDetached(blob);
 		}
-		return this.mc.config.getBoolean("Fluid.Runtime.UploadBlobPlaceholders") === true
-			? this.createBlobPlaceholder(blob)
-			: this.createBlobLegacy(blob, signal);
-	}
 
-	private async createBlobLegacy(
-		blob: ArrayBufferLike,
-		signal?: AbortSignal,
-	): Promise<IFluidHandleInternal<ArrayBufferLike>> {
 		if (this.runtime.attachState === AttachState.Attaching) {
 			// blob upload is not supported in "Attaching" state
 			this.mc.logger.sendTelemetryEvent({ eventName: "CreateBlobWhileAttaching" });
@@ -471,6 +463,15 @@ export class BlobManager {
 			0x385 /* For clarity and paranoid defense against adding future attachment states */,
 		);
 
+		return this.mc.config.getBoolean("Fluid.Runtime.UploadBlobPlaceholders") === true
+			? this.createBlobPlaceholder(blob)
+			: this.createBlobLegacy(blob, signal);
+	}
+
+	private async createBlobLegacy(
+		blob: ArrayBufferLike,
+		signal?: AbortSignal,
+	): Promise<IFluidHandleInternal<ArrayBufferLike>> {
 		if (signal?.aborted) {
 			throw this.createAbortError();
 		}

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -274,7 +274,7 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 			},
 		);
 
-		itExpects.skip(
+		itExpects(
 			"fails retrieval of blobs that are de-duped in same container and are deleted",
 			[
 				{
@@ -315,6 +315,11 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 				// Reference and then unreference the blob via one of the handles so that it's unreferenced in next summary.
 				mainDataStore._root.set("blob1", blobHandle1);
 				mainDataStore._root.delete("blob1");
+
+				// With placeholder blobs enabled, calls to uploadBlob() won't actually upload/dedupe until the handle is
+				// attached. Set/delete the second handle to permit the dedupe to complete.
+				mainDataStore._root.set("blob2", blobHandle2);
+				mainDataStore._root.delete("blob2");
 
 				// Summarize so that the above attachment blobs are marked unreferenced.
 				await provider.ensureSynchronized();

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -175,7 +175,7 @@ describeCompat("GC attachment blob tombstone tests", "NoCompat", (getTestObjectP
 			},
 		);
 
-		itExpects.skip(
+		itExpects(
 			"fails retrieval of blobs that are de-duped in same container and are tombstoned",
 			[
 				{
@@ -206,6 +206,11 @@ describeCompat("GC attachment blob tombstone tests", "NoCompat", (getTestObjectP
 				// Reference and then unreference the blob via one of the handles so that it's unreferenced in next summary.
 				mainDataStore._root.set("blob1", blobHandle1);
 				mainDataStore._root.delete("blob1");
+
+				// With placeholder blobs enabled, calls to uploadBlob() won't actually upload/dedupe until the handle is
+				// attached. Set/delete the second handle to permit the dedupe to complete.
+				mainDataStore._root.set("blob2", blobHandle2);
+				mainDataStore._root.delete("blob2");
 
 				// Summarize so that the above attachment blobs are marked unreferenced.
 				await provider.ensureSynchronized();


### PR DESCRIPTION
The two dedupe tests were only attaching one handle, but with placeholder blobs this means the second one won't actually upload/attach/dedupe.  So the subsequent attempt to get the second handle will just wait forever (and would be kind of unrealistic since the second client would have never seen the second handle in the first place).

This updates the test to definitely attach both handles which should be safe/fine to do regardless of whether placeholder blobs is enabled or disabled, which makes the test work as before.

Additionally move the "wait if Attaching" logic to be shared between both paths per PR feedback.

[AB#34416](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/34416)