### PR TITLE
test(container-runtime) Add test for bug fix around old loader and flushing partial batches

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1757,6 +1757,7 @@ export class ContainerRuntime
 		const legacySendBatchFn = makeLegacySendBatchFn(submitFn, this.innerDeltaManager);
 
 		this.skipSafetyFlushDuringProcessStack =
+			// Keep the old flag name even though we renamed the class member (it shipped in 2.31.0)
 			this.mc.config.getBoolean("Fluid.ContainerRuntime.DisableFlushBeforeProcess") === true;
 
 		this.outbox = new Outbox({


### PR DESCRIPTION
## Description

Test for #24276.  The test makes sure that if a system op is processed before a scheduled flush happens, we properly cut a new batch.

See #24099 for the full story on this scenario and recent changes to it.