### PR TITLE
fix(launch.json) Add explicit linux platform-specific runtimeExecutable path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -412,6 +412,9 @@
 			"windows": {
 				"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha.cmd",
 			},
+			"linux": {
+				"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
+			},
 			"sourceMaps": true,
 			"program": "${file}",
 			"args": [


### PR DESCRIPTION
## Description

In my GitHub CodeSpace, the `Debug Current Mocha Test (auto build)` debug config seems to be using the Windows entry for `runtimeExecutable` even though it's a Linux environment, so F5 to debug has been broken for me.

Copilot suggested I add an explicit Linux platform-specific `runtimeExecutable` path to the `launch.json` file, which fixed the issue.

I tested this on my CodeSpace and also Windows directly.
