### PR TITLE
Revert PR #24309 due to failing tests

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
@@ -45,29 +45,25 @@ export type LocalBatch = IBatch<LocalBatchMessage[]>;
 /**
  * A batch of messages that has been virtualized as needed (grouped, compressed, chunked)
  * and is ready to be sent to the ordering service.
- * At the very least, the op contents have been serialized to string.
  */
-export interface OutboundBatch<
-	TMessages extends OutboundBatchMessage[] = OutboundBatchMessage[],
-> extends IBatch<TMessages> {
-	/**
-	 * Sum of the in-memory content sizes of all messages in the batch.
-	 * If the batch is compressed, this number reflects the post-compression size.
-	 */
-	readonly contentSizeInBytes: number;
-}
+export type OutboundBatch = IBatch<OutboundBatchMessage[]>;
 
 /**
  * An {@link OutboundBatch} with exactly one message
  * This type is helpful as Grouping yields this kind of batch, and Compression only operates on this type of batch.
  */
-export type OutboundSingletonBatch = OutboundBatch<[OutboundBatchMessage]>;
+export type OutboundSingletonBatch = IBatch<[OutboundBatchMessage]>;
 
 /**
  * Base batch interface used internally by the runtime.
  * See {@link LocalBatch} and {@link OutboundBatch} for the concrete types.
  */
 interface IBatch<TMessages extends LocalBatchMessage[] | OutboundBatchMessage[]> {
+	/**
+	 * Sum of the in-memory content sizes of all messages in the batch.
+	 * If the batch is compressed, this number reflects the post-compression size.
+	 */
+	readonly contentSizeInBytes: number;
 	/**
 	 * All the messages in the batch
 	 */

--- a/packages/runtime/container-runtime/src/opLifecycle/index.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/index.ts
@@ -7,6 +7,7 @@ export {
 	BatchId,
 	BatchManager,
 	BatchSequenceNumbers,
+	estimateSocketSize,
 	getEffectiveBatchId,
 	generateBatchId,
 	IBatchManagerOptions,
@@ -25,12 +26,7 @@ export {
 	serializeOp,
 	ensureContentsDeserialized,
 } from "./opSerialization.js";
-export {
-	estimateSocketSize,
-	localBatchToOutboundBatch,
-	Outbox,
-	getLongStack,
-} from "./outbox.js";
+export { Outbox, getLongStack } from "./outbox.js";
 export { OpCompressor } from "./opCompressor.js";
 export { OpDecompressor } from "./opDecompressor.js";
 export { OpSplitter, splitOp, isChunkedMessage } from "./opSplitter.js";

--- a/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
@@ -15,8 +15,8 @@ import { compress } from "lz4js";
 
 import { CompressionAlgorithms } from "../containerRuntime.js";
 
+import { estimateSocketSize } from "./batchManager.js";
 import { type OutboundBatchMessage, type OutboundSingletonBatch } from "./definitions.js";
-import { estimateSocketSize } from "./outbox.js";
 
 /**
  * Compresses batches of ops.

--- a/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
@@ -16,12 +16,12 @@ import {
 
 import { ContainerMessageType, ContainerRuntimeChunkedOpMessage } from "../messageTypes.js";
 
+import { estimateSocketSize } from "./batchManager.js";
 import {
 	IChunkedOp,
 	type OutboundBatchMessage,
 	type OutboundSingletonBatch,
 } from "./definitions.js";
-import { estimateSocketSize } from "./outbox.js";
 
 export function isChunkedMessage(message: ISequencedDocumentMessage): boolean {
 	return isChunkedContents(message.contents);

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -4,16 +4,13 @@
  */
 
 import { IBatchMessage } from "@fluidframework/container-definitions/internal";
-import {
-	ITelemetryBaseLogger,
-	type ITelemetryBaseProperties,
-} from "@fluidframework/core-interfaces";
+import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert, Lazy } from "@fluidframework/core-utils/internal";
 import {
 	DataProcessingError,
+	GenericError,
 	UsageError,
 	createChildLogger,
-	type IFluidErrorBase,
 	type ITelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -23,6 +20,7 @@ import { PendingMessageResubmitData, PendingStateManager } from "../pendingState
 import {
 	BatchManager,
 	BatchSequenceNumbers,
+	estimateSocketSize,
 	sequenceNumbersMatch,
 	type BatchId,
 } from "./batchManager.js";
@@ -109,55 +107,6 @@ export function getLongStack<T>(action: () => T, length: number = 50): T {
 }
 
 /**
- * Convert from local batch to outbound batch, including computing contentSizeInBytes.
- */
-export function localBatchToOutboundBatch(localBatch: LocalBatch): OutboundBatch {
-	// Shallow copy each message as we switch types
-	const outboundMessages = localBatch.messages.map<OutboundBatchMessage>(
-		({ serializedOp, ...message }) => ({
-			contents: serializedOp,
-			...message,
-		}),
-	);
-	const contentSizeInBytes = outboundMessages.reduce(
-		(acc, message) => acc + (message.contents?.length ?? 0),
-		0,
-	);
-
-	// Shallow copy the local batch, updating the messages to be outbound messages and adding contentSizeInBytes
-	const outboundBatch: OutboundBatch = {
-		...localBatch,
-		messages: outboundMessages,
-		contentSizeInBytes,
-	};
-
-	return outboundBatch;
-}
-
-/**
- * Estimated size of the stringification overhead for an op accumulated
- * from runtime to loader to the service.
- */
-const opOverhead = 200;
-
-/**
- * Estimates the real size in bytes on the socket for a given batch. It assumes that
- * the envelope size (and the size of an empty op) is 200 bytes, taking into account
- * extra overhead from stringification.
- *
- * @remarks
- * Also content will be stringified, and that adds a lot of overhead due to a lot of escape characters.
- * Not taking it into account, as compression work should help there - compressed payload will be
- * initially stored as base64, and that requires only 2 extra escape characters.
- *
- * @param batch - the batch to inspect
- * @returns An estimate of the payload size in bytes which will be produced when the batch is sent over the wire
- */
-export const estimateSocketSize = (batch: OutboundBatch): number => {
-	return batch.contentSizeInBytes + opOverhead * batch.messages.length;
-};
-
-/**
  * The Outbox collects messages submitted by the ContainerRuntime into a batch,
  * and then flushes the batch when requested.
  *
@@ -184,9 +133,18 @@ export class Outbox {
 	constructor(private readonly params: IOutboxParameters) {
 		this.logger = createChildLogger({ logger: params.logger, namespace: "Outbox" });
 
-		this.mainBatch = new BatchManager({ canRebase: true });
-		this.blobAttachBatch = new BatchManager({ canRebase: true });
+		const isCompressionEnabled =
+			this.params.config.compressionOptions.minimumBatchSizeInBytes !==
+			Number.POSITIVE_INFINITY;
+		// We need to allow infinite size batches if we enable compression
+		const hardLimit = isCompressionEnabled
+			? Number.POSITIVE_INFINITY
+			: this.params.config.maxBatchSizeInBytes;
+
+		this.mainBatch = new BatchManager({ hardLimit, canRebase: true });
+		this.blobAttachBatch = new BatchManager({ hardLimit, canRebase: true });
 		this.idAllocationBatch = new BatchManager({
+			hardLimit,
 			canRebase: false,
 			ignoreBatchId: true,
 		});
@@ -316,11 +274,20 @@ export class Outbox {
 		batchManager: BatchManager,
 		message: LocalBatchMessage,
 	): void {
-		batchManager.push(
-			message,
-			this.isContextReentrant(),
-			this.params.getCurrentSequenceNumbers().clientSequenceNumber,
-		);
+		if (
+			!batchManager.push(
+				message,
+				this.isContextReentrant(),
+				this.params.getCurrentSequenceNumbers().clientSequenceNumber,
+			)
+		) {
+			throw new GenericError("BatchTooLarge", /* error */ undefined, {
+				opSize: message.serializedOp?.length ?? 0,
+				batchSize: batchManager.contentSizeInBytes,
+				count: batchManager.length,
+				limit: batchManager.options.hardLimit,
+			});
+		}
 	}
 
 	/**
@@ -498,7 +465,15 @@ export class Outbox {
 	 */
 	private virtualizeBatch(localBatch: LocalBatch, groupingEnabled: boolean): OutboundBatch {
 		// Shallow copy the local batch, updating the messages to be outbound messages
-		const originalBatch = localBatchToOutboundBatch(localBatch);
+		const originalBatch: OutboundBatch = {
+			...localBatch,
+			messages: localBatch.messages.map<OutboundBatchMessage>(
+				({ serializedOp, ...message }) => ({
+					contents: serializedOp,
+					...message,
+				}),
+			),
+		};
 
 		const originalOrGroupedBatch = groupingEnabled
 			? this.params.groupingManager.groupBatch(originalBatch)
@@ -514,6 +489,7 @@ export class Outbox {
 		const singletonBatch = originalOrGroupedBatch as OutboundSingletonBatch;
 
 		if (
+			this.params.config.compressionOptions === undefined ||
 			this.params.config.compressionOptions.minimumBatchSizeInBytes >
 				singletonBatch.contentSizeInBytes ||
 			this.params.submitBatchFn === undefined
@@ -530,11 +506,21 @@ export class Outbox {
 				: this.params.splitter.splitSingletonBatchMessage(compressedBatch);
 		}
 
-		// We want to distinguish this "BatchTooLarge" case from the generic "BatchTooLarge" case in sendBatch
 		if (compressedBatch.contentSizeInBytes >= this.params.config.maxBatchSizeInBytes) {
-			throw this.makeBatchTooLargeError(compressedBatch, "CompressionInsufficient", {
-				uncompressedSizeInBytes: singletonBatch.contentSizeInBytes,
-			});
+			throw DataProcessingError.create(
+				"BatchTooLarge",
+				"compressionInsufficient",
+				/* sequencedMessage */ undefined,
+				{
+					batchSize: singletonBatch.contentSizeInBytes,
+					compressedBatchSize: compressedBatch.contentSizeInBytes,
+					count: compressedBatch.messages.length,
+					limit: this.params.config.maxBatchSizeInBytes,
+					chunkingEnabled: this.params.splitter.isBatchChunkingEnabled,
+					compressionOptions: JSON.stringify(this.params.config.compressionOptions),
+					socketSize: estimateSocketSize(singletonBatch),
+				},
+			);
 		}
 
 		return compressedBatch;
@@ -554,7 +540,12 @@ export class Outbox {
 
 		const socketSize = estimateSocketSize(batch);
 		if (socketSize >= this.params.config.maxBatchSizeInBytes) {
-			throw this.makeBatchTooLargeError(batch, "CannotSend");
+			this.logger.sendPerformanceEvent({
+				eventName: "LargeBatch",
+				length: batch.messages.length,
+				sizeInBytes: batch.contentSizeInBytes,
+				socketSize,
+			});
 		}
 
 		let clientSequenceNumber: number;
@@ -584,31 +575,6 @@ export class Outbox {
 		clientSequenceNumber -= length - 1;
 		assert(clientSequenceNumber >= 0, 0x3d0 /* clientSequenceNumber can't be negative */);
 		return clientSequenceNumber;
-	}
-
-	private makeBatchTooLargeError(
-		batch: OutboundBatch,
-		codepath: string,
-		moreDetails?: ITelemetryBaseProperties,
-	): IFluidErrorBase {
-		return DataProcessingError.create(
-			"BatchTooLarge",
-			codepath,
-			/* sequencedMessage */ undefined,
-			{
-				errorDetails: {
-					opCount: batch.messages.length,
-					contentSizeInBytes: batch.contentSizeInBytes,
-					socketSize: estimateSocketSize(batch),
-					maxBatchSizeInBytes: this.params.config.maxBatchSizeInBytes,
-					groupedBatchingEnabled: this.params.groupingManager.groupedBatchingEnabled(),
-					compressionOptions: JSON.stringify(this.params.config.compressionOptions),
-					chunkingEnabled: this.params.splitter.isBatchChunkingEnabled,
-					chunkSizeInBytes: this.params.splitter.chunkSizeInBytes,
-					...moreDetails,
-				},
-			},
-		);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -10,13 +10,20 @@ import {
 	BatchManager,
 	estimateSocketSize,
 	generateBatchId,
-	localBatchToOutboundBatch,
+	OutboundBatchMessage,
 } from "../../opLifecycle/index.js";
-import type { IBatchManagerOptions, LocalBatchMessage } from "../../opLifecycle/index.js";
+import type {
+	LocalBatch,
+	OutboundBatch,
+	IBatchManagerOptions,
+	LocalBatchMessage,
+} from "../../opLifecycle/index.js";
 
 describe("BatchManager", () => {
+	const hardLimit = 950 * 1024;
 	const smallMessageSize = 10;
 	const defaultOptions: IBatchManagerOptions = {
+		hardLimit,
 		canRebase: true,
 	};
 
@@ -27,21 +34,46 @@ describe("BatchManager", () => {
 		referenceSequenceNumber: 0,
 	});
 
+	it("BatchManager: 'infinity' hard limit allows everything", () => {
+		const message: LocalBatchMessage = {
+			serializedOp: generateStringOfSize(1024),
+			referenceSequenceNumber: 0,
+		};
+		const batchManager = new BatchManager({
+			...defaultOptions,
+			hardLimit: Number.POSITIVE_INFINITY,
+		});
+
+		for (let i = 1; i <= 10; i++) {
+			assert.equal(batchManager.push(message, /* reentrant */ false), true);
+			assert.equal(batchManager.length, i);
+		}
+	});
+
 	for (const includeBatchId of [true, false])
-		it(`Batch metadata is set correctly [${includeBatchId ? "with" : "without"} batchId]`, () => {
+		it(`Batch metadata is set correctly [with${includeBatchId ? "" : "out"} batchId]`, () => {
 			const batchManager = new BatchManager(defaultOptions);
 			const batchId = includeBatchId ? "BATCH_ID" : undefined;
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 0 },
-				/* reentrant */ false,
+			assert.equal(
+				batchManager.push(
+					{ ...smallMessage(), referenceSequenceNumber: 0 },
+					/* reentrant */ false,
+				),
+				true,
 			);
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 1 },
-				/* reentrant */ false,
+			assert.equal(
+				batchManager.push(
+					{ ...smallMessage(), referenceSequenceNumber: 1 },
+					/* reentrant */ false,
+				),
+				true,
 			);
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 2 },
-				/* reentrant */ false,
+			assert.equal(
+				batchManager.push(
+					{ ...smallMessage(), referenceSequenceNumber: 2 },
+					/* reentrant */ false,
+				),
+				true,
 			);
 
 			const batch = batchManager.popBatch(batchId);
@@ -54,9 +86,12 @@ describe("BatchManager", () => {
 				],
 			);
 
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 0 },
-				/* reentrant */ false,
+			assert.equal(
+				batchManager.push(
+					{ ...smallMessage(), referenceSequenceNumber: 0 },
+					/* reentrant */ false,
+				),
+				true,
 			);
 			const singleOpBatch = batchManager.popBatch(batchId);
 			assert.deepEqual(
@@ -75,36 +110,65 @@ describe("BatchManager", () => {
 		assert.equal(serialized, `{"batchId":"3627a2a9-963f-4e3b-a4d2-a31b1267ef29_[123]"}`);
 	});
 
+	it("Batch content size is tracked correctly", () => {
+		const batchManager = new BatchManager(defaultOptions);
+		assert.equal(batchManager.push(smallMessage(), /* reentrant */ false), true);
+		assert.equal(batchManager.contentSizeInBytes, smallMessageSize * batchManager.length);
+		assert.equal(batchManager.push(smallMessage(), /* reentrant */ false), true);
+		assert.equal(batchManager.contentSizeInBytes, smallMessageSize * batchManager.length);
+		assert.equal(batchManager.push(smallMessage(), /* reentrant */ false), true);
+		assert.equal(batchManager.contentSizeInBytes, smallMessageSize * batchManager.length);
+	});
+
 	it("Batch reference sequence number maps to the last message", () => {
 		const batchManager = new BatchManager(defaultOptions);
-		batchManager.push(
-			{ ...smallMessage(), referenceSequenceNumber: 0 },
-			/* reentrant */ false,
+		assert.equal(
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 0 },
+				/* reentrant */ false,
+			),
+			true,
 		);
-		batchManager.push(
-			{ ...smallMessage(), referenceSequenceNumber: 1 },
-			/* reentrant */ false,
+		assert.equal(
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 1 },
+				/* reentrant */ false,
+			),
+			true,
 		);
-		batchManager.push(
-			{ ...smallMessage(), referenceSequenceNumber: 2 },
-			/* reentrant */ false,
+		assert.equal(
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 2 },
+				/* reentrant */ false,
+			),
+			true,
 		);
 
 		assert.equal(batchManager.sequenceNumbers.referenceSequenceNumber, 2);
 	});
 
+	const convertToOutboundBatch = (batch: LocalBatch): OutboundBatch =>
+		({
+			...batch,
+			messages: batch.messages.map<OutboundBatchMessage>((message: LocalBatchMessage) => ({
+				...message,
+				contents: message.serializedOp,
+				serializedOp: undefined,
+			})),
+		}) satisfies OutboundBatch;
+
 	it("Batch size estimates", () => {
 		const batchManager = new BatchManager(defaultOptions);
 		batchManager.push(smallMessage(), /* reentrant */ false);
 		// 10 bytes of content + 200 bytes overhead
-		assert.equal(estimateSocketSize(localBatchToOutboundBatch(batchManager.popBatch())), 210);
+		assert.equal(estimateSocketSize(convertToOutboundBatch(batchManager.popBatch())), 210);
 
 		for (let i = 0; i < 10; i++) {
 			batchManager.push(smallMessage(), /* reentrant */ false);
 		}
 
 		// (10 bytes of content + 200 bytes overhead) x 10
-		assert.equal(estimateSocketSize(localBatchToOutboundBatch(batchManager.popBatch())), 2100);
+		assert.equal(estimateSocketSize(convertToOutboundBatch(batchManager.popBatch())), 2100);
 
 		batchManager.push(smallMessage(), /* reentrant */ false);
 		for (let i = 0; i < 9; i++) {
@@ -118,44 +182,65 @@ describe("BatchManager", () => {
 		}
 
 		// 10 bytes of content + 200 bytes overhead x 10
-		assert.equal(estimateSocketSize(localBatchToOutboundBatch(batchManager.popBatch())), 2010);
+		assert.equal(estimateSocketSize(convertToOutboundBatch(batchManager.popBatch())), 2010);
 	});
 
 	it("Batch op reentry state preserved during its lifetime", () => {
 		const batchManager = new BatchManager(defaultOptions);
-		batchManager.push(
-			{ ...smallMessage(), referenceSequenceNumber: 0 },
-			/* reentrant */ false,
+		assert.equal(
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 0 },
+				/* reentrant */ false,
+			),
+			true,
 		);
-		batchManager.push(
-			{ ...smallMessage(), referenceSequenceNumber: 1 },
-			/* reentrant */ false,
+		assert.equal(
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 1 },
+				/* reentrant */ false,
+			),
+			true,
 		);
-		batchManager.push(
-			{ ...smallMessage(), referenceSequenceNumber: 2 },
-			/* reentrant */ false,
+		assert.equal(
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 2 },
+				/* reentrant */ false,
+			),
+			true,
 		);
 
 		assert.equal(batchManager.popBatch().hasReentrantOps, false);
 
-		batchManager.push(
-			{ ...smallMessage(), referenceSequenceNumber: 0 },
-			/* reentrant */ false,
+		assert.equal(
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 0 },
+				/* reentrant */ false,
+			),
+			true,
 		);
-		batchManager.push(
-			{ ...smallMessage(), referenceSequenceNumber: 1 },
-			/* reentrant */ true,
-			/* currentClientSequenceNumber */ undefined,
+		assert.equal(
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 1 },
+				/* reentrant */ true,
+				/* currentClientSequenceNumber */ undefined,
+			),
+			true,
 		);
-		batchManager.push(
-			{ ...smallMessage(), referenceSequenceNumber: 2 },
-			/* reentrant */ false,
+		assert.equal(
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 2 },
+				/* reentrant */ false,
+			),
+			true,
 		);
 		assert.equal(batchManager.popBatch().hasReentrantOps, true);
 
-		batchManager.push(
-			{ ...smallMessage(), referenceSequenceNumber: 0 },
-			/* reentrant */ false,
+		assert.equal(
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 0 },
+				/* reentrant */ false,
+			),
+			true,
 		);
 		assert.equal(batchManager.popBatch().hasReentrantOps, false);
 	});
@@ -181,6 +266,7 @@ describe("BatchManager", () => {
 
 		// Verify state after rollback
 		assert.equal(batchManager.length, 2);
+		assert.equal(batchManager.contentSizeInBytes, smallMessageSize * 2);
 	});
 
 	it("should handle rollback with no additional messages", () => {
@@ -199,6 +285,7 @@ describe("BatchManager", () => {
 
 		// Verify state after rollback
 		assert.equal(batchManager.length, 1);
+		assert.equal(batchManager.contentSizeInBytes, smallMessageSize);
 	});
 
 	it("should throw error if ops are generated during rollback", () => {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -39,7 +39,6 @@ import {
 	Outbox,
 	type LocalBatchMessage,
 	type OutboundBatch,
-	localBatchToOutboundBatch,
 } from "../../opLifecycle/index.js";
 import {
 	PendingMessageResubmitData,
@@ -175,7 +174,7 @@ describe("Outbox", () => {
 	});
 
 	// Also converts to an OutboundBatchMessage
-	const addBatchMetadata = (messages: OutboundBatchMessage[]): void => {
+	const addBatchMetadata = (messages: LocalBatchMessage[]): OutboundBatchMessage[] => {
 		if (messages.length > 1) {
 			messages[0].metadata = {
 				...messages[0].metadata,
@@ -186,18 +185,21 @@ describe("Outbox", () => {
 				batch: false,
 			};
 		}
-	};
-	const toOutboundBatch = (messages: LocalBatchMessage[]): OutboundBatch => {
-		const outbound = localBatchToOutboundBatch({
-			messages,
-			referenceSequenceNumber:
-				messages.length === 0 ? undefined : messages[0].referenceSequenceNumber,
-			hasReentrantOps: false,
-		});
 
-		addBatchMetadata(outbound.messages);
-		return outbound;
+		return messages.map<OutboundBatchMessage>(({ serializedOp, ...message }) => ({
+			contents: serializedOp,
+			...message,
+		}));
 	};
+	const toOutboundBatch = (messages: LocalBatchMessage[]): OutboundBatch => ({
+		messages: addBatchMetadata(messages),
+		contentSizeInBytes: messages
+			.map((message) => message.serializedOp?.length ?? 0)
+			.reduce((a, b) => a + b, 0),
+		referenceSequenceNumber:
+			messages.length === 0 ? undefined : messages[0].referenceSequenceNumber,
+		hasReentrantOps: false,
+	});
 
 	const DefaultCompressionOptions = {
 		minimumBatchSizeInBytes: Number.POSITIVE_INFINITY,
@@ -270,29 +272,6 @@ describe("Outbox", () => {
 		state.isReentrant = false;
 		currentSeqNumbers = {};
 		mockLogger.clear();
-	});
-
-	it("localBatchToOutboundBatch", () => {
-		const localMessages: LocalBatchMessage[] = [
-			{ serializedOp: "hello", referenceSequenceNumber: 4 },
-			{ serializedOp: "world", referenceSequenceNumber: 4 },
-			{ serializedOp: "!", referenceSequenceNumber: 4 },
-		];
-		const localBatch = {
-			messages: localMessages,
-			referenceSequenceNumber: localMessages[0].referenceSequenceNumber,
-			hasReentrantOps: false,
-		};
-		const outboundBatch = localBatchToOutboundBatch(localBatch);
-
-		// Check that contentSizeInBytes and messages' contents are set propertly
-		assert.equal(outboundBatch.contentSizeInBytes, 11);
-		assert.equal(outboundBatch.messages.length, 3);
-		assert.deepEqual(
-			localMessages.map((m) => m.serializedOp),
-			outboundBatch.messages.map((m) => m.contents),
-			"Serialized contents do not match",
-		);
 	});
 
 	it("Sending batches", () => {
@@ -594,15 +573,12 @@ describe("Outbox", () => {
 		);
 	});
 
-	it("Does not compress if the batch is smaller than the configured limit", () => {
+	it("Compress only if the batch is larger than the configured limit", () => {
 		const outbox = getOutbox({
 			context: getMockContext(),
-			maxBatchSize: 1024,
-			opGroupingConfig: {
-				groupedBatchingEnabled: true, // Required for compression
-			},
+			maxBatchSize: 1,
 			compressionOptions: {
-				minimumBatchSizeInBytes: 512,
+				minimumBatchSizeInBytes: 1024,
 				compressionAlgorithm: CompressionAlgorithms.lz4,
 			},
 		});
@@ -621,15 +597,22 @@ describe("Outbox", () => {
 
 		outbox.flush();
 
-		assert.equal(
-			state.opsSubmitted,
-			2,
-			"Expected 2 ops to be submitted, on ID Allocation and one for the grouped batch",
-		);
+		assert.equal(state.opsSubmitted, messages.length);
 		assert.equal(state.batchesSubmitted.length, 2);
 		assert.equal(state.individualOpsSubmitted.length, 0);
 		assert.equal(state.deltaManagerFlushCalls, 0);
 		assert.deepEqual(state.batchesCompressed, []);
+		assert.deepEqual(
+			state.batchesSubmitted.map((x) => x.messages),
+			[
+				[toSubmittedMessage(messages[2])],
+				[
+					toSubmittedMessage(messages[0], true),
+					toSubmittedMessage(messages[1]),
+					toSubmittedMessage(messages[3], false),
+				],
+			],
+		);
 
 		// Note the expected CSN here is fixed to the batch's starting CSN
 		const expectedMessageOrderWithCsn = [
@@ -675,13 +658,7 @@ describe("Outbox", () => {
 		outbox.submit(messages[1]);
 		outbox.submit(messages[2]);
 
-		assert.throws(
-			() => outbox.flush(),
-			(e: Error) =>
-				"dataProcessingCodepath" in e &&
-				e.dataProcessingCodepath === "CompressionInsufficient",
-			"Expected 'CompressionInsufficient' error",
-		);
+		assert.throws(() => outbox.flush());
 		// The batch is compressed
 		assert.deepEqual(state.batchesCompressed, [
 			opGroupingManager.groupBatch(toOutboundBatch(messages)),
@@ -693,7 +670,7 @@ describe("Outbox", () => {
 	it("Chunks when compression is enabled, compressed batch is larger than the threshold and chunking is enabled", () => {
 		const outbox = getOutbox({
 			context: getMockContext(),
-			maxBatchSize: 1024,
+			maxBatchSize: 1,
 			compressionOptions: {
 				minimumBatchSizeInBytes: 1,
 				compressionAlgorithm: CompressionAlgorithms.lz4,
@@ -757,7 +734,7 @@ describe("Outbox", () => {
 	it("Does not chunk when compression and grouping are enabled, compressed batch is smaller than the threshold and chunking is enabled", () => {
 		const outbox = getOutbox({
 			context: getMockContext(),
-			maxBatchSize: 1024,
+			maxBatchSize: 1,
 			compressionOptions: {
 				minimumBatchSizeInBytes: 1,
 				compressionAlgorithm: CompressionAlgorithms.lz4,

--- a/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
@@ -254,6 +254,7 @@ describe("RemoteMessageProcessor", () => {
 		// Use BatchManager.popBatch to get the right batch metadata included
 		const batchManager = new BatchManager({
 			canRebase: false,
+			hardLimit: Number.MAX_VALUE,
 		});
 		batchManager.push({ serializedOp: "A1", referenceSequenceNumber }, false /* reentrant */);
 		batchManager.push({ serializedOp: "A2", referenceSequenceNumber }, false /* reentrant */);
@@ -426,6 +427,7 @@ describe("RemoteMessageProcessor", () => {
 			let csn = 1;
 			const batchManager = new BatchManager({
 				canRebase: false,
+				hardLimit: Number.MAX_VALUE,
 			});
 			batchManager.push(
 				{ serializedOp: "A1", referenceSequenceNumber: 1 },
@@ -481,6 +483,7 @@ describe("RemoteMessageProcessor", () => {
 			let csn = 1;
 			const batchManager = new BatchManager({
 				canRebase: false,
+				hardLimit: Number.MAX_VALUE,
 			});
 			batchManager.push(
 				{ serializedOp: "A1", referenceSequenceNumber: 1 },

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -66,7 +66,7 @@ describe("Pending State Manager", () => {
 			rollbackContent = [];
 			rollbackShouldThrow = false;
 
-			batchManager = new BatchManager({ canRebase: true });
+			batchManager = new BatchManager({ hardLimit: 950 * 1024, canRebase: true });
 		});
 
 		it("should do nothing when rolling back empty pending stack", () => {


### PR DESCRIPTION
This reverts PR #24309, which has been causing tests to fail on the CI pipeline ([example run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=332526&view=logs&j=f193e17a-f43e-518b-48dd-0a836d9f111c&t=8313d791-ee78-5f41-3fbb-b9b81d25bc65&l=5701)).