### PR TITLE
remove unsafe options from csp

### DIFF
--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
 	"globalHeaders": {
 		"cache-control": "must-revalidate, max-age=3600",
-		"Content-Security-Policy": "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; object-src 'none'; base-uri 'self';",
+		"Content-Security-Policy": "script-src 'self' 'strict-dynamic' https:; object-src 'none'; base-uri 'self';",
 		"Content-Security-Policy-Report-Only": "require-trusted-types-for 'script'; trusted-types default; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
 	},
 	"navigationFallback": {


### PR DESCRIPTION
Removing unsafe options from our content security policy and add strict-dynamic as appears in CSP TSG. Given that we don't see any violations on CREMS we shouldn't need any script nonce. Removed options are 'ok' according to our docs but now leaning to removing such options given that ff website is still flagged.