### PR TITLE
build: Update vite to address CVE

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15669,7 +15669,7 @@ importers:
         version: 23.0.1(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)
       '@previewjs/plugin-react':
         specifier: ^11.0.0
-        version: 11.0.0(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)(vite@4.5.10(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0))
+        version: 11.0.0(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)(vite@4.5.12(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0))
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -15777,7 +15777,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^4.5.9
-        version: 4.5.10(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)
+        version: 4.5.12(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)
 
   packages/tools/fetch-tool:
     dependencies:
@@ -27497,8 +27497,8 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
-  vite@4.5.10:
-    resolution: {integrity: sha512-f2ueoukYTMI/5kMMT7wW+ol3zL6z6PjN28zYrGKAjnbzXhRXWXPThD3uN6muCp+TbfXaDgGvRuPsg6mwVLaWwQ==}
+  vite@4.5.12:
+    resolution: {integrity: sha512-qrMwavANtSz91nDy3zEiUHMtL09x0mniQsSMvDkNxuCBM1W5vriJ22hEmwTth6DhLSWsZnHBT0yHFAQXt6efGA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -30809,9 +30809,9 @@ snapshots:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint-config-biome: 1.9.4
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
@@ -31730,14 +31730,14 @@ snapshots:
     dependencies:
       '@fluidframework/core-interfaces': 1.4.0
 
-  '@fwouts/vite-tsconfig-paths@4.2.1(typescript@5.4.5)(vite@4.5.10(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0))':
+  '@fwouts/vite-tsconfig-paths@4.2.1(typescript@5.4.5)(vite@4.5.12(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0))':
     dependencies:
       async-mutex: 0.4.1
       debug: 4.4.0(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 2.1.2(typescript@5.4.5)
     optionalDependencies:
-      vite: 4.5.10(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)
+      vite: 4.5.12(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -33331,7 +33331,7 @@ snapshots:
 
   '@previewjs/core@23.0.1(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)':
     dependencies:
-      '@fwouts/vite-tsconfig-paths': 4.2.1(typescript@5.4.5)(vite@4.5.10(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0))
+      '@fwouts/vite-tsconfig-paths': 4.2.1(typescript@5.4.5)(vite@4.5.12(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0))
       '@previewjs/api': 13.0.0
       '@previewjs/config': 4.9.16
       '@previewjs/iframe': 11.0.1
@@ -33353,7 +33353,7 @@ snapshots:
       ts-node: 10.9.2(@types/node@18.19.67)(typescript@5.4.5)
       tsconfig-paths: 4.2.0
       typescript: 5.4.5
-      vite: 4.5.10(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)
+      vite: 4.5.12(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -33369,14 +33369,14 @@ snapshots:
 
   '@previewjs/iframe@11.0.1': {}
 
-  '@previewjs/plugin-react@11.0.0(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)(vite@4.5.10(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0))':
+  '@previewjs/plugin-react@11.0.0(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)(vite@4.5.12(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0))':
     dependencies:
       '@previewjs/api': 13.0.0
       '@previewjs/serializable-values': 7.0.3
       '@previewjs/storybook-helpers': 3.0.0(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)
       '@previewjs/type-analyzer': 8.0.2
       '@previewjs/vfs': 2.1.4
-      '@vitejs/plugin-react': 4.3.4(vite@4.5.10(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0))
+      '@vitejs/plugin-react': 4.3.4(vite@4.5.12(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0))
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@swc/core'
@@ -34532,14 +34532,14 @@ snapshots:
 
   '@ungap/structured-clone@1.2.1': {}
 
-  '@vitejs/plugin-react@4.3.4(vite@4.5.10(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0))':
+  '@vitejs/plugin-react@4.3.4(vite@4.5.12(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 4.5.10(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)
+      vite: 4.5.12(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36834,33 +36834,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.55.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.0
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36874,13 +36874,13 @@ snapshots:
       eslint: 8.55.0
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       get-tsconfig: 4.10.0
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -44151,7 +44151,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@4.5.10(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0):
+  vite@4.5.12(@types/node@18.19.67)(less@3.12.2)(sass@1.82.0)(terser@5.37.0):
     dependencies:
       esbuild: 0.18.20
       postcss: 8.5.3


### PR DESCRIPTION
## Description

Update dependency to address https://nvd.nist.gov/vuln/detail/CVE-2025-31125 and https://nvd.nist.gov/vuln/detail/CVE-2025-31486.

Done by running (but had to do a bit of manual fixing after it failed due to unmet peer dependencies):

```bash
pnpm exec flub modify lockfile --dependencyName=vite --version=4.5.12
```

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#34574](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/34574)
[AB#35097](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/35097)