### PR TITLE
Cleanup map export tagging

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -85,8 +85,6 @@ interface IDirectoryMessageHandler {
 
 /**
  * Operation indicating a value should be set for a key.
- * @legacy
- * @alpha
  */
 export interface IDirectorySetOperation {
 	/**
@@ -113,8 +111,6 @@ export interface IDirectorySetOperation {
 
 /**
  * Operation indicating a key should be deleted from the directory.
- * @legacy
- * @alpha
  */
 export interface IDirectoryDeleteOperation {
 	/**
@@ -135,15 +131,11 @@ export interface IDirectoryDeleteOperation {
 
 /**
  * An operation on a specific key within a directory.
- * @legacy
- * @alpha
  */
 export type IDirectoryKeyOperation = IDirectorySetOperation | IDirectoryDeleteOperation;
 
 /**
  * Operation indicating the directory should be cleared.
- * @legacy
- * @alpha
  */
 export interface IDirectoryClearOperation {
 	/**
@@ -159,15 +151,11 @@ export interface IDirectoryClearOperation {
 
 /**
  * An operation on one or more of the keys within a directory.
- * @legacy
- * @alpha
  */
 export type IDirectoryStorageOperation = IDirectoryKeyOperation | IDirectoryClearOperation;
 
 /**
  * Operation indicating a subdirectory should be created.
- * @legacy
- * @alpha
  */
 export interface IDirectoryCreateSubDirectoryOperation {
 	/**
@@ -188,8 +176,6 @@ export interface IDirectoryCreateSubDirectoryOperation {
 
 /**
  * Operation indicating a subdirectory should be deleted.
- * @legacy
- * @alpha
  */
 export interface IDirectoryDeleteSubDirectoryOperation {
 	/**
@@ -210,8 +196,6 @@ export interface IDirectoryDeleteSubDirectoryOperation {
 
 /**
  * An operation on the subdirectories within a directory.
- * @legacy
- * @alpha
  */
 export type IDirectorySubDirectoryOperation =
 	| IDirectoryCreateSubDirectoryOperation
@@ -219,8 +203,6 @@ export type IDirectorySubDirectoryOperation =
 
 /**
  * Any operation on a directory.
- * @legacy
- * @alpha
  */
 export type IDirectoryOperation = IDirectoryStorageOperation | IDirectorySubDirectoryOperation;
 
@@ -424,8 +406,6 @@ class DirectoryCreationTracker {
  * ```
  *
  * @sealed
- * @legacy
- * @alpha
  */
 export class SharedDirectory
 	extends SharedObject<ISharedDirectoryEvents>

--- a/packages/dds/map/src/directoryFactory.ts
+++ b/packages/dds/map/src/directoryFactory.ts
@@ -17,7 +17,8 @@ import { pkgVersion } from "./packageVersion.js";
 
 /**
  * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link ISharedDirectory}.
- *
+ * @privateRemarks
+ * TODO: AB#35245: Deprecate and stop exporting this class.
  * @sealed
  * @legacy
  * @alpha

--- a/packages/dds/map/src/index.ts
+++ b/packages/dds/map/src/index.ts
@@ -28,7 +28,7 @@ export type {
 export { SharedMap } from "./mapFactory.js";
 export { SharedDirectory } from "./directoryFactory.js";
 
-// Legacy exports that should be deprecated and removed.
+// Legacy exports that should be deprecated and removed as part of AB#8004 or AB#35245
 export type { ISerializableValue } from "./internalInterfaces.js";
 export { MapFactory } from "./mapFactory.js";
 export { DirectoryFactory } from "./directoryFactory.js";

--- a/packages/dds/map/src/index.ts
+++ b/packages/dds/map/src/index.ts
@@ -25,11 +25,15 @@ export type {
 	ISharedMapEvents,
 	IValueChanged,
 } from "./interfaces.js";
-export { MapFactory, SharedMap } from "./mapFactory.js";
-export { DirectoryFactory, SharedDirectory } from "./directoryFactory.js";
+export { SharedMap } from "./mapFactory.js";
+export { SharedDirectory } from "./directoryFactory.js";
+
+// Legacy exports that should be deprecated and removed.
+export type { ISerializableValue } from "./internalInterfaces.js";
+export { MapFactory } from "./mapFactory.js";
+export { DirectoryFactory } from "./directoryFactory.js";
 export type {
 	ICreateInfo,
 	IDirectoryNewStorageFormat,
 	IDirectoryDataObject,
 } from "./directory.js";
-export type { ISerializableValue } from "./internalInterfaces.js";

--- a/packages/dds/map/src/internalInterfaces.ts
+++ b/packages/dds/map/src/internalInterfaces.ts
@@ -155,8 +155,6 @@ export interface ISerializableValue {
 
 /**
  * Serialized {@link ISerializableValue} counterpart.
- * @legacy
- * @alpha
  */
 export interface ISerializedValue {
 	/**

--- a/packages/dds/map/src/localValues.ts
+++ b/packages/dds/map/src/localValues.ts
@@ -17,8 +17,6 @@ import type { ISerializableValue, ISerializedValue } from "./internalInterfaces.
 
 /**
  * A local value to be stored in a container type Distributed Data Store (DDS).
- * @legacy
- * @alpha
  */
 export interface ILocalValue {
 	/**
@@ -100,8 +98,6 @@ export class PlainLocalValue implements ILocalValue {
 /**
  * Enables a container type {@link https://fluidframework.com/docs/build/dds/ | DDS} to produce and store local
  * values with minimal awareness of how those objects are stored, serialized, and deserialized.
- * @legacy
- * @alpha
  */
 export class LocalValueMaker {
 	/**

--- a/packages/dds/map/src/mapFactory.ts
+++ b/packages/dds/map/src/mapFactory.ts
@@ -17,7 +17,8 @@ import { pkgVersion } from "./packageVersion.js";
 
 /**
  * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link ISharedMap}.
- *
+ * @privateRemarks
+ * TODO: AB#35245: Deprecate and stop exporting this class.
  * @sealed
  * @legacy
  * @alpha


### PR DESCRIPTION
## Description

Remove alpha+legacy tagging on some non-exported API.

Group exports to indicate which ones are actually intended to be used.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
