### PR TITLE
Fix reupload blob if expired.

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -318,14 +318,16 @@ export class BlobManager {
 					expired,
 				});
 				if (expired) {
+					pendingEntry.attached = true;
+					const newLocalId = this.localBlobIdGenerator();
 					// reupload blob and reset previous fields
-					this.pendingBlobs.set(localId, {
+					this.pendingBlobs.set(newLocalId, {
 						...pendingEntry,
 						storageId: undefined,
 						uploadTime: undefined,
 						minTTLInSeconds: undefined,
 						opsent: false,
-						uploadP: this.uploadBlob(localId, pendingEntry.blob),
+						uploadP: this.uploadBlob(newLocalId, pendingEntry.blob),
 					});
 					return;
 				}

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -476,11 +476,7 @@ for (const createBlobPlaceholders of [false, true]) {
 			assert.strictEqual(summaryData.redirectTable?.length, 1);
 		});
 
-		it("reupload blob if expired", async function () {
-			// TODO AB#35004: test fails with 0x38f, there are duplicate localIds in the opsInFlight so the second one chokes.
-			if (createBlobPlaceholders) {
-				this.skip();
-			}
+		it("reupload blob if expired", async () => {
 			await runtime.attach();
 			await runtime.connect();
 			runtime.attachedStorage.minTTL = 0.001; // force expired TTL being less than connection time (50ms)


### PR DESCRIPTION
Reuploading an expired blob with the original localId caused a bug using blob placeholder approach since we remove pending blobs that are both acked and attached. So when we retry to upload the blob, it was already deleted since we're attached from the beginning in placeholder approach. 

I believe maybe trying to reupload with the same localId was a bug since the beginning but in any case, reuploading with a clean localId seems a more reasonable approach. In case of blob expiration, we reupload the blob with a new localId, and fake an attach for the previous one so it gets removed once its op is processed.