### PR TITLE
Revert "remove unsafe options from csp"

### DIFF
--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
 	"globalHeaders": {
 		"cache-control": "must-revalidate, max-age=3600",
-		"Content-Security-Policy": "script-src 'self' 'strict-dynamic' https:; object-src 'none'; base-uri 'self';",
+		"Content-Security-Policy": "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; object-src 'none'; base-uri 'self';",
 		"Content-Security-Policy-Report-Only": "require-trusted-types-for 'script'; trusted-types default; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
 	},
 	"navigationFallback": {


### PR DESCRIPTION
Reverts microsoft/FluidFramework#24274

Seeing issues with the dice roller example demo after merging these changes.