### PR TITLE
(tree): KeyedFieldEncoder related renames and doc updates

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
@@ -66,7 +66,7 @@ export type Shape = ShapeGeneric<EncodedChunkShape>;
  */
 export interface KeyedFieldEncoder {
 	readonly key: FieldKey;
-	readonly shape: FieldEncoder;
+	readonly encoder: FieldEncoder;
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeShape.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeShape.ts
@@ -28,7 +28,7 @@ import { isStableId } from "@fluidframework/id-compressor/internal";
 
 export class NodeShape extends Shape<EncodedChunkShape> implements NodeEncoder {
 	/**
-	 * Set of field keys that are encoded using specialized encoders.
+	 * Set of keys for fields that are encoded using {@link NodeShape.specializedFieldEncoders}.
 	 * TODO: Ensure uniform chunks, encoding and identifier generation sort fields the same.
 	 */
 	private readonly specializedFieldKeys: Set<FieldKey>;

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeShape.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeShape.ts
@@ -43,6 +43,9 @@ export class NodeShape extends Shape<EncodedChunkShape> implements NodeEncoder {
 		 * this avoids the need to explicitly include the key and shape in the encoded data for each node instance.
 		 * Instead, this information is here, and thus is encoded only once as part of the node shape.
 		 * These encoders will be used, even if the field they apply to is empty (which can add overhead for fields which are usually empty).
+		 *
+		 * Any fields not included here will be encoded using {@link NodeShape.otherFieldsEncoder}.
+		 * If {@link NodeShape.otherFieldsEncoder} is undefined, then this must handle all non-empty fields.
 		 */
 		public readonly specializedFieldEncoders: readonly KeyedFieldEncoder[],
 		/**

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeShape.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeShape.ts
@@ -37,10 +37,12 @@ export class NodeShape extends Shape<EncodedChunkShape> implements NodeEncoder {
 		public readonly type: undefined | TreeNodeSchemaIdentifier,
 		public readonly value: EncodedValueShape,
 		/**
-		 * Encoders for a specific set of fields, by key, in the order they will be encoded. These are fields for which
-		 * special encoding is required. For example, nested arrays.
-		 * Any fields not included here will be encoded using {@link NodeShape.otherFieldsEncoder}.
-		 * If `otherFieldsEncoder` is undefined, then these must handle all non-empty fields.
+		 * Encoders for a specific set of fields, by key, in the order they will be encoded.
+		 * These are fields for which specialized encoding is provided as an optimization.
+		 * Using these for a given field instead of falling back to {@link NodeShape.specializedFieldEncoders} is often more efficient:
+		 * this avoids the need to explicitly include the key and shape in the encoded data for each node instance.
+		 * Instead, this information is here, and thus is encoded only once as part of the node shape.
+		 * These encoders will be used, even if the field they apply to is empty (which can add overhead for fields which are usually empty).
 		 */
 		public readonly specializedFieldEncoders: readonly KeyedFieldEncoder[],
 		/**

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/schemaBasedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/schemaBasedEncode.ts
@@ -122,7 +122,7 @@ export function treeShaper(
 
 		const objectNodeFields: KeyedFieldEncoder[] = [];
 		for (const [key, field] of schema.objectNodeFields ?? []) {
-			objectNodeFields.push({ key, shape: fieldHandler.shapeFromField(field) });
+			objectNodeFields.push({ key, encoder: fieldHandler.shapeFromField(field) });
 		}
 
 		const shape = new NodeShape(schemaName, false, objectNodeFields, undefined);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/nodeShape.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/nodeShape.spec.ts
@@ -114,7 +114,7 @@ describe("nodeShape", () => {
 			);
 
 			// Shape which encodes to nothing.
-			const fieldShape1: FieldEncoder = asFieldEncoder(
+			const fieldEncoder1: FieldEncoder = asFieldEncoder(
 				new NodeShape(brand("1"), false, [], undefined),
 			);
 			// Shape which encodes to just the value.
@@ -128,9 +128,9 @@ describe("nodeShape", () => {
 				brand("type"),
 				true,
 				[
-					{ key: brand("nothing"), shape: fieldShape1 },
-					{ key: brand("shapeValueOnly"), shape: asFieldEncoder(shapeValueOnly) },
-					{ key: brand("shapeValues"), shape: shapeValues },
+					{ key: brand("nothing"), encoder: fieldEncoder1 },
+					{ key: brand("shapeValueOnly"), encoder: asFieldEncoder(shapeValueOnly) },
+					{ key: brand("shapeValues"), encoder: shapeValues },
 				],
 				undefined,
 			);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/schemaBasedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/schemaBasedEncode.spec.ts
@@ -253,7 +253,7 @@ describe("schemaBasedEncoding", () => {
 				new NodeShape(
 					brand(HasOptionalField.identifier),
 					false,
-					[{ key: brand("field"), shape: cache.nestedArray(numericShape) }],
+					[{ key: brand("field"), encoder: cache.nestedArray(numericShape) }],
 					undefined,
 				),
 			);


### PR DESCRIPTION
## Description

- In `KeyedFieldEncoder`, renamed the property `shape` to `encoder`. The type of this property is `FieldEncoder` so `encoder` seems like a more appropriate name.
Most of the shapes implementations are also encoders so the name `shape` makes sesne from that perspective. But, that is just an implementation detail and it is a little confusing to see code such as `fieldEncoder.shape.encode` where shape is of type `FieldEncoder`. 
- In `NodeShape`, renamed the property `fields` to `specializedFieldEncoders`. The type of this property is `KeyedFieldEncoders`, so having the term `encoder` in the name seems more appropriate. Also, it contains the keys of fields for which specialized encoding is provided for optimization.
- In `NodeShape`, renamed the property `extraLocal` to `otherFieldsEncoder`. This property is an encoder for fields that aren't in `specializedFieldEncoders`.
- In `NodeShape`, renamed the property `explicitKeys` to `specializedFieldKeys`. This property contains the keys of fields which are encoded using `specializedFieldEncoders`.
