### PR TITLE
Remove tree's forwarding fail function

### DIFF
--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -4,11 +4,11 @@
  */
 
 import { IsoBuffer, bufferToString } from "@fluid-internal/client-utils";
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 import type { Static, TAnySchema, TSchema } from "@sinclair/typebox";
 
 import type { ChangeEncodingContext } from "../core/index.js";
-import { type JsonCompatibleReadOnly, fail } from "../util/index.js";
+import type { JsonCompatibleReadOnly } from "../util/index.js";
 
 /**
  * Translates decoded data to encoded data.

--- a/packages/dds/tree/src/codec/discriminatedUnions.ts
+++ b/packages/dds/tree/src/codec/discriminatedUnions.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 import type { ObjectOptions } from "@sinclair/typebox";
 
-import { type _InlineTrick, fail, objectToMap } from "../util/index.js";
+import { type _InlineTrick, objectToMap } from "../util/index.js";
 
 /**
  * This module contains utilities for an encoding of a discriminated union that is efficient to validate using

--- a/packages/dds/tree/src/core/schema-stored/schema.ts
+++ b/packages/dds/tree/src/core/schema-stored/schema.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import { fail } from "@fluidframework/core-utils/internal";
 import type { ErasedType } from "@fluidframework/core-interfaces";
 import { DiscriminatedUnionDispatcher } from "../../codec/index.js";
-import { type MakeNominal, brand, fail, invertMap } from "../../util/index.js";
+import { type MakeNominal, brand, invertMap } from "../../util/index.js";
 import {
 	type FieldKey,
 	type FieldKindIdentifier,

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import type { Listenable } from "@fluidframework/core-interfaces/internal";
 import { createEmitter } from "@fluid-internal/client-utils";
@@ -17,7 +17,6 @@ import {
 	ReferenceCountedBase,
 	brand,
 	brandedSlot,
-	fail,
 	getOrAddEmptyToMap,
 	getOrCreate,
 } from "../../util/index.js";

--- a/packages/dds/tree/src/core/tree/treeTextFormat.ts
+++ b/packages/dds/tree/src/core/tree/treeTextFormat.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { fail } from "../../util/index.js";
+import { fail } from "@fluidframework/core-utils/internal";
 import type { FieldKey } from "../schema-stored/index.js";
 
 import type { NodeData } from "./types.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, oob } from "@fluidframework/core-utils/internal";
+import { assert, oob, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	CursorLocationType,
@@ -20,7 +20,7 @@ import {
 	cursorChunk,
 	dummyRoot,
 } from "../../core/index.js";
-import { ReferenceCountedBase, fail } from "../../util/index.js";
+import { ReferenceCountedBase } from "../../util/index.js";
 import { SynchronousCursor, prefixPath } from "../treeCursorUtils.js";
 
 /**

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, debugAssert, oob } from "@fluidframework/core-utils/internal";
+import { assert, debugAssert, oob, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	CursorLocationType,
@@ -24,7 +24,7 @@ import {
 	type TreeChunk,
 	tryGetChunk,
 } from "../../core/index.js";
-import { fail, getOrCreate } from "../../util/index.js";
+import { getOrCreate } from "../../util/index.js";
 import type { FullSchemaPolicy } from "../modular-schema/index.js";
 
 import { BasicChunk } from "./basicChunk.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, oob } from "@fluidframework/core-utils/internal";
+import { assert, oob, fail } from "@fluidframework/core-utils/internal";
 import type { Listenable } from "@fluidframework/core-interfaces";
 import { createEmitter } from "@fluid-internal/client-utils";
 
@@ -37,7 +37,6 @@ import {
 import {
 	assertValidRange,
 	brand,
-	fail,
 	getLast,
 	getOrAddEmptyToMap,
 	hasSome,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkEncodingGeneric.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkEncodingGeneric.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { fail } from "@fluidframework/core-utils/internal";
 import type { TreeValue } from "../../../core/index.js";
-import { fail } from "../../../util/index.js";
 import type { FluidSerializableReadOnly } from "../../valueUtilities.js";
 
 import {

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	CursorLocationType,
@@ -15,7 +15,7 @@ import {
 	type Value,
 	forEachNode,
 } from "../../../core/index.js";
-import { fail, getOrCreate } from "../../../util/index.js";
+import { getOrCreate } from "../../../util/index.js";
 import type { FlexFieldKind } from "../../modular-schema/index.js";
 
 import type { Counter, DeduplicationTable } from "./chunkCodecUtilities.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeShape.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeShape.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	type FieldKey,
@@ -12,7 +12,7 @@ import {
 	forEachField,
 	type Value,
 } from "../../../core/index.js";
-import { brand, fail } from "../../../util/index.js";
+import { brand } from "../../../util/index.js";
 
 import type { Counter, DeduplicationTable } from "./chunkCodecUtilities.js";
 import { type BufferFormat, IdentifierToken, Shape } from "./chunkEncodingGeneric.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/schemaBasedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/schemaBasedEncode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	LeafNodeStoredSchema,
@@ -16,7 +16,6 @@ import {
 	Multiplicity,
 	identifierFieldKindIdentifier,
 } from "../../../core/index.js";
-import { fail } from "../../../util/index.js";
 import type { FullSchemaPolicy } from "../../modular-schema/index.js";
 
 import {

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/emptyChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/emptyChunk.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { fail } from "@fluidframework/core-utils/internal";
 import {
 	CursorLocationType,
 	CursorMarker,
@@ -15,7 +16,6 @@ import {
 	cursorChunk,
 	dummyRoot,
 } from "../../core/index.js";
-import { fail } from "../../util/index.js";
 import { prefixFieldPath } from "../treeCursorUtils.js";
 
 /**

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, compareArrays, oob } from "@fluidframework/core-utils/internal";
+import { assert, compareArrays, oob, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	CursorLocationType,
@@ -19,7 +19,7 @@ import {
 	cursorChunk,
 	dummyRoot,
 } from "../../core/index.js";
-import { ReferenceCountedBase, fail, hasSome } from "../../util/index.js";
+import { ReferenceCountedBase, hasSome } from "../../util/index.js";
 import { SynchronousCursor, prefixFieldPath, prefixPath } from "../treeCursorUtils.js";
 
 import type { SessionSpaceCompressedId, IIdCompressor } from "@fluidframework/id-compressor";

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { fail } from "@fluidframework/core-utils/internal";
 import {
 	type ChangeAtomId,
 	type DeltaDetachedNodeId,
@@ -10,7 +11,6 @@ import {
 	forbiddenFieldKindIdentifier,
 	Multiplicity,
 } from "../../core/index.js";
-import { fail } from "../../util/index.js";
 import {
 	type FieldChangeDelta,
 	type FieldChangeHandler,

--- a/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { unreachableCase } from "@fluidframework/core-utils/internal";
+import { unreachableCase, fail } from "@fluidframework/core-utils/internal";
 import {
 	type MapTree,
 	type TreeFieldStoredSchema,
@@ -14,7 +14,6 @@ import {
 	type SchemaAndPolicy,
 } from "../../core/index.js";
 import { allowsValue } from "../valueUtilities.js";
-import { fail } from "../../util/index.js";
 
 export const enum SchemaValidationErrors {
 	NoError,

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
@@ -21,7 +21,7 @@ import {
 	iterateCursorField,
 	rootFieldKey,
 } from "../../core/index.js";
-import { disposeSymbol, fail, getOrCreate } from "../../util/index.js";
+import { disposeSymbol, getOrCreate } from "../../util/index.js";
 import {
 	FieldKinds,
 	MappedEditBuilder,

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	type Anchor,
@@ -21,7 +21,7 @@ import {
 	mapCursorFields,
 	rootFieldKey,
 } from "../../core/index.js";
-import { disposeSymbol, fail } from "../../util/index.js";
+import { disposeSymbol } from "../../util/index.js";
 import { FieldKinds } from "../default-schema/index.js";
 
 import type { Context } from "./context.js";

--- a/packages/dds/tree/src/feature-libraries/indexing/anchorTreeIndex.ts
+++ b/packages/dds/tree/src/feature-libraries/indexing/anchorTreeIndex.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
-import { disposeSymbol, fail, getOrCreate } from "../../util/index.js";
+import { assert, fail } from "@fluidframework/core-utils/internal";
+import { disposeSymbol, getOrCreate } from "../../util/index.js";
 import {
 	type Anchor,
 	type AnchorNode,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	LeafNodeStoredSchema,
@@ -16,7 +16,7 @@ import {
 	type ValueSchema,
 	storedEmptyFieldSchema,
 } from "../../core/index.js";
-import { compareSets, fail } from "../../util/index.js";
+import { compareSets } from "../../util/index.js";
 
 import type { FullSchemaPolicy } from "./fieldKind.js";
 import { withEditor } from "./fieldKindWithEditor.js";

--- a/packages/dds/tree/src/feature-libraries/modular-schema/isNeverTree.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/isNeverTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	LeafNodeStoredSchema,
@@ -14,7 +14,6 @@ import {
 	type TreeStoredSchema,
 	Multiplicity,
 } from "../../core/index.js";
-import { fail } from "../../util/index.js";
 
 import type { FullSchemaPolicy } from "./fieldKind.js";
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, oob } from "@fluidframework/core-utils/internal";
+import { assert, oob, fail } from "@fluidframework/core-utils/internal";
 import type { TAnySchema } from "@sinclair/typebox";
 
 import {
@@ -30,7 +30,6 @@ import {
 	type JsonCompatibleReadOnly,
 	type Mutable,
 	brand,
-	fail,
 	idAllocatorFromMaxId,
 	newTupleBTree,
 } from "../../util/index.js";

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 import { BTree } from "@tylerbu/sorted-btree-es6";
 
 import type { ICodecFamily } from "../../codec/index.js";
@@ -45,7 +45,6 @@ import {
 	type IdAllocator,
 	type Mutable,
 	brand,
-	fail,
 	idAllocatorFromMaxId,
 	idAllocatorFromState,
 	type RangeQueryResult,

--- a/packages/dds/tree/src/feature-libraries/node-identifier/mockNodeIdentifierManager.ts
+++ b/packages/dds/tree/src/feature-libraries/node-identifier/mockNodeIdentifierManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 import type { SessionSpaceCompressedId, StableId } from "@fluidframework/id-compressor";
 import { assertIsStableId } from "@fluidframework/id-compressor/internal";
 import type { LocalNodeIdentifier, StableNodeIdentifier } from "./nodeIdentifier.js";
@@ -11,7 +11,7 @@ import {
 	isStableNodeIdentifier,
 	type NodeIdentifierManager,
 } from "./nodeIdentifierManager.js";
-import { brand, extractFromOpaque, fail } from "../../util/index.js";
+import { brand, extractFromOpaque } from "../../util/index.js";
 
 /**
  * Mock {@link NodeIdentifierManager} that generates deterministic {@link StableNodeIdentifier}s and {@link LocalNodeIdentifier}s.

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 import { createEmitter } from "@fluid-internal/client-utils";
 import type { Listenable } from "@fluidframework/core-interfaces";
 
@@ -43,7 +43,6 @@ import {
 	assertValidIndex,
 	assertValidRange,
 	brand,
-	fail,
 } from "../../util/index.js";
 import { cursorForMapTreeNode, mapTreeFromCursor } from "../mapTreeCursor.js";
 import { type CursorWithNode, SynchronousCursor } from "../treeCursorUtils.js";

--- a/packages/dds/tree/src/feature-libraries/schema-index/codec.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-index/codec.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { fail } from "@fluidframework/core-utils/internal";
 import {
 	type ICodecOptions,
 	type IJsonCodec,
@@ -18,7 +19,7 @@ import {
 	storedSchemaDecodeDispatcher,
 	toTreeNodeSchemaDataFormat,
 } from "../../core/index.js";
-import { brand, fail } from "../../util/index.js";
+import { brand } from "../../util/index.js";
 
 import { Format } from "./format.js";
 

--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	type ChangeAtomId,
@@ -11,7 +11,7 @@ import {
 	type RevisionTag,
 	offsetChangeAtomId,
 } from "../../core/index.js";
-import { type IdAllocator, fail } from "../../util/index.js";
+import type { IdAllocator } from "../../util/index.js";
 import {
 	type CrossFieldManager,
 	CrossFieldTarget,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 
 import type { RevisionTag } from "../../core/index.js";
-import { type IdAllocator, type Mutable, fail, hasSingle } from "../../util/index.js";
+import { type IdAllocator, type Mutable, hasSingle } from "../../util/index.js";
 import {
 	type CrossFieldManager,
 	CrossFieldTarget,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV1.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV1.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 import type { TAnySchema } from "@sinclair/typebox";
 
 import { DiscriminatedUnionDispatcher, type IJsonCodec } from "../../codec/index.js";
@@ -13,7 +13,7 @@ import type {
 	EncodedRevisionTag,
 	RevisionTag,
 } from "../../core/index.js";
-import { type JsonCompatibleReadOnly, type Mutable, brand, fail } from "../../util/index.js";
+import { type JsonCompatibleReadOnly, type Mutable, brand } from "../../util/index.js";
 import { makeChangeAtomIdCodec } from "../changeAtomIdCodec.js";
 
 import {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV2.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV2.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 import type { TAnySchema } from "@sinclair/typebox";
 
 import {
@@ -17,7 +17,7 @@ import type {
 	EncodedRevisionTag,
 	RevisionTag,
 } from "../../core/index.js";
-import { type JsonCompatibleReadOnly, type Mutable, brand, fail } from "../../util/index.js";
+import { type JsonCompatibleReadOnly, type Mutable, brand } from "../../util/index.js";
 import { makeChangeAtomIdCodec } from "../changeAtomIdCodec.js";
 
 import { Changeset as ChangesetSchema, type Encoded } from "./formatV2.js";

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	type ChangeAtomId,
@@ -14,7 +14,7 @@ import {
 	areEqualChangeAtomIds,
 	makeChangeAtomId,
 } from "../../core/index.js";
-import { type Mutable, brand, fail } from "../../util/index.js";
+import { type Mutable, brand } from "../../util/index.js";
 import {
 	CrossFieldTarget,
 	type NodeId,

--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, oob, debugAssert } from "@fluidframework/core-utils/internal";
+import { assert, oob, debugAssert, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	CursorLocationType,
@@ -19,7 +19,6 @@ import {
 	detachedFieldAsKey,
 	rootField,
 } from "../core/index.js";
-import { fail } from "../util/index.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 /**

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 import { createEmitter } from "@fluid-internal/client-utils";
 import type { SessionId } from "@fluidframework/id-compressor";
 import { BTree } from "@tylerbu/sorted-btree-es6";
@@ -19,7 +19,7 @@ import {
 	type RebaseStatsWithDuration,
 	tagChange,
 } from "../core/index.js";
-import { type Mutable, brand, fail, getOrCreate, mapIterable } from "../util/index.js";
+import { type Mutable, brand, getOrCreate, mapIterable } from "../util/index.js";
 
 import { SharedTreeBranch, type BranchTrimmingEvents, onForkTransitive } from "./branch.js";
 import type {

--- a/packages/dds/tree/src/shared-tree/schematizeTree.ts
+++ b/packages/dds/tree/src/shared-tree/schematizeTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	AllowedUpdateType,
@@ -20,7 +20,7 @@ import {
 	defaultSchemaPolicy,
 	mapTreeFromCursor,
 } from "../feature-libraries/index.js";
-import { fail, isReadonlyArray } from "../util/index.js";
+import { isReadonlyArray } from "../util/index.js";
 
 import type { ITreeCheckout } from "./treeCheckout.js";
 import { toStoredSchema, type ViewSchema } from "../simple-tree/index.js";

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 import type {
 	ErasedType,
 	IFluidHandle,
@@ -103,7 +103,7 @@ import { SharedTreeChangeFamily } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import type { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
 import { type TreeCheckout, type BranchableTree, createTreeCheckout } from "./treeCheckout.js";
-import { Breakable, breakingClass, fail, throwIfBroken } from "../util/index.js";
+import { Breakable, breakingClass, throwIfBroken } from "../util/index.js";
 
 /**
  * Copy of data from an {@link ITreePrivate} at some point in time.

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import type { ICodecFamily, ICodecOptions } from "../codec/index.js";
 import {
@@ -31,7 +31,6 @@ import {
 	type Mutable,
 	type NestedSet,
 	addToNestedSet,
-	fail,
 	hasSingle,
 	nestedSetContains,
 } from "../util/index.js";

--- a/packages/dds/tree/src/shared-tree/treeApiAlpha.ts
+++ b/packages/dds/tree/src/shared-tree/treeApiAlpha.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 import { createIdCompressor } from "@fluidframework/id-compressor/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
@@ -38,7 +38,7 @@ import {
 	TreeViewConfiguration,
 	type TreeBranch,
 } from "../simple-tree/index.js";
-import { fail, type JsonCompatible } from "../util/index.js";
+import type { JsonCompatible } from "../util/index.js";
 import { noopValidator, type FluidClientVersion, type ICodecOptions } from "../codec/index.js";
 import type { ITreeCursorSynchronous } from "../core/index.js";
 import {

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 import type { Listenable } from "@fluidframework/core-interfaces/internal";
 import { createEmitter } from "@fluid-internal/client-utils";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
@@ -60,13 +60,7 @@ import {
 	type SharedTreeBranchChange,
 	type Transactor,
 } from "../shared-tree-core/index.js";
-import {
-	Breakable,
-	disposeSymbol,
-	fail,
-	getOrCreate,
-	type WithBreakable,
-} from "../util/index.js";
+import { Breakable, disposeSymbol, getOrCreate, type WithBreakable } from "../util/index.js";
 
 import { SharedTreeChangeFamily, hasSchemaChange } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";

--- a/packages/dds/tree/src/simple-tree/api/customTree.ts
+++ b/packages/dds/tree/src/simple-tree/api/customTree.ts
@@ -5,7 +5,7 @@
 
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	EmptyKey,
@@ -19,7 +19,7 @@ import {
 	type TreeNodeSchemaIdentifier,
 	type TreeNodeStoredSchema,
 } from "../../core/index.js";
-import { fail, cloneWithReplacements } from "../../util/index.js";
+import { cloneWithReplacements } from "../../util/index.js";
 import type { TreeLeafValue } from "../schemaTypes.js";
 import { NodeKind, type TreeNodeSchema } from "../core/index.js";
 import {

--- a/packages/dds/tree/src/simple-tree/api/schemaCreationUtilities.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCreationUtilities.ts
@@ -4,8 +4,7 @@
  */
 
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
-
-import { fail } from "../../util/index.js";
+import { fail } from "@fluidframework/core-utils/internal";
 
 import type { SchemaFactory, ScopedSchemaName } from "./schemaFactory.js";
 import type { NodeFromSchema } from "../schemaTypes.js";

--- a/packages/dds/tree/src/simple-tree/api/schemaFromSimple.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFromSimple.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { unreachableCase } from "@fluidframework/core-utils/internal";
-import { fail } from "../../util/index.js";
+import { unreachableCase, fail } from "@fluidframework/core-utils/internal";
 import { NodeKind, type TreeNodeSchema } from "../core/index.js";
 import {
 	type FieldSchema,

--- a/packages/dds/tree/src/simple-tree/api/simpleTreeIndex.ts
+++ b/packages/dds/tree/src/simple-tree/api/simpleTreeIndex.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { fail } from "@fluidframework/core-utils/internal";
 import type {
 	AnchorNode,
 	FieldKey,
@@ -18,7 +19,7 @@ import {
 	type TreeIndexKey,
 	type KeyFinder,
 } from "../../feature-libraries/index.js";
-import { brand, fail } from "../../util/index.js";
+import { brand } from "../../util/index.js";
 import type { ImplicitFieldSchema, NodeFromSchema } from "../schemaTypes.js";
 import { treeNodeFromAnchor, type TreeNode, type TreeNodeSchema } from "../core/index.js";
 import { treeNodeApi } from "./treeNodeApi.js";

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert, fail } from "@fluidframework/core-utils/internal";
 import type { IFluidLoadable, IDisposable, Listenable } from "@fluidframework/core-interfaces";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
@@ -32,9 +33,8 @@ import {
 import { NodeKind, type TreeNodeSchema } from "../core/index.js";
 import { toStoredSchema } from "../toStoredSchema.js";
 import { LeafNodeSchema } from "../leafNodeSchema.js";
-import { assert } from "@fluidframework/core-utils/internal";
 import { isObjectNodeSchema, type ObjectNodeSchema } from "../objectNodeTypes.js";
-import { fail, getOrCreate } from "../../util/index.js";
+import { getOrCreate } from "../../util/index.js";
 import type { MakeNominal } from "../../util/index.js";
 import { walkFieldSchema } from "../walkFieldSchema.js";
 import type { VerboseTree } from "./verboseTree.js";

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { assert, oob } from "@fluidframework/core-utils/internal";
+import { assert, oob, fail } from "@fluidframework/core-utils/internal";
 
 import { EmptyKey, rootFieldKey } from "../../core/index.js";
 import { type TreeStatus, isTreeValue, FieldKinds } from "../../feature-libraries/index.js";
-import { fail, extractFromOpaque } from "../../util/index.js";
+import { extractFromOpaque } from "../../util/index.js";
 import {
 	type TreeLeafValue,
 	type ImplicitFieldSchema,

--- a/packages/dds/tree/src/simple-tree/api/verboseTree.ts
+++ b/packages/dds/tree/src/simple-tree/api/verboseTree.ts
@@ -5,7 +5,7 @@
 
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	aboveRootPlaceholder,
@@ -16,7 +16,7 @@ import {
 	type ITreeCursorSynchronous,
 	type TreeNodeSchemaIdentifier,
 } from "../../core/index.js";
-import { brand, fail } from "../../util/index.js";
+import { brand } from "../../util/index.js";
 import type {
 	TreeLeafValue,
 	ImplicitFieldSchema,

--- a/packages/dds/tree/src/simple-tree/api/view.ts
+++ b/packages/dds/tree/src/simple-tree/api/view.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { unreachableCase, fail } from "@fluidframework/core-utils/internal";
 import {
 	AdaptedViewSchema,
 	type TreeNodeStoredSchema,
@@ -11,7 +12,6 @@ import {
 	type TreeNodeSchemaIdentifier,
 	type TreeStoredSchema,
 } from "../../core/index.js";
-import { fail } from "../../util/index.js";
 import {
 	FieldKinds,
 	type FullSchemaPolicy,
@@ -28,7 +28,6 @@ import {
 	type ImplicitFieldSchema,
 } from "../schemaTypes.js";
 import { toStoredSchema } from "../toStoredSchema.js";
-import { unreachableCase } from "@fluidframework/core-utils/internal";
 import type { SchemaCompatibilityStatus } from "./tree.js";
 
 /**

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Lazy, oob } from "@fluidframework/core-utils/internal";
+import { Lazy, oob, fail } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { EmptyKey, type ExclusiveMapTree } from "../core/index.js";
@@ -38,7 +38,6 @@ import {
 	type TreeNodeSchemaClass,
 } from "./core/index.js";
 import { type InsertableContent, mapTreeFromNodeData } from "./toMapTree.js";
-import { fail } from "../util/index.js";
 import {
 	getKernel,
 	UnhydratedFlexTreeNode,

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, Lazy } from "@fluidframework/core-utils/internal";
+import { assert, Lazy, fail } from "@fluidframework/core-utils/internal";
 import { createEmitter } from "@fluid-internal/client-utils";
 import type { Listenable, Off } from "@fluidframework/core-interfaces";
 import type { InternalTreeNode, TreeNode, Unhydrated } from "./types.js";
@@ -26,7 +26,6 @@ import {
 	type FlexTreeNode,
 } from "../../feature-libraries/index.js";
 import type { TreeNodeSchema } from "./treeNodeSchema.js";
-import { fail } from "../../util/index.js";
 // TODO: decide how to deal with dependencies on flex-tree implementation.
 // eslint-disable-next-line import/no-internal-modules
 import { makeTree } from "../../feature-libraries/flex-tree/lazyNode.js";

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, oob } from "@fluidframework/core-utils/internal";
+import { assert, oob, fail } from "@fluidframework/core-utils/internal";
 import { createEmitter } from "@fluid-internal/client-utils";
 import type { Listenable } from "@fluidframework/core-interfaces";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
@@ -25,7 +25,7 @@ import {
 	type TreeStoredSchema,
 	type Value,
 } from "../../core/index.js";
-import { brand, fail, getOrCreate, mapIterable } from "../../util/index.js";
+import { brand, getOrCreate, mapIterable } from "../../util/index.js";
 import {
 	type FlexTreeContext,
 	FlexTreeEntityKind,

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, Lazy } from "@fluidframework/core-utils/internal";
+import { assert, Lazy, fail } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import type { FieldKey, SchemaPolicy } from "../core/index.js";
@@ -44,7 +44,7 @@ import {
 	getOrCreateInnerNode,
 } from "./core/index.js";
 import { mapTreeFromNodeData, type InsertableContent } from "./toMapTree.js";
-import { type RestrictiveStringRecord, fail, type FlattenKeys } from "../util/index.js";
+import type { RestrictiveStringRecord, FlattenKeys } from "../util/index.js";
 import {
 	isObjectNodeSchema,
 	type ObjectNodeSchema,

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -4,7 +4,7 @@
  */
 
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
-
+import { fail } from "@fluidframework/core-utils/internal";
 import {
 	EmptyKey,
 	type IForestSubscription,
@@ -20,7 +20,7 @@ import {
 	type FlexTreeRequiredField,
 	type FlexTreeOptionalField,
 } from "../feature-libraries/index.js";
-import { type Mutable, fail, isReadonlyArray } from "../util/index.js";
+import { type Mutable, isReadonlyArray } from "../util/index.js";
 import {
 	getKernel,
 	type TreeNode,

--- a/packages/dds/tree/src/simple-tree/toMapTree.ts
+++ b/packages/dds/tree/src/simple-tree/toMapTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
 
@@ -21,7 +21,7 @@ import {
 	valueSchemaAllows,
 	type NodeIdentifierManager,
 } from "../feature-libraries/index.js";
-import { brand, fail, isReadonlyArray, find, hasSome, hasSingle } from "../util/index.js";
+import { brand, isReadonlyArray, find, hasSome, hasSingle } from "../util/index.js";
 
 import { nullSchema } from "./leafNodeSchema.js";
 import {

--- a/packages/dds/tree/src/simple-tree/toStoredSchema.ts
+++ b/packages/dds/tree/src/simple-tree/toStoredSchema.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
@@ -20,7 +20,7 @@ import {
 	type TreeTypeSet,
 } from "../core/index.js";
 import { FieldKinds, type FlexFieldKind } from "../feature-libraries/index.js";
-import { brand, fail, getOrCreate } from "../util/index.js";
+import { brand, getOrCreate } from "../util/index.js";
 import { NodeKind, type TreeNodeSchema } from "./core/index.js";
 import {
 	FieldKind,

--- a/packages/dds/tree/src/simple-tree/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/treeNodeValid.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	type TreeNodeSchema,
@@ -20,7 +20,6 @@ import {
 } from "./core/index.js";
 import { type FlexTreeNode, isFlexTreeNode } from "../feature-libraries/index.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
-import { fail } from "../util/index.js";
 
 import { getSimpleNodeSchemaFromInnerNode } from "./core/index.js";
 import { markEager } from "./flexList.js";

--- a/packages/dds/tree/src/test/changesetWrapper.ts
+++ b/packages/dds/tree/src/test/changesetWrapper.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict } from "node:assert";
-import { assert } from "@fluidframework/core-utils/internal";
+import { strict as assert } from "node:assert";
 import {
 	type ChangeAtomIdMap,
 	type RevisionTag,
@@ -22,7 +21,6 @@ import type {
 	ToDelta,
 } from "../feature-libraries/index.js";
 import {
-	fail,
 	forEachInNestedMap,
 	nestedMapFromFlatList,
 	nestedMapToFlatList,
@@ -130,7 +128,7 @@ function compose<T>(
 		const id =
 			taggedOptAtomId(id1, change1.revision) ??
 			taggedOptAtomId(id2, change2.revision) ??
-			fail("Should not compose two undefined nodes");
+			assert.fail("Should not compose two undefined nodes");
 
 		setInNestedMap(composedNodes, id.revision, id.localId, composedNode);
 		return id;
@@ -223,5 +221,5 @@ function assertEqual<T>(
 	assertFieldsEqual: (actual: T, expected: T) => void,
 ): void {
 	assertFieldsEqual(actual.fieldChange, expected.fieldChange);
-	strict.deepEqual(actual.nodes, expected.nodes);
+	assert.deepEqual(actual.nodes, expected.nodes);
 }

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from "node:assert";
 import { type TUnsafe, Type } from "@sinclair/typebox";
 
 import { makeCodecFamily } from "../../../codec/index.js";
@@ -16,7 +17,7 @@ import {
 	referenceFreeFieldChangeRebaser,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/modular-schema/index.js";
-import { fail, type Mutable } from "../../../util/index.js";
+import type { Mutable } from "../../../util/index.js";
 import { makeValueCodec } from "../../codec/index.js";
 
 /**
@@ -80,7 +81,7 @@ export const valueHandler = {
 		makeCodecFamily([
 			[1, makeValueCodec<TUnsafe<ValueChangeset>, FieldChangeEncodingContext>(Type.Any())],
 		]),
-	editor: { buildChildChanges: () => fail("Child changes not supported") },
+	editor: { buildChildChanges: () => assert.fail("Child changes not supported") },
 
 	intoDelta: (change): FieldChangeDelta => {
 		const delta: Mutable<FieldChangeDelta> = {};

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangesetUtil.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangesetUtil.ts
@@ -30,7 +30,6 @@ import {
 	type IdAllocator,
 	type Mutable,
 	brand,
-	fail,
 	idAllocatorFromMaxId,
 	newTupleBTree,
 } from "../../../util/index.js";
@@ -229,7 +228,7 @@ function addNodeToField(
 	return changeHandler.rebaser.compose(
 		fieldWithChange,
 		fieldChangeset,
-		(node1, node2) => node1 ?? node2 ?? fail("Should not compose two undefined nodes"),
+		(node1, node2) => node1 ?? node2 ?? assert.fail("Should not compose two undefined nodes"),
 		idAllocator,
 		dummyCrossFieldManager,
 		dummyRevisionMetadata,
@@ -242,15 +241,15 @@ const dummyCrossFieldManager: CrossFieldManager = {
 		start: { revision, localId: id },
 		length: count,
 	}),
-	set: () => fail("Not supported"),
-	onMoveIn: () => fail("Not supported"),
-	moveKey: () => fail("Not supported"),
+	set: () => assert.fail("Not supported"),
+	onMoveIn: () => assert.fail("Not supported"),
+	moveKey: () => assert.fail("Not supported"),
 };
 
 const dummyRevisionMetadata: RevisionMetadataSource = {
-	getIndex: () => fail("Not supported"),
-	tryGetInfo: () => fail("Not supported"),
-	hasRollback: () => fail("Not supported"),
+	getIndex: () => assert.fail("Not supported"),
+	tryGetInfo: () => assert.fail("Not supported"),
+	hasRollback: () => assert.fail("Not supported"),
 };
 
 export function removeAliases(changeset: ModularChangeset): ModularChangeset {

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -3,9 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { strict } from "node:assert";
+import { strict as assert } from "node:assert";
 
-import { assert } from "@fluidframework/core-utils/internal";
 import { createAlwaysFinalizedIdCompressor } from "@fluidframework/id-compressor/internal/test-utils";
 
 import {
@@ -66,7 +65,6 @@ import {
 	type IdAllocator,
 	type Mutable,
 	brand,
-	fail,
 	fakeIdAllocator,
 	getOrAddEmptyToMap,
 	idAllocatorFromMaxId,
@@ -107,9 +105,9 @@ export function assertChangesetsEqual(
 	if (ignoreMoveIds) {
 		const normalizedActual = normalizeMoveIds(actual);
 		const normalizedExpected = normalizeMoveIds(expected);
-		strict.deepEqual(normalizedActual, normalizedExpected);
+		assert.deepEqual(normalizedActual, normalizedExpected);
 	} else {
-		strict.deepEqual(actual, expected);
+		assert.deepEqual(actual, expected);
 	}
 }
 
@@ -214,7 +212,7 @@ function normalizeMoveIds(change: SF.Changeset): SF.Changeset {
 				return normalized as TEffect;
 			}
 			default:
-				fail(`Unexpected mark type: ${(effect as SF.Mark).type}`);
+				assert.fail(`Unexpected mark type: ${(effect as SF.Mark).type}`);
 		}
 	}
 	const output = new MarkListFactory();
@@ -260,7 +258,7 @@ export function composeNoVerify(
 export function composeShallow(changes: TaggedChange<SF.Changeset>[]): SF.Changeset {
 	return composeI(
 		changes,
-		(id1, id2) => id1 ?? id2 ?? fail("Should not compose two undefined IDs"),
+		(id1, id2) => id1 ?? id2 ?? assert.fail("Should not compose two undefined IDs"),
 	);
 }
 
@@ -297,7 +295,7 @@ export function shallowCompose(
 				child1 === undefined || child2 === undefined,
 				"Should only have one child to compose",
 			);
-			return child1 ?? child2 ?? fail("One of the children should be defined");
+			return child1 ?? child2 ?? assert.fail("One of the children should be defined");
 		},
 		revInfos,
 	);
@@ -568,7 +566,7 @@ export class DetachedNodeTracker {
 		for (const mark of change.change) {
 			const inputLength: number = getInputLength(mark);
 			if (markEmptiesCells(mark)) {
-				assert(isDetach(mark), 0x70d /* Only detach marks should empty cells */);
+				assert(isDetach(mark), "Only detach marks should empty cells");
 				const newNodes: Map<number, CellId> = new Map();
 				const after = index + inputLength;
 				for (const [k, v] of this.nodes) {
@@ -584,7 +582,7 @@ export class DetachedNodeTracker {
 										change.rollbackOf ??
 										mark.revision ??
 										change.revision ??
-										fail("Unable to track detached nodes"),
+										assert.fail("Unable to track detached nodes"),
 									localId: brand((mark.id as number) + (k - index)),
 								},
 							});
@@ -609,7 +607,7 @@ export class DetachedNodeTracker {
 						newNodes.set(k, v);
 					}
 				}
-				const detachEvent = mark.cellId ?? fail("Unable to track detached nodes");
+				const detachEvent = mark.cellId ?? assert.fail("Unable to track detached nodes");
 				for (let i = 0; i < mark.count; ++i) {
 					newNodes.set(index + i, {
 						revision: detachEvent.revision,
@@ -633,7 +631,7 @@ export class DetachedNodeTracker {
 	public isApplicable(change: Changeset): boolean {
 		for (const mark of change) {
 			if (isActiveReattach(mark)) {
-				const detachEvent = mark.cellId ?? fail("Unable to track detached nodes");
+				const detachEvent = mark.cellId ?? assert.fail("Unable to track detached nodes");
 				const revision = detachEvent.revision;
 				for (let i = 0; i < mark.count; ++i) {
 					const localId = brand<ChangesetLocalId>((detachEvent.localId as number) + i);
@@ -729,7 +727,7 @@ export function areRebasable(branch: Changeset, target: Changeset): boolean {
 		if (isActiveReattach(mark)) {
 			const list = getOrAddEmptyToMap(indexToReattach, index);
 			for (let i = 0; i < mark.count; ++i) {
-				const detachEvent = mark.cellId ?? fail("Unable to track detached nodes");
+				const detachEvent = mark.cellId ?? assert.fail("Unable to track detached nodes");
 				const entry: CellId = {
 					...detachEvent,
 					localId: brand((detachEvent.localId as number) + i),
@@ -737,7 +735,7 @@ export function areRebasable(branch: Changeset, target: Changeset): boolean {
 				const key = `${entry.revision}|${entry.localId}`;
 				assert(
 					!reattachToIndex.has(key),
-					0x506 /* First changeset as inconsistent characterization of detached nodes */,
+					"First changeset as inconsistent characterization of detached nodes",
 				);
 				list.push(key);
 				reattachToIndex.set(key, index);
@@ -751,7 +749,7 @@ export function areRebasable(branch: Changeset, target: Changeset): boolean {
 		if (isActiveReattach(mark)) {
 			const list = getOrAddEmptyToMap(indexToReattach, index);
 			for (let i = 0; i < mark.count; ++i) {
-				const detachEvent = mark.cellId ?? fail("Unable to track detached nodes");
+				const detachEvent = mark.cellId ?? assert.fail("Unable to track detached nodes");
 				const entry: CellId = {
 					...detachEvent,
 					localId: brand((detachEvent.localId as number) + i),

--- a/packages/dds/tree/src/test/objMerge.ts
+++ b/packages/dds/tree/src/test/objMerge.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "node:assert";
-import { fail } from "../util/index.js";
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class Merged {}
@@ -58,7 +57,7 @@ export function merge<T>(
 	transform: ObjectTransform = identityTransform,
 ): Conflicted | Conflict | ConflictedMap | T {
 	if (hasConflict(lhs) || hasConflict(rhs)) {
-		fail("This function does not accept its output type as an input type");
+		assert.fail("This function does not accept its output type as an input type");
 	}
 
 	// === is not reflective because of how NaN is handled, so use Object.is instead.

--- a/packages/dds/tree/src/test/rebase/rebaser.spec.ts
+++ b/packages/dds/tree/src/test/rebase/rebaser.spec.ts
@@ -10,13 +10,12 @@ import type { ChangeRebaser, RevisionTag } from "../../core/index.js";
 // Allow importing from these specific files which are being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 import { type GraphCommit, rebaseBranch } from "../../core/rebase/index.js";
-import { fail } from "../../util/index.js";
 import { mintRevisionTag } from "../utils.js";
 
 /** Given a number in the range [0, 15], turn it into a deterministic and human-rememberable v4 UUID */
 function makeRevisionTag(tag: number): RevisionTag {
 	if (tag > 15) {
-		fail("Tags bigger than 15 are not supported");
+		assert.fail("Tags bigger than 15 are not supported");
 	}
 
 	return tag as RevisionTag;
@@ -75,9 +74,9 @@ describe("rebaser", () => {
 					};
 					this[revision] = cur;
 				}
-				this.main = cur ?? fail("Expected main to have at least one commit");
+				this.main = cur ?? assert.fail("Expected main to have at least one commit");
 				const [baseInMain] = branch;
-				cur = this[baseInMain] ?? fail("branch base must be in main");
+				cur = this[baseInMain] ?? assert.fail("branch base must be in main");
 				for (const revision of branch.slice(1)) {
 					cur = {
 						revision: makeRevisionTag(revision),
@@ -86,7 +85,7 @@ describe("rebaser", () => {
 					};
 				}
 
-				this.branch = cur ?? fail("Expected branch to have at least one commit");
+				this.branch = cur ?? assert.fail("Expected branch to have at least one commit");
 			}
 
 			public assertParentage(head: DummyCommit, ...revisions: number[]): void {
@@ -129,7 +128,7 @@ describe("rebaser", () => {
 				const tester = new BranchTester(main, branch);
 				const base =
 					baseInMain !== undefined
-						? (tester[baseInMain] ?? fail("Expected baseInMain to be in main"))
+						? (tester[baseInMain] ?? assert.fail("Expected baseInMain to be in main"))
 						: tester.main;
 
 				const { newSourceHead } = rebaseBranch(

--- a/packages/dds/tree/src/test/rebaserAxiomaticTests.ts
+++ b/packages/dds/tree/src/test/rebaserAxiomaticTests.ts
@@ -16,7 +16,6 @@ import {
 } from "../core/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { rebaseRevisionMetadataFromInfo } from "../feature-libraries/modular-schema/index.js";
-import { fail } from "../util/index.js";
 
 import {
 	type BoundFieldChangeRebaser,
@@ -601,13 +600,13 @@ function verifyComposeAssociativity<TChangeset>(
 	const metadata = defaultRevisionMetadataFromChanges(edits);
 	const singlyComposed = makeAnonChange(composeArray(fieldRebaser, edits, metadata));
 	const leftPartialCompositions: TaggedChange<TChangeset>[] = [
-		edits.at(0) ?? fail("Expected at least one edit"),
+		edits.at(0) ?? assert.fail("Expected at least one edit"),
 	];
 	for (let i = 1; i < edits.length; i++) {
 		leftPartialCompositions.push(
 			makeAnonChange(
 				fieldRebaser.compose(
-					leftPartialCompositions.at(-1) ?? fail("Expected at least one edit"),
+					leftPartialCompositions.at(-1) ?? assert.fail("Expected at least one edit"),
 					edits[i],
 					metadata,
 				),
@@ -616,14 +615,14 @@ function verifyComposeAssociativity<TChangeset>(
 	}
 
 	const rightPartialCompositions: TaggedChange<TChangeset>[] = [
-		edits.at(-1) ?? fail("Expected at least one edit"),
+		edits.at(-1) ?? assert.fail("Expected at least one edit"),
 	];
 	for (let i = edits.length - 2; i >= 0; i--) {
 		rightPartialCompositions.push(
 			makeAnonChange(
 				fieldRebaser.compose(
 					edits[i],
-					rightPartialCompositions.at(-1) ?? fail("Expected at least one edit"),
+					rightPartialCompositions.at(-1) ?? assert.fail("Expected at least one edit"),
 					metadata,
 				),
 			),

--- a/packages/dds/tree/src/test/shared-tree-core/branch.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/branch.spec.ts
@@ -24,7 +24,7 @@ import {
 	type SharedTreeBranchChange,
 	onForkTransitive,
 } from "../../shared-tree-core/index.js";
-import { brand, fail } from "../../util/index.js";
+import { brand } from "../../util/index.js";
 import { chunkFromJsonableTrees, failCodecFamily, mintRevisionTag } from "../utils.js";
 
 const defaultChangeFamily = new DefaultChangeFamily(failCodecFamily);
@@ -107,7 +107,7 @@ describe("Branches", () => {
 		// Rebase the child onto the parent up to the first new commit
 		const parentCommit1 =
 			findAncestor(parent.getHead(), (c) => c.revision === tag1) ??
-			fail("Expected to find commit");
+			assert.fail("Expected to find commit");
 
 		child.rebaseOnto(parent, parentCommit1);
 		// Ensure that the changes are now present on the child

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -16,7 +16,7 @@ import {
 	type NormalizedUpPath,
 } from "../../core/index.js";
 import type { ITreeCheckout, TreeStoredContent } from "../../shared-tree/index.js";
-import { type JsonCompatible, brand, fail, makeArray } from "../../util/index.js";
+import { type JsonCompatible, brand, makeArray } from "../../util/index.js";
 import {
 	checkoutWithContent,
 	chunkFromJsonableTrees,
@@ -3019,7 +3019,7 @@ describe("Editing", () => {
 				tree.transaction.commit();
 				expectJsonTree(tree, [{ foo: "B" }]);
 
-				const changedFooAtoB = stack.undoStack[0] ?? fail("Missing undo");
+				const changedFooAtoB = stack.undoStack[0] ?? assert.fail("Missing undo");
 
 				// This change should not violate the constraint in the inverse because it is changing
 				// a different node on filed "bar".
@@ -3053,7 +3053,7 @@ describe("Editing", () => {
 				tree.transaction.commit();
 				expectJsonTree(tree, [{ foo: "B" }]);
 
-				const changedFooAtoB = stack.undoStack[0] ?? fail("Missing undo");
+				const changedFooAtoB = stack.undoStack[0] ?? assert.fail("Missing undo");
 
 				// This change should violate the inverse constraint because it changes the
 				// node "B" to "C" on field "foo".
@@ -3099,7 +3099,7 @@ describe("Editing", () => {
 				// and doesn't go through any more rebases. This validates the scenario where an inverse is
 				// directly applied without any rebases.
 				tree.merge(branch);
-				const changedBarOldToNew = stack.undoStack[0] ?? fail("Missing undo");
+				const changedBarOldToNew = stack.undoStack[0] ?? assert.fail("Missing undo");
 
 				expectJsonTree(tree, [{ foo: "C", bar: "new" }]);
 

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -25,7 +25,7 @@ import type {
 } from "../../../core/index.js";
 import { type DownPath, toDownPath } from "../../../feature-libraries/index.js";
 import { Tree, type ITreePrivate, type SharedTree } from "../../../shared-tree/index.js";
-import { fail, getOrCreate, makeArray } from "../../../util/index.js";
+import { getOrCreate, makeArray } from "../../../util/index.js";
 
 import {
 	type FuzzNode,
@@ -485,7 +485,7 @@ export const makeTreeEditGenerator = (
 					),
 				};
 			default:
-				fail("Unknown field type");
+				assert.fail("Unknown field type");
 		}
 	}
 
@@ -916,7 +916,7 @@ function trySelectTreeField(
 				break;
 			}
 			default:
-				fail(`Invalid option: ${option}`);
+				assert.fail(`Invalid option: ${option}`);
 		}
 	}
 

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -13,7 +13,6 @@ import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { Revertible } from "../../../core/index.js";
 import type { DownPath } from "../../../feature-libraries/index.js";
 import { Tree, type SharedTree } from "../../../shared-tree/index.js";
-import { fail } from "../../../util/index.js";
 import { validateFuzzTreeConsistency } from "../../utils.js";
 
 import {
@@ -181,7 +180,7 @@ export function applySchemaOp(state: FuzzTestState, operation: SchemaChange) {
 	newView.upgradeSchema();
 
 	newView.currentSchema =
-		nodeSchemaFromTreeSchema(newSchema) ?? fail("nodeSchema should not be undefined.");
+		nodeSchemaFromTreeSchema(newSchema) ?? assert.fail("nodeSchema should not be undefined.");
 
 	const transactionViews = state.transactionViews ?? new Map();
 	transactionViews.set(state.client.channel, newView);
@@ -263,7 +262,7 @@ export function applyFieldEdit(tree: FuzzView, fieldEdit: FieldEdit): void {
 				break;
 			}
 			default:
-				fail("Invalid edit.");
+				assert.fail("Invalid edit.");
 		}
 		return;
 	}
@@ -324,7 +323,7 @@ function applySequenceFieldEdit(
 			break;
 		}
 		default:
-			fail("Invalid edit.");
+			assert.fail("Invalid edit.");
 	}
 }
 
@@ -335,7 +334,7 @@ function applyRequiredFieldEdit(tree: FuzzView, parentNode: FuzzNode, change: Se
 			break;
 		}
 		default:
-			fail("Invalid edit.");
+			assert.fail("Invalid edit.");
 	}
 }
 
@@ -354,7 +353,7 @@ function applyOptionalFieldEdit(
 			break;
 		}
 		default:
-			fail("Invalid edit.");
+			assert.fail("Invalid edit.");
 	}
 }
 
@@ -456,7 +455,7 @@ function navigateToNode(tree: FuzzView, path: DownPath): TreeNode {
 			case "arrayChildren": {
 				const arrayChildren =
 					(currentNode as FuzzNode).arrayChildren ??
-					fail(`Unexpected field type: ${pathStep.field}`);
+					assert.fail(`Unexpected field type: ${pathStep.field}`);
 
 				currentNode = arrayChildren;
 				break;
@@ -465,19 +464,19 @@ function navigateToNode(tree: FuzzView, path: DownPath): TreeNode {
 			case "optionalChild": {
 				const optionalChild =
 					(currentNode as FuzzNode).optionalChild ??
-					fail(`Unexpected field type: ${pathStep.field}`);
+					assert.fail(`Unexpected field type: ${pathStep.field}`);
 				currentNode = optionalChild as FuzzNode;
 				break;
 			}
 			case "requiredChild": {
 				const requiredChild =
 					(currentNode as FuzzNode).requiredChild ??
-					fail(`Unexpected field type: ${pathStep.field}`);
+					assert.fail(`Unexpected field type: ${pathStep.field}`);
 				currentNode = requiredChild as FuzzNode;
 				break;
 			}
 			default:
-				fail(`Unexpected field type: ${pathStep.field}`);
+				assert.fail(`Unexpected field type: ${pathStep.field}`);
 		}
 	}
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -66,7 +66,7 @@ import {
 	type TreeViewAlpha,
 	TreeViewConfiguration,
 } from "../../simple-tree/index.js";
-import { brand, fail } from "../../util/index.js";
+import { brand } from "../../util/index.js";
 import {
 	type ITestTreeProvider,
 	SharedTreeTestFactory,
@@ -1589,7 +1589,7 @@ describe("SharedTree", () => {
 			await provider.ensureSynchronized();
 
 			const pausedContainer: IContainerExperimental = provider.containers[0];
-			const url = (await pausedContainer.getAbsoluteUrl("")) ?? fail("didn't get url");
+			const url = (await pausedContainer.getAbsoluteUrl("")) ?? assert.fail("didn't get url");
 			const pausedTree = view1;
 			await provider.opProcessingController.pauseProcessing(pausedContainer);
 			pausedTree.root.insertAt(1, "b");
@@ -1895,7 +1895,7 @@ describe("SharedTree", () => {
 			const provider = await TestTreeProvider.create(2);
 
 			const pausedContainer: IContainerExperimental = provider.containers[0];
-			const url = (await pausedContainer.getAbsoluteUrl("")) ?? fail("didn't get url");
+			const url = (await pausedContainer.getAbsoluteUrl("")) ?? assert.fail("didn't get url");
 			const pausedTree = provider.trees[0];
 			await provider.opProcessingController.pauseProcessing(pausedContainer);
 			const pausedView = pausedTree.viewWith(

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -38,7 +38,7 @@ import {
 	validateUsageError,
 	viewCheckout,
 } from "../utils.js";
-import { brand, fail } from "../../util/index.js";
+import { brand } from "../../util/index.js";
 import {
 	SchemaFactory,
 	TreeViewConfiguration,
@@ -485,7 +485,7 @@ describe("sharedTreeView", () => {
 						? "schemaA"
 						: t.storedSchema.rootFieldSchema.kind === FieldKinds.optional.identifier
 							? "schemaB"
-							: fail("Unexpected schema");
+							: assert.fail("Unexpected schema");
 				}
 
 				assert.equal(getSchema(parentView.checkout), "schemaA");

--- a/packages/dds/tree/src/test/simple-tree/simpleTreeIndex.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTreeIndex.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "node:assert";
-import { brand, fail } from "../../util/index.js";
+import { brand } from "../../util/index.js";
 import {
 	SchemaFactory,
 	type TreeNode,
@@ -99,7 +99,7 @@ describe("simple tree indexes", () => {
 		};
 		const anchor = forest.anchors.track(path);
 		const anchorNode =
-			forest.anchors.locate(anchor) ?? fail("should be able to find anchor to child");
+			forest.anchors.locate(anchor) ?? assert.fail("should be able to find anchor to child");
 		assert.equal(anchorNode.slots.has(flexTreeSlot), false);
 
 		const children = index.get(childId);

--- a/packages/dds/tree/src/test/testAnchor.ts
+++ b/packages/dds/tree/src/test/testAnchor.ts
@@ -19,7 +19,6 @@ import {
 	forEachNodeInSubtree,
 } from "../core/index.js";
 import { TreeStatus } from "../feature-libraries/index.js";
-import { fail } from "../util/index.js";
 
 /**
  * A helper class for common anchor operation.
@@ -51,7 +50,7 @@ export class TestAnchor {
 		const paths: UpPath[] = [];
 		forEachNodeInSubtree(cursor, (c): void => {
 			if (Object.is(c.value, value)) {
-				paths.push(c.getPath() ?? fail("Expected path"));
+				paths.push(c.getPath() ?? assert.fail("Expected path"));
 			}
 		});
 		cursor.free();

--- a/packages/dds/tree/src/util/idAllocator.ts
+++ b/packages/dds/tree/src/util/idAllocator.ts
@@ -3,9 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
-
-import { fail } from "./utils.js";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 /**
  * Used for allocating IDs unique to a particular instance of the allocator.

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -58,7 +58,6 @@ export {
 	balancedReduce,
 	clone,
 	compareSets,
-	fail,
 	getOrAddEmptyToMap,
 	getOrCreate,
 	isJsonObject,

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -47,9 +47,6 @@ export function asMutable<T>(readonly: T): Mutable<T> {
 
 export const clone = structuredClone;
 
-// TODO: update usages of this to use @fluidframework/core-utils/internal directly.
-export { fail } from "@fluidframework/core-utils/internal";
-
 /**
  * Checks whether or not the given object is a `readonly` array.
  *


### PR DESCRIPTION
## Description

Now that `@fluidframework/core-utils/internal` exists, use it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
