### PR TITLE
refactor(generate:changeset): Condense front matter into single section

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/changeset.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/changeset.ts
@@ -423,22 +423,20 @@ function createChangesetContent(
 	const frontMatterSeparator = "---";
 
 	const lines: string[] = [frontMatterSeparator];
+
+	// Add package version bumps
 	for (const [pkg, bump] of packages.entries()) {
 		lines.push(`"${pkg.name}": ${bump}`);
 	}
-	lines.push(frontMatterSeparator);
 
+	// Add Fluid-specific metadata with __ prefix
 	if (additionalMetadata !== undefined) {
-		lines.push(frontMatterSeparator);
 		for (const [name, value] of Object.entries(additionalMetadata)) {
-			lines.push(`"${name}": ${value}`);
+			lines.push(`"__${name}": ${value}`);
 		}
-		lines.push(
-			frontMatterSeparator,
-			// an extra empty line after the front matter
-			"",
-		);
 	}
+
+	lines.push(frontMatterSeparator);
 
 	const frontMatter = lines.join("\n");
 	const changesetContents = [frontMatter, body].join("\n");


### PR DESCRIPTION
Our custom changeset metadata is in its own separate front-matter section. However, most tools do not recognize more than one front-matter section, so this has not been an ideal solution when we want to use other tools on our changesets (e.g. review tools, formatters, linting tools, etc.).

This change condenses the fron matter into a single section, using `__` to prefix fluid-specific properties.

We already have to remove custom metadata when producing changelogs so that process has just been updated to remove the custom properties rather than the second front matter section.

The motivator for this change is to make it easier to use markdown-aware tools with our changesets. See https://github.com/microsoft/FluidFramework/pull/24252 for an example.