### PR TITLE
[fluid-runner] Wait for container to catch up before executing

### DIFF
--- a/packages/tools/fluid-runner/src/exportFile.ts
+++ b/packages/tools/fluid-runner/src/exportFile.ts
@@ -8,6 +8,7 @@ import * as fs from "fs";
 import { LoaderHeader } from "@fluidframework/container-definitions/internal";
 import {
 	loadExistingContainer,
+	waitContainerToCatchUp,
 	type ILoaderProps,
 } from "@fluidframework/container-loader/internal";
 import { createLocalOdspDocumentServiceFactory } from "@fluidframework/odsp-driver/internal";
@@ -145,6 +146,7 @@ export async function createContainerAndExecute(
 				},
 			},
 		});
+		await waitContainerToCatchUp(container);
 
 		return PerformanceEvent.timedExecAsync(logger, { eventName: "ExportFile" }, async () => {
 			try {


### PR DESCRIPTION
There was a flaky issue observed in Loop e2e tests where sometimes the trailing ops weren't completely processed. I wasn't able to reproduce this issue in FF, as these ops get processed due to the `opsBeforeReturn: "cached"` load mode. But, I added the call to `waitContainerToCatchUp(...)` as it doesn't harm anything.

[AB#34269](https://dev.azure.com/fluidframework/internal/_workitems/edit/34269)