### PR TITLE
refactor(client-presence): Rename LatestEvents and LatestMapEvents to include `remote`

### DIFF
--- a/.changeset/sour-mirrors-wave.md
+++ b/.changeset/sour-mirrors-wave.md
@@ -25,8 +25,12 @@ The following API changes have been made to improve clarity and consistency:
 | `ISessionClient` | `Attendee` |
 | `Latest` (import) | `StateFactory` |
 | `Latest` (call) | `StateFactory.latest` |
+| `LatestEvents.updated` | `LatestEvents.remoteUpdated` |
 | `LatestMap` (import) | `StateFactory` |
 | `LatestMap` (call) | `StateFactory.latestMap` |
+| `LatestMapEvents.itemRemoved` | `LatestMapEvents.remoteItemRemoved` |
+| `LatestMapEvents.itemUpdated` | `LatestMapEvents.remoteItemUpdated` |
+| `LatestMapEvents.updated` | `LatestMapEvents.remoteUpdated` |
 | `LatestMapItemValueClientData` | `LatestMapItemUpdatedClientData` |
 | `LatestMapValueClientData` | `LatestMapClientData` |
 | `LatestMapValueManager` | `LatestMap` |

--- a/examples/apps/ai-collab/src/app/presence.ts
+++ b/examples/apps/ai-collab/src/app/presence.ts
@@ -48,7 +48,7 @@ export class PresenceManager {
 		);
 
 		// Listen for updates to the userInfo property in the presence state
-		this.usersState.props.onlineUsers.events.on("updated", (update) => {
+		this.usersState.props.onlineUsers.events.on("remoteUpdated", (update) => {
 			// The remote client that updated the userInfo property
 			const remoteSessionClient = update.attendee;
 			// The new value of the userInfo property

--- a/examples/apps/presence-tracker/src/FocusTracker.ts
+++ b/examples/apps/presence-tracker/src/FocusTracker.ts
@@ -64,7 +64,7 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
 		this.focus = statesWorkspace.props.focus;
 
 		// When the focus state is updated, the FocusTracker should emit the focusChanged event.
-		this.focus.events.on("updated", ({ attendee, value }) => {
+		this.focus.events.on("remoteUpdated", ({ attendee, value }) => {
 			this.emit("focusChanged", this.focus.local);
 		});
 

--- a/examples/apps/presence-tracker/src/MouseTracker.ts
+++ b/examples/apps/presence-tracker/src/MouseTracker.ts
@@ -61,7 +61,7 @@ export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
 		this.cursor = statesWorkspace.props.cursor;
 
 		// When the cursor state is updated, the MouseTracker should emit the mousePositionChanged event.
-		this.cursor.events.on("updated", () => {
+		this.cursor.events.on("remoteUpdated", () => {
 			this.emit("mousePositionChanged");
 		});
 

--- a/examples/service-clients/azure-client/external-controller/src/app.ts
+++ b/examples/service-clients/azure-client/external-controller/src/app.ts
@@ -216,7 +216,7 @@ async function start(): Promise<void> {
 
 	// lastDiceRolls is here just to demonstrate an example of LatestMap
 	// Its updates are only logged to the console.
-	states.lastDiceRolls.events.on("itemUpdated", (update) => {
+	states.lastDiceRolls.events.on("remoteItemUpdated", (update) => {
 		console.log(
 			`Client ${update.attendee.attendeeId.slice(0, 8)}'s ${update.key} rolled to ${update.value.value}`,
 		);

--- a/examples/service-clients/azure-client/external-controller/src/view.ts
+++ b/examples/service-clients/azure-client/external-controller/src/view.ts
@@ -186,7 +186,7 @@ function makePresenceView(
 	}
 	logDiv.append(logHeaderDiv, logContentDiv);
 
-	presenceConfig.lastRoll.events.on("updated", (update) => {
+	presenceConfig.lastRoll.events.on("remoteUpdated", (update) => {
 		const connected = update.attendee.getConnectionStatus() === "Connected" ? "🔗" : "⛓️‍💥";
 		const updateText = `updated ${update.attendee.attendeeId.slice(0, 8)}'s ${connected} last rolls to ${JSON.stringify(update.value)}`;
 		addLogEntry(logContentDiv, updateText);

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -170,7 +170,7 @@ export interface LatestEvents<T> {
         value: InternalUtilityTypes.FullyReadonly<JsonSerializable<T> & JsonDeserialized<T>>;
     }) => void;
     // @eventProperty
-    updated: (update: LatestClientData<T>) => void;
+    remoteUpdated: (update: LatestClientData<T>) => void;
 }
 
 // @alpha @sealed
@@ -198,10 +198,6 @@ export interface LatestMapClientData<T, Keys extends string | number, SpecificAt
 // @alpha @sealed (undocumented)
 export interface LatestMapEvents<T, K extends string | number> {
     // @eventProperty
-    itemRemoved: (removedItem: LatestMapItemRemovedClientData<K>) => void;
-    // @eventProperty
-    itemUpdated: (updatedItem: LatestMapItemUpdatedClientData<T, K>) => void;
-    // @eventProperty
     localItemRemoved: (removedItem: {
         key: K;
     }) => void;
@@ -211,7 +207,11 @@ export interface LatestMapEvents<T, K extends string | number> {
         key: K;
     }) => void;
     // @eventProperty
-    updated: (updates: LatestMapClientData<T, K>) => void;
+    remoteItemRemoved: (removedItem: LatestMapItemRemovedClientData<K>) => void;
+    // @eventProperty
+    remoteItemUpdated: (updatedItem: LatestMapItemUpdatedClientData<T, K>) => void;
+    // @eventProperty
+    remoteUpdated: (updates: LatestMapClientData<T, K>) => void;
 }
 
 // @alpha @sealed

--- a/packages/framework/presence/src/latestMapValueManager.ts
+++ b/packages/framework/presence/src/latestMapValueManager.ts
@@ -81,7 +81,7 @@ export interface LatestMapEvents<T, K extends string | number> {
 	 *
 	 * @eventProperty
 	 */
-	updated: (updates: LatestMapClientData<T, K>) => void;
+	remoteUpdated: (updates: LatestMapClientData<T, K>) => void;
 
 	/**
 	 * Raised when specific item's value of remote client is updated.
@@ -89,7 +89,7 @@ export interface LatestMapEvents<T, K extends string | number> {
 	 *
 	 * @eventProperty
 	 */
-	itemUpdated: (updatedItem: LatestMapItemUpdatedClientData<T, K>) => void;
+	remoteItemUpdated: (updatedItem: LatestMapItemUpdatedClientData<T, K>) => void;
 
 	/**
 	 * Raised when specific item of remote client is removed.
@@ -97,7 +97,7 @@ export interface LatestMapEvents<T, K extends string | number> {
 	 *
 	 * @eventProperty
 	 */
-	itemRemoved: (removedItem: LatestMapItemRemovedClientData<K>) => void;
+	remoteItemRemoved: (removedItem: LatestMapItemRemovedClientData<K>) => void;
 
 	/**
 	 * Raised when specific local item's value is updated.
@@ -462,11 +462,11 @@ class LatestMapValueManagerImpl<
 					value: itemValue,
 					metadata,
 				};
-				postUpdateActions.push(() => this.events.emit("itemUpdated", updatedItem));
+				postUpdateActions.push(() => this.events.emit("remoteItemUpdated", updatedItem));
 				allUpdates.items.set(key, { value: itemValue, metadata });
 			} else if (hadPriorValue !== undefined) {
 				postUpdateActions.push(() =>
-					this.events.emit("itemRemoved", {
+					this.events.emit("remoteItemRemoved", {
 						attendee,
 						key,
 						metadata,
@@ -475,7 +475,7 @@ class LatestMapValueManagerImpl<
 			}
 		}
 		this.datastore.update(this.key, attendeeId, currentState);
-		postUpdateActions.push(() => this.events.emit("updated", allUpdates));
+		postUpdateActions.push(() => this.events.emit("remoteUpdated", allUpdates));
 		return postUpdateActions;
 	}
 }

--- a/packages/framework/presence/src/latestValueManager.ts
+++ b/packages/framework/presence/src/latestValueManager.ts
@@ -32,7 +32,7 @@ export interface LatestEvents<T> {
 	 *
 	 * @eventProperty
 	 */
-	updated: (update: LatestClientData<T>) => void;
+	remoteUpdated: (update: LatestClientData<T>) => void;
 
 	/**
 	 * Raised when local client's value is updated, which may be the same value.
@@ -163,7 +163,7 @@ class LatestValueManagerImpl<T, Key extends string>
 		this.datastore.update(this.key, attendeeId, value);
 		return [
 			() =>
-				this.events.emit("updated", {
+				this.events.emit("remoteUpdated", {
 					attendee,
 					value: value.value,
 					metadata: { revision: value.rev, timestamp: value.timestamp },

--- a/packages/framework/presence/src/test/eventing.spec.ts
+++ b/packages/framework/presence/src/test/eventing.spec.ts
@@ -344,9 +344,9 @@ describe("Presence", () => {
 					itemUpdatedEventSpy = spy(verify);
 					atteendeeEventSpy = spy(verify);
 
-					latest.events.on("updated", latestUpdatedEventSpy);
-					latestMap.events.on("updated", latestMapUpdatedEventSpy);
-					latestMap.events.on("itemUpdated", itemUpdatedEventSpy);
+					latest.events.on("remoteUpdated", latestUpdatedEventSpy);
+					latestMap.events.on("remoteUpdated", latestMapUpdatedEventSpy);
+					latestMap.events.on("remoteItemUpdated", itemUpdatedEventSpy);
 					presence.attendees.events.on("attendeeConnected", atteendeeEventSpy);
 				}
 
@@ -423,9 +423,9 @@ describe("Presence", () => {
 						itemRemovedEventSpy = spy(verify);
 						latestUpdatedEventSpy = spy(verify);
 						latestMapUpdatedEventSpy = spy(verify);
-						latest.events.on("updated", latestUpdatedEventSpy);
-						latestMap.events.on("updated", latestMapUpdatedEventSpy);
-						latestMap.events.on("itemRemoved", itemRemovedEventSpy);
+						latest.events.on("remoteUpdated", latestUpdatedEventSpy);
+						latestMap.events.on("remoteUpdated", latestMapUpdatedEventSpy);
+						latestMap.events.on("remoteItemRemoved", itemRemovedEventSpy);
 					}
 
 					function assertSpies(): void {
@@ -495,9 +495,9 @@ describe("Presence", () => {
 						latestMapUpdatedEventSpy = spy(verify);
 						itemUpdatedEventSpy = spy(verify);
 
-						latestMap.events.on("updated", latestMapUpdatedEventSpy);
-						latestMap.events.on("itemUpdated", itemUpdatedEventSpy);
-						latestMap.events.on("itemRemoved", itemRemovedEventSpy);
+						latestMap.events.on("remoteUpdated", latestMapUpdatedEventSpy);
+						latestMap.events.on("remoteItemUpdated", itemUpdatedEventSpy);
+						latestMap.events.on("remoteItemRemoved", itemRemovedEventSpy);
 					}
 
 					function assertSpies(): void {
@@ -574,8 +574,8 @@ describe("Presence", () => {
 				latestMapSpy = spy(verify);
 
 				notificationManager.notifications.on("newId", notificationSpy);
-				latest.events.on("updated", latestSpy);
-				latestMap.events.on("updated", latestMapSpy);
+				latest.events.on("remoteUpdated", latestSpy);
+				latestMap.events.on("remoteUpdated", latestMapSpy);
 				presence.attendees.events.on("attendeeConnected", attendeeSpy);
 			}
 

--- a/packages/framework/presence/src/test/latestMapValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestMapValueManager.spec.ts
@@ -154,7 +154,7 @@ export function checkCompiles(): void {
 
 	localPointers.set("pen", { x: 1, y: 2 });
 
-	const pointerItemUpdatedOff = pointers.events.on("itemUpdated", logClientValue);
+	const pointerItemUpdatedOff = pointers.events.on("remoteItemUpdated", logClientValue);
 	pointerItemUpdatedOff();
 
 	for (const attendee of pointers.getStateAttendees()) {
@@ -168,11 +168,11 @@ export function checkCompiles(): void {
 		for (const [key, { value }] of items.entries()) logClientValue({ attendee, key, value });
 	}
 
-	pointers.events.on("itemRemoved", ({ attendee, key }) =>
+	pointers.events.on("remoteItemRemoved", ({ attendee, key }) =>
 		logClientValue<string>({ attendee, key, value: "<removed>" }),
 	);
 
-	pointers.events.on("updated", ({ attendee, items }) => {
+	pointers.events.on("remoteUpdated", ({ attendee, items }) => {
 		for (const [key, { value }] of items.entries()) logClientValue({ attendee, key, value });
 	});
 }

--- a/packages/framework/presence/src/test/latestValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestValueManager.spec.ts
@@ -134,7 +134,7 @@ export function checkCompiles(): void {
 	cursor.local = { x: 1, y: 2 };
 
 	// Listen to others cursor updates
-	const cursorUpdatedOff = cursor.events.on("updated", ({ attendee, value }) =>
+	const cursorUpdatedOff = cursor.events.on("remoteUpdated", ({ attendee, value }) =>
 		console.log(`attendee ${attendee.attendeeId}'s cursor is now at (${value.x},${value.y})`),
 	);
 	cursorUpdatedOff();


### PR DESCRIPTION
## Description

| Original | New |
|----------|-----|
| `LatestEvents.updated` | `LatestEvents.remoteUpdated` |
| `LatestMapEvents.itemRemoved` | `LatestMapEvents.remoteItemRemoved` |
| `LatestMapEvents.itemUpdated` | `LatestMapEvents.remoteItemUpdated` |
| `LatestMapEvents.updated` | `LatestMapEvents.remoteUpdated` |