### PR TITLE
Update Uuid package from 9 to 11

### DIFF
--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -89,7 +89,7 @@
 	"dependencies": {
 		"@fluidframework/driver-definitions": "workspace:~",
 		"jsrsasign": "^11.0.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -101,7 +101,6 @@
 		"@fluidframework/eslint-config-fluid": "^5.7.3",
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/jsrsasign": "^10.5.12",
-		"@types/uuid": "^9.0.2",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.55.0",

--- a/examples/apps/ai-collab/package.json
+++ b/examples/apps/ai-collab/package.json
@@ -54,7 +54,6 @@
 		"@mui/material": "^6.2.1",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
-		"@types/uuid": "^9.0.2",
 		"eslint": "~8.55.0",
 		"fluid-framework": "workspace:~",
 		"mui": "^0.0.1",
@@ -67,7 +66,7 @@
 		"tinylicious": "^5.0.0",
 		"typechat": "^0.1.1",
 		"typescript": "~5.4.5",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"typeValidation": {
 		"disabled": true,

--- a/examples/apps/blobs/package.json
+++ b/examples/apps/blobs/package.json
@@ -57,7 +57,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -45,7 +45,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"style-loader": "^4.0.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -59,7 +59,6 @@
 		"@types/node": "^18.19.0",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
-		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.55.0",
 		"expect-puppeteer": "^9.0.2",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -59,7 +59,7 @@
 		"react-dom": "^18.3.1",
 		"react-grid-layout": "^1.4.4",
 		"scheduler": "^0.20.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -74,7 +74,6 @@
 		"@types/prop-types": "^15",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
-		"@types/uuid": "^9.0.2",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",

--- a/examples/apps/staging/package.json
+++ b/examples/apps/staging/package.json
@@ -53,7 +53,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -67,7 +67,6 @@
 		"@types/node": "^18.19.0",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
-		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"eslint": "~8.55.0",

--- a/examples/apps/tree-comparison/package.json
+++ b/examples/apps/tree-comparison/package.json
@@ -54,7 +54,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"tiny-typed-emitter": "^2.1.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -68,7 +68,6 @@
 		"@types/node": "^18.19.0",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
-		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"eslint": "~8.55.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/tree": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -64,7 +64,6 @@
 		"@types/node": "^18.19.0",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
-		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"eslint": "~8.55.0",

--- a/examples/service-clients/azure-client/external-controller/package.json
+++ b/examples/service-clients/azure-client/external-controller/package.json
@@ -49,7 +49,7 @@
 		"axios": "^1.8.4",
 		"events_pkg": "npm:events@^3.1.0",
 		"fluid-framework": "workspace:~",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -68,7 +68,6 @@
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "workspace:~",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.55.0",
 		"expect-puppeteer": "^9.0.2",

--- a/examples/utils/bundle-size-tests/webpack.config.cjs
+++ b/examples/utils/bundle-size-tests/webpack.config.cjs
@@ -118,8 +118,9 @@ module.exports = {
 			 * IMPORTANT: Do not add any new exceptions to this list without first doing a deep investigation on why a PR adds a new duplication, this hides a bundle size issue
 			 */
 			exclude: (instance) =>
-				// object-is depends on es-abstract 1.18.0-next, which does not satisfy the semver of other packages. We should be able to remove this when es-abstract moves to 1.18.0
-				instance.name === "es-abstract",
+				// @fluidframework/server-services-client pulls in uuid 9.0.1, and thus bundles using it get this package duplicated until the version of server used in client gets updated.
+				// This should not impact size sensitive application as they typically don't include a copy of the server.
+				instance.name === "uuid",
 		}),
 		new BundleAnalyzerPlugin({
 			analyzerMode: "static",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -85,7 +85,6 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
-		"@types/uuid": "^9.0.2",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.55.0",
 		"rimraf": "^4.4.0",

--- a/examples/utils/migration-tools/package.json
+++ b/examples/utils/migration-tools/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/server-local-server": "^5.0.0",
 		"@fluidframework/tinylicious-driver": "workspace:~",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -87,7 +87,6 @@
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.3",
 		"@microsoft/api-extractor": "7.50.1",
-		"@types/uuid": "^9.0.2",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.55.0",

--- a/examples/utils/webpack-fluid-loader/package.json
+++ b/examples/utils/webpack-fluid-loader/package.json
@@ -107,7 +107,7 @@
 		"isomorphic-fetch": "^3.0.0",
 		"nconf": "^0.12.0",
 		"sillyname": "^0.1.0",
-		"uuid": "^9.0.0",
+		"uuid": "^11.1.0",
 		"webpack-dev-server": "~4.15.2"
 	},
 	"devDependencies": {
@@ -122,7 +122,6 @@
 		"@types/fs-extra": "^9.0.11",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -56,7 +56,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -70,7 +70,6 @@
 		"@types/node": "^18.19.0",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
-		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"eslint": "~8.55.0",

--- a/examples/version-migration/separate-container/package.json
+++ b/examples/version-migration/separate-container/package.json
@@ -60,7 +60,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -74,7 +74,6 @@
 		"@types/node": "^18.19.0",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
-		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"eslint": "~8.55.0",

--- a/examples/version-migration/tree-shim/package.json
+++ b/examples/version-migration/tree-shim/package.json
@@ -55,7 +55,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"tiny-typed-emitter": "^2.1.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -68,7 +68,6 @@
 		"@types/jest-environment-puppeteer": "workspace:~",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
-		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"eslint": "~8.55.0",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -55,7 +55,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -70,7 +70,7 @@
 		"lz4js": "^0.2.0",
 		"msgpackr": "^1.10.1",
 		"pako": "^2.0.4",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -93,7 +93,6 @@
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"chai": "^4.2.0",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -76,7 +76,7 @@
 		"buffer": "^6.0.3",
 		"denque": "^1.5.1",
 		"lru-cache": "^6.0.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -99,7 +99,6 @@
 		"@types/chai": "^4.0.0",
 		"@types/lru-cache": "^5.1.0",
 		"@types/mocha": "^10.0.10",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"chai": "^4.2.0",
 		"concurrently": "^8.2.1",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -90,7 +90,7 @@
 		"@fluidframework/driver-utils": "workspace:~",
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/shared-object-base": "workspace:~",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -105,7 +105,6 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -124,7 +124,7 @@
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -140,7 +140,6 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -156,7 +156,7 @@
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"double-ended-queue": "^2.1.0-0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -177,7 +177,6 @@
 		"@types/double-ended-queue": "^2.1.0",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -126,7 +126,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -143,7 +143,6 @@
 		"@types/benchmark": "^2.1.0",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"benchmark": "^2.1.4",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -94,7 +94,7 @@
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"mocha": "^10.8.2",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -107,7 +107,6 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -166,7 +166,7 @@
 		"@tylerbu/sorted-btree-es6": "^1.8.0",
 		"@types/ungap__structured-clone": "^1.2.0",
 		"@ungap/structured-clone": "^1.2.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -190,7 +190,6 @@
 		"@types/easy-table": "^0.0.32",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"ajv": "^8.12.0",
 		"ajv-formats": "^3.0.1",
 		"c8": "^8.0.1",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -130,7 +130,7 @@
 		"@fluidframework/server-test-utils": "^5.0.0",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"jsrsasign": "^11.0.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -145,7 +145,6 @@
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -125,7 +125,7 @@
 		"@fluidframework/odsp-driver-definitions": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"socket.io-client": "~4.7.5",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -140,7 +140,6 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -126,7 +126,7 @@
 		"cross-fetch": "^3.1.5",
 		"json-stringify-safe": "5.0.1",
 		"socket.io-client": "~4.7.5",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -142,7 +142,6 @@
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
-		"@types/uuid": "^9.0.2",
 		"axios": "^1.8.4",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -89,7 +89,7 @@
 		"@fluidframework/driver-utils": "workspace:~",
 		"@fluidframework/routerlicious-driver": "workspace:~",
 		"jsrsasign": "^11.0.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -104,7 +104,6 @@
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -97,7 +97,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -109,7 +109,6 @@
 		"@fluidframework/eslint-config-fluid": "^5.7.3",
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.55.0",

--- a/packages/framework/ai-collab/package.json
+++ b/packages/framework/ai-collab/package.json
@@ -117,7 +117,7 @@
 		"fastest-levenshtein": "^1.0.16",
 		"openai": "^4.67.3",
 		"typechat": "^0.1.1",
-		"uuid": "^9.0.0",
+		"uuid": "^11.1.0",
 		"zod": "^3.23.8"
 	},
 	"devDependencies": {
@@ -134,7 +134,6 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -97,7 +97,7 @@
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/fluid-static": "workspace:~",
 		"@microsoft/applicationinsights-web": "^2.8.11",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -113,7 +113,6 @@
 		"@types/chai": "^4.0.0",
 		"@types/mocha": "^10.0.10",
 		"@types/sinon": "^17.0.3",
-		"@types/uuid": "^9.0.2",
 		"chai": "^4.2.0",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -179,7 +179,7 @@
 		"debug": "^4.3.4",
 		"double-ended-queue": "^2.1.0-0",
 		"events_pkg": "npm:events@^3.1.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -199,7 +199,6 @@
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
 		"@types/ungap__structured-clone": "^1.2.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -122,7 +122,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"axios": "^1.8.4",
 		"lz4js": "^0.2.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -137,7 +137,6 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -184,7 +184,7 @@
 		"@tylerbu/sorted-btree-es6": "^1.8.0",
 		"double-ended-queue": "^2.1.0-0",
 		"lz4js": "^0.2.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -205,7 +205,6 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -128,7 +128,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -145,7 +145,6 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@tylerbu/sorted-btree-es6": "^1.8.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -149,7 +149,6 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -126,7 +126,7 @@
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"jsrsasign": "^11.0.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -141,7 +141,6 @@
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -116,7 +116,6 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
@@ -127,7 +126,7 @@
 		"rimraf": "^4.4.0",
 		"start-server-and-test": "^2.0.3",
 		"typescript": "~5.4.5",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -89,7 +89,7 @@
 		"sinon": "^18.0.1",
 		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^5.0.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -101,7 +101,6 @@
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"eslint": "~8.55.0",
 		"nock": "^13.3.3",

--- a/packages/service-clients/end-to-end-tests/odsp-client/package.json
+++ b/packages/service-clients/end-to-end-tests/odsp-client/package.json
@@ -74,7 +74,7 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"moment": "^2.21.0",
 		"sinon": "^18.0.1",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -84,7 +84,6 @@
 		"@types/mocha": "^10.0.10",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.55.0",

--- a/packages/service-clients/odsp-client/package.json
+++ b/packages/service-clients/odsp-client/package.json
@@ -115,7 +115,7 @@
 		"@fluidframework/odsp-driver": "workspace:~",
 		"@fluidframework/odsp-driver-definitions": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -129,7 +129,6 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/test/local-server-stress-tests/package.json
+++ b/packages/test/local-server-stress-tests/package.json
@@ -83,13 +83,12 @@
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
 		"@fluidframework/tree": "workspace:~",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.55.0",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -70,7 +70,7 @@
 		"agentkeepalive": "^4.5.0",
 		"axios": "^1.8.4",
 		"semver": "^7.5.3",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -81,7 +81,6 @@
 		"@fluidframework/eslint-config-fluid": "^5.7.3",
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.55.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -126,7 +126,7 @@
 		"sinon": "^18.0.1",
 		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^5.0.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -138,7 +138,6 @@
 		"@types/mocha": "^10.0.10",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"eslint": "~8.55.0",
 		"mocha-multi-reporters": "^1.5.1",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -135,7 +135,7 @@
 		"best-random": "^1.0.0",
 		"debug": "^4.3.4",
 		"mocha": "^10.8.2",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -151,7 +151,6 @@
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -116,7 +116,6 @@
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",
 		"@types/semver": "^7.5.0",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
@@ -129,7 +128,7 @@
 		"rimraf": "^4.4.0",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",
-		"uuid": "^9.0.0",
+		"uuid": "^11.1.0",
 		"webpack": "^5.94.0",
 		"webpack-cli": "^5.1.4"
 	},

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -80,11 +80,10 @@
 		"@fluidframework/devtools-core": "workspace:~",
 		"@microsoft/1ds-core-js": "^3.2.13",
 		"@microsoft/1ds-post-js": "^3.2.13",
-		"@types/uuid": "^9.0.2",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"tslib": "^1.10.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -120,7 +120,7 @@
 		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"debug": "^4.3.4",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -136,7 +136,6 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,8 +154,8 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -184,9 +184,6 @@ importers:
       '@types/jsrsasign':
         specifier: ^10.5.12
         version: 10.5.15
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -280,9 +277,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       eslint:
         specifier: ~8.55.0
         version: 8.55.0
@@ -320,8 +314,8 @@ importers:
         specifier: ~5.4.5
         version: 5.4.5
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
 
   examples/apps/attributable-map:
     dependencies:
@@ -462,8 +456,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -716,8 +710,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.97.1)
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -752,9 +746,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -879,8 +870,8 @@ importers:
         specifier: ^0.20.0
         version: 0.20.2
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -918,9 +909,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -1181,8 +1169,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -1217,9 +1205,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1517,8 +1502,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -1553,9 +1538,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -3846,8 +3828,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -3885,9 +3867,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -4326,8 +4305,8 @@ importers:
         specifier: workspace:~
         version: link:../../../../packages/framework/fluid-framework
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -4377,9 +4356,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -4722,8 +4698,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -4752,9 +4728,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -4880,8 +4853,8 @@ importers:
         specifier: workspace:~
         version: link:../../../packages/drivers/tinylicious-driver
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -4904,9 +4877,6 @@ importers:
       '@microsoft/api-extractor':
         specifier: 7.50.1
         version: 7.50.1(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@22.10.1)
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -4998,8 +4968,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
       webpack-dev-server:
         specifier: ~4.15.2
         version: 4.15.2(webpack-cli@5.1.4)(webpack@5.97.1)
@@ -5037,9 +5007,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -5273,8 +5240,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -5309,9 +5276,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -5454,8 +5418,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -5490,9 +5454,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -5617,8 +5578,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -5650,9 +5611,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -5895,8 +5853,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -6358,8 +6316,8 @@ importers:
         specifier: ^2.0.4
         version: 2.1.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -6421,9 +6379,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       chai:
         specifier: ^4.2.0
         version: 4.5.0
@@ -6988,8 +6943,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -7045,9 +7000,6 @@ importers:
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -7909,8 +7861,8 @@ importers:
         specifier: workspace:~
         version: link:../shared-object-base
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -7948,9 +7900,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8399,8 +8348,8 @@ importers:
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -8441,9 +8390,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8711,8 +8657,8 @@ importers:
         specifier: ^2.1.0-0
         version: 2.1.0-0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -8768,9 +8714,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8844,8 +8787,8 @@ importers:
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -8889,9 +8832,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       benchmark:
         specifier: ^2.1.4
         version: 2.1.4
@@ -9180,8 +9120,8 @@ importers:
         specifier: ^10.8.2
         version: 10.8.2
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -9213,9 +9153,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -9295,8 +9232,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.1
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -9361,9 +9298,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       ajv:
         specifier: ^8.12.0
         version: 8.17.1
@@ -9741,8 +9675,8 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -9780,9 +9714,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -9850,8 +9781,8 @@ importers:
         specifier: ~4.7.5
         version: 4.7.5
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -9889,9 +9820,6 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -10163,8 +10091,8 @@ importers:
         specifier: ~4.7.5
         version: 4.7.5
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -10205,9 +10133,6 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       axios:
         specifier: ^1.8.4
         version: 1.8.4(debug@4.4.0)
@@ -10348,8 +10273,8 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -10387,9 +10312,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -10448,8 +10370,8 @@ importers:
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -10478,9 +10400,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -10521,8 +10440,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1(typescript@5.4.5)(zod@3.24.0)
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
       zod:
         specifier: ^3.23.8
         version: 3.24.0
@@ -10563,9 +10482,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -10930,8 +10846,8 @@ importers:
         specifier: ^2.8.11
         version: 2.8.18(tslib@1.14.1)
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -10972,9 +10888,6 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       chai:
         specifier: ^4.2.0
         version: 4.5.0
@@ -11843,8 +11756,8 @@ importers:
         specifier: npm:events@^3.1.0
         version: events@3.3.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -11894,9 +11807,6 @@ importers:
       '@types/ungap__structured-clone':
         specifier: ^1.2.0
         version: 1.2.0
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -11955,8 +11865,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -11994,9 +11904,6 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -12131,8 +12038,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -12188,9 +12095,6 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -12316,8 +12220,8 @@ importers:
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -12361,9 +12265,6 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -12474,8 +12375,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -12516,9 +12417,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -12756,8 +12654,8 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -12795,9 +12693,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -12898,9 +12793,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -12932,8 +12824,8 @@ importers:
         specifier: ~5.4.5
         version: 5.4.5
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
 
   packages/service-clients/end-to-end-tests/azure-client:
     dependencies:
@@ -13031,8 +12923,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -13061,9 +12953,6 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -13146,8 +13035,8 @@ importers:
         specifier: ^18.0.1
         version: 18.0.1
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -13170,9 +13059,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -13228,8 +13114,8 @@ importers:
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -13264,9 +13150,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -13623,8 +13506,8 @@ importers:
         specifier: workspace:~
         version: link:../../dds/tree
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -13635,9 +13518,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14141,8 +14021,8 @@ importers:
         specifier: ^7.5.3
         version: 7.7.1
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -14168,9 +14048,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -14340,8 +14217,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -14370,9 +14247,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14655,8 +14529,8 @@ importers:
         specifier: ^10.8.2
         version: 10.8.2
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -14697,9 +14571,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14863,9 +14734,6 @@ importers:
       '@types/semver':
         specifier: ^7.5.0
         version: 7.5.8
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14903,8 +14771,8 @@ importers:
         specifier: ~5.4.5
         version: 5.4.5
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
       webpack:
         specifier: ^5.94.0
         version: 5.97.1(webpack-cli@5.1.4)
@@ -15072,9 +14940,6 @@ importers:
       '@microsoft/1ds-post-js':
         specifier: ^3.2.13
         version: 3.2.18(tslib@1.14.1)
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -15085,8 +14950,8 @@ importers:
         specifier: ^1.10.0
         version: 1.14.1
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -16188,8 +16053,8 @@ importers:
         specifier: ^4.3.4
         version: 4.4.0(supports-color@8.1.1)
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -16230,9 +16095,6 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -19644,9 +19506,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/valid-url@1.0.7':
     resolution: {integrity: sha512-tgsWVG80dM5PVEBSbXUttPJTBCOo0IKbBh4R4z/SHsC5C81A3aaUH4fsbj+JYk7fopApU/Mao1c0EWTE592TSg==}
@@ -27436,6 +27295,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -34251,8 +34114,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/uuid@9.0.8': {}
 
   '@types/valid-url@1.0.7': {}
 
@@ -44076,6 +43937,8 @@ snapshots:
   utila@0.4.0: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@11.1.0: {}
 
   uuid@8.3.2: {}
 

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -74,7 +74,7 @@
 		"semver": "^7.5.3",
 		"serialize-error": "^8.1.0",
 		"sha.js": "^2.4.11",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "0.52.0-315632",
@@ -90,7 +90,6 @@
 		"@types/nconf": "^0.10.2",
 		"@types/node": "^18.19.39",
 		"@types/sinon": "^17.0.3",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -68,7 +68,7 @@
 		"debug": "^4.3.4",
 		"events_pkg": "npm:events@^3.1.0",
 		"jsrsasign": "^11.0.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "0.52.0-315632",
@@ -82,7 +82,6 @@
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.39",
 		"@types/sinon": "^17.0.3",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -74,7 +74,7 @@
 		"events": "^3.1.0",
 		"lodash": "^4.17.21",
 		"sillyname": "^0.1.0",
-		"uuid": "^9.0.0",
+		"uuid": "^11.1.0",
 		"ws": "^7.5.10"
 	},
 	"devDependencies": {
@@ -84,7 +84,6 @@
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@5.0.0",
 		"@types/mocha": "^10.0.1",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -81,7 +81,7 @@
 		"serialize-error": "^8.1.0",
 		"sha.js": "^2.4.11",
 		"sillyname": "^0.1.0",
-		"uuid": "^9.0.0",
+		"uuid": "^11.1.0",
 		"winston": "^3.6.0",
 		"ws": "^7.5.10"
 	},
@@ -109,7 +109,6 @@
 		"@types/sinon": "^17.0.3",
 		"@types/split": "^0.3.28",
 		"@types/supertest": "^2.0.5",
-		"@types/uuid": "^9.0.2",
 		"@types/ws": "^6.0.1",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -70,7 +70,7 @@
 		"jsrsasign": "^11.0.0",
 		"jwt-decode": "^4.0.0",
 		"sillyname": "^0.1.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "0.52.0-315632",
@@ -83,7 +83,6 @@
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.19.39",
-		"@types/uuid": "^9.0.2",
 		"axios-mock-adapter": "^1.19.0",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -75,7 +75,7 @@
 		"socket.io": "^4.8.0",
 		"socket.io-adapter": "^2.5.5",
 		"socket.io-parser": "^4.2.4",
-		"uuid": "^9.0.0",
+		"uuid": "^11.1.0",
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
@@ -92,7 +92,6 @@
 		"@types/nconf": "^0.10.2",
 		"@types/node": "^18.19.39",
 		"@types/supertest": "^2.0.5",
-		"@types/uuid": "^9.0.2",
 		"axios": "^1.8.4",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -56,7 +56,7 @@
 		"json-stringify-safe": "^5.0.1",
 		"path-browserify": "^1.0.1",
 		"serialize-error": "^8.1.0",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "0.52.0-315632",
@@ -68,7 +68,6 @@
 		"@types/node": "^18.19.39",
 		"@types/sinon": "^17.0.3",
 		"@types/supertest": "^2.0.5",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -67,7 +67,7 @@
 		"serialize-error": "^8.1.0",
 		"sillyname": "^0.1.0",
 		"split": "^1.0.0",
-		"uuid": "^9.0.0",
+		"uuid": "^11.1.0",
 		"winston": "^3.6.0",
 		"winston-transport": "^4.5.0"
 	},
@@ -88,7 +88,6 @@
 		"@types/nconf": "^0.10.2",
 		"@types/node": "^18.19.39",
 		"@types/supertest": "^2.0.5",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -73,7 +73,7 @@
 		"nconf": "^0.12.0",
 		"socket.io": "^4.8.0",
 		"telegrafjs": "^0.1.3",
-		"uuid": "^9.0.0",
+		"uuid": "^11.1.0",
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
@@ -89,7 +89,6 @@
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.19.39",
 		"@types/sinon": "^17.0.3",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -66,7 +66,7 @@
 		"ioredis-mock": "^8.8.2",
 		"lodash": "^4.17.21",
 		"string-hash": "^1.1.3",
-		"uuid": "^9.0.0"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@fluid-tools/build-cli": "0.52.0-315632",
@@ -79,7 +79,6 @@
 		"@types/node": "^18.19.39",
 		"@types/sinon": "^17.0.3",
 		"@types/string-hash": "^1.1.1",
-		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",

--- a/server/routerlicious/packages/tinylicious/package.json
+++ b/server/routerlicious/packages/tinylicious/package.json
@@ -67,7 +67,7 @@
 		"nconf": "^0.12.0",
 		"socket.io": "^4.8.0",
 		"split": "^1.0.0",
-		"uuid": "^9.0.0",
+		"uuid": "^11.1.0",
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
@@ -89,7 +89,6 @@
 		"@types/node": "^18.19.39",
 		"@types/rimraf": "^3.0.0",
 		"@types/split": "^0.3.28",
-		"@types/uuid": "^9.0.2",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.55.0",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -220,8 +220,8 @@ importers:
         specifier: ^2.4.11
         version: 2.4.11
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
         specifier: 0.52.0-315632
@@ -262,9 +262,6 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.2
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -420,8 +417,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
         specifier: 0.52.0-315632
@@ -456,9 +453,6 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.2
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -556,8 +550,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^11.1.0
+        version: 11.1.0
       ws:
         specifier: ^7.5.10
         version: 7.5.10
@@ -580,9 +574,6 @@ importers:
       '@types/mocha':
         specifier: ^10.0.1
         version: 10.0.1
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.2
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -871,8 +862,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^11.1.0
+        version: 11.1.0
       winston:
         specifier: ^3.6.0
         version: 3.9.0
@@ -949,9 +940,6 @@ importers:
       '@types/supertest':
         specifier: ^2.0.5
         version: 2.0.12
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.2
       '@types/ws':
         specifier: ^6.0.1
         version: 6.0.4
@@ -1052,8 +1040,8 @@ importers:
         specifier: ^0.1.3
         version: 0.1.3
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^11.1.0
+        version: 11.1.0
       winston:
         specifier: ^3.6.0
         version: 3.9.0
@@ -1094,9 +1082,6 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.2
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -1161,8 +1146,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
         specifier: 0.52.0-315632
@@ -1194,9 +1179,6 @@ importers:
       '@types/node':
         specifier: ^18.19.39
         version: 18.19.39
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.2
       axios-mock-adapter:
         specifier: ^1.19.0
         version: 1.21.5(axios@1.8.4(debug@4.3.4))
@@ -1592,8 +1574,8 @@ importers:
         specifier: ^4.2.4
         version: 4.2.4
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^11.1.0
+        version: 11.1.0
       winston:
         specifier: ^3.6.0
         version: 3.9.0
@@ -1637,9 +1619,6 @@ importers:
       '@types/supertest':
         specifier: ^2.0.5
         version: 2.0.12
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.2
       axios:
         specifier: ^1.8.4
         version: 1.8.4(debug@4.3.4)
@@ -1683,8 +1662,8 @@ importers:
         specifier: ^8.1.0
         version: 8.1.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
         specifier: 0.52.0-315632
@@ -1713,9 +1692,6 @@ importers:
       '@types/supertest':
         specifier: ^2.0.5
         version: 2.0.12
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.2
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -1786,8 +1762,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.1
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^11.1.0
+        version: 11.1.0
       winston:
         specifier: ^3.6.0
         version: 3.9.0
@@ -1843,9 +1819,6 @@ importers:
       '@types/supertest':
         specifier: ^2.0.5
         version: 2.0.12
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.2
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -1919,8 +1892,8 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
         specifier: 0.52.0-315632
@@ -1952,9 +1925,6 @@ importers:
       '@types/string-hash':
         specifier: ^1.1.1
         version: 1.1.1
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.2
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -2076,8 +2046,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.1
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
       winston:
         specifier: ^3.6.0
         version: 3.9.0
@@ -2136,9 +2106,6 @@ importers:
       '@types/split':
         specifier: ^0.3.28
         version: 0.3.28
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.2
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -2555,6 +2522,7 @@ packages:
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -2562,6 +2530,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.2':
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
+    deprecated: Use @eslint/object-schema instead
 
   '@inquirer/checkbox@4.0.6':
     resolution: {integrity: sha512-PgP35JfmGjHU0LSXOyRew0zHuA9N6OJwOlos1fZ20b7j8ISeAdib3L+n0jIxBtX958UeEpte6xhG/gxJ5iUqMw==}
@@ -3491,9 +3460,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/uuid@9.0.2':
-    resolution: {integrity: sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==}
 
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
@@ -5000,6 +4966,7 @@ packages:
   eslint@8.55.0:
     resolution: {integrity: sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.6.1:
@@ -5420,6 +5387,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -5649,6 +5617,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -6153,10 +6122,12 @@ packages:
   level-codec@9.0.2:
     resolution: {integrity: sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==}
     engines: {node: '>=6'}
+    deprecated: Superseded by level-transcoder (https://github.com/Level/community#faq)
 
   level-errors@2.0.1:
     resolution: {integrity: sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==}
     engines: {node: '>=6'}
+    deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
 
   level-iterator-stream@2.0.3:
     resolution: {integrity: sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==}
@@ -6224,6 +6195,7 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -6236,6 +6208,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -6873,6 +6846,7 @@ packages:
 
   npmlog@4.1.2:
     resolution: {integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==}
+    deprecated: This package is no longer supported.
 
   npmlog@6.0.2:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
@@ -8084,7 +8058,7 @@ packages:
   superagent@3.8.3:
     resolution: {integrity: sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   supertest@3.4.2:
     resolution: {integrity: sha512-WZWbwceHUo2P36RoEIdXvmqfs47idNNZjCuJOqDz6rvtkk8ym56aU5oglORCpPeXGxT7l9rkJ41+O1lffQXYSA==}
@@ -8508,13 +8482,13 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-
-  uuid@9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
 
   uuid@9.0.1:
@@ -11922,8 +11896,6 @@ snapshots:
   '@types/ungap__structured-clone@1.2.0': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/uuid@9.0.2': {}
 
   '@types/webidl-conversions@7.0.3': {}
 
@@ -17935,9 +17907,9 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@3.4.0: {}
+  uuid@11.1.0: {}
 
-  uuid@9.0.0: {}
+  uuid@3.4.0: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
## Description

Update the version of the uuid package. It is now written in TypeScript, avoids throwing a caught exception on load and now officially supports node 20 (which we use).

More details in [the changelog](https://github.com/uuidjs/uuid/blob/main/CHANGELOG.md).

The updated version of uuid, at least the subset of it pulled into the tree package is 1041 bytes, where the old one was 868, so this does regress bundle size by 173 bytes uncompressed: the regression should be less for the compressed and parsed sizes.

I think 173 bytes is acceptable for the developer workflow improvement of not having exceptions on startup (once the server update is pulled into client) or dealing with the separate types package. The tree bundle being considered here is 357568 making this a regression of approximately 0.048%, about the same as we would see from adding a nice UssageError to an API.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
