### PR TITLE
build(server,gitrest,historian): Bump build-tools to 0.55.0

### DIFF
--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -46,9 +46,9 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@types/async": "^3.2.9",
 		"@types/cors": "^2.8.4",

--- a/server/gitrest/package.json
+++ b/server/gitrest/package.json
@@ -46,9 +46,9 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@types/async": "^3.2.9",
 		"@types/cors": "^2.8.4",

--- a/server/gitrest/pnpm-lock.yaml
+++ b/server/gitrest/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
   .:
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.17.7)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.17.7)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.17.7)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.17.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.1.6)
@@ -599,13 +599,17 @@ packages:
   '@fluid-internal/eslint-plugin-fluid@0.1.2':
     resolution: {integrity: sha512-E7LF4ukpCoyZcxpDUQz0edXsKllbh4m8NAdiug6sSI1KIIQFwtq5vvW3kQ0Op5xA9w10T6crfcvmuAzdP84UGg==}
 
-  '@fluid-tools/build-cli@0.52.0-315632':
-    resolution: {integrity: sha512-mCnlGVEhssycNqW6N0xFjcbGjHsNG2aj+9gPtBdd4L0tWLMJyLag7SRfORdvcAuSUhvhiYbEdSGhwvRzkBl/Rw==}
+  '@fluid-tools/build-cli@0.52.0':
+    resolution: {integrity: sha512-LDR9EIEARbM1dLhoWn3DU9fZ24yXwrDa6IlkN2jaNRPb8E3gvIpukYY17n9ejhS801sx/6g1Uiu16FvyO2l3kQ==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
-  '@fluid-tools/version-tools@0.52.0-315632':
-    resolution: {integrity: sha512-GLglzryXTGCiBtxBnXOJcloepJhDFtujzkSqXgOMIHTMU8w+8P5qiLNDOa0N1kQHlb6Wt47sCoHG6Cz+bBQ7+Q==}
+  '@fluid-tools/build-infrastructure@0.52.0':
+    resolution: {integrity: sha512-pItNDnPtKiKQmh4lZ7YJC6Vvkt7RetZKOfUNTaudHTRNsrkI9FtVxrHgZe58JlAHIkdEr1wltEUG8nAlJrS8CA==}
+    hasBin: true
+
+  '@fluid-tools/version-tools@0.52.0':
+    resolution: {integrity: sha512-U8bxX3P7E5l1XGpcWEkONUCXVgBKXpZxjN4tqVy5Z9x1i3VKmjhd5zSH5Q5ndSs10iCM/25ukZb9xfXMXJwsYQ==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
@@ -613,13 +617,13 @@ packages:
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
     hasBin: true
 
-  '@fluidframework/build-tools@0.52.0-315632':
-    resolution: {integrity: sha512-L0mwaMA12xppnng21dp64nCJ6As06XOWsbG+pSi3T1n8RCharRkgUVNH7fGW+OeIUnBDGgqCp/k+I/AKnQfaww==}
+  '@fluidframework/build-tools@0.52.0':
+    resolution: {integrity: sha512-+TlVmwe88PdFkKt9ilLHf0b0h2LlzoyLIW3GuTL0chKTYCM9r1b0QgLwmLH/RFPb5e8vK4N1vb7os9JZCHAMyw==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
-  '@fluidframework/bundle-size-tools@0.52.0-315632':
-    resolution: {integrity: sha512-QHxAJDXqtngI3d1Qfxp+xNvPw2nIwEcT74yLYpNXTYOEyChffHtI6KZ/LpSjiogTeB0YnwR9egK4X2A/57esBQ==}
+  '@fluidframework/bundle-size-tools@0.52.0':
+    resolution: {integrity: sha512-P5m6P3pBUhVXVJvilaZdv1CEavRwFmsLAEMB04L306o6D7bWCozo0DE7onItoc+Ch5Bbh0kNBquvSfAvpvTbFA==}
 
   '@fluidframework/common-definitions@0.20.1':
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
@@ -748,10 +752,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^18.17.1
-
-  '@inquirer/figures@1.0.5':
-    resolution: {integrity: sha512-79hP/VWdZ2UVc9bFGJnoQ/lQMpL74mGgzSYX1xUqCVk7/v73vJCMw1VuyWN1jGkZ9B3z7THAbySqGbCNefcjfA==}
-    engines: {node: '>=18'}
 
   '@inquirer/figures@1.0.9':
     resolution: {integrity: sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==}
@@ -3790,6 +3790,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -4584,6 +4585,10 @@ packages:
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
+
+  picospinner@2.1.0:
+    resolution: {integrity: sha512-kaBFPNItKVivIKrWt0RuLz0UilZX8KgZeaBrjSUjjExza5ISWtBAtbDYTOon31EGGH6wTdQ22gTXiykmhv/Kqg==}
+    engines: {node: '>=18.0.0'}
 
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -6462,12 +6467,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluid-tools/build-cli@0.52.0-315632(@types/node@18.17.7)(encoding@0.1.13)(typescript@5.1.6)':
+  '@fluid-tools/build-cli@0.52.0(@types/node@18.17.7)(encoding@0.1.13)(typescript@5.1.6)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.17.7)
-      '@fluidframework/build-tools': 0.52.0-315632(@types/node@18.17.7)
-      '@fluidframework/bundle-size-tools': 0.52.0-315632
+      '@fluid-tools/build-infrastructure': 0.52.0(@types/node@18.17.7)
+      '@fluid-tools/version-tools': 0.52.0(@types/node@18.17.7)
+      '@fluidframework/build-tools': 0.52.0(@types/node@18.17.7)
+      '@fluidframework/bundle-size-tools': 0.52.0
       '@inquirer/prompts': 7.2.1(@types/node@18.17.7)
       '@microsoft/api-extractor': 7.49.0(@types/node@18.17.7)
       '@oclif/core': 4.2.2
@@ -6540,7 +6546,34 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/version-tools@0.52.0-315632(@types/node@18.17.7)':
+  '@fluid-tools/build-infrastructure@0.52.0(@types/node@18.17.7)':
+    dependencies:
+      '@fluid-tools/version-tools': 0.52.0(@types/node@18.17.7)
+      '@manypkg/get-packages': 2.2.2
+      '@oclif/core': 4.2.2
+      cosmiconfig: 8.3.6(typescript@5.4.5)
+      detect-indent: 6.1.0
+      execa: 5.1.1
+      fs-extra: 11.2.0
+      globby: 11.1.0
+      micromatch: 4.0.8
+      oclif: 4.17.10(@types/node@18.17.7)
+      picocolors: 1.1.1
+      read-pkg-up: 7.0.1
+      semver: 7.6.3
+      simple-git: 3.27.0
+      sort-package-json: 1.57.0
+      type-fest: 2.19.0
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - '@types/node'
+      - aws-crt
+      - bufferutil
+      - react-devtools-core
+      - supports-color
+      - utf-8-validate
+
+  '@fluid-tools/version-tools@0.52.0(@types/node@18.17.7)':
     dependencies:
       '@oclif/core': 4.2.2
       '@oclif/plugin-autocomplete': 3.2.16
@@ -6558,9 +6591,9 @@ snapshots:
 
   '@fluidframework/build-common@2.0.3': {}
 
-  '@fluidframework/build-tools@0.52.0-315632(@types/node@18.17.7)':
+  '@fluidframework/build-tools@0.52.0(@types/node@18.17.7)':
     dependencies:
-      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.17.7)
+      '@fluid-tools/version-tools': 0.52.0(@types/node@18.17.7)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -6578,6 +6611,7 @@ snapshots:
       multimatch: 5.0.0
       picocolors: 1.1.1
       picomatch: 2.3.1
+      picospinner: 2.1.0
       rimraf: 4.4.1
       semver: 7.6.3
       sort-package-json: 1.57.0
@@ -6593,7 +6627,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/bundle-size-tools@0.52.0-315632':
+  '@fluidframework/bundle-size-tools@0.52.0':
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -6979,7 +7013,7 @@ snapshots:
 
   '@inquirer/core@9.1.0':
     dependencies:
-      '@inquirer/figures': 1.0.5
+      '@inquirer/figures': 1.0.9
       '@inquirer/type': 1.5.3
       '@types/mute-stream': 0.0.4
       '@types/node': 18.17.7
@@ -7006,8 +7040,6 @@ snapshots:
       '@inquirer/type': 3.0.2(@types/node@18.17.7)
       '@types/node': 18.17.7
       yoctocolors-cjs: 2.1.2
-
-  '@inquirer/figures@1.0.5': {}
 
   '@inquirer/figures@1.0.9': {}
 
@@ -11852,6 +11884,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picospinner@2.1.0: {}
 
   pify@4.0.1: {}
 

--- a/server/gitrest/pnpm-lock.yaml
+++ b/server/gitrest/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
   .:
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.17.7)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.17.7)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.17.7)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.17.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.1.6)
@@ -599,31 +599,31 @@ packages:
   '@fluid-internal/eslint-plugin-fluid@0.1.2':
     resolution: {integrity: sha512-E7LF4ukpCoyZcxpDUQz0edXsKllbh4m8NAdiug6sSI1KIIQFwtq5vvW3kQ0Op5xA9w10T6crfcvmuAzdP84UGg==}
 
-  '@fluid-tools/build-cli@0.52.0':
-    resolution: {integrity: sha512-LDR9EIEARbM1dLhoWn3DU9fZ24yXwrDa6IlkN2jaNRPb8E3gvIpukYY17n9ejhS801sx/6g1Uiu16FvyO2l3kQ==}
-    engines: {node: '>=18.17.1'}
+  '@fluid-tools/build-cli@0.55.0':
+    resolution: {integrity: sha512-PnPoJx/7Fzz/jO8/0+QyYARtiJRIsj1NE79DPWbrBGdeSAacok/UgrEJ3JC1Kr68KKgnoIU3Zo7DnLPfBWx1PQ==}
+    engines: {node: '>=20.15.1'}
     hasBin: true
 
-  '@fluid-tools/build-infrastructure@0.52.0':
-    resolution: {integrity: sha512-pItNDnPtKiKQmh4lZ7YJC6Vvkt7RetZKOfUNTaudHTRNsrkI9FtVxrHgZe58JlAHIkdEr1wltEUG8nAlJrS8CA==}
+  '@fluid-tools/build-infrastructure@0.55.0':
+    resolution: {integrity: sha512-uctF9nN8yQqpizqj4ZEjT7Qet2YFMHzpdDFXrS8Dl4turfLPoiMhD+1sFGhE2tsvdx25QcBYe45u7IAsefCFiA==}
     hasBin: true
 
-  '@fluid-tools/version-tools@0.52.0':
-    resolution: {integrity: sha512-U8bxX3P7E5l1XGpcWEkONUCXVgBKXpZxjN4tqVy5Z9x1i3VKmjhd5zSH5Q5ndSs10iCM/25ukZb9xfXMXJwsYQ==}
-    engines: {node: '>=18.17.1'}
+  '@fluid-tools/version-tools@0.55.0':
+    resolution: {integrity: sha512-sdQq4poJz4/L9TcXZJXw3mNPzp0qZH/Qv4ufNSrPSDtWDHucgYsg1zR/VmSwf6EYRQ086Jij7vnFnkSGsIrKIA==}
+    engines: {node: '>=20.15.1'}
     hasBin: true
 
   '@fluidframework/build-common@2.0.3':
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
     hasBin: true
 
-  '@fluidframework/build-tools@0.52.0':
-    resolution: {integrity: sha512-+TlVmwe88PdFkKt9ilLHf0b0h2LlzoyLIW3GuTL0chKTYCM9r1b0QgLwmLH/RFPb5e8vK4N1vb7os9JZCHAMyw==}
-    engines: {node: '>=18.17.1'}
+  '@fluidframework/build-tools@0.55.0':
+    resolution: {integrity: sha512-BurYYIeAnVLMBr9UIJPzfN3V1qLJtItwLrxDJqyPqqZTFxqL4MvafilX8caKuSVUJqLuFCf+KS8ABg+6rXywtg==}
+    engines: {node: '>=20.15.1'}
     hasBin: true
 
-  '@fluidframework/bundle-size-tools@0.52.0':
-    resolution: {integrity: sha512-P5m6P3pBUhVXVJvilaZdv1CEavRwFmsLAEMB04L306o6D7bWCozo0DE7onItoc+Ch5Bbh0kNBquvSfAvpvTbFA==}
+  '@fluidframework/bundle-size-tools@0.55.0':
+    resolution: {integrity: sha512-1j2p1VDFjgRYFNkJRVQI82xTtyA3G3Q6JEp7ohraQknq116TB0FAfIKCADEcvaFawd9oeXcTsnFif9S3gChU1Q==}
 
   '@fluidframework/common-definitions@0.20.1':
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
@@ -870,11 +870,11 @@ packages:
     resolution: {integrity: sha512-3lBouSuF7CqlseLB+FKES0K4FQ02JrbEoRtJhxnsyB1s5v4AP03gsoohN8jp7DcOImhaR9scYdztq3/sLfk/qQ==}
     engines: {node: '>=14.18.0'}
 
-  '@microsoft/api-extractor-model@7.30.1':
-    resolution: {integrity: sha512-CTS2PlASJHxVY8hqHORVb1HdECWOEMcMnM6/kDkPr0RZapAFSIHhg9D4jxuE8g+OWYHtPc10LCpmde5pylTRlA==}
+  '@microsoft/api-extractor-model@7.30.5':
+    resolution: {integrity: sha512-0ic4rcbcDZHz833RaTZWTGu+NpNgrxVNjVaor0ZDUymfDFzjA/Uuk8hYziIUIOEOSTfmIQqyzVwlzxZxPe7tOA==}
 
-  '@microsoft/api-extractor@7.49.0':
-    resolution: {integrity: sha512-X5b462k0/yl8qWdGx3siq5vyI8fTDU9fRnwqTMlGHqFhLxpASmLWA2EU6nft+ZG8cQM2HRZlr4HSo62UqiAnug==}
+  '@microsoft/api-extractor@7.52.3':
+    resolution: {integrity: sha512-QEs6l8h7p9eOSHrQ9NBBUZhUuq+j/2QKcRgigbSs2YQepKz8glvsqmsUOp+nvuaY60ps7KkpVVYQCj81WLoMVQ==}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.16.2':
@@ -1118,11 +1118,19 @@ packages:
       '@types/node':
         optional: true
 
+  '@rushstack/node-core-library@5.13.0':
+    resolution: {integrity: sha512-IGVhy+JgUacAdCGXKUrRhwHMTzqhWwZUI+qEPcdzsb80heOw0QPbhhoVsoiMF7Klp8eYsp7hzpScMXmOa3Uhfg==}
+    peerDependencies:
+      '@types/node': ^18.17.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@rushstack/rig-package@0.5.3':
     resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
 
-  '@rushstack/terminal@0.14.4':
-    resolution: {integrity: sha512-NxACqERW0PHq8Rpq1V6v5iTHEwkRGxenjEW+VWqRYQ8T9puUzgmGHmEZUaUEDHAe9Qyvp0/Ew04sAiQw9XjhJg==}
+  '@rushstack/terminal@0.15.2':
+    resolution: {integrity: sha512-7Hmc0ysK5077R/IkLS9hYu0QuNafm+TbZbtYVzCMbeOdMjaRboLKrhryjwZSRJGJzu+TV1ON7qZHeqf58XfLpA==}
     peerDependencies:
       '@types/node': ^18.17.1
     peerDependenciesMeta:
@@ -1132,8 +1140,8 @@ packages:
   '@rushstack/tree-pattern@0.3.1':
     resolution: {integrity: sha512-2yn4qTkXZTByQffL3ymS6viYuyZk3YnJT49bopGBlm9Thtyfa7iuFUV6tt+09YIRO1sjmSWILf4dPj6+Dr5YVA==}
 
-  '@rushstack/ts-command-line@4.23.2':
-    resolution: {integrity: sha512-JJ7XZX5K3ThBBva38aomgsPv1L7FV6XmSOcR6HtM7HDFZJkepqT65imw26h9ggGqMjsY0R9jcl30tzKcVj9aOQ==}
+  '@rushstack/ts-command-line@4.23.7':
+    resolution: {integrity: sha512-Gr9cB7DGe6uz5vq2wdr89WbVDKz0UeuFEn5H2CfWDe7JvjFFaiV15gi6mqDBTbHhHCWS7w8mF1h3BnIfUndqdA==}
 
   '@sigstore/protobuf-specs@0.1.0':
     resolution: {integrity: sha512-a31EnjuIDSX8IXBUib3cYLDRlPMU36AWX4xS8ysLaNu4ZzUesDiPt83pgrW2X1YLMe5L2HbDyaKK5BrL4cNKaQ==}
@@ -2963,6 +2971,10 @@ packages:
 
   fs-extra@11.2.0:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.3.0:
+    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
@@ -5488,8 +5500,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.2:
-    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -6467,15 +6479,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluid-tools/build-cli@0.52.0(@types/node@18.17.7)(encoding@0.1.13)(typescript@5.1.6)':
+  '@fluid-tools/build-cli@0.55.0(@types/node@18.17.7)(encoding@0.1.13)(typescript@5.1.6)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/build-infrastructure': 0.52.0(@types/node@18.17.7)
-      '@fluid-tools/version-tools': 0.52.0(@types/node@18.17.7)
-      '@fluidframework/build-tools': 0.52.0(@types/node@18.17.7)
-      '@fluidframework/bundle-size-tools': 0.52.0
+      '@fluid-tools/build-infrastructure': 0.55.0(@types/node@18.17.7)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@18.17.7)
+      '@fluidframework/build-tools': 0.55.0(@types/node@18.17.7)
+      '@fluidframework/bundle-size-tools': 0.55.0
       '@inquirer/prompts': 7.2.1(@types/node@18.17.7)
-      '@microsoft/api-extractor': 7.49.0(@types/node@18.17.7)
+      '@microsoft/api-extractor': 7.52.3(@types/node@18.17.7)
       '@oclif/core': 4.2.2
       '@oclif/plugin-autocomplete': 3.2.16
       '@oclif/plugin-commands': 4.1.15
@@ -6546,9 +6558,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-infrastructure@0.52.0(@types/node@18.17.7)':
+  '@fluid-tools/build-infrastructure@0.55.0(@types/node@18.17.7)':
     dependencies:
-      '@fluid-tools/version-tools': 0.52.0(@types/node@18.17.7)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@18.17.7)
       '@manypkg/get-packages': 2.2.2
       '@oclif/core': 4.2.2
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -6573,7 +6585,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/version-tools@0.52.0(@types/node@18.17.7)':
+  '@fluid-tools/version-tools@0.55.0(@types/node@18.17.7)':
     dependencies:
       '@oclif/core': 4.2.2
       '@oclif/plugin-autocomplete': 3.2.16
@@ -6591,9 +6603,9 @@ snapshots:
 
   '@fluidframework/build-common@2.0.3': {}
 
-  '@fluidframework/build-tools@0.52.0(@types/node@18.17.7)':
+  '@fluidframework/build-tools@0.55.0(@types/node@18.17.7)':
     dependencies:
-      '@fluid-tools/version-tools': 0.52.0(@types/node@18.17.7)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@18.17.7)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -6627,7 +6639,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/bundle-size-tools@0.52.0':
+  '@fluidframework/bundle-size-tools@0.55.0':
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -7181,29 +7193,29 @@ snapshots:
       jju: 1.4.0
       js-yaml: 4.1.0
 
-  '@microsoft/api-extractor-model@7.30.1(@types/node@18.17.7)':
+  '@microsoft/api-extractor-model@7.30.5(@types/node@18.17.7)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.1(@types/node@18.17.7)
+      '@rushstack/node-core-library': 5.13.0(@types/node@18.17.7)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.49.0(@types/node@18.17.7)':
+  '@microsoft/api-extractor@7.52.3(@types/node@18.17.7)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.1(@types/node@18.17.7)
+      '@microsoft/api-extractor-model': 7.30.5(@types/node@18.17.7)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.1(@types/node@18.17.7)
+      '@rushstack/node-core-library': 5.13.0(@types/node@18.17.7)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.14.4(@types/node@18.17.7)
-      '@rushstack/ts-command-line': 4.23.2(@types/node@18.17.7)
+      '@rushstack/terminal': 0.15.2(@types/node@18.17.7)
+      '@rushstack/ts-command-line': 4.23.7(@types/node@18.17.7)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.7.2
+      typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
 
@@ -7591,23 +7603,36 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.17.7
 
+  '@rushstack/node-core-library@5.13.0(@types/node@18.17.7)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 11.3.0
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.8
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 18.17.7
+
   '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.14.4(@types/node@18.17.7)':
+  '@rushstack/terminal@0.15.2(@types/node@18.17.7)':
     dependencies:
-      '@rushstack/node-core-library': 5.10.1(@types/node@18.17.7)
+      '@rushstack/node-core-library': 5.13.0(@types/node@18.17.7)
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 18.17.7
 
   '@rushstack/tree-pattern@0.3.1': {}
 
-  '@rushstack/ts-command-line@4.23.2(@types/node@18.17.7)':
+  '@rushstack/ts-command-line@4.23.7(@types/node@18.17.7)':
     dependencies:
-      '@rushstack/terminal': 0.14.4(@types/node@18.17.7)
+      '@rushstack/terminal': 0.15.2(@types/node@18.17.7)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -9912,6 +9937,12 @@ snapshots:
   fs-exists-sync@0.1.0: {}
 
   fs-extra@11.2.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
+  fs-extra@11.3.0:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
@@ -12896,7 +12927,7 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  typescript@5.7.2: {}
+  typescript@5.8.2: {}
 
   uid2@1.0.0: {}
 

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -44,9 +44,9 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@types/compression": "0.0.36",
 		"@types/cors": "^2.8.4",

--- a/server/historian/package.json
+++ b/server/historian/package.json
@@ -44,9 +44,9 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.4.0",
 		"@types/compression": "0.0.36",
 		"@types/cors": "^2.8.4",

--- a/server/historian/packages/historian/package.json
+++ b/server/historian/packages/historian/package.json
@@ -28,7 +28,7 @@
 		"tslint": "tslint \"src/**/*.ts\""
 	},
 	"dependencies": {
-		"@fluidframework/historian-base": "^0.0.1",
+		"@fluidframework/historian-base": "workspace:~",
 		"@fluidframework/server-services-shared": "6.0.0-287165",
 		"@fluidframework/server-services-utils": "6.0.0-287165",
 		"body-parser": "^1.20.3",

--- a/server/historian/pnpm-lock.yaml
+++ b/server/historian/pnpm-lock.yaml
@@ -18,14 +18,14 @@ importers:
   .:
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.3)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.3)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.3)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.3)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.1.6)
@@ -535,13 +535,17 @@ packages:
   '@fluid-internal/eslint-plugin-fluid@0.1.2':
     resolution: {integrity: sha512-E7LF4ukpCoyZcxpDUQz0edXsKllbh4m8NAdiug6sSI1KIIQFwtq5vvW3kQ0Op5xA9w10T6crfcvmuAzdP84UGg==}
 
-  '@fluid-tools/build-cli@0.52.0-315632':
-    resolution: {integrity: sha512-mCnlGVEhssycNqW6N0xFjcbGjHsNG2aj+9gPtBdd4L0tWLMJyLag7SRfORdvcAuSUhvhiYbEdSGhwvRzkBl/Rw==}
+  '@fluid-tools/build-cli@0.52.0':
+    resolution: {integrity: sha512-LDR9EIEARbM1dLhoWn3DU9fZ24yXwrDa6IlkN2jaNRPb8E3gvIpukYY17n9ejhS801sx/6g1Uiu16FvyO2l3kQ==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
-  '@fluid-tools/version-tools@0.52.0-315632':
-    resolution: {integrity: sha512-GLglzryXTGCiBtxBnXOJcloepJhDFtujzkSqXgOMIHTMU8w+8P5qiLNDOa0N1kQHlb6Wt47sCoHG6Cz+bBQ7+Q==}
+  '@fluid-tools/build-infrastructure@0.52.0':
+    resolution: {integrity: sha512-pItNDnPtKiKQmh4lZ7YJC6Vvkt7RetZKOfUNTaudHTRNsrkI9FtVxrHgZe58JlAHIkdEr1wltEUG8nAlJrS8CA==}
+    hasBin: true
+
+  '@fluid-tools/version-tools@0.52.0':
+    resolution: {integrity: sha512-U8bxX3P7E5l1XGpcWEkONUCXVgBKXpZxjN4tqVy5Z9x1i3VKmjhd5zSH5Q5ndSs10iCM/25ukZb9xfXMXJwsYQ==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
@@ -549,13 +553,13 @@ packages:
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
     hasBin: true
 
-  '@fluidframework/build-tools@0.52.0-315632':
-    resolution: {integrity: sha512-L0mwaMA12xppnng21dp64nCJ6As06XOWsbG+pSi3T1n8RCharRkgUVNH7fGW+OeIUnBDGgqCp/k+I/AKnQfaww==}
+  '@fluidframework/build-tools@0.52.0':
+    resolution: {integrity: sha512-+TlVmwe88PdFkKt9ilLHf0b0h2LlzoyLIW3GuTL0chKTYCM9r1b0QgLwmLH/RFPb5e8vK4N1vb7os9JZCHAMyw==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
-  '@fluidframework/bundle-size-tools@0.52.0-315632':
-    resolution: {integrity: sha512-QHxAJDXqtngI3d1Qfxp+xNvPw2nIwEcT74yLYpNXTYOEyChffHtI6KZ/LpSjiogTeB0YnwR9egK4X2A/57esBQ==}
+  '@fluidframework/bundle-size-tools@0.52.0':
+    resolution: {integrity: sha512-P5m6P3pBUhVXVJvilaZdv1CEavRwFmsLAEMB04L306o6D7bWCozo0DE7onItoc+Ch5Bbh0kNBquvSfAvpvTbFA==}
 
   '@fluidframework/common-definitions@0.20.1':
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
@@ -696,10 +700,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': ^18.17.1
-
-  '@inquirer/figures@1.0.5':
-    resolution: {integrity: sha512-79hP/VWdZ2UVc9bFGJnoQ/lQMpL74mGgzSYX1xUqCVk7/v73vJCMw1VuyWN1jGkZ9B3z7THAbySqGbCNefcjfA==}
-    engines: {node: '>=18'}
 
   '@inquirer/figures@1.0.9':
     resolution: {integrity: sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==}
@@ -3863,6 +3863,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -4723,6 +4724,10 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
+  picospinner@2.1.0:
+    resolution: {integrity: sha512-kaBFPNItKVivIKrWt0RuLz0UilZX8KgZeaBrjSUjjExza5ISWtBAtbDYTOon31EGGH6wTdQ22gTXiykmhv/Kqg==}
+    engines: {node: '>=18.0.0'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -4948,10 +4953,6 @@ packages:
   regexp.prototype.flags@1.5.2:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
-
-  registry-auth-token@5.0.2:
-    resolution: {integrity: sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==}
-    engines: {node: '>=14'}
 
   registry-auth-token@5.0.3:
     resolution: {integrity: sha512-1bpc9IyC+e+CNFRaWyn77tk4xGG4PPUyfakSmA6F6cvUDjrm58dfyJ3II+9yb10EDkHoy1LaPSmHaWLOH3m6HA==}
@@ -6631,12 +6632,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluid-tools/build-cli@0.52.0-315632(@types/node@18.19.3)(encoding@0.1.13)(typescript@5.1.6)':
+  '@fluid-tools/build-cli@0.52.0(@types/node@18.19.3)(encoding@0.1.13)(typescript@5.1.6)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.19.3)
-      '@fluidframework/build-tools': 0.52.0-315632(@types/node@18.19.3)
-      '@fluidframework/bundle-size-tools': 0.52.0-315632
+      '@fluid-tools/build-infrastructure': 0.52.0(@types/node@18.19.3)
+      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.3)
+      '@fluidframework/build-tools': 0.52.0(@types/node@18.19.3)
+      '@fluidframework/bundle-size-tools': 0.52.0
       '@inquirer/prompts': 7.2.3(@types/node@18.19.3)
       '@microsoft/api-extractor': 7.49.1(@types/node@18.19.3)
       '@oclif/core': 4.2.4
@@ -6708,7 +6710,33 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/version-tools@0.52.0-315632(@types/node@18.19.3)':
+  '@fluid-tools/build-infrastructure@0.52.0(@types/node@18.19.3)':
+    dependencies:
+      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.3)
+      '@manypkg/get-packages': 2.2.2
+      '@oclif/core': 4.2.4
+      cosmiconfig: 8.3.6(typescript@5.4.5)
+      detect-indent: 6.1.0
+      execa: 5.1.1
+      fs-extra: 11.2.0
+      globby: 11.1.0
+      micromatch: 4.0.8
+      oclif: 4.17.17(@types/node@18.19.3)
+      picocolors: 1.1.1
+      read-pkg-up: 7.0.1
+      semver: 7.6.3
+      simple-git: 3.27.0
+      sort-package-json: 1.57.0
+      type-fest: 2.19.0
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - react-devtools-core
+      - supports-color
+      - utf-8-validate
+
+  '@fluid-tools/version-tools@0.52.0(@types/node@18.19.3)':
     dependencies:
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
@@ -6726,9 +6754,9 @@ snapshots:
 
   '@fluidframework/build-common@2.0.3': {}
 
-  '@fluidframework/build-tools@0.52.0-315632(@types/node@18.19.3)':
+  '@fluidframework/build-tools@0.52.0(@types/node@18.19.3)':
     dependencies:
-      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.19.3)
+      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.3)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -6746,6 +6774,7 @@ snapshots:
       multimatch: 5.0.0
       picocolors: 1.1.1
       picomatch: 2.3.1
+      picospinner: 2.1.0
       rimraf: 4.4.1
       semver: 7.6.3
       sort-package-json: 1.57.0
@@ -6761,7 +6790,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/bundle-size-tools@0.52.0-315632':
+  '@fluidframework/bundle-size-tools@0.52.0':
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -7213,7 +7242,7 @@ snapshots:
 
   '@inquirer/core@9.1.0':
     dependencies:
-      '@inquirer/figures': 1.0.5
+      '@inquirer/figures': 1.0.9
       '@inquirer/type': 1.5.3
       '@types/mute-stream': 0.0.4
       '@types/node': 18.19.3
@@ -7240,8 +7269,6 @@ snapshots:
       '@inquirer/type': 3.0.2(@types/node@18.19.3)
       '@types/node': 18.19.3
       yoctocolors-cjs: 2.1.2
-
-  '@inquirer/figures@1.0.5': {}
 
   '@inquirer/figures@1.0.9': {}
 
@@ -7301,7 +7328,7 @@ snapshots:
   '@inquirer/select@2.5.0':
     dependencies:
       '@inquirer/core': 9.1.0
-      '@inquirer/figures': 1.0.5
+      '@inquirer/figures': 1.0.9
       '@inquirer/type': 1.5.3
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
@@ -10435,7 +10462,7 @@ snapshots:
       dir-glob: 3.0.1
       fast-glob: 3.3.2
       glob: 7.2.3
-      ignore: 5.3.0
+      ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
 
@@ -10444,7 +10471,7 @@ snapshots:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.0
+      ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
 
@@ -12197,14 +12224,14 @@ snapshots:
   package-json@10.0.1:
     dependencies:
       ky: 1.7.4
-      registry-auth-token: 5.0.2
+      registry-auth-token: 5.0.3
       registry-url: 6.0.1
       semver: 7.6.3
 
   package-json@8.1.0:
     dependencies:
       got: 12.6.1
-      registry-auth-token: 5.0.2
+      registry-auth-token: 5.0.3
       registry-url: 6.0.1
       semver: 7.6.3
 
@@ -12335,6 +12362,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picospinner@2.1.0: {}
 
   pify@2.3.0: {}
 
@@ -12580,10 +12609,6 @@ snapshots:
       define-properties: 1.2.1
       es-errors: 1.3.0
       set-function-name: 2.0.2
-
-  registry-auth-token@5.0.2:
-    dependencies:
-      '@pnpm/npm-conf': 2.2.0
 
   registry-auth-token@5.0.3:
     dependencies:

--- a/server/historian/pnpm-lock.yaml
+++ b/server/historian/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
   packages/historian:
     dependencies:
       '@fluidframework/historian-base':
-        specifier: ^0.0.1
+        specifier: workspace:~
         version: link:../historian-base
       '@fluidframework/server-services-shared':
         specifier: 6.0.0-287165

--- a/server/historian/pnpm-lock.yaml
+++ b/server/historian/pnpm-lock.yaml
@@ -18,14 +18,14 @@ importers:
   .:
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.3)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.3)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.3)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.3)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.4.0
         version: 5.4.0(eslint@8.55.0)(typescript@5.1.6)
@@ -535,31 +535,31 @@ packages:
   '@fluid-internal/eslint-plugin-fluid@0.1.2':
     resolution: {integrity: sha512-E7LF4ukpCoyZcxpDUQz0edXsKllbh4m8NAdiug6sSI1KIIQFwtq5vvW3kQ0Op5xA9w10T6crfcvmuAzdP84UGg==}
 
-  '@fluid-tools/build-cli@0.52.0':
-    resolution: {integrity: sha512-LDR9EIEARbM1dLhoWn3DU9fZ24yXwrDa6IlkN2jaNRPb8E3gvIpukYY17n9ejhS801sx/6g1Uiu16FvyO2l3kQ==}
-    engines: {node: '>=18.17.1'}
+  '@fluid-tools/build-cli@0.55.0':
+    resolution: {integrity: sha512-PnPoJx/7Fzz/jO8/0+QyYARtiJRIsj1NE79DPWbrBGdeSAacok/UgrEJ3JC1Kr68KKgnoIU3Zo7DnLPfBWx1PQ==}
+    engines: {node: '>=20.15.1'}
     hasBin: true
 
-  '@fluid-tools/build-infrastructure@0.52.0':
-    resolution: {integrity: sha512-pItNDnPtKiKQmh4lZ7YJC6Vvkt7RetZKOfUNTaudHTRNsrkI9FtVxrHgZe58JlAHIkdEr1wltEUG8nAlJrS8CA==}
+  '@fluid-tools/build-infrastructure@0.55.0':
+    resolution: {integrity: sha512-uctF9nN8yQqpizqj4ZEjT7Qet2YFMHzpdDFXrS8Dl4turfLPoiMhD+1sFGhE2tsvdx25QcBYe45u7IAsefCFiA==}
     hasBin: true
 
-  '@fluid-tools/version-tools@0.52.0':
-    resolution: {integrity: sha512-U8bxX3P7E5l1XGpcWEkONUCXVgBKXpZxjN4tqVy5Z9x1i3VKmjhd5zSH5Q5ndSs10iCM/25ukZb9xfXMXJwsYQ==}
-    engines: {node: '>=18.17.1'}
+  '@fluid-tools/version-tools@0.55.0':
+    resolution: {integrity: sha512-sdQq4poJz4/L9TcXZJXw3mNPzp0qZH/Qv4ufNSrPSDtWDHucgYsg1zR/VmSwf6EYRQ086Jij7vnFnkSGsIrKIA==}
+    engines: {node: '>=20.15.1'}
     hasBin: true
 
   '@fluidframework/build-common@2.0.3':
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
     hasBin: true
 
-  '@fluidframework/build-tools@0.52.0':
-    resolution: {integrity: sha512-+TlVmwe88PdFkKt9ilLHf0b0h2LlzoyLIW3GuTL0chKTYCM9r1b0QgLwmLH/RFPb5e8vK4N1vb7os9JZCHAMyw==}
-    engines: {node: '>=18.17.1'}
+  '@fluidframework/build-tools@0.55.0':
+    resolution: {integrity: sha512-BurYYIeAnVLMBr9UIJPzfN3V1qLJtItwLrxDJqyPqqZTFxqL4MvafilX8caKuSVUJqLuFCf+KS8ABg+6rXywtg==}
+    engines: {node: '>=20.15.1'}
     hasBin: true
 
-  '@fluidframework/bundle-size-tools@0.52.0':
-    resolution: {integrity: sha512-P5m6P3pBUhVXVJvilaZdv1CEavRwFmsLAEMB04L306o6D7bWCozo0DE7onItoc+Ch5Bbh0kNBquvSfAvpvTbFA==}
+  '@fluidframework/bundle-size-tools@0.55.0':
+    resolution: {integrity: sha512-1j2p1VDFjgRYFNkJRVQI82xTtyA3G3Q6JEp7ohraQknq116TB0FAfIKCADEcvaFawd9oeXcTsnFif9S3gChU1Q==}
 
   '@fluidframework/common-definitions@0.20.1':
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
@@ -818,11 +818,11 @@ packages:
     resolution: {integrity: sha512-3lBouSuF7CqlseLB+FKES0K4FQ02JrbEoRtJhxnsyB1s5v4AP03gsoohN8jp7DcOImhaR9scYdztq3/sLfk/qQ==}
     engines: {node: '>=14.18.0'}
 
-  '@microsoft/api-extractor-model@7.30.2':
-    resolution: {integrity: sha512-3/t2F+WhkJgBzSNwlkTIL0tBgUoBqDqL66pT+nh2mPbM0NIDGVGtpqbGWPgHIzn/mn7kGS/Ep8D8po58e8UUIw==}
+  '@microsoft/api-extractor-model@7.30.5':
+    resolution: {integrity: sha512-0ic4rcbcDZHz833RaTZWTGu+NpNgrxVNjVaor0ZDUymfDFzjA/Uuk8hYziIUIOEOSTfmIQqyzVwlzxZxPe7tOA==}
 
-  '@microsoft/api-extractor@7.49.1':
-    resolution: {integrity: sha512-jRTR/XbQF2kb+dYn8hfYSicOGA99+Fo00GrsdMwdfE3eIgLtKdH6Qa2M3wZV9S2XmbgCaGX1OdPtYctbfu5jQg==}
+  '@microsoft/api-extractor@7.52.3':
+    resolution: {integrity: sha512-QEs6l8h7p9eOSHrQ9NBBUZhUuq+j/2QKcRgigbSs2YQepKz8glvsqmsUOp+nvuaY60ps7KkpVVYQCj81WLoMVQ==}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.16.2':
@@ -1069,11 +1069,19 @@ packages:
       '@types/node':
         optional: true
 
+  '@rushstack/node-core-library@5.13.0':
+    resolution: {integrity: sha512-IGVhy+JgUacAdCGXKUrRhwHMTzqhWwZUI+qEPcdzsb80heOw0QPbhhoVsoiMF7Klp8eYsp7hzpScMXmOa3Uhfg==}
+    peerDependencies:
+      '@types/node': ^18.17.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@rushstack/rig-package@0.5.3':
     resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
 
-  '@rushstack/terminal@0.14.5':
-    resolution: {integrity: sha512-TEOpNwwmsZVrkp0omnuTUTGZRJKTr6n6m4OITiNjkqzLAkcazVpwR1SOtBg6uzpkIBLgrcNHETqI8rbw3uiUfw==}
+  '@rushstack/terminal@0.15.2':
+    resolution: {integrity: sha512-7Hmc0ysK5077R/IkLS9hYu0QuNafm+TbZbtYVzCMbeOdMjaRboLKrhryjwZSRJGJzu+TV1ON7qZHeqf58XfLpA==}
     peerDependencies:
       '@types/node': ^18.17.1
     peerDependenciesMeta:
@@ -1083,8 +1091,8 @@ packages:
   '@rushstack/tree-pattern@0.3.1':
     resolution: {integrity: sha512-2yn4qTkXZTByQffL3ymS6viYuyZk3YnJT49bopGBlm9Thtyfa7iuFUV6tt+09YIRO1sjmSWILf4dPj6+Dr5YVA==}
 
-  '@rushstack/ts-command-line@4.23.3':
-    resolution: {integrity: sha512-HazKL8fv4HMQMzrKJCrOrhyBPPdzk7iajUXgsASwjQ8ROo1cmgyqxt/k9+SdmrNLGE1zATgRqMUH3s/6smbRMA==}
+  '@rushstack/ts-command-line@4.23.7':
+    resolution: {integrity: sha512-Gr9cB7DGe6uz5vq2wdr89WbVDKz0UeuFEn5H2CfWDe7JvjFFaiV15gi6mqDBTbHhHCWS7w8mF1h3BnIfUndqdA==}
 
   '@sigstore/protobuf-specs@0.1.0':
     resolution: {integrity: sha512-a31EnjuIDSX8IXBUib3cYLDRlPMU36AWX4xS8ysLaNu4ZzUesDiPt83pgrW2X1YLMe5L2HbDyaKK5BrL4cNKaQ==}
@@ -2994,6 +3002,10 @@ packages:
 
   fs-extra@11.2.0:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.3.0:
+    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
@@ -5734,8 +5746,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.2:
-    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -6632,15 +6644,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluid-tools/build-cli@0.52.0(@types/node@18.19.3)(encoding@0.1.13)(typescript@5.1.6)':
+  '@fluid-tools/build-cli@0.55.0(@types/node@18.19.3)(encoding@0.1.13)(typescript@5.1.6)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/build-infrastructure': 0.52.0(@types/node@18.19.3)
-      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.3)
-      '@fluidframework/build-tools': 0.52.0(@types/node@18.19.3)
-      '@fluidframework/bundle-size-tools': 0.52.0
+      '@fluid-tools/build-infrastructure': 0.55.0(@types/node@18.19.3)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@18.19.3)
+      '@fluidframework/build-tools': 0.55.0(@types/node@18.19.3)
+      '@fluidframework/bundle-size-tools': 0.55.0
       '@inquirer/prompts': 7.2.3(@types/node@18.19.3)
-      '@microsoft/api-extractor': 7.49.1(@types/node@18.19.3)
+      '@microsoft/api-extractor': 7.52.3(@types/node@18.19.3)
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
       '@oclif/plugin-commands': 4.1.17
@@ -6710,9 +6722,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-infrastructure@0.52.0(@types/node@18.19.3)':
+  '@fluid-tools/build-infrastructure@0.55.0(@types/node@18.19.3)':
     dependencies:
-      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.3)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@18.19.3)
       '@manypkg/get-packages': 2.2.2
       '@oclif/core': 4.2.4
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -6736,7 +6748,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/version-tools@0.52.0(@types/node@18.19.3)':
+  '@fluid-tools/version-tools@0.55.0(@types/node@18.19.3)':
     dependencies:
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
@@ -6754,9 +6766,9 @@ snapshots:
 
   '@fluidframework/build-common@2.0.3': {}
 
-  '@fluidframework/build-tools@0.52.0(@types/node@18.19.3)':
+  '@fluidframework/build-tools@0.55.0(@types/node@18.19.3)':
     dependencies:
-      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.3)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@18.19.3)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -6790,7 +6802,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/bundle-size-tools@0.52.0':
+  '@fluidframework/bundle-size-tools@0.55.0':
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -7410,29 +7422,29 @@ snapshots:
       jju: 1.4.0
       js-yaml: 4.1.0
 
-  '@microsoft/api-extractor-model@7.30.2(@types/node@18.19.3)':
+  '@microsoft/api-extractor-model@7.30.5(@types/node@18.19.3)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.2(@types/node@18.19.3)
+      '@rushstack/node-core-library': 5.13.0(@types/node@18.19.3)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.49.1(@types/node@18.19.3)':
+  '@microsoft/api-extractor@7.52.3(@types/node@18.19.3)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.2(@types/node@18.19.3)
+      '@microsoft/api-extractor-model': 7.30.5(@types/node@18.19.3)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.2(@types/node@18.19.3)
+      '@rushstack/node-core-library': 5.13.0(@types/node@18.19.3)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.14.5(@types/node@18.19.3)
-      '@rushstack/ts-command-line': 4.23.3(@types/node@18.19.3)
+      '@rushstack/terminal': 0.15.2(@types/node@18.19.3)
+      '@rushstack/ts-command-line': 4.23.7(@types/node@18.19.3)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.7.2
+      typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
 
@@ -7824,23 +7836,36 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.3
 
+  '@rushstack/node-core-library@5.13.0(@types/node@18.19.3)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 11.3.0
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.8
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 18.19.3
+
   '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.14.5(@types/node@18.19.3)':
+  '@rushstack/terminal@0.15.2(@types/node@18.19.3)':
     dependencies:
-      '@rushstack/node-core-library': 5.10.2(@types/node@18.19.3)
+      '@rushstack/node-core-library': 5.13.0(@types/node@18.19.3)
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 18.19.3
 
   '@rushstack/tree-pattern@0.3.1': {}
 
-  '@rushstack/ts-command-line@4.23.3(@types/node@18.19.3)':
+  '@rushstack/ts-command-line@4.23.7(@types/node@18.19.3)':
     dependencies:
-      '@rushstack/terminal': 0.14.5(@types/node@18.19.3)
+      '@rushstack/terminal': 0.15.2(@types/node@18.19.3)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -10267,6 +10292,12 @@ snapshots:
   fs-exists-sync@0.1.0: {}
 
   fs-extra@11.2.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
+  fs-extra@11.3.0:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
@@ -13525,7 +13556,7 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  typescript@5.7.2: {}
+  typescript@5.8.2: {}
 
   uid2@1.0.0: {}
 

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -93,9 +93,9 @@
 	"devDependencies": {
 		"@changesets/cli": "^2.27.8",
 		"@fluid-private/changelog-generator-wrapper": "file:../../packages/tools/changelog-generator-wrapper",
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@microsoft/api-documenter": "^7.21.6",
 		"@microsoft/api-extractor": "^7.45.1",
 		"c8": "^8.0.1",

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -93,9 +93,9 @@
 	"devDependencies": {
 		"@changesets/cli": "^2.27.8",
 		"@fluid-private/changelog-generator-wrapper": "file:../../packages/tools/changelog-generator-wrapper",
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@microsoft/api-documenter": "^7.21.6",
 		"@microsoft/api-extractor": "^7.45.1",
 		"c8": "^8.0.1",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -29,9 +29,9 @@
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -29,9 +29,9 @@
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -32,9 +32,9 @@
 		"@fluidframework/server-services-core": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@5.0.0",
 		"@types/node": "^18.19.39",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -32,9 +32,9 @@
 		"@fluidframework/server-services-core": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@5.0.0",
 		"@types/node": "^18.19.39",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -64,9 +64,9 @@
 		"serialize-error": "^8.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -64,9 +64,9 @@
 		"serialize-error": "^8.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -77,9 +77,9 @@
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -77,9 +77,9 @@
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -71,9 +71,9 @@
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -71,9 +71,9 @@
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -78,9 +78,9 @@
 		"ws": "^7.5.10"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@5.0.0",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -78,9 +78,9 @@
 		"ws": "^7.5.10"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@5.0.0",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -65,9 +65,9 @@
 		"events_pkg": "npm:events@^3.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -65,9 +65,9 @@
 		"events_pkg": "npm:events@^3.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -86,9 +86,9 @@
 		"ws": "^7.5.10"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-local-server": "workspace:~",
 		"@fluidframework/server-routerlicious-base-previous": "npm:@fluidframework/server-routerlicious-base@5.0.0",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -86,9 +86,9 @@
 		"ws": "^7.5.10"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-local-server": "workspace:~",
 		"@fluidframework/server-routerlicious-base-previous": "npm:@fluidframework/server-routerlicious-base@5.0.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -59,9 +59,9 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-local-server": "workspace:~",
 		"@fluidframework/server-routerlicious-previous": "npm:@fluidframework/server-routerlicious@5.0.0",

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -59,9 +59,9 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-local-server": "workspace:~",
 		"@fluidframework/server-routerlicious-previous": "npm:@fluidframework/server-routerlicious@5.0.0",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -73,9 +73,9 @@
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -73,9 +73,9 @@
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -44,9 +44,9 @@
 		"nconf": "^0.12.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@5.0.0",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -44,9 +44,9 @@
 		"nconf": "^0.12.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@5.0.0",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -39,9 +39,9 @@
 		"sillyname": "^0.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -39,9 +39,9 @@
 		"sillyname": "^0.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -39,9 +39,9 @@
 		"sillyname": "^0.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -39,9 +39,9 @@
 		"sillyname": "^0.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -32,9 +32,9 @@
 		"zookeeper": "^5.3.2"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -32,9 +32,9 @@
 		"zookeeper": "^5.3.2"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -79,9 +79,9 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -79,9 +79,9 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -59,9 +59,9 @@
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@5.0.0",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -59,9 +59,9 @@
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@5.0.0",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -72,9 +72,9 @@
 		"winston-transport": "^4.5.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -72,9 +72,9 @@
 		"winston-transport": "^4.5.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -77,9 +77,9 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -77,9 +77,9 @@
 		"winston": "^3.6.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -69,9 +69,9 @@
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "^0.52.0",
+		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.52.0",
+		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@5.0.0",
 		"@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -69,9 +69,9 @@
 		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
-		"@fluid-tools/build-cli": "0.52.0-315632",
+		"@fluid-tools/build-cli": "^0.52.0",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "0.52.0-315632",
+		"@fluidframework/build-tools": "^0.52.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@5.0.0",
 		"@types/lodash": "^4.14.118",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -27,14 +27,14 @@ importers:
         specifier: file:../../packages/tools/changelog-generator-wrapper
         version: file:../../packages/tools/changelog-generator-wrapper
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@22.10.7)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@22.10.7)
       '@microsoft/api-documenter':
         specifier: ^7.21.6
         version: 7.22.21(@types/node@22.10.7)
@@ -72,14 +72,14 @@ importers:
   packages/gitresources:
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@22.10.7)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@22.10.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -118,14 +118,14 @@ importers:
         version: link:../services-core
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -224,14 +224,14 @@ importers:
         version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -330,14 +330,14 @@ importers:
         version: 8.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -421,14 +421,14 @@ importers:
         version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)(webpack-cli@5.1.4)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -557,14 +557,14 @@ importers:
         version: 7.5.10
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -615,14 +615,14 @@ importers:
         version: events@3.3.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -727,14 +727,14 @@ importers:
         version: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -872,14 +872,14 @@ importers:
         version: 7.5.10
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1047,14 +1047,14 @@ importers:
         version: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1150,14 +1150,14 @@ importers:
         version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1241,14 +1241,14 @@ importers:
         version: 0.12.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1314,14 +1314,14 @@ importers:
         version: 0.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1393,14 +1393,14 @@ importers:
         version: 0.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1454,14 +1454,14 @@ importers:
         version: 5.6.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1581,14 +1581,14 @@ importers:
         version: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1666,14 +1666,14 @@ importers:
         version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1772,14 +1772,14 @@ importers:
         version: 4.5.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1896,14 +1896,14 @@ importers:
         version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: 0.52.0-315632
-        version: 0.52.0-315632(@types/node@18.19.39)
+        specifier: ^0.52.0
+        version: 0.52.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -2410,13 +2410,17 @@ packages:
   '@fluid-private/changelog-generator-wrapper@file:../../packages/tools/changelog-generator-wrapper':
     resolution: {directory: ../../packages/tools/changelog-generator-wrapper, type: directory}
 
-  '@fluid-tools/build-cli@0.52.0-315632':
-    resolution: {integrity: sha512-mCnlGVEhssycNqW6N0xFjcbGjHsNG2aj+9gPtBdd4L0tWLMJyLag7SRfORdvcAuSUhvhiYbEdSGhwvRzkBl/Rw==}
+  '@fluid-tools/build-cli@0.52.0':
+    resolution: {integrity: sha512-LDR9EIEARbM1dLhoWn3DU9fZ24yXwrDa6IlkN2jaNRPb8E3gvIpukYY17n9ejhS801sx/6g1Uiu16FvyO2l3kQ==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
-  '@fluid-tools/version-tools@0.52.0-315632':
-    resolution: {integrity: sha512-GLglzryXTGCiBtxBnXOJcloepJhDFtujzkSqXgOMIHTMU8w+8P5qiLNDOa0N1kQHlb6Wt47sCoHG6Cz+bBQ7+Q==}
+  '@fluid-tools/build-infrastructure@0.52.0':
+    resolution: {integrity: sha512-pItNDnPtKiKQmh4lZ7YJC6Vvkt7RetZKOfUNTaudHTRNsrkI9FtVxrHgZe58JlAHIkdEr1wltEUG8nAlJrS8CA==}
+    hasBin: true
+
+  '@fluid-tools/version-tools@0.52.0':
+    resolution: {integrity: sha512-U8bxX3P7E5l1XGpcWEkONUCXVgBKXpZxjN4tqVy5Z9x1i3VKmjhd5zSH5Q5ndSs10iCM/25ukZb9xfXMXJwsYQ==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
@@ -2424,13 +2428,13 @@ packages:
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
     hasBin: true
 
-  '@fluidframework/build-tools@0.52.0-315632':
-    resolution: {integrity: sha512-L0mwaMA12xppnng21dp64nCJ6As06XOWsbG+pSi3T1n8RCharRkgUVNH7fGW+OeIUnBDGgqCp/k+I/AKnQfaww==}
+  '@fluidframework/build-tools@0.52.0':
+    resolution: {integrity: sha512-+TlVmwe88PdFkKt9ilLHf0b0h2LlzoyLIW3GuTL0chKTYCM9r1b0QgLwmLH/RFPb5e8vK4N1vb7os9JZCHAMyw==}
     engines: {node: '>=18.17.1'}
     hasBin: true
 
-  '@fluidframework/bundle-size-tools@0.52.0-315632':
-    resolution: {integrity: sha512-QHxAJDXqtngI3d1Qfxp+xNvPw2nIwEcT74yLYpNXTYOEyChffHtI6KZ/LpSjiogTeB0YnwR9egK4X2A/57esBQ==}
+  '@fluidframework/bundle-size-tools@0.52.0':
+    resolution: {integrity: sha512-P5m6P3pBUhVXVJvilaZdv1CEavRwFmsLAEMB04L306o6D7bWCozo0DE7onItoc+Ch5Bbh0kNBquvSfAvpvTbFA==}
 
   '@fluidframework/common-definitions@1.1.0':
     resolution: {integrity: sha512-WQYtG9tkx2j7i1JSXPvwLnQsqCOZAghMj0aGciqjZVNppUly/XBpAjb4V6FEUCEjxCScPKhyE+1rhV1ep52NgA==}
@@ -4086,9 +4090,6 @@ packages:
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
-
-  builtins@5.0.1:
-    resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
 
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -6532,10 +6533,6 @@ packages:
     resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minimatch@9.0.4:
-    resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -7140,6 +7137,10 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
+  picospinner@2.1.0:
+    resolution: {integrity: sha512-kaBFPNItKVivIKrWt0RuLz0UilZX8KgZeaBrjSUjjExza5ISWtBAtbDYTOon31EGGH6wTdQ22gTXiykmhv/Kqg==}
+    engines: {node: '>=18.0.0'}
+
   pidusage@2.0.21:
     resolution: {integrity: sha512-cv3xAQos+pugVX+BfXpHsbyz/dLzX+lr44zNMsYiGxUw+kV5sgQCIcLd1z+0vq+KyC7dJ+/ts2PsfgWfSC3WXA==}
     engines: {node: '>=8'}
@@ -7466,10 +7467,6 @@ packages:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
 
-  registry-auth-token@5.0.2:
-    resolution: {integrity: sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==}
-    engines: {node: '>=14'}
-
   registry-auth-token@5.0.3:
     resolution: {integrity: sha512-1bpc9IyC+e+CNFRaWyn77tk4xGG4PPUyfakSmA6F6cvUDjrm58dfyJ3II+9yb10EDkHoy1LaPSmHaWLOH3m6HA==}
     engines: {node: '>=14'}
@@ -7682,11 +7679,6 @@ packages:
 
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.6.3:
-    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -8493,10 +8485,6 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
-
-  validate-npm-package-name@5.0.0:
-    resolution: {integrity: sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -9479,12 +9467,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluid-tools/build-cli@0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)':
+  '@fluid-tools/build-cli@0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.19.39)
-      '@fluidframework/build-tools': 0.52.0-315632(@types/node@18.19.39)
-      '@fluidframework/bundle-size-tools': 0.52.0-315632
+      '@fluid-tools/build-infrastructure': 0.52.0(@types/node@18.19.39)
+      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.39)
+      '@fluidframework/build-tools': 0.52.0(@types/node@18.19.39)
+      '@fluidframework/bundle-size-tools': 0.52.0
       '@inquirer/prompts': 7.2.3(@types/node@18.19.39)
       '@microsoft/api-extractor': 7.49.1(@types/node@18.19.39)
       '@oclif/core': 4.2.4
@@ -9531,7 +9520,7 @@ snapshots:
       remark-toc: 9.0.0
       replace-in-file: 7.2.0
       resolve.exports: 2.0.2
-      semver: 7.6.3
+      semver: 7.7.1
       semver-utils: 1.1.4
       simple-git: 3.27.0
       sort-json: 2.0.1
@@ -9556,12 +9545,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-cli@0.52.0-315632(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)(webpack-cli@5.1.4)':
+  '@fluid-tools/build-cli@0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)(webpack-cli@5.1.4)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.19.39)
-      '@fluidframework/build-tools': 0.52.0-315632(@types/node@18.19.39)
-      '@fluidframework/bundle-size-tools': 0.52.0-315632(webpack-cli@5.1.4)
+      '@fluid-tools/build-infrastructure': 0.52.0(@types/node@18.19.39)
+      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.39)
+      '@fluidframework/build-tools': 0.52.0(@types/node@18.19.39)
+      '@fluidframework/bundle-size-tools': 0.52.0(webpack-cli@5.1.4)
       '@inquirer/prompts': 7.2.3(@types/node@18.19.39)
       '@microsoft/api-extractor': 7.49.1(@types/node@18.19.39)
       '@oclif/core': 4.2.4
@@ -9608,7 +9598,7 @@ snapshots:
       remark-toc: 9.0.0
       replace-in-file: 7.2.0
       resolve.exports: 2.0.2
-      semver: 7.6.3
+      semver: 7.7.1
       semver-utils: 1.1.4
       simple-git: 3.27.0
       sort-json: 2.0.1
@@ -9633,12 +9623,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-cli@0.52.0-315632(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)':
+  '@fluid-tools/build-cli@0.52.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@22.10.7)
-      '@fluidframework/build-tools': 0.52.0-315632(@types/node@22.10.7)
-      '@fluidframework/bundle-size-tools': 0.52.0-315632
+      '@fluid-tools/build-infrastructure': 0.52.0(@types/node@22.10.7)
+      '@fluid-tools/version-tools': 0.52.0(@types/node@22.10.7)
+      '@fluidframework/build-tools': 0.52.0(@types/node@22.10.7)
+      '@fluidframework/bundle-size-tools': 0.52.0
       '@inquirer/prompts': 7.2.3(@types/node@22.10.7)
       '@microsoft/api-extractor': 7.49.1(@types/node@22.10.7)
       '@oclif/core': 4.2.4
@@ -9685,7 +9676,7 @@ snapshots:
       remark-toc: 9.0.0
       replace-in-file: 7.2.0
       resolve.exports: 2.0.2
-      semver: 7.6.3
+      semver: 7.7.1
       semver-utils: 1.1.4
       simple-git: 3.27.0
       sort-json: 2.0.1
@@ -9710,7 +9701,59 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/version-tools@0.52.0-315632(@types/node@18.19.39)':
+  '@fluid-tools/build-infrastructure@0.52.0(@types/node@18.19.39)':
+    dependencies:
+      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.39)
+      '@manypkg/get-packages': 2.2.2
+      '@oclif/core': 4.2.4
+      cosmiconfig: 8.3.6(typescript@5.4.5)
+      detect-indent: 6.1.0
+      execa: 5.1.1
+      fs-extra: 11.3.0
+      globby: 11.1.0
+      micromatch: 4.0.8
+      oclif: 4.17.17(@types/node@18.19.39)
+      picocolors: 1.1.1
+      read-pkg-up: 7.0.1
+      semver: 7.7.1
+      simple-git: 3.27.0
+      sort-package-json: 1.57.0
+      type-fest: 2.19.0
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - react-devtools-core
+      - supports-color
+      - utf-8-validate
+
+  '@fluid-tools/build-infrastructure@0.52.0(@types/node@22.10.7)':
+    dependencies:
+      '@fluid-tools/version-tools': 0.52.0(@types/node@22.10.7)
+      '@manypkg/get-packages': 2.2.2
+      '@oclif/core': 4.2.4
+      cosmiconfig: 8.3.6(typescript@5.4.5)
+      detect-indent: 6.1.0
+      execa: 5.1.1
+      fs-extra: 11.3.0
+      globby: 11.1.0
+      micromatch: 4.0.8
+      oclif: 4.17.17(@types/node@22.10.7)
+      picocolors: 1.1.1
+      read-pkg-up: 7.0.1
+      semver: 7.7.1
+      simple-git: 3.27.0
+      sort-package-json: 1.57.0
+      type-fest: 2.19.0
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - react-devtools-core
+      - supports-color
+      - utf-8-validate
+
+  '@fluid-tools/version-tools@0.52.0(@types/node@18.19.39)':
     dependencies:
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
@@ -9726,7 +9769,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/version-tools@0.52.0-315632(@types/node@22.10.7)':
+  '@fluid-tools/version-tools@0.52.0(@types/node@22.10.7)':
     dependencies:
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
@@ -9744,9 +9787,9 @@ snapshots:
 
   '@fluidframework/build-common@2.0.3': {}
 
-  '@fluidframework/build-tools@0.52.0-315632(@types/node@18.19.39)':
+  '@fluidframework/build-tools@0.52.0(@types/node@18.19.39)':
     dependencies:
-      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@18.19.39)
+      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.39)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -9764,8 +9807,9 @@ snapshots:
       multimatch: 5.0.0
       picocolors: 1.1.1
       picomatch: 2.3.1
+      picospinner: 2.1.0
       rimraf: 4.4.1
-      semver: 7.6.3
+      semver: 7.7.1
       sort-package-json: 1.57.0
       ts-deepmerge: 7.0.2
       ts-morph: 22.0.0
@@ -9779,9 +9823,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/build-tools@0.52.0-315632(@types/node@22.10.7)':
+  '@fluidframework/build-tools@0.52.0(@types/node@22.10.7)':
     dependencies:
-      '@fluid-tools/version-tools': 0.52.0-315632(@types/node@22.10.7)
+      '@fluid-tools/version-tools': 0.52.0(@types/node@22.10.7)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -9799,8 +9843,9 @@ snapshots:
       multimatch: 5.0.0
       picocolors: 1.1.1
       picomatch: 2.3.1
+      picospinner: 2.1.0
       rimraf: 4.4.1
-      semver: 7.6.3
+      semver: 7.7.1
       sort-package-json: 1.57.0
       ts-deepmerge: 7.0.2
       ts-morph: 22.0.0
@@ -9814,7 +9859,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/bundle-size-tools@0.52.0-315632':
+  '@fluidframework/bundle-size-tools@0.52.0':
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -9828,7 +9873,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@fluidframework/bundle-size-tools@0.52.0-315632(webpack-cli@5.1.4)':
+  '@fluidframework/bundle-size-tools@0.52.0(webpack-cli@5.1.4)':
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -9870,7 +9915,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 6.7.5(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0)(typescript@5.1.6)
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.1.6)
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
       eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
@@ -11908,7 +11953,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.7.5(eslint@8.55.0)(typescript@5.1.6)
       '@typescript-eslint/utils': 6.7.5(eslint@8.55.0)(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.7.5
-      debug: 4.3.4
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.55.0
       graphemer: 1.4.0
       ignore: 5.3.0
@@ -11934,7 +11979,7 @@ snapshots:
       '@typescript-eslint/types': 6.7.5
       '@typescript-eslint/typescript-estree': 6.7.5(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.7.5
-      debug: 4.3.4
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.55.0
     optionalDependencies:
       typescript: 5.1.6
@@ -12654,10 +12699,6 @@ snapshots:
   buffers@0.1.1: {}
 
   builtin-modules@3.3.0: {}
-
-  builtins@5.0.1:
-    dependencies:
-      semver: 7.7.1
 
   bytes@3.0.0: {}
 
@@ -13555,12 +13596,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.55.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
       eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
@@ -13572,14 +13613,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.1.6)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13595,7 +13636,7 @@ snapshots:
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
       get-tsconfig: 4.7.2
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -13611,7 +13652,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.40.1
       are-docs-informative: 0.0.2
       comment-parser: 1.4.0
-      debug: 4.3.4
+      debug: 4.4.0(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint: 8.55.0
       esquery: 1.5.0
@@ -14220,7 +14261,7 @@ snapshots:
       dir-glob: 3.0.1
       fast-glob: 3.3.2
       glob: 7.2.3
-      ignore: 5.3.0
+      ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
 
@@ -14229,7 +14270,7 @@ snapshots:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.0
+      ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
 
@@ -15547,10 +15588,6 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
-  minimatch@9.0.4:
-    dependencies:
-      brace-expansion: 2.0.1
-
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
@@ -15881,7 +15918,7 @@ snapshots:
       jsonlines: 0.1.1
       lodash: 4.17.21
       make-fetch-happen: 11.1.1
-      minimatch: 9.0.4
+      minimatch: 9.0.5
       p-map: 4.0.0
       pacote: 15.2.0
       parse-github-url: 1.0.2
@@ -15913,7 +15950,7 @@ snapshots:
       hosted-git-info: 6.1.1
       proc-log: 3.0.0
       semver: 7.7.1
-      validate-npm-package-name: 5.0.0
+      validate-npm-package-name: 5.0.1
 
   npm-packlist@7.0.4:
     dependencies:
@@ -16173,14 +16210,14 @@ snapshots:
   package-json@10.0.1:
     dependencies:
       ky: 1.7.4
-      registry-auth-token: 5.0.2
+      registry-auth-token: 5.0.3
       registry-url: 6.0.1
       semver: 7.7.1
 
   package-json@8.1.1:
     dependencies:
       got: 12.6.1
-      registry-auth-token: 5.0.2
+      registry-auth-token: 5.0.3
       registry-url: 6.0.1
       semver: 7.7.1
 
@@ -16312,6 +16349,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picospinner@2.1.0: {}
 
   pidusage@2.0.21:
     dependencies:
@@ -16722,10 +16761,6 @@ snapshots:
       es-errors: 1.3.0
       set-function-name: 2.0.2
 
-  registry-auth-token@5.0.2:
-    dependencies:
-      '@pnpm/npm-conf': 2.2.2
-
   registry-auth-token@5.0.3:
     dependencies:
       '@pnpm/npm-conf': 2.2.2
@@ -16956,8 +16991,6 @@ snapshots:
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
-
-  semver@7.6.3: {}
 
   semver@7.7.1: {}
 
@@ -17907,10 +17940,6 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
-
-  validate-npm-package-name@5.0.0:
-    dependencies:
-      builtins: 5.0.1
 
   validate-npm-package-name@5.0.1: {}
 

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -27,14 +27,14 @@ importers:
         specifier: file:../../packages/tools/changelog-generator-wrapper
         version: file:../../packages/tools/changelog-generator-wrapper
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@22.10.7)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@22.10.7)
       '@microsoft/api-documenter':
         specifier: ^7.21.6
         version: 7.22.21(@types/node@22.10.7)
@@ -72,14 +72,14 @@ importers:
   packages/gitresources:
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@22.10.7)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@22.10.7)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -118,14 +118,14 @@ importers:
         version: link:../services-core
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -224,14 +224,14 @@ importers:
         version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -330,14 +330,14 @@ importers:
         version: 8.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -421,14 +421,14 @@ importers:
         version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)(webpack-cli@5.1.4)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)(webpack-cli@5.1.4)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -557,14 +557,14 @@ importers:
         version: 7.5.10
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -615,14 +615,14 @@ importers:
         version: events@3.3.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -727,14 +727,14 @@ importers:
         version: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -872,14 +872,14 @@ importers:
         version: 7.5.10
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1047,14 +1047,14 @@ importers:
         version: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1150,14 +1150,14 @@ importers:
         version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1241,14 +1241,14 @@ importers:
         version: 0.12.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1314,14 +1314,14 @@ importers:
         version: 0.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1393,14 +1393,14 @@ importers:
         version: 0.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1454,14 +1454,14 @@ importers:
         version: 5.6.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1581,14 +1581,14 @@ importers:
         version: 3.9.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1666,14 +1666,14 @@ importers:
         version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1772,14 +1772,14 @@ importers:
         version: 4.5.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -1896,14 +1896,14 @@ importers:
         version: 11.1.0
     devDependencies:
       '@fluid-tools/build-cli':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.52.0
-        version: 0.52.0(@types/node@18.19.39)
+        specifier: ^0.55.0
+        version: 0.55.0(@types/node@18.19.39)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -2410,31 +2410,31 @@ packages:
   '@fluid-private/changelog-generator-wrapper@file:../../packages/tools/changelog-generator-wrapper':
     resolution: {directory: ../../packages/tools/changelog-generator-wrapper, type: directory}
 
-  '@fluid-tools/build-cli@0.52.0':
-    resolution: {integrity: sha512-LDR9EIEARbM1dLhoWn3DU9fZ24yXwrDa6IlkN2jaNRPb8E3gvIpukYY17n9ejhS801sx/6g1Uiu16FvyO2l3kQ==}
-    engines: {node: '>=18.17.1'}
+  '@fluid-tools/build-cli@0.55.0':
+    resolution: {integrity: sha512-PnPoJx/7Fzz/jO8/0+QyYARtiJRIsj1NE79DPWbrBGdeSAacok/UgrEJ3JC1Kr68KKgnoIU3Zo7DnLPfBWx1PQ==}
+    engines: {node: '>=20.15.1'}
     hasBin: true
 
-  '@fluid-tools/build-infrastructure@0.52.0':
-    resolution: {integrity: sha512-pItNDnPtKiKQmh4lZ7YJC6Vvkt7RetZKOfUNTaudHTRNsrkI9FtVxrHgZe58JlAHIkdEr1wltEUG8nAlJrS8CA==}
+  '@fluid-tools/build-infrastructure@0.55.0':
+    resolution: {integrity: sha512-uctF9nN8yQqpizqj4ZEjT7Qet2YFMHzpdDFXrS8Dl4turfLPoiMhD+1sFGhE2tsvdx25QcBYe45u7IAsefCFiA==}
     hasBin: true
 
-  '@fluid-tools/version-tools@0.52.0':
-    resolution: {integrity: sha512-U8bxX3P7E5l1XGpcWEkONUCXVgBKXpZxjN4tqVy5Z9x1i3VKmjhd5zSH5Q5ndSs10iCM/25ukZb9xfXMXJwsYQ==}
-    engines: {node: '>=18.17.1'}
+  '@fluid-tools/version-tools@0.55.0':
+    resolution: {integrity: sha512-sdQq4poJz4/L9TcXZJXw3mNPzp0qZH/Qv4ufNSrPSDtWDHucgYsg1zR/VmSwf6EYRQ086Jij7vnFnkSGsIrKIA==}
+    engines: {node: '>=20.15.1'}
     hasBin: true
 
   '@fluidframework/build-common@2.0.3':
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
     hasBin: true
 
-  '@fluidframework/build-tools@0.52.0':
-    resolution: {integrity: sha512-+TlVmwe88PdFkKt9ilLHf0b0h2LlzoyLIW3GuTL0chKTYCM9r1b0QgLwmLH/RFPb5e8vK4N1vb7os9JZCHAMyw==}
-    engines: {node: '>=18.17.1'}
+  '@fluidframework/build-tools@0.55.0':
+    resolution: {integrity: sha512-BurYYIeAnVLMBr9UIJPzfN3V1qLJtItwLrxDJqyPqqZTFxqL4MvafilX8caKuSVUJqLuFCf+KS8ABg+6rXywtg==}
+    engines: {node: '>=20.15.1'}
     hasBin: true
 
-  '@fluidframework/bundle-size-tools@0.52.0':
-    resolution: {integrity: sha512-P5m6P3pBUhVXVJvilaZdv1CEavRwFmsLAEMB04L306o6D7bWCozo0DE7onItoc+Ch5Bbh0kNBquvSfAvpvTbFA==}
+  '@fluidframework/bundle-size-tools@0.55.0':
+    resolution: {integrity: sha512-1j2p1VDFjgRYFNkJRVQI82xTtyA3G3Q6JEp7ohraQknq116TB0FAfIKCADEcvaFawd9oeXcTsnFif9S3gChU1Q==}
 
   '@fluidframework/common-definitions@1.1.0':
     resolution: {integrity: sha512-WQYtG9tkx2j7i1JSXPvwLnQsqCOZAghMj0aGciqjZVNppUly/XBpAjb4V6FEUCEjxCScPKhyE+1rhV1ep52NgA==}
@@ -2709,15 +2709,15 @@ packages:
   '@microsoft/api-extractor-model@7.28.21':
     resolution: {integrity: sha512-AZSdhK/vO4ddukfheXZmrkI5180XLeAqwzu/5pTsJHsXYSyNt3H3VJyynUYKMeNcveG9QLgljH3XRr/LqEfC0Q==}
 
-  '@microsoft/api-extractor-model@7.30.2':
-    resolution: {integrity: sha512-3/t2F+WhkJgBzSNwlkTIL0tBgUoBqDqL66pT+nh2mPbM0NIDGVGtpqbGWPgHIzn/mn7kGS/Ep8D8po58e8UUIw==}
+  '@microsoft/api-extractor-model@7.30.5':
+    resolution: {integrity: sha512-0ic4rcbcDZHz833RaTZWTGu+NpNgrxVNjVaor0ZDUymfDFzjA/Uuk8hYziIUIOEOSTfmIQqyzVwlzxZxPe7tOA==}
 
   '@microsoft/api-extractor@7.45.1':
     resolution: {integrity: sha512-FZgcJxEmHA15gxTb1PpXHTforRcyIOLp6GKMqqk+ok8M58QJ0y54Bk+dcTcBC92nmanZppKn5/VRXPP4XvzB3Q==}
     hasBin: true
 
-  '@microsoft/api-extractor@7.49.1':
-    resolution: {integrity: sha512-jRTR/XbQF2kb+dYn8hfYSicOGA99+Fo00GrsdMwdfE3eIgLtKdH6Qa2M3wZV9S2XmbgCaGX1OdPtYctbfu5jQg==}
+  '@microsoft/api-extractor@7.52.3':
+    resolution: {integrity: sha512-QEs6l8h7p9eOSHrQ9NBBUZhUuq+j/2QKcRgigbSs2YQepKz8glvsqmsUOp+nvuaY60ps7KkpVVYQCj81WLoMVQ==}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.16.2':
@@ -2977,6 +2977,14 @@ packages:
       '@types/node':
         optional: true
 
+  '@rushstack/node-core-library@5.13.0':
+    resolution: {integrity: sha512-IGVhy+JgUacAdCGXKUrRhwHMTzqhWwZUI+qEPcdzsb80heOw0QPbhhoVsoiMF7Klp8eYsp7hzpScMXmOa3Uhfg==}
+    peerDependencies:
+      '@types/node': ^18.19.39
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@rushstack/node-core-library@5.3.0':
     resolution: {integrity: sha512-t23gjdZV6aWkbwXSE3TkKr1UXJFbXICvAOJ0MRQEB/ZYGhfSJqqrQFaGd20I1a/nIIHJEkNO0xzycHixjcbCPw==}
     peerDependencies:
@@ -2999,8 +3007,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@rushstack/terminal@0.14.5':
-    resolution: {integrity: sha512-TEOpNwwmsZVrkp0omnuTUTGZRJKTr6n6m4OITiNjkqzLAkcazVpwR1SOtBg6uzpkIBLgrcNHETqI8rbw3uiUfw==}
+  '@rushstack/terminal@0.15.2':
+    resolution: {integrity: sha512-7Hmc0ysK5077R/IkLS9hYu0QuNafm+TbZbtYVzCMbeOdMjaRboLKrhryjwZSRJGJzu+TV1ON7qZHeqf58XfLpA==}
     peerDependencies:
       '@types/node': ^18.19.39
     peerDependenciesMeta:
@@ -3016,8 +3024,8 @@ packages:
   '@rushstack/ts-command-line@4.21.4':
     resolution: {integrity: sha512-3ZjQ11kpQwk/lDQqbmxC8UuU6yD20Sy4uNTWIaBEJ5474hEFEE4cbDOS4F9R4zcyCkkaQYv674K2QTunDF5dsQ==}
 
-  '@rushstack/ts-command-line@4.23.3':
-    resolution: {integrity: sha512-HazKL8fv4HMQMzrKJCrOrhyBPPdzk7iajUXgsASwjQ8ROo1cmgyqxt/k9+SdmrNLGE1zATgRqMUH3s/6smbRMA==}
+  '@rushstack/ts-command-line@4.23.7':
+    resolution: {integrity: sha512-Gr9cB7DGe6uz5vq2wdr89WbVDKz0UeuFEn5H2CfWDe7JvjFFaiV15gi6mqDBTbHhHCWS7w8mF1h3BnIfUndqdA==}
 
   '@sigstore/protobuf-specs@0.1.0':
     resolution: {integrity: sha512-a31EnjuIDSX8IXBUib3cYLDRlPMU36AWX4xS8ysLaNu4ZzUesDiPt83pgrW2X1YLMe5L2HbDyaKK5BrL4cNKaQ==}
@@ -8336,8 +8344,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.2:
-    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -9467,15 +9475,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluid-tools/build-cli@0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)':
+  '@fluid-tools/build-cli@0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/build-infrastructure': 0.52.0(@types/node@18.19.39)
-      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.39)
-      '@fluidframework/build-tools': 0.52.0(@types/node@18.19.39)
-      '@fluidframework/bundle-size-tools': 0.52.0
+      '@fluid-tools/build-infrastructure': 0.55.0(@types/node@18.19.39)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@18.19.39)
+      '@fluidframework/build-tools': 0.55.0(@types/node@18.19.39)
+      '@fluidframework/bundle-size-tools': 0.55.0
       '@inquirer/prompts': 7.2.3(@types/node@18.19.39)
-      '@microsoft/api-extractor': 7.49.1(@types/node@18.19.39)
+      '@microsoft/api-extractor': 7.52.3(@types/node@18.19.39)
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
       '@oclif/plugin-commands': 4.1.17
@@ -9545,15 +9553,15 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-cli@0.52.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)(webpack-cli@5.1.4)':
+  '@fluid-tools/build-cli@0.55.0(@types/node@18.19.39)(encoding@0.1.13)(typescript@5.1.6)(webpack-cli@5.1.4)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/build-infrastructure': 0.52.0(@types/node@18.19.39)
-      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.39)
-      '@fluidframework/build-tools': 0.52.0(@types/node@18.19.39)
-      '@fluidframework/bundle-size-tools': 0.52.0(webpack-cli@5.1.4)
+      '@fluid-tools/build-infrastructure': 0.55.0(@types/node@18.19.39)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@18.19.39)
+      '@fluidframework/build-tools': 0.55.0(@types/node@18.19.39)
+      '@fluidframework/bundle-size-tools': 0.55.0(webpack-cli@5.1.4)
       '@inquirer/prompts': 7.2.3(@types/node@18.19.39)
-      '@microsoft/api-extractor': 7.49.1(@types/node@18.19.39)
+      '@microsoft/api-extractor': 7.52.3(@types/node@18.19.39)
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
       '@oclif/plugin-commands': 4.1.17
@@ -9623,15 +9631,15 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-cli@0.52.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)':
+  '@fluid-tools/build-cli@0.55.0(@types/node@22.10.7)(encoding@0.1.13)(typescript@5.1.6)':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      '@fluid-tools/build-infrastructure': 0.52.0(@types/node@22.10.7)
-      '@fluid-tools/version-tools': 0.52.0(@types/node@22.10.7)
-      '@fluidframework/build-tools': 0.52.0(@types/node@22.10.7)
-      '@fluidframework/bundle-size-tools': 0.52.0
+      '@fluid-tools/build-infrastructure': 0.55.0(@types/node@22.10.7)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@22.10.7)
+      '@fluidframework/build-tools': 0.55.0(@types/node@22.10.7)
+      '@fluidframework/bundle-size-tools': 0.55.0
       '@inquirer/prompts': 7.2.3(@types/node@22.10.7)
-      '@microsoft/api-extractor': 7.49.1(@types/node@22.10.7)
+      '@microsoft/api-extractor': 7.52.3(@types/node@22.10.7)
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
       '@oclif/plugin-commands': 4.1.17
@@ -9701,9 +9709,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@fluid-tools/build-infrastructure@0.52.0(@types/node@18.19.39)':
+  '@fluid-tools/build-infrastructure@0.55.0(@types/node@18.19.39)':
     dependencies:
-      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.39)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@18.19.39)
       '@manypkg/get-packages': 2.2.2
       '@oclif/core': 4.2.4
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -9727,9 +9735,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/build-infrastructure@0.52.0(@types/node@22.10.7)':
+  '@fluid-tools/build-infrastructure@0.55.0(@types/node@22.10.7)':
     dependencies:
-      '@fluid-tools/version-tools': 0.52.0(@types/node@22.10.7)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@22.10.7)
       '@manypkg/get-packages': 2.2.2
       '@oclif/core': 4.2.4
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -9753,7 +9761,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/version-tools@0.52.0(@types/node@18.19.39)':
+  '@fluid-tools/version-tools@0.55.0(@types/node@18.19.39)':
     dependencies:
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
@@ -9769,7 +9777,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/version-tools@0.52.0(@types/node@22.10.7)':
+  '@fluid-tools/version-tools@0.55.0(@types/node@22.10.7)':
     dependencies:
       '@oclif/core': 4.2.4
       '@oclif/plugin-autocomplete': 3.2.18
@@ -9787,9 +9795,9 @@ snapshots:
 
   '@fluidframework/build-common@2.0.3': {}
 
-  '@fluidframework/build-tools@0.52.0(@types/node@18.19.39)':
+  '@fluidframework/build-tools@0.55.0(@types/node@18.19.39)':
     dependencies:
-      '@fluid-tools/version-tools': 0.52.0(@types/node@18.19.39)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@18.19.39)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -9823,9 +9831,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/build-tools@0.52.0(@types/node@22.10.7)':
+  '@fluidframework/build-tools@0.55.0(@types/node@22.10.7)':
     dependencies:
-      '@fluid-tools/version-tools': 0.52.0(@types/node@22.10.7)
+      '@fluid-tools/version-tools': 0.55.0(@types/node@22.10.7)
       '@manypkg/get-packages': 2.2.2
       async: 3.2.6
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -9859,7 +9867,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/bundle-size-tools@0.52.0':
+  '@fluidframework/bundle-size-tools@0.55.0':
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -9873,7 +9881,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@fluidframework/bundle-size-tools@0.52.0(webpack-cli@5.1.4)':
+  '@fluidframework/bundle-size-tools@0.55.0(webpack-cli@5.1.4)':
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -10678,19 +10686,19 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.30.2(@types/node@18.19.39)':
+  '@microsoft/api-extractor-model@7.30.5(@types/node@18.19.39)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.2(@types/node@18.19.39)
+      '@rushstack/node-core-library': 5.13.0(@types/node@18.19.39)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.30.2(@types/node@22.10.7)':
+  '@microsoft/api-extractor-model@7.30.5(@types/node@22.10.7)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.2(@types/node@22.10.7)
+      '@rushstack/node-core-library': 5.13.0(@types/node@22.10.7)
     transitivePeerDependencies:
       - '@types/node'
 
@@ -10730,39 +10738,39 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.49.1(@types/node@18.19.39)':
+  '@microsoft/api-extractor@7.52.3(@types/node@18.19.39)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.2(@types/node@18.19.39)
+      '@microsoft/api-extractor-model': 7.30.5(@types/node@18.19.39)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.2(@types/node@18.19.39)
+      '@rushstack/node-core-library': 5.13.0(@types/node@18.19.39)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.14.5(@types/node@18.19.39)
-      '@rushstack/ts-command-line': 4.23.3(@types/node@18.19.39)
+      '@rushstack/terminal': 0.15.2(@types/node@18.19.39)
+      '@rushstack/ts-command-line': 4.23.7(@types/node@18.19.39)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.7.2
+      typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.49.1(@types/node@22.10.7)':
+  '@microsoft/api-extractor@7.52.3(@types/node@22.10.7)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.2(@types/node@22.10.7)
+      '@microsoft/api-extractor-model': 7.30.5(@types/node@22.10.7)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.2(@types/node@22.10.7)
+      '@rushstack/node-core-library': 5.13.0(@types/node@22.10.7)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.14.5(@types/node@22.10.7)
-      '@rushstack/ts-command-line': 4.23.3(@types/node@22.10.7)
+      '@rushstack/terminal': 0.15.2(@types/node@22.10.7)
+      '@rushstack/ts-command-line': 4.23.7(@types/node@22.10.7)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.7.2
+      typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
 
@@ -11229,6 +11237,32 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.7
 
+  '@rushstack/node-core-library@5.13.0(@types/node@18.19.39)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 11.3.0
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.8
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 18.19.39
+
+  '@rushstack/node-core-library@5.13.0(@types/node@22.10.7)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 11.3.0
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.8
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 22.10.7
+
   '@rushstack/node-core-library@5.3.0(@types/node@18.19.39)':
     dependencies:
       ajv: 8.13.0
@@ -11279,16 +11313,16 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.7
 
-  '@rushstack/terminal@0.14.5(@types/node@18.19.39)':
+  '@rushstack/terminal@0.15.2(@types/node@18.19.39)':
     dependencies:
-      '@rushstack/node-core-library': 5.10.2(@types/node@18.19.39)
+      '@rushstack/node-core-library': 5.13.0(@types/node@18.19.39)
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 18.19.39
 
-  '@rushstack/terminal@0.14.5(@types/node@22.10.7)':
+  '@rushstack/terminal@0.15.2(@types/node@22.10.7)':
     dependencies:
-      '@rushstack/node-core-library': 5.10.2(@types/node@22.10.7)
+      '@rushstack/node-core-library': 5.13.0(@types/node@22.10.7)
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 22.10.7
@@ -11320,18 +11354,18 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/ts-command-line@4.23.3(@types/node@18.19.39)':
+  '@rushstack/ts-command-line@4.23.7(@types/node@18.19.39)':
     dependencies:
-      '@rushstack/terminal': 0.14.5(@types/node@18.19.39)
+      '@rushstack/terminal': 0.15.2(@types/node@18.19.39)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/ts-command-line@4.23.3(@types/node@22.10.7)':
+  '@rushstack/ts-command-line@4.23.7(@types/node@22.10.7)':
     dependencies:
-      '@rushstack/terminal': 0.14.5(@types/node@22.10.7)
+      '@rushstack/terminal': 0.15.2(@types/node@22.10.7)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -17775,7 +17809,7 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  typescript@5.7.2: {}
+  typescript@5.8.2: {}
 
   typewise-core@1.2.0: {}
 


### PR DESCRIPTION
Bumps server release groups to latest build-tools, 0.55.0.

In historian, I changed an in-workspace dep to use the workspace: protocol. This was missed in earlier build reactoring.

I'll follow up with a separate change to update changesets to the new format.