### PR TITLE
build(bundle-size-test): Add webpack to the build task dependency graph

### DIFF
--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -80,7 +80,7 @@
 	],
 	"fluidBuild": {
 		"tasks": {
-			"build": {
+			"build:test": {
 				"dependsOn": [
 					"...",
 					"webpack"

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -80,6 +80,13 @@
 	],
 	"fluidBuild": {
 		"tasks": {
+			"build": {
+				"dependsOn": [
+					"...",
+					"webpack"
+				],
+				"script": false
+			},
 			"webpack": [
 				"^build:esnext"
 			],

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -80,13 +80,10 @@
 	],
 	"fluidBuild": {
 		"tasks": {
-			"build:test": {
-				"dependsOn": [
-					"...",
-					"webpack"
-				],
-				"script": false
-			},
+			"build:test": [
+				"...",
+				"webpack"
+			],
 			"webpack": [
 				"^build:esnext"
 			],


### PR DESCRIPTION
## Description

Make sure webpack runs when building the tests, since the tests for the debug assert feature need the webpack bundle to have been generated.

See https://github.com/microsoft/FluidFramework/pull/24322 for more discussion.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
