### PR TITLE
Reduce factory use

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -65,7 +65,7 @@ import {
 	type TreeNode,
 	type TreeNodeSchema,
 } from "../../../simple-tree/index.js";
-import type { TreeFactory } from "../../../treeFactory.js";
+import type { IChannelFactory } from "@fluidframework/datastore-definitions/internal";
 
 export type FuzzView = SchematizingSimpleTreeView<typeof fuzzFieldSchema> & {
 	/**
@@ -95,7 +95,7 @@ export type FuzzTransactionView = SchematizingSimpleTreeView<typeof fuzzFieldSch
 	currentSchema: FuzzNodeSchema;
 };
 
-export interface FuzzTestState extends DDSFuzzTestState<TreeFactory> {
+export interface FuzzTestState extends DDSFuzzTestState<IChannelFactory<ISharedTree>> {
 	/**
 	 * Schematized view of clients and their nodeSchemas. Created lazily by viewFromState.
 	 *
@@ -123,7 +123,7 @@ export interface FuzzTestState extends DDSFuzzTestState<TreeFactory> {
 
 export function viewFromState(
 	state: FuzzTestState,
-	client: Client<TreeFactory> = state.client,
+	client: Client<IChannelFactory<ISharedTree>> = state.client,
 	forkedBranchIndex?: number | undefined,
 ): FuzzView {
 	state.clientViews ??= new Map();
@@ -695,7 +695,7 @@ export const makeConstraintEditGenerator = (
 
 export function makeOpGenerator(
 	weightsArg: Partial<EditGeneratorOpWeights> = defaultEditGeneratorOpWeights,
-): AsyncGenerator<Operation, DDSFuzzTestState<TreeFactory>> {
+): AsyncGenerator<Operation, DDSFuzzTestState<IChannelFactory<ISharedTree>>> {
 	const weights = {
 		...defaultEditGeneratorOpWeights,
 		...weightsArg,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -62,9 +62,12 @@ import {
 	type TreeNode,
 	type TreeNodeSchema,
 } from "../../../simple-tree/index.js";
-import type { TreeFactory } from "../../../treeFactory.js";
+import type { IChannelFactory } from "@fluidframework/datastore-definitions/internal";
 
-const syncFuzzReducer = combineReducers<Operation, DDSFuzzTestState<TreeFactory>>({
+const syncFuzzReducer = combineReducers<
+	Operation,
+	DDSFuzzTestState<IChannelFactory<ISharedTree>>
+>({
 	treeEdit: (state, { edit, forkedViewIndex }) => {
 		switch (edit.type) {
 			case "fieldEdit": {
@@ -96,18 +99,20 @@ const syncFuzzReducer = combineReducers<Operation, DDSFuzzTestState<TreeFactory>
 		applyForkMergeOperation(state, operation);
 	},
 });
-export const fuzzReducer: Reducer<Operation, DDSFuzzTestState<TreeFactory>> = (
-	state,
-	operation,
-) => syncFuzzReducer(state, operation);
+export const fuzzReducer: Reducer<
+	Operation,
+	DDSFuzzTestState<IChannelFactory<ISharedTree>>
+> = (state, operation) => syncFuzzReducer(state, operation);
 
-export function checkTreesAreSynchronized(trees: readonly Client<TreeFactory>[]) {
+export function checkTreesAreSynchronized(
+	trees: readonly Client<IChannelFactory<ISharedTree>>[],
+) {
 	for (const tree of trees) {
 		validateFuzzTreeConsistency(trees[0], tree);
 	}
 }
 
-export function applySynchronizationOp(state: DDSFuzzTestState<TreeFactory>) {
+export function applySynchronizationOp(state: DDSFuzzTestState<IChannelFactory<ISharedTree>>) {
 	state.containerRuntimeFactory.processAllMessages();
 	const connectedClients = state.clients.filter((client) => client.containerRuntime.connected);
 	if (connectedClients.length > 0) {

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -86,6 +86,7 @@ import {
 	expectEqualPaths,
 	type TreeMockContainerRuntime,
 	type SharedTreeWithContainerRuntime,
+	DefaultTestSharedTreeKind,
 } from "../utils.js";
 import {
 	configuredSharedTree,
@@ -95,6 +96,7 @@ import {
 import {
 	SharedObjectCore,
 	type ISharedObjectKind,
+	type SharedObjectKind,
 } from "@fluidframework/shared-object-base/internal";
 import { TestAnchor } from "../testAnchor.js";
 // eslint-disable-next-line import/no-internal-modules
@@ -115,7 +117,7 @@ const enableSchemaValidation = true;
 const DebugSharedTree = configuredSharedTree({
 	jsonValidator: typeboxValidator,
 	forest: ForestTypeReference,
-}) as ISharedObjectKind<unknown> as ISharedObjectKind<ISharedTree>;
+}) as SharedObjectKind<ISharedTree> & ISharedObjectKind<ISharedTree>;
 
 class MockSharedTreeRuntime extends MockFluidDataStoreRuntime {
 	public constructor() {
@@ -2212,9 +2214,8 @@ describe("SharedTree", () => {
 	});
 
 	it("throws an error if attaching during a transaction", () => {
-		const sharedTreeFactory = new TreeFactory({});
 		const runtime = new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() });
-		const tree = sharedTreeFactory.create(runtime, "tree");
+		const tree = DefaultTestSharedTreeKind.getFactory().create(runtime, "tree");
 		const runtimeFactory = new MockContainerRuntimeFactory();
 		runtimeFactory.createContainerRuntime(runtime);
 		const view = asTreeViewAlpha(

--- a/packages/dds/tree/src/test/shared-tree/summary.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/summary.bench.ts
@@ -32,7 +32,7 @@ import {
 	makeJsWideTreeWithEndValue,
 	WideRoot,
 } from "../scalableTestTrees.js";
-import { TreeFactory } from "../../treeFactory.js";
+import { configuredSharedTree } from "../../treeFactory.js";
 
 // TODO: these tests currently only cover tree content.
 // It might make sense to extend them to cover complex collaboration windows.
@@ -115,7 +115,7 @@ describe("Summary benchmarks", () => {
 			type: BenchmarkType,
 		) {
 			let summaryTree: ITree;
-			const factory = new TreeFactory({});
+			const factory = configuredSharedTree({}).getFactory();
 			benchmark({
 				title,
 				type,

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -16,6 +16,7 @@ import { type JsonCompatible, brand } from "../../util/index.js";
 import {
 	chunkFromJsonTrees,
 	createTestUndoRedoStacks,
+	DefaultTestSharedTreeKind,
 	expectJsonTree,
 	getView,
 	moveWithin,
@@ -36,7 +37,6 @@ import {
 } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { initialize } from "../../shared-tree/schematizeTree.js";
-import { TreeFactory } from "../../treeFactory.js";
 
 const rootPath: NormalizedUpPath = {
 	detachedNodeId: undefined,
@@ -489,9 +489,8 @@ describe("Undo and redo", () => {
 	it("can undo while detached", () => {
 		const sf = new SchemaFactory(undefined);
 		class Schema extends sf.object("Object", { foo: sf.number }) {}
-		const sharedTreeFactory = new TreeFactory({});
 		const runtime = new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() });
-		const tree = sharedTreeFactory.create(runtime, "tree");
+		const tree = DefaultTestSharedTreeKind.getFactory().create(runtime, "tree");
 		const view = asTreeViewAlpha(tree.viewWith(new TreeViewConfiguration({ schema: Schema })));
 		view.initialize({ foo: 1 });
 		assert.equal(tree.isAttached(), false);
@@ -703,7 +702,7 @@ describe("Undo and redo", () => {
  * @param attachTree - whether or not the SharedTree should be attached to the Fluid runtime
  */
 export function createCheckout(json: JsonCompatible[], attachTree: boolean): ITreeCheckout {
-	const sharedTreeFactory = new TreeFactory({});
+	const sharedTreeFactory = DefaultTestSharedTreeKind.getFactory();
 	const runtime = new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() });
 	const tree = sharedTreeFactory.create(runtime, "tree");
 	const runtimeFactory = new MockContainerRuntimeFactory();

--- a/packages/dds/tree/src/test/simple-tree/api/schemaCreationUtilities.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaCreationUtilities.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "node:assert";
 
 import { unreachableCase } from "@fluidframework/core-utils/internal";
-import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import {
 	type NodeFromSchema,
@@ -22,8 +21,7 @@ import {
 	enumFromStrings,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../simple-tree/api/schemaCreationUtilities.js";
-import { TreeFactory } from "../../../treeFactory.js";
-import { testIdCompressor, validateUsageError } from "../../utils.js";
+import { getView, validateUsageError } from "../../utils.js";
 import {
 	unsafeArrayToTuple,
 	type areSafelyAssignable,
@@ -40,12 +38,7 @@ describe("schemaCreationUtilities", () => {
 		class Parent extends schema.object("Parent", { mode: Mode.schema }) {}
 		const config = new TreeViewConfiguration({ schema: Parent });
 
-		const factory = new TreeFactory({});
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: testIdCompressor }),
-			"tree",
-		);
-		const view: TreeView<typeof Parent> = tree.viewWith(config);
+		const view: TreeView<typeof Parent> = getView(config);
 		view.initialize(
 			new Parent({
 				mode: new Mode.Bonus(),
@@ -293,8 +286,6 @@ describe("schemaCreationUtilities", () => {
 	});
 
 	it("enum interop - enumFromStrings", () => {
-		const factory = new TreeFactory({});
-
 		enum Day {
 			Today = "Today",
 			Tomorrow = "Tomorrow",
@@ -302,14 +293,9 @@ describe("schemaCreationUtilities", () => {
 
 		const DayNodes = enumFromStrings(schema, unsafeArrayToTuple(Object.values(Day)));
 
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: testIdCompressor }),
-			"tree",
-		);
-
 		const day = Day.Today;
 
-		const view = tree.viewWith(new TreeViewConfiguration({ schema: DayNodes.schema }));
+		const view = getView(new TreeViewConfiguration({ schema: DayNodes.schema }));
 		view.initialize(DayNodes(day));
 
 		switch (view.root.value) {
@@ -326,8 +312,6 @@ describe("schemaCreationUtilities", () => {
 	});
 
 	it("enum interop - adaptEnum", () => {
-		const factory = new TreeFactory({});
-
 		enum Day {
 			Today = "today",
 			Tomorrow = "tomorrow",
@@ -335,18 +319,13 @@ describe("schemaCreationUtilities", () => {
 
 		const DayNodes = adaptEnum(schema, Day);
 
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: testIdCompressor }),
-			"tree",
-		);
-
 		// Can convert enum to unhydrated node:
 		const x = DayNodes(Day.Today);
 		// Can construct unhydrated node from enum's key:
 		const y = new DayNodes.Today();
 		const z: Day.Today = y.value;
 
-		const view = tree.viewWith(new TreeViewConfiguration({ schema: DayNodes.schema }));
+		const view = getView(new TreeViewConfiguration({ schema: DayNodes.schema }));
 		view.initialize(DayNodes(Day.Today));
 
 		switch (view.root.value) {
@@ -371,8 +350,6 @@ describe("schemaCreationUtilities", () => {
 	});
 
 	it("enum interop - adaptEnum numeric", () => {
-		const factory = new TreeFactory({});
-
 		enum Day {
 			Today = 2,
 			Tomorrow = 3,
@@ -380,18 +357,13 @@ describe("schemaCreationUtilities", () => {
 
 		const DayNodes = adaptEnum(schema, Day);
 
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: testIdCompressor }),
-			"tree",
-		);
-
 		// Can convert enum to unhydrated node:
 		const x = DayNodes(Day.Today);
 		// Can construct unhydrated node from enum's key:
 		const y = new DayNodes.Today();
 		const z: Day.Today = y.value;
 
-		const view = tree.viewWith(new TreeViewConfiguration({ schema: DayNodes.schema }));
+		const view = getView(new TreeViewConfiguration({ schema: DayNodes.schema }));
 		view.initialize(DayNodes(Day.Today));
 
 		switch (view.root.value) {

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactory.examples.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactory.examples.spec.ts
@@ -15,7 +15,7 @@ import {
 	TreeViewConfiguration,
 	type TreeView,
 } from "../../../simple-tree/index.js";
-import { TreeFactory } from "../../../treeFactory.js";
+import { DefaultTestSharedTreeKind, getView } from "../../utils.js";
 
 // Since this no longer follows the builder pattern, it is a SchemaFactory instead of a SchemaBuilder.
 const schema = new SchemaFactory("com.example");
@@ -101,7 +101,7 @@ function setup(tree: ITree): Note[] {
 
 describe("Class based end to end example", () => {
 	it("run example", () => {
-		const factory = new TreeFactory({});
+		const factory = DefaultTestSharedTreeKind.getFactory();
 		const theTree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
@@ -111,12 +111,7 @@ describe("Class based end to end example", () => {
 
 	// Confirm that the alternative syntax for initialTree from the example above actually works.
 	it("using a mix of insertable content and nodes", () => {
-		const factory = new TreeFactory({});
-		const theTree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view: TreeView<typeof Canvas> = theTree.viewWith(config);
+		const view: TreeView<typeof Canvas> = getView(config);
 		view.initialize(
 			new Canvas({
 				stuff: [

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
@@ -6,9 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import { oob, unreachableCase } from "@fluidframework/core-utils/internal";
-import { createIdCompressor } from "@fluidframework/id-compressor/internal";
 import {
-	MockFluidDataStoreRuntime,
 	MockHandle,
 	validateAssertionError,
 } from "@fluidframework/test-runtime-utils/internal";
@@ -47,7 +45,6 @@ import type {
 	TreeNodeFromImplicitAllowedTypes,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../simple-tree/schemaTypes.js";
-import { TreeFactory } from "../../../treeFactory.js";
 import type {
 	areSafelyAssignable,
 	requireAssignableTo,
@@ -55,7 +52,7 @@ import type {
 } from "../../../util/index.js";
 
 import { hydrate } from "../utils.js";
-import { validateUsageError } from "../../utils.js";
+import { getView, validateUsageError } from "../../utils.js";
 
 {
 	const schema = new SchemaFactory("Blah");
@@ -119,12 +116,7 @@ describe("schemaFactory", () => {
 
 		const config = new TreeViewConfiguration({ schema: schema.number });
 
-		const factory = new TreeFactory({});
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		view.initialize(5);
 		assert.equal(view.root, 5);
 	});
@@ -241,12 +233,7 @@ describe("schemaFactory", () => {
 
 			const config = new TreeViewConfiguration({ schema: Point });
 
-			const factory = new TreeFactory({});
-			const tree = factory.create(
-				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-				"tree",
-			);
-			const view = tree.viewWith(config);
+			const view = getView(config);
 			view.initialize(new Point({ x: 1, y: 2 }));
 			const { root } = view;
 			assert.equal(root.x, 1);
@@ -280,12 +267,7 @@ describe("schemaFactory", () => {
 
 			const config = new TreeViewConfiguration({ schema: Point });
 
-			const factory = new TreeFactory({});
-			const tree = factory.create(
-				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-				"tree",
-			);
-			const view = tree.viewWith(config);
+			const view = getView(config);
 			view.initialize(new Point({ x: 1 }));
 			const { root } = view;
 			assert.equal(root.x, 1);
@@ -473,12 +455,7 @@ describe("schemaFactory", () => {
 
 		const config = new TreeViewConfiguration({ schema: Canvas });
 
-		const factory = new TreeFactory({});
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
-		const view: TreeView<typeof Canvas> = tree.viewWith(config);
+		const view: TreeView<typeof Canvas> = getView(config);
 		view.initialize(
 			new Canvas({
 				stuff: new NodeList([new Note({ text: "hi", location: undefined })]),
@@ -501,20 +478,13 @@ describe("schemaFactory", () => {
 
 			const treeConfiguration = new TreeViewConfiguration({ schema: Inventory });
 
-			const factory = new TreeFactory({});
-			const tree = factory.create(
-				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-				"tree",
-			);
-			const view = tree.viewWith(treeConfiguration);
+			const view = getView(treeConfiguration);
 			view.initialize(
 				new Inventory({
 					parts: [1, 2],
 				}),
 			);
 		});
-
-		const treeFactory = new TreeFactory({});
 
 		it("Structural", () => {
 			const factory = new SchemaFactory("test");
@@ -545,11 +515,7 @@ describe("schemaFactory", () => {
 
 			// Due to lack of support for navigating unhydrated nodes, create an actual tree so we can navigate to the list node:
 			const treeConfiguration = new TreeViewConfiguration({ schema: Parent });
-			const tree = treeFactory.create(
-				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-				"tree",
-			);
-			const view = tree.viewWith(treeConfiguration);
+			const view = getView(treeConfiguration);
 			view.initialize(new Parent({ child: [5] }));
 
 			const listNode = view.root.child;
@@ -591,8 +557,6 @@ describe("schemaFactory", () => {
 	});
 
 	describe("Map", () => {
-		const treeFactory = new TreeFactory({});
-
 		it("Structural", () => {
 			const factory = new SchemaFactory("test");
 
@@ -620,11 +584,7 @@ describe("schemaFactory", () => {
 
 			// Due to lack of support for navigating unhydrated nodes, create an actual tree so we can navigate to the map node:
 			const treeConfiguration = new TreeViewConfiguration({ schema: Parent });
-			const tree = treeFactory.create(
-				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-				"tree",
-			);
-			const view = tree.viewWith(treeConfiguration);
+			const view = getView(treeConfiguration);
 			view.initialize(new Parent({ child: new Map([["x", 5]]) }));
 
 			const mapNode = view.root.child;
@@ -825,14 +785,9 @@ describe("schemaFactory", () => {
 			validate: (view: TreeView<typeof ComboRoot>, nodes: ComboNode[]) => void,
 		) {
 			const config = new TreeViewConfiguration({ schema: ComboRoot });
-			const factory = new TreeFactory({});
-			const tree = factory.create(
-				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-				"tree",
-			);
 
 			// Check that nodes in the initial tree are hydrated
-			const view = tree.viewWith(config);
+			const view = getView(config);
 			const { parent: initialParent, nodes: initialNodes } = createComboTree({
 				parentType,
 				childType,

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactoryRecursive.spec.ts
@@ -36,7 +36,7 @@ import type {
 	TreeNodeFromImplicitAllowedTypesUnsafe,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../simple-tree/api/typesUnsafe.js";
-import { TreeFactory } from "../../../treeFactory.js";
+import { SharedTree } from "../../../treeFactory.js";
 import type {
 	areSafelyAssignable,
 	requireAssignableTo,
@@ -63,7 +63,6 @@ const sf = new SchemaFactory("recursive");
 describe("SchemaFactory Recursive methods", () => {
 	describe("objectRecursive", () => {
 		it("End-to-end with recursive object", () => {
-			const factory = new TreeFactory({});
 			const schema = new SchemaFactory("com.example");
 
 			/**
@@ -86,8 +85,11 @@ describe("SchemaFactory Recursive methods", () => {
 
 			const config = new TreeViewConfiguration({ schema: Box });
 
-			const tree = factory.create(
-				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			const tree = SharedTree.create(
+				new MockFluidDataStoreRuntime({
+					idCompressor: createIdCompressor(),
+					registry: [SharedTree.getFactory()],
+				}),
 				"tree",
 			);
 

--- a/packages/dds/tree/src/test/simple-tree/core/treeNodeKernel.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/treeNodeKernel.spec.ts
@@ -5,16 +5,13 @@
 
 import { strict as assert } from "node:assert";
 
-import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
-import { createIdCompressor } from "@fluidframework/id-compressor/internal";
-
 import { SchemaFactory, TreeViewConfiguration } from "../../../simple-tree/index.js";
 // TODO: test other things from "treeNodeKernel" file.
 // eslint-disable-next-line import/no-internal-modules
 import { isTreeNode } from "../../../simple-tree/core/treeNodeKernel.js";
 
 import { hydrate } from "../utils.js";
-import { TreeFactory } from "../../../treeFactory.js";
+import { getView } from "../../utils.js";
 
 describe("simple-tree proxies", () => {
 	const sb = new SchemaFactory("test");
@@ -46,13 +43,8 @@ describe("simple-tree proxies", () => {
 
 	it("Marinated isTreeNode - initialize", () => {
 		const config = new TreeViewConfiguration({ schema: sb.optional(schema) });
-		const factory = new TreeFactory({});
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
 
-		const view = tree.viewWith(config);
+		const view = getView(config);
 
 		view.initialize(undefined);
 		const root = new schema({ object: { content: 6 } });
@@ -64,13 +56,8 @@ describe("simple-tree proxies", () => {
 
 	it("Marinated isTreeNode - inserted", () => {
 		const config = new TreeViewConfiguration({ schema });
-		const factory = new TreeFactory({});
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"tree",
-		);
 
-		const view = tree.viewWith(config);
+		const view = getView(config);
 		const inner = { content: 6 };
 		const root = new schema({ object: inner });
 		assert(isTreeNode(root));

--- a/packages/dds/tree/src/test/snapshots/gc.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/gc.spec.ts
@@ -15,14 +15,14 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 
 import { typeboxValidator } from "../../external-utilities/index.js";
-import { type ISharedTree, SharedTree } from "../../shared-tree/index.js";
+import type { ISharedTree } from "../../shared-tree/index.js";
 import {
 	SchemaFactory,
 	TreeViewConfiguration,
 	type TreeView,
 } from "../../simple-tree/index.js";
 import { TreeFactory } from "../../treeFactory.js";
-import { SharedTreeAttributes } from "../../sharedTreeAttributes.js";
+import { DefaultTestSharedTreeKind } from "../utils.js";
 
 const builder = new SchemaFactory("test");
 class Bar extends builder.object("bar", {
@@ -41,14 +41,13 @@ function createConnectedTree(
 	const dataStoreRuntime = new MockFluidDataStoreRuntime({
 		idCompressor: createIdCompressor(),
 	});
-	const tree = new SharedTree(id, dataStoreRuntime, SharedTreeAttributes, {});
+	const tree = DefaultTestSharedTreeKind.getFactory().create(dataStoreRuntime, id);
 	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
 		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(undefined),
 	};
 	tree.connect(services);
-	tree.initializeLocal();
 	return tree;
 }
 

--- a/packages/dds/tree/src/test/snapshots/opFormat.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/opFormat.spec.ts
@@ -13,10 +13,11 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 import { takeJsonSnapshot, useSnapshotDirectory } from "./snapshotTools.js";
-import { SchemaFactory, TreeViewConfiguration } from "../../simple-tree/index.js";
-import { type ISharedTree, SharedTreeFormatVersion } from "../../shared-tree/index.js";
+import { SchemaFactory, TreeViewConfiguration, type ITree } from "../../simple-tree/index.js";
+import { SharedTreeFormatVersion } from "../../shared-tree/index.js";
 import type { JsonCompatibleReadOnly } from "../../util/index.js";
-import { TreeFactory } from "../../treeFactory.js";
+import { configuredSharedTree } from "../../treeFactory.js";
+import type { IChannel } from "@fluidframework/datastore-definitions/internal";
 
 /**
  * This suite provides some e2e snapshot coverage for how SharedTree ops look.
@@ -40,16 +41,16 @@ describe("SharedTree op format snapshots", () => {
 	}) {}
 
 	let containerRuntime: MockContainerRuntime;
-	let tree: ISharedTree;
+	let tree: ITree & IChannel;
 
 	for (const versionKey of Object.keys(SharedTreeFormatVersion)) {
 		describe(`using SharedTreeFormatVersion.${versionKey}`, () => {
 			useSnapshotDirectory(`op-format/${versionKey}`);
 			beforeEach(() => {
-				const factory = new TreeFactory({
+				const factory = configuredSharedTree({
 					formatVersion:
 						SharedTreeFormatVersion[versionKey as keyof typeof SharedTreeFormatVersion],
-				});
+				}).getFactory();
 				const containerRuntimeFactory = new MockContainerRuntimeFactory();
 				const sessionId = "00000000-0000-4000-b000-000000000000" as SessionId;
 				const runtime = new MockFluidDataStoreRuntime({

--- a/packages/test/test-utils/src/testFluidObjectInternal.ts
+++ b/packages/test/test-utils/src/testFluidObjectInternal.ts
@@ -21,7 +21,10 @@ import {
 	IFluidDataStoreContext,
 } from "@fluidframework/runtime-definitions/internal";
 import { create404Response } from "@fluidframework/runtime-utils/internal";
-import type { ISharedObject } from "@fluidframework/shared-object-base/internal";
+import type {
+	ISharedObject,
+	SharedObjectKind,
+} from "@fluidframework/shared-object-base/internal";
 
 /**
  * A test Fluid object that will create a shared object for each key-value pair in the factoryEntries passed to load.
@@ -67,6 +70,22 @@ export class TestFluidObjectInternal implements IFluidLoadable {
 	 */
 	public async getInitialSharedObject(id: string): Promise<IChannel> {
 		return (await this.runtime.getChannel(id)) ?? fail("Shared object not found");
+	}
+
+	/**
+	 * Retrieves a shared object with the given id.
+	 * @param kind - The kind of object to retrieve.
+	 * @param id - The id of the shared object to retrieve.
+	 */
+	public async getInitialSharedObjectTyped<T>(
+		kind: SharedObjectKind<T>,
+		id: string,
+	): Promise<IChannel & T> {
+		const result = (await this.runtime.getChannel(id)) ?? fail("Shared object not found");
+		if (kind.is(result)) {
+			return result;
+		}
+		return fail("Wrong kind of shared object");
 	}
 
 	public async request(request: IRequest): Promise<IResponse> {


### PR DESCRIPTION
## Description

Tidy up tests a bit for more type safety where practical and less direct use of SharedTree class and TreeFactory.

This should reduce the impact of changes like https://github.com/microsoft/FluidFramework/pull/23729 which change how the factory and class are setup.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

