### PR TITLE
Tombstone local pending blobs to be resilient to reupload

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -744,7 +744,7 @@ export class BlobManager {
 							this.tombstoneBlobs.has(pendingLocalId),
 							"local online BlobAttach op with no pending blob entry",
 						);
-						return;
+						continue;
 					}
 					this.setRedirection(pendingLocalId, blobId);
 					entry.acked = true;

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -476,11 +476,7 @@ for (const createBlobPlaceholders of [false, true]) {
 			assert.strictEqual(summaryData.redirectTable?.length, 1);
 		});
 
-		it("reupload blob if expired", async function () {
-			// TODO AB#35004: test fails with 0x38f, there are duplicate localIds in the opsInFlight so the second one chokes.
-			if (createBlobPlaceholders) {
-				this.skip();
-			}
+		it("reupload blob if expired", async () => {
 			await runtime.attach();
 			await runtime.connect();
 			runtime.attachedStorage.minTTL = 0.001; // force expired TTL being less than connection time (50ms)


### PR DESCRIPTION
When a blob attach op is reuploaded (resubmit/ expired or stashed scenarios), we could hit asserts checking for its existence in the pending blob list if such op was already processed. Adding a tombstone list to make sure we recognize such blobs