### PR TITLE
test: cleanup attw deps

### DIFF
--- a/examples/benchmarks/tablebench/package.json
+++ b/examples/benchmarks/tablebench/package.json
@@ -34,7 +34,7 @@
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"prepack": "npm run webpack",
-		"postpack": "tar -cf ./tablebench.test-files.tar ./src/test ./lib/test",
+		"pack:tests": "tar -cf ./tablebench.test-files.tar ./src/test ./lib/test",
 		"start": "start-server-and-test tinylicious 7070 start:webpack",
 		"start:t9s": "tinylicious",
 		"start:webpack": "webpack serve --config webpack.config.cjs --env mode=tinylicious",

--- a/examples/benchmarks/tablebench/package.json
+++ b/examples/benchmarks/tablebench/package.json
@@ -34,7 +34,7 @@
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"prepack": "npm run webpack",
-		"pack:tests": "tar -cf ./tablebench.test-files.tar ./src/test ./lib/test",
+		"postpack": "tar -cf ./tablebench.test-files.tar ./src/test ./lib/test",
 		"start": "start-server-and-test tinylicious 7070 start:webpack",
 		"start:t9s": "tinylicious",
 		"start:webpack": "webpack serve --config webpack.config.cjs --env mode=tinylicious",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -51,7 +51,7 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./map.test-files.tar ./src/test ./dist/test ./lib/test",
+		"pack:tests": "tar -cf ./map.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
 		"test:memory": "mocha --config ./src/test/memory/.mocharc.cjs",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -48,7 +48,7 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./experimental-tree.test-files.tar ./src/test ./dist/test ./lib/test",
+		"pack:tests": "tar -cf ./experimental-tree.test-files.tar ./src/test ./dist/test ./lib/test",
 		"perf": "cross-env FLUID_TEST_VERBOSE=1 mocha \"dist/**/*.tests.js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000",
 		"perf:measure": "npm run perf -- --fgrep @Measurement",
 		"test": "npm run test:mocha",

--- a/experimental/framework/tree-react-api/package.json
+++ b/experimental/framework/tree-react-api/package.json
@@ -63,7 +63,7 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./tree-react-api.test-files.tar ./src/test ./dist/test ./lib/test",
+		"pack:tests": "tar -cf ./tree-react-api.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -118,7 +118,7 @@ module.exports = {
 		// The package's local 'api-extractor-lint.json' may use the entrypoint from either CJS or ESM,
 		// therefore we need to require both before running api-extractor.
 		"check:release-tags": ["tsc", "build:esnext"],
-		"check:are-the-types-wrong": ["build"],
+		"check:are-the-types-wrong": ["tsc", "build:esnext", "api"],
 		"check:format": {
 			dependencies: [],
 			script: true,

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -94,7 +94,7 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./map.test-files.tar ./src/test ./dist/test ./lib/test",
+		"pack:tests": "tar -cf ./map.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
 		"test:memory": "mocha --config ./src/test/memory/.mocharc.cjs",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -84,7 +84,7 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./matrix.test-files.tar ./src/test ./dist/test ./lib/test",
+		"pack:tests": "tar -cf ./matrix.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
 		"test:memory": "mocha --config src/test/memory/.mocharc.cjs",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -93,7 +93,7 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cvf ./merge-tree.test-files.tar ./src/test ./dist/test ./lib/test",
+		"pack:tests": "tar -cvf ./merge-tree.test-files.tar ./src/test ./dist/test ./lib/test",
 		"perf": "cross-env FLUID_TEST_VERBOSE=1 mocha \"dist/**/*.spec.*js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000",
 		"perf:measure": "npm run perf -- --fgrep @Measurement",
 		"perf:profile": "node --inspect-brk ./node_modules/mocha/bin/mocha.js \"dist/**/*.spec.*js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -104,7 +104,7 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./sequence.test-files.tar ./src/test ./dist/test ./lib/test",
+		"pack:tests": "tar -cf ./sequence.test-files.tar ./src/test ./dist/test ./lib/test",
 		"perf": "cross-env FLUID_TEST_VERBOSE=1 mocha \"lib/**/*.spec.*js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000",
 		"perf:measure": "npm run perf -- --fgrep @Measurement",
 		"test": "npm run test:mocha",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -110,7 +110,7 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./tree.test-files.tar ./src/test ./dist/test ./lib/test",
+		"pack:tests": "tar -cf ./tree.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
 		"test:benchmark:report": "mocha --exit --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
 		"test:coverage": "c8 npm test",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -132,7 +132,7 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./container-runtime.test-files.tar ./src/test ./dist/test ./lib/test",
+		"pack:tests": "tar -cf ./container-runtime.test-files.tar ./src/test ./dist/test ./lib/test",
 		"place:cjs:package-stub": "copyfiles -f ../../../common/build/build-common/src/cjs/package.json ./dist",
 		"test": "npm run test:mocha",
 		"test:benchmark:report": "mocha --timeout 10s --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js \"./dist/**/*.perf.spec.*js\"",

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -81,7 +81,7 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./azure-client.test-files.tar ./dist/test ./lib/test",
+		"pack:tests": "tar -cf ./azure-client.test-files.tar ./dist/test ./lib/test",
 		"start:tinylicious:test": "npx @fluidframework/azure-local-service > tinylicious.log 2>&1",
 		"test": "npm run test:realsvc",
 		"test:realsvc": "npm run test:realsvc:tinylicious",

--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -17,7 +17,7 @@ mkdir $STAGING_PATH/test-files/
 # Note: use of package's pack:tests is only supported for pnpm as PACKAGE_MANAGER.
 if [ -f ".releaseGroup" ]; then
   if [ "$PACKAGE_MANAGER" == "pnpm" ]; then
-    pnpm -r --if-present pack:tests
+    flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "pnpm --if-present pack:tests"
   fi
   flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "$PACKAGE_MANAGER pack" && \
   flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "mv -t $STAGING_PATH/pack/tarballs/ ./*.tgz" && \

--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -14,12 +14,19 @@ mkdir $STAGING_PATH/test-files/
 
 # Runs pack on all packages in the release group and moves the tarballs to the staging folder.
 # If test files are found, they are moved to the test-files folder.
+# Note: use of package's pack:tests is only supported for pnpm as PACKAGE_MANAGER.
 if [ -f ".releaseGroup" ]; then
+  if [ "$PACKAGE_MANAGER" == "pnpm" ]; then
+    pnpm -r --if-present pack:tests
+  fi
   flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "$PACKAGE_MANAGER pack" && \
   flub exec --no-private --concurrency=1 --releaseGroup $RELEASE_GROUP -- "mv -t $STAGING_PATH/pack/tarballs/ ./*.tgz" && \
   flub exec --no-private --releaseGroup $RELEASE_GROUP -- "[ ! -f ./*test-files.tar ] || (echo 'test files found' && mv -t $STAGING_PATH/test-files/ ./*test-files.tar)"
 
 else
+  if [ "$PACKAGE_MANAGER" == "pnpm" ]; then
+    pnpm --if-present pack:tests
+  fi
   $PACKAGE_MANAGER pack && mv -t $STAGING_PATH/pack/tarballs/ ./*.tgz
 fi
 


### PR DESCRIPTION
are-the-types-wrong checks should not require tests to be built. Reduce requirements to production steps.

Refactor test packs in non-private packages from automatic with `pack` to an explicit package script. Otherwise, those packages will require tests to be built before attw as attw does a pack. (postpack in such cases would fail without the test files present.)

This also prevents unstaged test tar files from showing up after running `check:are-the-types-wrong`.

`examples/benchmark/tablebench` is left packing tests automatically in postpack. (It is private and doesn't use attw.)