### PR TITLE
Remove unneeded "replace-in-file" and "moment" deps

### DIFF
--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -109,7 +109,6 @@
 		"jest-puppeteer": "^10.1.3",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"prettier": "~3.0.3",
 		"puppeteer": "^23.6.0",
 		"rewire": "^5.0.0",

--- a/common/lib/common-utils/pnpm-lock.yaml
+++ b/common/lib/common-utils/pnpm-lock.yaml
@@ -110,9 +110,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.29.4
       prettier:
         specifier: ~3.0.3
         version: 3.0.3
@@ -584,6 +581,7 @@ packages:
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -591,6 +589,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.2':
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
+    deprecated: Use @eslint/object-schema instead
 
   '@inquirer/confirm@3.2.0':
     resolution: {integrity: sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==}
@@ -2695,6 +2694,7 @@ packages:
   eslint-plugin-i@2.29.1:
     resolution: {integrity: sha512-ORizX37MelIWLbMyqI7hi8VJMf7A0CskMmYkB+lkCX3aF4pkGV7kwx5bSEb4qx7Yce2rAf9s34HqDRPjGRZPNQ==}
     engines: {node: '>=12'}
+    deprecated: Please migrate to the brand new `eslint-plugin-import-x` instead
     peerDependencies:
       eslint: ^7.2.0 || ^8
 
@@ -2774,6 +2774,7 @@ packages:
   eslint@8.55.0:
     resolution: {integrity: sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@6.2.1:
@@ -3148,6 +3149,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -4057,6 +4059,7 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -4066,6 +4069,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -4454,9 +4458,6 @@ packages:
     resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
     engines: {node: '>= 14.0.0'}
     hasBin: true
-
-  moment@2.29.4:
-    resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -12421,8 +12422,6 @@ snapshots:
       yargs: 16.2.0
       yargs-parser: 20.2.9
       yargs-unparser: 2.0.0
-
-  moment@2.29.4: {}
 
   ms@2.1.2: {}
 

--- a/examples/benchmarks/bubblebench/common/package.json
+++ b/examples/benchmarks/bubblebench/common/package.json
@@ -57,7 +57,6 @@
 		"@types/react": "^18.3.11",
 		"@types/react-dom": "^18.3.0",
 		"eslint": "~8.55.0",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/examples/benchmarks/tablebench/package.json
+++ b/examples/benchmarks/tablebench/package.json
@@ -72,7 +72,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^5.0.0",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -108,7 +108,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -112,7 +112,6 @@
 		"jsdom-global": "^3.0.2",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"style-loader": "^4.0.0",
 		"ts-loader": "^9.5.1",

--- a/examples/utils/webpack-fluid-loader/package.json
+++ b/examples/utils/webpack-fluid-loader/package.json
@@ -130,7 +130,6 @@
 		"fs-extra": "^9.1.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"source-map-loader": "^5.0.0",
 		"ts-loader": "^9.5.1",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -106,7 +106,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"nock": "^13.3.3",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -87,7 +87,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"nock": "^13.3.3",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -102,7 +102,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -86,7 +86,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"nock": "^13.3.3",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -121,7 +121,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -111,7 +111,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"quill-delta": "^4.2.2",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -111,7 +111,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -113,7 +113,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -111,7 +111,6 @@
 		"eslint-config-prettier": "~9.0.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/experimental/framework/tree-react-api/package.json
+++ b/experimental/framework/tree-react-api/package.json
@@ -125,7 +125,6 @@
 		"eslint-config-prettier": "~9.0.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -160,7 +160,6 @@
 		"jest-puppeteer": "^10.1.3",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"puppeteer": "^23.6.0",
 		"rewire": "^5.0.0",
 		"rimraf": "^4.4.0",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -136,7 +136,6 @@
 		"eslint-config-prettier": "~9.0.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",
 		"typescript": "~5.4.5"

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -127,8 +127,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -144,8 +144,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -113,8 +113,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -170,8 +170,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -164,8 +164,6 @@
 		"hotloop": "^1.2.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"ts-node": "^10.9.1",
 		"typescript": "~5.4.5"

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -168,8 +168,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -148,8 +148,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/pact-map/package.json
+++ b/packages/dds/pact-map/package.json
@@ -111,8 +111,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -145,8 +145,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -186,9 +186,7 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"random-js": "^2.1.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -152,8 +152,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"ts-node": "^10.9.1",
 		"typescript": "~5.4.5"

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -146,8 +146,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -148,8 +148,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
-		"replace-in-file": "^6.3.5",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -115,7 +115,6 @@
 		"eslint": "~8.55.0",
 		"execa": "^5.1.1",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -204,7 +204,6 @@
 		"eslint-config-prettier": "~9.0.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -123,7 +123,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"socket.io-client": "~4.7.5",
 		"typescript": "~5.4.5"

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -153,7 +153,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"socket.io-client": "~4.7.5",
 		"typescript": "~5.4.5"

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -148,7 +148,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",
 		"typescript": "~5.4.5"

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -98,7 +98,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -151,7 +151,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"nock": "^13.3.3",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -98,7 +98,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -150,7 +150,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -119,7 +119,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -111,7 +111,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -132,7 +132,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -141,7 +141,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -138,7 +138,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -124,7 +124,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -207,7 +207,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",
 		"typescript": "~5.4.5"

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -145,7 +145,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",
 		"typescript": "~5.4.5"

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -213,7 +213,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",
 		"typescript": "~5.4.5"

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -153,7 +153,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",
 		"typescript": "~5.4.5"

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -157,7 +157,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -145,7 +145,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",
 		"ts-node": "^10.9.1",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -149,7 +149,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -85,7 +85,6 @@
 		"cross-env": "^7.0.3",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"sinon": "^18.0.1",
 		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^5.0.0",

--- a/packages/service-clients/end-to-end-tests/odsp-client/package.json
+++ b/packages/service-clients/end-to-end-tests/odsp-client/package.json
@@ -72,7 +72,6 @@
 		"@types/sinon": "^17.0.3",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"sinon": "^18.0.1",
 		"uuid": "^9.0.0"
 	},

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -94,7 +94,6 @@
 		"events_pkg": "npm:events@^3.1.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",
 		"ts-loader": "^9.5.1",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -99,7 +99,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -115,7 +115,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"random-js": "^2.1.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -142,7 +142,6 @@
 		"c8": "^8.0.1",
 		"eslint": "~8.55.0",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"nock": "^13.3.3",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -159,7 +159,6 @@
 		"diff": "^3.5.0",
 		"eslint": "~8.55.0",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -124,7 +124,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"nock": "^13.3.3",
 		"rimraf": "^4.4.0",
 		"ts-loader": "^9.5.1",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -152,7 +152,6 @@
 		"eslint-plugin-chai-expect": "~3.0.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -123,7 +123,6 @@
 		"jest-junit": "^16.0.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"playwright": "^1.36.0",
 		"prop-types": "^15.8.1",
 		"rimraf": "^4.4.0",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -142,7 +142,6 @@
 		"eslint-plugin-chai-expect": "~3.0.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -147,7 +147,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -143,7 +143,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -144,7 +144,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"sinon": "^18.0.1",
 		"typescript": "~5.4.5"

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -127,7 +127,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"rimraf": "^4.4.0",
 		"typescript": "~5.4.5"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1782,9 +1782,6 @@ importers:
       eslint:
         specifier: ~8.55.0
         version: 8.55.0
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -2288,9 +2285,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -3808,9 +3802,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -4065,9 +4056,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -5066,9 +5054,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -6187,9 +6172,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       nock:
         specifier: ^13.3.3
         version: 13.5.6
@@ -6290,9 +6272,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       nock:
         specifier: ^13.3.3
         version: 13.5.6
@@ -6453,9 +6432,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -6529,9 +6505,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       nock:
         specifier: ^13.3.3
         version: 13.5.6
@@ -6650,9 +6623,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -6744,9 +6714,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       quill-delta:
         specifier: ^4.2.2
         version: 4.2.2
@@ -6838,9 +6805,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -6932,9 +6896,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -7086,9 +7047,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -7317,9 +7275,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -7438,9 +7393,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       puppeteer:
         specifier: ^23.6.0
         version: 23.10.3(typescript@5.4.5)
@@ -7637,9 +7589,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -7783,12 +7732,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -7880,12 +7823,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -7977,12 +7914,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -8101,12 +8032,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -8240,12 +8165,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -8361,12 +8280,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -8470,12 +8383,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -8567,12 +8474,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -8667,12 +8568,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -8800,15 +8695,9 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       random-js:
         specifier: ^2.1.0
         version: 2.1.0
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -8921,12 +8810,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -9024,12 +8907,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -9133,12 +9010,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
-      replace-in-file:
-        specifier: ^6.3.5
-        version: 6.3.5
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -9242,9 +9113,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -9408,9 +9276,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -9554,9 +9419,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -9809,9 +9671,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -9918,9 +9777,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -10052,9 +9908,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -10237,9 +10090,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       nock:
         specifier: ^13.3.3
         version: 13.5.6
@@ -10325,9 +10175,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -10707,9 +10554,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -10822,9 +10666,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -11171,9 +11012,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -11362,9 +11200,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -11629,9 +11464,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -11708,9 +11540,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -11799,9 +11628,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -11923,9 +11749,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -12023,9 +11846,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -12217,9 +12037,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -12390,9 +12207,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -12545,9 +12359,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -12703,9 +12514,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -12824,9 +12632,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -13023,9 +12828,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       sinon:
         specifier: ^18.0.1
         version: 18.0.1
@@ -13144,9 +12946,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       sinon:
         specifier: ^18.0.1
         version: 18.0.1
@@ -13516,9 +13315,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -13948,9 +13744,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -14027,9 +13820,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       random-js:
         specifier: ^2.1.0
         version: 2.1.0
@@ -14387,9 +14177,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       nock:
         specifier: ^13.3.3
         version: 13.5.6
@@ -14726,9 +14513,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -14892,9 +14676,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       nock:
         specifier: ^13.3.3
         version: 13.5.6
@@ -15044,9 +14825,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -15376,9 +15154,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -15753,9 +15528,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       playwright:
         specifier: ^1.36.0
         version: 1.49.1
@@ -15953,9 +15725,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -16165,9 +15934,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -16259,9 +16025,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -16359,9 +16122,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.30.1
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -25954,11 +25714,6 @@ packages:
   repeat-string@1.6.1:
     resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
     engines: {node: '>=0.10'}
-
-  replace-in-file@6.3.5:
-    resolution: {integrity: sha512-arB9d3ENdKva2fxRnSjwBEXfK1npgyci7ZZuwysgAp7ORjHSyxz6oqIjTEv8R0Ydl4Ll7uOAZXL4vbkhGIizCg==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   replace-in-file@7.2.0:
     resolution: {integrity: sha512-CiLXVop3o8/h2Kd1PwKPPimmS9wUV0Ki6Fl8+1ITD35nB3Gl/PrW5IONpTE0AXk0z4v8WYcpEpdeZqMXvSnWpg==}
@@ -42357,12 +42112,6 @@ snapshots:
       strip-ansi: 6.0.1
 
   repeat-string@1.6.1: {}
-
-  replace-in-file@6.3.5:
-    dependencies:
-      chalk: 4.1.2
-      glob: 7.2.3
-      yargs: 17.7.2
 
   replace-in-file@7.2.0:
     dependencies:

--- a/server/routerlicious/packages/tinylicious/package.json
+++ b/server/routerlicious/packages/tinylicious/package.json
@@ -94,7 +94,6 @@
 		"eslint": "~8.55.0",
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
-		"moment": "^2.21.0",
 		"pm2": "^5.4.2",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -2124,9 +2124,6 @@ importers:
       mocha-multi-reporters:
         specifier: ^1.5.1
         version: 1.5.1(mocha@10.8.2)
-      moment:
-        specifier: ^2.21.0
-        version: 2.29.4
       pm2:
         specifier: ^5.4.2
         version: 5.4.2
@@ -6626,9 +6623,6 @@ packages:
   module-error@1.0.2:
     resolution: {integrity: sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==}
     engines: {node: '>=10'}
-
-  moment@2.29.4:
-    resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
 
   mongodb-connection-string-url@2.6.0:
     resolution: {integrity: sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==}
@@ -15691,8 +15685,6 @@ snapshots:
   module-details-from-path@1.0.3: {}
 
   module-error@1.0.2: {}
-
-  moment@2.29.4: {}
 
   mongodb-connection-string-url@2.6.0:
     dependencies:


### PR DESCRIPTION
## Description

As far as I can tell, there is a single use of "replace-in-file" in the repo, but it's installed in 14 packages. This removes the unneeded extra 13 dependencies on it (which is all the users of version 6).

"moment" does not appear to be used at all in our repo but is depended on by 70 packages. Remove those deps as well.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


