### PR TITLE
IntervalCollection: Use deterministic id in tests

### DIFF
--- a/packages/dds/sequence/src/test/intervalIndexTestUtils.ts
+++ b/packages/dds/sequence/src/test/intervalIndexTestUtils.ts
@@ -8,7 +8,6 @@ import { strict as assert } from "assert";
 import { IRandom } from "@fluid-private/stochastic-test-utils";
 import { type SequencePlace, Side } from "@fluidframework/merge-tree/internal";
 import type { TestClient } from "@fluidframework/merge-tree/internal/test";
-import { v4 as uuid } from "uuid";
 
 import {
 	createSequenceInterval,
@@ -58,6 +57,7 @@ export function assertOrderedSequenceIntervals(
 	}
 }
 
+let currentId = 0;
 /**
  * Creates a new (regular) Interval object with the specified start and end values.
  * @param start - The start value of the interval.
@@ -65,7 +65,7 @@ export function assertOrderedSequenceIntervals(
  * @returns The created Interval object.
  */
 export function createTestSequenceInterval(client: TestClient, p1: number, p2: number) {
-	const id = uuid();
+	const id = `${currentId++}`;
 	const interval = createSequenceInterval(id, p1, p2, client, IntervalType.SlideOnRemove);
 	interval.properties[reservedIntervalIdKey] = id;
 	return interval;


### PR DESCRIPTION
Use deterministic id as a non-deterministic id makes the tests flakey. This is because we use the id in validation to tie-break, so a random id leads to a random tie break, which then can fail the expected output.