### PR TITLE
Reduce use of symbols where no longer needed

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/context.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/context.ts
@@ -17,7 +17,7 @@ import { type IDisposable, disposeSymbol } from "../../util/index.js";
 import type { NodeIdentifierManager } from "../node-identifier/index.js";
 
 import type { FlexTreeField } from "./flexTreeTypes.js";
-import { type LazyEntity, prepareForEditSymbol } from "./lazyEntity.js";
+import type { LazyEntity } from "./lazyEntity.js";
 import { makeField } from "./lazyField.js";
 import type { ITreeCheckout } from "../../shared-tree/index.js";
 
@@ -120,7 +120,7 @@ export class Context implements FlexTreeHydratedContext, IDisposable {
 	private prepareForEdit(): void {
 		assert(this.disposed === false, 0x802 /* use after dispose */);
 		for (const target of this.withCursors) {
-			target[prepareForEditSymbol]();
+			target.prepareForEdit();
 		}
 		assert(this.withCursors.size === 0, 0x773 /* prepareForEdit should remove all cursors */);
 	}

--- a/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
@@ -39,7 +39,6 @@ export { type FlexTreeNodeEvents } from "./treeEvents.js";
 
 export {
 	assertFlexTreeEntityNotFreed,
-	isFreedSymbol,
 	LazyEntity,
 } from "./lazyEntity.js";
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -46,14 +46,7 @@ import {
 	flexTreeMarker,
 	flexTreeSlot,
 } from "./flexTreeTypes.js";
-import {
-	LazyEntity,
-	anchorSymbol,
-	cursorSymbol,
-	forgetAnchorSymbol,
-	isFreedSymbol,
-	tryMoveCursorToAnchorSymbol,
-} from "./lazyEntity.js";
+import { LazyEntity } from "./lazyEntity.js";
 import { type LazyTreeNode, makeTree } from "./lazyNode.js";
 import { indexForAt, treeStatusFromAnchorCache } from "./utilities.js";
 import { cursorForMapTreeField } from "../mapTreeCursor.js";
@@ -167,36 +160,36 @@ export abstract class LazyField extends LazyEntity<FieldAnchor> implements FlexT
 	}
 
 	public get parent(): FlexTreeNode | undefined {
-		if (this[anchorSymbol].parent === undefined) {
+		if (this.anchor.parent === undefined) {
 			return undefined;
 		}
 
-		const cursor = this[cursorSymbol];
+		const cursor = this.cursor;
 		cursor.exitField();
 		const output = makeTree(this.context, cursor);
 		cursor.enterField(this.key);
 		return output;
 	}
 
-	protected override [tryMoveCursorToAnchorSymbol](
+	protected override tryMoveCursorToAnchor(
 		cursor: ITreeSubscriptionCursor,
 	): TreeNavigationResult {
-		return this.context.checkout.forest.tryMoveCursorToField(this[anchorSymbol], cursor);
+		return this.context.checkout.forest.tryMoveCursorToField(this.anchor, cursor);
 	}
 
-	protected override [forgetAnchorSymbol](): void {
+	protected override forgetAnchor(): void {
 		this.offAfterDestroy?.();
-		if (this[anchorSymbol].parent === undefined) return;
-		this.context.checkout.forest.anchors.forget(this[anchorSymbol].parent);
+		if (this.anchor.parent === undefined) return;
+		this.context.checkout.forest.anchors.forget(this.anchor.parent);
 	}
 
 	public get length(): number {
-		return this[cursorSymbol].getFieldLength();
+		return this.cursor.getFieldLength();
 	}
 
 	public atIndex(index: number): FlexTreeUnknownUnboxed {
-		return inCursorNode(this[cursorSymbol], index, (cursor) =>
-			unboxedFlexNode(this.context, cursor, this[anchorSymbol]),
+		return inCursorNode(this.cursor, index, (cursor) =>
+			unboxedFlexNode(this.context, cursor, this.anchor),
 		);
 	}
 
@@ -207,9 +200,7 @@ export abstract class LazyField extends LazyEntity<FieldAnchor> implements FlexT
 			return undefined;
 		}
 
-		return inCursorNode(this[cursorSymbol], finalIndex, (cursor) =>
-			makeTree(this.context, cursor),
-		);
+		return inCursorNode(this.cursor, finalIndex, (cursor) => makeTree(this.context, cursor));
 	}
 
 	public map<U>(callbackfn: (value: FlexTreeUnknownUnboxed, index: number) => U): U[] {
@@ -217,12 +208,12 @@ export abstract class LazyField extends LazyEntity<FieldAnchor> implements FlexT
 	}
 
 	public boxedIterator(): IterableIterator<FlexTreeNode> {
-		return iterateCursorField(this[cursorSymbol], (cursor) => makeTree(this.context, cursor));
+		return iterateCursorField(this.cursor, (cursor) => makeTree(this.context, cursor));
 	}
 
 	public [Symbol.iterator](): IterableIterator<FlexTreeUnknownUnboxed> {
-		return iterateCursorField(this[cursorSymbol], (cursor) =>
-			unboxedFlexNode(this.context, cursor, this[anchorSymbol]),
+		return iterateCursorField(this.cursor, (cursor) =>
+			unboxedFlexNode(this.context, cursor, this.anchor),
 		);
 	}
 
@@ -235,10 +226,10 @@ export abstract class LazyField extends LazyEntity<FieldAnchor> implements FlexT
 	 * This path is not valid to hold onto across edits: this must be recalled for each edit.
 	 */
 	public getFieldPathForEditing(): NormalizedFieldUpPath {
-		if (!this[isFreedSymbol]()) {
+		if (!this.isFreed()) {
 			if (
 				// Only allow editing if we are the root document field...
-				(this.parent === undefined && this[anchorSymbol].fieldKey === rootFieldKey) ||
+				(this.parent === undefined && this.anchor.fieldKey === rootFieldKey) ||
 				// ...or are under a node in the document
 				(this.parent !== undefined &&
 					treeStatusFromAnchorCache(this.parent.anchorNode) === TreeStatus.InDocument)

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -164,7 +164,6 @@ export {
 	assertFlexTreeEntityNotFreed,
 	flexTreeSlot,
 	getSchemaAndPolicy,
-	isFreedSymbol,
 	LazyEntity,
 	treeStatusFromAnchorCache,
 	indexForAt,

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -19,7 +19,6 @@ import {
 	assertFlexTreeEntityNotFreed,
 	ContextSlot,
 	flexTreeSlot,
-	isFreedSymbol,
 	LazyEntity,
 	TreeStatus,
 	treeStatusFromAnchorCache,
@@ -248,7 +247,7 @@ export class TreeNodeKernel {
 		const flex = this.#hydrationState.anchorNode.slots.get(flexTreeSlot);
 		if (flex !== undefined) {
 			assert(flex instanceof LazyEntity, 0x9b4 /* Unexpected flex node implementation */);
-			if (flex[isFreedSymbol]()) {
+			if (flex.isFreed()) {
 				return TreeStatus.Deleted;
 			}
 		}

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -19,7 +19,6 @@ import {
 	type UpPath,
 	rootFieldKey,
 } from "../../../core/index.js";
-import { isFreedSymbol } from "../../../feature-libraries/flex-tree/lazyEntity.js";
 import {
 	LazyField,
 	LazyOptionalField,
@@ -183,9 +182,9 @@ describe("LazyField", () => {
 			detachedFieldAnchor,
 		);
 
-		assert(!field[isFreedSymbol]());
+		assert(!field.isFreed());
 		context[disposeSymbol]();
-		assert(field[isFreedSymbol]());
+		assert(field.isFreed());
 	});
 
 	it("Disposes when parent is disposed", () => {
@@ -203,10 +202,10 @@ describe("LazyField", () => {
 		const field = holder.getBoxed(brand("f"));
 		assert(field instanceof LazyField);
 
-		assert(!field[isFreedSymbol]());
+		assert(!field.isFreed());
 		const v = forest.anchors.acquireVisitor();
 		v.destroy(rootFieldKey, 1);
-		assert(field[isFreedSymbol]());
+		assert(field.isFreed());
 
 		// Should not double free.
 		context[disposeSymbol]();
@@ -227,9 +226,9 @@ describe("LazyField", () => {
 		const field = holder.getBoxed(brand("f"));
 		assert(field instanceof LazyField);
 
-		assert(!field[isFreedSymbol]());
+		assert(!field.isFreed());
 		context[disposeSymbol]();
-		assert(field[isFreedSymbol]());
+		assert(field.isFreed());
 		// Should not double free.
 		const v = forest.anchors.acquireVisitor();
 		v.destroy(rootFieldKey, 1);


### PR DESCRIPTION
## Description

Back when the lazy entity types where originally implemented, the FlexTree API for object nodes exposed fields as properties, which could collide with members used in the implementation, so symbols were used to avoid this.

As this these properties are no longer used, these APIs can be migrated away from symbols for cleaner code and easier debugging.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
