### PR TITLE
ci: Fix git tagging during releases

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -42,6 +42,7 @@ parameters:
   default: $(Pipeline.Workspace)/.pnpm-store
 
 jobs:
+# Note: must be kept in sync with the name of the dependsOn job below
 - deployment: publish_${{ replace(parameters.environment, '-', '_') }}
   displayName: Publish ${{ parameters.environment }}
   pool: ${{ parameters.pool }}

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -94,10 +94,6 @@ jobs:
               feedKind: ${{ parameters.feedKind }}
               publishFlags: ${{ parameters.publishFlags }}
 
-          - template: /tools/pipelines/templates/include-git-tag-steps.yml@self
-            parameters:
-              tagName: ${{ parameters.tagName }}
-
 - job: TagRelease
   displayName: Tag Release
   dependsOn: publish_${{ replace(parameters.environment, '-', '_') }}
@@ -106,8 +102,6 @@ jobs:
   steps:
   - checkout: self
     clean: true
-    lfs: '${{ parameters.checkoutSubmodules }}'
-    submodules: '${{ parameters.checkoutSubmodules }}'
   - template: /tools/pipelines/templates/include-git-tag-steps.yml@self
     parameters:
       tagName: ${{ parameters.tagName }}

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -96,8 +96,9 @@ jobs:
 
 - job: TagRelease
   displayName: Tag Release
+  # Note: must be kept in sync with the name of the deployment job above
   dependsOn: publish_${{ replace(parameters.environment, '-', '_') }}
-  # Only tag the repo if a tag name if provided.
+  # Only tag the repo if a tag name is provided.
   condition: and(succeeded(), ne(parameters.tagName, ''))
   steps:
   - checkout: self

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -97,3 +97,18 @@ jobs:
           - template: /tools/pipelines/templates/include-git-tag-steps.yml@self
             parameters:
               tagName: ${{ parameters.tagName }}
+
+- job: TagRelease
+  displayName: Tag Release
+  dependsOn: publish_${{ replace(parameters.environment, '-', '_') }}
+  # Only tag the repo if a tag name if provided.
+  condition: and(succeeded(), ne(parameters.tagName, ''))
+  steps:
+  - checkout: self
+    clean: true
+    lfs: '${{ parameters.checkoutSubmodules }}'
+    submodules: '${{ parameters.checkoutSubmodules }}'
+  - template: /tools/pipelines/templates/include-use-node-version.yml@self
+  - template: /tools/pipelines/templates/include-git-tag-steps.yml@self
+    parameters:
+      tagName: ${{ parameters.tagName }}

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -108,7 +108,6 @@ jobs:
     clean: true
     lfs: '${{ parameters.checkoutSubmodules }}'
     submodules: '${{ parameters.checkoutSubmodules }}'
-  - template: /tools/pipelines/templates/include-use-node-version.yml@self
   - template: /tools/pipelines/templates/include-git-tag-steps.yml@self
     parameters:
       tagName: ${{ parameters.tagName }}


### PR DESCRIPTION
Recent pipeline refactoring broke the git tagging of releases. This change updates the pipeline to check out the repo in a separate job and tag the commit. This keeps it separate from the deployment job.