### PR TITLE
Parse alt package manager's 'run' scripts and fix sequential dependency group tasks

### DIFF
--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
@@ -10,9 +10,10 @@ import { createRequire } from "node:module";
 import { EOL as newline } from "node:os";
 import path from "node:path";
 import {
+	findGitRootSync,
 	updatePackageJsonFile,
 	updatePackageJsonFileAsync,
- findGitRootSync } from "@fluid-tools/build-infrastructure";
+} from "@fluid-tools/build-infrastructure";
 import { PackageJson, getApiExtractorConfigFilePath } from "@fluidframework/build-tools";
 import { writeJson } from "fs-extra/esm";
 import JSON5 from "json5";

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
@@ -12,8 +12,7 @@ import path from "node:path";
 import {
 	updatePackageJsonFile,
 	updatePackageJsonFileAsync,
-} from "@fluid-tools/build-infrastructure";
-import { findGitRootSync } from "@fluid-tools/build-infrastructure";
+ findGitRootSync } from "@fluid-tools/build-infrastructure";
 import { PackageJson, getApiExtractorConfigFilePath } from "@fluidframework/build-tools";
 import { writeJson } from "fs-extra/esm";
 import JSON5 from "json5";

--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -110,7 +110,7 @@ export class MonoRepo {
 	constructor(
 		public readonly kind: string,
 		public readonly repoPath: string,
-		private readonly packageManager: PackageManager,
+		public readonly packageManager: PackageManager,
 		packageDirs: string[],
 		ignoredDirs?: string[],
 		private readonly logger: Logger = defaultLogger,

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -122,11 +122,13 @@ export class Package {
 		[this._packageJson, this._indent] = readPackageJsonAndIndent(packageJsonFileName);
 		const pnpmWorkspacePath = path.join(this.directory, "pnpm-workspace.yaml");
 		const yarnLockPath = path.join(this.directory, "yarn.lock");
-		this.packageManager = existsSync(pnpmWorkspacePath)
-			? "pnpm"
-			: existsSync(yarnLockPath)
-				? "yarn"
-				: "npm";
+		this.packageManager = monoRepo
+			? monoRepo.packageManager
+			: existsSync(pnpmWorkspacePath)
+				? "pnpm"
+				: existsSync(yarnLockPath)
+					? "yarn"
+					: "npm";
 		traceInit(`${this.nameColored}: Package loaded`);
 		Object.assign(this, additionalProperties);
 	}

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -228,7 +228,7 @@ export class BuildPackage {
 		return task;
 	}
 
-	// Create or return and existing task with a name.  If it is a script, it will also create an return the pre/post script task if it exists
+	// Create or return and existing task with a name.  If it is a script, it will also create and return the pre/post script task if it exists
 	private getTask(taskName: string, pendingInitDep: Task[] | undefined): Task | undefined {
 		const existing = this.targetTasks.get(taskName);
 		if (existing) {

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -220,6 +220,7 @@ export class BuildPackage {
 		}
 
 		const task = TaskFactory.Create(this, command, this.context, pendingInitDep, taskName);
+		this.tasks.set(taskName, task);
 		pendingInitDep.push(task);
 		return task;
 	}

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -83,7 +83,10 @@ class BuildGraphContext implements BuildContext {
 }
 
 export class BuildPackage {
-	private readonly tasks = new Map<string, Task>();
+	private readonly tasks: Task[] = [];
+
+	// tasks (with lifecycle) to resolved named reference.
+	private readonly targetTasks = new Map<string, Task>();
 
 	// track a script task without the lifecycle (pre/post) tasks
 	private readonly scriptTasks = new Map<string, Task>();
@@ -106,10 +109,6 @@ export class BuildPackage {
 		traceTaskDef(
 			`${pkg.nameColored}: Task def: ${JSON.stringify(this._taskDefinitions, undefined, 2)}`,
 		);
-	}
-
-	public get taskCount() {
-		return this.tasks.size;
 	}
 
 	public createTasks(buildTaskNames: string[]) {
@@ -169,6 +168,8 @@ export class BuildPackage {
 		if (config?.script === false) {
 			const task = TaskFactory.CreateTargetTask(this, this.context, taskName);
 			pendingInitDep.push(task);
+			this.tasks.push(task);
+			this.targetTasks.set(taskName, task);
 			return task;
 		}
 		return this.createScriptTask(taskName, pendingInitDep);
@@ -182,6 +183,7 @@ export class BuildPackage {
 			if (scriptTask === undefined) {
 				scriptTask = TaskFactory.Create(this, command, this.context, pendingInitDep, taskName);
 				pendingInitDep.push(scriptTask);
+				this.tasks.push(scriptTask);
 				this.scriptTasks.set(taskName, scriptTask);
 			}
 
@@ -196,10 +198,10 @@ export class BuildPackage {
 				this.ensureScriptTask(`post${taskName}`, pendingInitDep),
 			);
 			if (task !== scriptTask) {
-				// We are doing duplicate work initializeDependentTasks as both the lifecycle task
-				// and script task will have the task name and dependency
 				pendingInitDep.push(task);
+				this.tasks.push(task);
 			}
+			this.targetTasks.set(taskName, task);
 			return task;
 		}
 		return undefined;
@@ -220,14 +222,15 @@ export class BuildPackage {
 		}
 
 		const task = TaskFactory.Create(this, command, this.context, pendingInitDep, taskName);
-		this.tasks.set(taskName, task);
 		pendingInitDep.push(task);
+		this.tasks.push(task);
+		this.scriptTasks.set(taskName, task);
 		return task;
 	}
 
 	// Create or return and existing task with a name.  If it is a script, it will also create an return the pre/post script task if it exists
 	private getTask(taskName: string, pendingInitDep: Task[] | undefined): Task | undefined {
-		const existing = this.tasks.get(taskName);
+		const existing = this.targetTasks.get(taskName);
 		if (existing) {
 			return existing;
 		}
@@ -237,11 +240,7 @@ export class BuildPackage {
 			return undefined;
 		}
 
-		const task = this.createTask(taskName, pendingInitDep);
-		if (task !== undefined) {
-			this.tasks.set(taskName, task);
-		}
-		return task;
+		return this.createTask(taskName, pendingInitDep);
 	}
 
 	public getScriptTask(taskName: string, pendingInitDep: Task[]): Task | undefined {
@@ -250,16 +249,12 @@ export class BuildPackage {
 			// it is not a script task
 			return undefined;
 		}
-		const existing = this.tasks.get(taskName);
+		const existing = this.targetTasks.get(taskName);
 		if (existing) {
 			return existing;
 		}
 
-		const task = this.createScriptTask(taskName, pendingInitDep);
-		if (task !== undefined) {
-			this.tasks.set(taskName, task);
-		}
-		return task;
+		return this.createScriptTask(taskName, pendingInitDep);
 	}
 
 	public getDependsOnTasks(task: Task, taskName: string, pendingInitDep: Task[]) {
@@ -291,7 +286,7 @@ export class BuildPackage {
 				for (const depPackage of this.dependentPackages) {
 					if (taskName === "*") {
 						assert.strictEqual(pendingInitDep, undefined);
-						matchedTasks.push(...depPackage.tasks.values());
+						matchedTasks.push(...depPackage.targetTasks.values());
 					} else {
 						const depTask = depPackage.getTask(taskName, pendingInitDep);
 						if (depTask !== undefined) {
@@ -335,7 +330,7 @@ export class BuildPackage {
 				return beforeStarTaskNames;
 			}
 			// avoid circular dependency. ignore mutual before "*" */
-			beforeStarTaskNames = Array.from(this.tasks.keys()).filter(
+			beforeStarTaskNames = Array.from(this.targetTasks.keys()).filter(
 				(depTaskName) => !this.getTaskDefinition(depTaskName)?.before.includes("*"),
 			);
 			return beforeStarTaskNames;
@@ -347,7 +342,7 @@ export class BuildPackage {
 				return afterStarTaskNames;
 			}
 			// avoid circular dependency. ignore mutual after "*" */
-			afterStarTaskNames = Array.from(this.tasks.keys()).filter(
+			afterStarTaskNames = Array.from(this.targetTasks.keys()).filter(
 				(depTaskName) => !this.getTaskDefinition(depTaskName)?.after.includes("*"),
 			);
 			return afterStarTaskNames;
@@ -382,7 +377,6 @@ export class BuildPackage {
 				const matchedTasks = this.getMatchedTasks(before);
 				const dependentTask = [task];
 				for (const matchedTask of matchedTasks) {
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					matchedTask.addDependentTasks(dependentTask, taskConfig.isDefault);
 				}
 			}
@@ -395,18 +389,11 @@ export class BuildPackage {
 					} -> ${JSON.stringify(after)}`,
 				);
 				const matchedTasks = this.getMatchedTasks(after);
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				task.addDependentTasks(matchedTasks, taskConfig.isDefault);
 			}
 		};
 
 		this.tasks.forEach(finalizeTask);
-		this.scriptTasks.forEach((task: Task, name: string) => {
-			// Process named script task that hasn't been processed yet.
-			if (this.tasks.get(name) !== task) {
-				finalizeTask(task);
-			}
-		});
 	}
 
 	public initializeDependentLeafTasks() {
@@ -422,11 +409,11 @@ export class BuildPackage {
 	}
 
 	public async isUpToDate(): Promise<boolean> {
-		if (this.tasks.size == 0) {
+		if (this.tasks.length === 0) {
 			return true;
 		}
 		const isUpToDateP = new Array<Promise<boolean>>();
-		for (const task of this.tasks.values()) {
+		for (const task of this.tasks) {
 			isUpToDateP.push(task.isUpToDate());
 		}
 		const isUpToDateArr = await Promise.all(isUpToDateP);
@@ -435,14 +422,14 @@ export class BuildPackage {
 
 	private async buildAllTasks(q: AsyncPriorityQueue<TaskExec>): Promise<BuildResult> {
 		const runP: Promise<BuildResult>[] = [];
-		for (const task of this.tasks.values()) {
+		for (const task of this.tasks) {
 			runP.push(task.run(q));
 		}
 		return summarizeBuildResult(await Promise.all(runP));
 	}
 	public async build(q: AsyncPriorityQueue<TaskExec>): Promise<BuildResult> {
 		if (!this.buildP) {
-			if (this.tasks.size !== 0) {
+			if (this.tasks.length !== 0) {
 				this.buildP = this.buildAllTasks(q);
 			} else {
 				this.buildP = Promise.resolve(BuildResult.UpToDate);

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
@@ -95,6 +95,22 @@ function getTaskForExecutable(executable: string, context: BuildContext): TaskHa
 	return builtInHandler ?? UnknownLeafTask;
 }
 
+function getRunScriptName(command: string, packageManager: string): string | undefined {
+	// Remove the package manager name from the command
+	if (command.startsWith("npm run ")) {
+		return command.substring("npm run ".length);
+	}
+	// Only support yarn and pnpm for now
+	if (packageManager === "yarn" || packageManager === "pnpm") {
+		const packageManagerRun = `${packageManager} run `;
+
+		if (command.startsWith(packageManagerRun)) {
+			return command.substring(packageManagerRun.length);
+		}
+	}
+	return undefined;
+}
+
 export class TaskFactory {
 	public static Create(
 		node: BuildPackage,
@@ -151,17 +167,15 @@ export class TaskFactory {
 			return new GroupTask(node, command, context, subTasks, taskName);
 		}
 
-		// Resolve "npm run" to the actual script
-		if (command.startsWith("npm run ")) {
-			const scriptName = command.substring("npm run ".length);
-			const subTask = node.getScriptTask(scriptName, pendingInitDep);
-			if (subTask === undefined) {
-				throw new Error(
-					`${node.pkg.nameColored}: Unable to find script '${scriptName}' in 'npm run' command`,
-				);
+		// Resolve "npm run" (or other package manager's run command) to the actual script if possible
+		const runScript = getRunScriptName(command, node.pkg.packageManager);
+		if (runScript !== undefined) {
+			const subTask = node.getScriptTask(runScript, pendingInitDep);
+			if (subTask !== undefined) {
+				// Even though there is only one task, create a group task for the taskName
+				return new GroupTask(node, command, context, [subTask], taskName);
 			}
-			// Even though there is only one task, create a group task for the taskName
-			return new GroupTask(node, command, context, [subTask], taskName);
+			// Unable find the script.  Treat it as if it is a plain leaf task.
 		}
 
 		// Leaf tasks; map the executable to a known task type. If none is found, the UnknownLeafTask is used.


### PR DESCRIPTION
- Allow alternate package manager run scripts (e.g. `pnpm run`) scripts to be resolved.
- There is a bug where lifecycle script's (e.g. pre/post) sequential task doesn't set up the dependency correctly to establish execution order, because we didn't keep track of the lifecycle script in the list of "tasks".
