### PR TITLE
add missing unit tests for tableSchema

### DIFF
--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -134,7 +134,7 @@ export namespace TableSchema {
 
 		/**
 		 * Sets the cell in the specified column.
-		 * @remarks To delete a cell, call {@link TableSchema.IRow.deleteCell} instead.
+		 * @remarks To remove a cell, call {@link TableSchema.IRow.removeCell} instead.
 		 * @privateRemarks TODO: add overload that takes column ID.
 		 */
 		setCell(
@@ -143,10 +143,10 @@ export namespace TableSchema {
 		): void;
 
 		/**
-		 * Deletes the cell in the specified column.
+		 * Removes the cell in the specified column.
 		 * @privateRemarks TODO: add overload that takes column ID.
 		 */
-		deleteCell(column: TreeNodeFromImplicitAllowedTypes<TColumnSchema>): void;
+		removeCell(column: TreeNodeFromImplicitAllowedTypes<TColumnSchema>): void;
 	}
 
 	/**
@@ -197,7 +197,7 @@ export namespace TableSchema {
 				this.cells.set(column.id, value);
 			}
 
-			public deleteCell(column: ColumnValueType): void {
+			public removeCell(column: ColumnValueType): void {
 				if (!this.cells.has(column.id)) return;
 				this.cells.delete(column.id);
 			}
@@ -361,7 +361,7 @@ export namespace TableSchema {
 
 		/**
 		 * Sets the cell at the specified location in the table.
-		 * @remarks To delete a cell, call {@link TableSchema.ITable.deleteCell} instead.
+		 * @remarks To remove a cell, call {@link TableSchema.ITable.removeCell} instead.
 		 * @privateRemarks TODO: add overload that takes column/row nodes?
 		 */
 		setCell(
@@ -379,21 +379,21 @@ export namespace TableSchema {
 		removeColumn: (column: TreeNodeFromImplicitAllowedTypes<TColumnSchema>) => void;
 
 		/**
-		 * Deletes 0 or more rows from the table.
+		 * Removes 0 or more rows from the table.
 		 * @privateRemarks TODO: policy for when 1 or more rows are not in the table.
 		 */
-		deleteRows: (rows: readonly TreeNodeFromImplicitAllowedTypes<TRowSchema>[]) => void;
+		removeRows: (rows: readonly TreeNodeFromImplicitAllowedTypes<TRowSchema>[]) => void;
 
 		/**
-		 * Deletes all rows from the table.
+		 * Removes all rows from the table.
 		 */
-		deleteAllRows: () => void;
+		removeAllRows: () => void;
 
 		/**
-		 * Deletes the cell at the specified location in the table.
+		 * Removes the cell at the specified location in the table.
 		 * @privateRemarks TODO: add overload that takes column/row nodes?
 		 */
-		deleteCell: (key: CellKey) => void;
+		removeCell: (key: CellKey) => void;
 	}
 
 	/**
@@ -457,7 +457,7 @@ export namespace TableSchema {
 
 	/**
 	 * Factory for creating new table schema.
-	 * @internal
+	 * @system @internal
 	 */
 	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Return type is too complex to be reasonable to specify
 	export function createTableInternal<
@@ -591,22 +591,22 @@ export namespace TableSchema {
 				this.columns.removeAt(index);
 			}
 
-			public deleteRows(rows: readonly RowValueType[]): void {
-				// If there are no rows to delete, do nothing
+			public removeRows(rows: readonly RowValueType[]): void {
+				// If there are no rows to remove, do nothing
 				if (rows.length === 0) {
 					return;
 				}
 
-				// If there is only one row to delete, delete it
+				// If there is only one row to remove, remove it
 				if (rows.length === 1) {
 					const index = this.rows.indexOf(rows[0] ?? oob());
 					this.rows.removeAt(index);
 					return;
 				}
-				// If there are multiple rows to delete, delete them in a transaction
+				// If there are multiple rows to remove, remove them in a transaction
 				// This is to avoid the performance issues of deleting multiple rows at once
 				Tree.runTransaction(this, () => {
-					// Iterate over the rows and delete them
+					// Iterate over the rows and remove them
 					for (const row of rows) {
 						const index = this.rows.indexOf(row);
 						this.rows.removeAt(index);
@@ -614,17 +614,17 @@ export namespace TableSchema {
 				});
 			}
 
-			public deleteAllRows(): void {
+			public removeAllRows(): void {
 				this.rows.removeRange();
 			}
 
-			public deleteCell(key: CellKey): void {
+			public removeCell(key: CellKey): void {
 				const { columnId, rowId } = key;
 				const row = this.getRow(rowId);
 				if (row !== undefined) {
 					const column = this.getColumn(columnId);
 					if (column !== undefined) {
-						row.deleteCell(column);
+						row.removeCell(column);
 					}
 				}
 			}

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -17,6 +17,7 @@ import {
 	TreeArrayNode,
 	type TreeNode,
 	type TreeNodeFromImplicitAllowedTypes,
+	type TreeNodeSchema,
 	type TreeNodeSchemaClass,
 	type WithType,
 } from "./simple-tree/index.js";
@@ -396,12 +397,70 @@ export namespace TableSchema {
 	}
 
 	/**
+	 * Factory for creating new table schema without specifying row or column schema.
+	 * @internal
+	 */
+	export function createTable<
+		const TInputScope extends string | undefined,
+		const TCell extends ImplicitAllowedTypes,
+	>(
+		inputSchemaFactory: SchemaFactoryAlpha<TInputScope>,
+		_cellSchema: TCell,
+	): ReturnType<typeof createTableInternal<TInputScope, TCell>>;
+	/**
+	 * Factory for creating new table schema without specifyint row schema
+	 * @internal
+	 */
+	export function createTable<
+		const TInputScope extends string | undefined,
+		const TCell extends ImplicitAllowedTypes,
+		const TColumn extends ColumnSchemaBase<TInputScope>,
+	>(
+		inputSchemaFactory: SchemaFactoryAlpha<TInputScope>,
+		_cellSchema: TCell,
+		columnSchema: TColumn,
+	): ReturnType<typeof createTableInternal<TInputScope, TCell, TColumn>>;
+	/**
 	 * Factory for creating new table schema.
-	 * @privateRemarks TODO: add overloads to make column/row schema optional.
+	 * @internal
+	 */
+	export function createTable<
+		const TInputScope extends string | undefined,
+		const TCell extends ImplicitAllowedTypes,
+		const TColumn extends ColumnSchemaBase<TInputScope>,
+		const TRow extends RowSchemaBase<TInputScope, TCell, TColumn>,
+	>(
+		inputSchemaFactory: SchemaFactoryAlpha<TInputScope>,
+		_cellSchema: TCell,
+		columnSchema: TColumn,
+		rowSchema: TRow,
+	): ReturnType<typeof createTableInternal<TInputScope, TCell, TColumn, TRow>>;
+	export function createTable<
+		const TInputScope extends string | undefined,
+		const TCell extends ImplicitAllowedTypes,
+		const TColumn extends ColumnSchemaBase<TInputScope>,
+		const TRow extends RowSchemaBase<TInputScope, TCell, TColumn>,
+	>(
+		inputSchemaFactory: SchemaFactoryAlpha<TInputScope>,
+		_cellSchema: TCell,
+		columnSchema?: TColumn,
+		rowSchema?: TRow,
+	): TreeNodeSchema {
+		const column = columnSchema ?? createColumn(inputSchemaFactory);
+		return createTableInternal(
+			inputSchemaFactory,
+			_cellSchema,
+			column as TColumn,
+			rowSchema ?? (createRow(inputSchemaFactory, _cellSchema, column) as TRow),
+		);
+	}
+
+	/**
+	 * Factory for creating new table schema.
 	 * @internal
 	 */
 	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Return type is too complex to be reasonable to specify
-	export function createTable<
+	export function createTableInternal<
 		const TInputScope extends string | undefined,
 		const TCell extends ImplicitAllowedTypes,
 		const TColumn extends ColumnSchemaBase<TInputScope> = ColumnSchemaBase<TInputScope>,

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -170,7 +170,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		// TODO: There is currently no policy from prohibiting insertion of a column that already exists.
-		// Once that work if finished, the usage error in this test should be updated, and the test can be unskipped.
+		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
 		it.skip("Appending existing column fails.", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({ rows: [], columns: [{ id: "column-a" }, { id: "column-b" }] });
@@ -326,7 +326,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		// TODO: There is currently no policy from prohibiting insertion of a row that already exists.
-		// Once that work if finished, the usage error in this test should be updated, and the test can be unskipped.
+		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
 		it.skip("Inserting row that already exists fails", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
@@ -404,7 +404,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		// TODO: There is currently no policy from prohibiting insertion of a cell that already exists.
-		// Once that work if finished, the usage error in this test should be updated, and the test can be unskipped.
+		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
 		it.skip("inserting cell that already exists fails.", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
@@ -444,7 +444,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		// TODO: There is currently no policy from prohibiting insertion of an invalid cell.
-		// Once that work if finished, the usage error in this test should be updated, and the test can be unskipped.
+		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
 		it.skip("inserting invalid cell fails.", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
@@ -505,7 +505,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		// TODO: There is currently no policy from prohibiting removal of non-existant columns.
-		// Once that work if finished, the usage error in this test should be updated, and the test can be unskipped.
+		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
 		it.skip("removing column that does not exist on table fails", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
@@ -684,7 +684,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		// TODO: There is currently no usage error for deleting invalid cells.
-		// Once that work if finished, the usage error in this test should be updated, and the test can be unskipped.
+		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
 		it.skip("deleting invalid cell fails.", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -739,20 +739,15 @@ describe("TableFactory unit tests", () => {
 
 		treeView.initialize({
 			columns: [
-				{
-					id: "column-0",
-				},
+				column0,
 			],
 			rows: [
-				{
-					id: "row-0",
-					cells: { "column-0": { value: "Hello world!" } },
-				},
+				row0,
 			],
 		});
 
 		const cell = treeView.root.getCell({ columnId: "column-0", rowId: "row-0" });
-		const column = treeView.root.getColumn("column-1");
+		const column = treeView.root.getColumn("column-0");
 		const row = treeView.root.getRow("row-0");
 
 		assert.equal(cell, cell0);

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -172,7 +172,7 @@ describe("TableFactory unit tests", () => {
 
 		// TODO: There is currently no policy from prohibiting insertion of a column that already exists.
 		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
-		it.skip("Appending existing column fails.", () => {
+		it.skip("Appending existing column errors", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({ rows: [], columns: [{ id: "column-a" }, { id: "column-b" }] });
 
@@ -360,7 +360,7 @@ describe("TableFactory unit tests", () => {
 	});
 
 	describe("Set cell", () => {
-		it("Append rows", () => {
+		it("set cell in a valid location", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
 				columns: [
@@ -404,49 +404,9 @@ describe("TableFactory unit tests", () => {
 			});
 		});
 
-		// TODO: There is currently no policy from prohibiting insertion of a cell that already exists.
-		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
-		it.skip("inserting cell that already exists fails.", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
-				columns: [
-					{
-						id: "column-0",
-					},
-				],
-				rows: [
-					{
-						id: "row-0",
-						cells: {},
-					},
-				],
-			});
-
-			treeView.root.setCell({
-				key: {
-					rowId: "row-0",
-					columnId: "column-0",
-				},
-				cell: { value: "Hello world!" },
-			});
-
-			// Insert the same cell again.
-			assert.throws(
-				() =>
-					treeView.root.setCell({
-						key: {
-							rowId: "row-0",
-							columnId: "column-0",
-						},
-						cell: { value: "Hello world!" },
-					}),
-				validateUsageError(/Placeholder usage error/),
-			);
-		});
-
 		// TODO: There is currently no policy from prohibiting insertion of an invalid cell.
 		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
-		it.skip("inserting invalid cell fails.", () => {
+		it.skip("setting cell in an invalid location errors", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
 				columns: [
@@ -507,7 +467,7 @@ describe("TableFactory unit tests", () => {
 
 		// TODO: There is currently no policy from prohibiting removal of non-existant columns.
 		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
-		it.skip("removing column that does not exist on table fails", () => {
+		it.skip("removing column that does not exist on table errors", () => {
 			const { treeView, Column } = createTableTree();
 			treeView.initialize({
 				columns: [],
@@ -521,22 +481,22 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("Delete rows", () => {
-		it("delete empty list", () => {
+	describe("Remove rows", () => {
+		it("remove empty list", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
 				columns: [],
 				rows: [],
 			});
 
-			treeView.root.deleteAllRows();
+			treeView.root.removeAllRows();
 			assertEqualTrees(treeView.root, {
 				columns: [],
 				rows: [],
 			});
 		});
 
-		it("delete single row", () => {
+		it("remove single row", () => {
 			const { treeView, Row } = createTableTree();
 			const row0 = new Row({ id: "row-0", cells: {} });
 			const row1 = new Row({ id: "row-1", cells: {} });
@@ -545,22 +505,22 @@ describe("TableFactory unit tests", () => {
 				rows: [row0, row1],
 			});
 
-			// Delete row0
-			treeView.root.deleteRows([row0]);
+			// Remove row0
+			treeView.root.removeRows([row0]);
 			assertEqualTrees(treeView.root, {
 				columns: [],
 				rows: [{ id: "row-1", cells: {} }],
 			});
 
-			// Delete row1
-			treeView.root.deleteRows([row1]);
+			// Remove row1
+			treeView.root.removeRows([row1]);
 			assertEqualTrees(treeView.root, {
 				columns: [],
 				rows: [],
 			});
 		});
 
-		it("delete multiple rows", () => {
+		it("remove multiple rows", () => {
 			const { treeView, Row } = createTableTree();
 			const row0 = new Row({ id: "row-0", cells: {} });
 			const row1 = new Row({ id: "row-1", cells: {} });
@@ -571,8 +531,8 @@ describe("TableFactory unit tests", () => {
 				rows: [row0, row1, row2, row3],
 			});
 
-			// Delete rows 1 and 3
-			treeView.root.deleteRows([row1, row3]);
+			// Remove rows 1 and 3
+			treeView.root.removeRows([row1, row3]);
 			assertEqualTrees(treeView.root, {
 				columns: [],
 				rows: [
@@ -587,15 +547,15 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 
-			// Delete rows 0 and 3
-			treeView.root.deleteRows([row0, row2]);
+			// Remove rows 0 and 3
+			treeView.root.removeRows([row0, row2]);
 			assertEqualTrees(treeView.root, {
 				columns: [],
 				rows: [],
 			});
 		});
 
-		it("deleting single row that doesn't exist on table fails", () => {
+		it("removing single row that doesn't exist on table errors", () => {
 			const { treeView, Row } = createTableTree();
 			treeView.initialize({
 				columns: [],
@@ -603,12 +563,12 @@ describe("TableFactory unit tests", () => {
 			});
 
 			assert.throws(
-				() => treeView.root.deleteRows([new Row({ id: "row-0", cells: {} })]),
+				() => treeView.root.removeRows([new Row({ id: "row-0", cells: {} })]),
 				validateUsageError(/Expected non-negative index, got -1./),
 			);
 		});
 
-		it("deleting multiple rows that doesn't exist on table fails", () => {
+		it("removing multiple rows that doesn't exist on table errors", () => {
 			const { treeView, Row } = createTableTree();
 			treeView.initialize({
 				columns: [],
@@ -617,17 +577,19 @@ describe("TableFactory unit tests", () => {
 
 			assert.throws(
 				() =>
-					treeView.root.deleteRows([
+					treeView.root.removeRows([
 						new Row({ id: "row-0", cells: {} }),
 						new Row({ id: "row-1", cells: {} }),
 					]),
+				// TODO: The usage error here comes from the arrayNode layer.
+				// Once removeRows gets updated to return a usage error that makes more sense, update usage error here.
 				validateUsageError(/Expected non-negative index, got -1./),
 			);
 		});
 	});
 
-	describe("Delete cell", () => {
-		it("delete valid cell with existing data.", () => {
+	describe("Remove cell", () => {
+		it("remove cell in valid location with existing data", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
 				columns: [
@@ -650,7 +612,7 @@ describe("TableFactory unit tests", () => {
 				key: cellKey,
 				cell: { value: "Hello world!" },
 			});
-			treeView.root.deleteCell(cellKey);
+			treeView.root.removeCell(cellKey);
 			assertEqualTrees(treeView.root, {
 				columns: [
 					{
@@ -666,7 +628,7 @@ describe("TableFactory unit tests", () => {
 			});
 		});
 
-		it("delete valid cell with no data.", () => {
+		it("remove cell in valid location with no data", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
 				columns: [
@@ -685,7 +647,7 @@ describe("TableFactory unit tests", () => {
 				rowId: "row-0",
 				columnId: "column-0",
 			};
-			treeView.root.deleteCell(cellKey);
+			treeView.root.removeCell(cellKey);
 			assertEqualTrees(treeView.root, {
 				columns: [
 					{
@@ -703,7 +665,7 @@ describe("TableFactory unit tests", () => {
 
 		// TODO: There is currently no usage error for deleting invalid cells.
 		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
-		it.skip("deleting invalid cell fails.", () => {
+		it.skip("removing cell from nonexistent row and column errors", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
 				columns: [
@@ -724,13 +686,13 @@ describe("TableFactory unit tests", () => {
 			};
 
 			assert.throws(
-				() => treeView.root.deleteCell(invalidCellKey),
+				() => treeView.root.removeCell(invalidCellKey),
 				validateUsageError(/Placeholder usage error./),
 			);
 		});
 	});
 
-	it("gets proper table elements with getter methods.", () => {
+	it("gets proper table elements with getter methods", () => {
 		const { treeView, Column, Row, Cell } = createTableTree();
 
 		const cell0 = new Cell({ value: "Hello World!" });

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -738,12 +738,8 @@ describe("TableFactory unit tests", () => {
 		const row0 = new Row({ id: "row-0", cells: { "column-0": cell0 } });
 
 		treeView.initialize({
-			columns: [
-				column0,
-			],
-			rows: [
-				row0,
-			],
+			columns: [column0],
+			rows: [row0],
 		});
 
 		const cell = treeView.root.getCell({ columnId: "column-0", rowId: "row-0" });


### PR DESCRIPTION
## Description

Adds missing PR tests to `tableSchema.spec.ts`. Some of the tests added in this PR are skipped, as there are certain cases where we do not have a policy for yet (ex: inserting existing row, deleting invalid cell, etc.). Once we come up with a policy for these cases, we can update the usage errors and un-skip the tests.

Also adds overloads to the `createTable` method to allow it to be called without passing in a `Row` or `Column` schema.