### PR TITLE
build(client): Tag asserts for 2.31.0 release

### DIFF
--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -832,7 +832,6 @@ export const shortCodeMap = {
 	"0x5dd": "cannot group ops with metadata",
 	"0x5df": "Summarize should not be called when not tracking the summary",
 	"0x5e0": "Used route should always be an absolute route",
-	"0x5e1": "interval ID should not be undefined",
 	"0x5e2": "interval ID should not be undefined",
 	"0x5e6": "Requested coded for unsupported format.",
 	"0x5ea": "Tried to encode unsupported fieldKind",


### PR DESCRIPTION
Tag asserts for 2.31.0 release. Follow-up from #24197.