### PR TITLE
Ensure assert.fail() doesn't get caught and suppressed

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
@@ -72,13 +72,17 @@ describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, api
 			const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
 			const ac = new AbortController();
 			ac.abort("abort test");
+			let surprisingSuccess = false;
 			try {
 				await dataStore1.runtime.uploadBlob(stringToBuffer(testString, "utf-8"), ac.signal);
-				assert.fail("Should not succeed");
+				surprisingSuccess = true;
 			} catch (error: any) {
 				assert.strictEqual(error.status, undefined);
 				assert.strictEqual(error.uploadTime, undefined);
 				assert.strictEqual(error.acked, undefined);
+			}
+			if (surprisingSuccess) {
+				assert.fail("Should not succeed");
 			}
 
 			const pendingState = (await runtimeOf(dataStore1).getPendingLocalState()) as


### PR DESCRIPTION
This one should have been failing with blob placeholders enabled, but since the `assert.fail()` call is inside the try/catch block, the failure it generates just gets caught and suppressed.

[AB#34459](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/34459)