### PR TITLE
build: Update changesets to new format

### DIFF
--- a/.changeset/salty-tools-carry.md
+++ b/.changeset/salty-tools-carry.md
@@ -1,9 +1,7 @@
 ---
 "fluid-framework": minor
 "@fluidframework/tree": minor
----
----
-"section": tree
+"__section": tree
 ---
 
 Cleanup of several tree and schema alpha APIs for content import and export

--- a/.changeset/tired-places-cough.md
+++ b/.changeset/tired-places-cough.md
@@ -1,9 +1,7 @@
 ---
 "fluid-framework": minor
 "@fluidframework/tree": minor
----
----
-"section": tree
+"__section": tree
 ---
 
 Provide alpha APIs for accessing tree content and stored schema without requiring a compatible view schema

--- a/.changeset/true-doors-ring.md
+++ b/.changeset/true-doors-ring.md
@@ -1,8 +1,6 @@
 ---
 "@fluidframework/container-loader": minor
----
----
-"section": feature
+"__section": feature
 ---
 
 Blobs in Detached Container Supported by Default


### PR DESCRIPTION
changesets have a new format, but the build-tools were only recently updated in client, so old changesets need to be manually converted.