### PR TITLE
refactor(fluid-static): Add flexibility to createDOProviderContainerRuntimeFactory()

### DIFF
--- a/packages/framework/fluid-static/src/compatibilityConfiguration.ts
+++ b/packages/framework/fluid-static/src/compatibilityConfiguration.ts
@@ -12,8 +12,7 @@ import { FlushMode } from "@fluidframework/runtime-definitions/internal";
 import type { CompatibilityMode } from "./types.js";
 
 /**
- * The CompatibilityMode selected determines the set of runtime options to use. In "1" mode we support
- * full interop with true 1.x clients, while in "2" mode we only support interop with 2.x clients.
+ * Specifies the configured runtime options for each {@link CompatibilityMode}..
  */
 export const compatibilityModeRuntimeOptions: Record<
 	CompatibilityMode,

--- a/packages/framework/fluid-static/src/index.ts
+++ b/packages/framework/fluid-static/src/index.ts
@@ -17,11 +17,7 @@ export {
 	type IFluidContainerInternal,
 	type InitialObjects,
 } from "./fluidContainer.js";
-export {
-	createDOProviderContainerRuntimeFactory,
-	RootDataObject,
-	type RootDataObjectProps,
-} from "./rootDataObject.js";
+export { createDOProviderContainerRuntimeFactory } from "./rootDataObject.js";
 export { createServiceAudience } from "./serviceAudience.js";
 export type {
 	CompatibilityMode,
@@ -34,7 +30,6 @@ export type {
 	IServiceAudience,
 	IServiceAudienceEvents,
 	LoadableObjectRecord,
-	LoadableObjectKindRecord,
 	MemberChangedListener,
 	Myself,
 } from "./types.js";

--- a/packages/framework/fluid-static/src/index.ts
+++ b/packages/framework/fluid-static/src/index.ts
@@ -17,7 +17,12 @@ export {
 	type IFluidContainerInternal,
 	type InitialObjects,
 } from "./fluidContainer.js";
-export { createDOProviderContainerRuntimeFactory } from "./rootDataObject.js";
+export {
+	createDOProviderContainerRuntimeFactory,
+	DOProviderContainerRuntimeFactory,
+	RootDataObject,
+	type RootDataObjectProps,
+} from "./rootDataObject.js";
 export { createServiceAudience } from "./serviceAudience.js";
 export type {
 	CompatibilityMode,
@@ -30,6 +35,7 @@ export type {
 	IServiceAudience,
 	IServiceAudienceEvents,
 	LoadableObjectRecord,
+	LoadableObjectKindRecord,
 	MemberChangedListener,
 	Myself,
 } from "./types.js";

--- a/packages/framework/fluid-static/src/index.ts
+++ b/packages/framework/fluid-static/src/index.ts
@@ -19,7 +19,6 @@ export {
 } from "./fluidContainer.js";
 export {
 	createDOProviderContainerRuntimeFactory,
-	DOProviderContainerRuntimeFactory,
 	RootDataObject,
 	type RootDataObjectProps,
 } from "./rootDataObject.js";

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -167,17 +167,27 @@ const rootDataStoreId = "rootDOId";
  * @internal
  */
 export function createDOProviderContainerRuntimeFactory(props: {
+	/**
+	 * The schema for the container
+	 */
 	schema: ContainerSchema;
+	/**
+	 * Compatibility mode
+	 */
 	compatibilityMode: CompatibilityMode;
+	/**
+	 * Optional factory for the root data object.
+	 * If not provided, a default factory will be created based on the schema.
+	 */
+	rootDataObjectFactory?: DataObjectFactory<
+		RootDataObject,
+		{ InitialState: RootDataObjectProps }
+	>;
 }): IRuntimeFactory {
 	const [registryEntries, sharedObjects] = parseDataObjectsFromSharedObjects(props.schema);
-	const rootDataObjectFactory = new DataObjectFactory(
-		"rootDO",
-		RootDataObject,
-		sharedObjects,
-		{},
-		registryEntries,
-	);
+	const rootDataObjectFactory =
+		props.rootDataObjectFactory ??
+		new DataObjectFactory("rootDO", RootDataObject, sharedObjects, {}, registryEntries);
 	return new DOProviderContainerRuntimeFactory(
 		props.schema,
 		props.compatibilityMode,
@@ -188,10 +198,8 @@ export function createDOProviderContainerRuntimeFactory(props: {
 /**
  * Factory for Container Runtime instances that provide a single {@link IRootDataObject}
  * as their entry point.
- *
- * @internal
  */
-export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
+class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
 	private readonly rootDataObjectFactory: DataObjectFactory<
 		RootDataObject,
 		{
@@ -209,7 +217,7 @@ export class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFacto
 	 * DataStore/DDS types that the schema says can be constructed).
 	 *
 	 * Most scenarios probably want to use {@link createDOProviderContainerRuntimeFactory} instead,
-	 * since it takes care of constructing the root data object factory based on the schema.
+	 * since it can take care of constructing the root data object factory based on the schema.
 	 *
 	 * @param schema - The schema for the container
 	 * @param compatibilityMode - Compatibility mode

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -169,11 +169,11 @@ const rootDataStoreId = "rootDOId";
  */
 export function createDOProviderContainerRuntimeFactory(props: {
 	/**
-	 * The schema for the container
+	 * The schema for the container.
 	 */
 	schema: ContainerSchema;
 	/**
-	 * Compatibility mode
+	 * See {@link CompatibilityMode} and compatibilityModeRuntimeOptions for more details.
 	 */
 	compatibilityMode: CompatibilityMode;
 	/**

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -9,7 +9,10 @@ import type { SharedObjectKind } from "@fluidframework/shared-object-base";
 import type { ISharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
 /**
- * Valid compatibility modes that may be specified when creating a DOProviderContainerRuntimeFactory.
+ * Determines the set of runtime options that Fluid Framework will use when running.
+ * In "1" mode we support full interop between 2.x clients and 1.x clients,
+ * while in "2" mode we only support interop between 2.x clients.
+ *
  * @public
  */
 export type CompatibilityMode = "1" | "2";

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -23,6 +23,7 @@ export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 /**
  * A mapping of string identifiers to classes that will later be used to instantiate a corresponding `DataObject`
  * or `SharedObject`.
+ * @internal
  */
 export type LoadableObjectKindRecord = Record<string, SharedObjectKind>;
 

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -23,7 +23,6 @@ export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 /**
  * A mapping of string identifiers to classes that will later be used to instantiate a corresponding `DataObject`
  * or `SharedObject`.
- * @internal
  */
 export type LoadableObjectKindRecord = Record<string, SharedObjectKind>;
 


### PR DESCRIPTION
## Description

Updates `createDOProviderContainerRuntimeFactory()` so it can optionally take in a `IFluidDataStoreRegistry` to use in the root data object factory, so callers can pass one in instead of always using the default one. Motivated by a scenario where we want to use a custom registry that doesn't prevent a container from loading when there are unknown components/DataStores in the snapshot.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#31300](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/31300)