### PR TITLE
test(container): add test for container remaining dirty if changes made while attaching

### DIFF
--- a/packages/test/local-server-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/local-server-tests/src/test/documentDirty.spec.ts
@@ -589,8 +589,6 @@ describe("Document Dirty", () => {
 			loaderContainerTracker.reset();
 		});
 
-
-
 		it("clears the dirty flag after container is attached", async () => {
 			checkDirtyState("before attach", true, 0);
 


### PR DESCRIPTION
## Description
Fixes [AB#31553](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/31553)

After reported an [incident](https://portal.microsofticm.com/imp/v5/incidents/details/588496721/summary) where they were running into issues with missing "saved" events from container, they realized this was due to the container unable to connect to service during Push outage. But, during our investigation we looked into adding support for validating "saved" events in these specific scenarios: 
(1) If there are no changes, the container should be non-dirty upon attach
(2) If there were changes during attaching, the container should remain dirty upon attach

There seems to be enough testing in place for scenario (1), but not explicitly for (2). This change adds this test case.