### PR TITLE
Fix build for ES2022

### DIFF
--- a/packages/runtime/container-runtime/src/test/createChildDataStoreSync.spec.ts
+++ b/packages/runtime/container-runtime/src/test/createChildDataStoreSync.spec.ts
@@ -31,7 +31,12 @@ describe("createChildDataStore", () => {
 	};
 	const testContext = class TestContext extends FluidDataStoreContext {
 		protected pkg = ["ParentDataStore"];
-		public registry: IFluidDataStoreRegistry | undefined;
+		// This is a override of a protected property to expose it publicly, however TypeScript does not allow override to be used here to make this explicit.
+		// This TypeScript issue is tracked by https://github.com/microsoft/TypeScript/issues/51515.
+		// When targeting ES2022 or newer, TypeScript uses ESM properties here, which would overwrite the base property giving the error:
+		// "Property 'registry' will overwrite the base property in 'FluidDataStoreContext'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.ts(2612)"
+		// This is mitigated using `declare` to indicate that this property is only here for TypeScript typing reasons, and its declaration should have no effect at runtime.
+		public declare registry: IFluidDataStoreRegistry | undefined;
 		public getInitialSnapshotDetails = throwNYI;
 		public setAttachState = throwNYI;
 		public getAttachSummary = throwNYI;


### PR DESCRIPTION
## Description

If building client with ES2022, this fixes the only compile error.

Since using ES2022 saves over 2% (7309 bytes) on bundle size (measured using SharedTree bundles which includes all of the runtime shared tree uses as well), making it easy to enable and experiment with seems like a good idea.

Also building targeting ES2022 provides a better debug experience for JS private properties by not polyfilling them to weak map lookups.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


