### PR TITLE
build(client-devtools-core): split test from production

### DIFF
--- a/packages/tools/devtools/devtools-core/.eslintrc.cjs
+++ b/packages/tools/devtools/devtools-core/.eslintrc.cjs
@@ -6,7 +6,7 @@
 module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
 	parserOptions: {
-		project: ["./tsconfig.json"],
+		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
 		// Disabled because they conflict with Prettier.

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -56,6 +56,9 @@
 		"build:docs": "api-extractor run --local",
 		"build:esnext": "tsc --project ./tsconfig.json",
 		"build:genver": "gen-version",
+		"build:test": "npm run build:test:esm && npm run build:test:cjs",
+		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack .",
 		"check:biome": "biome check .",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
@@ -152,18 +155,6 @@
 		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
-	},
-	"fluidBuild": {
-		"tasks": {
-			"build:esnext": [
-				"...",
-				"typetests:gen"
-			],
-			"tsc": [
-				"...",
-				"typetests:gen"
-			]
-		}
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DataVisualization.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DataVisualization.ts
@@ -130,7 +130,7 @@ export interface DataVisualizerEvents extends IEvent {
 	 *
 	 * @eventProperty
 	 */
-	(event: "update", listener: (visualTree: FluidObjectNode) => void);
+	(event: "update", listener: (visualTree: FluidObjectNode) => void): unknown;
 }
 
 /**

--- a/packages/tools/devtools/devtools-core/src/messaging/MessageRelay.ts
+++ b/packages/tools/devtools/devtools-core/src/messaging/MessageRelay.ts
@@ -18,7 +18,7 @@ export interface IMessageRelayEvents<
 	/**
 	 * Emitted when a message is received from the external sender.
 	 */
-	(event: "message", listener: (message: TMessage) => void);
+	(event: "message", listener: (message: TMessage) => void): unknown;
 }
 
 /**

--- a/packages/tools/devtools/devtools-core/src/test/tsconfig.cjs.json
+++ b/packages/tools/devtools/devtools-core/src/test/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use fluid-tsc commonjs.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/test",
+	},
+	"references": [
+		{
+			"path": "../../tsconfig.cjs.json",
+		},
+	],
+}

--- a/packages/tools/devtools/devtools-core/src/test/tsconfig.json
+++ b/packages/tools/devtools/devtools-core/src/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"include": ["./**/*"],
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../../lib/test",
+		"types": ["chai", "mocha"],
+		"noImplicitAny": true,
+		"noUnusedLocals": true,
+		"noImplicitOverride": true,
+		"exactOptionalPropertyTypes": false,
+	},
+	"references": [
+		{
+			"path": "../..",
+		},
+	],
+}

--- a/packages/tools/devtools/devtools-core/tsconfig.json
+++ b/packages/tools/devtools/devtools-core/tsconfig.json
@@ -1,10 +1,12 @@
 {
 	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"include": ["src/**/*"],
+	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"rootDir": "src",
+		"rootDir": "./src",
 		"outDir": "./lib",
-		"types": ["chai", "mocha"],
+		"noImplicitAny": true,
+		"noImplicitOverride": true,
 		"exactOptionalPropertyTypes": false,
 	},
-	"include": ["src/**/*"],
 }


### PR DESCRIPTION
and enable preferred noImplicitAny and noUnusedLocals.
 - Give events explicit return to satisfy noImplicitAny

This fixes dependencies for `build-and-test:unit*` commands.