### PR TITLE
Test both with/without blob placeholders enabled

### DIFF
--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -328,591 +328,190 @@ export const validateSummary = (
 	return { ids, redirectTable };
 };
 
-describe("BlobManager", () => {
-	const handlePs: Promise<IFluidHandle<ArrayBufferLike>>[] = [];
-	const mockLogger = new MockLogger();
-	let runtime: MockRuntime;
-	let createBlob: (blob: ArrayBufferLike, signal?: AbortSignal) => Promise<void>;
-	let waitForBlob: (blob: ArrayBufferLike) => Promise<void>;
-	let mc: MonitoringContext;
-	let injectedSettings: Record<string, ConfigTypes> = {};
+for (const enableBlobPlaceholdersFlag of [false, true]) {
+	describe(`BlobManager (blob placeholders: ${enableBlobPlaceholdersFlag})`, () => {
+		const handlePs: Promise<IFluidHandle<ArrayBufferLike>>[] = [];
+		const mockLogger = new MockLogger();
+		let runtime: MockRuntime;
+		let createBlob: (blob: ArrayBufferLike, signal?: AbortSignal) => Promise<void>;
+		let waitForBlob: (blob: ArrayBufferLike) => Promise<void>;
+		let mc: MonitoringContext;
+		let injectedSettings: Record<string, ConfigTypes> = enableBlobPlaceholdersFlag
+			? {
+					"Fluid.Runtime.UploadBlobPlaceholders": true,
+				}
+			: {};
 
-	beforeEach(() => {
-		const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
-			getRawConfig: (name: string): ConfigTypes => settings[name],
+		beforeEach(() => {
+			const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+				getRawConfig: (name: string): ConfigTypes => settings[name],
+			});
+			mc = mixinMonitoringContext(
+				createChildLogger({ logger: mockLogger }),
+				configProvider(injectedSettings),
+			);
+			runtime = new MockRuntime(mc);
+			handlePs.length = 0;
+
+			// ensures this blob will be processed next time runtime.processBlobs() is called
+			waitForBlob = async (blob) => {
+				if (!runtime.unprocessedBlobs.has(blob)) {
+					await new Promise<void>((resolve) =>
+						runtime.on("blob", () => {
+							if (!runtime.unprocessedBlobs.has(blob)) {
+								resolve();
+							}
+						}),
+					);
+				}
+			};
+
+			// create blob and await the handle after the test
+			createBlob = async (blob: ArrayBufferLike, signal?: AbortSignal) => {
+				const handleP = runtime.createBlob(blob, signal);
+				handlePs.push(handleP);
+				await waitForBlob(blob);
+			};
+
+			const onNoPendingBlobs = () => {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- Accessing private property
+				assert((runtime.blobManager as any).pendingBlobs.size === 0);
+			};
+
+			runtime.blobManager.events.on("noPendingBlobs", () => onNoPendingBlobs());
 		});
-		mc = mixinMonitoringContext(
-			createChildLogger({ logger: mockLogger }),
-			configProvider(injectedSettings),
-		);
-		runtime = new MockRuntime(mc);
-		handlePs.length = 0;
 
-		// ensures this blob will be processed next time runtime.processBlobs() is called
-		waitForBlob = async (blob) => {
-			if (!runtime.unprocessedBlobs.has(blob)) {
-				await new Promise<void>((resolve) =>
-					runtime.on("blob", () => {
-						if (!runtime.unprocessedBlobs.has(blob)) {
-							resolve();
-						}
-					}),
-				);
-			}
-		};
-
-		// create blob and await the handle after the test
-		createBlob = async (blob: ArrayBufferLike, signal?: AbortSignal) => {
-			const handleP = runtime.createBlob(blob, signal);
-			handlePs.push(handleP);
-			await waitForBlob(blob);
-		};
-
-		const onNoPendingBlobs = () => {
+		afterEach(async () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- Accessing private property
 			assert((runtime.blobManager as any).pendingBlobs.size === 0);
-		};
-
-		runtime.blobManager.events.on("noPendingBlobs", () => onNoPendingBlobs());
-	});
-
-	afterEach(async () => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- Accessing private property
-		assert((runtime.blobManager as any).pendingBlobs.size === 0);
-		injectedSettings = {};
-		mockLogger.clear();
-	});
-
-	it("empty snapshot", () => {
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 0);
-		assert.strictEqual(summaryData.redirectTable, undefined);
-	});
-
-	it("non empty snapshot", async () => {
-		await runtime.attach();
-		await runtime.connect();
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processAll();
-
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable?.length, 1);
-	});
-
-	it("hasPendingBlobs", async () => {
-		await runtime.attach();
-		await runtime.connect();
-
-		assert.strictEqual(runtime.blobManager.hasPendingBlobs, false);
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await createBlob(IsoBuffer.from("blob2", "utf8"));
-		assert.strictEqual(runtime.blobManager.hasPendingBlobs, true);
-		await runtime.processAll();
-		assert.strictEqual(runtime.blobManager.hasPendingBlobs, false);
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 2);
-		assert.strictEqual(summaryData.redirectTable?.length, 2);
-	});
-
-	it("NoPendingBlobs count", async () => {
-		await runtime.attach();
-		await runtime.connect();
-		let count = 0;
-		runtime.blobManager.events.on("noPendingBlobs", () => count++);
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processAll();
-		assert.strictEqual(count, 1);
-		await createBlob(IsoBuffer.from("blob2", "utf8"));
-		await createBlob(IsoBuffer.from("blob3", "utf8"));
-		await runtime.processAll();
-		assert.strictEqual(count, 2);
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 3);
-		assert.strictEqual(summaryData.redirectTable?.length, 3);
-	});
-
-	it("detached snapshot", async () => {
-		assert.strictEqual(runtime.blobManager.hasPendingBlobs, false);
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processAll();
-		assert.strictEqual(runtime.blobManager.hasPendingBlobs, true);
-
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable, undefined);
-	});
-
-	it("detached->attached snapshot", async () => {
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processAll();
-		assert.strictEqual(runtime.blobManager.hasPendingBlobs, true);
-		await runtime.attach();
-		assert.strictEqual(runtime.blobManager.hasPendingBlobs, false);
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable?.length, 1);
-	});
-
-	it("uploads while disconnected", async () => {
-		await runtime.attach();
-		const handleP = runtime.createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.connect();
-		await runtime.processAll();
-		await assert.doesNotReject(handleP);
-
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable?.length, 1);
-	});
-
-	it("reupload blob if expired", async () => {
-		await runtime.attach();
-		await runtime.connect();
-		runtime.attachedStorage.minTTL = 0.001; // force expired TTL being less than connection time (50ms)
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processBlobs(true);
-		runtime.disconnect();
-		await new Promise<void>((resolve) => setTimeout(resolve, 50));
-		await runtime.connect();
-		await runtime.processAll();
-	});
-
-	it("completes after disconnection while upload pending", async () => {
-		await runtime.attach();
-		await runtime.connect();
-
-		const handleP = runtime.createBlob(IsoBuffer.from("blob", "utf8"));
-		runtime.disconnect();
-		await runtime.connect(10); // adding some delay to reconnection
-		await runtime.processAll();
-		await assert.doesNotReject(handleP);
-
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable?.length, 1);
-	});
-
-	it("upload fails gracefully", async () => {
-		await runtime.attach();
-		await runtime.connect();
-
-		const handleP = runtime.createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processBlobs(false);
-		runtime.processOps();
-		try {
-			await handleP;
-			assert.fail("should fail");
-		} catch (error: unknown) {
-			assert.strictEqual((error as Error).message, "fake driver error");
-		}
-		await assert.rejects(handleP);
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 0);
-		assert.strictEqual(summaryData.redirectTable, undefined);
-	});
-
-	it.skip("upload fails and retries for retriable errors", async () => {
-		// Needs to use some sort of fake timer or write test in a different way as it is waiting
-		// for actual time which is causing timeouts.
-		await runtime.attach();
-		await runtime.connect();
-		const handleP = runtime.createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processBlobs(false, true, 0);
-		// wait till next retry
-		await new Promise<void>((resolve) => setTimeout(resolve, 1));
-		// try again successfully
-		await runtime.processBlobs(true);
-		runtime.processOps();
-		await runtime.processHandles();
-		assert(handleP);
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable?.length, 1);
-	});
-
-	it("completes after disconnection while op in flight", async () => {
-		await runtime.attach();
-		await runtime.connect();
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processBlobs(true);
-
-		runtime.disconnect();
-		await runtime.connect();
-		await runtime.processAll();
-
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable?.length, 2);
-	});
-
-	it("multiple disconnect/connects", async () => {
-		await runtime.attach();
-		await runtime.connect();
-
-		const blob = IsoBuffer.from("blob", "utf8");
-		const handleP = runtime.createBlob(blob);
-		runtime.disconnect();
-		await runtime.connect(10);
-
-		const blob2 = IsoBuffer.from("blob2", "utf8");
-		const handleP2 = runtime.createBlob(blob2);
-		runtime.disconnect();
-
-		await runtime.connect(10);
-		await runtime.processAll();
-		await assert.doesNotReject(handleP);
-		await assert.doesNotReject(handleP2);
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 2);
-		assert.strictEqual(summaryData.redirectTable?.length, 2);
-	});
-
-	it("handles deduped IDs", async () => {
-		await runtime.attach();
-		await runtime.connect();
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		runtime.disconnect();
-		await runtime.connect();
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processBlobs(true);
-
-		runtime.disconnect();
-		await runtime.connect();
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processAll();
-
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable?.length, 6);
-	});
-
-	it("handles deduped IDs in detached", async () => {
-		runtime.detachedStorage = new DedupeStorage();
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processAll();
-
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable, undefined);
-	});
-
-	it("handles deduped IDs in detached->attached", async () => {
-		runtime.detachedStorage = new DedupeStorage();
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processAll();
-
-		await runtime.attach();
-		await runtime.connect();
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-
-		runtime.disconnect();
-		await runtime.connect();
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-
-		await runtime.processAll();
-
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable?.length, 4);
-	});
-
-	it("can load from summary", async () => {
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processAll();
-
-		await runtime.attach();
-		const handle = runtime.createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.connect();
-
-		await runtime.processAll();
-		await assert.doesNotReject(handle);
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processAll();
-
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable?.length, 3);
-
-		const runtime2 = new MockRuntime(mc, summaryData, true);
-		const summaryData2 = validateSummary(runtime2);
-		assert.strictEqual(summaryData2.ids.length, 1);
-		assert.strictEqual(summaryData2.redirectTable?.length, 3);
-	});
-
-	it("handles duplicate remote upload", async () => {
-		await runtime.attach();
-		await runtime.connect();
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.remoteUpload(IsoBuffer.from("blob", "utf8"));
-		await runtime.processAll();
-
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable?.length, 2);
-	});
-
-	it("handles duplicate remote upload between upload and op", async () => {
-		await runtime.attach();
-		await runtime.connect();
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.processBlobs(true);
-		await runtime.remoteUpload(IsoBuffer.from("blob", "utf8"));
-		await runtime.processAll();
-
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable?.length, 2);
-	});
-
-	it("handles duplicate remote upload with local ID", async () => {
-		await runtime.attach();
-
-		await createBlob(IsoBuffer.from("blob", "utf8"));
-		await runtime.connect();
-		await runtime.processBlobs(true);
-		await runtime.remoteUpload(IsoBuffer.from("blob", "utf8"));
-		await runtime.processAll();
-
-		const summaryData = validateSummary(runtime);
-		assert.strictEqual(summaryData.ids.length, 1);
-		assert.strictEqual(summaryData.redirectTable?.length, 2);
-	});
-
-	it("includes blob IDs in summary while attaching", async () => {
-		await createBlob(IsoBuffer.from("blob1", "utf8"));
-		await createBlob(IsoBuffer.from("blob2", "utf8"));
-		await createBlob(IsoBuffer.from("blob3", "utf8"));
-		await runtime.processAll();
-
-		// While attaching with blobs, Container takes a summary while still in "Detached"
-		// state. BlobManager should know to include the list of attached blob
-		// IDs since this summary will be used to create the document
-		const summaryData = await runtime.attach();
-		assert.strictEqual(summaryData?.ids.length, 3);
-		assert.strictEqual(summaryData?.redirectTable?.length, 3);
-	});
-
-	it("all blobs attached", async () => {
-		await runtime.attach();
-		await runtime.connect();
-		assert.strictEqual(runtime.blobManager.allBlobsAttached, true);
-		await createBlob(IsoBuffer.from("blob1", "utf8"));
-		assert.strictEqual(runtime.blobManager.allBlobsAttached, false);
-		await runtime.processBlobs(true);
-		assert.strictEqual(runtime.blobManager.allBlobsAttached, false);
-		await runtime.processAll();
-		assert.strictEqual(runtime.blobManager.allBlobsAttached, true);
-		await createBlob(IsoBuffer.from("blob1", "utf8"));
-		await createBlob(IsoBuffer.from("blob2", "utf8"));
-		await createBlob(IsoBuffer.from("blob3", "utf8"));
-		assert.strictEqual(runtime.blobManager.allBlobsAttached, false);
-		await runtime.processAll();
-		assert.strictEqual(runtime.blobManager.allBlobsAttached, true);
-	});
-
-	it("runtime disposed during readBlob - log no error", async () => {
-		const someId = "someId";
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- Accessing private property
-		(runtime.blobManager as any).setRedirection(someId, undefined); // To appease an assert
-
-		// Mock storage.readBlob to dispose the runtime and throw an error
-		Sinon.stub(runtime.storage, "readBlob").callsFake(async (_id: string) => {
-			runtime.disposed = true;
-			throw new Error("BOOM!");
+			injectedSettings = {};
+			mockLogger.clear();
 		});
 
-		await assert.rejects(
-			async () => runtime.blobManager.getBlob(someId),
-			(e: Error) => e.message === "BOOM!",
-			"Expected getBlob to throw with test error message",
-		);
-		assert(runtime.disposed, "Runtime should be disposed");
-		mockLogger.assertMatchNone(
-			[{ category: "error" }],
-			"Should not have logged any errors",
-			undefined,
-			false /* clearEventsAfterCheck */,
-		);
-		mockLogger.assertMatch(
-			[{ category: "generic", eventName: "BlobManager:AttachmentReadBlob_cancel" }],
-			"Expected the _cancel event to be logged with 'generic' category",
-		);
-	});
-
-	describe("Abort Signal", () => {
-		it("abort before upload", async () => {
-			await runtime.attach();
-			await runtime.connect();
-			const ac = new AbortController();
-			ac.abort("abort test");
-			try {
-				const blob = IsoBuffer.from("blob", "utf8");
-				await runtime.createBlob(blob, ac.signal);
-				assert.fail("Should not succeed");
-
-				// TODO: better typing
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			} catch (error: any) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.strictEqual(error.status, undefined);
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.strictEqual(error.uploadTime, undefined);
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.strictEqual(error.acked, undefined);
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.strictEqual(error.message, "uploadBlob aborted");
-			}
+		it("empty snapshot", () => {
 			const summaryData = validateSummary(runtime);
 			assert.strictEqual(summaryData.ids.length, 0);
 			assert.strictEqual(summaryData.redirectTable, undefined);
 		});
 
-		it("abort while upload", async () => {
+		it("non empty snapshot", async () => {
 			await runtime.attach();
 			await runtime.connect();
-			const ac = new AbortController();
-			const blob = IsoBuffer.from("blob", "utf8");
-			const handleP = runtime.createBlob(blob, ac.signal);
-			ac.abort("abort test");
-			assert.strictEqual(runtime.unprocessedBlobs.size, 1);
-			await runtime.processBlobs(true);
-			try {
-				await handleP;
-				assert.fail("Should not succeed");
-				// TODO: better typing
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			} catch (error: any) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.strictEqual(error.uploadTime, undefined);
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.strictEqual(error.acked, false);
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.strictEqual(error.message, "uploadBlob aborted");
-			}
-			assert(handleP);
-			await assert.rejects(handleP);
-			const summaryData = validateSummary(runtime);
-			assert.strictEqual(summaryData.ids.length, 0);
-			assert.strictEqual(summaryData.redirectTable, undefined);
-		});
 
-		it("abort while failed upload", async () => {
-			await runtime.attach();
-			await runtime.connect();
-			const ac = new AbortController();
-			const blob = IsoBuffer.from("blob", "utf8");
-			const handleP = runtime.createBlob(blob, ac.signal);
-			const handleP2 = runtime.createBlob(IsoBuffer.from("blob2", "utf8"));
-			ac.abort("abort test");
-			assert.strictEqual(runtime.unprocessedBlobs.size, 2);
-			await runtime.processBlobs(false);
-			try {
-				await handleP;
-				assert.fail("Should not succeed");
-			} catch (error: unknown) {
-				assert.strictEqual((error as Error).message, "uploadBlob aborted");
-			}
-			try {
-				await handleP2;
-				assert.fail("Should not succeed");
-			} catch (error: unknown) {
-				assert.strictEqual((error as Error).message, "fake driver error");
-			}
-			await assert.rejects(handleP);
-			await assert.rejects(handleP2);
-			const summaryData = validateSummary(runtime);
-			assert.strictEqual(summaryData.ids.length, 0);
-			assert.strictEqual(summaryData.redirectTable, undefined);
-		});
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processAll();
 
-		it("abort while disconnected", async () => {
-			await runtime.attach();
-			await runtime.connect();
-			const ac = new AbortController();
-			const blob = IsoBuffer.from("blob", "utf8");
-			const handleP = runtime.createBlob(blob, ac.signal);
-			runtime.disconnect();
-			ac.abort();
-			await runtime.processBlobs(true);
-			try {
-				await handleP;
-				assert.fail("Should not succeed");
-			} catch (error: unknown) {
-				assert.strictEqual((error as Error).message, "uploadBlob aborted");
-			}
-			await assert.rejects(handleP);
-			const summaryData = validateSummary(runtime);
-			assert.strictEqual(summaryData.ids.length, 0);
-			assert.strictEqual(summaryData.redirectTable, undefined);
-		});
-
-		it("abort after blob suceeds", async () => {
-			await runtime.attach();
-			await runtime.connect();
-			const ac = new AbortController();
-			let handleP: Promise<IFluidHandleInternal<ArrayBufferLike>> | undefined;
-			try {
-				const blob = IsoBuffer.from("blob", "utf8");
-				handleP = runtime.createBlob(blob, ac.signal);
-				await runtime.processAll();
-				ac.abort();
-			} catch {
-				assert.fail("abort after processing should not throw");
-			}
-			assert(handleP);
-			await assert.doesNotReject(handleP);
 			const summaryData = validateSummary(runtime);
 			assert.strictEqual(summaryData.ids.length, 1);
 			assert.strictEqual(summaryData.redirectTable?.length, 1);
 		});
 
-		it("abort while waiting for op", async () => {
+		it("hasPendingBlobs", async () => {
 			await runtime.attach();
 			await runtime.connect();
-			const ac = new AbortController();
-			const blob = IsoBuffer.from("blob", "utf8");
-			const handleP = runtime.createBlob(blob, ac.signal);
-			const p1 = runtime.processBlobs(true);
-			const p2 = runtime.processHandles();
-			// finish upload
-			await Promise.race([p1, p2]);
-			ac.abort();
+
+			assert.strictEqual(runtime.blobManager.hasPendingBlobs, false);
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await createBlob(IsoBuffer.from("blob2", "utf8"));
+			assert.strictEqual(runtime.blobManager.hasPendingBlobs, true);
+			await runtime.processAll();
+			assert.strictEqual(runtime.blobManager.hasPendingBlobs, false);
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 2);
+			assert.strictEqual(summaryData.redirectTable?.length, 2);
+		});
+
+		it("NoPendingBlobs count", async () => {
+			await runtime.attach();
+			await runtime.connect();
+			let count = 0;
+			runtime.blobManager.events.on("noPendingBlobs", () => count++);
+
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processAll();
+			assert.strictEqual(count, 1);
+			await createBlob(IsoBuffer.from("blob2", "utf8"));
+			await createBlob(IsoBuffer.from("blob3", "utf8"));
+			await runtime.processAll();
+			assert.strictEqual(count, 2);
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 3);
+			assert.strictEqual(summaryData.redirectTable?.length, 3);
+		});
+
+		it("detached snapshot", async () => {
+			assert.strictEqual(runtime.blobManager.hasPendingBlobs, false);
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processAll();
+			assert.strictEqual(runtime.blobManager.hasPendingBlobs, true);
+
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable, undefined);
+		});
+
+		it("detached->attached snapshot", async () => {
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processAll();
+			assert.strictEqual(runtime.blobManager.hasPendingBlobs, true);
+			await runtime.attach();
+			assert.strictEqual(runtime.blobManager.hasPendingBlobs, false);
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable?.length, 1);
+		});
+
+		it("uploads while disconnected", async () => {
+			await runtime.attach();
+			const handleP = runtime.createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.connect();
+			await runtime.processAll();
+			await assert.doesNotReject(handleP);
+
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable?.length, 1);
+		});
+
+		it("reupload blob if expired", async () => {
+			await runtime.attach();
+			await runtime.connect();
+			runtime.attachedStorage.minTTL = 0.001; // force expired TTL being less than connection time (50ms)
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processBlobs(true);
+			runtime.disconnect();
+			await new Promise<void>((resolve) => setTimeout(resolve, 50));
+			await runtime.connect();
+			await runtime.processAll();
+		});
+
+		it("completes after disconnection while upload pending", async () => {
+			await runtime.attach();
+			await runtime.connect();
+
+			const handleP = runtime.createBlob(IsoBuffer.from("blob", "utf8"));
+			runtime.disconnect();
+			await runtime.connect(10); // adding some delay to reconnection
+			await runtime.processAll();
+			await assert.doesNotReject(handleP);
+
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable?.length, 1);
+		});
+
+		it("upload fails gracefully", async () => {
+			await runtime.attach();
+			await runtime.connect();
+
+			const handleP = runtime.createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processBlobs(false);
 			runtime.processOps();
 			try {
-				// finish op
 				await handleP;
-				assert.fail("Should not succeed");
-
-				// TODO: better typing
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			} catch (error: any) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.strictEqual(error.message, "uploadBlob aborted");
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.ok(error.uploadTime);
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.strictEqual(error.acked, false);
+				assert.fail("should fail");
+			} catch (error: unknown) {
+				assert.strictEqual((error as Error).message, "fake driver error");
 			}
 			await assert.rejects(handleP);
 			const summaryData = validateSummary(runtime);
@@ -920,202 +519,615 @@ describe("BlobManager", () => {
 			assert.strictEqual(summaryData.redirectTable, undefined);
 		});
 
-		it("resubmit on aborted pending op", async () => {
+		it.skip("upload fails and retries for retriable errors", async () => {
+			// Needs to use some sort of fake timer or write test in a different way as it is waiting
+			// for actual time which is causing timeouts.
 			await runtime.attach();
 			await runtime.connect();
-			const ac = new AbortController();
-			let handleP: Promise<IFluidHandleInternal<ArrayBufferLike>> | undefined;
-			try {
-				handleP = runtime.createBlob(IsoBuffer.from("blob", "utf8"), ac.signal);
+			const handleP = runtime.createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processBlobs(false, true, 0);
+			// wait till next retry
+			await new Promise<void>((resolve) => setTimeout(resolve, 1));
+			// try again successfully
+			await runtime.processBlobs(true);
+			runtime.processOps();
+			await runtime.processHandles();
+			assert(handleP);
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable?.length, 1);
+		});
+
+		it("completes after disconnection while op in flight", async () => {
+			await runtime.attach();
+			await runtime.connect();
+
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processBlobs(true);
+
+			runtime.disconnect();
+			await runtime.connect();
+			await runtime.processAll();
+
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable?.length, 2);
+		});
+
+		it("multiple disconnect/connects", async () => {
+			await runtime.attach();
+			await runtime.connect();
+
+			const blob = IsoBuffer.from("blob", "utf8");
+			const handleP = runtime.createBlob(blob);
+			runtime.disconnect();
+			await runtime.connect(10);
+
+			const blob2 = IsoBuffer.from("blob2", "utf8");
+			const handleP2 = runtime.createBlob(blob2);
+			runtime.disconnect();
+
+			await runtime.connect(10);
+			await runtime.processAll();
+			await assert.doesNotReject(handleP);
+			await assert.doesNotReject(handleP2);
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 2);
+			assert.strictEqual(summaryData.redirectTable?.length, 2);
+		});
+
+		it("handles deduped IDs", async () => {
+			await runtime.attach();
+			await runtime.connect();
+
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			runtime.disconnect();
+			await runtime.connect();
+
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processBlobs(true);
+
+			runtime.disconnect();
+			await runtime.connect();
+
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processAll();
+
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable?.length, 6);
+		});
+
+		it("handles deduped IDs in detached", async () => {
+			runtime.detachedStorage = new DedupeStorage();
+
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processAll();
+
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable, undefined);
+		});
+
+		it("handles deduped IDs in detached->attached", async () => {
+			runtime.detachedStorage = new DedupeStorage();
+
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processAll();
+
+			await runtime.attach();
+			await runtime.connect();
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+
+			runtime.disconnect();
+			await runtime.connect();
+
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+
+			await runtime.processAll();
+
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable?.length, 4);
+		});
+
+		it("can load from summary", async () => {
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processAll();
+
+			await runtime.attach();
+			const handle = runtime.createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.connect();
+
+			await runtime.processAll();
+			await assert.doesNotReject(handle);
+
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processAll();
+
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable?.length, 3);
+
+			const runtime2 = new MockRuntime(mc, summaryData, true);
+			const summaryData2 = validateSummary(runtime2);
+			assert.strictEqual(summaryData2.ids.length, 1);
+			assert.strictEqual(summaryData2.redirectTable?.length, 3);
+		});
+
+		it("handles duplicate remote upload", async () => {
+			await runtime.attach();
+			await runtime.connect();
+
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.remoteUpload(IsoBuffer.from("blob", "utf8"));
+			await runtime.processAll();
+
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable?.length, 2);
+		});
+
+		it("handles duplicate remote upload between upload and op", async () => {
+			await runtime.attach();
+			await runtime.connect();
+
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.processBlobs(true);
+			await runtime.remoteUpload(IsoBuffer.from("blob", "utf8"));
+			await runtime.processAll();
+
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable?.length, 2);
+		});
+
+		it("handles duplicate remote upload with local ID", async () => {
+			await runtime.attach();
+
+			await createBlob(IsoBuffer.from("blob", "utf8"));
+			await runtime.connect();
+			await runtime.processBlobs(true);
+			await runtime.remoteUpload(IsoBuffer.from("blob", "utf8"));
+			await runtime.processAll();
+
+			const summaryData = validateSummary(runtime);
+			assert.strictEqual(summaryData.ids.length, 1);
+			assert.strictEqual(summaryData.redirectTable?.length, 2);
+		});
+
+		it("includes blob IDs in summary while attaching", async () => {
+			await createBlob(IsoBuffer.from("blob1", "utf8"));
+			await createBlob(IsoBuffer.from("blob2", "utf8"));
+			await createBlob(IsoBuffer.from("blob3", "utf8"));
+			await runtime.processAll();
+
+			// While attaching with blobs, Container takes a summary while still in "Detached"
+			// state. BlobManager should know to include the list of attached blob
+			// IDs since this summary will be used to create the document
+			const summaryData = await runtime.attach();
+			assert.strictEqual(summaryData?.ids.length, 3);
+			assert.strictEqual(summaryData?.redirectTable?.length, 3);
+		});
+
+		it("all blobs attached", async () => {
+			await runtime.attach();
+			await runtime.connect();
+			assert.strictEqual(runtime.blobManager.allBlobsAttached, true);
+			await createBlob(IsoBuffer.from("blob1", "utf8"));
+			assert.strictEqual(runtime.blobManager.allBlobsAttached, false);
+			await runtime.processBlobs(true);
+			assert.strictEqual(runtime.blobManager.allBlobsAttached, false);
+			await runtime.processAll();
+			assert.strictEqual(runtime.blobManager.allBlobsAttached, true);
+			await createBlob(IsoBuffer.from("blob1", "utf8"));
+			await createBlob(IsoBuffer.from("blob2", "utf8"));
+			await createBlob(IsoBuffer.from("blob3", "utf8"));
+			assert.strictEqual(runtime.blobManager.allBlobsAttached, false);
+			await runtime.processAll();
+			assert.strictEqual(runtime.blobManager.allBlobsAttached, true);
+		});
+
+		it("runtime disposed during readBlob - log no error", async () => {
+			const someId = "someId";
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- Accessing private property
+			(runtime.blobManager as any).setRedirection(someId, undefined); // To appease an assert
+
+			// Mock storage.readBlob to dispose the runtime and throw an error
+			Sinon.stub(runtime.storage, "readBlob").callsFake(async (_id: string) => {
+				runtime.disposed = true;
+				throw new Error("BOOM!");
+			});
+
+			await assert.rejects(
+				async () => runtime.blobManager.getBlob(someId),
+				(e: Error) => e.message === "BOOM!",
+				"Expected getBlob to throw with test error message",
+			);
+			assert(runtime.disposed, "Runtime should be disposed");
+			mockLogger.assertMatchNone(
+				[{ category: "error" }],
+				"Should not have logged any errors",
+				undefined,
+				false /* clearEventsAfterCheck */,
+			);
+			mockLogger.assertMatch(
+				[{ category: "generic", eventName: "BlobManager:AttachmentReadBlob_cancel" }],
+				"Expected the _cancel event to be logged with 'generic' category",
+			);
+		});
+
+		describe("Abort Signal", () => {
+			it("abort before upload", async () => {
+				await runtime.attach();
+				await runtime.connect();
+				const ac = new AbortController();
+				ac.abort("abort test");
+				try {
+					const blob = IsoBuffer.from("blob", "utf8");
+					await runtime.createBlob(blob, ac.signal);
+					assert.fail("Should not succeed");
+
+					// TODO: better typing
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				} catch (error: any) {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.strictEqual(error.status, undefined);
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.strictEqual(error.uploadTime, undefined);
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.strictEqual(error.acked, undefined);
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.strictEqual(error.message, "uploadBlob aborted");
+				}
+				const summaryData = validateSummary(runtime);
+				assert.strictEqual(summaryData.ids.length, 0);
+				assert.strictEqual(summaryData.redirectTable, undefined);
+			});
+
+			it("abort while upload", async () => {
+				await runtime.attach();
+				await runtime.connect();
+				const ac = new AbortController();
+				const blob = IsoBuffer.from("blob", "utf8");
+				const handleP = runtime.createBlob(blob, ac.signal);
+				ac.abort("abort test");
+				assert.strictEqual(runtime.unprocessedBlobs.size, 1);
+				await runtime.processBlobs(true);
+				try {
+					await handleP;
+					assert.fail("Should not succeed");
+					// TODO: better typing
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				} catch (error: any) {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.strictEqual(error.uploadTime, undefined);
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.strictEqual(error.acked, false);
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.strictEqual(error.message, "uploadBlob aborted");
+				}
+				assert(handleP);
+				await assert.rejects(handleP);
+				const summaryData = validateSummary(runtime);
+				assert.strictEqual(summaryData.ids.length, 0);
+				assert.strictEqual(summaryData.redirectTable, undefined);
+			});
+
+			it("abort while failed upload", async () => {
+				await runtime.attach();
+				await runtime.connect();
+				const ac = new AbortController();
+				const blob = IsoBuffer.from("blob", "utf8");
+				const handleP = runtime.createBlob(blob, ac.signal);
+				const handleP2 = runtime.createBlob(IsoBuffer.from("blob2", "utf8"));
+				ac.abort("abort test");
+				assert.strictEqual(runtime.unprocessedBlobs.size, 2);
+				await runtime.processBlobs(false);
+				try {
+					await handleP;
+					assert.fail("Should not succeed");
+				} catch (error: unknown) {
+					assert.strictEqual((error as Error).message, "uploadBlob aborted");
+				}
+				try {
+					await handleP2;
+					assert.fail("Should not succeed");
+				} catch (error: unknown) {
+					assert.strictEqual((error as Error).message, "fake driver error");
+				}
+				await assert.rejects(handleP);
+				await assert.rejects(handleP2);
+				const summaryData = validateSummary(runtime);
+				assert.strictEqual(summaryData.ids.length, 0);
+				assert.strictEqual(summaryData.redirectTable, undefined);
+			});
+
+			it("abort while disconnected", async () => {
+				await runtime.attach();
+				await runtime.connect();
+				const ac = new AbortController();
+				const blob = IsoBuffer.from("blob", "utf8");
+				const handleP = runtime.createBlob(blob, ac.signal);
+				runtime.disconnect();
+				ac.abort();
+				await runtime.processBlobs(true);
+				try {
+					await handleP;
+					assert.fail("Should not succeed");
+				} catch (error: unknown) {
+					assert.strictEqual((error as Error).message, "uploadBlob aborted");
+				}
+				await assert.rejects(handleP);
+				const summaryData = validateSummary(runtime);
+				assert.strictEqual(summaryData.ids.length, 0);
+				assert.strictEqual(summaryData.redirectTable, undefined);
+			});
+
+			it("abort after blob suceeds", async () => {
+				await runtime.attach();
+				await runtime.connect();
+				const ac = new AbortController();
+				let handleP: Promise<IFluidHandleInternal<ArrayBufferLike>> | undefined;
+				try {
+					const blob = IsoBuffer.from("blob", "utf8");
+					handleP = runtime.createBlob(blob, ac.signal);
+					await runtime.processAll();
+					ac.abort();
+				} catch {
+					assert.fail("abort after processing should not throw");
+				}
+				assert(handleP);
+				await assert.doesNotReject(handleP);
+				const summaryData = validateSummary(runtime);
+				assert.strictEqual(summaryData.ids.length, 1);
+				assert.strictEqual(summaryData.redirectTable?.length, 1);
+			});
+
+			it("abort while waiting for op", async () => {
+				await runtime.attach();
+				await runtime.connect();
+				const ac = new AbortController();
+				const blob = IsoBuffer.from("blob", "utf8");
+				const handleP = runtime.createBlob(blob, ac.signal);
 				const p1 = runtime.processBlobs(true);
 				const p2 = runtime.processHandles();
 				// finish upload
 				await Promise.race([p1, p2]);
-				runtime.disconnect();
 				ac.abort();
-				await handleP;
-				assert.fail("Should not succeed");
-				// TODO: better typing
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			} catch (error: any) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.strictEqual(error.message, "uploadBlob aborted");
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.ok(error.uploadTime);
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				assert.strictEqual(error.acked, false);
+				runtime.processOps();
+				try {
+					// finish op
+					await handleP;
+					assert.fail("Should not succeed");
+
+					// TODO: better typing
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				} catch (error: any) {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.strictEqual(error.message, "uploadBlob aborted");
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.ok(error.uploadTime);
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.strictEqual(error.acked, false);
+				}
+				await assert.rejects(handleP);
+				const summaryData = validateSummary(runtime);
+				assert.strictEqual(summaryData.ids.length, 0);
+				assert.strictEqual(summaryData.redirectTable, undefined);
+			});
+
+			it("resubmit on aborted pending op", async () => {
+				await runtime.attach();
+				await runtime.connect();
+				const ac = new AbortController();
+				let handleP: Promise<IFluidHandleInternal<ArrayBufferLike>> | undefined;
+				try {
+					handleP = runtime.createBlob(IsoBuffer.from("blob", "utf8"), ac.signal);
+					const p1 = runtime.processBlobs(true);
+					const p2 = runtime.processHandles();
+					// finish upload
+					await Promise.race([p1, p2]);
+					runtime.disconnect();
+					ac.abort();
+					await handleP;
+					assert.fail("Should not succeed");
+					// TODO: better typing
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				} catch (error: any) {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.strictEqual(error.message, "uploadBlob aborted");
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.ok(error.uploadTime);
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					assert.strictEqual(error.acked, false);
+				}
+				await runtime.connect();
+				runtime.processOps();
+
+				// TODO: `handleP` can be `undefined`; this should be made safer.
+				await assert.rejects(handleP as Promise<IFluidHandleInternal<ArrayBufferLike>>);
+				const summaryData = validateSummary(runtime);
+				assert.strictEqual(summaryData.ids.length, 0);
+				assert.strictEqual(summaryData.redirectTable, undefined);
+			});
+		});
+
+		describe("Garbage Collection", () => {
+			let redirectTable: Map<string, string | undefined>;
+
+			/**
+			 * Creates a blob with the given content and returns its local and storage id.
+			 */
+			async function createBlobAndGetIds(content: string) {
+				// For a given blob's GC node id, returns the blob id.
+				const getBlobIdFromGCNodeId = (gcNodeId: string) => {
+					const pathParts = gcNodeId.split("/");
+					assert(
+						pathParts.length === 3 && pathParts[1] === blobManagerBasePath,
+						"Invalid blob node path",
+					);
+					return pathParts[2];
+				};
+
+				// For a given blob's id, returns the GC node id.
+				const getGCNodeIdFromBlobId = (blobId: string) => {
+					return `/${blobManagerBasePath}/${blobId}`;
+				};
+
+				const blobContents = IsoBuffer.from(content, "utf8");
+				const handleP = runtime.createBlob(blobContents);
+				await runtime.processAll();
+
+				const blobHandle = await handleP;
+				const localId = getBlobIdFromGCNodeId(blobHandle.absolutePath);
+				assert(redirectTable.has(localId), "blob not found in redirect table");
+				const storageId = redirectTable.get(localId);
+				assert(storageId !== undefined, "storage id not found in redirect table");
+				return {
+					localId,
+					localGCNodeId: getGCNodeIdFromBlobId(localId),
+					storageId,
+					storageGCNodeId: getGCNodeIdFromBlobId(storageId),
+				};
 			}
-			await runtime.connect();
-			runtime.processOps();
 
-			// TODO: `handleP` can be `undefined`; this should be made safer.
-			await assert.rejects(handleP as Promise<IFluidHandleInternal<ArrayBufferLike>>);
-			const summaryData = validateSummary(runtime);
-			assert.strictEqual(summaryData.ids.length, 0);
-			assert.strictEqual(summaryData.redirectTable, undefined);
-		});
-	});
+			beforeEach(() => {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment -- Mutating private property
+				redirectTable = (runtime.blobManager as any).redirectTable;
+			});
 
-	describe("Garbage Collection", () => {
-		let redirectTable: Map<string, string | undefined>;
+			it("fetching deleted blob fails", async () => {
+				await runtime.attach();
+				await runtime.connect();
+				const blob1Contents = IsoBuffer.from("blob1", "utf8");
+				const blob2Contents = IsoBuffer.from("blob2", "utf8");
+				const handle1P = runtime.createBlob(blob1Contents);
+				const handle2P = runtime.createBlob(blob2Contents);
+				await runtime.processAll();
 
-		/**
-		 * Creates a blob with the given content and returns its local and storage id.
-		 */
-		async function createBlobAndGetIds(content: string) {
-			// For a given blob's GC node id, returns the blob id.
-			const getBlobIdFromGCNodeId = (gcNodeId: string) => {
-				const pathParts = gcNodeId.split("/");
-				assert(
-					pathParts.length === 3 && pathParts[1] === blobManagerBasePath,
-					"Invalid blob node path",
+				const blob1Handle = await handle1P;
+				const blob2Handle = await handle2P;
+
+				// Validate that the blobs can be retrieved.
+				assert.strictEqual(await runtime.getBlob(blob1Handle), blob1Contents);
+				assert.strictEqual(await runtime.getBlob(blob2Handle), blob2Contents);
+
+				// Delete blob1. Retrieving it should result in an error.
+				runtime.deleteBlob(blob1Handle);
+				await assert.rejects(
+					async () => runtime.getBlob(blob1Handle),
+					(error: IErrorBase & { code: number | undefined }) => {
+						const blob1Id = blob1Handle.absolutePath.split("/")[2];
+						const correctErrorType = error.code === 404;
+						const correctErrorMessage = error.message === `Blob was deleted: ${blob1Id}`;
+						return correctErrorType && correctErrorMessage;
+					},
+					"Deleted blob2 fetch should have failed",
 				);
-				return pathParts[2];
-			};
 
-			// For a given blob's id, returns the GC node id.
-			const getGCNodeIdFromBlobId = (blobId: string) => {
-				return `/${blobManagerBasePath}/${blobId}`;
-			};
+				// Delete blob2. Retrieving it should result in an error.
+				runtime.deleteBlob(blob2Handle);
+				await assert.rejects(
+					async () => runtime.getBlob(blob2Handle),
+					(error: IErrorBase & { code: number | undefined }) => {
+						const blob2Id = blob2Handle.absolutePath.split("/")[2];
+						const correctErrorType = error.code === 404;
+						const correctErrorMessage = error.message === `Blob was deleted: ${blob2Id}`;
+						return correctErrorType && correctErrorMessage;
+					},
+					"Deleted blob2 fetch should have failed",
+				);
+			});
 
-			const blobContents = IsoBuffer.from(content, "utf8");
-			const handleP = runtime.createBlob(blobContents);
-			await runtime.processAll();
+			// Support for this config has been removed.
+			const legacyKey_disableAttachmentBlobSweep =
+				"Fluid.GarbageCollection.DisableAttachmentBlobSweep";
+			for (const disableAttachmentBlobsSweep of [true, undefined])
+				it(`deletes unused blobs regardless of DisableAttachmentBlobsSweep setting [DisableAttachmentBlobsSweep=${disableAttachmentBlobsSweep}]`, async () => {
+					injectedSettings[legacyKey_disableAttachmentBlobSweep] = disableAttachmentBlobsSweep;
 
-			const blobHandle = await handleP;
-			const localId = getBlobIdFromGCNodeId(blobHandle.absolutePath);
-			assert(redirectTable.has(localId), "blob not found in redirect table");
-			const storageId = redirectTable.get(localId);
-			assert(storageId !== undefined, "storage id not found in redirect table");
-			return {
-				localId,
-				localGCNodeId: getGCNodeIdFromBlobId(localId),
-				storageId,
-				storageGCNodeId: getGCNodeIdFromBlobId(storageId),
-			};
-		}
+					await runtime.attach();
+					await runtime.connect();
 
-		beforeEach(() => {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment -- Mutating private property
-			redirectTable = (runtime.blobManager as any).redirectTable;
-		});
+					const blob1 = await createBlobAndGetIds("blob1");
+					const blob2 = await createBlobAndGetIds("blob2");
 
-		it("fetching deleted blob fails", async () => {
-			await runtime.attach();
-			await runtime.connect();
-			const blob1Contents = IsoBuffer.from("blob1", "utf8");
-			const blob2Contents = IsoBuffer.from("blob2", "utf8");
-			const handle1P = runtime.createBlob(blob1Contents);
-			const handle2P = runtime.createBlob(blob2Contents);
-			await runtime.processAll();
+					// Delete blob1's local id. The local id and the storage id should both be deleted from the redirect table
+					// since the blob only had one reference.
+					runtime.blobManager.deleteSweepReadyNodes([blob1.localGCNodeId]);
+					assert(!redirectTable.has(blob1.localId));
+					assert(!redirectTable.has(blob1.storageId));
 
-			const blob1Handle = await handle1P;
-			const blob2Handle = await handle2P;
+					// Delete blob2's local id. The local id and the storage id should both be deleted from the redirect table
+					// since the blob only had one reference.
+					runtime.blobManager.deleteSweepReadyNodes([blob2.localGCNodeId]);
+					assert(!redirectTable.has(blob2.localId));
+					assert(!redirectTable.has(blob2.storageId));
+				});
 
-			// Validate that the blobs can be retrieved.
-			assert.strictEqual(await runtime.getBlob(blob1Handle), blob1Contents);
-			assert.strictEqual(await runtime.getBlob(blob2Handle), blob2Contents);
-
-			// Delete blob1. Retrieving it should result in an error.
-			runtime.deleteBlob(blob1Handle);
-			await assert.rejects(
-				async () => runtime.getBlob(blob1Handle),
-				(error: IErrorBase & { code: number | undefined }) => {
-					const blob1Id = blob1Handle.absolutePath.split("/")[2];
-					const correctErrorType = error.code === 404;
-					const correctErrorMessage = error.message === `Blob was deleted: ${blob1Id}`;
-					return correctErrorType && correctErrorMessage;
-				},
-				"Deleted blob2 fetch should have failed",
-			);
-
-			// Delete blob2. Retrieving it should result in an error.
-			runtime.deleteBlob(blob2Handle);
-			await assert.rejects(
-				async () => runtime.getBlob(blob2Handle),
-				(error: IErrorBase & { code: number | undefined }) => {
-					const blob2Id = blob2Handle.absolutePath.split("/")[2];
-					const correctErrorType = error.code === 404;
-					const correctErrorMessage = error.message === `Blob was deleted: ${blob2Id}`;
-					return correctErrorType && correctErrorMessage;
-				},
-				"Deleted blob2 fetch should have failed",
-			);
-		});
-
-		// Support for this config has been removed.
-		const legacyKey_disableAttachmentBlobSweep =
-			"Fluid.GarbageCollection.DisableAttachmentBlobSweep";
-		for (const disableAttachmentBlobsSweep of [true, undefined])
-			it(`deletes unused blobs regardless of DisableAttachmentBlobsSweep setting [DisableAttachmentBlobsSweep=${disableAttachmentBlobsSweep}]`, async () => {
-				injectedSettings[legacyKey_disableAttachmentBlobSweep] = disableAttachmentBlobsSweep;
-
+			it("deletes unused de-duped blobs", async () => {
 				await runtime.attach();
 				await runtime.connect();
 
+				// Create 2 blobs with the same content. They should get de-duped.
 				const blob1 = await createBlobAndGetIds("blob1");
+				const blob1Duplicate = await createBlobAndGetIds("blob1");
+				assert(blob1.storageId === blob1Duplicate.storageId, "blob1 not de-duped");
+
+				// Create another 2 blobs with the same content. They should get de-duped.
 				const blob2 = await createBlobAndGetIds("blob2");
+				const blob2Duplicate = await createBlobAndGetIds("blob2");
+				assert(blob2.storageId === blob2Duplicate.storageId, "blob2 not de-duped");
 
-				// Delete blob1's local id. The local id and the storage id should both be deleted from the redirect table
-				// since the blob only had one reference.
+				// Delete blob1's local id. The local id should both be deleted from the redirect table but the storage id
+				// should not because the blob has another referenced from the de-duped blob.
 				runtime.blobManager.deleteSweepReadyNodes([blob1.localGCNodeId]);
-				assert(!redirectTable.has(blob1.localId));
-				assert(!redirectTable.has(blob1.storageId));
+				assert(!redirectTable.has(blob1.localId), "blob1 localId should have been deleted");
+				assert(
+					redirectTable.has(blob1.storageId),
+					"blob1 storageId should not have been deleted",
+				);
+				// Delete blob1's de-duped local id. The local id and the storage id should both be deleted from the redirect table
+				// since all the references for the blob are now deleted.
+				runtime.blobManager.deleteSweepReadyNodes([blob1Duplicate.localGCNodeId]);
+				assert(
+					!redirectTable.has(blob1Duplicate.localId),
+					"blob1Duplicate localId should have been deleted",
+				);
+				assert(
+					!redirectTable.has(blob1.storageId),
+					"blob1 storageId should have been deleted",
+				);
 
-				// Delete blob2's local id. The local id and the storage id should both be deleted from the redirect table
-				// since the blob only had one reference.
+				// Delete blob2's local id. The local id should both be deleted from the redirect table but the storage id
+				// should not because the blob has another referenced from the de-duped blob.
 				runtime.blobManager.deleteSweepReadyNodes([blob2.localGCNodeId]);
-				assert(!redirectTable.has(blob2.localId));
-				assert(!redirectTable.has(blob2.storageId));
+				assert(!redirectTable.has(blob2.localId), "blob2 localId should have been deleted");
+				assert(
+					redirectTable.has(blob2.storageId),
+					"blob2 storageId should not have been deleted",
+				);
+				// Delete blob2's de-duped local id. The local id and the storage id should both be deleted from the redirect table
+				// since all the references for the blob are now deleted.
+				runtime.blobManager.deleteSweepReadyNodes([blob2Duplicate.localGCNodeId]);
+				assert(
+					!redirectTable.has(blob2Duplicate.localId),
+					"blob2Duplicate localId should have been deleted",
+				);
+				assert(
+					!redirectTable.has(blob2.storageId),
+					"blob2 storageId should have been deleted",
+				);
 			});
-
-		it("deletes unused de-duped blobs", async () => {
-			await runtime.attach();
-			await runtime.connect();
-
-			// Create 2 blobs with the same content. They should get de-duped.
-			const blob1 = await createBlobAndGetIds("blob1");
-			const blob1Duplicate = await createBlobAndGetIds("blob1");
-			assert(blob1.storageId === blob1Duplicate.storageId, "blob1 not de-duped");
-
-			// Create another 2 blobs with the same content. They should get de-duped.
-			const blob2 = await createBlobAndGetIds("blob2");
-			const blob2Duplicate = await createBlobAndGetIds("blob2");
-			assert(blob2.storageId === blob2Duplicate.storageId, "blob2 not de-duped");
-
-			// Delete blob1's local id. The local id should both be deleted from the redirect table but the storage id
-			// should not because the blob has another referenced from the de-duped blob.
-			runtime.blobManager.deleteSweepReadyNodes([blob1.localGCNodeId]);
-			assert(!redirectTable.has(blob1.localId), "blob1 localId should have been deleted");
-			assert(
-				redirectTable.has(blob1.storageId),
-				"blob1 storageId should not have been deleted",
-			);
-			// Delete blob1's de-duped local id. The local id and the storage id should both be deleted from the redirect table
-			// since all the references for the blob are now deleted.
-			runtime.blobManager.deleteSweepReadyNodes([blob1Duplicate.localGCNodeId]);
-			assert(
-				!redirectTable.has(blob1Duplicate.localId),
-				"blob1Duplicate localId should have been deleted",
-			);
-			assert(!redirectTable.has(blob1.storageId), "blob1 storageId should have been deleted");
-
-			// Delete blob2's local id. The local id should both be deleted from the redirect table but the storage id
-			// should not because the blob has another referenced from the de-duped blob.
-			runtime.blobManager.deleteSweepReadyNodes([blob2.localGCNodeId]);
-			assert(!redirectTable.has(blob2.localId), "blob2 localId should have been deleted");
-			assert(
-				redirectTable.has(blob2.storageId),
-				"blob2 storageId should not have been deleted",
-			);
-			// Delete blob2's de-duped local id. The local id and the storage id should both be deleted from the redirect table
-			// since all the references for the blob are now deleted.
-			runtime.blobManager.deleteSweepReadyNodes([blob2Duplicate.localGCNodeId]);
-			assert(
-				!redirectTable.has(blob2Duplicate.localId),
-				"blob2Duplicate localId should have been deleted",
-			);
-			assert(!redirectTable.has(blob2.storageId), "blob2 storageId should have been deleted");
 		});
 	});
-});
+}

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -20,7 +20,12 @@ import {
 	DefaultSummaryConfiguration,
 	type IContainerRuntimeOptionsInternal,
 } from "@fluidframework/container-runtime/internal";
-import { IErrorBase, IFluidHandle } from "@fluidframework/core-interfaces";
+import type {
+	ConfigTypes,
+	IConfigProviderBase,
+	IErrorBase,
+	IFluidHandle,
+} from "@fluidframework/core-interfaces";
 import { Deferred } from "@fluidframework/core-utils/internal";
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions/internal";
 import { ReferenceType } from "@fluidframework/merge-tree/internal";
@@ -45,7 +50,21 @@ import {
 	getUrlFromDetachedBlobStorage,
 } from "./mockDetachedBlobStorage.js";
 
-function makeTestContainerConfig(registry: ChannelFactoryRegistry): ITestContainerConfig {
+const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+	getRawConfig: (name: string): ConfigTypes => settings[name],
+});
+
+function makeTestContainerConfig(
+	registry: ChannelFactoryRegistry,
+	enableBlobPlaceholdersFlag: boolean,
+): ITestContainerConfig {
+	const loaderProps = enableBlobPlaceholdersFlag
+		? {
+				configProvider: configProvider({
+					"Fluid.Runtime.UploadBlobPlaceholders": true,
+				}),
+			}
+		: {};
 	return {
 		runtimeOptions: {
 			summaryOptions: {
@@ -64,6 +83,7 @@ function makeTestContainerConfig(registry: ChannelFactoryRegistry): ITestContain
 			},
 		},
 		registry,
+		loaderProps,
 	};
 }
 
@@ -91,354 +111,376 @@ const ContainerStateEventsOrErrors: ExpectedEvents = {
 	],
 };
 
-describeCompat("blobs", "FullCompat", (getTestObjectProvider, apis) => {
-	const { SharedString } = apis.dds;
-	const testContainerConfig = makeTestContainerConfig([
-		["sharedString", SharedString.getFactory()],
-	]);
-
-	let provider: ITestObjectProvider;
-	beforeEach("getTestObjectProvider", async function () {
-		provider = getTestObjectProvider();
-		// Currently, AFR does not support blob API.
-		if (provider.driver.type === "routerlicious" && provider.driver.endpointName === "frs") {
-			this.skip();
-		}
-	});
-
-	it("attach sends an op", async function () {
-		const container = await provider.makeTestContainer(testContainerConfig);
-
-		const dataStore = await getContainerEntryPointBackCompat<ITestDataObject>(container);
-
-		const blobOpP = new Promise<void>((resolve, reject) =>
-			dataStore._context.containerRuntime.on("op", (op) => {
-				if (op.type === ContainerMessageType.BlobAttach) {
-					if ((op.metadata as { blobId?: unknown } | undefined)?.blobId) {
-						resolve();
-					} else {
-						reject(new Error("no op metadata"));
-					}
-				}
-			}),
-		);
-
-		const blob = await dataStore._runtime.uploadBlob(
-			stringToBuffer("some random text", "utf-8"),
-		);
-
-		dataStore._root.set("my blob", blob);
-
-		await blobOpP;
-	});
-
-	it("can get remote attached blob", async function () {
-		// TODO: Re-enable after cross version compat bugs are fixed - ADO:6286
-		if (provider.type === "TestObjectProviderWithVersionedLoad") {
-			this.skip();
-		}
-		const testString = "this is a test string";
-		const testKey = "a blob";
-		const container1 = await provider.makeTestContainer(testContainerConfig);
-
-		const dataStore1 = await getContainerEntryPointBackCompat<ITestDataObject>(container1);
-
-		const blob = await dataStore1._runtime.uploadBlob(stringToBuffer(testString, "utf-8"));
-		dataStore1._root.set(testKey, blob);
-
-		const container2 = await provider.loadTestContainer(testContainerConfig);
-		const dataStore2 = await getContainerEntryPointBackCompat<ITestDataObject>(container2);
-
-		await provider.ensureSynchronized();
-
-		const blobHandle = dataStore2._root.get<IFluidHandle<ArrayBufferLike>>(testKey);
-		assert(blobHandle);
-		assert.strictEqual(bufferToString(await blobHandle.get(), "utf-8"), testString);
-	});
-
-	it("round trip blob handle on shared string property", async function () {
-		// TODO: Re-enable after cross version compat bugs are fixed - ADO:6286
-		if (provider.type === "TestObjectProviderWithVersionedLoad") {
-			this.skip();
-		}
-		const container1 = await provider.makeTestContainer(testContainerConfig);
-		const container2 = await provider.loadTestContainer(testContainerConfig);
-		const testString = "this is a test string";
-		// setup
-		{
-			const dataStore = await getContainerEntryPointBackCompat<ITestDataObject>(container2);
-			const sharedString = SharedString.create(dataStore._runtime, uuid());
-			dataStore._root.set("sharedString", sharedString.handle);
-
-			const blob = await dataStore._runtime.uploadBlob(stringToBuffer(testString, "utf-8"));
-
-			sharedString.insertMarker(0, ReferenceType.Simple, { blob });
-
-			// wait for summarize, then summary ack so the next container will load from snapshot
-			await new Promise<void>((resolve, reject) => {
-				let summarized = false;
-				container1.on("op", (op) => {
-					switch (op.type) {
-						case "summaryAck": {
-							if (summarized) {
-								resolve();
-							}
-							break;
-						}
-						case "summaryNack": {
-							reject(new Error("summaryNack"));
-							break;
-						}
-						case "summarize": {
-							summarized = true;
-							break;
-						}
-						default: {
-							break;
-						}
-					}
-				});
-			});
-		}
-
-		// validate on remote container, local container, and container loaded from summary
-		for (const container of [
-			container1,
-			container2,
-			await provider.loadTestContainer(testContainerConfig),
-		]) {
-			const dataStore2 = await getContainerEntryPointBackCompat<ITestDataObject>(container);
-			await provider.ensureSynchronized();
-			const handle = dataStore2._root.get<IFluidHandle<SharedString>>("sharedString");
-			assert(handle);
-			const sharedString2 = await handle.get();
-
-			const props = sharedString2.getPropertiesAtPosition(0);
-
-			assert.strictEqual(bufferToString(await props?.blob.get(), "utf-8"), testString);
-		}
-	});
-
-	it("correctly handles simultaneous identical blob upload on one container", async () => {
-		const container = await provider.makeTestContainer(testContainerConfig);
-		const dataStore = await getContainerEntryPointBackCompat<ITestDataObject>(container);
-		const blob = stringToBuffer("some different yet still random text", "utf-8");
-
-		// upload the blob twice and make sure nothing bad happens.
-		await Promise.all([
-			dataStore._runtime.uploadBlob(blob),
-			dataStore._runtime.uploadBlob(blob),
-		]);
-	});
-
-	[false, true].forEach((enableGroupedBatching) => {
-		it(`attach sends ops with compression enabled and ${
-			enableGroupedBatching ? "grouped" : "regular"
-		} batching`, async function () {
-			// Tracked by AB#4130, the test run on the tinylicous driver is disabled temporarily to ensure normal operation of the build-client package pipeline
-			if (provider.driver.type === "tinylicious" || provider.driver.type === "t9s") {
-				this.skip();
-			}
-
-			// Skip this test for standard r11s as its flaky and non-reproducible
-			if (provider.driver.type === "r11s" && provider.driver.endpointName !== "frs") {
-				this.skip();
-			}
-
-			const runtimeOptions: IContainerRuntimeOptionsInternal = {
-				...testContainerConfig.runtimeOptions,
-				compressionOptions: {
-					minimumBatchSizeInBytes: enableGroupedBatching ? 1 : Number.POSITIVE_INFINITY,
-					compressionAlgorithm: CompressionAlgorithms.lz4,
-				},
-				enableGroupedBatching,
-			};
-
-			const container = await provider.makeTestContainer({
-				...testContainerConfig,
-				runtimeOptions,
-			});
-
-			const dataStore = await getContainerEntryPointBackCompat<ITestDataObject>(container);
-			const blobOpP = timeoutPromise((resolve, reject) =>
-				dataStore._context.containerRuntime.on("op", (op) => {
-					if (op.type === ContainerMessageType.BlobAttach) {
-						if ((op.metadata as { blobId?: unknown } | undefined)?.blobId) {
-							resolve();
-						} else {
-							reject(new Error("no op metadata"));
-						}
-					}
-				}),
+for (const enableBlobPlaceholdersFlag of [false, true]) {
+	describeCompat(
+		`blobs (blob placeholders: ${enableBlobPlaceholdersFlag})`,
+		"FullCompat",
+		(getTestObjectProvider, apis) => {
+			const { SharedString } = apis.dds;
+			const testContainerConfig = makeTestContainerConfig(
+				[["sharedString", SharedString.getFactory()]],
+				enableBlobPlaceholdersFlag,
 			);
 
-			for (let i = 0; i < 5; i++) {
+			let provider: ITestObjectProvider;
+			beforeEach("getTestObjectProvider", async function () {
+				provider = getTestObjectProvider();
+				// Currently, AFR does not support blob API.
+				if (
+					provider.driver.type === "routerlicious" &&
+					provider.driver.endpointName === "frs"
+				) {
+					this.skip();
+				}
+			});
+
+			it("attach sends an op", async function () {
+				const container = await provider.makeTestContainer(testContainerConfig);
+
+				const dataStore = await getContainerEntryPointBackCompat<ITestDataObject>(container);
+
+				const blobOpP = new Promise<void>((resolve, reject) =>
+					dataStore._context.containerRuntime.on("op", (op) => {
+						if (op.type === ContainerMessageType.BlobAttach) {
+							if ((op.metadata as { blobId?: unknown } | undefined)?.blobId) {
+								resolve();
+							} else {
+								reject(new Error("no op metadata"));
+							}
+						}
+					}),
+				);
+
 				const blob = await dataStore._runtime.uploadBlob(
 					stringToBuffer("some random text", "utf-8"),
 				);
 
-				dataStore._root.set(`Blob #${i}`, blob);
-			}
+				dataStore._root.set("my blob", blob);
 
-			await blobOpP;
-		});
-	});
-});
+				await blobOpP;
+			});
 
-// this functionality was added in 0.47 and can be added to the compat-enabled
-// tests above when the LTS version is bumped > 0.47
-describeCompat("blobs", "NoCompat", (getTestObjectProvider, apis) => {
-	const { SharedString } = apis.dds;
-	const testContainerConfig = makeTestContainerConfig([
-		["sharedString", SharedString.getFactory()],
-	]);
-
-	let provider: ITestObjectProvider;
-	let testPersistedCache: TestPersistedCache;
-	beforeEach("getTestObjectProvider", async function () {
-		testPersistedCache = new TestPersistedCache();
-		provider = getTestObjectProvider({ persistedCache: testPersistedCache });
-		// Currently AFR does not support blob API.
-		if (provider.driver.type === "routerlicious" && provider.driver.endpointName === "frs") {
-			this.skip();
-		}
-	});
-
-	// this test relies on an internal function that has been renamed (snapshot -> summarize)
-	it("loads from snapshot", async function () {
-		// GitHub Issue: #9534
-		if (!driverSupportsBlobs(provider.driver)) {
-			this.skip();
-		}
-		const container1 = await provider.makeTestContainer(testContainerConfig);
-		const dataStore = (await container1.getEntryPoint()) as ITestDataObject;
-
-		const attachOpP = new Promise<void>((resolve, reject) =>
-			container1.on("op", (op) => {
-				if (
-					typeof op.contents === "string" &&
-					(JSON.parse(op.contents) as { type?: unknown })?.type ===
-						ContainerMessageType.BlobAttach
-				) {
-					if ((op.metadata as { blobId?: unknown } | undefined)?.blobId) {
-						resolve();
-					} else {
-						reject(new Error("no op metadata"));
-					}
+			it("can get remote attached blob", async function () {
+				// TODO: Re-enable after cross version compat bugs are fixed - ADO:6286
+				if (provider.type === "TestObjectProviderWithVersionedLoad") {
+					this.skip();
 				}
-			}),
-		);
+				const testString = "this is a test string";
+				const testKey = "a blob";
+				const container1 = await provider.makeTestContainer(testContainerConfig);
 
-		const blob = await dataStore._runtime.uploadBlob(
-			stringToBuffer("some random text", "utf-8"),
-		);
+				const dataStore1 = await getContainerEntryPointBackCompat<ITestDataObject>(container1);
 
-		// this will send the blob attach op on < 0.41 runtime (otherwise it's sent at time of upload)
-		dataStore._root.set("my blob", blob);
-		await attachOpP;
+				const blob = await dataStore1._runtime.uploadBlob(stringToBuffer(testString, "utf-8"));
+				dataStore1._root.set(testKey, blob);
 
-		const snapshot1 = (container1 as any).runtime.blobManager.summarize();
+				const container2 = await provider.loadTestContainer(testContainerConfig);
+				const dataStore2 = await getContainerEntryPointBackCompat<ITestDataObject>(container2);
 
-		// wait for summarize, then summary ack so the next container will load from snapshot
-		await new Promise<void>((resolve, reject) => {
-			let summarized = false;
-			container1.on("op", (op) => {
-				switch (op.type) {
-					case "summaryAck": {
-						if (summarized) {
-							resolve();
-						}
-						break;
-					}
-					case "summaryNack": {
-						reject(new Error("summaryNack"));
-						break;
-					}
-					case "summarize": {
-						summarized = true;
-						break;
-					}
-					default: {
-						break;
-					}
+				await provider.ensureSynchronized();
+
+				const blobHandle = dataStore2._root.get<IFluidHandle<ArrayBufferLike>>(testKey);
+				assert(blobHandle);
+				assert.strictEqual(bufferToString(await blobHandle.get(), "utf-8"), testString);
+			});
+
+			it("round trip blob handle on shared string property", async function () {
+				// TODO: Re-enable after cross version compat bugs are fixed - ADO:6286
+				if (provider.type === "TestObjectProviderWithVersionedLoad") {
+					this.skip();
+				}
+				const container1 = await provider.makeTestContainer(testContainerConfig);
+				const container2 = await provider.loadTestContainer(testContainerConfig);
+				const testString = "this is a test string";
+				// setup
+				{
+					const dataStore =
+						await getContainerEntryPointBackCompat<ITestDataObject>(container2);
+					const sharedString = SharedString.create(dataStore._runtime, uuid());
+					dataStore._root.set("sharedString", sharedString.handle);
+
+					const blob = await dataStore._runtime.uploadBlob(
+						stringToBuffer(testString, "utf-8"),
+					);
+
+					sharedString.insertMarker(0, ReferenceType.Simple, { blob });
+
+					// wait for summarize, then summary ack so the next container will load from snapshot
+					await new Promise<void>((resolve, reject) => {
+						let summarized = false;
+						container1.on("op", (op) => {
+							switch (op.type) {
+								case "summaryAck": {
+									if (summarized) {
+										resolve();
+									}
+									break;
+								}
+								case "summaryNack": {
+									reject(new Error("summaryNack"));
+									break;
+								}
+								case "summarize": {
+									summarized = true;
+									break;
+								}
+								default: {
+									break;
+								}
+							}
+						});
+					});
+				}
+
+				// validate on remote container, local container, and container loaded from summary
+				for (const container of [
+					container1,
+					container2,
+					await provider.loadTestContainer(testContainerConfig),
+				]) {
+					const dataStore2 =
+						await getContainerEntryPointBackCompat<ITestDataObject>(container);
+					await provider.ensureSynchronized();
+					const handle = dataStore2._root.get<IFluidHandle<SharedString>>("sharedString");
+					assert(handle);
+					const sharedString2 = await handle.get();
+
+					const props = sharedString2.getPropertiesAtPosition(0);
+
+					assert.strictEqual(bufferToString(await props?.blob.get(), "utf-8"), testString);
 				}
 			});
-		});
 
-		// Make sure the next container loads from the network so as to get latest snapshot.
-		testPersistedCache.clearCache();
-		const container2 = await provider.loadTestContainer(testContainerConfig);
-		const snapshot2 = (container2 as any).runtime.blobManager.summarize();
-		assert.strictEqual(snapshot2.stats.treeNodeCount, 1);
-		assert.strictEqual(snapshot1.summary.tree[0].id, snapshot2.summary.tree[0].id);
-	});
+			it("correctly handles simultaneous identical blob upload on one container", async () => {
+				const container = await provider.makeTestContainer(testContainerConfig);
+				const dataStore = await getContainerEntryPointBackCompat<ITestDataObject>(container);
+				const blob = stringToBuffer("some different yet still random text", "utf-8");
 
-	for (const getDetachedBlobStorage of [undefined, () => new MockDetachedBlobStorage()]) {
-		serializationTests({ getDetachedBlobStorage, testContainerConfig });
-	}
+				// upload the blob twice and make sure nothing bad happens.
+				await Promise.all([
+					dataStore._runtime.uploadBlob(blob),
+					dataStore._runtime.uploadBlob(blob),
+				]);
+			});
 
-	// regression test for https://github.com/microsoft/FluidFramework/issues/9702
-	// this was fixed in 0.58.3000
-	it("correctly handles simultaneous identical blob upload on separate containers", async () => {
-		const container1 = await provider.makeTestContainer(testContainerConfig);
-		const container2 = await provider.loadTestContainer(testContainerConfig);
-		const dataStore1 = (await container1.getEntryPoint()) as ITestDataObject;
-		const dataStore2 = (await container2.getEntryPoint()) as ITestDataObject;
-		const blob = stringToBuffer("some different yet still random text", "utf-8");
-		await waitForContainerConnection(container1);
-		await waitForContainerConnection(container2);
-		// pause so the ops are in flight at the same time
-		await provider.opProcessingController.pauseProcessing();
+			[false, true].forEach((enableGroupedBatching) => {
+				it(`attach sends ops with compression enabled and ${
+					enableGroupedBatching ? "grouped" : "regular"
+				} batching`, async function () {
+					// Tracked by AB#4130, the test run on the tinylicous driver is disabled temporarily to ensure normal operation of the build-client package pipeline
+					if (provider.driver.type === "tinylicious" || provider.driver.type === "t9s") {
+						this.skip();
+					}
 
-		// upload the blob twice and make sure nothing bad happens.
-		const uploadP = Promise.all([
-			dataStore1._runtime.uploadBlob(blob),
-			dataStore2._runtime.uploadBlob(blob),
-		]);
-		provider.opProcessingController.resumeProcessing();
-		await uploadP;
-	});
+					// Skip this test for standard r11s as its flaky and non-reproducible
+					if (provider.driver.type === "r11s" && provider.driver.endpointName !== "frs") {
+						this.skip();
+					}
 
-	it("reconnection does not block ops when having pending blobs", async () => {
-		const uploadBlobPromise = new Deferred<void>();
-		const container1 = await provider.makeTestContainer({
-			...testContainerConfig,
-			loaderProps: {
-				documentServiceFactory: wrapObjectAndOverride(provider.documentServiceFactory, {
-					createDocumentService: {
-						connectToStorage: {
-							createBlob: (dss) => async (blob) => {
-								// Wait for the uploadBlobPromise to be resolved
-								await uploadBlobPromise.promise;
-								return dss.createBlob(blob);
-							},
+					const runtimeOptions: IContainerRuntimeOptionsInternal = {
+						...testContainerConfig.runtimeOptions,
+						compressionOptions: {
+							minimumBatchSizeInBytes: enableGroupedBatching ? 1 : Number.POSITIVE_INFINITY,
+							compressionAlgorithm: CompressionAlgorithms.lz4,
 						},
+						enableGroupedBatching,
+					};
+
+					const container = await provider.makeTestContainer({
+						...testContainerConfig,
+						runtimeOptions,
+					});
+
+					const dataStore = await getContainerEntryPointBackCompat<ITestDataObject>(container);
+					const blobOpP = timeoutPromise((resolve, reject) =>
+						dataStore._context.containerRuntime.on("op", (op) => {
+							if (op.type === ContainerMessageType.BlobAttach) {
+								if ((op.metadata as { blobId?: unknown } | undefined)?.blobId) {
+									resolve();
+								} else {
+									reject(new Error("no op metadata"));
+								}
+							}
+						}),
+					);
+
+					for (let i = 0; i < 5; i++) {
+						const blob = await dataStore._runtime.uploadBlob(
+							stringToBuffer("some random text", "utf-8"),
+						);
+
+						dataStore._root.set(`Blob #${i}`, blob);
+					}
+
+					await blobOpP;
+				});
+			});
+		},
+	);
+
+	// this functionality was added in 0.47 and can be added to the compat-enabled
+	// tests above when the LTS version is bumped > 0.47
+	describeCompat(
+		`blobs (blob placeholders: ${enableBlobPlaceholdersFlag})`,
+		"NoCompat",
+		(getTestObjectProvider, apis) => {
+			const { SharedString } = apis.dds;
+			const testContainerConfig = makeTestContainerConfig(
+				[["sharedString", SharedString.getFactory()]],
+				enableBlobPlaceholdersFlag,
+			);
+
+			let provider: ITestObjectProvider;
+			let testPersistedCache: TestPersistedCache;
+			beforeEach("getTestObjectProvider", async function () {
+				testPersistedCache = new TestPersistedCache();
+				provider = getTestObjectProvider({ persistedCache: testPersistedCache });
+				// Currently AFR does not support blob API.
+				if (
+					provider.driver.type === "routerlicious" &&
+					provider.driver.endpointName === "frs"
+				) {
+					this.skip();
+				}
+			});
+
+			// this test relies on an internal function that has been renamed (snapshot -> summarize)
+			it("loads from snapshot", async function () {
+				// GitHub Issue: #9534
+				if (!driverSupportsBlobs(provider.driver)) {
+					this.skip();
+				}
+				const container1 = await provider.makeTestContainer(testContainerConfig);
+				const dataStore = (await container1.getEntryPoint()) as ITestDataObject;
+
+				const attachOpP = new Promise<void>((resolve, reject) =>
+					container1.on("op", (op) => {
+						if (
+							typeof op.contents === "string" &&
+							(JSON.parse(op.contents) as { type?: unknown })?.type ===
+								ContainerMessageType.BlobAttach
+						) {
+							if ((op.metadata as { blobId?: unknown } | undefined)?.blobId) {
+								resolve();
+							} else {
+								reject(new Error("no op metadata"));
+							}
+						}
+					}),
+				);
+
+				const blob = await dataStore._runtime.uploadBlob(
+					stringToBuffer("some random text", "utf-8"),
+				);
+
+				// this will send the blob attach op on < 0.41 runtime (otherwise it's sent at time of upload)
+				dataStore._root.set("my blob", blob);
+				await attachOpP;
+
+				const snapshot1 = (container1 as any).runtime.blobManager.summarize();
+
+				// wait for summarize, then summary ack so the next container will load from snapshot
+				await new Promise<void>((resolve, reject) => {
+					let summarized = false;
+					container1.on("op", (op) => {
+						switch (op.type) {
+							case "summaryAck": {
+								if (summarized) {
+									resolve();
+								}
+								break;
+							}
+							case "summaryNack": {
+								reject(new Error("summaryNack"));
+								break;
+							}
+							case "summarize": {
+								summarized = true;
+								break;
+							}
+							default: {
+								break;
+							}
+						}
+					});
+				});
+
+				// Make sure the next container loads from the network so as to get latest snapshot.
+				testPersistedCache.clearCache();
+				const container2 = await provider.loadTestContainer(testContainerConfig);
+				const snapshot2 = (container2 as any).runtime.blobManager.summarize();
+				assert.strictEqual(snapshot2.stats.treeNodeCount, 1);
+				assert.strictEqual(snapshot1.summary.tree[0].id, snapshot2.summary.tree[0].id);
+			});
+
+			for (const getDetachedBlobStorage of [undefined, () => new MockDetachedBlobStorage()]) {
+				serializationTests({ getDetachedBlobStorage, testContainerConfig });
+			}
+
+			// regression test for https://github.com/microsoft/FluidFramework/issues/9702
+			// this was fixed in 0.58.3000
+			it("correctly handles simultaneous identical blob upload on separate containers", async () => {
+				const container1 = await provider.makeTestContainer(testContainerConfig);
+				const container2 = await provider.loadTestContainer(testContainerConfig);
+				const dataStore1 = (await container1.getEntryPoint()) as ITestDataObject;
+				const dataStore2 = (await container2.getEntryPoint()) as ITestDataObject;
+				const blob = stringToBuffer("some different yet still random text", "utf-8");
+				await waitForContainerConnection(container1);
+				await waitForContainerConnection(container2);
+				// pause so the ops are in flight at the same time
+				await provider.opProcessingController.pauseProcessing();
+
+				// upload the blob twice and make sure nothing bad happens.
+				const uploadP = Promise.all([
+					dataStore1._runtime.uploadBlob(blob),
+					dataStore2._runtime.uploadBlob(blob),
+				]);
+				provider.opProcessingController.resumeProcessing();
+				await uploadP;
+			});
+
+			it("reconnection does not block ops when having pending blobs", async () => {
+				const uploadBlobPromise = new Deferred<void>();
+				const container1 = await provider.makeTestContainer({
+					...testContainerConfig,
+					loaderProps: {
+						documentServiceFactory: wrapObjectAndOverride(provider.documentServiceFactory, {
+							createDocumentService: {
+								connectToStorage: {
+									createBlob: (dss) => async (blob) => {
+										// Wait for the uploadBlobPromise to be resolved
+										await uploadBlobPromise.promise;
+										return dss.createBlob(blob);
+									},
+								},
+							},
+						}),
 					},
-				}),
-			},
-		});
-		const dataStore1 = (await container1.getEntryPoint()) as ITestDataObject;
+				});
+				const dataStore1 = (await container1.getEntryPoint()) as ITestDataObject;
 
-		const handleP = dataStore1._runtime.uploadBlob(stringToBuffer("test string", "utf8"));
+				const handleP = dataStore1._runtime.uploadBlob(stringToBuffer("test string", "utf8"));
 
-		container1.disconnect();
-		container1.connect();
-		await waitForContainerConnection(container1);
-		// sending some ops to confirm pending blob is not blocking other ops
-		dataStore1._root.set("key", "value");
-		dataStore1._root.set("another key", "another value");
+				container1.disconnect();
+				container1.connect();
+				await waitForContainerConnection(container1);
+				// sending some ops to confirm pending blob is not blocking other ops
+				dataStore1._root.set("key", "value");
+				dataStore1._root.set("another key", "another value");
 
-		const container2 = await provider.loadTestContainer(testContainerConfig);
-		const dataStore2 = (await container2.getEntryPoint()) as ITestDataObject;
-		await provider.ensureSynchronized();
+				const container2 = await provider.loadTestContainer(testContainerConfig);
+				const dataStore2 = (await container2.getEntryPoint()) as ITestDataObject;
+				await provider.ensureSynchronized();
 
-		assert.strictEqual(dataStore2._root.get("key"), "value");
-		assert.strictEqual(dataStore2._root.get("another key"), "another value");
+				assert.strictEqual(dataStore2._root.get("key"), "value");
+				assert.strictEqual(dataStore2._root.get("another key"), "another value");
 
-		uploadBlobPromise.resolve();
-		await assert.doesNotReject(handleP);
-	});
-});
+				uploadBlobPromise.resolve();
+				await assert.doesNotReject(handleP);
+			});
+		},
+	);
+}
 
 function serializationTests({
 	getDetachedBlobStorage,

--- a/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
@@ -16,7 +16,11 @@ import {
 // eslint-disable-next-line import/no-internal-modules
 import { type IPendingRuntimeState } from "@fluidframework/container-runtime/internal/test/containerRuntime";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import type {
+	ConfigTypes,
+	IConfigProviderBase,
+	IFluidHandle,
+} from "@fluidframework/core-interfaces";
 import type {
 	ISharedMap,
 	ISharedDirectory,
@@ -33,307 +37,345 @@ import {
 
 import { MockDetachedBlobStorage, driverSupportsBlobs } from "./mockDetachedBlobStorage.js";
 
+const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+	getRawConfig: (name: string): ConfigTypes => settings[name],
+});
+
 const mapId = "map";
 const directoryId = "directoryKey";
+for (const enableBlobPlaceholdersFlag of [false, true]) {
+	describeCompat(
+		`blob handle isAttached (blob placeholders: ${enableBlobPlaceholdersFlag})`,
+		"NoCompat",
+		(getTestObjectProvider, apis) => {
+			const { SharedMap, SharedDirectory } = apis.dds;
+			const registry: ChannelFactoryRegistry = [
+				[mapId, SharedMap.getFactory()],
+				[directoryId, SharedDirectory.getFactory()],
+			];
 
-describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, apis) => {
-	const { SharedMap, SharedDirectory } = apis.dds;
-	const registry: ChannelFactoryRegistry = [
-		[mapId, SharedMap.getFactory()],
-		[directoryId, SharedDirectory.getFactory()],
-	];
+			const featureFlags = enableBlobPlaceholdersFlag
+				? {
+						"Fluid.Runtime.UploadBlobPlaceholders": true,
+					}
+				: {};
+			const testContainerConfig: ITestContainerConfig = {
+				fluidDataObjectType: DataObjectFactoryType.Test,
+				registry,
+				loaderProps: {
+					configProvider: configProvider(featureFlags),
+				},
+			};
 
-	const testContainerConfig: ITestContainerConfig = {
-		fluidDataObjectType: DataObjectFactoryType.Test,
-		registry,
-	};
+			describe("from attached container", () => {
+				let provider: ITestObjectProvider;
+				let loader: IHostLoader;
+				let container: IContainer;
 
-	describe("from attached container", () => {
-		let provider: ITestObjectProvider;
-		let loader: IHostLoader;
-		let container: IContainer;
+				const runtimeOf = (dataObject: ITestFluidObject): IContainerRuntime & IRuntime =>
+					dataObject.context.containerRuntime as IContainerRuntime & IRuntime;
 
-		const runtimeOf = (dataObject: ITestFluidObject): IContainerRuntime & IRuntime =>
-			dataObject.context.containerRuntime as IContainerRuntime & IRuntime;
+				beforeEach("createContainer", async () => {
+					provider = getTestObjectProvider();
+					loader = provider.makeTestLoader(testContainerConfig);
+					container = await createAndAttachContainer(
+						provider.defaultCodeDetails,
+						loader,
+						provider.driver.createCreateNewRequest(provider.documentId),
+					);
+					provider.updateDocumentId(container.resolvedUrl);
+				});
 
-		beforeEach("createContainer", async () => {
-			provider = getTestObjectProvider();
-			loader = provider.makeTestLoader(testContainerConfig);
-			container = await createAndAttachContainer(
-				provider.defaultCodeDetails,
-				loader,
-				provider.driver.createCreateNewRequest(provider.documentId),
-			);
-			provider.updateDocumentId(container.resolvedUrl);
-		});
+				it("blob is aborted before uploading", async function () {
+					if (enableBlobPlaceholdersFlag) {
+						// Blob placeholders doesn't support abort
+						this.skip();
+					}
+					const testString = "this is a test string";
+					const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
+					const ac = new AbortController();
+					ac.abort("abort test");
+					let surprisingSuccess = false;
+					try {
+						await dataStore1.runtime.uploadBlob(
+							stringToBuffer(testString, "utf-8"),
+							ac.signal,
+						);
+						surprisingSuccess = true;
+					} catch (error: any) {
+						assert.strictEqual(error.status, undefined);
+						assert.strictEqual(error.uploadTime, undefined);
+						assert.strictEqual(error.acked, undefined);
+					}
+					if (surprisingSuccess) {
+						assert.fail("Should not succeed");
+					}
 
-		it("blob is aborted before uploading", async function () {
-			const testString = "this is a test string";
-			const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
-			const ac = new AbortController();
-			ac.abort("abort test");
-			let surprisingSuccess = false;
-			try {
-				await dataStore1.runtime.uploadBlob(stringToBuffer(testString, "utf-8"), ac.signal);
-				surprisingSuccess = true;
-			} catch (error: any) {
-				assert.strictEqual(error.status, undefined);
-				assert.strictEqual(error.uploadTime, undefined);
-				assert.strictEqual(error.acked, undefined);
-			}
-			if (surprisingSuccess) {
-				assert.fail("Should not succeed");
-			}
+					const pendingState = (await runtimeOf(dataStore1).getPendingLocalState()) as
+						| IPendingRuntimeState
+						| undefined;
+					assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
+				});
 
-			const pendingState = (await runtimeOf(dataStore1).getPendingLocalState()) as
-				| IPendingRuntimeState
-				| undefined;
-			assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
-		});
+				it("blob is aborted after upload succeds", async function () {
+					if (enableBlobPlaceholdersFlag) {
+						// Blob placeholders doesn't support abort
+						this.skip();
+					}
+					const testString = "this is a test string";
+					const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
+					const map = await dataStore1.getSharedObject<ISharedMap>(mapId);
+					const ac = new AbortController();
+					let blob: IFluidHandle<ArrayBufferLike>;
+					try {
+						blob = await dataStore1.runtime.uploadBlob(
+							stringToBuffer(testString, "utf-8"),
+							ac.signal,
+						);
+						ac.abort();
+						map.set("key", blob);
+					} catch (error: any) {
+						assert.fail("Should succeed");
+					}
+					const pendingState = (await runtimeOf(dataStore1).getPendingLocalState({
+						notifyImminentClosure: true,
+					})) as IPendingRuntimeState | undefined;
+					assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
+				});
 
-		it.skip("blob is aborted after upload succeds", async function () {
-			const testString = "this is a test string";
-			const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
-			const map = await dataStore1.getSharedObject<ISharedMap>(mapId);
-			const ac = new AbortController();
-			let blob: IFluidHandle<ArrayBufferLike>;
-			try {
-				blob = await dataStore1.runtime.uploadBlob(
-					stringToBuffer(testString, "utf-8"),
-					ac.signal,
-				);
-				ac.abort();
-				map.set("key", blob);
-			} catch (error: any) {
-				assert.fail("Should succeed");
-			}
-			const pendingState = (await runtimeOf(dataStore1).getPendingLocalState({
-				notifyImminentClosure: true,
-			})) as IPendingRuntimeState | undefined;
-			assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
-		});
+				it("blob is attached after usage in map", async function () {
+					const testString = "this is a test string";
+					const testKey = "a blob";
+					const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
+					const map = await dataStore1.getSharedObject<ISharedMap>(mapId);
 
-		it("blob is attached after usage in map", async function () {
-			const testString = "this is a test string";
-			const testKey = "a blob";
-			const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
-			const map = await dataStore1.getSharedObject<ISharedMap>(mapId);
+					const blob = await dataStore1.runtime.uploadBlob(
+						stringToBuffer(testString, "utf-8"),
+					);
+					assert.strictEqual(blob.isAttached, false);
+					map.set(testKey, blob);
+					assert.strictEqual(blob.isAttached, true);
+				});
 
-			const blob = await dataStore1.runtime.uploadBlob(stringToBuffer(testString, "utf-8"));
-			assert.strictEqual(blob.isAttached, false);
-			map.set(testKey, blob);
-			assert.strictEqual(blob.isAttached, true);
-		});
+				it("blob is attached after usage in directory", async function () {
+					const testString = "this is a test string";
+					const testKey = "a blob";
+					const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
+					const directory = await dataStore1.getSharedObject<SharedDirectory>(directoryId);
 
-		it("blob is attached after usage in directory", async function () {
-			const testString = "this is a test string";
-			const testKey = "a blob";
-			const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
-			const directory = await dataStore1.getSharedObject<SharedDirectory>(directoryId);
+					const blob = await dataStore1.runtime.uploadBlob(
+						stringToBuffer(testString, "utf-8"),
+					);
+					assert.strictEqual(blob.isAttached, false);
+					directory.set(testKey, blob);
+					assert.strictEqual(blob.isAttached, true);
+				});
 
-			const blob = await dataStore1.runtime.uploadBlob(stringToBuffer(testString, "utf-8"));
-			assert.strictEqual(blob.isAttached, false);
-			directory.set(testKey, blob);
-			assert.strictEqual(blob.isAttached, true);
-		});
+				it("removes pending blob when waiting for blob to be attached", async function () {
+					const testString = "this is a test string";
+					const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
+					const map = await dataStore1.getSharedObject<ISharedMap>(mapId);
+					const blob = await dataStore1.runtime.uploadBlob(
+						stringToBuffer(testString, "utf-8"),
+					);
+					const pendingStateP: any = runtimeOf(dataStore1).getPendingLocalState({
+						notifyImminentClosure: true,
+					});
+					map.set("key", blob);
+					const pendingState = await pendingStateP;
+					assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
+				});
 
-		it("removes pending blob when waiting for blob to be attached", async function () {
-			const testString = "this is a test string";
-			const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
-			const map = await dataStore1.getSharedObject<ISharedMap>(mapId);
-			const blob = await dataStore1.runtime.uploadBlob(stringToBuffer(testString, "utf-8"));
-			const pendingStateP: any = runtimeOf(dataStore1).getPendingLocalState({
-				notifyImminentClosure: true,
+				it("removes pending blob after attached and acked", async function () {
+					const testString = "this is a test string";
+					const testKey = "a blob";
+					const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
+
+					const map = await dataStore1.getSharedObject<ISharedMap>(mapId);
+					const blob = await dataStore1.runtime.uploadBlob(
+						stringToBuffer(testString, "utf-8"),
+					);
+					map.set(testKey, blob);
+					const pendingState = (await runtimeOf(dataStore1).getPendingLocalState()) as
+						| IPendingRuntimeState
+						| undefined;
+					assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
+				});
+
+				it("removes multiple pending blobs after attached and acked", async function () {
+					const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
+					const map = await dataStore1.getSharedObject<ISharedMap>(mapId);
+					const lots = 10;
+					for (let i = 0; i < lots; i++) {
+						const blob = await dataStore1.runtime.uploadBlob(stringToBuffer(`${i}`, "utf-8"));
+						map.set(`${i}`, blob);
+					}
+					const pendingState = (await runtimeOf(dataStore1).getPendingLocalState()) as
+						| IPendingRuntimeState
+						| undefined;
+					assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
+				});
 			});
-			map.set("key", blob);
-			const pendingState = await pendingStateP;
-			assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
-		});
 
-		it("removes pending blob after attached and acked", async function () {
-			const testString = "this is a test string";
-			const testKey = "a blob";
-			const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
+			describe("from detached container", () => {
+				let provider: ITestObjectProvider;
+				let loader: IHostLoader;
+				let container: IContainer;
+				let detachedBlobStorage: MockDetachedBlobStorage;
+				let detachedDataStore: ITestFluidObject;
+				let map: ISharedMap;
+				let directory: ISharedDirectory;
+				let text: string;
+				let blobHandle: IFluidHandle<ArrayBufferLike>;
 
-			const map = await dataStore1.getSharedObject<ISharedMap>(mapId);
-			const blob = await dataStore1.runtime.uploadBlob(stringToBuffer(testString, "utf-8"));
-			map.set(testKey, blob);
-			const pendingState = (await runtimeOf(dataStore1).getPendingLocalState()) as
-				| IPendingRuntimeState
-				| undefined;
-			assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
-		});
+				beforeEach("createContainer", async function () {
+					provider = getTestObjectProvider();
+					if (!driverSupportsBlobs(provider.driver)) {
+						this.skip();
+					}
+					detachedBlobStorage = new MockDetachedBlobStorage();
+					loader = provider.makeTestLoader({
+						...testContainerConfig,
+						loaderProps: { detachedBlobStorage },
+					});
+					container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+					provider.updateDocumentId(container.resolvedUrl);
+					detachedDataStore = (await container.getEntryPoint()) as ITestFluidObject;
+					map = SharedMap.create(detachedDataStore.runtime);
+					directory = SharedDirectory.create(detachedDataStore.runtime);
+					text = "this is some example text";
+					blobHandle = await detachedDataStore.runtime.uploadBlob(
+						stringToBuffer(text, "utf-8"),
+					);
+				});
 
-		it("removes multiple pending blobs after attached and acked", async function () {
-			const dataStore1 = (await container.getEntryPoint()) as ITestFluidObject;
-			const map = await dataStore1.getSharedObject<ISharedMap>(mapId);
-			const lots = 10;
-			for (let i = 0; i < lots; i++) {
-				const blob = await dataStore1.runtime.uploadBlob(stringToBuffer(`${i}`, "utf-8"));
-				map.set(`${i}`, blob);
-			}
-			const pendingState = (await runtimeOf(dataStore1).getPendingLocalState()) as
-				| IPendingRuntimeState
-				| undefined;
-			assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
-		});
-	});
+				const checkForDetachedHandles = (dds: ISharedMap | ISharedDirectory) => {
+					assert.strictEqual(
+						container.attachState,
+						AttachState.Detached,
+						"container should be detached",
+					);
+					assert.strictEqual(
+						detachedDataStore.handle.isAttached,
+						false,
+						"data store handle should be detached",
+					);
+					assert.strictEqual(dds.handle.isAttached, false, "dds handle should be detached");
+					assert.strictEqual(blobHandle.isAttached, false, "blob handle should be detached");
+				};
 
-	describe("from detached container", () => {
-		let provider: ITestObjectProvider;
-		let loader: IHostLoader;
-		let container: IContainer;
-		let detachedBlobStorage: MockDetachedBlobStorage;
-		let detachedDataStore: ITestFluidObject;
-		let map: ISharedMap;
-		let directory: ISharedDirectory;
-		let text: string;
-		let blobHandle: IFluidHandle<ArrayBufferLike>;
+				const checkForAttachedHandles = (dds: ISharedMap | ISharedDirectory) => {
+					assert.strictEqual(
+						container.attachState,
+						AttachState.Attached,
+						"container should be attached",
+					);
+					assert.strictEqual(
+						detachedDataStore.handle.isAttached,
+						true,
+						"data store handle should be attached",
+					);
+					assert.strictEqual(dds.handle.isAttached, true, "dds handle should be attached");
+					assert.strictEqual(blobHandle.isAttached, true, "blob handle should be attached");
+				};
 
-		beforeEach("createContainer", async function () {
-			provider = getTestObjectProvider();
-			if (!driverSupportsBlobs(provider.driver)) {
-				this.skip();
-			}
-			detachedBlobStorage = new MockDetachedBlobStorage();
-			loader = provider.makeTestLoader({
-				...testContainerConfig,
-				loaderProps: { detachedBlobStorage },
+				it("all detached", async function () {
+					checkForDetachedHandles(map);
+					checkForDetachedHandles(directory);
+				});
+
+				it("after map is set in root directory", async function () {
+					detachedDataStore.root.set(mapId, map.handle);
+					checkForDetachedHandles(map);
+				});
+
+				it("after directory is set in root directory", async function () {
+					detachedDataStore.root.set(directoryId, directory.handle);
+					checkForDetachedHandles(directory);
+				});
+
+				it("after blob handle is set in map", async function () {
+					detachedDataStore.root.set("map", map.handle);
+					map.set("my blob", blobHandle);
+					checkForDetachedHandles(map);
+				});
+
+				it("after blob handle is set in directory", async function () {
+					detachedDataStore.root.set(directoryId, directory.handle);
+					directory.set("my blob", blobHandle);
+					checkForDetachedHandles(directory);
+				});
+
+				it("after container is attached with map", async function () {
+					detachedDataStore.root.set("map", map.handle);
+					map.set("my blob", blobHandle);
+					await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+					detachedBlobStorage.dispose();
+					checkForAttachedHandles(map);
+				});
+
+				it("after container is attached with directory", async function () {
+					detachedDataStore.root.set(directoryId, directory.handle);
+					directory.set("my blob", blobHandle);
+					await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+					detachedBlobStorage.dispose();
+					checkForAttachedHandles(directory);
+				});
+
+				it("after container is attached and dds is detached in map", async function () {
+					map.set("my blob", blobHandle);
+					await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+					assert.strictEqual(
+						map.handle.isAttached,
+						false,
+						"map should be detached after container attaches",
+					);
+					assert.strictEqual(
+						blobHandle.isAttached,
+						false,
+						"blob should be detached in a detached dds and attached container",
+					);
+					detachedBlobStorage.dispose();
+					detachedDataStore.root.set(mapId, map.handle);
+					assert.strictEqual(
+						map.handle.isAttached,
+						true,
+						"map should be attached after dds attaches",
+					);
+					assert.strictEqual(
+						blobHandle.isAttached,
+						true,
+						"blob should be attached in an attached dds",
+					);
+				});
+
+				it("after container is attached and dds is detached in directory", async function () {
+					directory.set("my blob", blobHandle);
+					await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
+					assert.strictEqual(
+						directory.handle.isAttached,
+						false,
+						"directory should be detached after container attaches",
+					);
+					assert.strictEqual(
+						blobHandle.isAttached,
+						false,
+						"blob should be detached in a detached dds and attached container",
+					);
+					detachedBlobStorage.dispose();
+					detachedDataStore.root.set(directoryId, directory.handle);
+					assert.strictEqual(
+						directory.handle.isAttached,
+						true,
+						"directory should be attached after dds attaches",
+					);
+					assert.strictEqual(
+						blobHandle.isAttached,
+						true,
+						"blob should be attached in an attached dds",
+					);
+				});
 			});
-			container = await loader.createDetachedContainer(provider.defaultCodeDetails);
-			provider.updateDocumentId(container.resolvedUrl);
-			detachedDataStore = (await container.getEntryPoint()) as ITestFluidObject;
-			map = SharedMap.create(detachedDataStore.runtime);
-			directory = SharedDirectory.create(detachedDataStore.runtime);
-			text = "this is some example text";
-			blobHandle = await detachedDataStore.runtime.uploadBlob(stringToBuffer(text, "utf-8"));
-		});
-
-		const checkForDetachedHandles = (dds: ISharedMap | ISharedDirectory) => {
-			assert.strictEqual(
-				container.attachState,
-				AttachState.Detached,
-				"container should be detached",
-			);
-			assert.strictEqual(
-				detachedDataStore.handle.isAttached,
-				false,
-				"data store handle should be detached",
-			);
-			assert.strictEqual(dds.handle.isAttached, false, "dds handle should be detached");
-			assert.strictEqual(blobHandle.isAttached, false, "blob handle should be detached");
-		};
-
-		const checkForAttachedHandles = (dds: ISharedMap | ISharedDirectory) => {
-			assert.strictEqual(
-				container.attachState,
-				AttachState.Attached,
-				"container should be attached",
-			);
-			assert.strictEqual(
-				detachedDataStore.handle.isAttached,
-				true,
-				"data store handle should be attached",
-			);
-			assert.strictEqual(dds.handle.isAttached, true, "dds handle should be attached");
-			assert.strictEqual(blobHandle.isAttached, true, "blob handle should be attached");
-		};
-
-		it("all detached", async function () {
-			checkForDetachedHandles(map);
-			checkForDetachedHandles(directory);
-		});
-
-		it("after map is set in root directory", async function () {
-			detachedDataStore.root.set(mapId, map.handle);
-			checkForDetachedHandles(map);
-		});
-
-		it("after directory is set in root directory", async function () {
-			detachedDataStore.root.set(directoryId, directory.handle);
-			checkForDetachedHandles(directory);
-		});
-
-		it("after blob handle is set in map", async function () {
-			detachedDataStore.root.set("map", map.handle);
-			map.set("my blob", blobHandle);
-			checkForDetachedHandles(map);
-		});
-
-		it("after blob handle is set in directory", async function () {
-			detachedDataStore.root.set(directoryId, directory.handle);
-			directory.set("my blob", blobHandle);
-			checkForDetachedHandles(directory);
-		});
-
-		it("after container is attached with map", async function () {
-			detachedDataStore.root.set("map", map.handle);
-			map.set("my blob", blobHandle);
-			await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-			detachedBlobStorage.dispose();
-			checkForAttachedHandles(map);
-		});
-
-		it("after container is attached with directory", async function () {
-			detachedDataStore.root.set(directoryId, directory.handle);
-			directory.set("my blob", blobHandle);
-			await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-			detachedBlobStorage.dispose();
-			checkForAttachedHandles(directory);
-		});
-
-		it("after container is attached and dds is detached in map", async function () {
-			map.set("my blob", blobHandle);
-			await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-			assert.strictEqual(
-				map.handle.isAttached,
-				false,
-				"map should be detached after container attaches",
-			);
-			assert.strictEqual(
-				blobHandle.isAttached,
-				false,
-				"blob should be detached in a detached dds and attached container",
-			);
-			detachedBlobStorage.dispose();
-			detachedDataStore.root.set(mapId, map.handle);
-			assert.strictEqual(
-				map.handle.isAttached,
-				true,
-				"map should be attached after dds attaches",
-			);
-			assert.strictEqual(
-				blobHandle.isAttached,
-				true,
-				"blob should be attached in an attached dds",
-			);
-		});
-
-		it("after container is attached and dds is detached in directory", async function () {
-			directory.set("my blob", blobHandle);
-			await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-			assert.strictEqual(
-				directory.handle.isAttached,
-				false,
-				"directory should be detached after container attaches",
-			);
-			assert.strictEqual(
-				blobHandle.isAttached,
-				false,
-				"blob should be detached in a detached dds and attached container",
-			);
-			detachedBlobStorage.dispose();
-			detachedDataStore.root.set(directoryId, directory.handle);
-			assert.strictEqual(
-				directory.handle.isAttached,
-				true,
-				"directory should be attached after dds attaches",
-			);
-			assert.strictEqual(
-				blobHandle.isAttached,
-				true,
-				"blob should be attached in an attached dds",
-			);
-		});
-	});
-});
+		},
+	);
+}


### PR DESCRIPTION
Run 3 explicitly blob-related tests with/without blob placeholders flag enabled.  Mostly just prettier reformatting everything, only real changes are:
1. Set the flag both ways for each of the tests
2. Skip the two AbortSignal tests in blobisAttached.spec.ts when the flag is true

[AB#34458](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/34458)