### PR TITLE
Make ids allocated by createSnapshotCompressor actually deterministic

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldSnapshots.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldSnapshots.test.ts
@@ -7,12 +7,10 @@ import type { GenericChangeset } from "../../../feature-libraries/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { makeGenericChangeCodec } from "../../../feature-libraries/modular-schema/genericFieldKindCodecs.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "../../snapshots/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import { snapshotSessionId } from "../../snapshots/snapshotTestScenarios.js";
 import { brand } from "../../../util/index.js";
 import { TestNodeId } from "../../testNodeId.js";
 import { TestChange } from "../../testChange.js";
-import { testIdCompressor } from "../../utils.js";
+import { snapshotSessionId, testIdCompressor } from "../../utils.js";
 // eslint-disable-next-line import/no-internal-modules
 import { newGenericChangeset } from "../../../feature-libraries/modular-schema/genericFieldKindTypes.js";
 

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldSnapshots.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldSnapshots.test.ts
@@ -15,12 +15,10 @@ import {
 } from "../../../feature-libraries/optional-field/index.js";
 import { brand } from "../../../util/index.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "../../snapshots/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import { createSnapshotCompressor } from "../../snapshots/snapshotTestScenarios.js";
 import { TestNodeId } from "../../testNodeId.js";
 import { Change } from "./optionalFieldUtils.js";
 import { TestChange } from "../../testChange.js";
-import { testIdCompressor } from "../../utils.js";
+import { createSnapshotCompressor, testIdCompressor } from "../../utils.js";
 
 function generateTestChangesets(
 	idCompressor: IIdCompressor,

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldSnapshots.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldSnapshots.test.ts
@@ -8,10 +8,8 @@ import path from "node:path";
 import { RevisionTagCodec } from "../../../core/index.js";
 import { SequenceField } from "../../../feature-libraries/index.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "../../snapshots/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import { createSnapshotCompressor } from "../../snapshots/snapshotTestScenarios.js";
 import { TestNodeId } from "../../testNodeId.js";
-import { testIdCompressor } from "../../utils.js";
+import { createSnapshotCompressor, testIdCompressor } from "../../utils.js";
 import { generatePopulatedMarks } from "./populatedMarks.js";
 
 export function testSnapshots() {

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -35,6 +35,7 @@ import {
 	createTestUndoRedoStacks,
 	expectSchemaEqual,
 	getView,
+	getViewConfigured,
 	validateUsageError,
 	viewCheckout,
 } from "../utils.js";
@@ -1450,7 +1451,7 @@ function itView<
 		logger: IMockLoggerExt;
 	} {
 		const logger = createMockLoggerExt();
-		const view = getView(config, undefined, logger);
+		const view = getViewConfigured(config, undefined, logger);
 		if (fork) {
 			const treeBranch = getBranch(view).branch();
 			const viewBranch = treeBranch.viewWith(view.config);

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -19,8 +19,13 @@ import {
 	EmptyKey,
 	type RevertibleFactory,
 	type NormalizedFieldUpPath,
+	TreeStoredSchemaRepository,
 } from "../../core/index.js";
-import { FieldKinds } from "../../feature-libraries/index.js";
+import {
+	buildForest,
+	FieldKinds,
+	MockNodeIdentifierManager,
+} from "../../feature-libraries/index.js";
 import {
 	getBranch,
 	Tree,
@@ -28,6 +33,7 @@ import {
 	type ITreeCheckout,
 	type ITreeCheckoutFork,
 	type BranchableTree,
+	createTreeCheckout,
 } from "../../shared-tree/index.js";
 import {
 	TestTreeProviderLite,
@@ -35,7 +41,9 @@ import {
 	createTestUndoRedoStacks,
 	expectSchemaEqual,
 	getView,
-	getViewConfigured,
+	mintRevisionTag,
+	testIdCompressor,
+	testRevisionTagCodec,
 	validateUsageError,
 	viewCheckout,
 } from "../utils.js";
@@ -1451,7 +1459,23 @@ function itView<
 		logger: IMockLoggerExt;
 	} {
 		const logger = createMockLoggerExt();
-		const view = getViewConfigured(config, undefined, logger);
+
+		const checkout = createTreeCheckout(
+			testIdCompressor,
+			mintRevisionTag,
+			testRevisionTagCodec,
+			{
+				forest: buildForest(),
+				schema: new TreeStoredSchemaRepository(),
+				logger,
+			},
+		);
+		const view = new SchematizingSimpleTreeView<TRootSchema>(
+			checkout,
+			config,
+			new MockNodeIdentifierManager(),
+		);
+
 		if (fork) {
 			const treeBranch = getBranch(view).branch();
 			const viewBranch = treeBranch.viewWith(view.config);

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -408,7 +408,7 @@ describe("simple-tree tree", () => {
 		// TODO: Identifier roots should be able to be defaulted, but currently throw a usage error.
 		it.skip("adds identifier to unpopulated root", () => {
 			const config = new TreeViewConfiguration({ schema: schema.identifier });
-			const view = getViewConfigured(config);
+			const view = getView(config);
 			view.initialize(undefined);
 			assert.equal(view.root, "beefbeef-beef-4000-8000-000000000001");
 		});

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -14,7 +14,7 @@ import {
 	type TreeNodeSchema,
 } from "../../../simple-tree/index.js";
 import { TreeFactory } from "../../../treeFactory.js";
-import { getView, getViewConfigured, validateUsageError } from "../../utils.js";
+import { getView, validateUsageError } from "../../utils.js";
 import { independentView, Tree } from "../../../shared-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { checkUnion } from "../../../simple-tree/api/tree.js";

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -14,8 +14,7 @@ import {
 	type TreeNodeSchema,
 } from "../../../simple-tree/index.js";
 import { TreeFactory } from "../../../treeFactory.js";
-import { getView, validateUsageError } from "../../utils.js";
-import { MockNodeIdentifierManager } from "../../../feature-libraries/index.js";
+import { getView, getViewConfigured, validateUsageError } from "../../utils.js";
 import { independentView, Tree } from "../../../shared-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { checkUnion } from "../../../simple-tree/api/tree.js";
@@ -367,26 +366,51 @@ describe("simple-tree tree", () => {
 	});
 
 	describe("field defaults", () => {
-		it("adds identifier to unpopulated identifier fields.", () => {
+		it("initialize with identifier to unpopulated identifier fields.", () => {
 			const schemaWithIdentifier = schema.object("parent", {
 				identifier: schema.identifier,
 			});
-			const nodeKeyManager = new MockNodeIdentifierManager();
 			const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
-			const view = getView(config, nodeKeyManager);
+			const view = getView(config);
 			view.initialize({ identifier: undefined });
-			assert.equal(view.root.identifier, "a110ca7e-add1-4000-8000-000000000000");
+			assert.equal(view.root.identifier, "beefbeef-beef-4000-8000-000000000001");
+		});
+
+		it("adds identifier to unpopulated identifier fields.", () => {
+			class SchemaWithIdentifier extends schema.object("parent", {
+				identifier: schema.identifier,
+			}) {}
+			const config = new TreeViewConfiguration({
+				schema: SchemaFactory.optional(SchemaWithIdentifier),
+			});
+			const view = getView(config);
+			view.initialize(undefined);
+			const toHydrate = new SchemaWithIdentifier({ identifier: undefined });
+
+			view.root = toHydrate;
+			assert.equal(toHydrate, view.root);
+			assert.equal(toHydrate.identifier, "beefbeef-beef-4000-8000-000000000004");
+
+			view.root = { identifier: undefined };
+			assert.equal(view.root?.identifier, "beefbeef-beef-4000-8000-000000000006");
 		});
 
 		it("populates field when no field defaulter is provided.", () => {
 			const schemaWithIdentifier = schema.object("parent", {
 				testOptionalField: schema.optional(schema.string),
 			});
-			const nodeKeyManager = new MockNodeIdentifierManager();
 			const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
-			const view = getView(config, nodeKeyManager);
+			const view = getView(config);
 			view.initialize({ testOptionalField: undefined });
 			assert.equal(view.root.testOptionalField, undefined);
+		});
+
+		// TODO: Identifier roots should be able to be defaulted, but currently throw a usage error.
+		it.skip("adds identifier to unpopulated root", () => {
+			const config = new TreeViewConfiguration({ schema: schema.identifier });
+			const view = getViewConfigured(config);
+			view.initialize(undefined);
+			assert.equal(view.root, "beefbeef-beef-4000-8000-000000000001");
 		});
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -217,12 +217,12 @@ describe("treeNodeApi", () => {
 			const schemaWithIdentifier = schema.object("parent", {
 				identifier: schema.identifier,
 			});
-			const nodeKeyManager = new MockNodeIdentifierManager();
+			const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
+			const view = getView(config);
+			const nodeKeyManager = view.nodeKeyManager;
 			const id = nodeKeyManager.stabilizeNodeIdentifier(
 				nodeKeyManager.generateLocalNodeIdentifier(),
 			);
-			const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
-			const view = getView(config, nodeKeyManager);
 			view.initialize({ identifier: id });
 
 			assert.equal(Tree.shortId(view.root), nodeKeyManager.localizeNodeIdentifier(id));
@@ -315,9 +315,9 @@ describe("treeNodeApi", () => {
 
 			// TODO: this policy seems questionable, but its whats implemented, and is documented in TreeStatus.new
 			it("returns string when unhydrated then local id when hydrated", () => {
-				const nodeKeyManager = new MockNodeIdentifierManager();
 				const config = new TreeViewConfiguration({ schema: HasIdentifier });
-				const view = getView(config, nodeKeyManager);
+				const view = getView(config);
+				const nodeKeyManager = view.nodeKeyManager;
 				view.initialize({});
 				const identifier = view.root.identifier;
 				const shortId = Tree.shortId(view.root);

--- a/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
@@ -9,7 +9,6 @@ import { MockHandle } from "@fluidframework/test-runtime-utils/internal";
 
 // TODO: import and unit test other things from "proxies" file.
 
-import { MockNodeIdentifierManager } from "../../feature-libraries/index.js";
 import {
 	type booleanSchema,
 	type InsertableTreeNodeFromImplicitAllowedTypes,
@@ -167,13 +166,14 @@ describe("SharedTreeObject", () => {
 		const schemaWithIdentifier = sb.object("parent", {
 			identifier: sb.identifier,
 		});
-		const nodeKeyManager = new MockNodeIdentifierManager();
+
+		const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
+
+		const view = getView(config);
+		const nodeKeyManager = view.nodeKeyManager;
 		const id = nodeKeyManager.stabilizeNodeIdentifier(
 			nodeKeyManager.generateLocalNodeIdentifier(),
 		);
-		const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
-
-		const view = getView(config, nodeKeyManager);
 		view.initialize({ identifier: id });
 		const { root } = view;
 

--- a/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
@@ -4,8 +4,6 @@
  */
 
 import { strict as assert } from "node:assert";
-import type { SessionId } from "@fluidframework/id-compressor";
-import { createAlwaysFinalizedIdCompressor } from "@fluidframework/id-compressor/internal/test-utils";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import { typeboxValidator } from "../../external-utilities/index.js";
@@ -15,19 +13,9 @@ import {
 	type SharedTreeOptions,
 	Tree,
 } from "../../shared-tree/index.js";
-import { TestTreeProviderLite, treeTestFactory } from "../utils.js";
+import { createSnapshotCompressor, TestTreeProviderLite, treeTestFactory } from "../utils.js";
 import { SchemaFactory, TreeViewConfiguration } from "../../simple-tree/index.js";
 import { TreeFactory } from "../../treeFactory.js";
-
-// Session ids used for the created trees' IdCompressors must be deterministic.
-// TestTreeProviderLite does this by default.
-// Test trees which manually create their data store runtime must set up their trees'
-// session ids explicitly.
-export const snapshotSessionId = "beefbeef-beef-4000-8000-000000000001" as SessionId;
-
-export function createSnapshotCompressor() {
-	return createAlwaysFinalizedIdCompressor(snapshotSessionId);
-}
 
 const enableSchemaValidation = true;
 

--- a/packages/dds/tree/src/test/testUtilsTests.spec.ts
+++ b/packages/dds/tree/src/test/testUtilsTests.spec.ts
@@ -8,7 +8,11 @@ import { strict as assert } from "node:assert";
 import type { JsonableTree } from "../core/index.js";
 import { brand } from "../util/index.js";
 
-import { prepareTreeForCompare } from "./utils.js";
+import {
+	createSnapshotCompressor,
+	prepareTreeForCompare,
+	snapshotSessionId,
+} from "./utils.js";
 import { MockHandle } from "@fluidframework/test-runtime-utils/internal";
 
 describe("Test utils", () => {
@@ -61,6 +65,24 @@ describe("Test utils", () => {
 				withHandleExpected,
 				{ type: "foo", fields: { f: [withHandleExpected] } },
 			]);
+		});
+
+		it("createSnapshotCompressor", () => {
+			// Test that createSnapshotCompressor gives a deterministic compressor
+			const compressor = createSnapshotCompressor();
+
+			{
+				const compressed = compressor.generateCompressedId();
+				assert.equal(compressed, 0);
+				const stable = compressor.decompress(compressed);
+				assert.equal(stable, snapshotSessionId);
+			}
+			{
+				const compressed = compressor.generateCompressedId();
+				assert.equal(compressed, 1);
+				const stable = compressor.decompress(compressed);
+				assert.equal(stable, "beefbeef-beef-4000-8000-000000000002");
+			}
 		});
 	});
 });

--- a/packages/dds/tree/src/test/tree/detachedFieldIndex.spec.ts
+++ b/packages/dds/tree/src/test/tree/detachedFieldIndex.spec.ts
@@ -23,9 +23,7 @@ import {
 	idAllocatorFromMaxId,
 } from "../../util/index.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "../snapshots/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import { createSnapshotCompressor } from "../snapshots/snapshotTestScenarios.js";
-import { testIdCompressor, testRevisionTagCodec } from "../utils.js";
+import { testIdCompressor, testRevisionTagCodec, createSnapshotCompressor } from "../utils.js";
 
 const mintedTag = testIdCompressor.generateCompressedId();
 const finalizedTag = testIdCompressor.normalizeToOpSpace(mintedTag);

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -28,7 +28,7 @@ import type {
 	IChannelServices,
 	IChannelFactory,
 } from "@fluidframework/datastore-definitions/internal";
-import type { SessionId } from "@fluidframework/id-compressor";
+import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
 import { assertIsStableId, createIdCompressor } from "@fluidframework/id-compressor/internal";
 import { createAlwaysFinalizedIdCompressor } from "@fluidframework/id-compressor/internal/test-utils";
 import { FlushMode } from "@fluidframework/runtime-definitions/internal";
@@ -127,6 +127,7 @@ import {
 	createTreeCheckout,
 	type ISharedTreeEditor,
 	type ITreeCheckoutFork,
+	independentView,
 } from "../shared-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import type { TreeStoredContent } from "../shared-tree/schematizeTree.js";
@@ -135,6 +136,7 @@ import {
 	// eslint-disable-next-line import/no-internal-modules
 } from "../shared-tree/schematizingTreeView.js";
 import type {
+	ForestOptions,
 	ISharedTree,
 	SharedTreeOptions,
 	SharedTreeOptionsInternal,
@@ -1229,9 +1231,38 @@ export function treeTestFactory(
  *
  * Typically, users will want to initialize the returned view with some content (thereby setting its schema) using `TreeView.initialize`.
  *
- * Like `SchematizingSimpleTreeView` but using internal types and defaults to test id compressor.
+ * Like `SchematizingSimpleTreeView` but using internal types and uses {@link createSnapshotCompressor}.
  */
 export function getView<const TSchema extends ImplicitFieldSchema>(
+	config: TreeViewConfiguration<TSchema>,
+	options: ForestOptions & {
+		idCompressor?: IIdCompressor | undefined;
+	} = {},
+): SchematizingSimpleTreeView<TSchema> {
+	const view = independentView(config, {
+		idCompressor: createSnapshotCompressor(),
+		...options,
+	});
+	assert(view instanceof SchematizingSimpleTreeView);
+	return view;
+}
+
+/**
+ * Session ids used for the created trees' IdCompressors must be deterministic.
+ * TestTreeProviderLite does this by default.
+ * Test trees which manually create their data store runtime must set up their trees'
+ * session ids explicitly.
+ */
+export const snapshotSessionId = assertIsSessionId("beefbeef-beef-4000-8000-000000000001");
+
+export function createSnapshotCompressor() {
+	return createAlwaysFinalizedIdCompressor(snapshotSessionId);
+}
+
+/**
+ * {@link getView} but with more package internal specific customization.
+ */
+export function getViewConfigured<const TSchema extends ImplicitFieldSchema>(
 	config: TreeViewConfiguration<TSchema>,
 	nodeKeyManager?: NodeIdentifierManager,
 	logger?: ITelemetryLoggerExt,

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -12,7 +12,6 @@ import type {
 import {
 	createMockLoggerExt,
 	type IMockLoggerExt,
-	type ITelemetryLoggerExt,
 	UsageError,
 } from "@fluidframework/telemetry-utils/internal";
 
@@ -1257,31 +1256,6 @@ export const snapshotSessionId = assertIsSessionId("beefbeef-beef-4000-8000-0000
 
 export function createSnapshotCompressor() {
 	return createAlwaysFinalizedIdCompressor(snapshotSessionId);
-}
-
-/**
- * {@link getView} but with more package internal specific customization.
- */
-export function getViewConfigured<const TSchema extends ImplicitFieldSchema>(
-	config: TreeViewConfiguration<TSchema>,
-	nodeKeyManager?: NodeIdentifierManager,
-	logger?: ITelemetryLoggerExt,
-): SchematizingSimpleTreeView<TSchema> {
-	const checkout = createTreeCheckout(
-		testIdCompressor,
-		mintRevisionTag,
-		testRevisionTagCodec,
-		{
-			forest: buildForest(),
-			schema: new TreeStoredSchemaRepository(),
-			logger,
-		},
-	);
-	return new SchematizingSimpleTreeView<TSchema>(
-		checkout,
-		config,
-		nodeKeyManager ?? new MockNodeIdentifierManager(),
-	);
 }
 
 /**


### PR DESCRIPTION
## Description

Migrate SharedTree test util "getView" to use "independentView" with createSnapshotCompressor.

Fix createSnapshotCompressor so it's produced IDs are actually deterministic (and thus safe to use in snapshot tests).

This required changing createAlwaysFinalizedIdCompressor so the ids it allocates are based on the session id passed into it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

