### PR TITLE
Downgrade UUID in client to version 9 to align it with the version of server client depends on

### DIFF
--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -89,7 +89,7 @@
 	"dependencies": {
 		"@fluidframework/driver-definitions": "workspace:~",
 		"jsrsasign": "^11.0.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -101,6 +101,7 @@
 		"@fluidframework/eslint-config-fluid": "^5.7.3",
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/jsrsasign": "^10.5.12",
+		"@types/uuid": "^9.0.2",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.55.0",

--- a/examples/apps/ai-collab/package.json
+++ b/examples/apps/ai-collab/package.json
@@ -54,6 +54,7 @@
 		"@mui/material": "^6.2.1",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
+		"@types/uuid": "^9.0.2",
 		"eslint": "~8.55.0",
 		"fluid-framework": "workspace:~",
 		"mui": "^0.0.1",
@@ -66,7 +67,7 @@
 		"tinylicious": "^5.0.0",
 		"typechat": "^0.1.1",
 		"typescript": "~5.4.5",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"typeValidation": {
 		"disabled": true,

--- a/examples/apps/blobs/package.json
+++ b/examples/apps/blobs/package.json
@@ -57,7 +57,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -45,7 +45,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"style-loader": "^4.0.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -59,6 +59,7 @@
 		"@types/node": "^18.19.0",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
+		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.55.0",
 		"expect-puppeteer": "^9.0.2",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -59,7 +59,7 @@
 		"react-dom": "^18.3.1",
 		"react-grid-layout": "^1.4.4",
 		"scheduler": "^0.20.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -74,6 +74,7 @@
 		"@types/prop-types": "^15",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
+		"@types/uuid": "^9.0.2",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",

--- a/examples/apps/staging/package.json
+++ b/examples/apps/staging/package.json
@@ -53,7 +53,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -67,6 +67,7 @@
 		"@types/node": "^18.19.0",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
+		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"eslint": "~8.55.0",

--- a/examples/apps/tree-comparison/package.json
+++ b/examples/apps/tree-comparison/package.json
@@ -54,7 +54,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"tiny-typed-emitter": "^2.1.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -68,6 +68,7 @@
 		"@types/node": "^18.19.0",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
+		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"eslint": "~8.55.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/tree": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -64,6 +64,7 @@
 		"@types/node": "^18.19.0",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
+		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"eslint": "~8.55.0",

--- a/examples/service-clients/azure-client/external-controller/package.json
+++ b/examples/service-clients/azure-client/external-controller/package.json
@@ -49,7 +49,7 @@
 		"axios": "^1.8.4",
 		"events_pkg": "npm:events@^3.1.0",
 		"fluid-framework": "workspace:~",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -68,6 +68,7 @@
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "workspace:~",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.55.0",
 		"expect-puppeteer": "^9.0.2",

--- a/examples/utils/bundle-size-tests/webpack.config.cjs
+++ b/examples/utils/bundle-size-tests/webpack.config.cjs
@@ -117,10 +117,7 @@ module.exports = {
 			 * We try to avoid duplicate packages, but sometimes we have to allow them since the duplication is coming from a third party library we do not control
 			 * IMPORTANT: Do not add any new exceptions to this list without first doing a deep investigation on why a PR adds a new duplication, this hides a bundle size issue
 			 */
-			exclude: (instance) =>
-				// @fluidframework/server-services-client pulls in uuid 9.0.1, and thus bundles using it get this package duplicated until the version of server used in client gets updated.
-				// This should not impact size sensitive application as they typically don't include a copy of the server.
-				instance.name === "uuid",
+			exclude: (instance) => false,
 		}),
 		new BundleAnalyzerPlugin({
 			analyzerMode: "static",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -85,6 +85,7 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
+		"@types/uuid": "^9.0.2",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.55.0",
 		"rimraf": "^4.4.0",

--- a/examples/utils/migration-tools/package.json
+++ b/examples/utils/migration-tools/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/server-local-server": "^5.0.0",
 		"@fluidframework/tinylicious-driver": "workspace:~",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -87,6 +87,7 @@
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.3",
 		"@microsoft/api-extractor": "7.50.1",
+		"@types/uuid": "^9.0.2",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.55.0",

--- a/examples/utils/webpack-fluid-loader/package.json
+++ b/examples/utils/webpack-fluid-loader/package.json
@@ -107,7 +107,7 @@
 		"isomorphic-fetch": "^3.0.0",
 		"nconf": "^0.12.0",
 		"sillyname": "^0.1.0",
-		"uuid": "^11.1.0",
+		"uuid": "^9.0.0",
 		"webpack-dev-server": "~4.15.2"
 	},
 	"devDependencies": {
@@ -122,6 +122,7 @@
 		"@types/fs-extra": "^9.0.11",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -56,7 +56,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -70,6 +70,7 @@
 		"@types/node": "^18.19.0",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
+		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"eslint": "~8.55.0",

--- a/examples/version-migration/separate-container/package.json
+++ b/examples/version-migration/separate-container/package.json
@@ -60,7 +60,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -74,6 +74,7 @@
 		"@types/node": "^18.19.0",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
+		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"eslint": "~8.55.0",

--- a/examples/version-migration/tree-shim/package.json
+++ b/examples/version-migration/tree-shim/package.json
@@ -55,7 +55,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"tiny-typed-emitter": "^2.1.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -68,6 +68,7 @@
 		"@types/jest-environment-puppeteer": "workspace:~",
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
+		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^7.1.2",
 		"eslint": "~8.55.0",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -55,7 +55,7 @@
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -70,7 +70,7 @@
 		"lz4js": "^0.2.0",
 		"msgpackr": "^1.10.1",
 		"pako": "^2.0.4",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -93,6 +93,7 @@
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"chai": "^4.2.0",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -76,7 +76,7 @@
 		"buffer": "^6.0.3",
 		"denque": "^1.5.1",
 		"lru-cache": "^6.0.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -99,6 +99,7 @@
 		"@types/chai": "^4.0.0",
 		"@types/lru-cache": "^5.1.0",
 		"@types/mocha": "^10.0.10",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"chai": "^4.2.0",
 		"concurrently": "^8.2.1",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -90,7 +90,7 @@
 		"@fluidframework/driver-utils": "workspace:~",
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/shared-object-base": "workspace:~",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -105,6 +105,7 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -124,7 +124,7 @@
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -140,6 +140,7 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -156,7 +156,7 @@
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"double-ended-queue": "^2.1.0-0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -177,6 +177,7 @@
 		"@types/double-ended-queue": "^2.1.0",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -126,7 +126,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -143,6 +143,7 @@
 		"@types/benchmark": "^2.1.0",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"benchmark": "^2.1.4",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -94,7 +94,7 @@
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"mocha": "^10.8.2",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -107,6 +107,7 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -166,7 +166,7 @@
 		"@tylerbu/sorted-btree-es6": "^1.8.0",
 		"@types/ungap__structured-clone": "^1.2.0",
 		"@ungap/structured-clone": "^1.2.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -190,6 +190,7 @@
 		"@types/easy-table": "^0.0.32",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"ajv": "^8.12.0",
 		"ajv-formats": "^3.0.1",
 		"c8": "^8.0.1",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -130,7 +130,7 @@
 		"@fluidframework/server-test-utils": "^5.0.0",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"jsrsasign": "^11.0.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -145,6 +145,7 @@
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -125,7 +125,7 @@
 		"@fluidframework/odsp-driver-definitions": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"socket.io-client": "~4.7.5",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -140,6 +140,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -126,7 +126,7 @@
 		"cross-fetch": "^3.1.5",
 		"json-stringify-safe": "5.0.1",
 		"socket.io-client": "~4.7.5",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -142,6 +142,7 @@
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
+		"@types/uuid": "^9.0.2",
 		"axios": "^1.8.4",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -89,7 +89,7 @@
 		"@fluidframework/driver-utils": "workspace:~",
 		"@fluidframework/routerlicious-driver": "workspace:~",
 		"jsrsasign": "^11.0.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -104,6 +104,7 @@
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -97,7 +97,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -109,6 +109,7 @@
 		"@fluidframework/eslint-config-fluid": "^5.7.3",
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.55.0",

--- a/packages/framework/ai-collab/package.json
+++ b/packages/framework/ai-collab/package.json
@@ -117,7 +117,7 @@
 		"fastest-levenshtein": "^1.0.16",
 		"openai": "^4.67.3",
 		"typechat": "^0.1.1",
-		"uuid": "^11.1.0",
+		"uuid": "^9.0.0",
 		"zod": "^3.23.8"
 	},
 	"devDependencies": {
@@ -134,6 +134,7 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -97,7 +97,7 @@
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/fluid-static": "workspace:~",
 		"@microsoft/applicationinsights-web": "^2.8.11",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -113,6 +113,7 @@
 		"@types/chai": "^4.0.0",
 		"@types/mocha": "^10.0.10",
 		"@types/sinon": "^17.0.3",
+		"@types/uuid": "^9.0.2",
 		"chai": "^4.2.0",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -179,7 +179,7 @@
 		"debug": "^4.3.4",
 		"double-ended-queue": "^2.1.0-0",
 		"events_pkg": "npm:events@^3.1.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -199,6 +199,7 @@
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
 		"@types/ungap__structured-clone": "^1.2.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -122,7 +122,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"axios": "^1.8.4",
 		"lz4js": "^0.2.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -137,6 +137,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -184,7 +184,7 @@
 		"@tylerbu/sorted-btree-es6": "^1.8.0",
 		"double-ended-queue": "^2.1.0-0",
 		"lz4js": "^0.2.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -205,6 +205,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -128,7 +128,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -145,6 +145,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@tylerbu/sorted-btree-es6": "^1.8.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -149,6 +149,7 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -126,7 +126,7 @@
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"jsrsasign": "^11.0.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -141,6 +141,7 @@
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -116,6 +116,7 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
@@ -126,7 +127,7 @@
 		"rimraf": "^4.4.0",
 		"start-server-and-test": "^2.0.3",
 		"typescript": "~5.4.5",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -89,7 +89,7 @@
 		"sinon": "^18.0.1",
 		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^5.0.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -101,6 +101,7 @@
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"eslint": "~8.55.0",
 		"nock": "^13.3.3",

--- a/packages/service-clients/end-to-end-tests/odsp-client/package.json
+++ b/packages/service-clients/end-to-end-tests/odsp-client/package.json
@@ -74,7 +74,7 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"moment": "^2.21.0",
 		"sinon": "^18.0.1",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -84,6 +84,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.55.0",

--- a/packages/service-clients/odsp-client/package.json
+++ b/packages/service-clients/odsp-client/package.json
@@ -115,7 +115,7 @@
 		"@fluidframework/odsp-driver": "workspace:~",
 		"@fluidframework/odsp-driver-definitions": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -129,6 +129,7 @@
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/test/local-server-stress-tests/package.json
+++ b/packages/test/local-server-stress-tests/package.json
@@ -83,12 +83,13 @@
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
 		"@fluidframework/tree": "workspace:~",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.55.0",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -70,7 +70,7 @@
 		"agentkeepalive": "^4.5.0",
 		"axios": "^1.8.4",
 		"semver": "^7.7.1",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -81,6 +81,7 @@
 		"@fluidframework/eslint-config-fluid": "^5.7.3",
 		"@microsoft/api-extractor": "7.50.1",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.55.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -126,7 +126,7 @@
 		"sinon": "^18.0.1",
 		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^5.0.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
@@ -138,6 +138,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"eslint": "~8.55.0",
 		"mocha-multi-reporters": "^1.5.1",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -135,7 +135,7 @@
 		"best-random": "^1.0.0",
 		"debug": "^4.3.4",
 		"mocha": "^10.8.2",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -151,6 +151,7 @@
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -116,6 +116,7 @@
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",
 		"@types/semver": "^7.7.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
@@ -128,7 +129,7 @@
 		"rimraf": "^4.4.0",
 		"ts-loader": "^9.5.1",
 		"typescript": "~5.4.5",
-		"uuid": "^11.1.0",
+		"uuid": "^9.0.0",
 		"webpack": "^5.94.0",
 		"webpack-cli": "^5.1.4"
 	},

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -80,10 +80,11 @@
 		"@fluidframework/devtools-core": "workspace:~",
 		"@microsoft/1ds-core-js": "^3.2.13",
 		"@microsoft/1ds-post-js": "^3.2.13",
+		"@types/uuid": "^9.0.2",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"tslib": "^1.10.0",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -120,7 +120,7 @@
 		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"debug": "^4.3.4",
-		"uuid": "^11.1.0"
+		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
@@ -136,6 +136,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,8 +158,8 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -188,6 +188,9 @@ importers:
       '@types/jsrsasign':
         specifier: ^10.5.12
         version: 10.5.15
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -281,6 +284,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       eslint:
         specifier: ~8.55.0
         version: 8.55.0
@@ -318,8 +324,8 @@ importers:
         specifier: ~5.4.5
         version: 5.4.5
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
 
   examples/apps/attributable-map:
     dependencies:
@@ -460,8 +466,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -714,8 +720,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.97.1)
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -750,6 +756,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -874,8 +883,8 @@ importers:
         specifier: ^0.20.0
         version: 0.20.2
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -913,6 +922,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -1173,8 +1185,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -1209,6 +1221,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1506,8 +1521,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -1542,6 +1557,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -3832,8 +3850,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -3871,6 +3889,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -4309,8 +4330,8 @@ importers:
         specifier: workspace:~
         version: link:../../../../packages/framework/fluid-framework
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -4360,6 +4381,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -4702,8 +4726,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -4732,6 +4756,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -4857,8 +4884,8 @@ importers:
         specifier: workspace:~
         version: link:../../../packages/drivers/tinylicious-driver
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -4881,6 +4908,9 @@ importers:
       '@microsoft/api-extractor':
         specifier: 7.50.1
         version: 7.50.1(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@22.10.1)
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -4972,8 +5002,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
       webpack-dev-server:
         specifier: ~4.15.2
         version: 4.15.2(webpack-cli@5.1.4)(webpack@5.97.1)
@@ -5011,6 +5041,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -5244,8 +5277,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -5280,6 +5313,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -5422,8 +5458,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -5458,6 +5494,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -5582,8 +5621,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -5615,6 +5654,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.3(@types/react@18.3.15)
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -5857,8 +5899,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -6320,8 +6362,8 @@ importers:
         specifier: ^2.0.4
         version: 2.1.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -6383,6 +6425,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       chai:
         specifier: ^4.2.0
         version: 4.5.0
@@ -6947,8 +6992,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -7004,6 +7049,9 @@ importers:
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -7865,8 +7913,8 @@ importers:
         specifier: workspace:~
         version: link:../shared-object-base
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -7904,6 +7952,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8352,8 +8403,8 @@ importers:
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -8394,6 +8445,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8661,8 +8715,8 @@ importers:
         specifier: ^2.1.0-0
         version: 2.1.0-0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -8718,6 +8772,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -8791,8 +8848,8 @@ importers:
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -8836,6 +8893,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       benchmark:
         specifier: ^2.1.4
         version: 2.1.4
@@ -9124,8 +9184,8 @@ importers:
         specifier: ^10.8.2
         version: 10.8.2
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -9157,6 +9217,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -9236,8 +9299,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.1
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -9302,6 +9365,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       ajv:
         specifier: ^8.12.0
         version: 8.17.1
@@ -9679,8 +9745,8 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -9718,6 +9784,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -9785,8 +9854,8 @@ importers:
         specifier: ~4.7.5
         version: 4.7.5
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -9824,6 +9893,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -10095,8 +10167,8 @@ importers:
         specifier: ~4.7.5
         version: 4.7.5
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -10137,6 +10209,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       axios:
         specifier: ^1.8.4
         version: 1.8.4(debug@4.4.0)
@@ -10277,8 +10352,8 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -10316,6 +10391,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -10374,8 +10452,8 @@ importers:
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -10404,6 +10482,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -10444,8 +10525,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1(typescript@5.4.5)(zod@3.24.0)
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
       zod:
         specifier: ^3.23.8
         version: 3.24.0
@@ -10486,6 +10567,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -10850,8 +10934,8 @@ importers:
         specifier: ^2.8.11
         version: 2.8.18(tslib@1.14.1)
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -10892,6 +10976,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       chai:
         specifier: ^4.2.0
         version: 4.5.0
@@ -11760,8 +11847,8 @@ importers:
         specifier: npm:events@^3.1.0
         version: events@3.3.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -11811,6 +11898,9 @@ importers:
       '@types/ungap__structured-clone':
         specifier: ^1.2.0
         version: 1.2.0
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -11869,8 +11959,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -11908,6 +11998,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -12042,8 +12135,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -12099,6 +12192,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -12224,8 +12320,8 @@ importers:
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -12269,6 +12365,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -12379,8 +12478,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -12421,6 +12520,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -12658,8 +12760,8 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -12697,6 +12799,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -12797,6 +12902,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -12828,8 +12936,8 @@ importers:
         specifier: ~5.4.5
         version: 5.4.5
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
 
   packages/service-clients/end-to-end-tests/azure-client:
     dependencies:
@@ -12927,8 +13035,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -12957,6 +13065,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -13039,8 +13150,8 @@ importers:
         specifier: ^18.0.1
         version: 18.0.1
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -13063,6 +13174,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -13118,8 +13232,8 @@ importers:
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -13154,6 +13268,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -13510,8 +13627,8 @@ importers:
         specifier: workspace:~
         version: link:../../dds/tree
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -13522,6 +13639,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14025,8 +14145,8 @@ importers:
         specifier: ^7.7.1
         version: 7.7.1
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -14052,6 +14172,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       concurrently:
         specifier: ^8.2.1
         version: 8.2.2
@@ -14221,8 +14344,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -14251,6 +14374,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14533,8 +14659,8 @@ importers:
         specifier: ^10.8.2
         version: 10.8.2
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -14575,6 +14701,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14738,6 +14867,9 @@ importers:
       '@types/semver':
         specifier: ^7.7.0
         version: 7.7.0
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -14775,8 +14907,8 @@ importers:
         specifier: ~5.4.5
         version: 5.4.5
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
       webpack:
         specifier: ^5.94.0
         version: 5.97.1(webpack-cli@5.1.4)
@@ -14944,6 +15076,9 @@ importers:
       '@microsoft/1ds-post-js':
         specifier: ^3.2.13
         version: 3.2.18(tslib@1.14.1)
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -14954,8 +15089,8 @@ importers:
         specifier: ^1.10.0
         version: 1.14.1
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ~1.9.3
@@ -16057,8 +16192,8 @@ importers:
         specifier: ^4.3.4
         version: 4.4.0(supports-color@8.1.1)
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.1
@@ -16099,6 +16234,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.8
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -19529,6 +19667,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/uuid@9.0.8':
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
+
   '@types/valid-url@1.0.7':
     resolution: {integrity: sha512-tgsWVG80dM5PVEBSbXUttPJTBCOo0IKbBh4R4z/SHsC5C81A3aaUH4fsbj+JYk7fopApU/Mao1c0EWTE592TSg==}
 
@@ -21748,6 +21889,7 @@ packages:
   eslint-plugin-i@2.29.1:
     resolution: {integrity: sha512-ORizX37MelIWLbMyqI7hi8VJMf7A0CskMmYkB+lkCX3aF4pkGV7kwx5bSEb4qx7Yce2rAf9s34HqDRPjGRZPNQ==}
     engines: {node: '>=12'}
+    deprecated: Please migrate to the brand new `eslint-plugin-import-x` instead
     peerDependencies:
       eslint: ^7.2.0 || ^8
 
@@ -27359,10 +27501,6 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -30739,9 +30877,9 @@ snapshots:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint-config-biome: 1.9.4
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
@@ -34188,6 +34326,8 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/uuid@9.0.8': {}
+
   '@types/valid-url@1.0.7': {}
 
   '@types/webpack-hot-middleware@2.25.9(webpack-cli@5.1.4)':
@@ -36795,33 +36935,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.55.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.0
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36835,13 +36975,13 @@ snapshots:
       eslint: 8.55.0
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       get-tsconfig: 4.10.0
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -44067,8 +44207,6 @@ snapshots:
   utila@0.4.0: {}
 
   utils-merge@1.0.1: {}
-
-  uuid@11.1.0: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
## Description

This is a partial revert of https://github.com/microsoft/FluidFramework/pull/24321 (for the client portion) to avoid duplicating the UUID package while we sort out either updating client's use of server ( https://github.com/microsoft/FluidFramework/pull/24330 ) or removing use of the uuid package ( https://github.com/microsoft/FluidFramework/pull/24342 )

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

