### PR TITLE
docs: Replace URL links with file path links

### DIFF
--- a/docs/docs/build/tokenproviders.mdx
+++ b/docs/docs/build/tokenproviders.mdx
@@ -3,6 +3,6 @@ title: "Tutorial: Writing a TokenProvider with an Azure Function"
 sidebar_position: 6
 ---
 
-In the [Fluid Framework](https://fluidframework.com/), TokenProviders are responsible for creating and signing tokens that the `@fluidframework/azure-client` uses to make requests to the Azure Fluid Relay. Each Fluid service must implement a custom TokenProvider based on the particular service's authentication and security considerations.
+In the Fluid Framework, TokenProviders are responsible for creating and signing tokens that the `@fluidframework/azure-client` uses to make requests to the Azure Fluid Relay. Each Fluid service must implement a custom TokenProvider based on the particular service's authentication and security considerations.
 
 To learn more about using TokenProviders, see [How to: Write a TokenProvider with an Azure Function](https://learn.microsoft.com/azure/azure-fluid-relay/how-tos/azure-function-token-provider).

--- a/docs/docs/concepts/signals.mdx
+++ b/docs/docs/concepts/signals.mdx
@@ -55,7 +55,7 @@ const signaler = container.initialObjects.signaler; // type is ISignaler
 
 `signaler` can then be directly used in your Fluid application!
 
-For more information on using `ContainerSchema` to create objects please see [Data modeling](https://fluidframework.com/docs/build/data-modeling/).
+For more information on using `ContainerSchema` to create objects please see [Data modeling](../build/data-modeling.mdx).
 
 ### API
 

--- a/docs/docs/data-structures/tree/reading-and-editing.mdx
+++ b/docs/docs/data-structures/tree/reading-and-editing.mdx
@@ -236,4 +236,4 @@ moveRangeToIndex(destinationGap: number, sourceStartIndex: number, sourceEndInde
 Moves the items to the specified `destinationGap` in the destination array.
 Specify a `source` array if it is different from the destination array.
 If the items are being moved within the same array, the `destinationGap` position is interpreted including the items being moved (as if a new copy of the moved items were being inserted, without removing the originals).
-See [the doc comments](https://fluidframework.com/docs/api/tree/treearraynode-interface#moverangetoindex-methodsignature) for details.
+See [the doc comments](../../api/fluid-framework/treearraynode-interface.md#moverangetoindex-methodsignature) for details.

--- a/docs/versioned_docs/version-1/build/tokenproviders.mdx
+++ b/docs/versioned_docs/version-1/build/tokenproviders.mdx
@@ -3,6 +3,6 @@ title: "Tutorial: Writing a TokenProvider with an Azure Function"
 sidebar_position: 6
 ---
 
-In the [Fluid Framework](https://fluidframework.com/), TokenProviders are responsible for creating and signing tokens that the `@fluidframework/azure-client` uses to make requests to the Azure Fluid Relay. Each Fluid service must implement a custom TokenProvider based on the particular service's authentication and security considerations.
+In the Fluid Framework, TokenProviders are responsible for creating and signing tokens that the `@fluidframework/azure-client` uses to make requests to the Azure Fluid Relay. Each Fluid service must implement a custom TokenProvider based on the particular service's authentication and security considerations.
 
 To learn more about using TokenProviders, see [How to: Write a TokenProvider with an Azure Function](https://learn.microsoft.com/azure/azure-fluid-relay/how-tos/azure-function-token-provider).

--- a/docs/versioned_docs/version-1/concepts/signals.mdx
+++ b/docs/versioned_docs/version-1/concepts/signals.mdx
@@ -45,7 +45,7 @@ const signaler = container.initialObjects.signaler; // type is ISignaler
 
 `signaler` can then be directly used in your Fluid application!
 
-For more information on using `ContainerSchema` to create objects please see [Data modeling](https://fluidframework.com/docs/build/data-modeling/).
+For more information on using `ContainerSchema` to create objects please see [Data modeling](../build/data-modeling.mdx).
 
 ### API
 


### PR DESCRIPTION
Follows our documented best practices for maintainable links.