### PR TITLE
[Staging Mode] Revert Deferred Handles code

### DIFF
--- a/packages/dds/shared-object-base/src/handle.ts
+++ b/packages/dds/shared-object-base/src/handle.ts
@@ -56,7 +56,8 @@ export class SharedObjectHandle extends FluidObjectHandle<ISharedObject> {
 
 	public bind(handle: IFluidHandleInternal): void {
 		// We don't bind handles in staging mode to defer the attachment of any new objects
-		// until we've exited staging mode. This way if a new object is "squashed away" it will never sync.
+		// until we've exited staging mode. This way if we discard changes or a new handle is not present in the final
+		// committed state, we will never end up attaching the discarded object.
 		if (this.runtime.inStagingMode !== true) {
 			super.bind(handle);
 		}

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -243,6 +243,7 @@ export class FluidSerializer implements IFluidSerializer {
 		if (this.runtime.inStagingMode === true) {
 			this.deferedHandleMap.set(handle.absolutePath, handle);
 		} else {
+			//* NEXT: Remove this if-else, since SharedObjectHandle is handling this in its bind method
 			bind.bind(handle);
 		}
 		return encodeHandleForSerialization(handle);

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -776,7 +776,7 @@ export abstract class SharedObject<
 	) {
 		super(id, runtime, attributes);
 
-		this._serializer = new FluidSerializer(this.runtime);
+		this._serializer = new FluidSerializer(this.runtime.IFluidHandleContext);
 	}
 
 	/**
@@ -841,7 +841,7 @@ export abstract class SharedObject<
 
 		let gcData: IGarbageCollectionData;
 		try {
-			const handleVisitor = new GCHandleVisitor(this.runtime);
+			const handleVisitor = new GCHandleVisitor(this.runtime.IFluidHandleContext);
 			this.processGCDataCore(handleVisitor);
 			// The GC data for this shared object contains a single GC node. The outbound routes of this node are the
 			// routes of handles serialized during summarization.

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -20,6 +20,8 @@ import {
 	type IChannelFactory,
 	IFluidDataStoreRuntime,
 	type IDeltaHandler,
+	// eslint-disable-next-line import/no-deprecated
+	type IFluidDataStoreRuntimeExperimental,
 } from "@fluidframework/datastore-definitions/internal";
 import {
 	type IDocumentMessage,
@@ -144,7 +146,12 @@ export abstract class SharedObjectCore<
 
 		assert(!id.includes("/"), 0x304 /* Id cannot contain slashes */);
 
-		this.handle = new SharedObjectHandle(this, id, runtime.IFluidHandleContext);
+		this.handle = new SharedObjectHandle(
+			this,
+			id,
+			// eslint-disable-next-line import/no-deprecated
+			runtime as IFluidDataStoreRuntimeExperimental,
+		);
 
 		this.logger = createChildLogger({
 			logger: runtime.logger,

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -96,10 +96,7 @@ class MySharedObjectCore extends SharedObjectCore {
 		return true;
 	}
 
-	protected readonly serializer = new FluidSerializer({
-		inStagingMode: false,
-		channelsRoutingContext: {} as unknown as IFluidHandleContext,
-	});
+	protected readonly serializer = new FluidSerializer({} as unknown as IFluidHandleContext);
 
 	protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats {
 		throw new Error("Method not implemented.");

--- a/packages/dds/tree/src/test/mockSerializer.ts
+++ b/packages/dds/tree/src/test/mockSerializer.ts
@@ -32,7 +32,4 @@ class MockHandleContext implements IFluidHandleContext {
  *
  * Mainly useful when an IFluidSerializer is required but when handles being encoded don't need to be decoded and resolved.
  */
-export const mockSerializer = new FluidSerializer({
-	channelsRoutingContext: new MockHandleContext(),
-	inStagingMode: false,
-});
+export const mockSerializer = new FluidSerializer(new MockHandleContext());

--- a/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
@@ -8,7 +8,7 @@ import {
 	IFluidHandleContext,
 	type IFluidHandleInternal,
 } from "@fluidframework/core-interfaces/internal";
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import { responseToException } from "./dataStoreHelpers.js";
 import { FluidHandleBase } from "./handles.js";
@@ -66,6 +66,6 @@ export class RemoteFluidObjectHandle extends FluidHandleBase<FluidObject> {
 	}
 
 	public bind(handle: IFluidHandleInternal): void {
-		handle.attachGraph();
+		fail("RemoteFluidObjectHandle not supported as a bind source");
 	}
 }

--- a/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
@@ -8,7 +8,7 @@ import {
 	IFluidHandleContext,
 	type IFluidHandleInternal,
 } from "@fluidframework/core-interfaces/internal";
-import { assert, fail } from "@fluidframework/core-utils/internal";
+import { assert } from "@fluidframework/core-utils/internal";
 
 import { responseToException } from "./dataStoreHelpers.js";
 import { FluidHandleBase } from "./handles.js";
@@ -66,6 +66,6 @@ export class RemoteFluidObjectHandle extends FluidHandleBase<FluidObject> {
 	}
 
 	public bind(handle: IFluidHandleInternal): void {
-		fail("RemoteFluidObjectHandle not supported as a bind source");
+		handle.attachGraph();
 	}
 }

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTestSummaryUtils.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTestSummaryUtils.ts
@@ -165,7 +165,7 @@ export function manufactureHandle<T>(
 	runtime: IFluidDataStoreRuntime,
 	url: string,
 ): IFluidHandleInternal<T> {
-	const serializer = new FluidSerializer(runtime);
+	const serializer = new FluidSerializer(runtime.IFluidHandleContext);
 	const handle: IFluidHandleInternal<T> = parseHandles(
 		{ type: "__fluid_handle__", url },
 		serializer,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -579,7 +579,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 					unreferencedId,
 				);
 
-				const serializer = new FluidSerializer(dataObject._runtime);
+				const serializer = new FluidSerializer(dataObject._runtime.IFluidHandleContext);
 				const handle: IFluidHandle = parseHandles(
 					{ type: "__fluid_handle__", url: `/${unreferencedId}` },
 					serializer,


### PR DESCRIPTION
## Description

Fixes [AB#36351](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/36351)

Now that we are retaining the original runtime op in Pending State Manager (See #24364), we no longer need to track deferred handles in Serializer.

Additionally we can move the Staging Mode check into the implementation of `IFluidHandle.bind`, removing it from the serializer code.

### Change of plan

The plan of record was to move the bind call up to DataStoreRuntime layer, but this is more expedient without breaking abstractions IMO.
