### PR TITLE
server: upgrade to Node 20

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-FROM node:20.19.0-bookworm-slim@sha256:d6e4ec9eaf2390129b5d23904d07ae03ef744818386bcab3fc45fe63405b5eb2 AS runnerbase
+FROM node:20.19.0-bookworm-slim@sha256:990084211ea3d72132f286a038bf27e0f79b8cad532ae623b090f3486490e62e AS runnerbase
 
 ARG SETVERSION_VERSION=dev
 ENV SETVERSION_VERSION=$SETVERSION_VERSION

--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-FROM node:18.20.5-bookworm-slim@sha256:c4a278056a0f79abf472d912bbf5af6c874126ae450faad9df52069e9ad78335 AS runnerbase
+FROM node:20.19.0-bookworm-slim@sha256:d6e4ec9eaf2390129b5d23904d07ae03ef744818386bcab3fc45fe63405b5eb2 AS runnerbase
 
 ARG SETVERSION_VERSION=dev
 ENV SETVERSION_VERSION=$SETVERSION_VERSION

--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
+# Use the manifest digest's sha256 hash to ensure we are always using the same version of the base image.
+# That version of the base image must also be baked into the CI build agent by a repo maintainer.
+# This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
 FROM node:20.19.0-bookworm-slim@sha256:990084211ea3d72132f286a038bf27e0f79b8cad532ae623b090f3486490e62e AS runnerbase
 
 ARG SETVERSION_VERSION=dev

--- a/server/gitssh/Dockerfile
+++ b/server/gitssh/Dockerfile
@@ -3,6 +3,9 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
+# Use the manifest digest's sha256 hash to ensure we are always using the same version of the base image.
+# That version of the base image must also be baked into the CI build agent by a repo maintainer.
+# This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
 FROM alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69
 
 # Install Git and OpenSSH so we can run a git server

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -3,6 +3,9 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
+# Use the manifest digest's sha256 hash to ensure we are always using the same version of the base image.
+# That version of the base image must also be baked into the CI build agent by a repo maintainer.
+# This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
 FROM node:20.19.0-bookworm-slim@sha256:990084211ea3d72132f286a038bf27e0f79b8cad532ae623b090f3486490e62e AS runnerbase
 
 ARG SETVERSION_VERSION=dev

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -3,7 +3,7 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-FROM node:20.19.0-bookworm-slim@sha256:d6e4ec9eaf2390129b5d23904d07ae03ef744818386bcab3fc45fe63405b5eb2 AS runnerbase
+FROM node:20.19.0-bookworm-slim@sha256:990084211ea3d72132f286a038bf27e0f79b8cad532ae623b090f3486490e62e AS runnerbase
 
 ARG SETVERSION_VERSION=dev
 ENV SETVERSION_VERSION=$SETVERSION_VERSION

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -3,7 +3,7 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-FROM node:18.20.5-bookworm-slim@sha256:c4a278056a0f79abf472d912bbf5af6c874126ae450faad9df52069e9ad78335 AS runnerbase
+FROM node:20.19.0-bookworm-slim@sha256:d6e4ec9eaf2390129b5d23904d07ae03ef744818386bcab3fc45fe63405b5eb2 AS runnerbase
 
 ARG SETVERSION_VERSION=dev
 ENV SETVERSION_VERSION=$SETVERSION_VERSION

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -3,7 +3,8 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-# Use a direct sha256 hash to ensure we are always using the same version of the base image.
+# Use the manifest digest's sha256 hash to ensure we are always using the same version of the base image.
+# That version of the base image must also be baked into the CI build agent by a repo maintainer.
 # This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
 FROM node:20.19.0-bookworm-slim@sha256:990084211ea3d72132f286a038bf27e0f79b8cad532ae623b090f3486490e62e AS runnerbase
 

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -5,7 +5,7 @@
 
 # Use a direct sha256 hash to ensure we are always using the same version of the base image.
 # This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
-FROM node:18.20.5-bookworm-slim@sha256:c4a278056a0f79abf472d912bbf5af6c874126ae450faad9df52069e9ad78335 AS runnerbase
+FROM node:20.19.0-bookworm-slim@sha256:d6e4ec9eaf2390129b5d23904d07ae03ef744818386bcab3fc45fe63405b5eb2 AS runnerbase
 
 ARG SETVERSION_VERSION=dev
 ENV SETVERSION_VERSION=$SETVERSION_VERSION

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -5,7 +5,7 @@
 
 # Use a direct sha256 hash to ensure we are always using the same version of the base image.
 # This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
-FROM node:20.19.0-bookworm-slim@sha256:d6e4ec9eaf2390129b5d23904d07ae03ef744818386bcab3fc45fe63405b5eb2 AS runnerbase
+FROM node:20.19.0-bookworm-slim@sha256:990084211ea3d72132f286a038bf27e0f79b8cad532ae623b090f3486490e62e AS runnerbase
 
 ARG SETVERSION_VERSION=dev
 ENV SETVERSION_VERSION=$SETVERSION_VERSION

--- a/server/routerlicious/README.md
+++ b/server/routerlicious/README.md
@@ -39,7 +39,7 @@ below steps if you'd like to run a local version of the service or need to make 
 
 #### For Development
 
--   [Node v18.x](https://nodejs.org/en/)
+-   [Node v20.x](https://nodejs.org/en/)
 -   [Node-gyp](https://github.com/nodejs/node-gyp) dependencies
     -   (Notes for Windows users, **not** using [WSL](https://docs.microsoft.com/en-us/windows/wsl/about)):
         -   The easiest way to install the dependencies is with windows-build-tools: `npm install --global --production windows-build-tools`

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -66,6 +66,7 @@
 		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@5.0.0",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.19.39",
+		"@types/sinon": "^17.0.3",
 		"@types/supertest": "^2.0.5",
 		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",

--- a/server/routerlicious/packages/services-telemetry/src/lumber.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumber.ts
@@ -5,7 +5,6 @@
 
 import safeStringify from "json-stringify-safe";
 import { v4 as uuid } from "uuid";
-import { performance } from "@fluidframework/common-utils";
 import { LumberEventName } from "./lumberEventNames";
 import {
 	LogLevel,
@@ -16,6 +15,8 @@ import {
 	ILumberFormatter,
 } from "./resources";
 
+const performanceNow = () => globalThis.performance.now();
+
 // Lumber represents the telemetry data being captured, and it uses a list of
 // ILumberjackEngine to emit the data according to the engine implementation.
 // Lumber should be created through Lumberjack. Additional properties can be set through
@@ -25,7 +26,7 @@ import {
  * @internal
  */
 export class Lumber<T extends string = LumberEventName> {
-	private readonly _startTime = performance.now();
+	private readonly _startTime = performanceNow();
 	private _properties = new Map<string, any>();
 	private _durationInMs?: number;
 	private _successful?: boolean;
@@ -157,7 +158,7 @@ export class Lumber<T extends string = LumberEventName> {
 
 		const durationOverwrite = parseFloat(this.properties.get("durationInMs"));
 		this._durationInMs = isNaN(durationOverwrite)
-			? performance.now() - this._startTime
+			? performanceNow() - this._startTime
 			: durationOverwrite;
 
 		if (this._formatters) {

--- a/server/routerlicious/packages/services-telemetry/src/test/lumber.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/lumber.spec.ts
@@ -5,7 +5,6 @@
 
 import assert from "assert";
 import Sinon from "sinon";
-import { performance } from "@fluidframework/common-utils";
 import { Lumber } from "../lumber";
 import { LumberEventName } from "../lumberEventNames";
 import * as resources from "../resources";
@@ -15,7 +14,6 @@ describe("Lumber", () => {
 	beforeEach(() => {
 		// use fake timers to have full control over the passage of time
 		Sinon.useFakeTimers();
-		Sinon.stub(performance, "now").callsFake(() => globalThis.performance.now());
 	});
 
 	afterEach(() => {

--- a/server/routerlicious/packages/services-telemetry/src/test/lumber.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/lumber.spec.ts
@@ -5,6 +5,7 @@
 
 import assert from "assert";
 import Sinon from "sinon";
+import { performance } from "@fluidframework/common-utils";
 import { Lumber } from "../lumber";
 import { LumberEventName } from "../lumberEventNames";
 import * as resources from "../resources";
@@ -14,6 +15,7 @@ describe("Lumber", () => {
 	beforeEach(() => {
 		// use fake timers to have full control over the passage of time
 		Sinon.useFakeTimers();
+		Sinon.stub(performance, "now").callsFake(() => globalThis.performance.now());
 	});
 
 	afterEach(() => {

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -1707,6 +1707,9 @@ importers:
       '@types/node':
         specifier: ^18.19.39
         version: 18.19.39
+      '@types/sinon':
+        specifier: ^17.0.3
+        version: 17.0.3
       '@types/supertest':
         specifier: ^2.0.5
         version: 2.0.12


### PR DESCRIPTION
## Description

Following #24215, this upgrades the server Dockerfiles to use Node 20. Only thing that broke were some Sinon Fake Timers that weren't applying to the common-utils package's performance export. Not certain why, but addressed with a quick mock.

The chosen Node Docker image has 1 high-severity vulnerability for the npm cross-spawn package. However, this is not a regression from v18, and it has 1 fewer high-sev linux vulns, making this a net reduction in vulnerability.
