### PR TITLE
Streamline logic around grouping/compressing in outbox.flushInternal

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
@@ -19,9 +19,10 @@ import { estimateSocketSize } from "./batchManager.js";
 import { BatchMessage, IBatch } from "./definitions.js";
 
 /**
- * Compresses batches of ops. It generates a single compressed op that contains
- * the contents of each op in the batch. It then submits empty ops for each original
- * op to reserve sequence numbers.
+ * Compresses batches of ops.
+ *
+ * @remarks Only single-message batches are supported
+ * Use opGroupingManager to group a batch into a singleton batch suitable for compression.
  */
 export class OpCompressor {
 	private readonly logger: ITelemetryLoggerExt;
@@ -31,12 +32,10 @@ export class OpCompressor {
 	}
 
 	/**
-	 * Combines the contents of the batch into a single JSON string and compresses it, putting
-	 * the resulting string as the first message of the batch. The rest of the messages are
-	 * empty placeholders to reserve sequence numbers.
-	 * This should only take a single message batch and compress it.
-	 * @param batch - The batch to compress
-	 * @returns A batch of the same length as the input batch, containing a single compressed message followed by empty placeholders
+	 * Combines the contents of the singleton batch into a single JSON string and compresses it, putting
+	 * the resulting string as the message contents in place of the original uncompressed payload.
+	 * @param batch - The batch to compress. Must have only 1 message
+	 * @returns A singleton batch containing a single compressed message
 	 */
 	public compressBatch(batch: IBatch<[BatchMessage]>): IBatch<[BatchMessage]> {
 		assert(
@@ -82,13 +81,15 @@ export class OpCompressor {
 	/**
 	 * Combine the batch's content strings into a single JSON string (a serialized array)
 	 */
-	private serializeBatchContents(batch: IBatch): string {
+	private serializeBatchContents(batch: IBatch<[BatchMessage]>): string {
+		const [message, ...none] = batch.messages;
+		assert(none.length === 0, "Batch should only contain a single message");
 		try {
-			// Yields a valid JSON array, since each message.contents is already serialized to JSON
-			return `[${batch.messages.map(({ contents }) => contents).join(",")}]`;
+			// This is expressed as a JSON array, for legacy reasons
+			return `[${message.contents}]`;
 		} catch (newError: unknown) {
 			if ((newError as Partial<Error>).message === "Invalid string length") {
-				// This is how JSON.stringify signals that
+				// This is how string interpolation signals that
 				// the content size exceeds its capacity
 				const error = new UsageError("Payload too large");
 				this.logger.sendErrorEvent(

--- a/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
@@ -38,7 +38,7 @@ export class OpCompressor {
 	 * @param batch - The batch to compress
 	 * @returns A batch of the same length as the input batch, containing a single compressed message followed by empty placeholders
 	 */
-	public compressBatch(batch: IBatch): IBatch<[BatchMessage]> {
+	public compressBatch(batch: IBatch<[BatchMessage]>): IBatch<[BatchMessage]> {
 		assert(
 			batch.contentSizeInBytes > 0 && batch.messages.length === 1,
 			0x5a4 /* Batch should not be empty and should contain a single message */,

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -97,11 +97,12 @@ export class OpGroupingManager {
 	 * must be parsed first, and then the type and contents mentioned above are hidden in that JSON serialization.
 	 */
 	public groupBatch(batch: IBatch): IBatch<[BatchMessage]> {
+		assert(this.groupedBatchingEnabled(), "grouping disabled!");
+		assert(batch.messages.length > 0, "Unexpected attempt to group an empty batch");
+
 		if (batch.messages.length === 1) {
 			return batch as IBatch<[BatchMessage]>;
 		}
-
-		assert(this.shouldGroup(batch), 0x946 /* cannot group the provided batch */);
 
 		if (batch.messages.length >= 1000) {
 			this.logger.sendTelemetryEvent({
@@ -159,16 +160,6 @@ export class OpGroupingManager {
 		}));
 	}
 
-	public shouldGroup(batch: IBatch): boolean {
-		return (
-			// Grouped batching must be enabled
-			this.config.groupedBatchingEnabled &&
-			// The number of ops in the batch must be 2 or more
-			// or be empty (to allow for empty batches to be grouped)
-			batch.messages.length !== 1
-			// Support for reentrant batches will be on by default
-		);
-	}
 	public groupedBatchingEnabled(): boolean {
 		return this.config.groupedBatchingEnabled;
 	}

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -91,10 +91,16 @@ export class OpGroupingManager {
 	 * Converts the given batch into a "grouped batch" - a batch with a single message of type "groupedBatch",
 	 * with contents being an array of the original batch's messages.
 	 *
+	 * If the group only has 1 message, it is returned as-is.
+	 *
 	 * @remarks - Remember that a BatchMessage has its content JSON serialized, so the incoming batch message contents
 	 * must be parsed first, and then the type and contents mentioned above are hidden in that JSON serialization.
 	 */
 	public groupBatch(batch: IBatch): IBatch<[BatchMessage]> {
+		if (batch.messages.length === 1) {
+			return batch as IBatch<[BatchMessage]>;
+		}
+
 		assert(this.shouldGroup(batch), 0x946 /* cannot group the provided batch */);
 
 		if (batch.messages.length >= 1000) {

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -91,7 +91,7 @@ export class OpGroupingManager {
 	 * Converts the given batch into a "grouped batch" - a batch with a single message of type "groupedBatch",
 	 * with contents being an array of the original batch's messages.
 	 *
-	 * If the group only has 1 message, it is returned as-is.
+	 * If the batch already has only 1 message, it is returned as-is.
 	 *
 	 * @remarks - Remember that a BatchMessage has its content JSON serialized, so the incoming batch message contents
 	 * must be parsed first, and then the type and contents mentioned above are hidden in that JSON serialization.

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -360,9 +360,13 @@ export class Outbox {
 		}
 
 		const rawBatch = batchManager.popBatch(resubmittingBatchId);
-		const canGroup =
+		const groupingEnabled =
 			!disableGroupedBatching && this.params.groupingManager.groupedBatchingEnabled();
-		if (batchManager.options.canRebase && rawBatch.hasReentrantOps === true && canGroup) {
+		if (
+			batchManager.options.canRebase &&
+			rawBatch.hasReentrantOps === true &&
+			groupingEnabled
+		) {
 			assert(!this.rebasing, 0x6fa /* A rebased batch should never have reentrant ops */);
 			// If a batch contains reentrant ops (ops created as a result from processing another op)
 			// it needs to be rebased so that we can ensure consistent reference sequence numbers
@@ -376,10 +380,8 @@ export class Outbox {
 		// If so, do nothing, as pending state manager will resubmit it correctly on reconnect.
 		// Because flush() is a task that executes async (on clean stack), we can get here in disconnected state.
 		if (this.params.shouldSend()) {
-			const processedBatch = canGroup
-				? this.compressAndChunkBatch(this.params.groupingManager.groupBatch(rawBatch))
-				: rawBatch;
-			clientSequenceNumber = this.sendBatch(processedBatch);
+			const virtualizedBatch = this.virtualizeBatch(rawBatch, groupingEnabled);
+			clientSequenceNumber = this.sendBatch(virtualizedBatch);
 			assert(
 				clientSequenceNumber === undefined || clientSequenceNumber >= 0,
 				0x9d2 /* unexpected negative clientSequenceNumber (empty batch should yield undefined) */,
@@ -434,28 +436,43 @@ export class Outbox {
 	}
 
 	/**
-	 * As necessary and enabled, compresses and chunks the given batch.
+	 * As necessary and enabled, groups / compresses / chunks the given batch.
 	 *
 	 * @remarks - If chunking happens, a side effect here is that 1 or more chunks are queued immediately for sending in next JS turn.
 	 *
-	 * @param batch - Raw or Grouped batch to consider for compression/chunking
-	 * @returns Either (A) the original batch, (B) a compressed batch (same length as original)
-	 * or (C) a batch containing the last chunk.
+	 * @param singletonBatch - Raw or Grouped batch to consider for compression/chunking
+	 * @param groupingEnabled - If true, Grouped batching is enabled.
+	 * @returns One of the following:
+	 * - (A) The original batch (Based on what's enabled)
+	 * - (B) A grouped batch (it's a singleton batch)
+	 * - (C) A compressed singleton batch
+	 * - (D) A singleton batch containing the last chunk.
 	 */
-	private compressAndChunkBatch(batch: IBatch): IBatch {
-		assert(batch.messages.length === 1, "Expected a singleton batch");
+	private virtualizeBatch(localBatch: IBatch, groupingEnabled: boolean): IBatch {
+		const originalOrGroupedBatch = groupingEnabled
+			? this.params.groupingManager.groupBatch(localBatch)
+			: localBatch;
+
+		if (originalOrGroupedBatch.messages.length !== 1) {
+			// Compression requires a single message, so return early otherwise.
+			return originalOrGroupedBatch;
+		}
+
+		// Regardless of whether we grouped or not, we now have a batch with a single message.
+		// Now proceed to compress/chunk it if necessary.
+		const singletonBatch = originalOrGroupedBatch as IBatch<[BatchMessage]>;
+
 		if (
 			this.params.config.compressionOptions === undefined ||
 			this.params.config.compressionOptions.minimumBatchSizeInBytes >
-				batch.contentSizeInBytes ||
-			this.params.submitBatchFn === undefined ||
-			!this.params.groupingManager.groupedBatchingEnabled()
+				singletonBatch.contentSizeInBytes ||
+			this.params.submitBatchFn === undefined
 		) {
-			// Nothing to do if the batch is empty or if compression is disabled or not supported, or if we don't need to compress
-			return batch;
+			// Nothing to do if compression is disabled, unnecessary or unsupported.
+			return singletonBatch;
 		}
 
-		const compressedBatch = this.params.compressor.compressBatch(batch);
+		const compressedBatch = this.params.compressor.compressBatch(singletonBatch);
 
 		if (this.params.splitter.isBatchChunkingEnabled) {
 			return compressedBatch.contentSizeInBytes <= this.params.splitter.chunkSizeInBytes
@@ -465,13 +482,13 @@ export class Outbox {
 
 		if (compressedBatch.contentSizeInBytes >= this.params.config.maxBatchSizeInBytes) {
 			throw new GenericError("BatchTooLarge", /* error */ undefined, {
-				batchSize: batch.contentSizeInBytes,
+				batchSize: singletonBatch.contentSizeInBytes,
 				compressedBatchSize: compressedBatch.contentSizeInBytes,
 				count: compressedBatch.messages.length,
 				limit: this.params.config.maxBatchSizeInBytes,
 				chunkingEnabled: this.params.splitter.isBatchChunkingEnabled,
 				compressionOptions: JSON.stringify(this.params.config.compressionOptions),
-				socketSize: estimateSocketSize(batch),
+				socketSize: estimateSocketSize(singletonBatch),
 			});
 		}
 

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -365,7 +365,10 @@ export class Outbox {
 		if (
 			batchManager.options.canRebase &&
 			rawBatch.hasReentrantOps === true &&
-			groupingEnabled
+			// Rebase if the reentrant ops will be grouped together - this ensures the grouped batch has a singular referenceSequenceNumber.
+			// Otherwise, no concerns about reentrant ops.
+			groupingEnabled &&
+			rawBatch.messages.length > 1
 		) {
 			assert(!this.rebasing, 0x6fa /* A rebased batch should never have reentrant ops */);
 			// If a batch contains reentrant ops (ops created as a result from processing another op)

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -1057,6 +1057,25 @@ describe("Outbox", () => {
 			validateCounts(0, 0, 2);
 		});
 
+		it("batch has a single reentrant op", () => {
+			const outbox = getOutbox({
+				context: getMockContext(),
+				opGroupingConfig: {
+					groupedBatchingEnabled: true,
+				},
+			});
+
+			const messages = [createMessage(ContainerMessageType.FluidDataStoreOp, "0")];
+
+			state.isReentrant = true;
+			outbox.submit(messages[0]);
+			state.isReentrant = false;
+
+			outbox.flush();
+
+			validateCounts(0, 0, 1);
+		});
+
 		it("should group the batch", () => {
 			const outbox = getOutbox({
 				context: getMockContext(),
@@ -1119,5 +1138,9 @@ describe("Outbox", () => {
 
 			validateCounts(2, 1, 0);
 		});
+	});
+
+	describe("virtualizeBatch", () => {
+		it("should virtualize a batch", () => {});
 	});
 });

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -1139,8 +1139,4 @@ describe("Outbox", () => {
 			validateCounts(2, 1, 0);
 		});
 	});
-
-	describe("virtualizeBatch", () => {
-		it("should virtualize a batch", () => {});
-	});
 });

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -1057,7 +1057,7 @@ describe("Outbox", () => {
 			validateCounts(0, 0, 2);
 		});
 
-		it("batch has a single reentrant op", () => {
+		it("batch has a single reentrant op - don't rebase", () => {
 			const outbox = getOutbox({
 				context: getMockContext(),
 				opGroupingConfig: {
@@ -1073,7 +1073,7 @@ describe("Outbox", () => {
 
 			outbox.flush();
 
-			validateCounts(0, 0, 1);
+			validateCounts(1, 1, 0);
 		});
 
 		it("should group the batch", () => {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
@@ -31,6 +31,10 @@ import {
 
 import { compressMultipleMessageBatch } from "./legacyCompression.js";
 
+function isSingletonBatch(batch: IBatch): batch is IBatch<[BatchMessage]> {
+	return batch.messages.length === 1;
+}
+
 describe("RemoteMessageProcessor", () => {
 	function getMessageProcessor(): RemoteMessageProcessor {
 		const logger = new MockLogger();
@@ -138,7 +142,7 @@ describe("RemoteMessageProcessor", () => {
 			let leadingChunkCount = 0;
 			const outboundMessages: IBatchMessage[] = [];
 			if (option.compressionAndChunking.compression) {
-				if (batch.messages.length === 1) {
+				if (isSingletonBatch(batch)) {
 					const compressor = new OpCompressor(mockLogger);
 					batch = compressor.compressBatch(batch);
 				} else {


### PR DESCRIPTION
## Description

The cases around when to group and/or compress when flushing a batch are nuanced. This step is called "Op Virtualization" since it takes a batch of raw local runtime ops and results in a completely different set of ops to transmit the data to the server.

There is a pretty simple decision tree to follow, now that compression only works on singleton batches:

1. If grouping is enabled, try to group (it's a no-op if already a single message)
2. If we are left with a multi-message batch, don't compress (this is no longer supported), just return.
3. If we can / need to compress, do it

### ~~Bug fix~~

~~While here, I also fixed [AB#33427](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/33427), where we had the wrong check guarding whether to rebase (it excluded single-message batches).~~

When I made that change, some Data Migration tests started failing.  Not sure why.  But reverting it for now, fixing that isn't urgent, and it's even debatable whether it's a bug or not.

### Typing improvement

I also updated `OpCompressor.compressBatch` to take a singleton batch (enforced by the type system).