### PR TITLE
Reduce direct references to SharedTree class and its factory class

### DIFF
--- a/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -251,7 +251,7 @@ describe("SharedTreeCore", () => {
 			{
 				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: MockStorage.createFromSummary(
-					tree1.summarizeCore(mockSerializer).summary,
+					tree1.kernel.summarizeCore(mockSerializer).summary,
 				),
 			},
 			factory.attributes,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -24,7 +24,7 @@ import type {
 	TreeNodeSchemaIdentifier,
 } from "../../../core/index.js";
 import { type DownPath, toDownPath } from "../../../feature-libraries/index.js";
-import { Tree, type ITreePrivate, type SharedTree } from "../../../shared-tree/index.js";
+import { Tree, type ISharedTree, type ITreePrivate } from "../../../shared-tree/index.js";
 import { getOrCreate, makeArray } from "../../../util/index.js";
 
 import {
@@ -102,7 +102,7 @@ export interface FuzzTestState extends DDSFuzzTestState<TreeFactory> {
 	 * SharedTrees undergoing a transaction will have a forked view in {@link transactionViews} instead,
 	 * which should be used in place of this view until the transaction is complete.
 	 */
-	clientViews?: Map<SharedTree, FuzzView>;
+	clientViews?: Map<ISharedTree, FuzzView>;
 	/**
 	 * Schematized view of clients undergoing transactions with their nodeSchemas.
 	 * Edits to this view are not visible to other clients until the transaction is closed.
@@ -118,7 +118,7 @@ export interface FuzzTestState extends DDSFuzzTestState<TreeFactory> {
 	 * SharedTrees undergoing a transaction will have a forked view in {@link transactionViews} instead,
 	 * which should be used in place of this view until the transaction is complete.
 	 */
-	forkedViews?: Map<SharedTree, FuzzView[]>;
+	forkedViews?: Map<ISharedTree, FuzzView[]>;
 }
 
 export function viewFromState(

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -12,7 +12,7 @@ import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 import type { Revertible } from "../../../core/index.js";
 import type { DownPath } from "../../../feature-libraries/index.js";
-import { Tree, type SharedTree } from "../../../shared-tree/index.js";
+import { Tree, type ISharedTree } from "../../../shared-tree/index.js";
 import { validateFuzzTreeConsistency } from "../../utils.js";
 
 import {
@@ -190,7 +190,7 @@ export function applySchemaOp(state: FuzzTestState, operation: SchemaChange) {
 export function applyForkMergeOperation(state: FuzzTestState, branchEdit: ForkMergeOperation) {
 	switch (branchEdit.contents.type) {
 		case "fork": {
-			const forkedViews = state.forkedViews ?? new Map<SharedTree, FuzzView[]>();
+			const forkedViews = state.forkedViews ?? new Map<ISharedTree, FuzzView[]>();
 			const clientForkedViews = forkedViews.get(state.client.channel) ?? [];
 
 			if (branchEdit.contents.branchNumber !== undefined) {
@@ -211,7 +211,7 @@ export function applyForkMergeOperation(state: FuzzTestState, branchEdit: ForkMe
 		}
 		case "merge": {
 			const forkBranchIndex = branchEdit.contents.forkBranch;
-			const forkedViews = state.forkedViews ?? new Map<SharedTree, FuzzView[]>();
+			const forkedViews = state.forkedViews ?? new Map<ISharedTree, FuzzView[]>();
 			const clientForkedViews = forkedViews.get(state.client.channel) ?? [];
 
 			const baseBranch =

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzUtils.ts
@@ -27,7 +27,6 @@ import {
 import type {
 	ITreeCheckout,
 	SchematizingSimpleTreeView,
-	SharedTree,
 	TreeCheckout,
 } from "../../../shared-tree/index.js";
 import { testSrcPath } from "../../testSrcPath.cjs";
@@ -45,8 +44,11 @@ import {
 } from "../../../simple-tree/index.js";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
-// eslint-disable-next-line import/no-internal-modules
-import type { SharedTreeOptionsInternal } from "../../../shared-tree/sharedTree.js";
+import type {
+	ISharedTree,
+	SharedTreeOptionsInternal,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../../shared-tree/sharedTree.js";
 import { typeboxValidator } from "../../../external-utilities/index.js";
 import type { FuzzView } from "./fuzzEditGenerators.js";
 
@@ -161,8 +163,8 @@ export class SharedTreeFuzzTestFactory extends SharedTreeTestFactory {
 	 * @param onLoad - Called once for each tree that is loaded from a summary.
 	 */
 	public constructor(
-		protected override readonly onCreate: (tree: SharedTree) => void,
-		protected override readonly onLoad?: (tree: SharedTree) => void,
+		protected override readonly onCreate: (tree: ISharedTree) => void,
+		protected override readonly onLoad?: (tree: ISharedTree) => void,
 		options: SharedTreeOptionsInternal = {},
 	) {
 		super(onCreate, onLoad, {

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -12,12 +12,11 @@ import {
 	SchemaFactory,
 	TreeViewConfiguration,
 	type TreeNodeSchema,
-	type TreeView,
 } from "../../../simple-tree/index.js";
 import { TreeFactory } from "../../../treeFactory.js";
 import { getView, validateUsageError } from "../../utils.js";
 import { MockNodeIdentifierManager } from "../../../feature-libraries/index.js";
-import { Tree } from "../../../shared-tree/index.js";
+import { independentView, Tree } from "../../../shared-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { checkUnion } from "../../../simple-tree/api/tree.js";
 
@@ -32,33 +31,21 @@ const factory = new TreeFactory({});
 describe("simple-tree tree", () => {
 	it("ListRoot", () => {
 		const config = new TreeViewConfiguration({ schema: NodeList });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view: TreeView<typeof NodeList> = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize(new NodeList(["a", "b"]));
 		assert.deepEqual([...view.root], ["a", "b"]);
 	});
 
 	it("Implicit ListRoot", () => {
 		const config = new TreeViewConfiguration({ schema: NodeList });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view: TreeView<typeof NodeList> = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize(["a", "b"]);
 		assert.deepEqual([...view.root], ["a", "b"]);
 	});
 
 	it("ObjectRoot - Data", () => {
 		const config = new TreeViewConfiguration({ schema: Canvas });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view: TreeView<typeof Canvas> = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize({ stuff: ["a", "b"] });
 	});
 
@@ -90,12 +77,6 @@ describe("simple-tree tree", () => {
 	});
 
 	it("preventAmbiguity - example ambiguous", () => {
-		// TODO: this is left out of the example since we don't have a nice public facing way to create a test tree. We should fix that.
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-
 		const schemaFactory = new SchemaFactory("com.example");
 		class Feet extends schemaFactory.object("Feet", { length: schemaFactory.number }) {}
 		class Meters extends schemaFactory.object("Meters", { length: schemaFactory.number }) {}
@@ -104,7 +85,7 @@ describe("simple-tree tree", () => {
 			schema: [Feet, Meters],
 			preventAmbiguity: false,
 		});
-		const view = tree.viewWith(config);
+		const view = independentView(config, { idCompressor: createIdCompressor() });
 		// This is invalid since it is ambiguous which type of node is being constructed:
 		// view.initialize({ length: 5 });
 		// To work, an explicit type can be provided by using an {@link Unhydrated} Node:
@@ -112,12 +93,6 @@ describe("simple-tree tree", () => {
 	});
 
 	it("preventAmbiguity - example unambiguous", () => {
-		// TODO: this is left out of the example since we don't have a nice public facing way to create a test tree. We should fix that.
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-
 		const schemaFactory = new SchemaFactory("com.example");
 		class Feet extends schemaFactory.object("Feet", { length: schemaFactory.number }) {}
 		class Meters extends schemaFactory.object("Meters", {
@@ -131,7 +106,7 @@ describe("simple-tree tree", () => {
 			schema: [Feet, Meters],
 			preventAmbiguity: true,
 		});
-		const view = tree.viewWith(config);
+		const view = independentView(config, { idCompressor: createIdCompressor() });
 		// This now works, since the field is sufficient to determine this is a `Meters` node.
 		view.initialize({ meters: 5 });
 	});
@@ -249,11 +224,7 @@ describe("simple-tree tree", () => {
 	it("default identifier with schema validation", () => {
 		class HasId extends schema.object("hasID", { id: schema.identifier }) {}
 		const config = new TreeViewConfiguration({ schema: HasId, enableSchemaValidation: true });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		// TODO: Issues prevent this test from detecting the bug this would otherwise detect.
 		// This would error (due to schema validation being done before default is provided, see note on mapTreeFromNodeData),
 		// but this issue is not detected since we fail to validate the initial tree due to issue noted in isNodeInSchema ( AB#8197 )
@@ -317,11 +288,7 @@ describe("simple-tree tree", () => {
 
 	it("accessing view.root does not leak LazyEntities", () => {
 		const config = new TreeViewConfiguration({ schema: Canvas });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize({ stuff: [] });
 		const _unused = view.root;
 		const context = view.getView().context;
@@ -336,11 +303,7 @@ describe("simple-tree tree", () => {
 
 	it("accessing root via Tree.parent does not leak LazyEntities", () => {
 		const config = new TreeViewConfiguration({ schema: Canvas });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize({ stuff: [] });
 		const child = view.root.stuff;
 		Tree.parent(child);
@@ -356,32 +319,20 @@ describe("simple-tree tree", () => {
 
 	it("ObjectRoot - unhydrated", () => {
 		const config = new TreeViewConfiguration({ schema: Canvas });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view: TreeView<typeof Canvas> = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize(new Canvas({ stuff: ["a", "b"] }));
 	});
 
 	it("Union Root", () => {
 		const config = new TreeViewConfiguration({ schema: [schema.string, schema.number] });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize("a");
 		assert.equal(view.root, "a");
 	});
 
 	it("optional Root - initialized to undefined", () => {
 		const config = new TreeViewConfiguration({ schema: schema.optional(schema.string) });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		// Note: the tree's schema hasn't been initialized at this point, so even though the view schema
 		// allows an optional field, explicit initialization must occur.
 		assert.throws(() => view.root, /Document is out of schema./);
@@ -391,22 +342,14 @@ describe("simple-tree tree", () => {
 
 	it("optional Root - initializing only schema", () => {
 		const config = new TreeViewConfiguration({ schema: schema.optional(schema.string) });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		view.upgradeSchema();
 		assert.equal(view.root, undefined);
 	});
 
 	it("optional Root - full", () => {
 		const config = new TreeViewConfiguration({ schema: schema.optional(schema.string) });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize("x");
 		assert.equal(view.root, "x");
 	});
@@ -414,11 +357,7 @@ describe("simple-tree tree", () => {
 	it("Nested list", () => {
 		const nestedList = schema.array(schema.array(schema.string));
 		const config = new TreeViewConfiguration({ schema: nestedList });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize([["a"]]);
 		assert.equal(view.root?.length, 1);
 		const child = view.root[0];
@@ -456,11 +395,7 @@ describe("object allocation tests", () => {
 	it("accessing leaf on object node does not allocate flex nodes", () => {
 		class TreeWithLeaves extends schema.object("TreeWithLeaves", { leaf: schema.number }) {}
 		const config = new TreeViewConfiguration({ schema: TreeWithLeaves });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize({ leaf: 1 });
 		const context = view.getView().context;
 		// Note: access the root before trying to access just the leaf, to not count any object allocations that result from
@@ -481,11 +416,7 @@ describe("object allocation tests", () => {
 	it("accessing leaf on map node does not allocate flex nodes", () => {
 		class TreeWithLeaves extends schema.map("MapOfLeaves", schema.number) {}
 		const config = new TreeViewConfiguration({ schema: TreeWithLeaves });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize(new Map([["1", 1]]));
 		const context = view.getView().context;
 		// Note: access the map that contains leaves before trying to access just the leaf at one of the keys, to not
@@ -506,11 +437,7 @@ describe("object allocation tests", () => {
 	it("accessing leaf on array node does not allocate flex nodes", () => {
 		class TreeWithLeaves extends schema.array("ArrayOfLeaves", schema.number) {}
 		const config = new TreeViewConfiguration({ schema: TreeWithLeaves });
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize([1, 2]);
 		const context = view.getView().context;
 		// Note: prior to taking the "before count", access the array that contains leaves *and the first leaf in it*,

--- a/packages/dds/tree/src/test/snapshots/gc.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/gc.spec.ts
@@ -22,6 +22,7 @@ import {
 	type TreeView,
 } from "../../simple-tree/index.js";
 import { TreeFactory } from "../../treeFactory.js";
+import { SharedTreeAttributes } from "../../sharedTreeAttributes.js";
 
 const builder = new SchemaFactory("test");
 class Bar extends builder.object("bar", {
@@ -40,7 +41,7 @@ function createConnectedTree(
 	const dataStoreRuntime = new MockFluidDataStoreRuntime({
 		idCompressor: createIdCompressor(),
 	});
-	const tree = new SharedTree(id, dataStoreRuntime, new TreeFactory({}).attributes, {});
+	const tree = new SharedTree(id, dataStoreRuntime, SharedTreeAttributes, {});
 	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
 		deltaConnection: dataStoreRuntime.createDeltaConnection(),

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -17,6 +17,7 @@ import {
 
 import {
 	SharedTree as SharedTreeImpl,
+	type ISharedTree,
 	type SharedTreeOptions,
 	type SharedTreeOptionsInternal,
 } from "./shared-tree/index.js";
@@ -27,7 +28,7 @@ import { SharedTreeFactoryType, SharedTreeAttributes } from "./sharedTreeAttribu
 /**
  * A channel factory that creates an {@link ITree}.
  */
-export class TreeFactory implements IChannelFactory<ITree> {
+export class TreeFactory implements IChannelFactory<ISharedTree> {
 	public static Type: string = SharedTreeFactoryType;
 	public readonly type: string = SharedTreeFactoryType;
 
@@ -40,13 +41,13 @@ export class TreeFactory implements IChannelFactory<ITree> {
 		id: string,
 		services: IChannelServices,
 		channelAttributes: Readonly<IChannelAttributes>,
-	): Promise<SharedTreeImpl> {
+	): Promise<ISharedTree> {
 		const tree = new SharedTreeImpl(id, runtime, channelAttributes, this.options);
 		await tree.load(services);
 		return tree;
 	}
 
-	public create(runtime: IFluidDataStoreRuntime, id: string): SharedTreeImpl {
+	public create(runtime: IFluidDataStoreRuntime, id: string): ISharedTree {
 		const tree = new SharedTreeImpl(id, runtime, this.attributes, this.options);
 		tree.initializeLocal();
 		return tree;


### PR DESCRIPTION
## Description

Tweak SharedTree tests to make less direct use of the SharedTreeClass and instead prefer its interfaces.

Also reduce unnecessary use of its factory.

These changes make the test suite more compatible with changes like https://github.com/microsoft/FluidFramework/pull/23729 which adjust how the kernel is used to implement the SharedObject.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


