### PR TITLE
Revert "Enable use of shortids by default"

### DIFF
--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -621,11 +621,11 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 	 */
 	protected createDataStoreId(): string {
 		/**
-		 * Return uuid if short-ids are explicitly disabled via feature flags.
+		 * There is currently a bug where certain data store ids such as "[" are getting converted to ASCII characters
+		 * in the snapshot.
+		 * So, return short ids only if explicitly enabled via feature flags. Else, return uuid();
 		 */
-		if (this.mc.config.getBoolean("Fluid.Runtime.DisableShortIds") === true) {
-			return uuid();
-		} else {
+		if (this.mc.config.getBoolean("Fluid.Runtime.IsShortIdEnabled") === true) {
 			// We use three non-overlapping namespaces:
 			// - detached state: even numbers
 			// - attached state: odd numbers
@@ -641,6 +641,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			}
 			return id;
 		}
+		return uuid();
 	}
 
 	public createDetachedDataStore(

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -459,11 +459,11 @@ export class FluidDataStoreRuntime
 			this.validateChannelId(id);
 		} else {
 			/**
-			 * Return uuid if short-ids are explicitly disabled via feature flags.
+			 * There is currently a bug where certain data store ids such as "[" are getting converted to ASCII characters
+			 * in the snapshot.
+			 * So, return short ids only if explicitly enabled via feature flags. Else, return uuid();
 			 */
-			if (this.mc.config.getBoolean("Fluid.Runtime.DisableShortIds") === true) {
-				id = uuid();
-			} else {
+			if (this.mc.config.getBoolean("Fluid.Runtime.IsShortIdEnabled") === true) {
 				// We use three non-overlapping namespaces:
 				// - detached state: even numbers
 				// - attached state: odd numbers
@@ -480,6 +480,8 @@ export class FluidDataStoreRuntime
 						this.dataStoreContext.containerRuntime.generateDocumentUniqueId?.() ?? uuid();
 					id = typeof res === "number" ? encodeCompactIdToString(2 * res + 1, "_") : res;
 				}
+			} else {
+				id = uuid();
 			}
 			assert(!id.includes("/"), 0x8fc /* slash */);
 		}

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -945,13 +945,25 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 		);
 	});
 
+	/**
+	 * Function that asserts that the value is not as expected. e have a bug in one of our customer's app where a short
+	 * data store ID created is `[` but in a downloaded snapshot, it is converted to its ASCII equivalent `%5B` in
+	 * certain conditions. So, when an op comes for this data store with id `[`, containers loaded with this snapshot
+	 * cannot find the data store.
+	 *
+	 * While we figure out the fix, we are disabling the ability to create short IDs and this assert validates it.
+	 */
+	function assertInvert(value: boolean, message: string) {
+		assert(!value, message);
+	}
+
 	async function TestCompactIds(enableRuntimeIdCompressor: IdCompressorMode) {
 		const container = await createContainer({
 			runtimeOptions: { enableRuntimeIdCompressor },
 		});
 		const defaultDataStore = (await container.getEntryPoint()) as ITestDataObject;
 		// This data store was created in detached container, so it has to be short!
-		assert(
+		assertInvert(
 			defaultDataStore._runtime.id.length <= 2,
 			"short data store ID created in detached container",
 		);
@@ -990,14 +1002,14 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 		// Check directly that ID compressor is issuing short IDs!
 		// If it does not, the rest of the tests would fail - this helps isolate where the bug is.
 		const idTest = defaultDataStore._context.containerRuntime.generateDocumentUniqueId();
-		assert(typeof idTest === "number" && idTest >= 0, "short IDs should be issued");
+		assertInvert(typeof idTest === "number" && idTest >= 0, "short IDs should be issued");
 
 		// create another datastore
 		const ds2 = await defaultDataStore._context.containerRuntime.createDataStore(pkg);
 		const entryPoint2 = (await ds2.entryPoint.get()) as ITestDataObject;
 
 		// This data store was created in attached  container, and should have used ID compressor to assign ID!
-		assert(
+		assertInvert(
 			entryPoint2._runtime.id.length <= 2,
 			"short data store ID created in attached container",
 		);
@@ -1016,7 +1028,7 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 			undefined,
 			SharedDirectory.getFactory().type,
 		);
-		assert(channel.id.length <= 2, "DDS ID created in detached data store");
+		assertInvert(channel.id.length <= 2, "DDS ID created in detached data store");
 
 		// attached data store.
 		await ds2.trySetAlias("foo");
@@ -1031,7 +1043,7 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 			undefined,
 			SharedDirectory.getFactory().type,
 		);
-		assert(channel2.id.length <= 2, "DDS ID created in attached data store");
+		assertInvert(channel2.id.length <= 2, "DDS ID created in attached data store");
 	}
 
 	it("Container uses short DataStore & DDS IDs in delayed mode", async () => {
@@ -1050,17 +1062,19 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 		};
 		const container = await loader.createDetachedContainer(defaultCodeDetails);
 		const defaultDataStore = (await container.getEntryPoint()) as ITestFluidObject;
-		assert(
+		assertInvert(
 			defaultDataStore.context.id.length <= 2,
-			"Default data store's ID should be short.",
+			"Default data store's ID should be short",
 		);
 		const dataStore1 =
 			await defaultDataStore.context.containerRuntime.createDataStore(TestDataObjectType);
 		const ds1 = (await dataStore1.entryPoint.get()) as ITestFluidObject;
-		assert(
+		assertInvert(
 			ds1.context.id.length <= 2,
 			"Data store's ID in detached container should not be short",
 		);
+		const dds1 = SharedDirectory.create(ds1.runtime);
+		assertInvert(dds1.id.length <= 2, "DDS's ID in detached container should not be short");
 
 		await container.attach(provider.driver.createCreateNewRequest());
 
@@ -1071,14 +1085,15 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 			ds2.context.id.length > 8,
 			"Data store's ID in attached container should not be short",
 		);
+		const dds2 = SharedDirectory.create(ds2.runtime);
+		assert(dds2.id.length > 8, "DDS's ID in attached container should not be short");
 	});
 });
 
 /**
- * These tests try to reproduce a bug where ODSP driver did not correctly decode encoded snapshot tree paths.
- * Data store / DDS created with special characters were encoded during summary upload but during
- * download, they were not correctly decoded in certain scenarios.
- * The bug has been resolved, but these tests are kept to ensure that the bug does not regress.
+ * These tests repro a bug where ODSP driver does not correctly decode encoded snapshot tree paths.
+ * Data store / DDS created with special characters are encoded during summary upload but during
+ * download, they are not correctly decoded in certain scenarios.
  */
 describeCompat(
 	"Short IDs in detached container",
@@ -1104,6 +1119,7 @@ describeCompat(
 			if (provider.driver.type !== "odsp") {
 				this.skip();
 			}
+			configProvider.set("Fluid.Runtime.IsShortIdEnabled", true);
 		});
 
 		/**

--- a/packages/test/test-end-to-end-tests/src/test/summarization/summaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summaryHandles.spec.ts
@@ -62,6 +62,8 @@ describeCompat.skip(
 		});
 
 		it("A data store id with special character `[` works properly with summary handles", async () => {
+			// Enable short ids for this test to create a data store with special character.
+			configProvider.set("Fluid.Runtime.IsShortIdEnabled", true);
 			// Enable single-commit summaries so that when the test runs with old odsp driver, it doesn't fail with summary nacks.
 			configProvider.set("Fluid.Container.summarizeProtocolTree2", true);
 			const container = await provider.createDetachedContainer(runtimeFactory, {


### PR DESCRIPTION
Reverts microsoft/FluidFramework#24142 as suspect of breaking an integration pipeline:

```
2025-03-27T21:26:39.3187847Z ##[error]    expected -         "content": <REDACTED FOR BREVITY> {\"type\":\"__fluid_handle__\",\"url\":\"/b0000000-7bb9-4f5f-98a7-2332508cefbd/14000000-7bb9-4f5f-98a7-2332508cefbd\"}},\"resolvedState\":{\"type\":\"Plain\",\"value\":false},\"draftKey\":{\"type\":\"Plain\",\"value\":\"17000000-7bb9-4f5f-98a7-2332508cefbd\"}}}}",
2025-03-27T21:26:39.3188537Z ##[error]      actual +         "content": <REDACTED FOR BREVITY> {\"type\":\"__fluid_handle__\",\"url\":\"/A/_C\"}},\"resolvedState\":{\"type\":\"Plain\",\"value\":false},\"draftKey\":{\"type\":\"Plain\",\"value\":\"13000000-7bb9-4f5f-98a7-2332508cefbd\"}}}}",
```