### PR TITLE
fix(container-runtime): Always close the container if ContainerRuntime.flush throws

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -369,7 +369,7 @@ export interface IContainerRuntimeOptions {
 	 * regardless of the overhead of an individual op.
 	 *
 	 * Any value of `chunkSizeInBytes` exceeding {@link IContainerRuntimeOptions.maxBatchSizeInBytes} will disable this feature, therefore if a compressed batch's content
-	 * size exceeds {@link IContainerRuntimeOptions.maxBatchSizeInBytes} after compression, the container will close with an instance of `GenericError` with
+	 * size exceeds {@link IContainerRuntimeOptions.maxBatchSizeInBytes} after compression, the container will close with an instance of `DataProcessingError` with
 	 * the `BatchTooLarge` message.
 	 */
 	readonly chunkSizeInBytes?: number;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3114,7 +3114,11 @@ export class ContainerRuntime
 			this.outbox.flush(resubmittingBatchId);
 			assert(this.outbox.isEmpty, 0x3cf /* reentrancy */);
 		} catch (error) {
-			const error2 = normalizeError(error);
+			const error2 = normalizeError(error, {
+				props: {
+					orderSequentiallyCalls: this.batchRunner.runs,
+				},
+			});
 			this.closeFn(error2);
 			throw error2;
 		}

--- a/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
@@ -7,7 +7,7 @@ import { IsoBuffer } from "@fluid-internal/client-utils";
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import {
-	UsageError,
+	DataProcessingError,
 	createChildLogger,
 	type ITelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
@@ -87,23 +87,23 @@ export class OpCompressor {
 		try {
 			// This is expressed as a JSON array, for legacy reasons
 			return `[${message.contents}]`;
-		} catch (newError: unknown) {
-			if ((newError as Partial<Error>).message === "Invalid string length") {
+		} catch (error: unknown) {
+			if ((error as Partial<Error>).message === "Invalid string length") {
 				// This is how string interpolation signals that
 				// the content size exceeds its capacity
-				const error = new UsageError("Payload too large");
+				const dpe = DataProcessingError.create("Payload too large", "OpCompressor");
 				this.logger.sendErrorEvent(
 					{
 						eventName: "BatchTooLarge",
 						size: batch.contentSizeInBytes,
 						length: batch.messages.length,
 					},
-					error,
+					dpe,
 				);
-				throw error;
+				throw dpe;
 			}
 
-			throw newError;
+			throw error;
 		}
 	}
 }

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import { IBatchMessage } from "@fluidframework/container-definitions/internal";
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert, Lazy } from "@fluidframework/core-utils/internal";
@@ -66,7 +65,6 @@ export interface IOutboxParameters {
 	readonly getCurrentSequenceNumbers: () => BatchSequenceNumbers;
 	readonly reSubmit: (message: PendingMessageResubmitData) => void;
 	readonly opReentrancy: () => boolean;
-	readonly closeContainer: (error?: ICriticalContainerError) => void;
 }
 
 /**
@@ -295,15 +293,16 @@ export class Outbox {
 	/**
 	 * Flush all the batches to the ordering service.
 	 * This method is expected to be called at the end of a batch.
+	 *
+	 * @throws If called from a reentrant context, or if the batch being flushed is too large.
 	 * @param resubmittingBatchId - If defined, indicates this is a resubmission of a batch
 	 * with the given Batch ID, which must be preserved
 	 */
 	public flush(resubmittingBatchId?: BatchId): void {
-		if (this.isContextReentrant()) {
-			const error = new UsageError("Flushing is not supported inside DDS event handlers");
-			this.params.closeContainer(error);
-			throw error;
-		}
+		assert(
+			!this.isContextReentrant(),
+			"Flushing must not happen while incoming changes are being processed",
+		);
 
 		this.flushAll(resubmittingBatchId);
 	}
@@ -508,15 +507,21 @@ export class Outbox {
 		}
 
 		if (compressedBatch.contentSizeInBytes >= this.params.config.maxBatchSizeInBytes) {
-			throw new GenericError("BatchTooLarge", /* error */ undefined, {
-				batchSize: singletonBatch.contentSizeInBytes,
-				compressedBatchSize: compressedBatch.contentSizeInBytes,
-				count: compressedBatch.messages.length,
-				limit: this.params.config.maxBatchSizeInBytes,
-				chunkingEnabled: this.params.splitter.isBatchChunkingEnabled,
-				compressionOptions: JSON.stringify(this.params.config.compressionOptions),
-				socketSize: estimateSocketSize(singletonBatch),
-			});
+			const dpe = DataProcessingError.create(
+				"Compressed batch still too large",
+				"flush",
+				/* sequencedMessage */ undefined,
+				{
+					batchSize: singletonBatch.contentSizeInBytes,
+					compressedBatchSize: compressedBatch.contentSizeInBytes,
+					count: compressedBatch.messages.length,
+					limit: this.params.config.maxBatchSizeInBytes,
+					chunkingEnabled: this.params.splitter.isBatchChunkingEnabled,
+					compressionOptions: JSON.stringify(this.params.config.compressionOptions),
+					socketSize: estimateSocketSize(singletonBatch),
+				},
+			);
+			this.logger.sendErrorEvent({ eventName: "BatchTooLarge" }, dpe);
 		}
 
 		return compressedBatch;

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -522,6 +522,7 @@ export class Outbox {
 				},
 			);
 			this.logger.sendErrorEvent({ eventName: "BatchTooLarge" }, dpe);
+			throw dpe;
 		}
 
 		return compressedBatch;

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -507,9 +507,9 @@ export class Outbox {
 		}
 
 		if (compressedBatch.contentSizeInBytes >= this.params.config.maxBatchSizeInBytes) {
-			const dpe = DataProcessingError.create(
-				"Compressed batch still too large",
-				"flush",
+			throw DataProcessingError.create(
+				"BatchTooLarge",
+				"compressionInsufficient",
 				/* sequencedMessage */ undefined,
 				{
 					batchSize: singletonBatch.contentSizeInBytes,
@@ -521,8 +521,6 @@ export class Outbox {
 					socketSize: estimateSocketSize(singletonBatch),
 				},
 			);
-			this.logger.sendErrorEvent({ eventName: "BatchTooLarge" }, dpe);
-			throw dpe;
 		}
 
 		return compressedBatch;

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -543,10 +543,7 @@ describe("Runtime", () => {
 						const error = getFirstContainerError();
 						assert(isFluidError(error));
 						assert.strictEqual(error.errorType, ContainerErrorTypes.genericError);
-						assert.strictEqual(
-							error.message,
-							`${expectedOrderSequentiallyErrorMessage}: 0x24c`,
-						);
+						assert.strictEqual(error.message, "0x24c");
 						assert.strictEqual(error.getTelemetryProperties().orderSequentiallyCalls, 1);
 					});
 
@@ -563,10 +560,7 @@ describe("Runtime", () => {
 						const error = getFirstContainerError();
 						assert(isFluidError(error));
 						assert.strictEqual(error.errorType, ContainerErrorTypes.genericError);
-						assert.strictEqual(
-							error.message,
-							`${expectedOrderSequentiallyErrorMessage}: 0x24c`,
-						);
+						assert.strictEqual(error.message, "0x24c");
 						assert.strictEqual(error.getTelemetryProperties().orderSequentiallyCalls, 2);
 					});
 
@@ -585,10 +579,7 @@ describe("Runtime", () => {
 						const error = getFirstContainerError();
 						assert(isFluidError(error));
 						assert.strictEqual(error.errorType, ContainerErrorTypes.genericError);
-						assert.strictEqual(
-							error.message,
-							`${expectedOrderSequentiallyErrorMessage}: 0x24c`,
-						);
+						assert.strictEqual(error.message, "0x24c");
 						assert.strictEqual(error.getTelemetryProperties().orderSequentiallyCalls, 2);
 					});
 

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "node:assert";
 
-import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import {
 	IDeltaManager,
 	IBatchMessage,
@@ -250,7 +249,6 @@ describe("Outbox", () => {
 				state.opsResubmitted++;
 			},
 			opReentrancy: () => state.isReentrant,
-			closeContainer: (error?: ICriticalContainerError) => {},
 		});
 	};
 

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -138,7 +138,7 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 			} catch {}
 
 			const error = await errorEvent;
-			assert.equal(error?.errorType, FluidErrorTypes.genericError);
+			assert.equal(error?.errorType, FluidErrorTypes.dataProcessingError);
 			assert.ok(error.getTelemetryProperties?.().opSize ?? 0 > maxMessageSizeInBytes);
 
 			// Limit has to be around 1Mb, but we should not assume here precise number.


### PR DESCRIPTION
## Description

Flush is often called from secondary callstacks such that an error thrown will not propagate up to user code.  However, failure to flush is a fatal error that we cannot recover from.

This change adds a try-catch to `ContainerRuntime.flush` to ensure that the container is always closed if an error is thrown.  I also went through all the errors thrown underneath there and made some tweaks to make them easier to interpret.  e.g. using `DataProcessingError` more, since this is an error type we expect consumers to monitor closely (we wouldn't want an app to sweep these flush errors under the rug).
