### PR TITLE
Added support to cache getSession responses

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -59,6 +59,7 @@ export function create(
 	enableClientIPLogging?: boolean,
 	readinessCheck?: IReadinessCheck,
 	fluidAccessTokenGenerator?: IFluidAccessTokenGenerator,
+	redisCacheForGetSession?: ICache,
 ) {
 	// Maximum REST request size
 	const requestSize = config.get("alfred:restJsonSize");
@@ -179,6 +180,7 @@ export function create(
 		clusterDrainingChecker,
 		readinessCheck,
 		fluidAccessTokenGenerator,
+		redisCacheForGetSession,
 	);
 
 	app.use(routes.api);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/customizations.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/customizations.ts
@@ -31,6 +31,7 @@ export interface IAlfredResourcesCustomizations {
 	clusterDrainingChecker?: IClusterDrainingChecker;
 	redisClientConnectionManagerForJwtCache?: IRedisClientConnectionManager;
 	redisClientConnectionManagerForThrottling?: IRedisClientConnectionManager;
+	redisClientConnectionManagerForGetSession?: IRedisClientConnectionManager;
 	readinessCheck?: IReadinessCheck;
 	fluidAccessTokenGenerator?: IFluidAccessTokenGenerator;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/index.ts
@@ -48,6 +48,7 @@ export function create(
 	clusterDrainingChecker?: IClusterDrainingChecker,
 	readinessCheck?: IReadinessCheck,
 	fluidAccessTokenGenerator?: IFluidAccessTokenGenerator,
+	redisCacheForGetSession?: ICache,
 ): Router {
 	const router: Router = Router();
 	const deltasRoute = deltas.create(
@@ -73,6 +74,7 @@ export function create(
 		tokenRevocationManager,
 		revokedTokenChecker,
 		clusterDrainingChecker,
+		redisCacheForGetSession,
 	);
 	const apiRoute = api.create(
 		config,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/index.ts
@@ -49,6 +49,7 @@ export function create(
 	clusterDrainingChecker?: IClusterDrainingChecker,
 	readinessCheck?: IReadinessCheck,
 	fluidAccessTokenGenerator?: IFluidAccessTokenGenerator,
+	redisCacheForGetSession?: ICache,
 ) {
 	return {
 		api: api.create(
@@ -70,6 +71,7 @@ export function create(
 			clusterDrainingChecker,
 			readinessCheck,
 			fluidAccessTokenGenerator,
+			redisCacheForGetSession,
 		),
 	};
 }

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runner.ts
@@ -62,6 +62,7 @@ export class AlfredRunner implements IRunner {
 		private readonly enableClientIPLogging?: boolean,
 		private readonly readinessCheck?: IReadinessCheck,
 		private readonly fluidAccessTokenGenerator?: IFluidAccessTokenGenerator,
+		private readonly redisCacheForGetSession?: ICache,
 	) {}
 
 	// eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -94,6 +95,7 @@ export class AlfredRunner implements IRunner {
 				this.enableClientIPLogging,
 				this.readinessCheck,
 				this.fluidAccessTokenGenerator,
+				this.redisCacheForGetSession,
 			);
 			alfred.set("port", this.port);
 			this.server = this.serverFactory.create(alfred);

--- a/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
@@ -7,5 +7,5 @@ export { Constants } from "./constants";
 export { createDocumentRouter, IPlugin } from "./documentRouter";
 export { catch404, handleError } from "./middleware";
 export { getIdFromRequest, getTenantIdFromRequest } from "./params";
-export { getSession } from "./sessionHelper";
+export { getSession, generateCacheKey } from "./sessionHelper";
 export { StageTrace } from "./trace";

--- a/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/index.ts
@@ -7,5 +7,5 @@ export { Constants } from "./constants";
 export { createDocumentRouter, IPlugin } from "./documentRouter";
 export { catch404, handleError } from "./middleware";
 export { getIdFromRequest, getTenantIdFromRequest } from "./params";
-export { getSession, generateCacheKey } from "./sessionHelper";
+export { getSession, generateCacheKey, setGetSessionResultInCache } from "./sessionHelper";
 export { StageTrace } from "./trace";

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -454,7 +454,7 @@ export async function getSession(
 	}
 	// Handle the case where the document is ephemeral. Set the TTL to the time remaining before expiration.
 	const cacheTTLInSeconds = documentExpirationTime
-		? getEphemeralContainerTtlInSeconds(documentExpirationTime)
+		? Math.floor(0.95 * getEphemeralContainerTtlInSeconds(documentExpirationTime))
 		: defaultGetSessionCacheTtlInSeconds;
 	connectionTrace?.stampStage("EphemeralExipiryChecked");
 

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -9,12 +9,14 @@ import {
 	runWithRetry,
 	IDocumentRepository,
 	IClusterDrainingChecker,
+	type ICache,
 } from "@fluidframework/server-services-core";
 import { getLumberBaseProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
 import { StageTrace } from "./trace";
 import { delay } from "@fluidframework/common-utils";
 
 const defaultSessionStickinessDurationMs = 60 * 60 * 1000; // 60 minutes
+const defaultGetSessionCacheTtlInSeconds = 5 * 60; // 5 mins
 
 /**
  * Create a new session for a document that does not have a session defined,
@@ -269,6 +271,70 @@ function convertSessionToFreshSession(session: ISession, lumberjackProperties): 
 	return discoveredNewSession;
 }
 
+export function generateCacheKey(tenantId: string, documentId: string): string {
+	return `session:${tenantId}:${documentId}`;
+}
+
+/**
+ * Get the session from cache if it exists. If it doesn't exist, return undefined.
+ * If the session is "404", return "404" to indicate that the document is deleted.
+ * @internal
+ */
+async function getSessionFromCache(
+	tenantId: string,
+	documentId: string,
+	redisCacheForGetSession: ICache,
+): Promise<ISession | string | undefined> {
+	const session = await redisCacheForGetSession
+		.get(generateCacheKey(tenantId, documentId))
+		.catch((error) => {
+			Lumberjack.error("Error getting session from cache", { tenantId, documentId }, error);
+		});
+	try {
+		if (session) {
+			if (session === "404") {
+				return session;
+			}
+			const sessionObject = JSON.parse(session);
+			return sessionObject as ISession;
+		}
+	} catch (error) {
+		Lumberjack.error("Error parsing session from cache", { tenantId, documentId }, error);
+	}
+	return undefined;
+}
+
+function getEphemeralContainerTtlInSeconds(documentExpirationTime: number): number {
+	// Calculate the TTL based on the document expiration time
+	const currentTime = Date.now();
+	const ttlInSeconds = Math.floor((documentExpirationTime - currentTime) / 1000);
+	return Math.max(ttlInSeconds, 0); // Ensure TTL is not negative
+}
+
+/**
+ * Set the session to cache. If the session is "404", set it as "404" to indicate that the document is deleted.
+ * @internal
+ */
+async function setGetSessionResultInCache(
+	tenantId: string,
+	documentId: string,
+	session: ISession | string,
+	redisCacheForGetSession: ICache,
+	cacheTTLInSeconds: number = defaultGetSessionCacheTtlInSeconds,
+): Promise<void> {
+	const cacheKey = generateCacheKey(tenantId, documentId);
+	try {
+		// If the document is deleted, we set the session as "404" in the cache for a longer time.
+		await redisCacheForGetSession.set(
+			cacheKey,
+			typeof session === "string" && session === "404" ? session : JSON.stringify(session),
+			typeof session === "string" && session === "404" ? 24 * 60 * 60 : cacheTTLInSeconds,
+		);
+	} catch (error) {
+		Lumberjack.error("Error setting session to cache", { tenantId, documentId }, error);
+	}
+}
+
 /**
  * Return to the caller with the status of the session.
  * @internal
@@ -287,11 +353,30 @@ export async function getSession(
 	connectionTrace?: StageTrace<string>,
 	readDocumentRetryDelay: number = 150,
 	readDocumentMaxRetries: number = 2,
+	redisCacheForGetSession?: ICache,
 ): Promise<ISession> {
 	const baseLumberjackProperties = getLumberBaseProperties(documentId, tenantId);
 
 	let document: IDocument | null;
 	const docDeletedError = new NetworkError(404, "Document is deleted and cannot be accessed.");
+
+	if (redisCacheForGetSession) {
+		const cachedSession = await getSessionFromCache(
+			tenantId,
+			documentId,
+			redisCacheForGetSession,
+		);
+		if (cachedSession && typeof cachedSession === "string" && cachedSession === "404") {
+			// Document is deleted and cannot be accessed.
+			connectionTrace?.stampStage("DocumentDeletedFoundInCache");
+			throw docDeletedError;
+		}
+		if (cachedSession && typeof cachedSession === "object") {
+			connectionTrace?.stampStage("SessionFromCache");
+			return cachedSession;
+		}
+		connectionTrace?.stampStage("SessionNotFoundCache");
+	}
 	try {
 		const docParams = { tenantId, documentId };
 		document = await documentRepository.readOne(docParams);
@@ -303,6 +388,14 @@ export async function getSession(
 			connectionTrace?.stampStage("SecondAttemptFinished");
 		}
 		if (document === null) {
+			if (redisCacheForGetSession) {
+				await setGetSessionResultInCache(
+					tenantId,
+					documentId,
+					"404",
+					redisCacheForGetSession,
+				);
+			}
 			// Retry once in case of DB replication lag should be enough
 			throw docDeletedError;
 		}
@@ -316,6 +409,9 @@ export async function getSession(
 	// Check whether document was soft deleted
 	if (document.scheduledDeletionTime !== undefined) {
 		connectionTrace?.stampStage("DocumentSoftDeleted");
+		if (redisCacheForGetSession) {
+			await setGetSessionResultInCache(tenantId, documentId, "404", redisCacheForGetSession);
+		}
 		throw docDeletedError;
 	}
 	connectionTrace?.stampStage("DocumentExistenceChecked");
@@ -324,10 +420,12 @@ export async function getSession(
 		...baseLumberjackProperties,
 		isEphemeralContainer: document.isEphemeralContainer,
 	};
+	let currentTime: number | undefined;
+	let documentExpirationTime: number | undefined;
 	if (document.isEphemeralContainer && ephemeralDocumentTTLSec !== undefined) {
 		// Check if the document is ephemeral and has expired.
-		const currentTime = Date.now();
-		const documentExpirationTime = document.createTime + ephemeralDocumentTTLSec * 1000;
+		currentTime = Date.now();
+		documentExpirationTime = document.createTime + ephemeralDocumentTTLSec * 1000;
 		if (currentTime > documentExpirationTime) {
 			// If the document is ephemeral and older than the max ephemeral document TTL, throw an error indicating that it can't be accessed.
 			const documentExpiredByMs = currentTime - documentExpirationTime;
@@ -343,9 +441,24 @@ export async function getSession(
 				docDeletedError,
 			);
 			connectionTrace?.stampStage("EphemeralDocumentExpired");
+			if (redisCacheForGetSession) {
+				await setGetSessionResultInCache(
+					tenantId,
+					documentId,
+					"404",
+					redisCacheForGetSession,
+				);
+			}
 			throw docDeletedError;
 		}
 	}
+	// Handle the case where the document is ephemeral, has not expired yet but might expire within the next 5 minutes. In this case, we set the cache TTL to the time remaining until expiration.
+	const cacheTTLInSeconds = documentExpirationTime
+		? Math.min(
+				getEphemeralContainerTtlInSeconds(documentExpirationTime),
+				defaultGetSessionCacheTtlInSeconds,
+		  )
+		: defaultGetSessionCacheTtlInSeconds;
 	connectionTrace?.stampStage("EphemeralExipiryChecked");
 
 	// Session can be undefined for documents that existed before the concept of service sessions.
@@ -373,6 +486,15 @@ export async function getSession(
 			lumberjackProperties,
 		);
 		connectionTrace?.stampStage("NewSessionCreated");
+		if (redisCacheForGetSession) {
+			await setGetSessionResultInCache(
+				tenantId,
+				documentId,
+				freshSession,
+				redisCacheForGetSession,
+				cacheTTLInSeconds,
+			);
+		}
 		return freshSession;
 	}
 	connectionTrace?.stampStage("SessionExistenceChecked");
@@ -380,6 +502,15 @@ export async function getSession(
 	if (existingSession.isSessionAlive || existingSession.isSessionActive) {
 		// Existing session is considered alive/discovered or active, so return to consumer as-is.
 		connectionTrace?.stampStage("SessionIsAlive");
+		if (redisCacheForGetSession) {
+			await setGetSessionResultInCache(
+				tenantId,
+				documentId,
+				existingSession,
+				redisCacheForGetSession,
+				cacheTTLInSeconds,
+			);
+		}
 		return existingSession;
 	}
 	connectionTrace?.stampStage("SessionLivenessChecked");
@@ -406,6 +537,15 @@ export async function getSession(
 			updatedSession,
 			lumberjackProperties,
 		);
+		if (redisCacheForGetSession) {
+			await setGetSessionResultInCache(
+				tenantId,
+				documentId,
+				freshSession,
+				redisCacheForGetSession,
+				cacheTTLInSeconds,
+			);
+		}
 		connectionTrace?.stampStage("UpdatedExistingSession");
 		return freshSession;
 	} catch (error) {


### PR DESCRIPTION
## Description

We have seen a large number of `getSession` API calls for the same documentId. This PR introduces a cache to store the responses for a short duration of 5 mins to reduce the number of DB calls. It also caches deleted documents for a longer time of 24 hours to prevent DB calls. It also caches deleted docs info in the data-plane delete API.

For EC, since documents are limited to the cluster Redis, we set `getSession` cache TTL as the TTL of the EC. THis would reduce the DB access for an EC to almost 0.

All changes were tested locally using Docker.
