### PR TITLE
Removed denyList from Historian delete calls

### DIFF
--- a/server/historian/packages/historian-base/src/routes/git/refs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/refs.ts
@@ -129,6 +129,7 @@ export function create(
 		authorization: string | undefined,
 		ref: string,
 	): Promise<void> {
+		// Do not pass the denyList to the git service, as it is not needed for delete operations
 		const service = await utils.createGitService({
 			config,
 			tenantId,
@@ -137,7 +138,6 @@ export function create(
 			storageNameRetriever,
 			documentManager,
 			cache,
-			denyList,
 			ephemeralDocumentTTLSec,
 		});
 		return service.deleteRef(ref);

--- a/server/historian/packages/historian-base/src/routes/summaries.ts
+++ b/server/historian/packages/historian-base/src/routes/summaries.ts
@@ -136,6 +136,7 @@ export function create(
 		authorization: string | undefined,
 		softDelete: boolean,
 	): Promise<boolean[]> {
+		// Do not pass the denyList to the git service, as it is not needed for delete operations
 		const service = await utils.createGitService({
 			config,
 			tenantId,
@@ -145,7 +146,6 @@ export function create(
 			documentManager,
 			cache,
 			allowDisabledTenant: true,
-			denyList,
 			ephemeralDocumentTTLSec,
 		});
 		const deletionPs = [service.deleteSummary(softDelete)];


### PR DESCRIPTION
## Description

Historian denyList is used to prevent DoS issues with our services. However, we do not need to use the denyList for delete ops. This PR removes the denyList from ops that are handled by the delete APIs of Historian.