### PR TITLE
feat(DDS): Only encode handles in DDS layer if ContainerRuntime won't do it

### DIFF
--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -143,6 +143,7 @@
 		"@types/benchmark": "^2.1.0",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
+		"@types/sinon": "^17.0.3",
 		"@types/uuid": "^9.0.2",
 		"benchmark": "^2.1.4",
 		"c8": "^8.0.1",
@@ -153,6 +154,7 @@
 		"mocha": "^10.8.2",
 		"mocha-multi-reporters": "^1.5.1",
 		"rimraf": "^4.4.0",
+		"sinon": "^18.0.1",
 		"ts-node": "^10.9.1",
 		"typescript": "~5.4.5"
 	},

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -20,6 +20,7 @@ import {
 	type IChannelFactory,
 	IFluidDataStoreRuntime,
 	type IDeltaHandler,
+	type IFluidDataStoreRuntimeInternalConfig,
 } from "@fluidframework/datastore-definitions/internal";
 import {
 	type IDocumentMessage,
@@ -57,7 +58,7 @@ import { GCHandleVisitor } from "./gcHandleVisitor.js";
 import { SharedObjectHandle } from "./handle.js";
 import { FluidSerializer, IFluidSerializer } from "./serializer.js";
 import { ISharedObject, ISharedObjectEvents } from "./types.js";
-import { makeHandlesSerializable, parseHandles } from "./utils.js";
+import { bindHandles, makeHandlesSerializable, parseHandles } from "./utils.js";
 
 /**
  * Custom telemetry properties used in {@link SharedObjectCore} to instantiate {@link TelemetryEventBatcher} class.
@@ -459,8 +460,13 @@ export abstract class SharedObjectCore<
 		this.verifyNotClosed();
 		if (this.isAttached()) {
 			// NOTE: We may also be encoding in the ContainerRuntime layer.
-			// Once the layer-compat window passes we can stop encoding here and only bind
-			const contentToSubmit = makeHandlesSerializable(content, this.serializer, this.handle);
+			// Once the layer-compat window passes we can remove the encoding codepath here altogether
+			const onlyBind =
+				(this.runtime as IFluidDataStoreRuntimeInternalConfig)
+					.submitMessagesWithoutEncodingHandles === true;
+			const contentToSubmit = onlyBind
+				? bindHandles(content, this.serializer, this.handle)
+				: makeHandlesSerializable(content, this.serializer, this.handle);
 
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			this.services!.deltaConnection.submit(contentToSubmit, localOpMetadata);

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -5,29 +5,51 @@
 
 import { strict as assert } from "node:assert";
 
+// Add IFluidHandle import for mock handle
+import type { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import {
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
+	IFluidDataStoreRuntimeInternalConfig,
 } from "@fluidframework/datastore-definitions/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
 	IGarbageCollectionData,
 	ISummaryTreeWithStats,
 } from "@fluidframework/runtime-definitions/internal";
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
+import { isSerializedHandle } from "@fluidframework/runtime-utils/internal";
+import {
+	MockFluidDataStoreRuntime,
+	MockHandle,
+	validateAssertionError,
+} from "@fluidframework/test-runtime-utils/internal";
+import sinon from "sinon";
 
-import { IFluidSerializer } from "../serializer.js";
+import { FluidSerializer, IFluidSerializer } from "../serializer.js";
 import { SharedObject, SharedObjectCore } from "../sharedObject.js";
 
 class MySharedObject extends SharedObject {
-	constructor(id: string) {
+	constructor(
+		id: string,
+		//* Move to Core
+		private readonly attached: boolean = false,
+	) {
 		super(
 			id,
 			undefined as unknown as IFluidDataStoreRuntime,
 			undefined as unknown as IChannelAttributes,
 			"",
 		);
+	}
+
+	// Make submitLocalMessage public for testing
+	public submitLocalMessage(content: unknown, localOpMetadata: unknown = undefined): void {
+		super.submitLocalMessage(content, localOpMetadata);
+	}
+
+	public override isAttached(): boolean {
+		return this.attached;
 	}
 
 	protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats {
@@ -52,15 +74,29 @@ class MySharedObject extends SharedObject {
 }
 
 class MySharedObjectCore extends SharedObjectCore {
-	constructor(id: string) {
-		super(
-			id,
-			undefined as unknown as IFluidDataStoreRuntime,
-			undefined as unknown as IChannelAttributes,
-		);
+	constructor(
+		id: string,
+		runtime: IFluidDataStoreRuntime = new MockFluidDataStoreRuntime(), // Use mock runtime
+		attributes: IChannelAttributes = { type: "test" } as unknown as IChannelAttributes,
+	) {
+		super(id, runtime, attributes);
 	}
 
-	protected readonly serializer = {} as unknown as IFluidSerializer;
+	// Make submitLocalMessage public for testing
+	public submitLocalMessage(content: unknown, localOpMetadata: unknown = undefined): void {
+		super.submitLocalMessage(content, localOpMetadata);
+	}
+
+	public stubSubmitFn(submitFn: sinon.SinonSpy): void {
+		Object.assign(this, { services: { deltaConnection: { submit: submitFn } } });
+	}
+
+	// Override isAttached to always return true for simplified testing
+	public override isAttached(): boolean {
+		return true;
+	}
+
+	protected readonly serializer = new FluidSerializer({} as unknown as IFluidHandleContext);
 
 	protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats {
 		throw new Error("Method not implemented.");
@@ -112,5 +148,104 @@ describe("SharedObjectCore", () => {
 		assert.throws(codeBlock, (e: Error) =>
 			validateAssertionError(e, "Id cannot contain slashes"),
 		);
+	});
+
+	describe("handle encoding in submitLocalMessage", () => {
+		let sharedObject: MySharedObjectCore;
+		let dataStoreRuntime: MockFluidDataStoreRuntime;
+		let submitSpy: sinon.SinonSpy;
+
+		// Define a mock handle object
+		const mockHandle = new MockHandle("some data");
+
+		// Define message content with the handle
+		const messageContentWithHandle = {
+			type: "opWithHandle",
+			handle: mockHandle,
+		};
+
+		const serializedMockHandleMatcher = sinon.match(
+			(value: unknown) => isSerializedHandle(value) && value.url === mockHandle.absolutePath,
+			"serialized handle string",
+		);
+
+		function set_submitMessagesWithoutEncodingHandles(value: boolean | undefined): void {
+			(
+				dataStoreRuntime as unknown as {
+					submitMessagesWithoutEncodingHandles?: boolean;
+				} satisfies Partial<IFluidDataStoreRuntimeInternalConfig>
+			).submitMessagesWithoutEncodingHandles = value;
+		}
+
+		beforeEach(() => {
+			dataStoreRuntime = new MockFluidDataStoreRuntime(); //* unneeded (same as default)
+			set_submitMessagesWithoutEncodingHandles(undefined); // Reset config
+
+			submitSpy = sinon.fake();
+
+			sharedObject = new MySharedObjectCore("testId", dataStoreRuntime);
+			sharedObject.stubSubmitFn(submitSpy); //* Move to ctor param
+		});
+
+		afterEach(() => {
+			// Reset the submit spy after each test
+			submitSpy.resetHistory();
+		});
+
+		it("submits handle object when submitMessagesWithoutEncodingHandles is true", () => {
+			set_submitMessagesWithoutEncodingHandles(true);
+
+			sharedObject.submitLocalMessage(messageContentWithHandle);
+
+			// Assert submit was called once with the exact object containing the handle object
+			assert(
+				submitSpy.calledOnceWithExactly(
+					messageContentWithHandle,
+					undefined /* localOpMetadata */,
+				),
+				"Submit should be called with the exact message content including the handle object",
+			);
+		});
+
+		it("submits stringified handle when submitMessagesWithoutEncodingHandles is false", () => {
+			set_submitMessagesWithoutEncodingHandles(false);
+
+			sharedObject.submitLocalMessage(messageContentWithHandle);
+
+			// Assert submit was called once with an object where 'handle' matches the serialized string pattern
+			assert(
+				submitSpy.calledOnceWith(
+					sinon.match({
+						type: messageContentWithHandle.type,
+						handle: serializedMockHandleMatcher,
+					}),
+					undefined /* localOpMetadata */,
+				),
+				"Submit should be called with message content including a serialized handle string",
+			);
+		});
+
+		it("submits stringified handle when submitMessagesWithoutEncodingHandles is undefined", () => {
+			assert.strictEqual(
+				(dataStoreRuntime as Partial<IFluidDataStoreRuntimeInternalConfig>)
+					.submitMessagesWithoutEncodingHandles,
+				undefined,
+				"Config should be undefined initially",
+			);
+
+			sharedObject.submitLocalMessage(messageContentWithHandle);
+
+			// Assert submit was called once with an object where 'handle' matches the serialized string pattern
+			assert(
+				submitSpy.calledOnceWith(
+					sinon.match({
+						type: messageContentWithHandle.type,
+						handle: serializedMockHandleMatcher, // Use the custom matcher
+					}),
+					undefined /* localOpMetadata */,
+				),
+				"Submit should be called with message content including a serialized handle string (default case)",
+			);
+		});
 	});
 });

--- a/packages/dds/shared-object-base/src/utils.ts
+++ b/packages/dds/shared-object-base/src/utils.ts
@@ -86,16 +86,19 @@ export function createSingleBlobSummary(
  *
  * @internal
  */
-export function bindHandles(
-	value: unknown,
+export function bindHandles<T = unknown>(
+	value: T,
 	serializer: IFluidSerializer,
 	bind: IFluidHandle,
-): void {
+): T {
 	// N.B. AB#7316 this could be made more efficient by writing an ad hoc
 	// implementation that doesn't clone at all. Today the distinction between
 	// this function and `encode` is purely semantic -- encoding both serializes
 	// handles and binds them, but sometimes we only wish to do the latter
 	serializer.encode(value, bind);
+
+	// Return the input value so this function can be swapped in for makeHandlesSerializable
+	return value;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -193,10 +193,17 @@ export function findFirstCharacterMismatched(
 	return [index, charA, charB];
 }
 
-function withoutLocalOpMetadata(message: IPendingMessage): IPendingMessage {
+/**
+ * Returns a shallow copy of the given message with the non-serializable properties removed.
+ * Note that the runtimeOp's data has already been serialized in the content property.
+ */
+function toSerializableForm(
+	message: IPendingMessage,
+): IPendingMessage & { runtimeOp: undefined; localOpMetadata: undefined } {
 	return {
 		...message,
 		localOpMetadata: undefined,
+		runtimeOp: undefined,
 	};
 }
 
@@ -286,7 +293,7 @@ export class PendingStateManager implements IDisposable {
 		return {
 			pendingStates: [
 				...newSavedOps,
-				...this.pendingMessages.toArray().map((message) => withoutLocalOpMetadata(message)),
+				...this.pendingMessages.toArray().map((message) => toSerializableForm(message)),
 			],
 		};
 	}
@@ -538,7 +545,7 @@ export class PendingStateManager implements IDisposable {
 		);
 
 		pendingMessage.sequenceNumber = sequenceNumber;
-		this.savedOps.push(withoutLocalOpMetadata(pendingMessage));
+		this.savedOps.push(toSerializableForm(pendingMessage));
 
 		this.pendingMessages.shift();
 

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -150,3 +150,13 @@ export interface IFluidDataStoreRuntime
 	 */
 	readonly entryPoint: IFluidHandle<FluidObject>;
 }
+
+/**
+ * Internal configs possibly implemented by IFuidDataStoreRuntimes, for use only within the runtime layer.
+ * For example, temporary layer compatibility details
+ *
+ * @internal
+ */
+export interface IFluidDataStoreRuntimeInternalConfig {
+	readonly submitMessagesWithoutEncodingHandles?: boolean;
+}

--- a/packages/runtime/datastore-definitions/src/index.ts
+++ b/packages/runtime/datastore-definitions/src/index.ts
@@ -21,6 +21,7 @@ export type {
 export type {
 	IFluidDataStoreRuntime,
 	IFluidDataStoreRuntimeEvents,
+	IFluidDataStoreRuntimeInternalConfig,
 	IDeltaManagerErased,
 } from "./dataStoreRuntime.js";
 export type {

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -16,6 +16,7 @@ import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
 import {
 	assert,
+	debugAssert,
 	Deferred,
 	LazyPromise,
 	unreachableCase,
@@ -56,6 +57,7 @@ import {
 	IInboundSignalMessage,
 	type IRuntimeMessageCollection,
 	type IRuntimeMessagesContent,
+	encodeHandlesInContainerRuntime,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	GCDataBuilder,
@@ -101,6 +103,18 @@ import {
 } from "./localChannelContext.js";
 import { pkgVersion } from "./packageVersion.js";
 import { RemoteChannelContext } from "./remoteChannelContext.js";
+
+interface IFluidDataStoreContextFeaturesToTypes {
+	[encodeHandlesInContainerRuntime]: IFluidDataStoreContext; // No difference in typing with this feature
+}
+
+function contextSupportsFeature<K extends keyof IFluidDataStoreContextFeaturesToTypes>(
+	obj: IFluidDataStoreContext,
+	feature: K,
+): obj is IFluidDataStoreContextFeaturesToTypes[K] {
+	const { ILayerCompatDetails } = obj as FluidObject<ILayerCompatDetails>;
+	return ILayerCompatDetails?.supportedFeatures.has(feature) ?? false;
+}
 
 /**
  * @legacy
@@ -230,6 +244,15 @@ export class FluidDataStoreRuntime
 	public readonly ILayerCompatDetails?: unknown = dataStoreCompatDetailsForRuntime;
 
 	/**
+	 * See IFluidDataStoreRuntimeInternalConfig.submitMessagesWithoutEncodingHandles
+	 *
+	 * Note: this class doesn't declare that it implements IFluidDataStoreRuntimeInternalConfig,
+	 * and we keep this property as private, but consumers may optimistically cast
+	 * to the internal interface to access this property.
+	 */
+	private readonly submitMessagesWithoutEncodingHandles: boolean;
+
+	/**
 	 * Create an instance of a DataStore runtime.
 	 *
 	 * @param dataStoreContext - Context object for the runtime.
@@ -254,11 +277,16 @@ export class FluidDataStoreRuntime
 		);
 
 		// Validate that the Runtime is compatible with this DataStore.
-		const maybeRuntimeCompatDetails = dataStoreContext as FluidObject<ILayerCompatDetails>;
-		validateRuntimeCompatibility(
-			maybeRuntimeCompatDetails.ILayerCompatDetails,
-			this.dispose.bind(this),
+		const { ILayerCompatDetails: runtimeCompatDetails } =
+			dataStoreContext as FluidObject<ILayerCompatDetails>;
+		validateRuntimeCompatibility(runtimeCompatDetails, this.dispose.bind(this));
+
+		this.submitMessagesWithoutEncodingHandles = contextSupportsFeature(
+			dataStoreContext,
+			encodeHandlesInContainerRuntime,
 		);
+		// We read this property here to avoid a compiler error (unused private member)
+		debugAssert(() => this.submitMessagesWithoutEncodingHandles !== undefined);
 
 		this.mc = createChildMonitoringContext({
 			logger: dataStoreContext.baseLogger,

--- a/packages/runtime/runtime-definitions/src/runtimeLayerCompatFeatureNames.ts
+++ b/packages/runtime/runtime-definitions/src/runtimeLayerCompatFeatureNames.ts
@@ -5,7 +5,7 @@
 
 /**
  * This feature indicates the ContainerRuntime will encode handles
- * If the Runtime layer supports this feature, the DataStore layer need not encode handles (but do bind them)
+ * If the Runtime layer supports this feature, the DataStore layer should not encode handles (but do bind them)
  *
  * @internal
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8783,6 +8783,9 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
+      '@types/sinon':
+        specifier: ^17.0.3
+        version: 17.0.3
       '@types/uuid':
         specifier: ^9.0.2
         version: 9.0.8
@@ -8813,6 +8816,9 @@ importers:
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
+      sinon:
+        specifier: ^18.0.1
+        version: 18.0.1
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@18.19.67)(typescript@5.4.5)


### PR DESCRIPTION
## Description

We recently started encoding handles in the ContainerRuntime layer.  However, due to compat requirements for DataStore/Runtime boundary, we can't _stop_ encoding in the DDS layer yet.  So the code in ContainerRuntime is a no-op and we don't get the benefits intended by this change.

This PR adds a check of the ContainerRuntime's layer compat details, and if it's going to encode the handles, we don't do it in the DDS layer.

## Reviewer Guidance

Feedback welcome on how I'm hiding the config property on `FluidDataStoreRuntime` to avoid exposing on the legacy-alpha API.

e.g. another alternative would be to use the `FluidObject` pattern to expose an `IDataStoreRuntimeInternalConfigs` object or something.  I didn't go for that since this is isolated within the runtime layer (as opposed to `ILayerCompatDetails`, for instance).