### PR TITLE
Test: Move test function to test package: createDataStoreFactory

### DIFF
--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -5,11 +5,6 @@
 
 import { IRequest, IResponse } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import {
-	IFluidDataStoreFactory,
-	IFluidDataStoreRegistry,
-	IProvideFluidDataStoreRegistry,
-} from "@fluidframework/runtime-definitions/internal";
 import { generateErrorWithStack } from "@fluidframework/telemetry-utils/internal";
 
 interface IResponseException extends Error {
@@ -102,31 +97,5 @@ export function createResponseError(
 			return errWithStack.stack;
 		},
 		headers,
-	};
-}
-
-/**
- * @internal
- */
-export type Factory = IFluidDataStoreFactory & Partial<IProvideFluidDataStoreRegistry>;
-
-/**
- * @internal
- */
-export function createDataStoreFactory(
-	type: string,
-	factory: Factory | Promise<Factory>,
-): IFluidDataStoreFactory & IFluidDataStoreRegistry {
-	return {
-		type,
-		get IFluidDataStoreFactory() {
-			return this;
-		},
-		get IFluidDataStoreRegistry() {
-			return this;
-		},
-		instantiateDataStore: async (context, existing) =>
-			(await factory).instantiateDataStore(context, existing),
-		get: async (name: string) => (await factory).IFluidDataStoreRegistry?.get(name),
 	};
 }

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -6,10 +6,8 @@
 export { generateHandleContextPath } from "./dataStoreHandleContextUtils.js";
 export {
 	create404Response,
-	createDataStoreFactory,
 	createResponseError,
 	exceptionToResponse,
-	Factory,
 	responseToException,
 } from "./dataStoreHelpers.js";
 export {

--- a/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
@@ -25,12 +25,12 @@ import {
 } from "@fluidframework/local-driver/internal";
 import { SharedDirectory, type ISharedMap, SharedMap } from "@fluidframework/map/internal";
 import { FlushMode, IEnvelope } from "@fluidframework/runtime-definitions/internal";
-import { createDataStoreFactory } from "@fluidframework/runtime-utils/internal";
 import { SharedString } from "@fluidframework/sequence/internal";
 import {
 	ILocalDeltaConnectionServer,
 	LocalDeltaConnectionServer,
 } from "@fluidframework/server-local-server";
+import { createDataStoreFactory } from "@fluidframework/test-utils/internal";
 import {
 	createAndAttachContainerUsingProps,
 	ITestFluidObject,

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -22,8 +22,8 @@ import type { SharedMatrix } from "@fluidframework/matrix/internal";
 import type { ConsensusOrderedCollection } from "@fluidframework/ordered-collection/internal";
 import type { ConsensusRegisterCollection } from "@fluidframework/register-collection/internal";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions/internal";
-import { createDataStoreFactory } from "@fluidframework/runtime-utils/internal";
 import type { SequenceInterval, SharedString } from "@fluidframework/sequence/internal";
+import { createDataStoreFactory } from "@fluidframework/test-utils/internal";
 import {
 	ITestFluidObject,
 	ITestObjectProvider,

--- a/packages/test/test-utils/src/index.ts
+++ b/packages/test/test-utils/src/index.ts
@@ -9,6 +9,8 @@ export {
 	fluidEntryPoint,
 	LocalCodeLoader,
 	SupportedExportInterfaces,
+	Factory,
+	createDataStoreFactory,
 } from "./localCodeLoader.js";
 export {
 	createAndAttachContainer,


### PR DESCRIPTION
The function createDataStoreFactory is only used in test and doesn't make sense out of a test context. So, moving this function to a better location in a test package.