### PR TITLE
Revert "build(client): Release notes and changelogs generation for minor release 2.32.0  (#24350)"

### DIFF
--- a/.changeset/deep-mangos-stand.md
+++ b/.changeset/deep-mangos-stand.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/container-runtime": minor
+"@fluidframework/datastore": minor
+"__section": feature
+---
+
+Shorter IDs for DataStores and DDSes
+
+Fluid Framework will now use shorter IDs for Datastores and DDSes when `enableRuntimeIdCompressor:"on"` is set in `IContainerRuntimeOptions`. This change should help reduce summary and snapshot sizes as well as improve runtime performance because of a smaller memory footprint.

--- a/.changeset/salty-tools-carry.md
+++ b/.changeset/salty-tools-carry.md
@@ -1,0 +1,23 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+"__section": tree
+---
+
+Cleanup of several tree and schema alpha APIs for content import and export
+
+A new `TreeSchema` type has been introduced which extends `SimpleTreeSchema` but contains `TreeNodeSchema` instead of `SimpleNodeSchema`.
+
+`TreeViewConfigurationAlpha` is added which is just `TreeViewConfiguration` but implementing `TreeSchema`.
+
+`SimpleTreeSchema` was modified to have a `root` property instead of implementing `SimpleFieldSchema` directly:
+this makes it possible for `TreeViewConfigurationAlpha` to implement `TreeSchema` which extends `SimpleTreeSchema`.
+
+`generateSchemaFromSimpleSchema` now returns the new `TreeSchema` type.
+
+`EncodeOptions` and `ParseOptions` have been unified as `TreeEncodingOptions` which covers both the encoding and parsing cases.
+
+`getJsonSchema` now takes in `ImplicitAllowedTypes` instead of `ImplicitFieldSchema` since it can't handle optional roots.
+`getJsonSchema` also takes in the new `TreeSchemaEncodingOptions` to provide options for how to handle stored keys vs property keys, and fields with defaults.
+
+Now that `getJsonSchema` takes in configuration options, its results are no longer cached.

--- a/.changeset/tired-places-cough.md
+++ b/.changeset/tired-places-cough.md
@@ -1,0 +1,25 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+"__section": tree
+---
+
+Provide alpha APIs for accessing tree content and stored schema without requiring a compatible view schema
+
+Adds an `ITreeAlpha` interface (which `ITree` can be down-casted to) that provides access to both the tree content and the schema.
+This allows inspecting the content saved in a SharedTree in a generic way that can work on any SharedTree.
+
+This can be combined with the existing `generateSchemaFromSimpleSchema` to generate a schema that can be used with [`IIree.viewWith`](https://fluidframework.com/docs/api/fluid-framework/viewabletree-interface#viewwith-methodsignature) to allow constructing a [`TreeView`](https://fluidframework.com/docs/api/fluid-framework/treeview-interface) for any SharedTree, regardless of its schema.
+
+Note that the resulting TypeScript typing for such a view will not be friendly: the `TreeView` APIs are designed for statically known schema. Using them is possible with care and a lot of type casts but not recommended if it can be avoided: see disclaimer on `generateSchemaFromSimpleSchema`.
+Example using `ITreeAlpha` and `generateSchemaFromSimpleSchema`:
+
+```typescript
+const viewAlpha = tree as ITreeAlpha;
+const treeSchema = generateSchemaFromSimpleSchema(viewAlpha.exportSimpleSchema());
+const config = new TreeViewConfiguration({ schema: treeSchema.root });
+const view = viewAlpha.viewWith(config);
+```
+
+`getSimpleSchema` is also added as an `@alpha` API to provide a way to clone schema into the simple schema formats.
+Note that when using (or copying) a view schema as a simple schema, more metadata will be preserved than when deriving one from the stored schema using `ITreeAlpha`.

--- a/.changeset/true-doors-ring.md
+++ b/.changeset/true-doors-ring.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/container-loader": minor
+"__section": feature
+---
+
+Blobs in Detached Container Supported by Default
+
+It is no longer necessary or supported to provide `detachedBlobStorage` to the Loader. This functionality is now provided by default, and the deprecated `IDetachedBlobStorage` will be removed in the 2.40.0 release.
+The new behavior can be disabled by setting `Fluid.Container.MemoryBlobStorageEnabled` to `false`. This flag will also be removed in the 2.40.0 release if no issues are reported.

--- a/azure/packages/azure-local-service/CHANGELOG.md
+++ b/azure/packages/azure-local-service/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/azure-local-service
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/azure/packages/azure-service-utils/CHANGELOG.md
+++ b/azure/packages/azure-service-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/azure-service-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/apps/ai-collab/CHANGELOG.md
+++ b/examples/apps/ai-collab/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/ai-collab
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/apps/attributable-map/CHANGELOG.md
+++ b/examples/apps/attributable-map/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/attributable-map
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/apps/blobs/CHANGELOG.md
+++ b/examples/apps/blobs/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/blobs
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 New package.

--- a/examples/apps/collaborative-textarea/CHANGELOG.md
+++ b/examples/apps/collaborative-textarea/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/collaborative-textarea
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/apps/contact-collection/CHANGELOG.md
+++ b/examples/apps/contact-collection/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/contact-collection
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/apps/data-object-grid/CHANGELOG.md
+++ b/examples/apps/data-object-grid/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/data-object-grid
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/apps/presence-tracker/CHANGELOG.md
+++ b/examples/apps/presence-tracker/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/presence-tracker
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/apps/staging/CHANGELOG.md
+++ b/examples/apps/staging/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/staging
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/apps/task-selection/CHANGELOG.md
+++ b/examples/apps/task-selection/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/task-selection
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/apps/tree-cli-app/CHANGELOG.md
+++ b/examples/apps/tree-cli-app/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/tree-cli-app
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/apps/tree-comparison/CHANGELOG.md
+++ b/examples/apps/tree-comparison/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/tree-comparison
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/benchmarks/bubblebench/baseline/CHANGELOG.md
+++ b/examples/benchmarks/bubblebench/baseline/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/bubblebench-baseline
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/benchmarks/bubblebench/common/CHANGELOG.md
+++ b/examples/benchmarks/bubblebench/common/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/bubblebench-common
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/benchmarks/bubblebench/experimental-tree/CHANGELOG.md
+++ b/examples/benchmarks/bubblebench/experimental-tree/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/bubblebench-experimental-tree
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/benchmarks/bubblebench/ot/CHANGELOG.md
+++ b/examples/benchmarks/bubblebench/ot/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/bubblebench-ot
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/benchmarks/bubblebench/shared-tree/CHANGELOG.md
+++ b/examples/benchmarks/bubblebench/shared-tree/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/bubblebench-simple-tree
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/CHANGELOG.md
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/odspsnapshotfetch-perftestapp
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/benchmarks/tablebench/CHANGELOG.md
+++ b/examples/benchmarks/tablebench/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/tablebench
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/client-logger/app-insights-logger/CHANGELOG.md
+++ b/examples/client-logger/app-insights-logger/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/app-insights-logger
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/canvas/CHANGELOG.md
+++ b/examples/data-objects/canvas/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/canvas
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/clicker/CHANGELOG.md
+++ b/examples/data-objects/clicker/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/clicker
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/codemirror/CHANGELOG.md
+++ b/examples/data-objects/codemirror/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/codemirror
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/diceroller/CHANGELOG.md
+++ b/examples/data-objects/diceroller/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/diceroller
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/inventory-app/CHANGELOG.md
+++ b/examples/data-objects/inventory-app/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/inventory-app
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/monaco/CHANGELOG.md
+++ b/examples/data-objects/monaco/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/monaco
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/multiview/constellation-model/CHANGELOG.md
+++ b/examples/data-objects/multiview/constellation-model/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/multiview-constellation-model
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/multiview/constellation-view/CHANGELOG.md
+++ b/examples/data-objects/multiview/constellation-view/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/multiview-constellation-view
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/multiview/container/CHANGELOG.md
+++ b/examples/data-objects/multiview/container/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/multiview-container
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/multiview/coordinate-model/CHANGELOG.md
+++ b/examples/data-objects/multiview/coordinate-model/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/multiview-coordinate-model
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/multiview/interface/CHANGELOG.md
+++ b/examples/data-objects/multiview/interface/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/multiview-coordinate-interface
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/multiview/plot-coordinate-view/CHANGELOG.md
+++ b/examples/data-objects/multiview/plot-coordinate-view/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/multiview-plot-coordinate-view
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/multiview/slider-coordinate-view/CHANGELOG.md
+++ b/examples/data-objects/multiview/slider-coordinate-view/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/multiview-slider-coordinate-view
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/multiview/triangle-view/CHANGELOG.md
+++ b/examples/data-objects/multiview/triangle-view/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/multiview-triangle-view
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/prosemirror/CHANGELOG.md
+++ b/examples/data-objects/prosemirror/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/prosemirror
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/smde/CHANGELOG.md
+++ b/examples/data-objects/smde/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/smde
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/table-document/CHANGELOG.md
+++ b/examples/data-objects/table-document/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/table-document
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/todo/CHANGELOG.md
+++ b/examples/data-objects/todo/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/todo
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/data-objects/webflow/CHANGELOG.md
+++ b/examples/data-objects/webflow/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/webflow
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/external-data/CHANGELOG.md
+++ b/examples/external-data/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/app-integration-external-data
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/service-clients/azure-client/external-controller/CHANGELOG.md
+++ b/examples/service-clients/azure-client/external-controller/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/app-integration-external-controller
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/service-clients/odsp-client/shared-tree-demo/CHANGELOG.md
+++ b/examples/service-clients/odsp-client/shared-tree-demo/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/shared-tree-demo
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/utils/bundle-size-tests/CHANGELOG.md
+++ b/examples/utils/bundle-size-tests/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/bundle-size-tests
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/utils/example-utils/CHANGELOG.md
+++ b/examples/utils/example-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/example-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/utils/import-testing/CHANGELOG.md
+++ b/examples/utils/import-testing/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/import-testing
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/utils/migration-tools/CHANGELOG.md
+++ b/examples/utils/migration-tools/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/migration-tools
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/utils/webpack-fluid-loader/CHANGELOG.md
+++ b/examples/utils/webpack-fluid-loader/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/webpack-fluid-loader
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/version-migration/live-schema-upgrade/CHANGELOG.md
+++ b/examples/version-migration/live-schema-upgrade/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/app-integration-live-schema-upgrade
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/version-migration/same-container/CHANGELOG.md
+++ b/examples/version-migration/same-container/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/version-migration-same-container
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/version-migration/separate-container/CHANGELOG.md
+++ b/examples/version-migration/separate-container/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/version-migration-separate-container
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/version-migration/tree-shim/CHANGELOG.md
+++ b/examples/version-migration/tree-shim/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/tree-comparison
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/view-integration/container-views/CHANGELOG.md
+++ b/examples/view-integration/container-views/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/app-integration-container-views
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/view-integration/external-views/CHANGELOG.md
+++ b/examples/view-integration/external-views/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/app-integration-external-views
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/examples/view-integration/view-framework-sampler/CHANGELOG.md
+++ b/examples/view-integration/view-framework-sampler/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-example/view-framework-sampler
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/PropertyDDS/packages/property-changeset/CHANGELOG.md
+++ b/experimental/PropertyDDS/packages/property-changeset/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/property-changeset
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/PropertyDDS/packages/property-common/CHANGELOG.md
+++ b/experimental/PropertyDDS/packages/property-common/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/property-common
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/PropertyDDS/packages/property-common/platform-dependent/CHANGELOG.md
+++ b/experimental/PropertyDDS/packages/property-common/platform-dependent/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/platform-dependent
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/PropertyDDS/packages/property-dds/CHANGELOG.md
+++ b/experimental/PropertyDDS/packages/property-dds/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/property-dds
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/PropertyDDS/packages/property-properties/CHANGELOG.md
+++ b/experimental/PropertyDDS/packages/property-properties/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/property-properties
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/dds/attributable-map/CHANGELOG.md
+++ b/experimental/dds/attributable-map/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/attributable-map
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/dds/ot/ot/CHANGELOG.md
+++ b/experimental/dds/ot/ot/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/ot
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/dds/ot/sharejs/json1/CHANGELOG.md
+++ b/experimental/dds/ot/sharejs/json1/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/sharejs-json1
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/dds/sequence-deprecated/CHANGELOG.md
+++ b/experimental/dds/sequence-deprecated/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/sequence-deprecated
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/dds/tree/CHANGELOG.md
+++ b/experimental/dds/tree/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/tree
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/framework/data-objects/CHANGELOG.md
+++ b/experimental/framework/data-objects/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/data-objects
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/framework/last-edited/CHANGELOG.md
+++ b/experimental/framework/last-edited/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/last-edited
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/experimental/framework/tree-react-api/CHANGELOG.md
+++ b/experimental/framework/tree-react-api/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/tree-react-api
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 ### Minor Changes

--- a/packages/common/client-utils/CHANGELOG.md
+++ b/packages/common/client-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/client-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/common/container-definitions/CHANGELOG.md
+++ b/packages/common/container-definitions/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/container-definitions
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/common/core-interfaces/CHANGELOG.md
+++ b/packages/common/core-interfaces/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/core-interfaces
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/common/core-utils/CHANGELOG.md
+++ b/packages/common/core-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/core-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 ### Minor Changes

--- a/packages/common/driver-definitions/CHANGELOG.md
+++ b/packages/common/driver-definitions/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/driver-definitions
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/cell/CHANGELOG.md
+++ b/packages/dds/cell/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/cell
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/counter/CHANGELOG.md
+++ b/packages/dds/counter/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/counter
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/ink/CHANGELOG.md
+++ b/packages/dds/ink/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/ink
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/map/CHANGELOG.md
+++ b/packages/dds/map/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/map
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/matrix/CHANGELOG.md
+++ b/packages/dds/matrix/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/matrix
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/merge-tree/CHANGELOG.md
+++ b/packages/dds/merge-tree/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/merge-tree
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/ordered-collection/CHANGELOG.md
+++ b/packages/dds/ordered-collection/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/ordered-collection
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/pact-map/CHANGELOG.md
+++ b/packages/dds/pact-map/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/pact-map
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/register-collection/CHANGELOG.md
+++ b/packages/dds/register-collection/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/register-collection
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/sequence/CHANGELOG.md
+++ b/packages/dds/sequence/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/sequence
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/shared-object-base/CHANGELOG.md
+++ b/packages/dds/shared-object-base/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/shared-object-base
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/shared-summary-block/CHANGELOG.md
+++ b/packages/dds/shared-summary-block/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/shared-summary-block
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/task-manager/CHANGELOG.md
+++ b/packages/dds/task-manager/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/task-manager
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/test-dds-utils/CHANGELOG.md
+++ b/packages/dds/test-dds-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-private/test-dds-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/dds/tree/CHANGELOG.md
+++ b/packages/dds/tree/CHANGELOG.md
@@ -1,49 +1,5 @@
 # @fluidframework/tree
 
-## 2.32.0
-
-### Minor Changes
-
-- Cleanup of several tree and schema alpha APIs for content import and export ([#24255](https://github.com/microsoft/FluidFramework/pull/24255)) [c6563e57ac](https://github.com/microsoft/FluidFramework/commit/c6563e57ac42f002f844aea4d9d6e849908ae1b2)
-
-  A new `TreeSchema` type has been introduced which extends `SimpleTreeSchema` but contains `TreeNodeSchema` instead of `SimpleNodeSchema`.
-
-  `TreeViewConfigurationAlpha` is added which is just `TreeViewConfiguration` but implementing `TreeSchema`.
-
-  `SimpleTreeSchema` was modified to have a `root` property instead of implementing `SimpleFieldSchema` directly:
-  this makes it possible for `TreeViewConfigurationAlpha` to implement `TreeSchema` which extends `SimpleTreeSchema`.
-
-  `generateSchemaFromSimpleSchema` now returns the new `TreeSchema` type.
-
-  `EncodeOptions` and `ParseOptions` have been unified as `TreeEncodingOptions` which covers both the encoding and parsing cases.
-
-  `getJsonSchema` now takes in `ImplicitAllowedTypes` instead of `ImplicitFieldSchema` since it can't handle optional roots.
-  `getJsonSchema` also takes in the new `TreeSchemaEncodingOptions` to provide options for how to handle stored keys vs property keys, and fields with defaults.
-
-  Now that `getJsonSchema` takes in configuration options, its results are no longer cached.
-
-- Provide alpha APIs for accessing tree content and stored schema without requiring a compatible view schema ([#24225](https://github.com/microsoft/FluidFramework/pull/24225)) [18b6e05e4e](https://github.com/microsoft/FluidFramework/commit/18b6e05e4e85fdc1a6d373b15c2bfcc191ea1bc3)
-
-  Adds an `ITreeAlpha` interface (which `ITree` can be down-casted to) that provides access to both the tree content and the schema.
-  This allows inspecting the content saved in a SharedTree in a generic way that can work on any SharedTree.
-
-  This can be combined with the existing `generateSchemaFromSimpleSchema` to generate a schema that can be used with [`IIree.viewWith`](https://fluidframework.com/docs/api/fluid-framework/viewabletree-interface#viewwith-methodsignature) to allow constructing a [`TreeView`](https://fluidframework.com/docs/api/fluid-framework/treeview-interface) for any SharedTree, regardless of its schema.
-
-  Note that the resulting TypeScript typing for such a view will not be friendly: the `TreeView` APIs are designed for statically known schema. Using them is possible with care and a lot of type casts but not recommended if it can be avoided: see disclaimer on `generateSchemaFromSimpleSchema`.
-  Example using `ITreeAlpha` and `generateSchemaFromSimpleSchema`:
-
-  ```typescript
-  const viewAlpha = tree as ITreeAlpha;
-  const treeSchema = generateSchemaFromSimpleSchema(
-    viewAlpha.exportSimpleSchema(),
-  );
-  const config = new TreeViewConfiguration({ schema: treeSchema.root });
-  const view = viewAlpha.viewWith(config);
-  ```
-
-  `getSimpleSchema` is also added as an `@alpha` API to provide a way to clone schema into the simple schema formats.
-  Note that when using (or copying) a view schema as a simple schema, more metadata will be preserved than when deriving one from the stored schema using `ITreeAlpha`.
-
 ## 2.31.0
 
 ### Minor Changes

--- a/packages/drivers/debugger/CHANGELOG.md
+++ b/packages/drivers/debugger/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/debugger
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/drivers/driver-base/CHANGELOG.md
+++ b/packages/drivers/driver-base/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/driver-base
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/drivers/driver-web-cache/CHANGELOG.md
+++ b/packages/drivers/driver-web-cache/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/driver-web-cache
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/drivers/file-driver/CHANGELOG.md
+++ b/packages/drivers/file-driver/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/file-driver
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/drivers/local-driver/CHANGELOG.md
+++ b/packages/drivers/local-driver/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/local-driver
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/drivers/odsp-driver-definitions/CHANGELOG.md
+++ b/packages/drivers/odsp-driver-definitions/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/odsp-driver-definitions
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/drivers/odsp-driver/CHANGELOG.md
+++ b/packages/drivers/odsp-driver/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/odsp-driver
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/drivers/odsp-urlResolver/CHANGELOG.md
+++ b/packages/drivers/odsp-urlResolver/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/odsp-urlresolver
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/drivers/replay-driver/CHANGELOG.md
+++ b/packages/drivers/replay-driver/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/replay-driver
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/drivers/routerlicious-driver/CHANGELOG.md
+++ b/packages/drivers/routerlicious-driver/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/routerlicious-driver
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/drivers/routerlicious-urlResolver/CHANGELOG.md
+++ b/packages/drivers/routerlicious-urlResolver/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/routerlicious-urlresolver
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/drivers/tinylicious-driver/CHANGELOG.md
+++ b/packages/drivers/tinylicious-driver/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/tinylicious-driver
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/agent-scheduler/CHANGELOG.md
+++ b/packages/framework/agent-scheduler/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/agent-scheduler
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/ai-collab/CHANGELOG.md
+++ b/packages/framework/ai-collab/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/ai-collab
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/aqueduct/CHANGELOG.md
+++ b/packages/framework/aqueduct/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/aqueduct
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/attributor/CHANGELOG.md
+++ b/packages/framework/attributor/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/attributor
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/client-logger/app-insights-logger/CHANGELOG.md
+++ b/packages/framework/client-logger/app-insights-logger/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/app-insights-logger
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/client-logger/fluid-telemetry/CHANGELOG.md
+++ b/packages/framework/client-logger/fluid-telemetry/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/fluid-telemetry
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/data-object-base/CHANGELOG.md
+++ b/packages/framework/data-object-base/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/data-object-base
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/dds-interceptions/CHANGELOG.md
+++ b/packages/framework/dds-interceptions/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/dds-interceptions
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/fluid-framework/CHANGELOG.md
+++ b/packages/framework/fluid-framework/CHANGELOG.md
@@ -1,49 +1,5 @@
 # fluid-framework
 
-## 2.32.0
-
-### Minor Changes
-
-- Cleanup of several tree and schema alpha APIs for content import and export ([#24255](https://github.com/microsoft/FluidFramework/pull/24255)) [c6563e57ac](https://github.com/microsoft/FluidFramework/commit/c6563e57ac42f002f844aea4d9d6e849908ae1b2)
-
-  A new `TreeSchema` type has been introduced which extends `SimpleTreeSchema` but contains `TreeNodeSchema` instead of `SimpleNodeSchema`.
-
-  `TreeViewConfigurationAlpha` is added which is just `TreeViewConfiguration` but implementing `TreeSchema`.
-
-  `SimpleTreeSchema` was modified to have a `root` property instead of implementing `SimpleFieldSchema` directly:
-  this makes it possible for `TreeViewConfigurationAlpha` to implement `TreeSchema` which extends `SimpleTreeSchema`.
-
-  `generateSchemaFromSimpleSchema` now returns the new `TreeSchema` type.
-
-  `EncodeOptions` and `ParseOptions` have been unified as `TreeEncodingOptions` which covers both the encoding and parsing cases.
-
-  `getJsonSchema` now takes in `ImplicitAllowedTypes` instead of `ImplicitFieldSchema` since it can't handle optional roots.
-  `getJsonSchema` also takes in the new `TreeSchemaEncodingOptions` to provide options for how to handle stored keys vs property keys, and fields with defaults.
-
-  Now that `getJsonSchema` takes in configuration options, its results are no longer cached.
-
-- Provide alpha APIs for accessing tree content and stored schema without requiring a compatible view schema ([#24225](https://github.com/microsoft/FluidFramework/pull/24225)) [18b6e05e4e](https://github.com/microsoft/FluidFramework/commit/18b6e05e4e85fdc1a6d373b15c2bfcc191ea1bc3)
-
-  Adds an `ITreeAlpha` interface (which `ITree` can be down-casted to) that provides access to both the tree content and the schema.
-  This allows inspecting the content saved in a SharedTree in a generic way that can work on any SharedTree.
-
-  This can be combined with the existing `generateSchemaFromSimpleSchema` to generate a schema that can be used with [`IIree.viewWith`](https://fluidframework.com/docs/api/fluid-framework/viewabletree-interface#viewwith-methodsignature) to allow constructing a [`TreeView`](https://fluidframework.com/docs/api/fluid-framework/treeview-interface) for any SharedTree, regardless of its schema.
-
-  Note that the resulting TypeScript typing for such a view will not be friendly: the `TreeView` APIs are designed for statically known schema. Using them is possible with care and a lot of type casts but not recommended if it can be avoided: see disclaimer on `generateSchemaFromSimpleSchema`.
-  Example using `ITreeAlpha` and `generateSchemaFromSimpleSchema`:
-
-  ```typescript
-  const viewAlpha = tree as ITreeAlpha;
-  const treeSchema = generateSchemaFromSimpleSchema(
-    viewAlpha.exportSimpleSchema(),
-  );
-  const config = new TreeViewConfiguration({ schema: treeSchema.root });
-  const view = viewAlpha.viewWith(config);
-  ```
-
-  `getSimpleSchema` is also added as an `@alpha` API to provide a way to clone schema into the simple schema formats.
-  Note that when using (or copying) a view schema as a simple schema, more metadata will be preserved than when deriving one from the stored schema using `ITreeAlpha`.
-
 ## 2.31.0
 
 ### Minor Changes

--- a/packages/framework/fluid-static/CHANGELOG.md
+++ b/packages/framework/fluid-static/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/fluid-static
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/oldest-client-observer/CHANGELOG.md
+++ b/packages/framework/oldest-client-observer/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/oldest-client-observer
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/presence/CHANGELOG.md
+++ b/packages/framework/presence/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/presence
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/request-handler/CHANGELOG.md
+++ b/packages/framework/request-handler/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/request-handler
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/synthesize/CHANGELOG.md
+++ b/packages/framework/synthesize/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/synthesize
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/framework/undo-redo/CHANGELOG.md
+++ b/packages/framework/undo-redo/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/undo-redo
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/loader/container-loader/CHANGELOG.md
+++ b/packages/loader/container-loader/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @fluidframework/container-loader
 
-## 2.32.0
-
-### Minor Changes
-
-- Blobs in Detached Container Supported by Default ([#24119](https://github.com/microsoft/FluidFramework/pull/24119)) [fcf561a802](https://github.com/microsoft/FluidFramework/commit/fcf561a802b2a9f8f9f3ac2d9f42fa14b6cbaf5e)
-
-  It is no longer necessary or supported to provide `detachedBlobStorage` to the Loader. This functionality is now provided by default, and the deprecated `IDetachedBlobStorage` will be removed in the 2.40.0 release.
-  The new behavior can be disabled by setting `Fluid.Container.MemoryBlobStorageEnabled` to `false`. This flag will also be removed in the 2.40.0 release if no issues are reported.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/loader/driver-utils/CHANGELOG.md
+++ b/packages/loader/driver-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/driver-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/loader/test-loader-utils/CHANGELOG.md
+++ b/packages/loader/test-loader-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-private/test-loader-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/runtime/container-runtime-definitions/CHANGELOG.md
+++ b/packages/runtime/container-runtime-definitions/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/container-runtime-definitions
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/runtime/container-runtime/CHANGELOG.md
+++ b/packages/runtime/container-runtime/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @fluidframework/container-runtime
 
-## 2.32.0
-
-### Minor Changes
-
-- Shorter IDs for DataStores and DDSes ([#24231](https://github.com/microsoft/FluidFramework/pull/24231)) [27bbb87a1f](https://github.com/microsoft/FluidFramework/commit/27bbb87a1f16b304767cd05e46ee0ed2876c4f57)
-
-  Fluid Framework will now use shorter IDs for Datastores and DDSes when `enableRuntimeIdCompressor:"on"` is set in `IContainerRuntimeOptions`. This change should help reduce summary and snapshot sizes as well as improve runtime performance because of a smaller memory footprint.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/runtime/datastore-definitions/CHANGELOG.md
+++ b/packages/runtime/datastore-definitions/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/datastore-definitions
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/runtime/datastore/CHANGELOG.md
+++ b/packages/runtime/datastore/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @fluidframework/datastore
 
-## 2.32.0
-
-### Minor Changes
-
-- Shorter IDs for DataStores and DDSes ([#24231](https://github.com/microsoft/FluidFramework/pull/24231)) [27bbb87a1f](https://github.com/microsoft/FluidFramework/commit/27bbb87a1f16b304767cd05e46ee0ed2876c4f57)
-
-  Fluid Framework will now use shorter IDs for Datastores and DDSes when `enableRuntimeIdCompressor:"on"` is set in `IContainerRuntimeOptions`. This change should help reduce summary and snapshot sizes as well as improve runtime performance because of a smaller memory footprint.
-
 ## 2.31.0
 
 ### Minor Changes

--- a/packages/runtime/id-compressor/CHANGELOG.md
+++ b/packages/runtime/id-compressor/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/id-compressor
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/runtime/runtime-definitions/CHANGELOG.md
+++ b/packages/runtime/runtime-definitions/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/runtime-definitions
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/runtime/runtime-utils/CHANGELOG.md
+++ b/packages/runtime/runtime-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/runtime-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/runtime/test-runtime-utils/CHANGELOG.md
+++ b/packages/runtime/test-runtime-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/test-runtime-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 ### Minor Changes

--- a/packages/service-clients/azure-client/CHANGELOG.md
+++ b/packages/service-clients/azure-client/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/azure-client
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/service-clients/end-to-end-tests/azure-client/CHANGELOG.md
+++ b/packages/service-clients/end-to-end-tests/azure-client/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/azure-end-to-end-tests
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/service-clients/end-to-end-tests/odsp-client/CHANGELOG.md
+++ b/packages/service-clients/end-to-end-tests/odsp-client/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/odsp-end-to-end-tests
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/service-clients/odsp-client/CHANGELOG.md
+++ b/packages/service-clients/odsp-client/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-experimental/odsp-client
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/service-clients/tinylicious-client/CHANGELOG.md
+++ b/packages/service-clients/tinylicious-client/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/tinylicious-client
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/functional-tests/CHANGELOG.md
+++ b/packages/test/functional-tests/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/functional-tests
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/local-server-stress-tests/CHANGELOG.md
+++ b/packages/test/local-server-stress-tests/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/local-server-stress-tests
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/local-server-tests/CHANGELOG.md
+++ b/packages/test/local-server-tests/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/local-server-tests
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/mocha-test-setup/CHANGELOG.md
+++ b/packages/test/mocha-test-setup/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/mocha-test-setup
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/snapshots/CHANGELOG.md
+++ b/packages/test/snapshots/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/test-snapshots
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/stochastic-test-utils/CHANGELOG.md
+++ b/packages/test/stochastic-test-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-private/stochastic-test-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/test-driver-definitions/CHANGELOG.md
+++ b/packages/test/test-driver-definitions/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/test-driver-definitions
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/test-drivers/CHANGELOG.md
+++ b/packages/test/test-drivers/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-private/test-drivers
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/test-end-to-end-tests/CHANGELOG.md
+++ b/packages/test/test-end-to-end-tests/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-private/test-end-to-end-tests
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/test-pairwise-generator/CHANGELOG.md
+++ b/packages/test/test-pairwise-generator/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-private/test-pairwise-generator
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/test-service-load/CHANGELOG.md
+++ b/packages/test/test-service-load/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/test-service-load
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/test-utils/CHANGELOG.md
+++ b/packages/test/test-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/test-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/test/test-version-utils/CHANGELOG.md
+++ b/packages/test/test-version-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-private/test-version-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/tools/changelog-generator-wrapper/CHANGELOG.md
+++ b/packages/tools/changelog-generator-wrapper/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-private/changelog-generator-wrapper
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/tools/devtools/devtools-browser-extension/CHANGELOG.md
+++ b/packages/tools/devtools/devtools-browser-extension/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/devtools-browser-extension
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/tools/devtools/devtools-core/CHANGELOG.md
+++ b/packages/tools/devtools/devtools-core/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/devtools-core
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/tools/devtools/devtools-test-app/CHANGELOG.md
+++ b/packages/tools/devtools/devtools-test-app/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-private/devtools-test-app
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/tools/devtools/devtools-view/CHANGELOG.md
+++ b/packages/tools/devtools/devtools-view/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/devtools-view
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/tools/devtools/devtools/CHANGELOG.md
+++ b/packages/tools/devtools/devtools/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/devtools
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/tools/fetch-tool/CHANGELOG.md
+++ b/packages/tools/fetch-tool/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-tools/fetch-tool
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/tools/fluid-runner/CHANGELOG.md
+++ b/packages/tools/fluid-runner/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/fluid-runner
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/tools/replay-tool/CHANGELOG.md
+++ b/packages/tools/replay-tool/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-internal/replay-tool
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/utils/odsp-doclib-utils/CHANGELOG.md
+++ b/packages/utils/odsp-doclib-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/odsp-doclib-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/utils/telemetry-utils/CHANGELOG.md
+++ b/packages/utils/telemetry-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/telemetry-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/packages/utils/tool-utils/CHANGELOG.md
+++ b/packages/utils/tool-utils/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluidframework/tool-utils
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.

--- a/tools/markdown-magic/CHANGELOG.md
+++ b/tools/markdown-magic/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @fluid-tools/markdown-magic
 
-## 2.32.0
-
-Dependency updates only.
-
 ## 2.31.0
 
 Dependency updates only.


### PR DESCRIPTION
Revert "build(client): Release notes and changelogs generation for minor release 2.32.0  (#24350)"
This is due to a release blocking PR which is going to be merged before release, so this need to be reverted and done again.