### PR TITLE
(tree) Fix for recursion not detected in unhydrated nodes

### DIFF
--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -162,8 +162,12 @@ export class TreeNodeKernel {
 							const kernel = getKernel(treeNode);
 							kernel.#unhydratedEvents.value.emit("subtreeChangedAfterBatch");
 						}
-						// This cast is safe because the parent (if it exists) of an unhydrated flex node is always another unhydrated flex node.
-						n = n.parentField.parent.parent as UnhydratedFlexTreeNode | undefined;
+						const p: FlexTreeNode | undefined = n.parentField.parent.parent;
+						assert(
+							p === undefined || p instanceof UnhydratedFlexTreeNode,
+							"Unhydrated node's parent should be an unhydrated node",
+						);
+						n = p;
 					}
 				}),
 			};

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -155,19 +155,20 @@ export class TreeNodeKernel {
 						changedFields,
 					});
 
-					let n: UnhydratedFlexTreeNode | undefined = innerNode;
-					while (n !== undefined) {
-						const treeNode = unhydratedFlexTreeNodeToTreeNodeInternal.get(n);
+					let unhydratedNode: UnhydratedFlexTreeNode | undefined = innerNode;
+					while (unhydratedNode !== undefined) {
+						const treeNode = unhydratedFlexTreeNodeToTreeNodeInternal.get(unhydratedNode);
 						if (treeNode !== undefined) {
 							const kernel = getKernel(treeNode);
 							kernel.#unhydratedEvents.value.emit("subtreeChangedAfterBatch");
 						}
-						const p: FlexTreeNode | undefined = n.parentField.parent.parent;
+						const parentNode: FlexTreeNode | undefined =
+							unhydratedNode.parentField.parent.parent;
 						assert(
-							p === undefined || p instanceof UnhydratedFlexTreeNode,
+							parentNode === undefined || parentNode instanceof UnhydratedFlexTreeNode,
 							"Unhydrated node's parent should be an unhydrated node",
 						);
-						n = p;
+						unhydratedNode = parentNode;
 					}
 				}),
 			};

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -152,9 +152,7 @@ export class UnhydratedFlexTreeNode implements UnhydratedFlexTreeNode {
 		if (parent !== undefined) {
 			assert(index !== undefined, 0xa08 /* Expected index */);
 			if (this.location !== unparentedLocation) {
-				throw new UsageError(
-					"A node may not be in more than one place in a tree or in more than one tree",
-				);
+				throw new UsageError("A node may not be inserted if it's already in a tree");
 			}
 			let n: UnhydratedFlexTreeNode | undefined = parent.parent;
 			while (n !== undefined) {

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -152,15 +152,23 @@ export class UnhydratedFlexTreeNode implements UnhydratedFlexTreeNode {
 		if (parent !== undefined) {
 			assert(index !== undefined, 0xa08 /* Expected index */);
 			if (this.location !== unparentedLocation) {
-				throw new UsageError("A node may not be in more than one place in the tree");
+				throw new UsageError(
+					"A node may not be in more than one place in a tree or in more than one tree",
+				);
 			}
 			let n: UnhydratedFlexTreeNode | undefined = parent.parent;
 			while (n !== undefined) {
 				if (n === this) {
-					throw new UsageError("A node may not be recursively inserted into the tree");
+					throw new UsageError(
+						"A node may not be inserted into a location that is under itself",
+					);
 				}
-				// This cast is safe because the parent (if it exists) of an unhydrated flex node is always another unhydrated flex node.
-				n = n.parentField.parent.parent as UnhydratedFlexTreeNode | undefined;
+				const p: FlexTreeNode | undefined = n.parentField.parent.parent;
+				assert(
+					p === undefined || p instanceof UnhydratedFlexTreeNode,
+					"Unhydrated node's parent should be an unhydrated node",
+				);
+				n = p;
 			}
 			this.location = { parent, index };
 		} else {

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -157,7 +157,7 @@ export class UnhydratedFlexTreeNode implements UnhydratedFlexTreeNode {
 			let n: UnhydratedFlexTreeNode | undefined = parent.parent;
 			while (n !== undefined) {
 				if (n === this) {
-					throw new UsageError("A node may not be inserted into the tree more than once");
+					throw new UsageError("A node may not be recursively inserted into the tree");
 				}
 				// This cast is safe because the parent (if it exists) of an unhydrated flex node is always another unhydrated flex node.
 				n = n.parentField.parent.parent as UnhydratedFlexTreeNode | undefined;

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -150,11 +150,18 @@ export class UnhydratedFlexTreeNode implements UnhydratedFlexTreeNode {
 	public adoptBy(parent: UnhydratedFlexTreeField, index: number): void;
 	public adoptBy(parent: UnhydratedFlexTreeField | undefined, index?: number): void {
 		if (parent !== undefined) {
-			assert(
-				this.location === unparentedLocation,
-				0x98c /* Node may not be adopted if it already has a parent */,
-			);
 			assert(index !== undefined, 0xa08 /* Expected index */);
+			if (this.location !== unparentedLocation) {
+				throw new UsageError("A node may not be in more than one place in the tree");
+			}
+			let n: UnhydratedFlexTreeNode | undefined = parent.parent;
+			while (n !== undefined) {
+				if (n === this) {
+					throw new UsageError("A node may not be inserted into the tree more than once");
+				}
+				// This cast is safe because the parent (if it exists) of an unhydrated flex node is always another unhydrated flex node.
+				n = n.parentField.parent.parent as UnhydratedFlexTreeNode | undefined;
+			}
 			this.location = { parent, index };
 		} else {
 			assert(

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -154,19 +154,19 @@ export class UnhydratedFlexTreeNode implements UnhydratedFlexTreeNode {
 			if (this.location !== unparentedLocation) {
 				throw new UsageError("A node may not be inserted if it's already in a tree");
 			}
-			let n: UnhydratedFlexTreeNode | undefined = parent.parent;
-			while (n !== undefined) {
-				if (n === this) {
+			let unhydratedNode: UnhydratedFlexTreeNode | undefined = parent.parent;
+			while (unhydratedNode !== undefined) {
+				if (unhydratedNode === this) {
 					throw new UsageError(
 						"A node may not be inserted into a location that is under itself",
 					);
 				}
-				const p: FlexTreeNode | undefined = n.parentField.parent.parent;
+				const parentNode: FlexTreeNode | undefined = unhydratedNode.parentField.parent.parent;
 				assert(
-					p === undefined || p instanceof UnhydratedFlexTreeNode,
+					parentNode === undefined || parentNode instanceof UnhydratedFlexTreeNode,
 					"Unhydrated node's parent should be an unhydrated node",
 				);
-				n = p;
+				unhydratedNode = parentNode;
 			}
 			this.location = { parent, index };
 		} else {

--- a/packages/dds/tree/src/test/simple-tree/api/integrationTests.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/integrationTests.spec.ts
@@ -15,19 +15,31 @@ import { validateUsageError } from "../../utils.js";
 const sf = new SchemaFactory("integration");
 
 describe("simple-tree API integration tests", () => {
-	it("making a recursive unhydrated object node errors", () => {
-		class O extends sf.objectRecursive("O", {
-			recursive: sf.optionalRecursive([() => O]),
-		}) {}
-		{
-			type _check = ValidateRecursiveSchema<typeof O>;
-		}
+	class O extends sf.objectRecursive("O", {
+		recursive: sf.optionalRecursive([() => O]),
+	}) {}
+	{
+		type _check = ValidateRecursiveSchema<typeof O>;
+	}
+
+	it("making a recursive unhydrated and un-parented object node errors", () => {
 		const obj = new O({ recursive: undefined });
 		assert.throws(
 			() => {
 				obj.recursive = obj;
 			},
 			validateUsageError(/recursive/),
+		);
+	});
+
+	it("making a recursive unhydrated and and parented object node errors", () => {
+		const obj = new O({ recursive: undefined });
+		const objOuter = new O({ recursive: obj });
+		assert.throws(
+			() => {
+				obj.recursive = obj;
+			},
+			validateUsageError(/more than one place/),
 		);
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/api/integrationTests.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/integrationTests.spec.ts
@@ -15,11 +15,7 @@ import { validateUsageError } from "../../utils.js";
 const sf = new SchemaFactory("integration");
 
 describe("simple-tree API integration tests", () => {
-	// TODO: AB#32207:
-	// This case should produce a usage error (and thus allow this test to be un-skipped).
-	// Currently this tests hangs forever, not even being terminated by the mocha timeout.
-	// Depending on where the error is detected, tests for recursive maps, arrays and co-recursive cases may be needed.
-	it.skip("making a recursive unhydrated object node errors", () => {
+	it("making a recursive unhydrated object node errors", () => {
 		class O extends sf.objectRecursive("O", {
 			recursive: sf.optionalRecursive([() => O]),
 		}) {}

--- a/packages/dds/tree/src/test/simple-tree/api/integrationTests.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/integrationTests.spec.ts
@@ -47,7 +47,7 @@ describe("simple-tree API integration tests", () => {
 				() => {
 					array.insertAtEnd(obj);
 				},
-				validateUsageError(/more than one place/),
+				validateUsageError(/already in a tree/),
 			);
 		});
 


### PR DESCRIPTION
## Bug
Recursively assinging an unhydrated and unparented node to itself hangs forever. Note that doing the same for a parented node does throw a usage error (added a test for this scenario)

## Fix
The root-cause of this bug is that it is stuck in a while loop in `TreeNodeKernel` trying to emit `subtreeChangedAfterBatch` event for the sub-tree of the node.
Added logic in `adoptBy` to detect recursion and throw a usage error. This is where the logic to detect this for parent node happens.

[AB#32207](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/32207)