### PR TITLE
Logging invalid token JTIs to get metrics

### DIFF
--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -470,7 +470,7 @@ export function getParam(params: Params, key: string) {
 
 export function getJtiClaimFromAccessToken(token: string): string | undefined {
 	const claims = decode(token) as ITokenClaims;
-	if (claims && claims.jti && validate(claims.jti)) {
+	if (claims?.jti && validate(claims.jti)) {
 		return claims.jti;
 	}
 	return undefined;

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -469,9 +469,13 @@ export function getParam(params: Params, key: string) {
 }
 
 export function getJtiClaimFromAccessToken(token: string): string | undefined {
-	const claims = decode(token) as ITokenClaims;
-	if (claims?.jti && validate(claims.jti)) {
-		return claims.jti;
+	try {
+		const claims = decode(token) as ITokenClaims;
+		if (claims?.jti && validate(claims.jti)) {
+			return claims.jti;
+		}
+	} catch (error) {
+		Lumberjack.error("Error decoding token", undefined, error);
 	}
 	return undefined;
 }

--- a/server/routerlicious/packages/services-utils/src/auth.ts
+++ b/server/routerlicious/packages/services-utils/src/auth.ts
@@ -8,7 +8,7 @@
 import { Params } from "express-serve-static-core";
 import { ITokenClaims, IUser, ScopeType } from "@fluidframework/protocol-definitions";
 import { decode, sign } from "jsonwebtoken";
-import { v4 as uuid } from "uuid";
+import { v4 as uuid, validate } from "uuid";
 import {
 	NetworkError,
 	isNetworkError,
@@ -466,4 +466,12 @@ export function validateTokenScopeClaims(expectedScopes: string): RequestHandler
  */
 export function getParam(params: Params, key: string) {
 	return Array.isArray(params) ? undefined : params[key];
+}
+
+export function getJtiClaimFromAccessToken(token: string): string | undefined {
+	const claims = decode(token) as ITokenClaims;
+	if (claims && claims.jti && validate(claims.jti)) {
+		return claims.jti;
+	}
+	return undefined;
 }

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -28,6 +28,7 @@ export {
 	isTokenValid,
 	extractTokenFromHeader,
 	getValidAccessToken,
+	getJtiClaimFromAccessToken,
 } from "./auth";
 export { getBooleanFromConfig, getNumberFromConfig } from "./configUtils";
 export { parseBoolean } from "./conversion";

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -12,13 +12,11 @@ import {
 	getAuthorizationTokenFromCredentials,
 	IGitManager,
 	parseToken,
-	isNetworkError,
 } from "@fluidframework/server-services-client";
 import * as core from "@fluidframework/server-services-core";
 import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 import {
 	extractTokenFromHeader,
-	getJtiClaimFromAccessToken,
 	getValidAccessToken,
 	logHttpMetrics,
 } from "@fluidframework/server-services-utils";
@@ -262,25 +260,9 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			undefined /* refreshTokenIfNeeded */,
 			logHttpMetrics,
 		);
-		try {
-			await restWrapper.post(`/api/tenants/${encodeURIComponent(tenantId)}/validate`, {
-				token,
-			});
-		} catch (error: unknown) {
-			if (isNetworkError(error)) {
-				if (error.code === 401 || error.code === 403) {
-					const jtiClaim = getJtiClaimFromAccessToken(token);
-					if (jtiClaim) {
-						Lumberjack.error("Token is invalid", {
-							tenantId,
-							jtiClaim,
-							status: error.code,
-						});
-					}
-				}
-			}
-			throw error;
-		}
+		await restWrapper.post(`/api/tenants/${encodeURIComponent(tenantId)}/validate`, {
+			token,
+		});
 	}
 
 	public async getKey(tenantId: string, includeDisabledTenant = false): Promise<string> {


### PR DESCRIPTION
## Description

We are trying to evaluate whether clients are using the same invalid token multiple times. To check these metrics, we want to log the JTI claim when a token validation fails with a 401 or a 403 error. Using these, we can enable invalid token caching if needed.
