### PR TITLE
Replace metadata with placeholder tagging

### DIFF
--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -102,18 +102,18 @@ export interface IFluidHandleInternal<
 }
 
 /**
+ * TODO: Better name to signal that this might be a placeholder - it's just placeholder-aware
  * @internal
  */
-export interface IFluidHandleInternalWithMetadata<
+export interface IFluidHandleInternalPlaceholder<
 	// REVIEW: Constrain `T` to something? How do we support dds and datastores safely?
 	out T = unknown, // FluidObject & IFluidLoadable,
 > extends IFluidHandleInternal<T> {
 	/**
-	 * The handle may contain metadata, generated and interpreted by the subsystem that the handle
-	 * relates to.  For instance, the BlobManager uses this to distinguish blob handles which may
-	 * not yet have an attached blob yet.
+	 * Whether the handle is a placeholder, meaning that it may exist before its payload is retrievable.
+	 * For instance, the BlobManager can generate handles before completing the blob upload/attach.
 	 */
-	readonly metadata: Readonly<Record<string, number | boolean | string>> | undefined;
+	readonly placeholder: boolean;
 }
 
 /**

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -31,7 +31,7 @@ export type {
 	IProvideFluidHandleContext,
 	IProvideFluidHandle,
 	IFluidHandleInternal,
-	IFluidHandleInternalWithMetadata,
+	IFluidHandleInternalPlaceholder,
 	IFluidHandleErased,
 } from "./handles.js";
 export { IFluidHandleContext, IFluidHandle, fluidHandleSymbol } from "./handles.js";

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -153,7 +153,7 @@ export class FluidSerializer implements IFluidSerializer {
 				? value.url
 				: generateHandleContextPath(value.url, this.context);
 
-			return new RemoteFluidObjectHandle(absolutePath, this.root, value.metadata);
+			return new RemoteFluidObjectHandle(absolutePath, this.root, value.placeholder === true);
 		} else {
 			return value;
 		}

--- a/packages/dds/shared-object-base/src/test/serializer.spec.ts
+++ b/packages/dds/shared-object-base/src/test/serializer.spec.ts
@@ -41,7 +41,11 @@ describe("FluidSerializer", () => {
 	describe("vanilla JSON", () => {
 		const context = new MockHandleContext();
 		const serializer = new FluidSerializer(context);
-		const handle = new RemoteFluidObjectHandle("/root", context);
+		const handle = new RemoteFluidObjectHandle(
+			"/root",
+			context,
+			false, // placeholder
+		);
 
 		// Start with the various JSON-serializable types.  A mix of "truthy" and "falsy" values
 		// are of particular interest.
@@ -167,7 +171,11 @@ describe("FluidSerializer", () => {
 	describe("JSON w/embedded handles", () => {
 		const context = new MockHandleContext();
 		const serializer = new FluidSerializer(context);
-		const handle = new RemoteFluidObjectHandle("/root", context);
+		const handle = new RemoteFluidObjectHandle(
+			"/root",
+			context,
+			false, // placeholder
+		);
 		const serializedHandle = {
 			type: "__fluid_handle__",
 			url: "/root",
@@ -329,8 +337,16 @@ describe("FluidSerializer", () => {
 	describe("Utils", () => {
 		const serializer = new FluidSerializer(new MockHandleContext());
 		it("makeSerializable is idempotent", () => {
-			const bind = new RemoteFluidObjectHandle("/", new MockHandleContext());
-			const handle = new RemoteFluidObjectHandle("/okay", new MockHandleContext());
+			const bind = new RemoteFluidObjectHandle(
+				"/",
+				new MockHandleContext(),
+				false, // placeholder
+			);
+			const handle = new RemoteFluidObjectHandle(
+				"/okay",
+				new MockHandleContext(),
+				false, // placeholder
+			);
 			const input = { x: handle, y: 123 };
 			const serializedOnce = makeHandlesSerializable(input, serializer, bind) as {
 				x: { type: "__fluid_handle__" };

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2260,12 +2260,16 @@ export class ContainerRuntime
 			}
 
 			if (id === blobManagerBasePath && requestParser.isLeaf(2)) {
-				const placeholder = requestParser.headers?.[RuntimeHeaders.wait] === true;
-				if (!this.blobManager.hasBlob(requestParser.pathParts[1]) && !placeholder) {
+				const localId = requestParser.pathParts[1];
+				const placeholder = requestParser.headers?.[RuntimeHeaders.placeholder] === true;
+				if (
+					!this.blobManager.hasBlob(localId) &&
+					requestParser.headers?.[RuntimeHeaders.wait] === false
+				) {
 					return create404Response(request);
 				}
 
-				const blob = await this.blobManager.getBlob(requestParser.pathParts[1], placeholder);
+				const blob = await this.blobManager.getBlob(localId, placeholder);
 
 				return {
 					status: 200,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2260,19 +2260,12 @@ export class ContainerRuntime
 			}
 
 			if (id === blobManagerBasePath && requestParser.isLeaf(2)) {
-				if (
-					!this.blobManager.hasBlob(requestParser.pathParts[1]) &&
-					requestParser.headers?.[RuntimeHeaders.wait] === false
-				) {
+				const placeholder = requestParser.headers?.[RuntimeHeaders.wait] === true;
+				if (!this.blobManager.hasBlob(requestParser.pathParts[1]) && !placeholder) {
 					return create404Response(request);
 				}
 
-				const blob = await this.blobManager.getBlob(
-					requestParser.pathParts[1],
-					requestParser.headers?.[RuntimeHeaders.metadata] as
-						| Readonly<Record<string, string | number | boolean>>
-						| undefined,
-				);
+				const blob = await this.blobManager.getBlob(requestParser.pathParts[1], placeholder);
 
 				return {
 					status: 200,

--- a/packages/runtime/runtime-utils/src/handles.ts
+++ b/packages/runtime/runtime-utils/src/handles.ts
@@ -7,7 +7,7 @@ import type { IFluidHandleErased } from "@fluidframework/core-interfaces";
 import { IFluidHandle, fluidHandleSymbol } from "@fluidframework/core-interfaces";
 import type {
 	IFluidHandleInternal,
-	IFluidHandleInternalWithMetadata,
+	IFluidHandleInternalPlaceholder,
 } from "@fluidframework/core-interfaces/internal";
 
 /**
@@ -22,15 +22,15 @@ export interface ISerializedHandle {
 	url: string;
 
 	/**
-	 * The handle may contain metadata, generated and interpreted by the subsystem that the handle
+	 * The handle may be a placeholder, as determined by and resolvable by the subsystem that the handle
 	 * relates to.  For instance, the BlobManager uses this to distinguish blob handles which may
 	 * not yet have an attached blob yet.
 	 *
 	 * @remarks
-	 * Will only exist if the handle has metadata, will be omitted entirely from the serialized format
-	 * if the handle has no metadata.
+	 * Will only exist if the handle is a placeholder, will be omitted entirely from the serialized format
+	 * if the handle is not a placeholder.
 	 */
-	readonly metadata?: Readonly<Record<string, string | number | boolean>> | undefined;
+	readonly placeholder?: true;
 }
 
 /**
@@ -40,10 +40,13 @@ export interface ISerializedHandle {
 export const isSerializedHandle = (value: any): value is ISerializedHandle =>
 	value?.type === "__fluid_handle__";
 
-const isFluidHandleInternalWithMetadata = (
+/**
+ * @internal
+ */
+export const isFluidHandleInternalPlaceholder = (
 	fluidHandleInternal: IFluidHandleInternal,
-): fluidHandleInternal is IFluidHandleInternalWithMetadata =>
-	"metadata" in fluidHandleInternal && fluidHandleInternal.metadata !== undefined;
+): fluidHandleInternal is IFluidHandleInternalPlaceholder =>
+	"placeholder" in fluidHandleInternal && fluidHandleInternal.placeholder === true;
 
 /**
  * Encodes the given IFluidHandle into a JSON-serializable form,
@@ -53,11 +56,11 @@ const isFluidHandleInternalWithMetadata = (
  * @internal
  */
 export function encodeHandleForSerialization(handle: IFluidHandleInternal): ISerializedHandle {
-	return isFluidHandleInternalWithMetadata(handle)
+	return isFluidHandleInternalPlaceholder(handle)
 		? {
 				type: "__fluid_handle__",
 				url: handle.absolutePath,
-				metadata: handle.metadata,
+				placeholder: true,
 			}
 		: {
 				type: "__fluid_handle__",

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -17,6 +17,7 @@ export {
 	ISerializedHandle,
 	isSerializedHandle,
 	isFluidHandle,
+	isFluidHandleInternalPlaceholder,
 	toFluidHandleErased,
 	toFluidHandleInternal,
 	FluidHandleBase,

--- a/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
@@ -51,7 +51,7 @@ export class RemoteFluidObjectHandle extends FluidHandleBase<FluidObject> {
 				url: this.absolutePath,
 				headers: {
 					[RuntimeHeaders.viaHandle]: true,
-					[RuntimeHeaders.wait]: this.placeholder,
+					[RuntimeHeaders.placeholder]: this.placeholder,
 				},
 			};
 			this.objectP = this.routeContext.resolveHandle(request).then<FluidObject>((response) => {

--- a/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
@@ -35,7 +35,7 @@ export class RemoteFluidObjectHandle extends FluidHandleBase<FluidObject> {
 	constructor(
 		public readonly absolutePath: string,
 		public readonly routeContext: IFluidHandleContext,
-		public readonly metadata?: Readonly<Record<string, string | number | boolean>> | undefined,
+		public readonly placeholder: boolean,
 	) {
 		super();
 		assert(
@@ -51,7 +51,7 @@ export class RemoteFluidObjectHandle extends FluidHandleBase<FluidObject> {
 				url: this.absolutePath,
 				headers: {
 					[RuntimeHeaders.viaHandle]: true,
-					[RuntimeHeaders.metadata]: this.metadata,
+					[RuntimeHeaders.wait]: this.placeholder,
 				},
 			};
 			this.objectP = this.routeContext.resolveHandle(request).then<FluidObject>((response) => {

--- a/packages/runtime/runtime-utils/src/utils.ts
+++ b/packages/runtime/runtime-utils/src/utils.ts
@@ -22,6 +22,10 @@ export enum RuntimeHeaders {
 	 * True if the request is coming from an IFluidHandle.
 	 */
 	viaHandle = "viaHandle",
+	/**
+	 * True if the request is coming from a placeholder handle.
+	 */
+	placeholder = "placeholder",
 }
 
 /**

--- a/packages/runtime/runtime-utils/src/utils.ts
+++ b/packages/runtime/runtime-utils/src/utils.ts
@@ -22,10 +22,6 @@ export enum RuntimeHeaders {
 	 * True if the request is coming from an IFluidHandle.
 	 */
 	viaHandle = "viaHandle",
-	/**
-	 * Contains the metadata record, if one exists.
-	 */
-	metadata = "metadata",
 }
 
 /**


### PR DESCRIPTION
Mostly prioritizing this portion as it changes the handle's serialized form.  Generalizes the "placeholder handle" such that it's not blob-specific anymore.

Later this will help in considering some of the changes that I looked at in [this branch](https://github.com/microsoft/FluidFramework/compare/test/blob-placeholders...ChumpChief:ArchThoughts?expand=1) - in particular consolidating handle handling in ContainerRuntime.  I originally was going to include more of that in this change but realized it would probably also require some of the GC moves too - so stopping here in the interest of expediency.