### PR TITLE
Add scope property to schema nodes

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -432,15 +432,15 @@ export namespace JsonAsTree {
     export class JsonObject extends _APIExtractorWorkaroundObjectBase {
     }
     const _APIExtractorWorkaroundObjectBase: TreeNodeSchemaClass<"com.fluidframework.json.object", NodeKind.Map, TreeMapNodeUnsafe<readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array]> & WithType<"com.fluidframework.json.object", NodeKind.Map, unknown>, {
-        [Symbol.iterator](): Iterator<[string, string | number | JsonObject | Array | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null], any, undefined>;
+        [Symbol.iterator](): Iterator<[string, string | number | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null], any, undefined>;
     } | {
-        readonly [x: string]: string | number | JsonObject | Array | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null;
+        readonly [x: string]: string | number | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null;
     }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined>;
     // (undocumented)
     export type Primitive = TreeNodeFromImplicitAllowedTypes<typeof Primitive>;
     export type _RecursiveArrayWorkaroundJsonArray = FixRecursiveArraySchema<typeof Array>;
     const _APIExtractorWorkaroundArrayBase: TreeNodeSchemaClass<"com.fluidframework.json.array", NodeKind.Array, TreeArrayNodeUnsafe<readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array]> & WithType<"com.fluidframework.json.array", NodeKind.Array, unknown>, {
-        [Symbol.iterator](): Iterator<string | number | JsonObject | Array | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null, any, undefined>;
+        [Symbol.iterator](): Iterator<string | number | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null, any, undefined>;
     }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined>;
     // (undocumented)
     export type Tree = TreeNodeFromImplicitAllowedTypes<typeof Tree>;
@@ -1140,6 +1140,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly identifier: Name;
     readonly implicitlyConstructable: ImplicitlyConstructable;
     readonly info: Info;
+    readonly scope?: string;
 }
 
 // @public @sealed

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -596,6 +596,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly identifier: Name;
     readonly implicitlyConstructable: ImplicitlyConstructable;
     readonly info: Info;
+    readonly scope?: string;
 }
 
 // @public @sealed

--- a/packages/dds/tree/api-report/tree.legacy.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.alpha.api.md
@@ -589,6 +589,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly identifier: Name;
     readonly implicitlyConstructable: ImplicitlyConstructable;
     readonly info: Info;
+    readonly scope?: string;
 }
 
 // @public @sealed

--- a/packages/dds/tree/api-report/tree.legacy.public.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.public.api.md
@@ -580,6 +580,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly identifier: Name;
     readonly implicitlyConstructable: ImplicitlyConstructable;
     readonly info: Info;
+    readonly scope?: string;
 }
 
 // @public @sealed

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -580,6 +580,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly identifier: Name;
     readonly implicitlyConstructable: ImplicitlyConstructable;
     readonly info: Info;
+    readonly scope?: string;
 }
 
 // @public @sealed

--- a/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
@@ -626,6 +626,7 @@ export class SchemaFactory<
 		T
 	> {
 		return objectSchema(
+			this.scope,
 			this.scoped(name),
 			fields,
 			true,
@@ -766,6 +767,7 @@ export class SchemaFactory<
 		undefined
 	> {
 		return mapSchema(
+			this.scope,
 			this.scoped(name),
 			allowedTypes,
 			implicitlyConstructable,
@@ -919,7 +921,13 @@ export class SchemaFactory<
 		T,
 		undefined
 	> {
-		return arraySchema(this.scoped(name), allowedTypes, implicitlyConstructable, customizable);
+		return arraySchema(
+			this.scope,
+			this.scoped(name),
+			allowedTypes,
+			implicitlyConstructable,
+			customizable,
+		);
 	}
 
 	/**

--- a/packages/dds/tree/src/simple-tree/api/schemaFactoryAlpha.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactoryAlpha.ts
@@ -83,6 +83,7 @@ export class SchemaFactoryAlpha<
 		readonly createFromInsertable: unknown;
 	} {
 		return objectSchema(
+			this.scope,
 			this.scoped2(name),
 			fields,
 			true,
@@ -196,7 +197,14 @@ export class SchemaFactoryAlpha<
 		allowedTypes: T,
 		options?: NodeSchemaOptions<TCustomMetadata>,
 	): MapNodeCustomizableSchema<ScopedSchemaName<TScope, Name>, T, true, TCustomMetadata> {
-		return mapSchema(this.scoped2(name), allowedTypes, true, true, options?.metadata);
+		return mapSchema(
+			this.scope,
+			this.scoped2(name),
+			allowedTypes,
+			true,
+			true,
+			options?.metadata,
+		);
 	}
 
 	/**
@@ -240,7 +248,14 @@ export class SchemaFactoryAlpha<
 		allowedTypes: T,
 		options?: NodeSchemaOptions<TCustomMetadata>,
 	): ArrayNodeCustomizableSchema<ScopedSchemaName<TScope, Name>, T, true, TCustomMetadata> {
-		return arraySchema(this.scoped2(name), allowedTypes, true, true, options?.metadata);
+		return arraySchema(
+			this.scope,
+			this.scoped2(name),
+			allowedTypes,
+			true,
+			true,
+			options?.metadata,
+		);
 	}
 
 	/**

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -1068,6 +1068,7 @@ export function arraySchema<
 	const ImplicitlyConstructable extends boolean,
 	const TCustomMetadata = unknown,
 >(
+	scope: string | undefined,
 	identifier: TName,
 	info: T,
 	implicitlyConstructable: ImplicitlyConstructable,
@@ -1162,6 +1163,7 @@ export function arraySchema<
 		}
 
 		public static readonly identifier = identifier;
+		public static readonly scope = scope;
 		public static readonly info = info;
 		public static readonly implicitlyConstructable: ImplicitlyConstructable =
 			implicitlyConstructable;

--- a/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
@@ -241,6 +241,13 @@ export interface TreeNodeSchemaCore<
 	out TCustomMetadata = unknown,
 > extends SimpleNodeSchemaBase<Kind, TCustomMetadata> {
 	/**
+	 * The scope in which this document's schema is defined.
+	 * @remarks Schema defined with the same {@link SchemaFactory.scope | factory share the same scope}.
+	 * The {@link TreeNodeSchemaCore.identifier | identifier} of this schema includes this scope.
+	 */
+	readonly scope?: string;
+
+	/**
 	 * Unique (within a document's schema) identifier used to associate nodes with their schema.
 	 * @remarks
 	 * This is used when encoding nodes, and when decoding nodes to re-associate them with the schema.

--- a/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
@@ -50,6 +50,8 @@ export class LeafNodeSchema<Name extends string, const T extends ValueSchema>
 
 	public readonly metadata: NodeSchemaMetadata = {};
 
+	public static readonly scope = "com.fluidframework.leaf";
+
 	public constructor(name: Name, t: T) {
 		this.identifier = name;
 		this.info = t;
@@ -65,7 +67,7 @@ function makeLeaf<Name extends string, const T extends ValueSchema>(
 	t: T,
 ): LeafSchema<Name, TreeValue<T>> & SimpleLeafNodeSchema {
 	// Names in this domain follow https://en.wikipedia.org/wiki/Reverse_domain_name_notation
-	return new LeafNodeSchema(`com.fluidframework.leaf.${name}`, t);
+	return new LeafNodeSchema(`${LeafNodeSchema.scope}.${name}`, t);
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -237,6 +237,7 @@ export function mapSchema<
 	const ImplicitlyConstructable extends boolean,
 	const TCustomMetadata = unknown,
 >(
+	scope: string | undefined,
 	identifier: TName,
 	info: T,
 	implicitlyConstructable: ImplicitlyConstructable,
@@ -286,6 +287,7 @@ export function mapSchema<
 		}
 
 		public static readonly identifier = identifier;
+		public static readonly scope = scope;
 		public static readonly info = info;
 		public static readonly implicitlyConstructable: ImplicitlyConstructable =
 			implicitlyConstructable;

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -349,6 +349,7 @@ export function objectSchema<
 	const ImplicitlyConstructable extends boolean,
 	const TCustomMetadata = unknown,
 >(
+	scope: string | undefined,
 	identifier: TName,
 	info: T,
 	implicitlyConstructable: ImplicitlyConstructable,
@@ -486,6 +487,7 @@ export function objectSchema<
 		}
 
 		public static readonly identifier = identifier;
+		public static readonly scope = scope;
 		public static readonly info = info;
 		public static readonly implicitlyConstructable: ImplicitlyConstructable =
 			implicitlyConstructable;

--- a/packages/dds/tree/src/test/simple-tree/core/types.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/types.spec.ts
@@ -132,6 +132,7 @@ describe("simple-tree types", () => {
 
 			class Subclass extends TreeNodeValid<number> {
 				public static readonly kind = NodeKind.Array;
+				public static readonly scope = "";
 				public static readonly identifier = "Subclass";
 				public static readonly metadata = {};
 				public static readonly info = numberSchema;
@@ -232,6 +233,7 @@ describe("simple-tree types", () => {
 			const log: string[] = [];
 			class Subclass extends TreeNodeValid<number> {
 				public static readonly kind = NodeKind.Array;
+				public static readonly scope = "";
 				public static readonly identifier = "Subclass";
 				public static readonly metadata = {};
 				public static readonly info = numberSchema;
@@ -286,6 +288,7 @@ describe("simple-tree types", () => {
 			const log: string[] = [];
 			class Subclass extends TreeNodeValid<number> {
 				public static readonly kind = NodeKind.Array;
+				public static readonly scope = "";
 				public static readonly identifier = "Subclass";
 				public static readonly metadata = {};
 				public static readonly info = numberSchema;

--- a/packages/dds/tree/src/test/simple-tree/schemaTypes.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaTypes.spec.ts
@@ -249,7 +249,7 @@ describe("schemaTypes", () => {
 			}
 
 			// Class that implements both TreeNodeSchemaNonClass and TreeNodeSchemaNonClass
-			class CustomizedBoth extends objectSchema("B", { x: [schema.number] }, true, false) {
+			class CustomizedBoth extends objectSchema("", "B", { x: [schema.number] }, true, false) {
 				public customized = true;
 			}
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -772,15 +772,15 @@ export namespace JsonAsTree {
     export class JsonObject extends _APIExtractorWorkaroundObjectBase {
     }
     const _APIExtractorWorkaroundObjectBase: TreeNodeSchemaClass<"com.fluidframework.json.object", NodeKind.Map, TreeMapNodeUnsafe<readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array]> & WithType<"com.fluidframework.json.object", NodeKind.Map, unknown>, {
-        [Symbol.iterator](): Iterator<[string, string | number | JsonObject | Array | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null], any, undefined>;
+        [Symbol.iterator](): Iterator<[string, string | number | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null], any, undefined>;
     } | {
-        readonly [x: string]: string | number | JsonObject | Array | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null;
+        readonly [x: string]: string | number | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null;
     }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined>;
     // (undocumented)
     export type Primitive = TreeNodeFromImplicitAllowedTypes<typeof Primitive>;
     export type _RecursiveArrayWorkaroundJsonArray = FixRecursiveArraySchema<typeof Array>;
     const _APIExtractorWorkaroundArrayBase: TreeNodeSchemaClass<"com.fluidframework.json.array", NodeKind.Array, TreeArrayNodeUnsafe<readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array]> & WithType<"com.fluidframework.json.array", NodeKind.Array, unknown>, {
-        [Symbol.iterator](): Iterator<string | number | JsonObject | Array | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | null, any, undefined>;
+        [Symbol.iterator](): Iterator<string | number | InsertableTypedNodeUnsafe<LeafSchema<"boolean", boolean>, LeafSchema<"boolean", boolean>> | JsonObject | Array | null, any, undefined>;
     }, false, readonly [LeafSchema<"null", null>, LeafSchema<"number", number>, LeafSchema<"string", string>, LeafSchema<"boolean", boolean>, () => typeof JsonObject, () => typeof Array], undefined>;
     // (undocumented)
     export type Tree = TreeNodeFromImplicitAllowedTypes<typeof Tree>;
@@ -1523,6 +1523,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly identifier: Name;
     readonly implicitlyConstructable: ImplicitlyConstructable;
     readonly info: Info;
+    readonly scope?: string;
 }
 
 // @public @sealed

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -973,6 +973,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly identifier: Name;
     readonly implicitlyConstructable: ImplicitlyConstructable;
     readonly info: Info;
+    readonly scope?: string;
 }
 
 // @public @sealed

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -1392,6 +1392,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly identifier: Name;
     readonly implicitlyConstructable: ImplicitlyConstructable;
     readonly info: Info;
+    readonly scope?: string;
 }
 
 // @public @sealed

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -997,6 +997,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly identifier: Name;
     readonly implicitlyConstructable: ImplicitlyConstructable;
     readonly info: Info;
+    readonly scope?: string;
 }
 
 // @public @sealed

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -957,6 +957,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly identifier: Name;
     readonly implicitlyConstructable: ImplicitlyConstructable;
     readonly info: Info;
+    readonly scope?: string;
 }
 
 // @public @sealed


### PR DESCRIPTION
## Description

The `scope` property is exposed on tree schema classes/objects and contains the scope of the factory by which they were created. Therefore, if defined, the `scope` property is equal to some leading portion of the node's identifier.