### PR TITLE
feat(ContainerRuntime): Flush on DeltaManager's "op" event

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1827,6 +1827,10 @@ export class ContainerRuntime
 			this.attachState !== AttachState.Attached || this.hasPendingMessages();
 		context.updateDirtyContainerState(this.dirtyContainer);
 
+		// Reference Sequence Number may have just changed, and it must be consistent across a batch, so flush now.
+		// This is coverage for old loaders that don't call ContainerRuntime.process for non-runtime messages.
+		this.deltaManager.on("op", () => this.flush());
+
 		if (this.summariesDisabled) {
 			this.mc.logger.sendTelemetryEvent({ eventName: "SummariesDisabled" });
 		} else {
@@ -2641,7 +2645,7 @@ export class ContainerRuntime
 
 		if (!this.disableFlushBeforeProcess) {
 			// Reference Sequence Number may be about to change, and it must be consistent across a batch, so flush now
-			this.outbox.flush();
+			this.flush();
 		}
 
 		this.ensureNoDataModelChanges(() => {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1315,11 +1315,11 @@ export class ContainerRuntime
 	}
 
 	/**
-	 * If true, will skip Outbox flushing before processing an incoming message,
+	 * If true, will skip Outbox flushing before processing an incoming message (and on DeltaManager "op" event for loader back-compat),
 	 * and instead the Outbox will check for a split batch on every submit.
 	 * This is a kill-bit switch for this simplification of logic, in case it causes unexpected issues.
 	 */
-	private readonly disableFlushBeforeProcess: boolean;
+	private readonly skipSafetyFlushDuringProcessStack: boolean;
 
 	/***/
 	protected constructor(
@@ -1756,7 +1756,7 @@ export class ContainerRuntime
 
 		const legacySendBatchFn = makeLegacySendBatchFn(submitFn, this.innerDeltaManager);
 
-		this.disableFlushBeforeProcess =
+		this.skipSafetyFlushDuringProcessStack =
 			this.mc.config.getBoolean("Fluid.ContainerRuntime.DisableFlushBeforeProcess") === true;
 
 		this.outbox = new Outbox({
@@ -1770,7 +1770,7 @@ export class ContainerRuntime
 				compressionOptions,
 				maxBatchSizeInBytes: runtimeOptions.maxBatchSizeInBytes,
 				// If we disable flush before process, we must be ready to flush partial batches
-				flushPartialBatches: this.disableFlushBeforeProcess,
+				flushPartialBatches: this.skipSafetyFlushDuringProcessStack,
 			},
 			logger: this.mc.logger,
 			groupingManager: opGroupingManager,
@@ -1827,9 +1827,14 @@ export class ContainerRuntime
 			this.attachState !== AttachState.Attached || this.hasPendingMessages();
 		context.updateDirtyContainerState(this.dirtyContainer);
 
-		// Reference Sequence Number may have just changed, and it must be consistent across a batch, so flush now.
-		// This is coverage for old loaders that don't call ContainerRuntime.process for non-runtime messages.
-		this.deltaManager.on("op", () => this.flush());
+		if (!this.skipSafetyFlushDuringProcessStack) {
+			// Reference Sequence Number may have just changed, and it must be consistent across a batch,
+			// so we should flush now to clear the way for the next ops.
+			// NOTE: This will be redundant whenever CR.process was called for the op (since we flush there too) -
+			// But we need this coverage for old loaders that don't call ContainerRuntime.process for non-runtime messages.
+			// (We have to call flush _before_ processing a runtime op, but after is ok for non-runtime op)
+			this.deltaManager.on("op", () => this.flush());
+		}
 
 		if (this.summariesDisabled) {
 			this.mc.logger.sendTelemetryEvent({ eventName: "SummariesDisabled" });
@@ -1955,7 +1960,7 @@ export class ContainerRuntime
 			featureGates: JSON.stringify({
 				...featureGatesForTelemetry,
 				closeSummarizerDelayOverride,
-				disableFlushBeforeProcess: this.disableFlushBeforeProcess,
+				disableFlushBeforeProcess: this.skipSafetyFlushDuringProcessStack,
 			}),
 			telemetryDocumentId: this.telemetryDocumentId,
 			groupedBatchingEnabled: this.groupedBatchingEnabled,
@@ -2643,7 +2648,7 @@ export class ContainerRuntime
 
 		this.verifyNotClosed();
 
-		if (!this.disableFlushBeforeProcess) {
+		if (!this.skipSafetyFlushDuringProcessStack) {
 			// Reference Sequence Number may be about to change, and it must be consistent across a batch, so flush now
 			this.flush();
 		}


### PR DESCRIPTION
## Description

Bug fix following on #24099

We need to flush whenever incoming ops are processed (even non-runtime ops), since we track the reference sequence number of the in-progress batch and throw if it ever changes mid-batch.  For this reason, we recently started calling `flush` in `ContainerRuntime.process`.

In old loader code, `ContainerRuntime.process` is only called for runtime messages, so it is possible for the reference sequence number to advance without ContainerRuntime flushing.

This PR adds another flush call in response to DeltaManager's "op" event to close this gap.

It's ok to call flush extra, it's a cheap no-op if there's nothing there.

## UPDATED CONTEXT (5/22/25)

Turns out this fix is not only needed for back compat, but fixes a real bug in the code with current loader/runtime.  See [comment below](https://github.com/microsoft/FluidFramework/pull/24276#issuecomment-2902640564)