### PR TITLE
Fix exception thrown when debugging tests using test browser in tree

### DIFF
--- a/packages/dds/tree/.vscode/settings.json
+++ b/packages/dds/tree/.vscode/settings.json
@@ -7,7 +7,7 @@
 	// "pruneFiles" is disabled because it causesd "source-map-support/register" to give `Unknown file extension ".ts"` errors.
 	// "mochaExplorer.pruneFiles": true,
 	"mochaExplorer.require": [
-		"node_modules/@fluid-internal/mocha-test-setup",
+		"node_modules/@fluid-internal/mocha-test-setup/dist/index.js",
 		"source-map-support/register",
 	],
 	"mochaExplorer.configFile": ".mocharc.cjs",


### PR DESCRIPTION
## Description

When using the vs-code test browser as configured by the tree workspace to debug tests, a handled exception is thrown who's messages suggested this change. Making this change seems to work, and the exception is gone which makes debugging with break on caught exceptions nicer.

## Breaking Changes

This changes when the debugger breaks, making it break less ;)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
