### PR TITLE
ci: Fix the fix on syntax in yaml file

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -100,7 +100,7 @@ jobs:
   # Note: must be kept in sync with the name of the deployment job above
   dependsOn: publish_${{ replace(parameters.environment, '-', '_') }}
   # Only tag the repo if a tag name is provided.
-  condition: and(succeeded(), ne(${{ parameters.tagName }}, ''))
+  condition: and(succeeded(), ne('${{ parameters.tagName }}', ''))
   steps:
   - checkout: self
     clean: true


### PR DESCRIPTION
## Description

Follow up to https://github.com/microsoft/FluidFramework/pull/24290 with further syntax fixing. `${{}}` syntax gets coalesced to a blank _at compile time_ when it produces no output, so that resulted in a syntax error. Wrapping the use of that syntax with quotes should result in an empty string which should have the intended effect.

Using https://github.com/microsoft/FluidFramework/blob/main/tools/pipelines/templates/build-npm-client-package.yml#L677 as reference that this should work.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
