### PR TITLE
Stop using processCore in tree

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -6,7 +6,6 @@
 import { assert } from "@fluidframework/core-utils/internal";
 import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
-import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import type {
 	IExperimentalIncrementalSummaryContext,
 	IRuntimeMessageCollection,
@@ -329,28 +328,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 			policy: schemaAndPolicy.policy,
 		});
 		this.resubmitMachine.onCommitSubmitted(enrichedCommit);
-	}
-
-	/**
-	 * Process a message from the runtime.
-	 * @deprecated - Use processMessagesCore to process a bunch of messages together.
-	 */
-	public processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		this.processMessagesCore({
-			envelope: message,
-			local,
-			messagesContent: [
-				{
-					clientSequenceNumber: message.clientSequenceNumber,
-					contents: message.contents,
-					localOpMetadata,
-				},
-			],
-		});
 	}
 
 	/**

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -250,7 +250,7 @@ export class SharedTree extends SharedObject implements ISharedTree {
 		local: boolean,
 		localOpMetadata: unknown,
 	): void {
-		this.kernel.processCore(message, local, localOpMetadata);
+		fail("processCore should not be called on SharedTree");
 	}
 
 	protected override processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {

--- a/packages/dds/tree/src/test/shared-tree-core/utils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/utils.ts
@@ -40,7 +40,7 @@ import {
 	type Summarizable,
 } from "../../shared-tree-core/index.js";
 import { testIdCompressor } from "../utils.js";
-import { strict as assert } from "node:assert";
+import { strict as assert, fail } from "node:assert";
 import {
 	SharedObject,
 	type IChannelView,
@@ -51,6 +51,7 @@ import type {
 	ISummaryTreeWithStats,
 	IExperimentalIncrementalSummaryContext,
 	ITelemetryContext,
+	IRuntimeMessageCollection,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	createIdCompressor,
@@ -273,9 +274,12 @@ export class TestSharedTreeCore extends SharedObject {
 		local: boolean,
 		localOpMetadata: unknown,
 	): void {
-		this.kernel.processCore(message, local, localOpMetadata);
+		fail("processCore should not be called on SharedTree");
 	}
 
+	protected override processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {
+		this.kernel.processMessagesCore(messagesCollection);
+	}
 	protected onDisconnect(): void {}
 
 	protected override async loadCore(services: IChannelStorageService): Promise<void> {


### PR DESCRIPTION
## Description

processCore should no longer be getting called, so remove its implementation and replace it with an assert.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).