### PR TITLE
Revert "IntervalCollection: Postpone deprecation until after next release"

### DIFF
--- a/.changeset/wild-poems-say.md
+++ b/.changeset/wild-poems-say.md
@@ -1,0 +1,19 @@
+---
+"fluid-framework": minor
+"@fluidframework/sequence": minor
+---
+---
+"section": deprecation
+---
+
+Replace generic types for IntervalCollections with non-generic types
+
+This change deprecates the following generic types and provides non-generic alternatives where necessary:
+
+- `IIntervalCollection` is replaced by `ISequenceIntervalCollection`
+- `IIntervalCollectionEvent` is replaced by `ISequenceIntervalCollectionEvents`
+- `IntervalIndex` is replaced by `SequenceIntervalIndex`
+- `IOverlappingIntervalsIndex` is replaced by `ISequenceOverlappingIntervalsIndex`
+- `ISharedIntervalCollection` is deprecated without replacement
+
+These types are no longer required to be generic, and replacing them with non-generic alternatives keeps our typing less complex.

--- a/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
+++ b/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
@@ -164,7 +164,7 @@ export enum IntervalType {
     SlideOnRemove = 2,// SlideOnRemove is default behavior - all intervals are SlideOnRemove
 }
 
-// @alpha
+// @alpha @deprecated
 export interface IOverlappingIntervalsIndex<TInterval extends ISerializableInterval> extends IntervalIndex<TInterval> {
     // (undocumented)
     findOverlappingIntervals(start: SequencePlace, end: SequencePlace): TInterval[];

--- a/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
+++ b/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
@@ -84,7 +84,7 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval> ex
     removeIntervalById(id: string): TInterval | undefined;
 }
 
-// @alpha
+// @alpha @deprecated
 export interface IIntervalCollectionEvent<TInterval extends ISerializableInterval> extends IEvent {
     (event: "changeInterval", listener: (interval: TInterval, previousInterval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): void;
     (event: "addInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
@@ -94,7 +94,7 @@ export interface IIntervalCollectionEvent<TInterval extends ISerializableInterva
 
 export { InteriorSequencePlace }
 
-// @alpha
+// @alpha @deprecated
 export interface IntervalIndex<TInterval extends ISerializableInterval> {
     add(interval: TInterval): void;
     remove(interval: TInterval): void;
@@ -259,7 +259,7 @@ export interface ISerializedInterval {
     stickiness?: IntervalStickiness;
 }
 
-// @alpha (undocumented)
+// @alpha @deprecated (undocumented)
 export interface ISharedIntervalCollection<TInterval extends ISerializableInterval> {
     // (undocumented)
     getIntervalCollection(label: string): IIntervalCollection<TInterval>;

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -393,7 +393,7 @@ class IntervalCollectionIterator implements Iterator<SequenceIntervalClass> {
  * Change events emitted by `IntervalCollection`s
  * @legacy
  * @alpha
- * @remarks The generic version of this interface is no longer used and will be removed. Use {@link ISequenceIntervalCollectionEvents} instead.
+ * @deprecated The generic version of this interface is no longer used and will be removed. Use {@link ISequenceIntervalCollectionEvents} instead.
  */
 export interface IIntervalCollectionEvent<TInterval extends ISerializableInterval>
 	extends IEvent {

--- a/packages/dds/sequence/src/intervalIndex/intervalIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/intervalIndex.ts
@@ -16,7 +16,7 @@ import { ISerializableInterval, type SequenceInterval } from "../intervals/index
  * @legacy
  * @alpha
  *
- * @remarks The generic version of this interface is no longer used and will be removed. Use {@link SequenceIntervalIndex} instead.
+ * @deprecated The generic version of this interface is no longer used and will be removed. Use {@link SequenceIntervalIndex} instead.
  */
 export interface IntervalIndex<TInterval extends ISerializableInterval> {
 	/**

--- a/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
@@ -26,7 +26,9 @@ import { IntervalIndex, type SequenceIntervalIndex } from "./intervalIndex.js";
  * Use {@link ISequenceOverlappingIntervalsIndex} instead.
  * @legacy
  * @alpha
- * @remarks The generic version of this interface is no longer used and will be removed. Use {@link ISequenceOverlappingIntervalsIndex} instead.
+ * @privateremarks
+ * TODO AB#34436 - Can't add a deprecated tag until the Pages codebase is already using
+ * the alternative so the integration pipeline doesn't break.
  */
 export interface IOverlappingIntervalsIndex<TInterval extends ISerializableInterval>
 	extends IntervalIndex<TInterval> {

--- a/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
@@ -26,9 +26,7 @@ import { IntervalIndex, type SequenceIntervalIndex } from "./intervalIndex.js";
  * Use {@link ISequenceOverlappingIntervalsIndex} instead.
  * @legacy
  * @alpha
- * @privateremarks
- * TODO AB#34436 - Can't add a deprecated tag until the Pages codebase is already using
- * the alternative so the integration pipeline doesn't break.
+* @deprecated The generic version of this interface is no longer used and will be removed. Use {@link ISequenceOverlappingIntervalsIndex} instead.
  */
 export interface IOverlappingIntervalsIndex<TInterval extends ISerializableInterval>
 	extends IntervalIndex<TInterval> {

--- a/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
@@ -26,7 +26,7 @@ import { IntervalIndex, type SequenceIntervalIndex } from "./intervalIndex.js";
  * Use {@link ISequenceOverlappingIntervalsIndex} instead.
  * @legacy
  * @alpha
-* @deprecated The generic version of this interface is no longer used and will be removed. Use {@link ISequenceOverlappingIntervalsIndex} instead.
+ * @deprecated The generic version of this interface is no longer used and will be removed. Use {@link ISequenceOverlappingIntervalsIndex} instead.
  */
 export interface IOverlappingIntervalsIndex<TInterval extends ISerializableInterval>
 	extends IntervalIndex<TInterval> {

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -10,7 +10,7 @@ import { ISerializableInterval } from "./intervals/index.js";
 /**
  * @legacy
  * @alpha
- * @remarks This interface is no longer used and will be removed.
+ * @deprecated This interface is no longer used and will be removed.
  */
 export interface ISharedIntervalCollection<TInterval extends ISerializableInterval> {
 	// eslint-disable-next-line import/no-deprecated

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -489,7 +489,7 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval> ex
     removeIntervalById(id: string): TInterval | undefined;
 }
 
-// @alpha
+// @alpha @deprecated
 export interface IIntervalCollectionEvent<TInterval extends ISerializableInterval> extends IEvent {
     (event: "changeInterval", listener: (interval: TInterval, previousInterval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): void;
     (event: "addInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
@@ -618,7 +618,7 @@ declare namespace InternalTypes {
 }
 export { InternalTypes }
 
-// @alpha
+// @alpha @deprecated
 export interface IntervalIndex<TInterval extends ISerializableInterval> {
     add(interval: TInterval): void;
     remove(interval: TInterval): void;
@@ -783,7 +783,7 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
-// @alpha (undocumented)
+// @alpha @deprecated (undocumented)
 export interface ISharedIntervalCollection<TInterval extends ISerializableInterval> {
     // (undocumented)
     getIntervalCollection(label: string): IIntervalCollection<TInterval>;


### PR DESCRIPTION
Reverts microsoft/FluidFramework#24182

We can bring these back now that deprecations don't break out automation.