### PR TITLE
Correct AuthorizationError field declarations for ES 2022

### DIFF
--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -115,7 +115,7 @@ export class AuthorizationError
 
 	// These properties are not assigned in this class, but instead assigned in the super constructor.
 	// When targeting ES 2022 or later, TypeScript generates ES6 class fields for these properties.
-	// This override the own properties dynamically created by the super constructor.
+	// This overrides the own properties dynamically created by the super constructor.
 	// To prevent this undesired overriding,
 	// these are declared using `declare` to indicate this definition is only for the TypeScript typing,
 	// and the actual fields come from elsewhere.

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -112,8 +112,16 @@ export class AuthorizationError
 	implements IAuthorizationError, IFluidErrorBase
 {
 	readonly errorType = DriverErrorTypes.authorizationError;
-	readonly claims?: string;
-	readonly tenantId?: string;
+
+	// These properties are not assigned in this class, but instead assigned in the super constructor.
+	// When targeting ES 2022 or later, TypeScript generates ES6 class fields for these properties.
+	// This override the own properties dynamically created by the super constructor.
+	// To prevent this undesired overriding,
+	// // these are declared using `declare` to indicate this definition is only for the TypeScript typing,
+	// and the actual fields come from elsewhere.
+	declare readonly claims?: string;
+	declare readonly tenantId?: string;
+
 	readonly canRetry = false;
 
 	constructor(

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -114,8 +114,9 @@ export class AuthorizationError
 	readonly errorType = DriverErrorTypes.authorizationError;
 
 	// These properties are not assigned in this class, but instead assigned in the super constructor.
-	// When targeting ES 2022 or later, TypeScript generates ES6 class fields for these properties.
-	// This overrides the own properties dynamically created by the super constructor.
+	// When targeting ES 2022 or later, TypeScript would generate ES6 class fields for these properties if they did not use "declare".
+	// That would override the own properties dynamically created in the super constructor
+	// resulting in these properties always holding `undefined` instead of their desired values.
 	// To prevent this undesired overriding,
 	// these are declared using `declare` to indicate this definition is only for the TypeScript typing,
 	// and the actual fields come from elsewhere.

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -117,7 +117,7 @@ export class AuthorizationError
 	// When targeting ES 2022 or later, TypeScript generates ES6 class fields for these properties.
 	// This override the own properties dynamically created by the super constructor.
 	// To prevent this undesired overriding,
-	// // these are declared using `declare` to indicate this definition is only for the TypeScript typing,
+	// these are declared using `declare` to indicate this definition is only for the TypeScript typing,
 	// and the actual fields come from elsewhere.
 	declare readonly claims?: string;
 	declare readonly tenantId?: string;


### PR DESCRIPTION
## Description

Fix `AuthorizationError.claims` and `AuthorizationError.tenantId` so they don't shadow the actual values from the super constructor that are manually copied onto the `this` object when TypeScript introduces an ES6 class fields by targeting ES 2022.

Issue detected by https://github.com/microsoft/FluidFramework/pull/24324

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

