### PR TITLE
`TreeAlpha.exportConcise` now supports `undefined`

### DIFF
--- a/.changeset/plenty-olives-speak.md
+++ b/.changeset/plenty-olives-speak.md
@@ -1,0 +1,12 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+---
+---
+"section": tree
+---
+
+`TreeAlpha.exportConcise` now supports `undefined`
+
+There is a new overload for `TreeAlpha.exportConcise` which makes exporting optional fields easier.
+THis overload allows `undefined` and returns `undefined `in this case.

--- a/.changeset/plenty-olives-speak.md
+++ b/.changeset/plenty-olives-speak.md
@@ -9,4 +9,4 @@
 `TreeAlpha.exportConcise` now supports `undefined`
 
 There is a new overload for `TreeAlpha.exportConcise` which makes exporting optional fields easier.
-THis overload allows `undefined` and returns `undefined `in this case.
+This overload allows `undefined` and returns `undefined` in this case.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -964,6 +964,7 @@ export const TreeAlpha: {
     importConcise<const TSchema extends ImplicitFieldSchema | UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: ConciseTree | undefined): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
     importVerbose<const TSchema extends ImplicitFieldSchema>(schema: TSchema, data: VerboseTree | undefined, options?: Partial<ParseOptions>): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
     exportConcise(node: TreeNode | TreeLeafValue, options?: EncodeOptions): ConciseTree;
+    exportConcise(node: TreeNode | TreeLeafValue | undefined, options?: EncodeOptions): ConciseTree | undefined;
     exportVerbose(node: TreeNode | TreeLeafValue, options?: EncodeOptions): VerboseTree;
     exportCompressed(tree: TreeNode | TreeLeafValue, options: {
         oldestCompatibleClient: FluidClientVersion;

--- a/packages/dds/tree/src/shared-tree/treeApiAlpha.ts
+++ b/packages/dds/tree/src/shared-tree/treeApiAlpha.ts
@@ -138,11 +138,19 @@ export const TreeAlpha: {
 	exportConcise(node: TreeNode | TreeLeafValue, options?: EncodeOptions): ConciseTree;
 
 	/**
+	 * Copy a snapshot of the current version of a TreeNode into a {@link ConciseTree}, allowing undefined.
+	 */
+	exportConcise(
+		node: TreeNode | TreeLeafValue | undefined,
+		options?: EncodeOptions,
+	): ConciseTree | undefined;
+
+	/**
 	 * Copy a snapshot of the current version of a TreeNode into a JSON compatible plain old JavaScript Object (except for {@link @fluidframework/core-interfaces#IFluidHandle|IFluidHandles}).
 	 * Uses the {@link VerboseTree} format, with an explicit type on every node.
 	 *
 	 * @remarks
-	 * There are several cases this may be preferred to {@link TreeAlpha.exportConcise}:
+	 * There are several cases this may be preferred to {@link TreeAlpha.(exportConcise:1)}:
 	 *
 	 * 1. When not using {@link ITreeConfigurationOptions.preventAmbiguity} (or when using `useStableFieldKeys`), `exportConcise` can produce ambiguous data (the type may be unclear on some nodes).
 	 * `exportVerbose` will always be unambiguous and thus lossless.
@@ -251,16 +259,7 @@ export const TreeAlpha: {
 		return createFromCursor(schema, cursor);
 	},
 
-	exportConcise(node: TreeNode | TreeLeafValue, options?: EncodeOptions): ConciseTree {
-		const config: EncodeOptions = { ...options };
-
-		const cursor = borrowCursorFromTreeNodeOrValue(node);
-		return conciseFromCursor(
-			cursor,
-			tryGetSchema(node) ?? fail(0xacd /* invalid input */),
-			config,
-		);
-	},
+	exportConcise,
 
 	exportVerbose(node: TreeNode | TreeLeafValue, options?: EncodeOptions): VerboseTree {
 		const config: EncodeOptions = { ...options };
@@ -314,6 +313,30 @@ export const TreeAlpha: {
 		return TreeBeta.clone<TSchema>(view.root);
 	},
 };
+
+function exportConcise(node: TreeNode | TreeLeafValue, options?: EncodeOptions): ConciseTree;
+
+function exportConcise(
+	node: TreeNode | TreeLeafValue | undefined,
+	options?: EncodeOptions,
+): ConciseTree | undefined;
+
+function exportConcise(
+	node: TreeNode | TreeLeafValue | undefined,
+	options?: EncodeOptions,
+): ConciseTree | undefined {
+	if (node === undefined) {
+		return undefined;
+	}
+	const config: EncodeOptions = { ...options };
+
+	const cursor = borrowCursorFromTreeNodeOrValue(node);
+	return conciseFromCursor(
+		cursor,
+		tryGetSchema(node) ?? fail(0xacd /* invalid input */),
+		config,
+	);
+}
 
 function borrowCursorFromTreeNodeOrValue(
 	node: TreeNode | TreeLeafValue,

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -1270,6 +1270,10 @@ describe("treeNodeApi", () => {
 				}
 			}
 		});
+
+		it("export-undefined", () => {
+			assert.equal(TreeAlpha.exportConcise(undefined), undefined);
+		});
 	});
 
 	describe("verbose", () => {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1347,6 +1347,7 @@ export const TreeAlpha: {
     importConcise<const TSchema extends ImplicitFieldSchema | UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: ConciseTree | undefined): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
     importVerbose<const TSchema extends ImplicitFieldSchema>(schema: TSchema, data: VerboseTree | undefined, options?: Partial<ParseOptions>): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
     exportConcise(node: TreeNode | TreeLeafValue, options?: EncodeOptions): ConciseTree;
+    exportConcise(node: TreeNode | TreeLeafValue | undefined, options?: EncodeOptions): ConciseTree | undefined;
     exportVerbose(node: TreeNode | TreeLeafValue, options?: EncodeOptions): VerboseTree;
     exportCompressed(tree: TreeNode | TreeLeafValue, options: {
         oldestCompatibleClient: FluidClientVersion;


### PR DESCRIPTION
## Description

`TreeAlpha.exportConcise` now supports `undefined`

See changeset for details.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


