### PR TITLE
fix(release): Fix check for git tag

### DIFF
--- a/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/checkFunctions.ts
@@ -688,7 +688,7 @@ export const checkReleaseIsDone: StateHandlerFunction = async (
 
 	const { context, releaseGroup, releaseVersion } = data;
 
-	const wasReleased = await isReleased(context, releaseGroup, releaseVersion);
+	const wasReleased = await isReleased(context, releaseGroup, releaseVersion, log);
 	if (wasReleased) {
 		BaseStateHandler.signalSuccess(machine, state);
 	} else {

--- a/build-tools/packages/build-cli/src/library/package.ts
+++ b/build-tools/packages/build-cli/src/library/package.ts
@@ -350,8 +350,8 @@ export async function isReleased(
 	}
 
 	log?.verbose(`Checking for tag '${tagName}'`);
-	const rawTag = await gitRepo.gitClient.tags({ list: tagName });
-	return rawTag.all?.[0] === tagName;
+	const rawTag = await gitRepo.gitClient.tag(["--list", tagName]);
+	return rawTag.trim() === tagName;
 }
 
 /**


### PR DESCRIPTION
Fixes the simple-git call to correctly invoke `git tag --list TAG_NAME` when checking for release tags. Tested manually against the 2.32 release branch.