### PR TITLE
build(build-tools): Enable unused variable linting

### DIFF
--- a/build-tools/packages/build-cli/.eslintrc.cjs
+++ b/build-tools/packages/build-cli/.eslintrc.cjs
@@ -16,6 +16,9 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
+		// Catch unused variables in at lint time instead of compile time
+		"@typescript-eslint/no-unused-vars": "error",
+
 		// This rule is often triggered when using custom Flags, so disabling.
 		"object-shorthand": "off",
 

--- a/build-tools/packages/build-cli/src/commands/generate/assertTags.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/assertTags.ts
@@ -167,8 +167,8 @@ The format of the configuration is specified by the "AssertTaggingPackageConfig"
 
 	// This should not be called due to processPackages being overridden instead.
 	protected override async processPackage<TPkg extends Package>(
-		pkg: TPkg,
-		kind: PackageKind,
+		_pkg: TPkg,
+		_kind: PackageKind,
 	): Promise<void> {
 		throw new Error("Method not implemented.");
 	}
@@ -227,7 +227,7 @@ The format of the configuration is specified by the "AssertTaggingPackageConfig"
 			return errors;
 		}
 
-		for (const [pkg, data] of dataMap) {
+		for (const [, data] of dataMap) {
 			errors.push(...this.tagAsserts(collected, data));
 		}
 

--- a/build-tools/packages/build-cli/src/commands/test-only-filter.ts
+++ b/build-tools/packages/build-cli/src/commands/test-only-filter.ts
@@ -43,11 +43,11 @@ export default class FilterCommand extends PackageCommand<typeof FilterCommand> 
 	static readonly enableJsonFlag = true;
 	protected defaultSelection = "dir" as PackageSelectionDefault;
 
-	protected async processPackage(pkg: Package): Promise<void> {
+	protected async processPackage(_pkg: Package): Promise<void> {
 		// do nothing
 	}
 
-	protected async processPackages(packages: PackageWithKind[]): Promise<string[]> {
+	protected async processPackages(_packages: PackageWithKind[]): Promise<string[]> {
 		// do nothing
 		return [];
 	}

--- a/build-tools/packages/build-cli/src/handlers/initFailedStateHandler.ts
+++ b/build-tools/packages/build-cli/src/handlers/initFailedStateHandler.ts
@@ -18,8 +18,8 @@ export abstract class InitFailedStateHandler extends BaseStateHandler {
 		state: MachineState,
 		machine: Machine<unknown>,
 		testMode: boolean,
-		log: CommandLogger,
-		data: unknown,
+		_log: CommandLogger,
+		_data: unknown,
 	): Promise<boolean> {
 		switch (state) {
 			case "Init": {

--- a/build-tools/packages/build-cli/src/library/branches.ts
+++ b/build-tools/packages/build-cli/src/library/branches.ts
@@ -281,7 +281,7 @@ export function getDefaultBumpTypeForBranch(
  * @internal
  */
 export function getReleaseSourceForReleaseGroup(
-	releaseGroupOrPackage: ReleaseGroup | ReleasePackage,
+	_releaseGroupOrPackage: ReleaseGroup | ReleasePackage,
 ): ReleaseSource {
 	// All packages and release groups use release branches.
 	return "releaseBranches";

--- a/build-tools/packages/build-cli/src/library/changesets.ts
+++ b/build-tools/packages/build-cli/src/library/changesets.ts
@@ -12,7 +12,6 @@ import globby from "globby";
 import matter from "gray-matter";
 import issueParser from "issue-parser";
 import { simpleGit } from "simple-git";
-const { test: hasFrontMatter } = matter;
 
 import type { ReleaseNotesSectionName } from "../config.js";
 import { ReleasePackage } from "../releaseGroups.js";

--- a/build-tools/packages/build-cli/src/library/githubRest.ts
+++ b/build-tools/packages/build-cli/src/library/githubRest.ts
@@ -189,7 +189,6 @@ export async function getCommentBody(
 		pull_number: prNumber,
 	});
 
-	let commentBody: string | undefined;
 	// Check the comments to find the comment with the identifier.
 	for (const comment of comments) {
 		if (comment.body.startsWith(commentIdentifier)) {

--- a/build-tools/packages/build-cli/src/library/markdown.ts
+++ b/build-tools/packages/build-cli/src/library/markdown.ts
@@ -112,7 +112,7 @@ export function removeSectionContent(options: { heading: string | RegExp }): (
 	tree: Root,
 ) => void {
 	return function (tree: Root) {
-		headingRange(tree, options.heading, (start, nodes, end, info) => {
+		headingRange(tree, options.heading, (start, _nodes, end, _info) => {
 			return [
 				start,
 				// No child nodes - effectively empties the section.

--- a/build-tools/packages/build-cli/tsconfig.json
+++ b/build-tools/packages/build-cli/tsconfig.json
@@ -7,7 +7,7 @@
 		"outDir": "./lib",
 		"types": ["node"],
 		"noImplicitAny": true,
-		"noUnusedLocals": false,
+		"noUnusedLocals": false, // Checked in lint instead
 		"target": "ES2022",
 		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,

--- a/build-tools/packages/build-cli/tsconfig.json
+++ b/build-tools/packages/build-cli/tsconfig.json
@@ -7,7 +7,7 @@
 		"outDir": "./lib",
 		"types": ["node"],
 		"noImplicitAny": true,
-		"noUnusedLocals": false, // Checked in lint instead
+		"noUnusedLocals": false, // Checked in lint instead so unused variables do not block compilation
 		"target": "ES2022",
 		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,

--- a/build-tools/packages/build-infrastructure/.eslintrc.cjs
+++ b/build-tools/packages/build-infrastructure/.eslintrc.cjs
@@ -14,6 +14,9 @@ module.exports = {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
 	rules: {
+		// Catch unused variables in at lint time instead of compile time
+		"@typescript-eslint/no-unused-vars": "error",
+
 		// This package is exclusively used in a Node.js context
 		"import/no-nodejs-modules": "off",
 

--- a/build-tools/packages/build-infrastructure/src/commands/list.ts
+++ b/build-tools/packages/build-infrastructure/src/commands/list.ts
@@ -32,7 +32,12 @@ export class ListCommand extends Command {
 
 		// load the BuildProject
 		const repo = loadBuildProject(searchPath);
-		const _ = full ? await this.logFullReport(repo) : await this.logCompactReport(repo);
+		// eslint-disable-next-line unicorn/prefer-ternary
+		if (full) {
+			await this.logFullReport(repo);
+		} else {
+			await this.logCompactReport(repo);
+		}
 	}
 
 	private async logFullReport(repo: IBuildProject): Promise<void> {

--- a/build-tools/packages/build-infrastructure/src/package.ts
+++ b/build-tools/packages/build-infrastructure/src/package.ts
@@ -6,8 +6,8 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-// Imports are written this way for CJS/ESM compat
 import fsePkg from "fs-extra";
+// eslint-disable-next-line import/no-named-as-default-member -- Imports are written this way for CJS/ESM compat
 const { readJsonSync } = fsePkg;
 import colors from "picocolors";
 

--- a/build-tools/packages/build-infrastructure/src/packageJsonUtils.ts
+++ b/build-tools/packages/build-infrastructure/src/packageJsonUtils.ts
@@ -8,8 +8,8 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import detectIndent from "detect-indent";
-// Imports are written this way for CJS/ESM compat
 import fsePkg from "fs-extra";
+// eslint-disable-next-line import/no-named-as-default-member -- Imports are written this way for CJS/ESM compat
 const { writeJson, writeJsonSync } = fsePkg;
 import sortPackageJson from "sort-package-json";
 

--- a/build-tools/packages/build-infrastructure/src/test/dirname.cts
+++ b/build-tools/packages/build-infrastructure/src/test/dirname.cts
@@ -10,5 +10,4 @@
 //   - Export '__dirname' from a .cjs file in the same directory.
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
-// eslint-disable-next-line unicorn/prefer-module -- this is used for ESM/CJS interop
 export const _dirname = __dirname;

--- a/build-tools/packages/build-infrastructure/src/test/packageJsonUtils.test.ts
+++ b/build-tools/packages/build-infrastructure/src/test/packageJsonUtils.test.ts
@@ -21,7 +21,7 @@ import { testDataPath } from "./init.js";
  * A transformer function that does nothing.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const testTransformer = (_json: PackageJson): void => {
+const testTransformer = (json: PackageJson): void => {
 	// do nothing
 	return;
 };

--- a/build-tools/packages/build-infrastructure/src/test/packageJsonUtils.test.ts
+++ b/build-tools/packages/build-infrastructure/src/test/packageJsonUtils.test.ts
@@ -20,7 +20,8 @@ import { testDataPath } from "./init.js";
 /**
  * A transformer function that does nothing.
  */
-const testTransformer = (json: PackageJson): void => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const testTransformer = (_json: PackageJson): void => {
 	// do nothing
 	return;
 };
@@ -28,6 +29,7 @@ const testTransformer = (json: PackageJson): void => {
 /**
  * A transformer function that does nothing.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const testTransformerAsync = async (json: PackageJson): Promise<void> => {
 	// do nothing
 	return;

--- a/build-tools/packages/build-infrastructure/src/test/packageJsonUtils.test.ts
+++ b/build-tools/packages/build-infrastructure/src/test/packageJsonUtils.test.ts
@@ -13,15 +13,13 @@ import {
 	updatePackageJsonFile,
 	updatePackageJsonFileAsync,
 } from "../packageJsonUtils.js";
-import { type PackageJson } from "../types.js";
 
 import { testDataPath } from "./init.js";
 
 /**
  * A transformer function that does nothing.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const testTransformer = (json: PackageJson): void => {
+const testTransformer = (): void => {
 	// do nothing
 	return;
 };
@@ -29,8 +27,7 @@ const testTransformer = (json: PackageJson): void => {
 /**
  * A transformer function that does nothing.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const testTransformerAsync = async (json: PackageJson): Promise<void> => {
+const testTransformerAsync = async (): Promise<void> => {
 	// do nothing
 	return;
 };

--- a/build-tools/packages/build-infrastructure/tsconfig.json
+++ b/build-tools/packages/build-infrastructure/tsconfig.json
@@ -7,6 +7,6 @@
 		"outDir": "./lib",
 		"types": ["node"],
 		"exactOptionalPropertyTypes": false,
-		"noUnusedLocals": false, // Checked in lint instead
+		"noUnusedLocals": false, // Checked in lint instead so unused variables do not block compilation
 	},
 }

--- a/build-tools/packages/build-infrastructure/tsconfig.json
+++ b/build-tools/packages/build-infrastructure/tsconfig.json
@@ -7,6 +7,6 @@
 		"outDir": "./lib",
 		"types": ["node"],
 		"exactOptionalPropertyTypes": false,
-		"noUnusedLocals": false,
+		"noUnusedLocals": false, // Checked in lint instead
 	},
 }

--- a/build-tools/packages/build-tools/.eslintrc.cjs
+++ b/build-tools/packages/build-tools/.eslintrc.cjs
@@ -19,7 +19,10 @@ module.exports = {
 		"@typescript-eslint/no-unsafe-member-access": "off",
 
 		"@typescript-eslint/no-non-null-assertion": "error",
+
+		// Catch unused variables in at lint time instead of compile time
 		"@typescript-eslint/no-unused-vars": "error",
+
 		"@typescript-eslint/switch-exhaustiveness-check": "error",
 
 		// This package is exclusively used in a Node.js context

--- a/build-tools/packages/build-tools/tsconfig.json
+++ b/build-tools/packages/build-tools/tsconfig.json
@@ -6,7 +6,7 @@
 		"composite": true,
 		"noImplicitAny": false,
 		"noImplicitThis": true,
-		"noUnusedLocals": false,
+		"noUnusedLocals": false, // Checked in lint instead
 		"strictBindCallApply": true,
 		"strictFunctionTypes": true,
 		"strictNullChecks": true,

--- a/build-tools/packages/build-tools/tsconfig.json
+++ b/build-tools/packages/build-tools/tsconfig.json
@@ -6,7 +6,7 @@
 		"composite": true,
 		"noImplicitAny": false,
 		"noImplicitThis": true,
-		"noUnusedLocals": false, // Checked in lint instead
+		"noUnusedLocals": false, // Checked in lint instead so unused variables do not block compilation
 		"strictBindCallApply": true,
 		"strictFunctionTypes": true,
 		"strictNullChecks": true,


### PR DESCRIPTION
The unused variable eslint rule was not enabled in build-tools and the tsconfig noUnusedLocals option was disabled (by design), so unused variables were not caught before merge.

This change updates the lint config in build-tools to catch these issues in lint and makes the necessary changes to the source.