### PR TITLE
ci: Fix missing variable in git tag steps

### DIFF
--- a/tools/pipelines/templates/include-git-tag-steps.yml
+++ b/tools/pipelines/templates/include-git-tag-steps.yml
@@ -17,7 +17,7 @@ steps:
       targetType: 'inline'
       script: |
         set -eu -o pipefail
-        tag=${{ parameters.tagName }}_v$(version)
+        tag=${{ parameters.tagName }}_v${{ parameters.version }}
         echo Tag=$tag
         git tag $tag
         git push origin $tag

--- a/tools/pipelines/templates/include-git-tag-steps.yml
+++ b/tools/pipelines/templates/include-git-tag-steps.yml
@@ -6,8 +6,6 @@
 parameters:
 - name: tagName
   type: string
-- name: version
-  type: string
 
 steps:
 # Assumes that the repo is already checked out
@@ -19,7 +17,7 @@ steps:
       targetType: 'inline'
       script: |
         set -eu -o pipefail
-        tag=${{ parameters.tagName }}_v${{ parameters.version }}
+        tag=${{ parameters.tagName }}_v$(version)
         echo Tag=$tag
         git tag $tag
         git push origin $tag

--- a/tools/pipelines/templates/include-git-tag-steps.yml
+++ b/tools/pipelines/templates/include-git-tag-steps.yml
@@ -6,6 +6,8 @@
 parameters:
 - name: tagName
   type: string
+- name: version
+  type: string
 
 steps:
 # Assumes that the repo is already checked out

--- a/tools/pipelines/templates/include-publish-docker-service-steps.yml
+++ b/tools/pipelines/templates/include-publish-docker-service-steps.yml
@@ -77,13 +77,14 @@ jobs:
   dependsOn: publish_${{ replace(parameters.environment, '-', '_') }}
   # Only tag the repo if a tag name is provided.
   condition: and(succeeded(), ne('${{ parameters.tagName }}', ''))
+  variables:
+    version: $[ stageDependencies.build.build.outputs['SetVersion.version']]
   steps:
   - checkout: self
     clean: true
   - template: /tools/pipelines/templates/include-git-tag-steps.yml@self
     parameters:
       tagName: ${{ parameters.tagName }}
-      version: $[ stageDependencies.build.build.outputs['SetVersion.version']]
 
   # templateContext is available because our templates were migrated to extend 1ES templates for pipelines, so
   # the stage defined in this file ends up being passed to a 1ES template which provides this functionality.

--- a/tools/pipelines/templates/include-publish-docker-service-steps.yml
+++ b/tools/pipelines/templates/include-publish-docker-service-steps.yml
@@ -71,9 +71,20 @@ jobs:
               ${{ parameters.containerRegistryUrl }}/${{ parameters.containerName }}:latest,
               ${{ parameters.containerRegistryUrl }}/${{ parameters.containerName }}:$(containerTagSuffix)
 
-        - template: /tools/pipelines/templates/include-git-tag-steps.yml@self
-          parameters:
-            tagName: ${{ parameters.tagName }}
+- job: TagRelease
+  displayName: Tag Release
+  # Note: must be kept in sync with the name of the deployment job above
+  dependsOn: publish_${{ replace(parameters.environment, '-', '_') }}
+  # Only tag the repo if a tag name is provided.
+  condition: and(succeeded(), ne('${{ parameters.tagName }}', ''))
+  steps:
+  - checkout: self
+    clean: true
+  - template: /tools/pipelines/templates/include-git-tag-steps.yml@self
+    parameters:
+      tagName: ${{ parameters.tagName }}
+      version: $[ stageDependencies.build.build.outputs['SetVersion.version']]
+
   # templateContext is available because our templates were migrated to extend 1ES templates for pipelines, so
   # the stage defined in this file ends up being passed to a 1ES template which provides this functionality.
   templateContext:

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -107,3 +107,4 @@ jobs:
   - template: /tools/pipelines/templates/include-git-tag-steps.yml@self
     parameters:
       tagName: ${{ parameters.tagName }}
+      version: $[ stageDependencies.build.build.outputs['SetVersion.version']]

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -101,10 +101,11 @@ jobs:
   dependsOn: publish_${{ replace(parameters.environment, '-', '_') }}
   # Only tag the repo if a tag name is provided.
   condition: and(succeeded(), ne('${{ parameters.tagName }}', ''))
+  variables:
+    version: $[ stageDependencies.build.build.outputs['SetVersion.version']]
   steps:
   - checkout: self
     clean: true
   - template: /tools/pipelines/templates/include-git-tag-steps.yml@self
     parameters:
       tagName: ${{ parameters.tagName }}
-      version: $[ stageDependencies.build.build.outputs['SetVersion.version']]


### PR DESCRIPTION
The version variable was not available in the git tag pipeline, so the script errored out. I updated the jobs calling the template to set the version as a variable.

Also updates the docker build pipeline to move the tagging into a job separate from the deployment job.