### PR TITLE
IntervalCollection: Use SequenceIntervalClass in implementations

### DIFF
--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -41,6 +41,7 @@ export {
 	ISequenceOverlappingIntervalsIndex,
 	createOverlappingIntervalsIndex,
 	createOverlappingSequenceIntervalsIndex,
+	createEndpointIndex,
 } from "./intervalIndex/index.js";
 export {
 	appendAddIntervalToRevertibles,

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -39,6 +39,7 @@ export {
 	SequenceIntervalIndexes,
 	IOverlappingIntervalsIndex,
 	ISequenceOverlappingIntervalsIndex,
+	IEndpointIndex,
 	createOverlappingIntervalsIndex,
 	createOverlappingSequenceIntervalsIndex,
 	createEndpointIndex,

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -32,8 +32,6 @@ export {
 	IIntervalCollection,
 	ISequenceIntervalCollection,
 	ISequenceIntervalCollectionEvents,
-	IntervalLocator,
-	intervalLocatorFromEndpoint,
 } from "./intervalCollection.js";
 export {
 	IntervalIndex,
@@ -43,14 +41,6 @@ export {
 	ISequenceOverlappingIntervalsIndex,
 	createOverlappingIntervalsIndex,
 	createOverlappingSequenceIntervalsIndex,
-	IEndpointInRangeIndex,
-	IStartpointInRangeIndex,
-	createEndpointInRangeIndex,
-	createStartpointInRangeIndex,
-	IIdIntervalIndex,
-	createIdIntervalIndex,
-	IEndpointIndex,
-	createEndpointIndex,
 } from "./intervalIndex/index.js";
 export {
 	appendAddIntervalToRevertibles,

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -177,8 +177,8 @@ export class LocalIntervalCollection {
 		private readonly options: Partial<SequenceOptions>,
 		/** Callback invoked each time one of the endpoints of an interval slides. */
 		private readonly onPositionChange?: (
-			interval: SequenceInterval,
-			previousInterval: SequenceInterval,
+			interval: SequenceIntervalClass,
+			previousInterval: SequenceIntervalClass,
 		) => void,
 	) {
 		this.overlappingIntervalsIndex = new OverlappingIntervalsIndex(client);
@@ -229,7 +229,7 @@ export class LocalIntervalCollection {
 		return id;
 	}
 
-	private removeIntervalFromIndexes(interval: SequenceInterval) {
+	private removeIntervalFromIndexes(interval: SequenceIntervalClass) {
 		for (const index of this.indexes) {
 			index.remove(interval);
 		}
@@ -243,7 +243,7 @@ export class LocalIntervalCollection {
 		return this.indexes.delete(index);
 	}
 
-	public removeExistingInterval(interval: SequenceInterval) {
+	public removeExistingInterval(interval: SequenceIntervalClass) {
 		this.removeIntervalFromIndexes(interval);
 		this.removeIntervalListeners(interval);
 	}
@@ -253,7 +253,7 @@ export class LocalIntervalCollection {
 		end: SequencePlace,
 		intervalType: IntervalType,
 		op?: ISequencedDocumentMessage,
-	): SequenceInterval {
+	): SequenceIntervalClass {
 		return createSequenceInterval(
 			this.label,
 			start,
@@ -273,7 +273,7 @@ export class LocalIntervalCollection {
 		props?: PropertySet,
 		op?: ISequencedDocumentMessage,
 	) {
-		const interval: SequenceInterval = this.createInterval(start, end, intervalType, op);
+		const interval: SequenceIntervalClass = this.createInterval(start, end, intervalType, op);
 		if (interval) {
 			if (!interval.properties) {
 				interval.properties = createMap<any>();
@@ -299,27 +299,25 @@ export class LocalIntervalCollection {
 		return interval;
 	}
 
-	private linkEndpointsToInterval(interval: SequenceInterval): void {
-		if (interval instanceof SequenceIntervalClass) {
-			interval.start.addProperties({ interval });
-			interval.end.addProperties({ interval });
-		}
+	private linkEndpointsToInterval(interval: SequenceIntervalClass): void {
+		interval.start.addProperties({ interval });
+		interval.end.addProperties({ interval });
 	}
 
-	private addIntervalToIndexes(interval: SequenceInterval) {
+	private addIntervalToIndexes(interval: SequenceIntervalClass) {
 		for (const index of this.indexes) {
 			index.add(interval);
 		}
 	}
 
-	public add(interval: SequenceInterval): void {
+	public add(interval: SequenceIntervalClass): void {
 		this.linkEndpointsToInterval(interval);
 		this.addIntervalToIndexes(interval);
 		this.addIntervalListeners(interval);
 	}
 
 	public changeInterval(
-		interval: SequenceInterval,
+		interval: SequenceIntervalClass,
 		start: SequencePlace | undefined,
 		end: SequencePlace | undefined,
 		op?: ISequencedDocumentMessage,
@@ -355,7 +353,7 @@ export class LocalIntervalCollection {
 		};
 	}
 
-	private addIntervalListeners(interval: SequenceInterval) {
+	private addIntervalListeners(interval: SequenceIntervalClass) {
 		const cloneRef = (ref: LocalReferencePosition) => {
 			const segment = ref.getSegment();
 			if (segment === undefined) {
@@ -374,40 +372,36 @@ export class LocalIntervalCollection {
 				ref.canSlideToEndpoint,
 			);
 		};
-		if (interval instanceof SequenceIntervalClass) {
-			let previousInterval: (SequenceInterval & SequenceIntervalClass) | undefined;
-			let pendingChanges = 0;
-			interval.addPositionChangeListeners(
-				() => {
-					pendingChanges++;
-					// Note: both start and end can change and invoke beforeSlide on each endpoint before afterSlide.
-					if (!previousInterval) {
-						previousInterval = interval.clone() as SequenceInterval & SequenceIntervalClass;
-						previousInterval.start = cloneRef(previousInterval.start);
-						previousInterval.end = cloneRef(previousInterval.end);
-						this.removeIntervalFromIndexes(interval);
-					}
-				},
-				() => {
-					assert(
-						previousInterval !== undefined,
-						0x3fa /* Invalid interleaving of before/after slide */,
-					);
-					pendingChanges--;
-					if (pendingChanges === 0) {
-						this.addIntervalToIndexes(interval);
-						this.onPositionChange?.(interval, previousInterval);
-						previousInterval = undefined;
-					}
-				},
-			);
-		}
+		let previousInterval: SequenceIntervalClass | undefined;
+		let pendingChanges = 0;
+		interval.addPositionChangeListeners(
+			() => {
+				pendingChanges++;
+				// Note: both start and end can change and invoke beforeSlide on each endpoint before afterSlide.
+				if (!previousInterval) {
+					previousInterval = interval.clone();
+					previousInterval.start = cloneRef(previousInterval.start);
+					previousInterval.end = cloneRef(previousInterval.end);
+					this.removeIntervalFromIndexes(interval);
+				}
+			},
+			() => {
+				assert(
+					previousInterval !== undefined,
+					0x3fa /* Invalid interleaving of before/after slide */,
+				);
+				pendingChanges--;
+				if (pendingChanges === 0) {
+					this.addIntervalToIndexes(interval);
+					this.onPositionChange?.(interval, previousInterval);
+					previousInterval = undefined;
+				}
+			},
+		);
 	}
 
-	private removeIntervalListeners(interval: SequenceInterval) {
-		if (interval instanceof SequenceIntervalClass) {
-			interval.removePositionChangeListeners();
-		}
+	private removeIntervalListeners(interval: SequenceIntervalClass) {
+		interval.removePositionChangeListeners();
 	}
 }
 
@@ -466,8 +460,8 @@ export const opsMap: Record<IntervalDeltaOpType, IIntervalCollectionOperation> =
  */
 export type DeserializeCallback = (properties: PropertySet) => void;
 
-class IntervalCollectionIterator implements Iterator<SequenceInterval> {
-	private readonly results: SequenceInterval[];
+class IntervalCollectionIterator implements Iterator<SequenceIntervalClass> {
+	private readonly results: SequenceIntervalClass[];
 	private index: number;
 
 	constructor(
@@ -482,7 +476,7 @@ class IntervalCollectionIterator implements Iterator<SequenceInterval> {
 		collection.gatherIterationResults(this.results, iteratesForward, start, end);
 	}
 
-	public next(): IteratorResult<SequenceInterval> {
+	public next(): IteratorResult<SequenceIntervalClass> {
 		if (this.index < this.results.length) {
 			return {
 				value: this.results[this.index++],
@@ -1328,8 +1322,8 @@ export class IntervalCollection
 	}
 
 	private emitChange(
-		interval: SequenceInterval,
-		previousInterval: SequenceInterval,
+		interval: SequenceIntervalClass,
+		previousInterval: SequenceIntervalClass,
 		local: boolean,
 		slide: boolean,
 		op?: ISequencedDocumentMessage,
@@ -1337,21 +1331,15 @@ export class IntervalCollection
 		// Temporarily make references transient so that positional queries work (non-transient refs
 		// on resolve to DetachedPosition on any segments that don't contain them). The original refType
 		// is restored as single-endpoint changes re-use previous references.
-		let startRefType: ReferenceType;
-		let endRefType: ReferenceType;
-		if (previousInterval instanceof SequenceIntervalClass) {
-			startRefType = previousInterval.start.refType;
-			endRefType = previousInterval.end.refType;
-			previousInterval.start.refType = ReferenceType.Transient;
-			previousInterval.end.refType = ReferenceType.Transient;
-			this.emit("changeInterval", interval, previousInterval, local, op, slide);
-			this.emit("changed", interval, undefined, previousInterval ?? undefined, local, slide);
-			previousInterval.start.refType = startRefType;
-			previousInterval.end.refType = endRefType;
-		} else {
-			this.emit("changeInterval", interval, previousInterval, local, op, slide);
-			this.emit("changed", interval, undefined, previousInterval ?? undefined, local, slide);
-		}
+
+		const startRefType = previousInterval.start.refType;
+		const endRefType = previousInterval.end.refType;
+		previousInterval.start.refType = ReferenceType.Transient;
+		previousInterval.end.refType = ReferenceType.Transient;
+		this.emit("changeInterval", interval, previousInterval, local, op, slide);
+		this.emit("changed", interval, undefined, previousInterval ?? undefined, local, slide);
+		previousInterval.start.refType = startRefType;
+		previousInterval.end.refType = endRefType;
 	}
 
 	/**
@@ -1386,7 +1374,7 @@ export class IntervalCollection
 		start: SequencePlace;
 		end: SequencePlace;
 		props?: PropertySet;
-	}): SequenceInterval {
+	}): SequenceIntervalClass {
 		if (!this.localCollection) {
 			throw new LoggingError("attach must be called prior to adding intervals");
 		}
@@ -1405,7 +1393,7 @@ export class IntervalCollection
 
 		this.assertStickinessEnabled(start, end);
 
-		const interval: SequenceInterval = this.localCollection.addInterval(
+		const interval: SequenceIntervalClass = this.localCollection.addInterval(
 			toSequencePlace(startPos, startSide),
 			toSequencePlace(endPos, endSide),
 			IntervalType.SlideOnRemove,
@@ -1413,7 +1401,7 @@ export class IntervalCollection
 		);
 
 		if (interval) {
-			if (!this.isCollaborating && interval instanceof SequenceIntervalClass) {
+			if (!this.isCollaborating) {
 				setSlideOnRemove(interval.start);
 				setSlideOnRemove(interval.end);
 			}
@@ -1449,7 +1437,7 @@ export class IntervalCollection
 	}
 
 	private deleteExistingInterval(
-		interval: SequenceInterval,
+		interval: SequenceIntervalClass,
 		local: boolean,
 		op?: ISequencedDocumentMessage,
 	) {
@@ -1484,7 +1472,7 @@ export class IntervalCollection
 	/**
 	 * {@inheritdoc IIntervalCollection.removeIntervalById}
 	 */
-	public removeIntervalById(id: string): SequenceInterval | undefined {
+	public removeIntervalById(id: string): SequenceIntervalClass | undefined {
 		if (!this.localCollection) {
 			throw new LoggingError("Attach must be called before accessing intervals");
 		}
@@ -1500,7 +1488,7 @@ export class IntervalCollection
 	public change(
 		id: string,
 		{ start, end, props }: { start?: SequencePlace; end?: SequencePlace; props?: PropertySet },
-	): SequenceInterval | undefined {
+	): SequenceIntervalClass | undefined {
 		if (!this.localCollection) {
 			throw new LoggingError("Attach must be called before accessing intervals");
 		}
@@ -1528,7 +1516,7 @@ export class IntervalCollection
 		const interval = this.getIntervalById(id);
 		if (interval) {
 			let deltaProps: PropertySet | undefined;
-			let newInterval: SequenceInterval | undefined;
+			let newInterval: SequenceIntervalClass | undefined;
 			if (props !== undefined) {
 				interval.propertyManager ??= new PropertiesManager();
 				deltaProps = interval.propertyManager.handleProperties(
@@ -1541,7 +1529,7 @@ export class IntervalCollection
 			}
 			if (start !== undefined && end !== undefined) {
 				newInterval = this.localCollection.changeInterval(interval, start, end);
-				if (!this.isCollaborating && newInterval instanceof SequenceIntervalClass) {
+				if (!this.isCollaborating && newInterval !== undefined) {
 					setSlideOnRemove(newInterval.start);
 					setSlideOnRemove(newInterval.end);
 				}
@@ -1587,10 +1575,8 @@ export class IntervalCollection
 			if (newInterval) {
 				this.addPendingChange(id, serializedInterval);
 				this.emitChange(newInterval, interval, true, false);
-				if (interval instanceof SequenceIntervalClass) {
-					this.client?.removeLocalReferencePosition(interval.start);
-					this.client?.removeLocalReferencePosition(interval.end);
-				}
+				this.client?.removeLocalReferencePosition(interval.start);
+				this.client?.removeLocalReferencePosition(interval.end);
 			}
 			return newInterval;
 		}
@@ -1833,11 +1819,6 @@ export class IntervalCollection
 		}
 
 		if (localInterval !== undefined) {
-			// we know we must be using `SequenceInterval` because `this.client` exists
-			assert(
-				localInterval instanceof SequenceIntervalClass,
-				0x3a0 /* localInterval must be `SequenceInterval` when used with client */,
-			);
 			// The rebased op may place this interval's endpoints on different segments. Calling `changeInterval` here
 			// updates the local client's state to be consistent with the emitted op.
 			this.localCollection?.changeInterval(
@@ -1878,12 +1859,7 @@ export class IntervalCollection
 		return value;
 	}
 
-	private ackInterval(interval: SequenceInterval, op: ISequencedDocumentMessage): void {
-		// Only SequenceIntervals need potential sliding
-		if (!(interval instanceof SequenceIntervalClass)) {
-			return;
-		}
-
+	private ackInterval(interval: SequenceIntervalClass, op: ISequencedDocumentMessage): void {
 		if (
 			!refTypeIncludesFlag(interval.start, ReferenceType.StayOnRemove) &&
 			!refTypeIncludesFlag(interval.end, ReferenceType.StayOnRemove)
@@ -2004,7 +1980,7 @@ export class IntervalCollection
 
 		this.localCollection.ensureSerializedId(serializedInterval);
 
-		const interval: SequenceInterval = this.localCollection.addInterval(
+		const interval: SequenceIntervalClass = this.localCollection.addInterval(
 			toSequencePlace(serializedInterval.start, serializedInterval.startSide ?? Side.Before),
 			toSequencePlace(serializedInterval.end, serializedInterval.endSide ?? Side.Before),
 			serializedInterval.intervalType,
@@ -2108,7 +2084,7 @@ export class IntervalCollection
 	 * {@inheritdoc IIntervalCollection.gatherIterationResults}
 	 */
 	public gatherIterationResults(
-		results: SequenceInterval[],
+		results: SequenceIntervalClass[],
 		iteratesForward: boolean,
 		start?: number,
 		end?: number,
@@ -2145,7 +2121,7 @@ export class IntervalCollection
 	/**
 	 * {@inheritdoc IIntervalCollection.map}
 	 */
-	public map(fn: (interval: SequenceInterval) => void) {
+	public map(fn: (interval: SequenceIntervalClass) => void) {
 		if (!this.localCollection) {
 			throw new LoggingError("attachSequence must be called");
 		}
@@ -2197,7 +2173,7 @@ export interface IntervalLocator {
 	/**
 	 * Interval within that collection
 	 */
-	interval: SequenceInterval;
+	interval: SequenceIntervalClass;
 }
 
 /**

--- a/packages/dds/sequence/src/intervalIndex/endpointInRangeIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/endpointInRangeIndex.ts
@@ -7,15 +7,10 @@
 
 import { Client, PropertyAction, RedBlackTree } from "@fluidframework/merge-tree/internal";
 
-import {
-	ISerializableInterval,
-	IntervalType,
-	SequenceInterval,
-	createSequenceInterval,
-} from "../intervals/index.js";
+import { IntervalType, SequenceInterval, createSequenceInterval } from "../intervals/index.js";
 import { ISharedString } from "../sharedString.js";
 
-import { IntervalIndex } from "./intervalIndex.js";
+import { type SequenceIntervalIndex } from "./intervalIndex.js";
 import {
 	HasComparisonOverride,
 	compareOverrideables,
@@ -28,15 +23,14 @@ import {
  * Provide additional APIs to support efficiently querying a collection of intervals whose endpoints fall within a specified range.
  * @internal
  */
-export interface IEndpointInRangeIndex<TInterval extends ISerializableInterval>
-	extends IntervalIndex<TInterval> {
+export interface IEndpointInRangeIndex extends SequenceIntervalIndex {
 	/**
 	 * @returns an array of all intervals contained in this collection whose endpoints locate in the range [start, end] (includes both ends)
 	 */
-	findIntervalsWithEndpointInRange(start: number, end: number): TInterval[];
+	findIntervalsWithEndpointInRange(start: number, end: number): SequenceInterval[];
 }
 
-export class EndpointInRangeIndex implements IEndpointInRangeIndex<SequenceInterval> {
+export class EndpointInRangeIndex implements IEndpointInRangeIndex {
 	private readonly intervalTree;
 
 	constructor(private readonly client: Client) {
@@ -113,7 +107,7 @@ export class EndpointInRangeIndex implements IEndpointInRangeIndex<SequenceInter
  */
 export function createEndpointInRangeIndex(
 	sharedString: ISharedString,
-): IEndpointInRangeIndex<SequenceInterval> {
+): IEndpointInRangeIndex {
 	const client = (sharedString as unknown as { client: Client }).client;
 	return new EndpointInRangeIndex(client);
 }

--- a/packages/dds/sequence/src/intervalIndex/idIntervalIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/idIntervalIndex.ts
@@ -6,22 +6,21 @@
 import { assert } from "@fluidframework/core-utils/internal";
 
 import { reservedIntervalIdKey } from "../intervalCollection.js";
-import { type SequenceInterval } from "../intervals/index.js";
+import { type SequenceIntervalClass } from "../intervals/index.js";
 
 import { type SequenceIntervalIndex } from "./intervalIndex.js";
 
-/**
- * @internal
- */
-export interface IIdIntervalIndex extends SequenceIntervalIndex, Iterable<SequenceInterval> {
-	getIntervalById(id: string): SequenceInterval | undefined;
+export interface IIdIntervalIndex
+	extends SequenceIntervalIndex,
+		Iterable<SequenceIntervalClass> {
+	getIntervalById(id: string): SequenceIntervalClass | undefined;
 
-	[Symbol.iterator](): Iterator<SequenceInterval>;
+	[Symbol.iterator](): Iterator<SequenceIntervalClass>;
 }
-class IdIntervalIndex implements IIdIntervalIndex, Iterable<SequenceInterval> {
-	private readonly intervalIdMap = new Map<string, SequenceInterval>();
+class IdIntervalIndex implements IIdIntervalIndex, Iterable<SequenceIntervalClass> {
+	private readonly intervalIdMap = new Map<string, SequenceIntervalClass>();
 
-	public add(interval: SequenceInterval) {
+	public add(interval: SequenceIntervalClass) {
 		const id = interval.getIntervalId();
 		assert(
 			id !== undefined,
@@ -36,24 +35,21 @@ class IdIntervalIndex implements IIdIntervalIndex, Iterable<SequenceInterval> {
 		this.intervalIdMap.set(id, interval);
 	}
 
-	public remove(interval: SequenceInterval) {
+	public remove(interval: SequenceIntervalClass) {
 		const id = interval.getIntervalId();
 		assert(id !== undefined, 0x311 /* expected id to exist on interval */);
 		this.intervalIdMap.delete(id);
 	}
 
-	public getIntervalById(id: string): SequenceInterval | undefined {
+	public getIntervalById(id: string): SequenceIntervalClass | undefined {
 		return this.intervalIdMap.get(id);
 	}
 
-	public [Symbol.iterator](): IterableIterator<SequenceInterval> {
+	public [Symbol.iterator](): IterableIterator<SequenceIntervalClass> {
 		return this.intervalIdMap.values();
 	}
 }
 
-/**
- * @internal
- */
 export function createIdIntervalIndex(): IIdIntervalIndex {
 	return new IdIntervalIndex();
 }

--- a/packages/dds/sequence/src/intervalIndex/startpointInRangeIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/startpointInRangeIndex.ts
@@ -7,15 +7,10 @@
 
 import { Client, PropertyAction, RedBlackTree } from "@fluidframework/merge-tree/internal";
 
-import {
-	ISerializableInterval,
-	IntervalType,
-	SequenceInterval,
-	createSequenceInterval,
-} from "../intervals/index.js";
+import { IntervalType, SequenceInterval, createSequenceInterval } from "../intervals/index.js";
 import { ISharedString } from "../sharedString.js";
 
-import { IntervalIndex } from "./intervalIndex.js";
+import { type SequenceIntervalIndex } from "./intervalIndex.js";
 import {
 	HasComparisonOverride,
 	compareOverrideables,
@@ -28,15 +23,14 @@ import {
  * Provide additional APIs to support efficiently querying a collection of intervals whose startpoints fall within a specified range.
  * @internal
  */
-export interface IStartpointInRangeIndex<TInterval extends ISerializableInterval>
-	extends IntervalIndex<TInterval> {
+export interface IStartpointInRangeIndex extends SequenceIntervalIndex {
 	/**
 	 * @returns an array of all intervals contained in this collection whose startpoints locate in the range [start, end] (includes both ends)
 	 */
-	findIntervalsWithStartpointInRange(start: number, end: number): TInterval[];
+	findIntervalsWithStartpointInRange(start: number, end: number): SequenceInterval[];
 }
 
-export class StartpointInRangeIndex implements IStartpointInRangeIndex<SequenceInterval> {
+export class StartpointInRangeIndex implements IStartpointInRangeIndex {
 	private readonly intervalTree;
 
 	constructor(private readonly client: Client) {
@@ -111,7 +105,7 @@ export class StartpointInRangeIndex implements IStartpointInRangeIndex<SequenceI
  */
 export function createStartpointInRangeIndex(
 	sharedString: ISharedString,
-): IStartpointInRangeIndex<SequenceInterval> {
+): IStartpointInRangeIndex {
 	const client = (sharedString as unknown as { client: Client }).client;
 	return new StartpointInRangeIndex(client);
 }

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -14,7 +14,7 @@ import {
 	Side,
 } from "@fluidframework/merge-tree/internal";
 
-import type { SequenceInterval } from "./sequenceInterval.js";
+import type { SequenceIntervalClass } from "./sequenceInterval.js";
 
 /**
  * Basic interval abstraction
@@ -171,7 +171,7 @@ export interface ISerializableInterval extends IInterval {
 	getIntervalId(): string;
 }
 
-export type ISerializableIntervalPrivate = SequenceInterval & {
+export type ISerializableIntervalPrivate = SequenceIntervalClass & {
 	propertyManager?: PropertiesManager;
 };
 

--- a/packages/dds/sequence/src/intervals/sequenceInterval.ts
+++ b/packages/dds/sequence/src/intervals/sequenceInterval.ts
@@ -290,7 +290,7 @@ export class SequenceIntervalClass implements SequenceInterval {
 	/**
 	 * {@inheritDoc IInterval.clone}
 	 */
-	public clone(): SequenceInterval {
+	public clone(): SequenceIntervalClass {
 		return new SequenceIntervalClass(
 			this.client,
 			this.start,
@@ -603,7 +603,7 @@ export function createSequenceInterval(
 	op?: ISequencedDocumentMessage,
 	fromSnapshot?: boolean,
 	useNewSlidingBehavior: boolean = false,
-): SequenceInterval {
+): SequenceIntervalClass {
 	const { startPos, startSide, endPos, endSide } = endpointPosAndSide(
 		start ?? "start",
 		end ?? "end",

--- a/packages/dds/sequence/src/test/endpointInRangeIndex.spec.ts
+++ b/packages/dds/sequence/src/test/endpointInRangeIndex.spec.ts
@@ -18,7 +18,7 @@ import {
 	generateRandomIntervals,
 } from "./intervalIndexTestUtils.js";
 
-class TestEndpointInRangeIndex implements IEndpointInRangeIndex<SequenceInterval> {
+class TestEndpointInRangeIndex implements IEndpointInRangeIndex {
 	private readonly intervals: {
 		start: Lazy<number>;
 		end: Lazy<number>;

--- a/packages/dds/sequence/src/test/startpointInRangeIndex.spec.ts
+++ b/packages/dds/sequence/src/test/startpointInRangeIndex.spec.ts
@@ -18,7 +18,7 @@ import {
 	generateRandomIntervals,
 } from "./intervalIndexTestUtils.js";
 
-class TestStartpointInRangeIndex implements IStartpointInRangeIndex<SequenceInterval> {
+class TestStartpointInRangeIndex implements IStartpointInRangeIndex {
 	private readonly intervals: {
 		start: Lazy<number>;
 		end: Lazy<number>;


### PR DESCRIPTION
 Use SequenceIntervalClass in implementations to avoid casting. Primarily removes a number of instance of checks where they are no longer necessary. Also cleaned up some missed generics.