### PR TITLE
fix(check:policy): Handle root package.json correctly

### DIFF
--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
@@ -808,10 +808,7 @@ export const handlers: Handler[] = [
 					ret.push(
 						`repository.directory: "${json.repository.directory}" field is present but should be omitted from root package`,
 					);
-				} else if (
-					json.repository?.directory !== undefined &&
-					json.repository.directory !== relativePkgDir
-				) {
+				} else if (relativePkgDir !== "." && json.repository?.directory !== relativePkgDir) {
 					ret.push(
 						`repository.directory: "${json.repository.directory}" !== "${relativePkgDir}"`,
 					);

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
@@ -804,11 +804,14 @@ export const handlers: Handler[] = [
 				const relativePkgDir = path.dirname(file).replace(/\\/g, "/");
 
 				// The directory field should be omitted from the root package, so consider this a policy failure.
-				if (relativePkgDir === ".") {
+				if (relativePkgDir === "." && json.repository.directory !== undefined) {
 					ret.push(
 						`repository.directory: "${json.repository.directory}" field is present but should be omitted from root package`,
 					);
-				} else if (json.repository?.directory !== relativePkgDir) {
+				} else if (
+					json.repository?.directory !== undefined &&
+					json.repository.directory !== relativePkgDir
+				) {
 					ret.push(
 						`repository.directory: "${json.repository.directory}" !== "${relativePkgDir}"`,
 					);


### PR DESCRIPTION
The root package.json was not properly accounted for in the policy checker. This change adjusts the conditions to correctly handle the case.

Fixes [AB#8640](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8640)