### PR TITLE
Remove direct use of TreeFactory and SharedTree class

### DIFF
--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -4,11 +4,10 @@
  */
 
 export {
-	type ISharedTree,
 	type ITreePrivate,
 	type SharedTreeOptionsInternal,
 	type SharedTreeOptions,
-	SharedTree,
+	SharedTreeKernel,
 	getBranch,
 	type ForestType,
 	type SharedTreeContentSnapshot,
@@ -40,7 +39,11 @@ export { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
 
 export { CheckoutFlexTreeView } from "./checkoutFlexTreeView.js";
 
-export type { ISharedTreeEditor, ISchemaEditor } from "./sharedTreeEditBuilder.js";
+export type {
+	ISharedTreeEditor,
+	ISchemaEditor,
+	SharedTreeEditBuilder,
+} from "./sharedTreeEditBuilder.js";
 
 export {
 	treeApi as Tree,
@@ -55,3 +58,5 @@ export {
 	type ViewContent,
 	independentView,
 } from "./independentView.js";
+
+export type { SharedTreeChange } from "./sharedTreeChangeTypes.js";

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -9,29 +9,16 @@ import type {
 	IFluidHandle,
 	IFluidLoadable,
 } from "@fluidframework/core-interfaces/internal";
+import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import type {
-	IChannelAttributes,
-	IFluidDataStoreRuntime,
-	IChannelStorageService,
-} from "@fluidframework/datastore-definitions/internal";
-import {
-	SharedObject,
-	type IChannelView,
-	type IFluidSerializer,
-	type ISharedObject,
+	IChannelView,
+	IFluidSerializer,
 } from "@fluidframework/shared-object-base/internal";
 import {
 	UsageError,
 	type ITelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
-import type {
-	ITelemetryContext,
-	IExperimentalIncrementalSummaryContext,
-	ISummaryTreeWithStats,
-	IRuntimeMessageCollection,
-} from "@fluidframework/runtime-definitions/internal";
-import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 
 import { type ICodecOptions, noopValidator } from "../codec/index.js";
 import {
@@ -103,7 +90,7 @@ import { SharedTreeChangeFamily } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import type { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
 import { type TreeCheckout, type BranchableTree, createTreeCheckout } from "./treeCheckout.js";
-import { Breakable, breakingClass, throwIfBroken } from "../util/index.js";
+import { type Breakable, breakingClass, throwIfBroken } from "../util/index.js";
 
 /**
  * Copy of data from an {@link ITreePrivate} at some point in time.
@@ -158,13 +145,6 @@ export interface ITreePrivate extends ITreeInternal {
 }
 
 /**
- * {@link ITreePrivate} extended with ISharedObject.
- * @remarks
- * This is used when integration testing this package with the Fluid runtime as it exposes the APIs the runtime consumes to manipulate the tree.
- */
-export interface ISharedTree extends ISharedObject, ITreePrivate {}
-
-/**
  * Has an entry for each codec which writes an explicit version into its data.
  *
  * This is used to map the single API entrypoint controlling the format {@link SharedTreeOptions.formatVersion}
@@ -207,120 +187,12 @@ function getCodecVersions(formatVersion: number): ExplicitCodecVersions {
 }
 
 /**
- * Shared object wrapping {@link SharedTreeKernel}.
- */
-export class SharedTree extends SharedObject implements ISharedTree {
-	private readonly breaker: Breakable = new Breakable("Shared Tree");
-
-	public readonly kernel: SharedTreeKernel;
-
-	public constructor(
-		id: string,
-		runtime: IFluidDataStoreRuntime,
-		attributes: IChannelAttributes,
-		optionsParam: SharedTreeOptionsInternal,
-		telemetryContextPrefix: string = "fluid_sharedTree_",
-	) {
-		super(id, runtime, attributes, telemetryContextPrefix);
-		if (runtime.idCompressor === undefined) {
-			throw new UsageError("IdCompressor must be enabled to use SharedTree");
-		}
-		this.kernel = new SharedTreeKernel(
-			this.breaker,
-			this,
-			this.serializer,
-			(content, localOpMetadata) => this.submitLocalMessage(content, localOpMetadata),
-			() => this.deltaManager.lastSequenceNumber,
-			this.logger,
-			runtime.idCompressor,
-			optionsParam,
-		);
-	}
-
-	public summarizeCore(
-		serializer: IFluidSerializer,
-		telemetryContext?: ITelemetryContext,
-		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
-	): ISummaryTreeWithStats {
-		return this.kernel.summarizeCore(serializer, telemetryContext, incrementalSummaryContext);
-	}
-
-	protected processCore(
-		message: ISequencedDocumentMessage,
-		local: boolean,
-		localOpMetadata: unknown,
-	): void {
-		fail(0xb75 /* processCore should not be called on SharedTree */);
-	}
-
-	protected override processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {
-		this.kernel.processMessagesCore(messagesCollection);
-	}
-
-	protected onDisconnect(): void {
-		this.kernel.onDisconnect();
-	}
-
-	public exportVerbose(): VerboseTree | undefined {
-		return this.kernel.exportVerbose();
-	}
-
-	public exportSimpleSchema(): SimpleTreeSchema {
-		return this.kernel.exportSimpleSchema();
-	}
-
-	public contentSnapshot(): SharedTreeContentSnapshot {
-		return this.kernel.contentSnapshot();
-	}
-
-	// For the new TreeViewAlpha API
-	public viewWith<TRoot extends ImplicitFieldSchema | UnsafeUnknownSchema>(
-		config: TreeViewConfiguration<ReadSchema<TRoot>>,
-	): SchematizingSimpleTreeView<TRoot> & TreeView<ReadSchema<TRoot>>;
-
-	// For the old TreeView API
-	public viewWith<TRoot extends ImplicitFieldSchema>(
-		config: TreeViewConfiguration<TRoot>,
-	): SchematizingSimpleTreeView<TRoot> & TreeView<TRoot>;
-
-	public viewWith<TRoot extends ImplicitFieldSchema | UnsafeUnknownSchema>(
-		config: TreeViewConfiguration<ReadSchema<TRoot>>,
-	): SchematizingSimpleTreeView<TRoot> & TreeView<ReadSchema<TRoot>> {
-		return this.kernel.viewWith(config);
-	}
-
-	protected override async loadCore(services: IChannelStorageService): Promise<void> {
-		await this.kernel.loadCore(services);
-	}
-
-	protected override didAttach(): void {
-		this.kernel.didAttach();
-	}
-
-	protected override applyStashedOp(
-		...args: Parameters<
-			SharedTreeCore<SharedTreeEditBuilder, SharedTreeChange>["applyStashedOp"]
-		>
-	): void {
-		this.kernel.applyStashedOp(...args);
-	}
-
-	protected override reSubmitCore(
-		...args: Parameters<
-			SharedTreeCore<SharedTreeEditBuilder, SharedTreeChange>["reSubmitCore"]
-		>
-	): void {
-		this.kernel.reSubmitCore(...args);
-	}
-}
-
-/**
  * SharedTreeCore, configured with a good set of indexes and field kinds which will maintain compatibility over time.
  *
  * TODO: detail compatibility requirements.
  */
 @breakingClass
-class SharedTreeKernel extends SharedTreeCore<SharedTreeEditBuilder, SharedTreeChange> {
+export class SharedTreeKernel extends SharedTreeCore<SharedTreeEditBuilder, SharedTreeChange> {
 	public readonly checkout: TreeCheckout;
 	public get storedSchema(): TreeStoredSchemaRepository {
 		return this.checkout.storedSchema;

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -52,7 +52,7 @@ import {
 	type ISharedTreeEditor,
 	Tree,
 	ForestTypeOptimized,
-	type ISharedTree,
+	type ITreePrivate,
 } from "../../../shared-tree/index.js";
 import {
 	MockTreeCheckout,
@@ -82,6 +82,7 @@ import { brand } from "../../../util/index.js";
 import { ChunkedForest } from "../../../feature-libraries/chunked-forest/chunkedForest.js";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 import { configuredSharedTree } from "../../../treeFactory.js";
+import type { IChannel } from "@fluidframework/datastore-definitions/internal";
 
 const options = {
 	jsonValidator: typeboxValidator,
@@ -402,7 +403,7 @@ describe("End to end chunked encoding", () => {
 				id: "test",
 				idCompressor: testIdCompressor,
 			});
-			const tree = factory.create(runtime, "TestSharedTree") as ISharedTree;
+			const tree = factory.create(runtime, "TestSharedTree") as ITreePrivate & IChannel;
 
 			const stableId = testIdCompressor.decompress(testIdCompressor.generateCompressedId());
 

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -24,7 +24,7 @@ import type {
 	TreeNodeSchemaIdentifier,
 } from "../../../core/index.js";
 import { type DownPath, toDownPath } from "../../../feature-libraries/index.js";
-import { Tree, type ISharedTree, type ITreePrivate } from "../../../shared-tree/index.js";
+import { Tree, type ITreePrivate } from "../../../shared-tree/index.js";
 import { getOrCreate, makeArray } from "../../../util/index.js";
 
 import {
@@ -66,6 +66,7 @@ import {
 	type TreeNodeSchema,
 } from "../../../simple-tree/index.js";
 import type { IChannelFactory } from "@fluidframework/datastore-definitions/internal";
+import type { ISharedTree } from "../../../treeFactory.js";
 
 export type FuzzView = SchematizingSimpleTreeView<typeof fuzzFieldSchema> & {
 	/**

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -12,7 +12,7 @@ import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 import type { Revertible } from "../../../core/index.js";
 import type { DownPath } from "../../../feature-libraries/index.js";
-import { Tree, type ISharedTree } from "../../../shared-tree/index.js";
+import { Tree } from "../../../shared-tree/index.js";
 import { validateFuzzTreeConsistency } from "../../utils.js";
 
 import {
@@ -63,6 +63,7 @@ import {
 	type TreeNodeSchema,
 } from "../../../simple-tree/index.js";
 import type { IChannelFactory } from "@fluidframework/datastore-definitions/internal";
+import type { ISharedTree } from "../../../treeFactory.js";
 
 const syncFuzzReducer = combineReducers<
 	Operation,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzUtils.ts
@@ -45,12 +45,12 @@ import {
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 import type {
-	ISharedTree,
 	SharedTreeOptionsInternal,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../shared-tree/sharedTree.js";
 import { typeboxValidator } from "../../../external-utilities/index.js";
 import type { FuzzView } from "./fuzzEditGenerators.js";
+import type { ISharedTree } from "../../../treeFactory.js";
 
 const builder = new SchemaFactory("treeFuzz");
 export class GUIDNode extends builder.object("GuidNode" as string, {

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -19,11 +19,9 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 
 import type { Value } from "../../core/index.js";
-import { typeboxValidator } from "../../external-utilities/index.js";
-import { TreeCompressionStrategy } from "../../feature-libraries/index.js";
 import { Tree, type ITreePrivate } from "../../shared-tree/index.js";
 import { type JsonCompatibleReadOnly, getOrAddEmptyToMap } from "../../util/index.js";
-import { treeTestFactory } from "../utils.js";
+import { DefaultTestSharedTreeKind } from "../utils.js";
 import {
 	SchemaFactory,
 	TreeViewConfiguration,
@@ -58,13 +56,7 @@ function createConnectedTree(): ITreePrivate {
 		idCompressor: createIdCompressor(),
 	});
 	containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
-	const tree = treeTestFactory({
-		runtime: dataStoreRuntime,
-		options: {
-			jsonValidator: typeboxValidator,
-			treeEncodeType: TreeCompressionStrategy.Uncompressed,
-		},
-	});
+	const tree = DefaultTestSharedTreeKind.getFactory().create(dataStoreRuntime, "tree");
 	tree.connect({
 		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -53,7 +53,7 @@ import {
 } from "../utils.js";
 import { insert } from "../sequenceRootUtils.js";
 import { cursorFromInsertable, TreeViewConfiguration } from "../../simple-tree/index.js";
-import { TreeFactory } from "../../treeFactory.js";
+import { configuredSharedTree } from "../../treeFactory.js";
 import { makeArray } from "../../util/index.js";
 
 // number of nodes in test for wide trees
@@ -70,10 +70,10 @@ const nodesCountDeep = [
 ];
 
 // TODO: ADO#7111 Schema should be fixed to enable schema based encoding.
-const factory = new TreeFactory({
+const factory = configuredSharedTree({
 	jsonValidator: typeboxValidator,
 	treeEncodeType: TreeCompressionStrategy.Uncompressed,
-});
+}).getFactory();
 
 // TODO: Once the "BatchTooLarge" error is no longer an issue, extend tests for larger trees.
 describe("SharedTree benchmarks", () => {

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -49,7 +49,6 @@ import {
 	ForestTypeOptimized,
 	ForestTypeReference,
 	getBranch,
-	type ISharedTree,
 	type ITreePrivate,
 	Tree,
 	type TreeCheckout,
@@ -90,7 +89,11 @@ import {
 	getView,
 	createSnapshotCompressor,
 } from "../utils.js";
-import { configuredSharedTree, SharedTree as SharedTreeKind } from "../../treeFactory.js";
+import {
+	configuredSharedTree,
+	SharedTree as SharedTreeKind,
+	type ISharedTree,
+} from "../../treeFactory.js";
 import {
 	SharedObjectCore,
 	type ISharedObjectKind,

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -76,7 +76,6 @@ import {
 	TestTreeProviderLite,
 	createTestUndoRedoStacks,
 	expectSchemaEqual,
-	treeTestFactory,
 	validateTreeConsistency,
 	validateTreeContent,
 	validateUsageError,
@@ -88,12 +87,10 @@ import {
 	type TreeMockContainerRuntime,
 	type SharedTreeWithContainerRuntime,
 	DefaultTestSharedTreeKind,
+	getView,
+	createSnapshotCompressor,
 } from "../utils.js";
-import {
-	configuredSharedTree,
-	TreeFactory,
-	SharedTree as SharedTreeKind,
-} from "../../treeFactory.js";
+import { configuredSharedTree, SharedTree as SharedTreeKind } from "../../treeFactory.js";
 import {
 	SharedObjectCore,
 	type ISharedObjectKind,
@@ -130,6 +127,24 @@ class MockSharedTreeRuntime extends MockFluidDataStoreRuntime {
 			registry: [DebugSharedTree.getFactory()],
 		});
 	}
+}
+
+/**
+ * Simple non-factory based wrapper around `new SharedTree` with test appropriate defaults.
+ *
+ * See TestTreeProvider, TestTreeProviderLite and TreeFactory for other ways to build trees.
+ *
+ * If what is needed is a view, see {@link getView}.
+ */
+function treeTestFactory(): ISharedTree {
+	return DebugSharedTree.getFactory().create(
+		new MockFluidDataStoreRuntime({
+			idCompressor: createSnapshotCompressor(),
+			clientId: "test-client",
+			id: "test",
+		}),
+		"test",
+	);
 }
 
 describe("SharedTree", () => {
@@ -286,10 +301,10 @@ describe("SharedTree", () => {
 		const provider = await TestTreeProvider.create(
 			2,
 			SummarizeType.disabled,
-			new TreeFactory({
+			configuredSharedTree({
 				jsonValidator: typeboxValidator,
 				treeEncodeType: TreeCompressionStrategy.Uncompressed,
-			}),
+			}).getFactory(),
 		);
 		assert(provider.trees[0].isAttached());
 		assert(provider.trees[1].isAttached());
@@ -698,7 +713,7 @@ describe("SharedTree", () => {
 		// Detached trees are not connected to the sequencing service, but they still "sequence" their edits as if they were totally ordered.
 		// The second tree must take care to avoid sequencing its edits with sequence numbers that the first tree already used.
 		// If it doesn't, the second tree will throw an error when trying to sequence a commit with sequence number that has "gone backwards" and this test will fail.
-		const sharedTreeFactory = new TreeFactory({});
+		const sharedTreeFactory = DefaultTestSharedTreeKind.getFactory();
 		const runtime = new MockFluidDataStoreRuntime({
 			idCompressor: createIdCompressor(),
 			attachState: AttachState.Detached,
@@ -2032,9 +2047,9 @@ describe("SharedTree", () => {
 		it("unspecified ForestType uses ObjectForest", () => {
 			const { trees } = new TestTreeProviderLite(
 				1,
-				new TreeFactory({
+				configuredSharedTree({
 					jsonValidator: typeboxValidator,
-				}),
+				}).getFactory(),
 			);
 			assert.equal(trees[0].kernel.checkout.forest instanceof ObjectForest, true);
 		});
@@ -2042,10 +2057,10 @@ describe("SharedTree", () => {
 		it("ForestType.Reference uses ObjectForest with additionalAsserts flag set to false", () => {
 			const { trees } = new TestTreeProviderLite(
 				1,
-				new TreeFactory({
+				configuredSharedTree({
 					jsonValidator: typeboxValidator,
 					forest: ForestTypeReference,
-				}),
+				}).getFactory(),
 			);
 			const forest = trees[0].kernel.checkout.forest;
 			assert(forest instanceof ObjectForest);
@@ -2055,10 +2070,10 @@ describe("SharedTree", () => {
 		it("ForestType.Optimized uses ChunkedForest", () => {
 			const { trees } = new TestTreeProviderLite(
 				1,
-				new TreeFactory({
+				configuredSharedTree({
 					jsonValidator: typeboxValidator,
 					forest: ForestTypeOptimized,
-				}),
+				}).getFactory(),
 			);
 			assert.equal(trees[0].kernel.checkout.forest instanceof ChunkedForest, true);
 		});
@@ -2066,10 +2081,10 @@ describe("SharedTree", () => {
 		it("ForestType.Expensive uses ObjectForest with additionalAsserts flag set to true", () => {
 			const { trees } = new TestTreeProviderLite(
 				1,
-				new TreeFactory({
+				configuredSharedTree({
 					jsonValidator: typeboxValidator,
 					forest: ForestTypeExpensiveDebug,
-				}),
+				}).getFactory(),
 			);
 			const forest = trees[0].kernel.checkout.forest;
 			assert(forest instanceof ObjectForest);
@@ -2079,10 +2094,10 @@ describe("SharedTree", () => {
 	describe("Schema based op encoding", () => {
 		// TODO:#8915: This test will fail until bug #8915 is fixed
 		it.skip("uses the correct schema for subsequent edits after schema change.", async () => {
-			const factory = new TreeFactory({
+			const factory = configuredSharedTree({
 				jsonValidator: typeboxValidator,
 				treeEncodeType: TreeCompressionStrategy.Compressed,
-			});
+			}).getFactory();
 			const provider = new TestTreeProviderLite(2, factory);
 			const tree = provider.trees[0];
 
@@ -2124,10 +2139,10 @@ describe("SharedTree", () => {
 
 		it("properly encodes ops using specified compression strategy", async () => {
 			// Check that ops are using uncompressed encoding with "Uncompressed" treeEncodeType
-			const factory = new TreeFactory({
+			const factory = configuredSharedTree({
 				jsonValidator: typeboxValidator,
 				treeEncodeType: TreeCompressionStrategy.Uncompressed,
-			});
+			}).getFactory();
 			const provider = await TestTreeProvider.create(1, SummarizeType.onDemand, factory);
 			provider.trees[0]
 				.viewWith(new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }))
@@ -2167,10 +2182,10 @@ describe("SharedTree", () => {
 			assert.deepEqual(encodedTreeData.data[0][1], expectedUncompressedTreeData);
 
 			// Check that ops are encoded using schema based compression with "Compressed" treeEncodeType
-			const factory2 = new TreeFactory({
+			const factory2 = configuredSharedTree({
 				jsonValidator: typeboxValidator,
 				treeEncodeType: TreeCompressionStrategy.Compressed,
-			});
+			}).getFactory();
 			const provider2 = await TestTreeProvider.create(1, SummarizeType.onDemand, factory2);
 
 			provider2.trees[0]
@@ -2198,17 +2213,11 @@ describe("SharedTree", () => {
 	});
 
 	describe("Identifiers", () => {
-		it("Can use identifiers and the static Tree Apis", async () => {
-			const factory = new TreeFactory({
-				jsonValidator: typeboxValidator,
-				treeEncodeType: TreeCompressionStrategy.Compressed,
-			});
-			const provider = new TestTreeProviderLite(1, factory, true);
-			const tree1 = provider.trees[0];
+		it("Can use identifiers and the static Tree Apis", () => {
 			const sf = new SchemaFactory("com.example");
 			class Widget extends sf.object("Widget", { id: sf.identifier }) {}
 
-			const view = tree1.viewWith(
+			const view = getView(
 				new TreeViewConfiguration({
 					schema: sf.array(Widget),
 					enableSchemaValidation,
@@ -2225,7 +2234,7 @@ describe("SharedTree", () => {
 	});
 
 	describe("Schema validation", () => {
-		it("can create tree with schema validation enabled", async () => {
+		it("can create tree with schema validation enabled", () => {
 			const provider = new TestTreeProviderLite(1);
 			const [sharedTree] = provider.trees;
 			const sf = new SchemaFactory("test");
@@ -2240,7 +2249,7 @@ describe("SharedTree", () => {
 	});
 
 	// Note: this is basically a more e2e version of some tests for `toMapTree`.
-	it("throws when an invalid type is inserted at runtime", async () => {
+	it("throws when an invalid type is inserted at runtime", () => {
 		const provider = new TestTreeProviderLite(1);
 		const [sharedTree] = provider.trees;
 		const sf = new SchemaFactory("test");

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -13,7 +13,7 @@ import {
 	TreeViewConfiguration,
 	type TreeNodeSchema,
 } from "../../../simple-tree/index.js";
-import { TreeFactory } from "../../../treeFactory.js";
+import { SharedTree } from "../../../treeFactory.js";
 import { getView, validateUsageError } from "../../utils.js";
 import { independentView, Tree } from "../../../shared-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
@@ -25,7 +25,7 @@ class NodeMap extends schema.map("NoteMap", schema.string) {}
 class NodeList extends schema.array("NoteList", schema.string) {}
 class Canvas extends schema.object("Canvas", { stuff: [NodeMap, NodeList] }) {}
 
-const factory = new TreeFactory({});
+const factory = SharedTree.getFactory();
 
 describe("simple-tree tree", () => {
 	it("ListRoot", () => {

--- a/packages/dds/tree/src/test/snapshots/gc.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/gc.spec.ts
@@ -14,13 +14,13 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import type { ISharedTree } from "../../shared-tree/index.js";
 import {
 	SchemaFactory,
 	TreeViewConfiguration,
 	type TreeView,
 } from "../../simple-tree/index.js";
 import { DefaultTestSharedTreeKind } from "../utils.js";
+import type { ISharedTree } from "../../treeFactory.js";
 
 const builder = new SchemaFactory("test");
 class Bar extends builder.object("bar", {

--- a/packages/dds/tree/src/test/snapshots/gc.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/gc.spec.ts
@@ -14,14 +14,12 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { typeboxValidator } from "../../external-utilities/index.js";
 import type { ISharedTree } from "../../shared-tree/index.js";
 import {
 	SchemaFactory,
 	TreeViewConfiguration,
 	type TreeView,
 } from "../../simple-tree/index.js";
-import { TreeFactory } from "../../treeFactory.js";
 import { DefaultTestSharedTreeKind } from "../utils.js";
 
 const builder = new SchemaFactory("test");
@@ -52,7 +50,7 @@ function createConnectedTree(
 }
 
 function createLocalTree(id: string): ISharedTree {
-	const factory = new TreeFactory({ jsonValidator: typeboxValidator });
+	const factory = DefaultTestSharedTreeKind.getFactory();
 	return factory.create(
 		new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 		id,

--- a/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
@@ -7,15 +7,10 @@ import { strict as assert } from "node:assert";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import { typeboxValidator } from "../../external-utilities/index.js";
-import {
-	getBranch,
-	type ISharedTree,
-	type SharedTreeOptions,
-	Tree,
-} from "../../shared-tree/index.js";
+import { getBranch, type SharedTreeOptions, Tree } from "../../shared-tree/index.js";
 import { createSnapshotCompressor, TestTreeProviderLite } from "../utils.js";
 import { SchemaFactory, TreeViewConfiguration } from "../../simple-tree/index.js";
-import { configuredSharedTree } from "../../treeFactory.js";
+import { configuredSharedTree, type ISharedTree } from "../../treeFactory.js";
 import type { IChannel } from "@fluidframework/datastore-definitions/internal";
 
 const enableSchemaValidation = true;

--- a/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTestScenarios.ts
@@ -13,11 +13,21 @@ import {
 	type SharedTreeOptions,
 	Tree,
 } from "../../shared-tree/index.js";
-import { createSnapshotCompressor, TestTreeProviderLite, treeTestFactory } from "../utils.js";
+import { createSnapshotCompressor, TestTreeProviderLite } from "../utils.js";
 import { SchemaFactory, TreeViewConfiguration } from "../../simple-tree/index.js";
-import { TreeFactory } from "../../treeFactory.js";
+import { configuredSharedTree } from "../../treeFactory.js";
+import type { IChannel } from "@fluidframework/datastore-definitions/internal";
 
 const enableSchemaValidation = true;
+
+export interface TestTree {
+	only?: boolean;
+	skip?: boolean;
+	name: string;
+	runScenario: (
+		takeSnapshot: (tree: IChannel, name: string) => Promise<void>,
+	) => Promise<void>;
+}
 
 // TODO: The generated test trees should eventually be updated to use the chunked-forest.
 export function generateTestTrees(options: SharedTreeOptions) {
@@ -25,15 +35,8 @@ export function generateTestTrees(options: SharedTreeOptions) {
 		jsonValidator: typeboxValidator,
 		...options,
 	};
-	const factory = new TreeFactory(factoryOptions);
-	const testTrees: {
-		only?: boolean;
-		skip?: boolean;
-		name: string;
-		runScenario: (
-			takeSnapshot: (tree: ISharedTree, name: string) => Promise<void>,
-		) => Promise<void>;
-	}[] = [
+	const factory = configuredSharedTree(factoryOptions).getFactory();
+	const testTrees: TestTree[] = [
 		{
 			name: "tree-with-identifier-field",
 			runScenario: async (takeSnapshot) => {
@@ -253,7 +256,11 @@ export function generateTestTrees(options: SharedTreeOptions) {
 						StringArray,
 					]) {}
 
-					const provider = new TestTreeProviderLite(1, new TreeFactory(options), true);
+					const provider = new TestTreeProviderLite(
+						1,
+						configuredSharedTree(options).getFactory(),
+						true,
+					);
 					const tree = provider.trees[0];
 					const view = tree.viewWith(
 						new TreeViewConfiguration({
@@ -374,14 +381,14 @@ export function generateTestTrees(options: SharedTreeOptions) {
 			runScenario: async (takeSnapshot) => {
 				// This test makes changes only while detached to test EditManager's optimization of evicting/trimming
 				// trunk commits outside of the collab window (which is all changes when detached).
-				const tree = treeTestFactory({
-					runtime: new MockFluidDataStoreRuntime({
+				const tree = factory.create(
+					new MockFluidDataStoreRuntime({
 						clientId: "test-client",
 						id: "test",
 						idCompressor: createSnapshotCompressor(),
 					}),
-					options: factoryOptions,
-				});
+					"tree",
+				);
 
 				const sf = new SchemaFactory("attachment-tree");
 				const view = tree.viewWith(

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -135,7 +135,6 @@ import {
 } from "../shared-tree/schematizingTreeView.js";
 import type {
 	ForestOptions,
-	ISharedTree,
 	SharedTreeOptionsInternal,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../shared-tree/sharedTree.js";
@@ -165,7 +164,7 @@ import type { TreeSimpleContent } from "./feature-libraries/flex-tree/utils.js";
 import type { Transactor } from "../shared-tree-core/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import type { FieldChangeDelta } from "../feature-libraries/modular-schema/fieldChangeHandler.js";
-import { configuredSharedTree } from "../treeFactory.js";
+import { configuredSharedTree, type ISharedTree } from "../treeFactory.js";
 import { JsonAsTree } from "../jsonDomainSchema.js";
 import {
 	MockContainerRuntimeFactoryWithOpBunching,

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -28,7 +28,7 @@ import { SharedTreeFactoryType, SharedTreeAttributes } from "./sharedTreeAttribu
 /**
  * A channel factory that creates an {@link ITree}.
  */
-export class TreeFactory implements IChannelFactory<ISharedTree> {
+class TreeFactory implements IChannelFactory<ISharedTree> {
 	public static Type: string = SharedTreeFactoryType;
 	public readonly type: string = SharedTreeFactoryType;
 

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -8,22 +8,165 @@ import type {
 	IChannelFactory,
 	IFluidDataStoreRuntime,
 	IChannelServices,
+	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
+import type {
+	ITelemetryContext,
+	IExperimentalIncrementalSummaryContext,
+	ISummaryTreeWithStats,
+	IRuntimeMessageCollection,
+} from "@fluidframework/runtime-definitions/internal";
+
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import type { SharedObjectKind } from "@fluidframework/shared-object-base";
 import {
+	type IFluidSerializer,
+	type ISharedObject,
 	type ISharedObjectKind,
+	SharedObject,
 	createSharedObjectKind,
 } from "@fluidframework/shared-object-base/internal";
 
-import {
-	SharedTree as SharedTreeImpl,
-	type ISharedTree,
-	type SharedTreeOptions,
-	type SharedTreeOptionsInternal,
+import type {
+	SchematizingSimpleTreeView,
+	SharedTreeContentSnapshot,
+	SharedTreeOptions,
+	SharedTreeOptionsInternal,
+	SharedTreeEditBuilder,
+	SharedTreeChange,
+	ITreePrivate,
 } from "./shared-tree/index.js";
-import type { ITree } from "./simple-tree/index.js";
-
+import type {
+	ImplicitFieldSchema,
+	ITree,
+	ReadSchema,
+	SimpleTreeSchema,
+	TreeView,
+	TreeViewConfiguration,
+	UnsafeUnknownSchema,
+	VerboseTree,
+} from "./simple-tree/index.js";
 import { SharedTreeFactoryType, SharedTreeAttributes } from "./sharedTreeAttributes.js";
+import { Breakable } from "./util/index.js";
+import { SharedTreeKernel } from "./shared-tree/index.js";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { fail } from "@fluidframework/core-utils/internal";
+import type { SharedTreeCore } from "./shared-tree-core/index.js";
+
+/**
+ * {@link ITreePrivate} extended with ISharedObject.
+ * @remarks
+ * This is used when integration testing this package with the Fluid runtime as it exposes the APIs the runtime consumes to manipulate the tree.
+ */
+export interface ISharedTree extends ISharedObject, ITreePrivate {}
+
+/**
+ * Shared object wrapping {@link SharedTreeKernel}.
+ */
+class SharedTreeImpl extends SharedObject implements ISharedTree {
+	private readonly breaker: Breakable = new Breakable("Shared Tree");
+
+	public readonly kernel: SharedTreeKernel;
+
+	public constructor(
+		id: string,
+		runtime: IFluidDataStoreRuntime,
+		attributes: IChannelAttributes,
+		optionsParam: SharedTreeOptionsInternal,
+		telemetryContextPrefix: string = "fluid_sharedTree_",
+	) {
+		super(id, runtime, attributes, telemetryContextPrefix);
+		if (runtime.idCompressor === undefined) {
+			throw new UsageError("IdCompressor must be enabled to use SharedTree");
+		}
+		this.kernel = new SharedTreeKernel(
+			this.breaker,
+			this,
+			this.serializer,
+			(content, localOpMetadata) => this.submitLocalMessage(content, localOpMetadata),
+			() => this.deltaManager.lastSequenceNumber,
+			this.logger,
+			runtime.idCompressor,
+			optionsParam,
+		);
+	}
+
+	public summarizeCore(
+		serializer: IFluidSerializer,
+		telemetryContext?: ITelemetryContext,
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
+	): ISummaryTreeWithStats {
+		return this.kernel.summarizeCore(serializer, telemetryContext, incrementalSummaryContext);
+	}
+
+	protected processCore(
+		message: ISequencedDocumentMessage,
+		local: boolean,
+		localOpMetadata: unknown,
+	): void {
+		fail(0xb75 /* processCore should not be called on SharedTree */);
+	}
+
+	protected override processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {
+		this.kernel.processMessagesCore(messagesCollection);
+	}
+
+	protected onDisconnect(): void {
+		this.kernel.onDisconnect();
+	}
+
+	public exportVerbose(): VerboseTree | undefined {
+		return this.kernel.exportVerbose();
+	}
+
+	public exportSimpleSchema(): SimpleTreeSchema {
+		return this.kernel.exportSimpleSchema();
+	}
+
+	public contentSnapshot(): SharedTreeContentSnapshot {
+		return this.kernel.contentSnapshot();
+	}
+
+	// For the new TreeViewAlpha API
+	public viewWith<TRoot extends ImplicitFieldSchema | UnsafeUnknownSchema>(
+		config: TreeViewConfiguration<ReadSchema<TRoot>>,
+	): SchematizingSimpleTreeView<TRoot> & TreeView<ReadSchema<TRoot>>;
+
+	// For the old TreeView API
+	public viewWith<TRoot extends ImplicitFieldSchema>(
+		config: TreeViewConfiguration<TRoot>,
+	): SchematizingSimpleTreeView<TRoot> & TreeView<TRoot>;
+
+	public viewWith<TRoot extends ImplicitFieldSchema | UnsafeUnknownSchema>(
+		config: TreeViewConfiguration<ReadSchema<TRoot>>,
+	): SchematizingSimpleTreeView<TRoot> & TreeView<ReadSchema<TRoot>> {
+		return this.kernel.viewWith(config);
+	}
+
+	protected override async loadCore(services: IChannelStorageService): Promise<void> {
+		await this.kernel.loadCore(services);
+	}
+
+	protected override didAttach(): void {
+		this.kernel.didAttach();
+	}
+
+	protected override applyStashedOp(
+		...args: Parameters<
+			SharedTreeCore<SharedTreeEditBuilder, SharedTreeChange>["applyStashedOp"]
+		>
+	): void {
+		this.kernel.applyStashedOp(...args);
+	}
+
+	protected override reSubmitCore(
+		...args: Parameters<
+			SharedTreeCore<SharedTreeEditBuilder, SharedTreeChange>["reSubmitCore"]
+		>
+	): void {
+		this.kernel.reSubmitCore(...args);
+	}
+}
 
 /**
  * A channel factory that creates an {@link ITree}.


### PR DESCRIPTION
## Description

The SharedTree class only exists to wrap SharedTreeKernel up in a ISharedObject for use with Fluid's factories and runtimes.

Thus stop using the class and factory directly so that how this adaption of the kernel into a SharedObjectKind is done is no longer implicitly depended on my tests.

This enables the refactor in show this is done from https://github.com/microsoft/FluidFramework/pull/23729 to not be nearly as disruptive.


## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

