### PR TITLE
Add metadata to handles and use in BlobManager for placeholder blobs

### DIFF
--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
@@ -271,6 +271,7 @@ export interface IFluidHandleInternal<out T = unknown> extends IFluidHandle<T>, 
     readonly absolutePath: string;
     attachGraph(): void;
     bind(handle: IFluidHandleInternal): void;
+    readonly metadata?: Readonly<Record<string, number | boolean | string>> | undefined;
 }
 
 // @public (undocumented)

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
@@ -271,7 +271,6 @@ export interface IFluidHandleInternal<out T = unknown> extends IFluidHandle<T>, 
     readonly absolutePath: string;
     attachGraph(): void;
     bind(handle: IFluidHandleInternal): void;
-    readonly metadata?: Readonly<Record<string, number | boolean | string>> | undefined;
 }
 
 // @public (undocumented)

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -90,15 +90,6 @@ export interface IFluidHandleInternal<
 	readonly absolutePath: string;
 
 	/**
-	 * The handle may contain metadata, generated and interpreted by the subsystem that the handle
-	 * relates to.  For instance, the BlobManager uses this to distinguish blob handles which may
-	 * not yet have an attached blob yet.
-	 *
-	 * @privateRemarks Should become non-optional in accordance with breaking change policy.
-	 */
-	readonly metadata?: Readonly<Record<string, number | boolean | string>> | undefined;
-
-	/**
 	 * Runs through the graph and attach the bounded handles.
 	 */
 	attachGraph(): void;
@@ -108,6 +99,21 @@ export interface IFluidHandleInternal<
 	 * A bound handle will also be attached once this handle is attached.
 	 */
 	bind(handle: IFluidHandleInternal): void;
+}
+
+/**
+ * @internal
+ */
+export interface IFluidHandleInternalWithMetadata<
+	// REVIEW: Constrain `T` to something? How do we support dds and datastores safely?
+	out T = unknown, // FluidObject & IFluidLoadable,
+> extends IFluidHandleInternal<T> {
+	/**
+	 * The handle may contain metadata, generated and interpreted by the subsystem that the handle
+	 * relates to.  For instance, the BlobManager uses this to distinguish blob handles which may
+	 * not yet have an attached blob yet.
+	 */
+	readonly metadata: Readonly<Record<string, number | boolean | string>> | undefined;
 }
 
 /**

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -90,6 +90,15 @@ export interface IFluidHandleInternal<
 	readonly absolutePath: string;
 
 	/**
+	 * The handle may contain metadata, generated and interpreted by the subsystem that the handle
+	 * relates to.  For instance, the BlobManager uses this to distinguish blob handles which may
+	 * not yet have an attached blob yet.
+	 *
+	 * @privateRemarks Should become non-optional in accordance with breaking change policy.
+	 */
+	readonly metadata?: Readonly<Record<string, number | boolean | string>> | undefined;
+
+	/**
 	 * Runs through the graph and attach the bounded handles.
 	 */
 	attachGraph(): void;

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -31,6 +31,7 @@ export type {
 	IProvideFluidHandleContext,
 	IProvideFluidHandle,
 	IFluidHandleInternal,
+	IFluidHandleInternalWithMetadata,
 	IFluidHandleErased,
 } from "./handles.js";
 export { IFluidHandleContext, IFluidHandle, fluidHandleSymbol } from "./handles.js";

--- a/packages/dds/shared-object-base/src/remoteObjectHandle.ts
+++ b/packages/dds/shared-object-base/src/remoteObjectHandle.ts
@@ -31,6 +31,7 @@ export class RemoteFluidObjectHandle extends FluidHandleBase<FluidObject> {
 	constructor(
 		public readonly absolutePath: string,
 		public readonly routeContext: IFluidHandleContext,
+		public readonly metadata?: Readonly<Record<string, string | number | boolean>> | undefined,
 	) {
 		super();
 		assert(
@@ -44,7 +45,10 @@ export class RemoteFluidObjectHandle extends FluidHandleBase<FluidObject> {
 			// Add `viaHandle` header to distinguish from requests from non-handle paths.
 			const request: IRequest = {
 				url: this.absolutePath,
-				headers: { [RuntimeHeaders.viaHandle]: true },
+				headers: {
+					[RuntimeHeaders.viaHandle]: true,
+					[RuntimeHeaders.metadata]: this.metadata,
+				},
 			};
 			this.objectP = this.routeContext.resolveHandle(request).then<FluidObject>((response) => {
 				if (response.mimeType === "fluid/object") {

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -7,6 +7,7 @@ import { IFluidHandle } from "@fluidframework/core-interfaces";
 import {
 	IFluidHandleContext,
 	type IFluidHandleInternal,
+	type IFluidHandleInternalWithMetadata,
 } from "@fluidframework/core-interfaces/internal";
 import { assert, shallowCloneObject } from "@fluidframework/core-utils/internal";
 import {
@@ -55,6 +56,11 @@ export interface IFluidSerializer {
 	 */
 	parse(value: string): unknown;
 }
+
+const isFluidHandleInternalWithMetadata = (
+	fluidHandleInternal: IFluidHandleInternal,
+): fluidHandleInternal is IFluidHandleInternalWithMetadata =>
+	"metadata" in fluidHandleInternal && fluidHandleInternal.metadata !== undefined;
 
 /**
  * Data Store serializer implementation
@@ -200,10 +206,15 @@ export class FluidSerializer implements IFluidSerializer {
 		bind: IFluidHandleInternal,
 	): ISerializedHandle {
 		bind.bind(handle);
-		return {
-			type: "__fluid_handle__",
-			url: handle.absolutePath,
-			metadata: handle.metadata,
-		};
+		return isFluidHandleInternalWithMetadata(handle)
+			? {
+					type: "__fluid_handle__",
+					url: handle.absolutePath,
+					metadata: handle.metadata,
+				}
+			: {
+					type: "__fluid_handle__",
+					url: handle.absolutePath,
+				};
 	}
 }

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -142,7 +142,7 @@ export class FluidSerializer implements IFluidSerializer {
 				? value.url
 				: generateHandleContextPath(value.url, this.context);
 
-			return new RemoteFluidObjectHandle(absolutePath, this.root);
+			return new RemoteFluidObjectHandle(absolutePath, this.root, value.metadata);
 		} else {
 			return value;
 		}
@@ -203,6 +203,7 @@ export class FluidSerializer implements IFluidSerializer {
 		return {
 			type: "__fluid_handle__",
 			url: handle.absolutePath,
+			metadata: handle.metadata,
 		};
 	}
 }

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -118,6 +118,10 @@ export enum RuntimeHeaders {
 	 * True if the request is coming from an IFluidHandle.
 	 */
 	viaHandle = "viaHandle",
+	/**
+	 * Contains the metadata record, if one exists.
+	 */
+	metadata = "metadata",
 }
 
 /**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2246,7 +2246,12 @@ export class ContainerRuntime
 					return create404Response(request);
 				}
 
-				const blob = await this.blobManager.getBlob(requestParser.pathParts[1]);
+				const blob = await this.blobManager.getBlob(
+					requestParser.pathParts[1],
+					requestParser.headers?.[RuntimeHeaders.metadata] as
+						| Readonly<Record<string, string | number | boolean>>
+						| undefined,
+				);
 
 				return {
 					status: 200,

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -160,7 +160,7 @@ export class MockRuntime
 	): Promise<ArrayBufferLike> {
 		const pathParts = blobHandle.absolutePath.split("/");
 		const blobId = pathParts[2];
-		return this.blobManager.getBlob(blobId);
+		return this.blobManager.getBlob(blobId, blobHandle.metadata);
 	}
 
 	public async getPendingLocalState(): Promise<(unknown[] | IPendingBlobs | undefined)[]> {

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -22,6 +22,7 @@ import {
 import {
 	type IFluidHandleContext,
 	type IFluidHandleInternal,
+	type IFluidHandleInternalWithMetadata,
 } from "@fluidframework/core-interfaces/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
 import { IClientDetails, SummaryType } from "@fluidframework/driver-definitions";
@@ -149,14 +150,14 @@ export class MockRuntime
 	public async createBlob(
 		blob: ArrayBufferLike,
 		signal?: AbortSignal,
-	): Promise<IFluidHandleInternal<ArrayBufferLike>> {
+	): Promise<IFluidHandleInternalWithMetadata<ArrayBufferLike>> {
 		const P = this.blobManager.createBlob(blob, signal);
 		this.handlePs.push(P);
 		return P;
 	}
 
 	public async getBlob(
-		blobHandle: IFluidHandleInternal<ArrayBufferLike>,
+		blobHandle: IFluidHandleInternalWithMetadata<ArrayBufferLike>,
 	): Promise<ArrayBufferLike> {
 		const pathParts = blobHandle.absolutePath.split("/");
 		const blobId = pathParts[2];

--- a/packages/runtime/runtime-utils/src/handles.ts
+++ b/packages/runtime/runtime-utils/src/handles.ts
@@ -17,6 +17,17 @@ export interface ISerializedHandle {
 
 	// URL to the object. Relative URLs are relative to the handle context passed to the stringify.
 	url: string;
+
+	/**
+	 * The handle may contain metadata, generated and interpreted by the subsystem that the handle
+	 * relates to.  For instance, the BlobManager uses this to distinguish blob handles which may
+	 * not yet have an attached blob yet.
+	 *
+	 * @remarks
+	 * Will only exist if the handle has metadata, will be omitted entirely from the serialized format
+	 * if the handle has no metadata.
+	 */
+	readonly metadata?: Readonly<Record<string, string | number | boolean>> | undefined;
 }
 
 /**


### PR DESCRIPTION
Based on @anthony-murphy 's https://github.com/microsoft/FluidFramework/compare/main...anthony-murphy:prototyp-handle-metadata

This would permit handles to carry metadata.  This metadata should be added and interpreted by the subsystems that generate and interpret handles today (i.e. BlobManager).  Outside of those subsystems, the metadata should be treated as a black-box and simply passed along.

The signature for getBlob() becomes a little weird, because this change spotlights that ContainerRuntime is "halfway unpacking" the handle (in particular, knowing that `requestParser.pathParts[1]` is the blob id).  It would be more appropriate for ContainerRuntime to stop unpacking beyond realizing the handle is a blob handle, and delegating the rest of the handle resolution to BlobManager (including both finding the blob id and any metadata).  However this is difficult today since the handle is not separable in that way.

[AB#34605](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/34605)