### PR TITLE
[take 2] refactor(container-runtime): Stop estimating batch size when accumulating a local batch

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -14,16 +14,10 @@ import { ICompressionRuntimeOptions } from "../containerRuntime.js";
 import { asBatchMetadata, type IBatchMetadata } from "../metadata.js";
 import type { IPendingMessage } from "../pendingStateManager.js";
 
-import {
-	LocalBatchMessage,
-	IBatchCheckpoint,
-	type LocalBatch,
-	type OutboundBatch,
-} from "./definitions.js";
+import { LocalBatchMessage, IBatchCheckpoint, type LocalBatch } from "./definitions.js";
 import type { BatchStartInfo } from "./remoteMessageProcessor.js";
 
 export interface IBatchManagerOptions {
-	readonly hardLimit: number;
 	readonly compressionOptions?: ICompressionRuntimeOptions;
 
 	/**
@@ -79,24 +73,14 @@ export function getEffectiveBatchId(
 }
 
 /**
- * Estimated size of the stringification overhead for an op accumulated
- * from runtime to loader to the service.
- */
-const opOverhead = 200;
-
-/**
  * Helper class that manages partial batch & rollback.
  */
 export class BatchManager {
 	private pendingBatch: LocalBatchMessage[] = [];
-	private batchContentSize = 0;
 	private hasReentrantOps = false;
 
 	public get length(): number {
 		return this.pendingBatch.length;
-	}
-	public get contentSizeInBytes(): number {
-		return this.batchContentSize;
 	}
 
 	public get sequenceNumbers(): BatchSequenceNumbers {
@@ -125,29 +109,14 @@ export class BatchManager {
 		message: LocalBatchMessage,
 		reentrant: boolean,
 		currentClientSequenceNumber?: number,
-	): boolean {
-		const contentSize = this.batchContentSize + (message.serializedOp?.length ?? 0);
-		const opCount = this.pendingBatch.length;
+	): void {
 		this.hasReentrantOps = this.hasReentrantOps || reentrant;
-
-		// Attempt to estimate batch size, aka socket message size.
-		// Each op has pretty large envelope, estimating to be 200 bytes.
-		// Also content will be strigified, and that adds a lot of overhead due to a lot of escape characters.
-		// Not taking it into account, as compression work should help there - compressed payload will be
-		// initially stored as base64, and that requires only 2 extra escape characters.
-		const socketMessageSize = contentSize + opOverhead * opCount;
-
-		if (socketMessageSize >= this.options.hardLimit) {
-			return false;
-		}
 
 		if (this.pendingBatch.length === 0) {
 			this.clientSequenceNumber = currentClientSequenceNumber;
 		}
 
-		this.batchContentSize = contentSize;
 		this.pendingBatch.push(message);
-		return true;
 	}
 
 	public get empty(): boolean {
@@ -160,13 +129,11 @@ export class BatchManager {
 	public popBatch(batchId?: BatchId): LocalBatch {
 		const batch: LocalBatch = {
 			messages: this.pendingBatch,
-			contentSizeInBytes: this.batchContentSize,
 			referenceSequenceNumber: this.referenceSequenceNumber,
 			hasReentrantOps: this.hasReentrantOps,
 		};
 
 		this.pendingBatch = [];
-		this.batchContentSize = 0;
 		this.clientSequenceNumber = undefined;
 		this.hasReentrantOps = false;
 
@@ -184,7 +151,6 @@ export class BatchManager {
 				this.clientSequenceNumber = startSequenceNumber;
 				const rollbackOpsLifo = this.pendingBatch.splice(startPoint).reverse();
 				for (const message of rollbackOpsLifo) {
-					this.batchContentSize -= message.serializedOp?.length ?? 0;
 					process(message);
 				}
 				const count = this.pendingBatch.length - startPoint;
@@ -231,18 +197,6 @@ const addBatchMetadata = (batch: LocalBatch, batchId?: BatchId): LocalBatch => {
 	}
 
 	return batch;
-};
-
-/**
- * Estimates the real size in bytes on the socket for a given batch. It assumes that
- * the envelope size (and the size of an empty op) is 200 bytes, taking into account
- * extra overhead from stringification.
- *
- * @param batch - the batch to inspect
- * @returns An estimate of the payload size in bytes which will be produced when the batch is sent over the wire
- */
-export const estimateSocketSize = (batch: OutboundBatch): number => {
-	return batch.contentSizeInBytes + opOverhead * batch.messages.length;
 };
 
 export const sequenceNumbersMatch = (

--- a/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
@@ -45,25 +45,29 @@ export type LocalBatch = IBatch<LocalBatchMessage[]>;
 /**
  * A batch of messages that has been virtualized as needed (grouped, compressed, chunked)
  * and is ready to be sent to the ordering service.
+ * At the very least, the op contents have been serialized to string.
  */
-export type OutboundBatch = IBatch<OutboundBatchMessage[]>;
+export interface OutboundBatch<
+	TMessages extends OutboundBatchMessage[] = OutboundBatchMessage[],
+> extends IBatch<TMessages> {
+	/**
+	 * Sum of the in-memory content sizes of all messages in the batch.
+	 * If the batch is compressed, this number reflects the post-compression size.
+	 */
+	readonly contentSizeInBytes: number;
+}
 
 /**
  * An {@link OutboundBatch} with exactly one message
  * This type is helpful as Grouping yields this kind of batch, and Compression only operates on this type of batch.
  */
-export type OutboundSingletonBatch = IBatch<[OutboundBatchMessage]>;
+export type OutboundSingletonBatch = OutboundBatch<[OutboundBatchMessage]>;
 
 /**
  * Base batch interface used internally by the runtime.
  * See {@link LocalBatch} and {@link OutboundBatch} for the concrete types.
  */
 interface IBatch<TMessages extends LocalBatchMessage[] | OutboundBatchMessage[]> {
-	/**
-	 * Sum of the in-memory content sizes of all messages in the batch.
-	 * If the batch is compressed, this number reflects the post-compression size.
-	 */
-	readonly contentSizeInBytes: number;
 	/**
 	 * All the messages in the batch
 	 */

--- a/packages/runtime/container-runtime/src/opLifecycle/index.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/index.ts
@@ -7,7 +7,6 @@ export {
 	BatchId,
 	BatchManager,
 	BatchSequenceNumbers,
-	estimateSocketSize,
 	getEffectiveBatchId,
 	generateBatchId,
 	IBatchManagerOptions,
@@ -26,7 +25,12 @@ export {
 	serializeOp,
 	ensureContentsDeserialized,
 } from "./opSerialization.js";
-export { Outbox, getLongStack } from "./outbox.js";
+export {
+	estimateSocketSize,
+	localBatchToOutboundBatch,
+	Outbox,
+	getLongStack,
+} from "./outbox.js";
 export { OpCompressor } from "./opCompressor.js";
 export { OpDecompressor } from "./opDecompressor.js";
 export { OpSplitter, splitOp, isChunkedMessage } from "./opSplitter.js";

--- a/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
@@ -15,8 +15,8 @@ import { compress } from "lz4js";
 
 import { CompressionAlgorithms } from "../containerRuntime.js";
 
-import { estimateSocketSize } from "./batchManager.js";
 import { type OutboundBatchMessage, type OutboundSingletonBatch } from "./definitions.js";
+import { estimateSocketSize } from "./outbox.js";
 
 /**
  * Compresses batches of ops.

--- a/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
@@ -16,12 +16,12 @@ import {
 
 import { ContainerMessageType, ContainerRuntimeChunkedOpMessage } from "../messageTypes.js";
 
-import { estimateSocketSize } from "./batchManager.js";
 import {
 	IChunkedOp,
 	type OutboundBatchMessage,
 	type OutboundSingletonBatch,
 } from "./definitions.js";
+import { estimateSocketSize } from "./outbox.js";
 
 export function isChunkedMessage(message: ISequencedDocumentMessage): boolean {
 	return isChunkedContents(message.contents);

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -4,13 +4,16 @@
  */
 
 import { IBatchMessage } from "@fluidframework/container-definitions/internal";
-import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import {
+	ITelemetryBaseLogger,
+	type ITelemetryBaseProperties,
+} from "@fluidframework/core-interfaces";
 import { assert, Lazy } from "@fluidframework/core-utils/internal";
 import {
 	DataProcessingError,
-	GenericError,
 	UsageError,
 	createChildLogger,
+	type IFluidErrorBase,
 	type ITelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -20,7 +23,6 @@ import { PendingMessageResubmitData, PendingStateManager } from "../pendingState
 import {
 	BatchManager,
 	BatchSequenceNumbers,
-	estimateSocketSize,
 	sequenceNumbersMatch,
 	type BatchId,
 } from "./batchManager.js";
@@ -107,6 +109,55 @@ export function getLongStack<T>(action: () => T, length: number = 50): T {
 }
 
 /**
+ * Convert from local batch to outbound batch, including computing contentSizeInBytes.
+ */
+export function localBatchToOutboundBatch(localBatch: LocalBatch): OutboundBatch {
+	// Shallow copy each message as we switch types
+	const outboundMessages = localBatch.messages.map<OutboundBatchMessage>(
+		({ serializedOp, ...message }) => ({
+			contents: serializedOp,
+			...message,
+		}),
+	);
+	const contentSizeInBytes = outboundMessages.reduce(
+		(acc, message) => acc + (message.contents?.length ?? 0),
+		0,
+	);
+
+	// Shallow copy the local batch, updating the messages to be outbound messages and adding contentSizeInBytes
+	const outboundBatch: OutboundBatch = {
+		...localBatch,
+		messages: outboundMessages,
+		contentSizeInBytes,
+	};
+
+	return outboundBatch;
+}
+
+/**
+ * Estimated size of the stringification overhead for an op accumulated
+ * from runtime to loader to the service.
+ */
+const opOverhead = 200;
+
+/**
+ * Estimates the real size in bytes on the socket for a given batch. It assumes that
+ * the envelope size (and the size of an empty op) is 200 bytes, taking into account
+ * extra overhead from stringification.
+ *
+ * @remarks
+ * Also content will be stringified, and that adds a lot of overhead due to a lot of escape characters.
+ * Not taking it into account, as compression work should help there - compressed payload will be
+ * initially stored as base64, and that requires only 2 extra escape characters.
+ *
+ * @param batch - the batch to inspect
+ * @returns An estimate of the payload size in bytes which will be produced when the batch is sent over the wire
+ */
+export const estimateSocketSize = (batch: OutboundBatch): number => {
+	return batch.contentSizeInBytes + opOverhead * batch.messages.length;
+};
+
+/**
  * The Outbox collects messages submitted by the ContainerRuntime into a batch,
  * and then flushes the batch when requested.
  *
@@ -133,18 +184,9 @@ export class Outbox {
 	constructor(private readonly params: IOutboxParameters) {
 		this.logger = createChildLogger({ logger: params.logger, namespace: "Outbox" });
 
-		const isCompressionEnabled =
-			this.params.config.compressionOptions.minimumBatchSizeInBytes !==
-			Number.POSITIVE_INFINITY;
-		// We need to allow infinite size batches if we enable compression
-		const hardLimit = isCompressionEnabled
-			? Number.POSITIVE_INFINITY
-			: this.params.config.maxBatchSizeInBytes;
-
-		this.mainBatch = new BatchManager({ hardLimit, canRebase: true });
-		this.blobAttachBatch = new BatchManager({ hardLimit, canRebase: true });
+		this.mainBatch = new BatchManager({ canRebase: true });
+		this.blobAttachBatch = new BatchManager({ canRebase: true });
 		this.idAllocationBatch = new BatchManager({
-			hardLimit,
 			canRebase: false,
 			ignoreBatchId: true,
 		});
@@ -274,20 +316,11 @@ export class Outbox {
 		batchManager: BatchManager,
 		message: LocalBatchMessage,
 	): void {
-		if (
-			!batchManager.push(
-				message,
-				this.isContextReentrant(),
-				this.params.getCurrentSequenceNumbers().clientSequenceNumber,
-			)
-		) {
-			throw new GenericError("BatchTooLarge", /* error */ undefined, {
-				opSize: message.serializedOp?.length ?? 0,
-				batchSize: batchManager.contentSizeInBytes,
-				count: batchManager.length,
-				limit: batchManager.options.hardLimit,
-			});
-		}
+		batchManager.push(
+			message,
+			this.isContextReentrant(),
+			this.params.getCurrentSequenceNumbers().clientSequenceNumber,
+		);
 	}
 
 	/**
@@ -465,15 +498,7 @@ export class Outbox {
 	 */
 	private virtualizeBatch(localBatch: LocalBatch, groupingEnabled: boolean): OutboundBatch {
 		// Shallow copy the local batch, updating the messages to be outbound messages
-		const originalBatch: OutboundBatch = {
-			...localBatch,
-			messages: localBatch.messages.map<OutboundBatchMessage>(
-				({ serializedOp, ...message }) => ({
-					contents: serializedOp,
-					...message,
-				}),
-			),
-		};
+		const originalBatch = localBatchToOutboundBatch(localBatch);
 
 		const originalOrGroupedBatch = groupingEnabled
 			? this.params.groupingManager.groupBatch(originalBatch)
@@ -489,7 +514,6 @@ export class Outbox {
 		const singletonBatch = originalOrGroupedBatch as OutboundSingletonBatch;
 
 		if (
-			this.params.config.compressionOptions === undefined ||
 			this.params.config.compressionOptions.minimumBatchSizeInBytes >
 				singletonBatch.contentSizeInBytes ||
 			this.params.submitBatchFn === undefined
@@ -506,21 +530,11 @@ export class Outbox {
 				: this.params.splitter.splitSingletonBatchMessage(compressedBatch);
 		}
 
+		// We want to distinguish this "BatchTooLarge" case from the generic "BatchTooLarge" case in sendBatch
 		if (compressedBatch.contentSizeInBytes >= this.params.config.maxBatchSizeInBytes) {
-			throw DataProcessingError.create(
-				"BatchTooLarge",
-				"compressionInsufficient",
-				/* sequencedMessage */ undefined,
-				{
-					batchSize: singletonBatch.contentSizeInBytes,
-					compressedBatchSize: compressedBatch.contentSizeInBytes,
-					count: compressedBatch.messages.length,
-					limit: this.params.config.maxBatchSizeInBytes,
-					chunkingEnabled: this.params.splitter.isBatchChunkingEnabled,
-					compressionOptions: JSON.stringify(this.params.config.compressionOptions),
-					socketSize: estimateSocketSize(singletonBatch),
-				},
-			);
+			throw this.makeBatchTooLargeError(compressedBatch, "CompressionInsufficient", {
+				uncompressedSizeInBytes: singletonBatch.contentSizeInBytes,
+			});
 		}
 
 		return compressedBatch;
@@ -540,12 +554,7 @@ export class Outbox {
 
 		const socketSize = estimateSocketSize(batch);
 		if (socketSize >= this.params.config.maxBatchSizeInBytes) {
-			this.logger.sendPerformanceEvent({
-				eventName: "LargeBatch",
-				length: batch.messages.length,
-				sizeInBytes: batch.contentSizeInBytes,
-				socketSize,
-			});
+			throw this.makeBatchTooLargeError(batch, "CannotSend");
 		}
 
 		let clientSequenceNumber: number;
@@ -575,6 +584,31 @@ export class Outbox {
 		clientSequenceNumber -= length - 1;
 		assert(clientSequenceNumber >= 0, 0x3d0 /* clientSequenceNumber can't be negative */);
 		return clientSequenceNumber;
+	}
+
+	private makeBatchTooLargeError(
+		batch: OutboundBatch,
+		codepath: string,
+		moreDetails?: ITelemetryBaseProperties,
+	): IFluidErrorBase {
+		return DataProcessingError.create(
+			"BatchTooLarge",
+			codepath,
+			/* sequencedMessage */ undefined,
+			{
+				errorDetails: {
+					opCount: batch.messages.length,
+					contentSizeInBytes: batch.contentSizeInBytes,
+					socketSize: estimateSocketSize(batch),
+					maxBatchSizeInBytes: this.params.config.maxBatchSizeInBytes,
+					groupedBatchingEnabled: this.params.groupingManager.groupedBatchingEnabled(),
+					compressionOptions: JSON.stringify(this.params.config.compressionOptions),
+					chunkingEnabled: this.params.splitter.isBatchChunkingEnabled,
+					chunkSizeInBytes: this.params.splitter.chunkSizeInBytes,
+					...moreDetails,
+				},
+			},
+		);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -10,20 +10,13 @@ import {
 	BatchManager,
 	estimateSocketSize,
 	generateBatchId,
-	OutboundBatchMessage,
+	localBatchToOutboundBatch,
 } from "../../opLifecycle/index.js";
-import type {
-	LocalBatch,
-	OutboundBatch,
-	IBatchManagerOptions,
-	LocalBatchMessage,
-} from "../../opLifecycle/index.js";
+import type { IBatchManagerOptions, LocalBatchMessage } from "../../opLifecycle/index.js";
 
 describe("BatchManager", () => {
-	const hardLimit = 950 * 1024;
 	const smallMessageSize = 10;
 	const defaultOptions: IBatchManagerOptions = {
-		hardLimit,
 		canRebase: true,
 	};
 
@@ -34,46 +27,21 @@ describe("BatchManager", () => {
 		referenceSequenceNumber: 0,
 	});
 
-	it("BatchManager: 'infinity' hard limit allows everything", () => {
-		const message: LocalBatchMessage = {
-			serializedOp: generateStringOfSize(1024),
-			referenceSequenceNumber: 0,
-		};
-		const batchManager = new BatchManager({
-			...defaultOptions,
-			hardLimit: Number.POSITIVE_INFINITY,
-		});
-
-		for (let i = 1; i <= 10; i++) {
-			assert.equal(batchManager.push(message, /* reentrant */ false), true);
-			assert.equal(batchManager.length, i);
-		}
-	});
-
 	for (const includeBatchId of [true, false])
-		it(`Batch metadata is set correctly [with${includeBatchId ? "" : "out"} batchId]`, () => {
+		it(`Batch metadata is set correctly [${includeBatchId ? "with" : "without"} batchId]`, () => {
 			const batchManager = new BatchManager(defaultOptions);
 			const batchId = includeBatchId ? "BATCH_ID" : undefined;
-			assert.equal(
-				batchManager.push(
-					{ ...smallMessage(), referenceSequenceNumber: 0 },
-					/* reentrant */ false,
-				),
-				true,
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 0 },
+				/* reentrant */ false,
 			);
-			assert.equal(
-				batchManager.push(
-					{ ...smallMessage(), referenceSequenceNumber: 1 },
-					/* reentrant */ false,
-				),
-				true,
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 1 },
+				/* reentrant */ false,
 			);
-			assert.equal(
-				batchManager.push(
-					{ ...smallMessage(), referenceSequenceNumber: 2 },
-					/* reentrant */ false,
-				),
-				true,
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 2 },
+				/* reentrant */ false,
 			);
 
 			const batch = batchManager.popBatch(batchId);
@@ -86,12 +54,9 @@ describe("BatchManager", () => {
 				],
 			);
 
-			assert.equal(
-				batchManager.push(
-					{ ...smallMessage(), referenceSequenceNumber: 0 },
-					/* reentrant */ false,
-				),
-				true,
+			batchManager.push(
+				{ ...smallMessage(), referenceSequenceNumber: 0 },
+				/* reentrant */ false,
 			);
 			const singleOpBatch = batchManager.popBatch(batchId);
 			assert.deepEqual(
@@ -110,65 +75,36 @@ describe("BatchManager", () => {
 		assert.equal(serialized, `{"batchId":"3627a2a9-963f-4e3b-a4d2-a31b1267ef29_[123]"}`);
 	});
 
-	it("Batch content size is tracked correctly", () => {
-		const batchManager = new BatchManager(defaultOptions);
-		assert.equal(batchManager.push(smallMessage(), /* reentrant */ false), true);
-		assert.equal(batchManager.contentSizeInBytes, smallMessageSize * batchManager.length);
-		assert.equal(batchManager.push(smallMessage(), /* reentrant */ false), true);
-		assert.equal(batchManager.contentSizeInBytes, smallMessageSize * batchManager.length);
-		assert.equal(batchManager.push(smallMessage(), /* reentrant */ false), true);
-		assert.equal(batchManager.contentSizeInBytes, smallMessageSize * batchManager.length);
-	});
-
 	it("Batch reference sequence number maps to the last message", () => {
 		const batchManager = new BatchManager(defaultOptions);
-		assert.equal(
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 0 },
-				/* reentrant */ false,
-			),
-			true,
+		batchManager.push(
+			{ ...smallMessage(), referenceSequenceNumber: 0 },
+			/* reentrant */ false,
 		);
-		assert.equal(
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 1 },
-				/* reentrant */ false,
-			),
-			true,
+		batchManager.push(
+			{ ...smallMessage(), referenceSequenceNumber: 1 },
+			/* reentrant */ false,
 		);
-		assert.equal(
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 2 },
-				/* reentrant */ false,
-			),
-			true,
+		batchManager.push(
+			{ ...smallMessage(), referenceSequenceNumber: 2 },
+			/* reentrant */ false,
 		);
 
 		assert.equal(batchManager.sequenceNumbers.referenceSequenceNumber, 2);
 	});
 
-	const convertToOutboundBatch = (batch: LocalBatch): OutboundBatch =>
-		({
-			...batch,
-			messages: batch.messages.map<OutboundBatchMessage>((message: LocalBatchMessage) => ({
-				...message,
-				contents: message.serializedOp,
-				serializedOp: undefined,
-			})),
-		}) satisfies OutboundBatch;
-
 	it("Batch size estimates", () => {
 		const batchManager = new BatchManager(defaultOptions);
 		batchManager.push(smallMessage(), /* reentrant */ false);
 		// 10 bytes of content + 200 bytes overhead
-		assert.equal(estimateSocketSize(convertToOutboundBatch(batchManager.popBatch())), 210);
+		assert.equal(estimateSocketSize(localBatchToOutboundBatch(batchManager.popBatch())), 210);
 
 		for (let i = 0; i < 10; i++) {
 			batchManager.push(smallMessage(), /* reentrant */ false);
 		}
 
 		// (10 bytes of content + 200 bytes overhead) x 10
-		assert.equal(estimateSocketSize(convertToOutboundBatch(batchManager.popBatch())), 2100);
+		assert.equal(estimateSocketSize(localBatchToOutboundBatch(batchManager.popBatch())), 2100);
 
 		batchManager.push(smallMessage(), /* reentrant */ false);
 		for (let i = 0; i < 9; i++) {
@@ -182,65 +118,44 @@ describe("BatchManager", () => {
 		}
 
 		// 10 bytes of content + 200 bytes overhead x 10
-		assert.equal(estimateSocketSize(convertToOutboundBatch(batchManager.popBatch())), 2010);
+		assert.equal(estimateSocketSize(localBatchToOutboundBatch(batchManager.popBatch())), 2010);
 	});
 
 	it("Batch op reentry state preserved during its lifetime", () => {
 		const batchManager = new BatchManager(defaultOptions);
-		assert.equal(
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 0 },
-				/* reentrant */ false,
-			),
-			true,
+		batchManager.push(
+			{ ...smallMessage(), referenceSequenceNumber: 0 },
+			/* reentrant */ false,
 		);
-		assert.equal(
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 1 },
-				/* reentrant */ false,
-			),
-			true,
+		batchManager.push(
+			{ ...smallMessage(), referenceSequenceNumber: 1 },
+			/* reentrant */ false,
 		);
-		assert.equal(
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 2 },
-				/* reentrant */ false,
-			),
-			true,
+		batchManager.push(
+			{ ...smallMessage(), referenceSequenceNumber: 2 },
+			/* reentrant */ false,
 		);
 
 		assert.equal(batchManager.popBatch().hasReentrantOps, false);
 
-		assert.equal(
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 0 },
-				/* reentrant */ false,
-			),
-			true,
+		batchManager.push(
+			{ ...smallMessage(), referenceSequenceNumber: 0 },
+			/* reentrant */ false,
 		);
-		assert.equal(
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 1 },
-				/* reentrant */ true,
-				/* currentClientSequenceNumber */ undefined,
-			),
-			true,
+		batchManager.push(
+			{ ...smallMessage(), referenceSequenceNumber: 1 },
+			/* reentrant */ true,
+			/* currentClientSequenceNumber */ undefined,
 		);
-		assert.equal(
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 2 },
-				/* reentrant */ false,
-			),
-			true,
+		batchManager.push(
+			{ ...smallMessage(), referenceSequenceNumber: 2 },
+			/* reentrant */ false,
 		);
 		assert.equal(batchManager.popBatch().hasReentrantOps, true);
 
-		assert.equal(
-			batchManager.push(
-				{ ...smallMessage(), referenceSequenceNumber: 0 },
-				/* reentrant */ false,
-			),
-			true,
+		batchManager.push(
+			{ ...smallMessage(), referenceSequenceNumber: 0 },
+			/* reentrant */ false,
 		);
 		assert.equal(batchManager.popBatch().hasReentrantOps, false);
 	});
@@ -266,7 +181,6 @@ describe("BatchManager", () => {
 
 		// Verify state after rollback
 		assert.equal(batchManager.length, 2);
-		assert.equal(batchManager.contentSizeInBytes, smallMessageSize * 2);
 	});
 
 	it("should handle rollback with no additional messages", () => {
@@ -285,7 +199,6 @@ describe("BatchManager", () => {
 
 		// Verify state after rollback
 		assert.equal(batchManager.length, 1);
-		assert.equal(batchManager.contentSizeInBytes, smallMessageSize);
 	});
 
 	it("should throw error if ops are generated during rollback", () => {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -39,6 +39,7 @@ import {
 	Outbox,
 	type LocalBatchMessage,
 	type OutboundBatch,
+	localBatchToOutboundBatch,
 } from "../../opLifecycle/index.js";
 import {
 	PendingMessageResubmitData,
@@ -174,7 +175,7 @@ describe("Outbox", () => {
 	});
 
 	// Also converts to an OutboundBatchMessage
-	const addBatchMetadata = (messages: LocalBatchMessage[]): OutboundBatchMessage[] => {
+	const addBatchMetadata = (messages: OutboundBatchMessage[]): void => {
 		if (messages.length > 1) {
 			messages[0].metadata = {
 				...messages[0].metadata,
@@ -185,21 +186,18 @@ describe("Outbox", () => {
 				batch: false,
 			};
 		}
-
-		return messages.map<OutboundBatchMessage>(({ serializedOp, ...message }) => ({
-			contents: serializedOp,
-			...message,
-		}));
 	};
-	const toOutboundBatch = (messages: LocalBatchMessage[]): OutboundBatch => ({
-		messages: addBatchMetadata(messages),
-		contentSizeInBytes: messages
-			.map((message) => message.serializedOp?.length ?? 0)
-			.reduce((a, b) => a + b, 0),
-		referenceSequenceNumber:
-			messages.length === 0 ? undefined : messages[0].referenceSequenceNumber,
-		hasReentrantOps: false,
-	});
+	const toOutboundBatch = (messages: LocalBatchMessage[]): OutboundBatch => {
+		const outbound = localBatchToOutboundBatch({
+			messages,
+			referenceSequenceNumber:
+				messages.length === 0 ? undefined : messages[0].referenceSequenceNumber,
+			hasReentrantOps: false,
+		});
+
+		addBatchMetadata(outbound.messages);
+		return outbound;
+	};
 
 	const DefaultCompressionOptions = {
 		minimumBatchSizeInBytes: Number.POSITIVE_INFINITY,
@@ -272,6 +270,29 @@ describe("Outbox", () => {
 		state.isReentrant = false;
 		currentSeqNumbers = {};
 		mockLogger.clear();
+	});
+
+	it("localBatchToOutboundBatch", () => {
+		const localMessages: LocalBatchMessage[] = [
+			{ serializedOp: "hello", referenceSequenceNumber: 4 },
+			{ serializedOp: "world", referenceSequenceNumber: 4 },
+			{ serializedOp: "!", referenceSequenceNumber: 4 },
+		];
+		const localBatch = {
+			messages: localMessages,
+			referenceSequenceNumber: localMessages[0].referenceSequenceNumber,
+			hasReentrantOps: false,
+		};
+		const outboundBatch = localBatchToOutboundBatch(localBatch);
+
+		// Check that contentSizeInBytes and messages' contents are set propertly
+		assert.equal(outboundBatch.contentSizeInBytes, 11);
+		assert.equal(outboundBatch.messages.length, 3);
+		assert.deepEqual(
+			localMessages.map((m) => m.serializedOp),
+			outboundBatch.messages.map((m) => m.contents),
+			"Serialized contents do not match",
+		);
 	});
 
 	it("Sending batches", () => {
@@ -573,12 +594,15 @@ describe("Outbox", () => {
 		);
 	});
 
-	it("Compress only if the batch is larger than the configured limit", () => {
+	it("Does not compress if the batch is smaller than the configured limit", () => {
 		const outbox = getOutbox({
 			context: getMockContext(),
-			maxBatchSize: 1,
+			maxBatchSize: 1024,
+			opGroupingConfig: {
+				groupedBatchingEnabled: true, // Required for compression
+			},
 			compressionOptions: {
-				minimumBatchSizeInBytes: 1024,
+				minimumBatchSizeInBytes: 512,
 				compressionAlgorithm: CompressionAlgorithms.lz4,
 			},
 		});
@@ -597,22 +621,15 @@ describe("Outbox", () => {
 
 		outbox.flush();
 
-		assert.equal(state.opsSubmitted, messages.length);
+		assert.equal(
+			state.opsSubmitted,
+			2,
+			"Expected 2 ops to be submitted, on ID Allocation and one for the grouped batch",
+		);
 		assert.equal(state.batchesSubmitted.length, 2);
 		assert.equal(state.individualOpsSubmitted.length, 0);
 		assert.equal(state.deltaManagerFlushCalls, 0);
 		assert.deepEqual(state.batchesCompressed, []);
-		assert.deepEqual(
-			state.batchesSubmitted.map((x) => x.messages),
-			[
-				[toSubmittedMessage(messages[2])],
-				[
-					toSubmittedMessage(messages[0], true),
-					toSubmittedMessage(messages[1]),
-					toSubmittedMessage(messages[3], false),
-				],
-			],
-		);
 
 		// Note the expected CSN here is fixed to the batch's starting CSN
 		const expectedMessageOrderWithCsn = [
@@ -658,7 +675,13 @@ describe("Outbox", () => {
 		outbox.submit(messages[1]);
 		outbox.submit(messages[2]);
 
-		assert.throws(() => outbox.flush());
+		assert.throws(
+			() => outbox.flush(),
+			(e: Error) =>
+				"dataProcessingCodepath" in e &&
+				e.dataProcessingCodepath === "CompressionInsufficient",
+			"Expected 'CompressionInsufficient' error",
+		);
 		// The batch is compressed
 		assert.deepEqual(state.batchesCompressed, [
 			opGroupingManager.groupBatch(toOutboundBatch(messages)),
@@ -670,7 +693,7 @@ describe("Outbox", () => {
 	it("Chunks when compression is enabled, compressed batch is larger than the threshold and chunking is enabled", () => {
 		const outbox = getOutbox({
 			context: getMockContext(),
-			maxBatchSize: 1,
+			maxBatchSize: 1024,
 			compressionOptions: {
 				minimumBatchSizeInBytes: 1,
 				compressionAlgorithm: CompressionAlgorithms.lz4,
@@ -734,7 +757,7 @@ describe("Outbox", () => {
 	it("Does not chunk when compression and grouping are enabled, compressed batch is smaller than the threshold and chunking is enabled", () => {
 		const outbox = getOutbox({
 			context: getMockContext(),
-			maxBatchSize: 1,
+			maxBatchSize: 1024,
 			compressionOptions: {
 				minimumBatchSizeInBytes: 1,
 				compressionAlgorithm: CompressionAlgorithms.lz4,

--- a/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
@@ -254,7 +254,6 @@ describe("RemoteMessageProcessor", () => {
 		// Use BatchManager.popBatch to get the right batch metadata included
 		const batchManager = new BatchManager({
 			canRebase: false,
-			hardLimit: Number.MAX_VALUE,
 		});
 		batchManager.push({ serializedOp: "A1", referenceSequenceNumber }, false /* reentrant */);
 		batchManager.push({ serializedOp: "A2", referenceSequenceNumber }, false /* reentrant */);
@@ -427,7 +426,6 @@ describe("RemoteMessageProcessor", () => {
 			let csn = 1;
 			const batchManager = new BatchManager({
 				canRebase: false,
-				hardLimit: Number.MAX_VALUE,
 			});
 			batchManager.push(
 				{ serializedOp: "A1", referenceSequenceNumber: 1 },
@@ -483,7 +481,6 @@ describe("RemoteMessageProcessor", () => {
 			let csn = 1;
 			const batchManager = new BatchManager({
 				canRebase: false,
-				hardLimit: Number.MAX_VALUE,
 			});
 			batchManager.push(
 				{ serializedOp: "A1", referenceSequenceNumber: 1 },

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -66,7 +66,7 @@ describe("Pending State Manager", () => {
 			rollbackContent = [];
 			rollbackShouldThrow = false;
 
-			batchManager = new BatchManager({ hardLimit: 950 * 1024, canRebase: true });
+			batchManager = new BatchManager({ canRebase: true });
 		});
 
 		it("should do nothing when rolling back empty pending stack", () => {

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -145,18 +145,21 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 				{
 					errorType,
 					dataProcessingCodepath,
-					errorDetails: { opCount, contentSizeInBytes, socketSize },
+					errorDetails: { opCount },
 				},
 				{
 					errorType: "dataProcessingError",
 					dataProcessingCodepath: "CannotSend",
 					errorDetails: {
 						opCount: 1,
-						contentSizeInBytes: 1048789,
-						socketSize: 1048989, // > maxMessageSizeInBytes: 716800
 					},
 				},
 				"Error not as expected",
+			);
+			assert.equal(
+				typeof contentSizeInBytes,
+				"number",
+				"contentSizeInBytes should be a number",
 			);
 			assert(
 				socketSize > maxMessageSizeInBytes,
@@ -280,18 +283,21 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 				{
 					errorType,
 					dataProcessingCodepath,
-					errorDetails: { opCount, contentSizeInBytes, socketSize },
+					errorDetails: { opCount },
 				},
 				{
 					errorType: "dataProcessingError",
 					dataProcessingCodepath: "CannotSend",
 					errorDetails: {
 						opCount: 1,
-						contentSizeInBytes: 15729276,
-						socketSize: 15729476, // > maxMessageSizeInBytes: 716800
 					},
 				},
 				"Error not as expected",
+			);
+			assert.equal(
+				typeof contentSizeInBytes,
+				"number",
+				"contentSizeInBytes should be a number",
 			);
 			assert(
 				socketSize > maxMessageSizeInBytes,

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -15,7 +15,6 @@ import {
 	disabledCompressionConfig,
 } from "@fluidframework/container-runtime/internal";
 import { ConfigTypes, IConfigProviderBase, IErrorBase } from "@fluidframework/core-interfaces";
-import { FluidErrorTypes } from "@fluidframework/core-interfaces/internal";
 import {
 	IDocumentMessage,
 	ISequencedDocumentMessage,
@@ -107,7 +106,7 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 		}
 	};
 
-	const containerError = async (container: IContainer) =>
+	const captureContainerCloseError = async (container: IContainer) =>
 		new Promise<IErrorBase | undefined>((resolve) =>
 			container.once("closed", (error) => {
 				resolve(error);
@@ -128,23 +127,41 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 			const maxMessageSizeInBytes = 1024 * 1024; // 1Mb
 			await setupContainers(configWithCompressionDisabled);
 
-			const errorEvent = containerError(localContainer);
+			const errorP = captureContainerCloseError(localContainer);
 
 			const largeString = generateStringOfSize(maxMessageSizeInBytes + 1);
 			const messageCount = 1;
-			try {
-				setMapKeys(localMap, messageCount, largeString);
-				assert(false, "should throw");
-			} catch {}
+			setMapKeys(localMap, messageCount, largeString);
 
-			const error = await errorEvent;
-			assert.equal(error?.errorType, FluidErrorTypes.dataProcessingError);
-			assert.ok(error.getTelemetryProperties?.().opSize ?? 0 > maxMessageSizeInBytes);
+			// Let the ops flush, which will close the container
+			await provider.ensureSynchronized();
 
-			// Limit has to be around 1Mb, but we should not assume here precise number.
-			const limit = error.getTelemetryProperties?.().limit as number;
-			assert(limit > maxMessageSizeInBytes / 2);
-			assert(limit < maxMessageSizeInBytes * 2);
+			const {
+				errorType,
+				dataProcessingCodepath,
+				errorDetails: { opCount, contentSizeInBytes, socketSize },
+			} = (await errorP) as any;
+			assert.deepEqual(
+				{
+					errorType,
+					dataProcessingCodepath,
+					errorDetails: { opCount, contentSizeInBytes, socketSize },
+				},
+				{
+					errorType: "dataProcessingError",
+					dataProcessingCodepath: "CannotSend",
+					errorDetails: {
+						opCount: 1,
+						contentSizeInBytes: 1048789,
+						socketSize: 1048989, // > maxMessageSizeInBytes: 716800
+					},
+				},
+				"Error not as expected",
+			);
+			assert(
+				socketSize > maxMessageSizeInBytes,
+				"Socket size should be larger than maxMessageSizeInBytes",
+			);
 		},
 	);
 
@@ -247,8 +264,43 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 
 			const largeString = generateRandomStringOfSize(maxMessageSizeInBytes);
 			const messageCount = 3; // Will result in a 15 MB payload
-			assert.throws(() => setMapKeys(localMap, messageCount, largeString));
+			setMapKeys(localMap, messageCount, largeString);
+
+			// Let the ops flush, which will close the container
+			const errorP = captureContainerCloseError(localContainer);
 			await provider.ensureSynchronized();
+
+			assert(localContainer.closed, "Local Container should be closed during flush");
+			const {
+				errorType,
+				dataProcessingCodepath,
+				errorDetails: { opCount, contentSizeInBytes, socketSize },
+			} = (await errorP) as any;
+			assert.deepEqual(
+				{
+					errorType,
+					dataProcessingCodepath,
+					errorDetails: { opCount, contentSizeInBytes, socketSize },
+				},
+				{
+					errorType: "dataProcessingError",
+					dataProcessingCodepath: "CannotSend",
+					errorDetails: {
+						opCount: 1,
+						contentSizeInBytes: 15729276,
+						socketSize: 15729476, // > maxMessageSizeInBytes: 716800
+					},
+				},
+				"Error not as expected",
+			);
+			assert(
+				socketSize > maxMessageSizeInBytes,
+				"Socket size should be larger than maxMessageSizeInBytes",
+			);
+
+			// Confirm the remote map didn't receive any of the large ops
+			remoteMap.delete("test"); // So we can just check for empty on the next line
+			assert(remoteMap.size === 0, "Remote map should not have received any of the large ops");
 		},
 	);
 


### PR DESCRIPTION
_Re-do of #24309 with less strict assertion conditions in `messageSize.spec.ts`.  See df114eac27269bd2c7b90c1e8125034c68e96c98_

## PR Description (from #24309)

We are preparing to update `LocalBatchMessage` to hold the original runtime op, not the serialized op.  So it will no longer be practical to estimate the content size of each op (we don't want to do an extra JSON stringify just for this purpose).

Here's a comparison of the places we would fail before / after this change:

Before:
* If no compression, then if est socket size is too big, throw when submitting. (in `Outbox.addMessageToBatchManager`)
  * "If no compression" because `hardLimit` would be infinity if compression was enabled
* If yes compression (and it happens), then throw if it was insufficient (in `Outbox.virtualizeBatch`)

Now:
* If yes compression (and it happens), then throw if it was insufficient (in `Outbox.virtualizeBatch`) -- _unchanged from before_
* Otherwise (no compression happened, or it did and appeared sufficient), if est socket size is too big, throw before send (in `Outbox.sendBatch`)
  * This case used to be possible even after compression if there were soooo many empty placeholders that it pushed it over the limit.  The log I'm deleting from there ("LargeBatch") is hit for some internal apps on old versions, when we did empty placeholders.  The log has not been hit on any recent version.
  * But now, if compression is sufficient or unnecessary, this will surely pass as well.  So this is just guarding the case where compression was disabled, so it's quite equivalent to the original check during submit.