### PR TITLE
don't check throw message on empty batch test

### DIFF
--- a/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "node:assert";
 
 import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
+import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import { ContainerMessageType } from "../../index.js";
 import {
@@ -126,14 +127,17 @@ describe("OpGroupingManager", () => {
 				contentSizeInBytes: 0,
 				referenceSequenceNumber: 0,
 			};
-			assert.throws(() => {
-				new OpGroupingManager(
-					{
-						groupedBatchingEnabled: true,
-					},
-					mockLogger,
-				).groupBatch(emptyBatch);
-			});
+			assert.throws(
+				() => {
+					new OpGroupingManager(
+						{
+							groupedBatchingEnabled: true,
+						},
+						mockLogger,
+					).groupBatch(emptyBatch);
+				},
+				(e: Error) => validateAssertionError(e, "Unexpected attempt to group an empty batch"),
+			);
 		});
 
 		it("singleton batch is returned as-is", () => {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
@@ -126,17 +126,14 @@ describe("OpGroupingManager", () => {
 				contentSizeInBytes: 0,
 				referenceSequenceNumber: 0,
 			};
-			assert.throws(
-				() => {
-					new OpGroupingManager(
-						{
-							groupedBatchingEnabled: true,
-						},
-						mockLogger,
-					).groupBatch(emptyBatch);
-				},
-				{ message: "Unexpected attempt to group an empty batch" },
-			);
+			assert.throws(() => {
+				new OpGroupingManager(
+					{
+						groupedBatchingEnabled: true,
+					},
+					mockLogger,
+				).groupBatch(emptyBatch);
+			});
 		});
 
 		it("singleton batch is returned as-is", () => {


### PR DESCRIPTION
Test is checking for exact error message. Once the asserts are tagged, the message will change to an hex code. We could be more precise later but suggesting this quick fix since seems it is release blocking.