### PR TITLE
Add missing options to CSP

### DIFF
--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
 	"globalHeaders": {
 		"cache-control": "must-revalidate, max-age=3600",
-		"Content-Security-Policy-Report-Only": "script-src 'self' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' ; base-uri 'self'; object-src 'none'; require-trusted-types-for 'script'; trusted-types default; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
+		"Content-Security-Policy-Report-Only": "script-src 'self' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'unsafe-eval' 'strict-dynamic'; base-uri 'self'; object-src 'none'; require-trusted-types-for 'script'; trusted-types default; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
 	},
 	"navigationFallback": {
 		"rewrite": "/api/fallback"


### PR DESCRIPTION
Even though there are no violations seen on our website while debugging in any environment, reporting shows some scripts-src violations. After getting feedback from internal CSP team, in order to have cleaner reporting, I'm adding back options suggested by them 'strict-dynamic' and 'unsafe-eval'.