### PR TITLE
tools: exclude `build` output directories

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -14,6 +14,7 @@
 			// Build output
 			"**/dist/*",
 			"**/lib/*",
+			"examples/**/build/*",
 			"**/*.done.build.log",
 			"**/.next", // NextJS
 


### PR DESCRIPTION
that will fail biome check after full build otherwise since #24162.