### PR TITLE
Logging socket.io HTTP requests and HTTP upgrade requests for socket.io

### DIFF
--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -93,7 +93,7 @@ const createAndConfigureHttpServer = (
 			const requestProperties = {
 				url: req.url,
 				method: req.method,
-				isWebSocketUpgrade: req.headers.upgrade?.toLowerCase() === 'websocket',
+				isWebSocketUpgrade: req.headers.upgrade?.toLowerCase() === "websocket",
 			};
 			Lumberjack.info("Socket.io request received", requestProperties);
 

--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -87,44 +87,6 @@ const createAndConfigureHttpServer = (
 	server.timeout =
 		httpServerConfig?.connectionTimeoutMs ?? defaultHttpServerConfig.connectionTimeoutMs;
 
-	// Log all socket.io requests and upgrades received by the HTTP server before they are passed to the Socket.io server.
-	server.on("request", (req, res) => {
-		if (req.url?.startsWith("/socket.io")) {
-			const requestProperties = {
-				url: req.url,
-				method: req.method,
-				isWebSocketUpgrade: req.headers.upgrade?.toLowerCase() === "websocket",
-			};
-			Lumberjack.info("Socket.io request received", requestProperties);
-
-			res.on("finish", () => {
-				Lumberjack.info("Socket.io request finished", {
-					...requestProperties,
-					statusCode: res.statusCode,
-				});
-			});
-
-			// Log any exceptions
-			res.on("error", (error) => {
-				Lumberjack.error("Socket.IO connection error", requestProperties, error);
-			});
-		}
-	});
-
-	server.on("upgrade", (req, socket, head) => {
-		if (req.url?.startsWith("/socket.io")) {
-			const requestProperties = {
-				url: req.url,
-				method: req.method,
-			};
-			Lumberjack.info("WebSocket upgrade received", requestProperties);
-
-			socket.on("error", (error) => {
-				Lumberjack.error("WebSocket upgrade error", requestProperties, error);
-			});
-		}
-	});
-
 	return server;
 };
 

--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -93,7 +93,6 @@ const createAndConfigureHttpServer = (
 			const requestProperties = {
 				url: req.url,
 				method: req.method,
-				remoteAddress: req.socket.remoteAddress,
 			};
 			Lumberjack.info("Socket.io request received", requestProperties);
 
@@ -116,7 +115,6 @@ const createAndConfigureHttpServer = (
 			const requestProperties = {
 				url: req.url,
 				method: req.method,
-				remoteAddress: req.socket.remoteAddress,
 			};
 			Lumberjack.info("WebSocket upgrade received", requestProperties);
 

--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -86,6 +86,28 @@ const createAndConfigureHttpServer = (
 	const server = http.createServer(requestListener);
 	server.timeout =
 		httpServerConfig?.connectionTimeoutMs ?? defaultHttpServerConfig.connectionTimeoutMs;
+
+	// Log all socket.io requests and upgrades received by the HTTP server before they are passed to the Socket.io server.
+	server.on("request", (req, res) => {
+		if (req.url?.startsWith("/socket.io")) {
+			// Socket.io requests should not be logged
+			Lumberjack.info("Socket.io request received", {
+				url: req.url,
+				method: req.method,
+			});
+		}
+	});
+
+	server.on("upgrade", (req, socket, head) => {
+		if (req.url?.startsWith("/socket.io")) {
+			// Socket.io requests should not be logged
+			Lumberjack.info("WebSocket upgrade received", {
+				url: req.url,
+				method: req.method,
+			});
+		}
+	});
+
 	return server;
 };
 

--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -86,7 +86,6 @@ const createAndConfigureHttpServer = (
 	const server = http.createServer(requestListener);
 	server.timeout =
 		httpServerConfig?.connectionTimeoutMs ?? defaultHttpServerConfig.connectionTimeoutMs;
-
 	return server;
 };
 

--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -93,6 +93,7 @@ const createAndConfigureHttpServer = (
 			const requestProperties = {
 				url: req.url,
 				method: req.method,
+				isWebSocketUpgrade: req.headers.upgrade?.toLowerCase() === 'websocket',
 			};
 			Lumberjack.info("Socket.io request received", requestProperties);
 

--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -90,18 +90,38 @@ const createAndConfigureHttpServer = (
 	// Log all socket.io requests and upgrades received by the HTTP server before they are passed to the Socket.io server.
 	server.on("request", (req, res) => {
 		if (req.url?.startsWith("/socket.io")) {
-			Lumberjack.info("Socket.io request received", {
+			const requestProperties = {
 				url: req.url,
 				method: req.method,
+				remoteAddress: req.socket.remoteAddress,
+			};
+			Lumberjack.info("Socket.io request received", requestProperties);
+
+			res.on("finish", () => {
+				Lumberjack.info("Socket.io request finished", {
+					...requestProperties,
+					statusCode: res.statusCode,
+				});
+			});
+
+			// Log any exceptions
+			res.on("error", (error) => {
+				Lumberjack.error("Socket.IO connection error", requestProperties, error);
 			});
 		}
 	});
 
 	server.on("upgrade", (req, socket, head) => {
 		if (req.url?.startsWith("/socket.io")) {
-			Lumberjack.info("WebSocket upgrade received", {
+			const requestProperties = {
 				url: req.url,
 				method: req.method,
+				remoteAddress: req.socket.remoteAddress,
+			};
+			Lumberjack.info("WebSocket upgrade received", requestProperties);
+
+			socket.on("error", (error) => {
+				Lumberjack.error("WebSocket upgrade error", requestProperties, error);
 			});
 		}
 	});

--- a/server/routerlicious/packages/services-shared/src/webServer.ts
+++ b/server/routerlicious/packages/services-shared/src/webServer.ts
@@ -90,7 +90,6 @@ const createAndConfigureHttpServer = (
 	// Log all socket.io requests and upgrades received by the HTTP server before they are passed to the Socket.io server.
 	server.on("request", (req, res) => {
 		if (req.url?.startsWith("/socket.io")) {
-			// Socket.io requests should not be logged
 			Lumberjack.info("Socket.io request received", {
 				url: req.url,
 				method: req.method,
@@ -100,7 +99,6 @@ const createAndConfigureHttpServer = (
 
 	server.on("upgrade", (req, socket, head) => {
 		if (req.url?.startsWith("/socket.io")) {
-			// Socket.io requests should not be logged
 			Lumberjack.info("WebSocket upgrade received", {
 				url: req.url,
 				method: req.method,

--- a/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberEventNames.ts
@@ -74,4 +74,5 @@ export enum LumberEventName {
 	ReadinessProbe = "ReadinessProbe",
 	CircuitBreaker = "CircuitBreaker",
 	RestWrapper = "RestWrapper",
+	SocketIoRequest = "SocketIoRequest",
 }


### PR DESCRIPTION
## Description

Socket.IO uses HTTP requests to establish a WebSocket connection with the server. Here's how it works:

Initial HTTP Request (Handshake):

The client first sends an HTTP request to initiate a "handshake" with the server. This allows the server and client to exchange information and establish the connection.

By default, this is an HTTP GET request to the server’s Socket.IO endpoint (e.g., /socket.io/?EIO=4...).

WebSocket Upgrade Request:

After the handshake, if the server and client both support WebSockets, the HTTP connection is upgraded to a WebSocket connection using an HTTP Upgrade request. This enables bi-directional, low-latency communication.

In this PR, I am adding some telemetry to track socket.io requests and upgrade requests to the HTTP server.
