### PR TITLE
improvement(client-container-runtime): compat utils cleanup

### DIFF
--- a/packages/runtime/container-runtime/src/compatUtils.ts
+++ b/packages/runtime/container-runtime/src/compatUtils.ts
@@ -16,48 +16,68 @@ import {
 	disabledCompressionConfig,
 	enabledCompressionConfig,
 } from "./compressionDefinitions.js";
-import { type IContainerRuntimeOptionsInternal } from "./containerRuntime.js";
+import type { IContainerRuntimeOptionsInternal } from "./containerRuntime.js";
 import { pkgVersion } from "./packageVersion.js";
 
 /**
- * Our policy is to support N/N-1 compatibility by default, where N is the most recent public major release of the runtime.
- * Therefore, if the customer does not provide a compatibility mode, we will default to use N-1.
+ * Our policy is to support N/N-1 compatibility by default, where N is the most
+ * recent public major release of the runtime.
+ * Therefore, if the customer does not provide a compatibility mode, we will
+ * default to use N-1.
  *
- * However, this is not consistent with today's behavior. Some options (i.e. batching, compression) are enabled by default
- * despite not being compatible with 1.x clients. Since the policy was introduced during 2.x's lifespan, N/N-1 compatibility
- * by **default** will be in effect starting with 3.0. Importantly though, N/N-1 compatibility is still guaranteed with the
- * proper configurations set.
+ * However, this is not consistent with today's behavior. Some options (i.e.
+ * batching, compression) are enabled by default despite not being compatible
+ * with 1.x clients. Since the policy was introduced during 2.x's lifespan,
+ * N/N-1 compatibility by **default** will be in effect starting with 3.0.
+ * Importantly though, N/N-1 compatibility is still guaranteed with the proper
+ * configurations set.
  *
+ * Further to distinguish unspecified `compatibilityVersion` from a specified
+ * version and allow `enableExplicitSchemaControl` to default to `true` for
+ * any 2.0.0+ version, we will use a special value of `2.0.0-defaults`, which
+ * is semantically less than 2.0.0.
  */
-export const defaultCompatibilityMode = "2.0.0" as const;
+export const defaultCompatibilityVersion = "2.0.0-defaults" as const;
 
 /**
- * String in a valid semver format.
+ * String in a valid semver format specifying bottom of a minor version
+ * or special "defaults" prerelease of a major.
+ * @remarks Only 2.0.0-defaults is expected, but index signatures cannot be a
+ * literal; so, just allow any major -defaults prerelease.
+ */
+export type MinimumMinorSemanticVersion = `${bigint}.${bigint}.0` | `${bigint}.0.0-defaults`;
+
+/**
+ * String in a valid semver format of a specific version at least specifying minor.
  */
 export type SemanticVersion =
-	| `${number}.${number}.${number}`
-	| `${number}.${number}.${number}-${string}`;
+	| `${bigint}.${bigint}.${bigint}`
+	| `${bigint}.${bigint}.${bigint}-${string}`;
 
 /**
  * Generic type for runtimeOptionsAffectingDocSchemaConfigMap
  */
 export type ConfigMap<T extends Record<string, unknown>> = {
-	[K in keyof T]: {
-		[version: SemanticVersion]: T[K];
+	[K in keyof T]-?: {
+		[version: MinimumMinorSemanticVersion]: T[K];
 	};
 };
 
 /**
- * Subset of the IContainerRuntimeOptionsInternal properties which affect the DocumentSchema.
+ * Subset of the {@link IContainerRuntimeOptionsInternal} properties which
+ * affect {@link IDocumentSchemaFeatures}.
  *
  * @remarks
- * When a new option is added to IContainerRuntimeOptionsInternal, we must consider if it changes the DocumentSchema.
- * If so, then a corresponding entry must be added to `runtimeOptionsAffectingDocSchemaConfigMap` below. If not, then
- * it must be omitted from this type.
+ * When a new option is added to {@link IContainerRuntimeOptionsInternal}, we
+ * must consider if it changes the DocumentSchema. If so, then a corresponding
+ * entry must be added to {@link runtimeOptionsAffectingDocSchemaConfigMap}
+ * below. If not, then it must be omitted from this type.
  *
- * Note: We use `Omit` instead of `Pick` to ensure that all new options are included in this type by default. If any new properties
- * are added to IContainerRuntimeOptionsInternal, they will be included in this type unless explicitly omitted. This will prevent
- * us from forgetting to account for any new properties in the future.
+ * Note: `Omit` is used instead of `Pick` to ensure that all new options are
+ * included in this type by default. If any new properties are added to
+ * {@link IContainerRuntimeOptionsInternal}, they will be included in this
+ * type unless explicitly omitted. This will prevent us from forgetting to
+ * account for any new properties in the future.
  */
 export type RuntimeOptionsAffectingDocSchema = Required<
 	Omit<
@@ -82,59 +102,78 @@ export type RuntimeOptionsAffectingDocSchema = Required<
  * default value for `enableGroupedBatching` will be true because clients running 2.0 or later will be able to understand the format changes associated
  * with the batching feature.
  */
-const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffectingDocSchema> =
-	{
-		enableGroupedBatching: {
-			"1.0.0": false,
-			"2.0.0": true,
-		},
-		compressionOptions: {
-			"1.0.0": disabledCompressionConfig,
-			"2.0.0": enabledCompressionConfig,
-		},
-		enableRuntimeIdCompressor: {
-			// For IdCompressorMode, `undefined` represents a logical state (off). However, to satisfy the Required<>
-			// constraint we need to have it defined, so we trick the type checker here.
-			"1.0.0": undefined as unknown as "on" | "delayed",
-			// We do not yet want to enable idCompressor by default since it will increase bundle sizes,
-			// and not all customers will benefit from it. Therefore, we will require customers to explicitly
-			// enable it. We are keeping it as a DocSchema affecting option for now as this may change in the future.
-		},
-		explicitSchemaControl: {
-			"1.0.0": false,
-			// This option's intention is to prevent 1.x clients from joining sessions when enabled. Ideally, we would set this to true
-			// when the compatibility mode is set to >=2.0.0. However, this option is unique because it was not enabled by default prior
-			// to the implementation of compatibilityMode. Because `defaultCompatibilityMode` is set to "2.0.0", we need to ensure this option
-			// is not suddenly enabled by default unexpectedly. Therefore, we will set it to true starting at compatibilityMode>="2.0.1" to
-			// ensure that customers who do not provide compatibilityMode will not see any behavior change.
-			"2.0.1": true,
-		},
-		flushMode: {
-			// Note: 1.x clients are compatible with TurnBased flushing, but here we elect to remain on Immediate flush mode
-			// as a work-around for inability to send batches larger than 1Mb. Immediate flushing keeps batches smaller as
-			// fewer messages will be included per flush.
-			"1.0.0": FlushMode.Immediate,
-			"2.0.0": FlushMode.TurnBased,
-		},
-		gcOptions: {
-			"1.0.0": {},
-			// Although sweep is supported in 2.x, it is disabled by default until compatibilityMode>=3.0.0 to be extra safe.
-			"3.0.0": { enableGCSweep: true },
-		},
-	};
+const runtimeOptionsAffectingDocSchemaConfigMap = {
+	enableGroupedBatching: {
+		"1.0.0": false,
+		"2.0.0-defaults": true,
+	} as const,
+	compressionOptions: {
+		"1.0.0": disabledCompressionConfig,
+		"2.0.0-defaults": enabledCompressionConfig,
+	} as const,
+	enableRuntimeIdCompressor: {
+		// For IdCompressorMode, `undefined` represents a logical state (off).
+		// However, to satisfy the Required<> constraint while
+		// `exactOptionalPropertyTypes` is `false` (TODO: AB#34168), we need
+		// to have it defined, so we trick the type checker here.
+		"1.0.0": undefined as unknown as "on" | "delayed",
+		// We do not yet want to enable idCompressor by default since it will
+		// increase bundle sizes, and not all customers will benefit from it.
+		// Therefore, we will require customers to explicitly enable it. We
+		// are keeping it as a DocSchema affecting option for now as this may
+		// change in the future.
+	} as const,
+	explicitSchemaControl: {
+		"1.0.0": false,
+		// This option's intention is to prevent 1.x clients from joining sessions
+		// when enabled. This is set to true when the compatibility version is set
+		// to >=2.0.0 (explicitly). This is different than other 2.0 defaults
+		// because it was not enabled by default prior to the implementation of
+		// `compatibilityVersion`.
+		// `defaultCompatibilityVersion` is set to "2.0.0-defaults" which "2.0.0"
+		// does not satisfy to avoiding enabling this option by default as of
+		// `compatibilityVersion` introduction, which could be unexpected.
+		// Only enable as a default when `compatibilityVersion` is specified at
+		// 2.0.0+.
+		"2.0.0": true,
+	} as const,
+	flushMode: {
+		// Note: 1.x clients are compatible with TurnBased flushing, but here we elect to remain on Immediate flush mode
+		// as a work-around for inability to send batches larger than 1Mb. Immediate flushing keeps batches smaller as
+		// fewer messages will be included per flush.
+		"1.0.0": FlushMode.Immediate,
+		"2.0.0-defaults": FlushMode.TurnBased,
+	} as const,
+	gcOptions: {
+		"1.0.0": {},
+		// Although sweep is supported in 2.x, it is disabled by default until compatibilityMode>=3.0.0 to be extra safe.
+		"3.0.0": { enableGCSweep: true },
+	} as const,
+} as const satisfies ConfigMap<RuntimeOptionsAffectingDocSchema>;
 
 /**
- * Returns the default RuntimeOptionsAffectingDocSchema configuration for a given compatibility mode.
+ * Returns the default RuntimeOptionsAffectingDocSchema configuration for a given compatibility version.
  */
-export function getConfigsForCompatMode<
-	T extends Record<string, unknown> = RuntimeOptionsAffectingDocSchema,
->(
-	compatibilityMode: SemanticVersion,
-	// We allow passing in a custom configMap for unit tests. Otherwise, we should never need to pass in a configMap.
-	configMap: ConfigMap<T> = runtimeOptionsAffectingDocSchemaConfigMap as ConfigMap<T>,
-): T {
-	const defaultConfigs = {};
-	// Iterate over runtimeOptionsAffectingDocSchemaConfigMap to get default values for each option.
+export function getCompatibilityVersionDefaults(
+	compatibilityVersion: SemanticVersion,
+): RuntimeOptionsAffectingDocSchema {
+	return getConfigsForCompatMode(
+		compatibilityVersion,
+		runtimeOptionsAffectingDocSchemaConfigMap,
+		// This is a bad cast away from Partial that getConfigsForCompatMode provides.
+		// ConfigMap should be restructured to provide RuntimeOptionsAffectingDocSchema guarantee.
+	) as RuntimeOptionsAffectingDocSchema;
+}
+
+/**
+ * Returns a default configuration given compatibility version and configuration version map.
+ */
+export function getConfigsForCompatMode<T extends Record<SemanticVersion, unknown>>(
+	compatibilityVersion: SemanticVersion,
+	configMap: ConfigMap<T>,
+): Partial<T> {
+	const defaultConfigs: Partial<T> = {};
+	// Iterate over configMap to get default values for each option.
 	for (const key of Object.keys(configMap)) {
 		const config = configMap[key as keyof T];
 		// Sort the versions in ascending order so we can short circuit the loop.
@@ -143,8 +182,8 @@ export function getConfigsForCompatMode<
 		// If so, we set it as the default value for the option. At the end of the loop we should have the most recent default
 		// value that is compatible with the version specified as the compatibilityMode.
 		for (const version of versions) {
-			if (semverGte(compatibilityMode, version)) {
-				defaultConfigs[key] = config[version as SemanticVersion];
+			if (semverGte(compatibilityVersion, version)) {
+				defaultConfigs[key] = config[version as MinimumMinorSemanticVersion];
 			} else {
 				// If the compatibility mode is less than the version, we break out of the loop since we don't need to check
 				// any later versions.
@@ -152,17 +191,17 @@ export function getConfigsForCompatMode<
 			}
 		}
 	}
-	return defaultConfigs as T;
+	return defaultConfigs;
 }
 
 /**
- * Checks if the compatibility mode is valid.
- * A valid compatibility mode is a string that is a valid semver version and is less than or equal to the current package version.
+ * Checks if the compatibility version is valid.
+ * A valid compatibility version is a string that is a valid semver version and is less than or equal to the current package version.
  */
-export function isValidCompatMode(compatibilityMode: SemanticVersion): boolean {
+export function isValidCompatVersion(compatibilityVersion: SemanticVersion): boolean {
 	return (
-		compatibilityMode !== undefined &&
-		semverValid(compatibilityMode) !== null &&
-		semverLte(compatibilityMode, pkgVersion)
+		compatibilityVersion !== undefined &&
+		semverValid(compatibilityVersion) !== null &&
+		semverLte(compatibilityVersion, pkgVersion)
 	);
 }

--- a/packages/runtime/container-runtime/src/compatUtils.ts
+++ b/packages/runtime/container-runtime/src/compatUtils.ts
@@ -30,7 +30,7 @@ import type { IdCompressorMode } from "./summary/index.js";
  * batching, compression) are enabled by default despite not being compatible
  * with 1.x clients. Since the policy was introduced during 2.x's lifespan,
  * N/N-1 compatibility by **default** will be in effect starting with 3.0.
- * Importantly though, N/N-1 compatibility is still guaranteed with the proper
+ * Importantly though, N/N-2 compatibility is still guaranteed with the proper
  * configurations set.
  *
  * Further to distinguish unspecified `compatibilityVersion` from a specified

--- a/packages/runtime/container-runtime/src/compressionDefinitions.ts
+++ b/packages/runtime/container-runtime/src/compressionDefinitions.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { ICompressionRuntimeOptions } from "./containerRuntime.js";
-
 /**
  * Available compression algorithms for op compression.
  * @legacy
@@ -12,6 +10,25 @@ import type { ICompressionRuntimeOptions } from "./containerRuntime.js";
  */
 export enum CompressionAlgorithms {
 	lz4 = "lz4",
+}
+
+/**
+ * Options for op compression.
+ * @legacy
+ * @alpha
+ */
+export interface ICompressionRuntimeOptions {
+	/**
+	 * The value the batch's content size must exceed for the batch to be compressed.
+	 * By default the value is 600 * 1024 = 614400 bytes. If the value is set to `Infinity`, compression will be disabled.
+	 */
+	readonly minimumBatchSizeInBytes: number;
+
+	/**
+	 * The compression algorithm that will be used to compress the op.
+	 * By default the value is `lz4` which is the only compression algorithm currently supported.
+	 */
+	readonly compressionAlgorithm: CompressionAlgorithms;
 }
 
 /**
@@ -23,8 +40,8 @@ export const disabledCompressionConfig: ICompressionRuntimeOptions = {
 	compressionAlgorithm: CompressionAlgorithms.lz4,
 };
 
-export const enabledCompressionConfig: ICompressionRuntimeOptions = {
+export const enabledCompressionConfig = {
 	// Batches with content size exceeding this value will be compressed
 	minimumBatchSizeInBytes: 614400,
 	compressionAlgorithm: CompressionAlgorithms.lz4,
-};
+} as const satisfies ICompressionRuntimeOptions;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -763,7 +763,7 @@ export class ContainerRuntime
 		// For example, if compatibility mode is set to "1.0.0", the default configs will ensure compatibility with FF runtime
 		// 1.0.0 or later. If the compatibility mode is set to "2.10.0", the default values will be generated to ensure compatibility
 		// with FF runtime 2.10.0 or later.
-		// TODO: We will add in a way for users to pass in compatibilityMode in a follow up PR.
+		// TODO: We will add in a way for users to pass in compatibilityVersion in a follow up PR.
 		const compatibilityVersion = defaultCompatibilityVersion;
 		if (!isValidCompatVersion(compatibilityVersion)) {
 			throw new UsageError(

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -14,9 +14,9 @@ export {
 	DeletedResponseHeaderKey,
 	TombstoneResponseHeaderKey,
 	InactiveResponseHeaderKey,
-	ICompressionRuntimeOptions,
 	RuntimeHeaderData,
 } from "./containerRuntime.js";
+export type { ICompressionRuntimeOptions } from "./compressionDefinitions.js";
 export { CompressionAlgorithms, disabledCompressionConfig } from "./compressionDefinitions.js";
 export {
 	ContainerMessageType,

--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -10,7 +10,7 @@ import {
 	TelemetryDataTag,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { ICompressionRuntimeOptions } from "../containerRuntime.js";
+import { ICompressionRuntimeOptions } from "../compressionDefinitions.js";
 import { asBatchMetadata, type IBatchMetadata } from "../metadata.js";
 import type { IPendingMessage } from "../pendingStateManager.js";
 

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -17,7 +17,7 @@ import {
 	type ITelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { ICompressionRuntimeOptions } from "../containerRuntime.js";
+import { ICompressionRuntimeOptions } from "../compressionDefinitions.js";
 import { PendingMessageResubmitData, PendingStateManager } from "../pendingStateManager.js";
 
 import {

--- a/packages/runtime/container-runtime/src/test/compatUtils.spec.ts
+++ b/packages/runtime/container-runtime/src/test/compatUtils.spec.ts
@@ -62,11 +62,11 @@ describe("compatUtils", () => {
 		};
 
 		const testCases: {
-			compatibilityMode: SemanticVersion;
+			compatibilityVersion: SemanticVersion;
 			expectedConfig: Partial<ITestConfigMap>;
 		}[] = [
 			{
-				compatibilityMode: "0.5.0",
+				compatibilityVersion: "0.5.0",
 				expectedConfig: {
 					featureA: "a1",
 					featureB: "b1",
@@ -77,7 +77,7 @@ describe("compatUtils", () => {
 				},
 			},
 			{
-				compatibilityMode: "1.0.0",
+				compatibilityVersion: "1.0.0",
 				expectedConfig: {
 					featureA: "a1",
 					featureB: "b1",
@@ -88,7 +88,7 @@ describe("compatUtils", () => {
 				},
 			},
 			{
-				compatibilityMode: "1.5.0",
+				compatibilityVersion: "1.5.0",
 				expectedConfig: {
 					featureA: "a1",
 					featureB: "b1",
@@ -99,7 +99,7 @@ describe("compatUtils", () => {
 				},
 			},
 			{
-				compatibilityMode: "2.0.0",
+				compatibilityVersion: "2.0.0",
 				expectedConfig: {
 					featureA: "a2",
 					featureB: "b1",
@@ -110,7 +110,7 @@ describe("compatUtils", () => {
 				},
 			},
 			{
-				compatibilityMode: "2.1.5",
+				compatibilityVersion: "2.1.5",
 				expectedConfig: {
 					featureA: "a2",
 					featureB: "b1",
@@ -121,7 +121,7 @@ describe("compatUtils", () => {
 				},
 			},
 			{
-				compatibilityMode: "2.5.0",
+				compatibilityVersion: "2.5.0",
 				expectedConfig: {
 					featureA: "a2",
 					featureB: "b1",
@@ -132,7 +132,7 @@ describe("compatUtils", () => {
 				},
 			},
 			{
-				compatibilityMode: "3.0.0",
+				compatibilityVersion: "3.0.0",
 				expectedConfig: {
 					featureA: "a2",
 					featureB: "b2",
@@ -143,7 +143,7 @@ describe("compatUtils", () => {
 				},
 			},
 			{
-				compatibilityMode: "3.7.2",
+				compatibilityVersion: "3.7.2",
 				expectedConfig: {
 					featureA: "a2",
 					featureB: "b2",
@@ -154,7 +154,7 @@ describe("compatUtils", () => {
 				},
 			},
 			{
-				compatibilityMode: "5.0.1",
+				compatibilityVersion: "5.0.1",
 				expectedConfig: {
 					featureA: "a3",
 					featureB: "b2",
@@ -165,7 +165,7 @@ describe("compatUtils", () => {
 				},
 			},
 			{
-				compatibilityMode: "6.9.9",
+				compatibilityVersion: "6.9.9",
 				expectedConfig: {
 					featureA: "a3",
 					featureB: "b3",
@@ -176,7 +176,7 @@ describe("compatUtils", () => {
 				},
 			},
 			{
-				compatibilityMode: "8.2.3",
+				compatibilityVersion: "8.2.3",
 				expectedConfig: {
 					featureA: "a4",
 					featureB: "b3",
@@ -187,7 +187,7 @@ describe("compatUtils", () => {
 				},
 			},
 			{
-				compatibilityMode: "9.7.0",
+				compatibilityVersion: "9.7.0",
 				expectedConfig: {
 					featureA: "a4",
 					featureB: "b4",
@@ -198,7 +198,7 @@ describe("compatUtils", () => {
 				},
 			},
 			{
-				compatibilityMode: "10.0.0",
+				compatibilityVersion: "10.0.0",
 				expectedConfig: {
 					featureA: "a4",
 					featureB: "b4",
@@ -211,12 +211,12 @@ describe("compatUtils", () => {
 		];
 
 		for (const testCase of testCases) {
-			it(`returns correct configs for compatibilityMode = "${testCase.compatibilityMode}"`, () => {
-				const config = getConfigsForCompatMode(testCase.compatibilityMode, testConfigMap);
+			it(`returns correct configs for compatibilityVersion = "${testCase.compatibilityVersion}"`, () => {
+				const config = getConfigsForCompatMode(testCase.compatibilityVersion, testConfigMap);
 				assert.deepEqual(
 					config,
 					testCase.expectedConfig,
-					`Failed for compatibilityMode: ${testCase.compatibilityMode}`,
+					`Failed for compatibilityVersion: ${testCase.compatibilityVersion}`,
 				);
 			});
 		}

--- a/packages/runtime/container-runtime/src/test/compatUtils.spec.ts
+++ b/packages/runtime/container-runtime/src/test/compatUtils.spec.ts
@@ -13,9 +13,15 @@ import {
 
 describe("compatUtils", () => {
 	describe("getConfigsForCompatMode", () => {
-		interface ITestConfigMap {
-			[key: string]: string;
-		}
+		// eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- type required for ConfigMap processing
+		type ITestConfigMap = {
+			featureA: string;
+			featureB: string;
+			featureC: string;
+			featureD: string;
+			featureE: string;
+			featureF: string;
+		};
 		const testConfigMap: ConfigMap<ITestConfigMap> = {
 			featureA: {
 				"0.5.0": "a1",
@@ -24,7 +30,7 @@ describe("compatUtils", () => {
 				"5.0.0": "a3",
 			},
 			featureB: {
-				"0.0.1": "b1",
+				"0.0.0-defaults": "b1",
 				"3.0.0": "b2",
 				"9.0.0": "b4",
 				"6.0.0": "b3",
@@ -57,7 +63,7 @@ describe("compatUtils", () => {
 
 		const testCases: {
 			compatibilityMode: SemanticVersion;
-			expectedConfig: Record<string, string | undefined>;
+			expectedConfig: Partial<ITestConfigMap>;
 		}[] = [
 			{
 				compatibilityMode: "0.5.0",
@@ -206,10 +212,7 @@ describe("compatUtils", () => {
 
 		for (const testCase of testCases) {
 			it(`returns correct configs for compatibilityMode = "${testCase.compatibilityMode}"`, () => {
-				const config = getConfigsForCompatMode<ITestConfigMap>(
-					testCase.compatibilityMode,
-					testConfigMap,
-				);
+				const config = getConfigsForCompatMode(testCase.compatibilityMode, testConfigMap);
 				assert.deepEqual(
 					config,
 					testCase.expectedConfig,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -73,7 +73,7 @@ import {
 import { SinonFakeTimers, createSandbox, useFakeTimers } from "sinon";
 
 import { ChannelCollection } from "../channelCollection.js";
-import { getConfigsForCompatMode } from "../compatUtils.js";
+import { getCompatibilityVersionDefaults } from "../compatUtils.js";
 import { CompressionAlgorithms } from "../compressionDefinitions.js";
 import {
 	ContainerRuntime,
@@ -3665,7 +3665,7 @@ describe("Runtime", () => {
 
 			it("compatibilityMode = 1.0.0", async () => {
 				const compatibilityMode = "1.0.0";
-				const defaultRuntimeOptions = getConfigsForCompatMode(compatibilityMode);
+				const defaultRuntimeOptions = getCompatibilityVersionDefaults(compatibilityMode);
 				const logger = new MockLogger();
 				await ContainerRuntime.loadRuntime({
 					context: getMockContext({ logger }) as IContainerContext,
@@ -3700,9 +3700,9 @@ describe("Runtime", () => {
 				]);
 			});
 
-			it("compatibilityMode = 2.0.0", async () => {
-				const compatibilityMode = "2.0.0";
-				const defaultRuntimeOptions = getConfigsForCompatMode(compatibilityMode);
+			it('compatibilityMode = 2.0.0-defaults ("default")', async () => {
+				const compatibilityMode = "2.0.0-defaults";
+				const defaultRuntimeOptions = getCompatibilityVersionDefaults(compatibilityMode);
 				const logger = new MockLogger();
 				await ContainerRuntime.loadRuntime({
 					context: getMockContext({ logger }) as IContainerContext,
@@ -3737,9 +3737,46 @@ describe("Runtime", () => {
 				]);
 			});
 
+			it("compatibilityMode = 2.0.0 (explicit)", async () => {
+				const compatibilityMode = "2.0.0";
+				const defaultRuntimeOptions = getCompatibilityVersionDefaults(compatibilityMode);
+				const logger = new MockLogger();
+				await ContainerRuntime.loadRuntime({
+					context: getMockContext({ logger }) as IContainerContext,
+					registryEntries: [],
+					existing: false,
+					runtimeOptions: defaultRuntimeOptions,
+					provideEntryPoint: mockProvideEntryPoint,
+				});
+
+				const expectedRuntimeOptions: IContainerRuntimeOptionsInternal = {
+					summaryOptions: {},
+					gcOptions: {},
+					loadSequenceNumberVerification: "close",
+					flushMode: FlushMode.TurnBased,
+					compressionOptions: {
+						minimumBatchSizeInBytes: 614400,
+						compressionAlgorithm: CompressionAlgorithms.lz4,
+					},
+					maxBatchSizeInBytes: 716800,
+					chunkSizeInBytes: 204800,
+					enableRuntimeIdCompressor: undefined,
+					enableGroupedBatching: true,
+					explicitSchemaControl: true,
+				};
+
+				logger.assertMatchAny([
+					{
+						eventName: "ContainerRuntime:ContainerLoadStats",
+						category: "generic",
+						options: JSON.stringify(expectedRuntimeOptions),
+					},
+				]);
+			});
+
 			it("compatibilityMode = 2.20.0", async () => {
 				const compatibilityMode = "2.20.0";
-				const defaultRuntimeOptions = getConfigsForCompatMode(compatibilityMode);
+				const defaultRuntimeOptions = getCompatibilityVersionDefaults(compatibilityMode);
 				const logger = new MockLogger();
 				await ContainerRuntime.loadRuntime({
 					context: getMockContext({ logger }) as IContainerContext,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -3626,9 +3626,9 @@ describe("Runtime", () => {
 			});
 		});
 
-		// TODO: Update these tests when compatibilityMode API is implemented - ADO:36088
+		// TODO: Update these tests when compatibilityVersion API is implemented - ADO:36088
 		describe("Default Configurations", () => {
-			it("compatibilityMode not provided", async () => {
+			it("compatibilityVersion not provided", async () => {
 				const logger = new MockLogger();
 				await ContainerRuntime.loadRuntime({
 					context: getMockContext({ logger }) as IContainerContext,
@@ -3663,9 +3663,9 @@ describe("Runtime", () => {
 				]);
 			});
 
-			it("compatibilityMode = 1.0.0", async () => {
-				const compatibilityMode = "1.0.0";
-				const defaultRuntimeOptions = getCompatibilityVersionDefaults(compatibilityMode);
+			it("compatibilityVersion = 1.0.0", async () => {
+				const compatibilityVersion = "1.0.0";
+				const defaultRuntimeOptions = getCompatibilityVersionDefaults(compatibilityVersion);
 				const logger = new MockLogger();
 				await ContainerRuntime.loadRuntime({
 					context: getMockContext({ logger }) as IContainerContext,
@@ -3700,9 +3700,9 @@ describe("Runtime", () => {
 				]);
 			});
 
-			it('compatibilityMode = 2.0.0-defaults ("default")', async () => {
-				const compatibilityMode = "2.0.0-defaults";
-				const defaultRuntimeOptions = getCompatibilityVersionDefaults(compatibilityMode);
+			it('compatibilityVersion = 2.0.0-defaults ("default")', async () => {
+				const compatibilityVersion = "2.0.0-defaults";
+				const defaultRuntimeOptions = getCompatibilityVersionDefaults(compatibilityVersion);
 				const logger = new MockLogger();
 				await ContainerRuntime.loadRuntime({
 					context: getMockContext({ logger }) as IContainerContext,
@@ -3737,9 +3737,9 @@ describe("Runtime", () => {
 				]);
 			});
 
-			it("compatibilityMode = 2.0.0 (explicit)", async () => {
-				const compatibilityMode = "2.0.0";
-				const defaultRuntimeOptions = getCompatibilityVersionDefaults(compatibilityMode);
+			it("compatibilityVersion = 2.0.0 (explicit)", async () => {
+				const compatibilityVersion = "2.0.0";
+				const defaultRuntimeOptions = getCompatibilityVersionDefaults(compatibilityVersion);
 				const logger = new MockLogger();
 				await ContainerRuntime.loadRuntime({
 					context: getMockContext({ logger }) as IContainerContext,
@@ -3774,9 +3774,9 @@ describe("Runtime", () => {
 				]);
 			});
 
-			it("compatibilityMode = 2.20.0", async () => {
-				const compatibilityMode = "2.20.0";
-				const defaultRuntimeOptions = getCompatibilityVersionDefaults(compatibilityMode);
+			it("compatibilityVersion = 2.20.0", async () => {
+				const compatibilityVersion = "2.20.0";
+				const defaultRuntimeOptions = getCompatibilityVersionDefaults(compatibilityVersion);
 				const logger = new MockLogger();
 				await ContainerRuntime.loadRuntime({
 					context: getMockContext({ logger }) as IContainerContext,
@@ -3811,7 +3811,7 @@ describe("Runtime", () => {
 				]);
 			});
 
-			it("compatibilityMode not provided, with manual configs for each property", async () => {
+			it("compatibilityVersion not provided, with manual configs for each property", async () => {
 				const logger = new MockLogger();
 				await ContainerRuntime.loadRuntime({
 					context: getMockContext({ logger }) as IContainerContext,
@@ -3856,12 +3856,14 @@ describe("Runtime", () => {
 				]);
 			});
 
-			it("all options explicitly undefined", async () => {
-				const logger = new MockLogger();
-				await ContainerRuntime.loadRuntime({
-					context: getMockContext({ logger }) as IContainerContext,
-					registryEntries: [],
-					existing: false,
+			for (const { desc, runtimeOptions } of [
+				{ desc: "all options unspecified", runtimeOptions: {} },
+				{
+					// This case tests degenerate specification that is permissible
+					// with exactOptionalPropertyTypes disabled. Even when enabled,
+					// this should be tested in case callers violate exactness.
+					// (use @ts-expect-error or `as` to ignore when needed)
+					desc: "all options explicitly undefined",
 					runtimeOptions: {
 						summaryOptions: undefined,
 						gcOptions: undefined,
@@ -3874,36 +3876,45 @@ describe("Runtime", () => {
 						compressionOptions: undefined,
 						explicitSchemaControl: undefined,
 					},
-					provideEntryPoint: mockProvideEntryPoint,
+				},
+			])
+				it(desc, async () => {
+					const logger = new MockLogger();
+					await ContainerRuntime.loadRuntime({
+						context: getMockContext({ logger }) as IContainerContext,
+						registryEntries: [],
+						existing: false,
+						runtimeOptions,
+						provideEntryPoint: mockProvideEntryPoint,
+					});
+
+					const expectedRuntimeOptions: IContainerRuntimeOptionsInternal = {
+						summaryOptions: {},
+						gcOptions: {},
+						loadSequenceNumberVerification: "close",
+						flushMode: FlushMode.TurnBased,
+						compressionOptions: {
+							minimumBatchSizeInBytes: 614400,
+							compressionAlgorithm: CompressionAlgorithms.lz4,
+						},
+						maxBatchSizeInBytes: 716800,
+						chunkSizeInBytes: 204800,
+						enableRuntimeIdCompressor: undefined, // idCompressor is undefined, since that represents a logical state (off)
+						enableGroupedBatching: true,
+						explicitSchemaControl: false,
+					};
+
+					logger.assertMatchAny([
+						{
+							eventName: "ContainerRuntime:ContainerLoadStats",
+							category: "generic",
+							options: JSON.stringify(expectedRuntimeOptions),
+						},
+					]);
 				});
 
-				const expectedRuntimeOptions: IContainerRuntimeOptionsInternal = {
-					summaryOptions: {},
-					gcOptions: {},
-					loadSequenceNumberVerification: "close",
-					flushMode: FlushMode.TurnBased,
-					compressionOptions: {
-						minimumBatchSizeInBytes: 614400,
-						compressionAlgorithm: CompressionAlgorithms.lz4,
-					},
-					maxBatchSizeInBytes: 716800,
-					chunkSizeInBytes: 204800,
-					enableRuntimeIdCompressor: undefined, // idCompressor is undefined, since that represents a logical state (off)
-					enableGroupedBatching: true,
-					explicitSchemaControl: false,
-				};
-
-				logger.assertMatchAny([
-					{
-						eventName: "ContainerRuntime:ContainerLoadStats",
-						category: "generic",
-						options: JSON.stringify(expectedRuntimeOptions),
-					},
-				]);
-			});
-
 			// Skipped since 3.0.0 is not an existing FF version yet
-			it.skip("compatibilityMode = 3.0.0", async () => {
+			it.skip("compatibilityVersion = 3.0.0", async () => {
 				const logger = new MockLogger();
 				await ContainerRuntime.loadRuntime({
 					context: getMockContext({ logger }) as IContainerContext,

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -18,8 +18,9 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 
+import type { ICompressionRuntimeOptions } from "../../compressionDefinitions.js";
 import { CompressionAlgorithms } from "../../compressionDefinitions.js";
-import { ICompressionRuntimeOptions, makeLegacySendBatchFn } from "../../containerRuntime.js";
+import { makeLegacySendBatchFn } from "../../containerRuntime.js";
 import {
 	ContainerMessageType,
 	type LocalContainerRuntimeMessage,


### PR DESCRIPTION
- correct compatibility range typo
- `*Compat[ibility]Mode` -> `*Compat[ibility]Version`
- make `runtimeOptionsAffectingDocSchemaConfigMap` immutable constant
- separate logical `getCompatibilityVersionDefaults` from testable unit `getConfigsForCompatMode`
- reflow wide comments and add links
- change `defaultCompatibilityVersion` to allow more natural config map for `explicitSchemaControl`
- correct typing for `getConfigsForCompatMode` to accurately note that only partial `T` can be guaranteed. This exposes potential hole in current logic and will need to be addressed. Compilation is preserved by using an inappropriate cast.
  - types in unit test for `getConfigsForCompatMode` are updated to be more realistic and then reveal the `Partial<T>` issue more directly.
- add test case for no runtime options sent to `ContainerRuntime.loadRuntime`