### PR TITLE
refactor(client-presence): Rename `props` to `states` for workspaces

### DIFF
--- a/.changeset/sour-mirrors-wave.md
+++ b/.changeset/sour-mirrors-wave.md
@@ -47,8 +47,10 @@ The following API changes have been made to improve clarity and consistency:
 | `PresenceEvents.attendeeDisconnected` | `AttendeesEvents.attendeeDisconnected`|
 | `PresenceEvents.attendeeJoined` | `AttendeesEvents.attendeeConnected`|
 | `PresenceNotifications` | `NotificationsWorkspace` |
+| `PresenceNotifications.props` | `NotificationsWorkspace.states` |
 | `PresenceNotificationsSchema` | `NotificationsWorkspaceSchema` |
 | `PresenceStates` | `StatesWorkspace` |
+| `PresenceStates.props` | `StatesWorkspace.states` |
 | `PresenceStatesEntries` | `StatesWorkspaceEntries` |
 | `PresenceStatesSchema` | `StatesWorkspaceSchema` |
 | `PresenceWorkspaceAddress` | `WorkspaceAddress` |

--- a/docs/docs/build/presence.md
+++ b/docs/docs/build/presence.md
@@ -142,7 +142,7 @@ const stateWorkspace = presence.states.getWorkspace(
 );
 
 // Temporarily set count updates to send as soon as possible
-const countState = stateWorkspace.props.count;
+const countState = stateWorkspace.states.count;
 countState.controls.allowableUpdateLatencyMs = 0;
 countState.local = { num: 5000 };
 

--- a/examples/apps/ai-collab/src/app/presence.ts
+++ b/examples/apps/ai-collab/src/app/presence.ts
@@ -48,7 +48,7 @@ export class PresenceManager {
 		);
 
 		// Listen for updates to the userInfo property in the presence state
-		this.usersState.props.onlineUsers.events.on("remoteUpdated", (update) => {
+		this.usersState.states.onlineUsers.events.on("remoteUpdated", (update) => {
 			// The remote client that updated the userInfo property
 			const remoteSessionClient = update.attendee;
 			// The new value of the userInfo property
@@ -74,12 +74,12 @@ export class PresenceManager {
 		// spe client
 		if (tenantId !== undefined && clientId !== undefined) {
 			const photoUrl = await getProfilePhoto();
-			this.usersState.props.onlineUsers.local = { photo: photoUrl };
+			this.usersState.states.onlineUsers.local = { photo: photoUrl };
 		}
 
 		this.userInfoMap.set(
 			this.presence.attendees.getMyself(),
-			this.usersState.props.onlineUsers.local,
+			this.usersState.states.onlineUsers.local,
 		);
 		this.userInfoCallback(this.userInfoMap);
 	}
@@ -101,7 +101,7 @@ export class PresenceManager {
 		for (const sessionClient of sessionList) {
 			// If local user or remote user is connected, then only add it to the list
 			try {
-				const userInfo = this.usersState.props.onlineUsers.getRemote(sessionClient).value;
+				const userInfo = this.usersState.states.onlineUsers.getRemote(sessionClient).value;
 				// If the user is local user, then add it to the beginning of the list
 				if (sessionClient.attendeeId === this.presence.attendees.getMyself().attendeeId) {
 					userInfoList.push(userInfo);

--- a/examples/apps/presence-tracker/src/FocusTracker.ts
+++ b/examples/apps/presence-tracker/src/FocusTracker.ts
@@ -61,7 +61,7 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
 		);
 
 		// Save a reference to the focus state for easy access within the FocusTracker.
-		this.focus = statesWorkspace.props.focus;
+		this.focus = statesWorkspace.states.focus;
 
 		// When the focus state is updated, the FocusTracker should emit the focusChanged event.
 		this.focus.events.on("remoteUpdated", ({ attendee, value }) => {

--- a/examples/apps/presence-tracker/src/MouseTracker.ts
+++ b/examples/apps/presence-tracker/src/MouseTracker.ts
@@ -58,7 +58,7 @@ export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
 		statesWorkspace.add("cursor", StateFactory.latest<IMousePosition>({ x: 0, y: 0 }));
 
 		// Save a reference to the cursor state for easy access within the MouseTracker.
-		this.cursor = statesWorkspace.props.cursor;
+		this.cursor = statesWorkspace.states.cursor;
 
 		// When the cursor state is updated, the MouseTracker should emit the mousePositionChanged event.
 		this.cursor.events.on("remoteUpdated", () => {

--- a/examples/apps/presence-tracker/src/reactions.ts
+++ b/examples/apps/presence-tracker/src/reactions.ts
@@ -47,7 +47,7 @@ export function initializeReactions(presence: Presence, mouseTracker: MouseTrack
 
 		// Check that we're connected before sending notifications.
 		if (presence.attendees.getMyself().getConnectionStatus() === "Connected") {
-			notificationsWorkspace.props.reactions.emit.broadcast(
+			notificationsWorkspace.states.reactions.emit.broadcast(
 				"reaction",
 				mouseTracker.getMyMousePosition(),
 				reactionValue ?? "?",

--- a/examples/service-clients/azure-client/external-controller/src/app.ts
+++ b/examples/service-clients/azure-client/external-controller/src/app.ts
@@ -183,7 +183,7 @@ async function start(): Promise<void> {
 	// Biome insist on no semicolon - https://dev.azure.com/fluidframework/internal/_workitems/edit/9083
 	const lastRoll: { die1?: DieValue; die2?: DieValue } = {};
 	const presence = getPresenceViaDataObject(container.initialObjects.presence);
-	const states = buildDicePresence(presence).props;
+	const states = buildDicePresence(presence).states;
 
 	// Initialize Devtools
 	initializeDevtools({

--- a/packages/framework/presence/README.md
+++ b/packages/framework/presence/README.md
@@ -159,7 +159,7 @@ const stateWorkspace = presence.states.getWorkspace("app:v1states",
 );
 
 // Temporarily set count updates to send as soon as possible
-const countState = stateWorkspace.props.count;
+const countState = stateWorkspace.states.count;
 countState.controls.allowableUpdateLatencyMs = 0;
 countState.local = { num: 5000 };
 

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -276,7 +276,7 @@ export type NotificationSubscriptions<E extends InternalUtilityTypes.Notificatio
 export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSchema> {
     add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<any>, TManager extends NotificationsManager<any>>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is NotificationsWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>>;
     readonly presence: Presence;
-    readonly props: StatesWorkspaceEntries<TSchema>;
+    readonly states: StatesWorkspaceEntries<TSchema>;
 }
 
 // @alpha
@@ -336,7 +336,7 @@ export interface StatesWorkspace<TSchema extends StatesWorkspaceSchema, TManager
     add<TKey extends string, TValue extends InternalTypes.ValueDirectoryOrState<any>, TManager extends TManagerConstraints>(key: TKey, manager: InternalTypes.ManagerFactory<TKey, TValue, TManager>): asserts this is StatesWorkspace<TSchema & Record<TKey, InternalTypes.ManagerFactory<TKey, TValue, TManager>>, TManagerConstraints>;
     readonly controls: BroadcastControls;
     readonly presence: Presence;
-    readonly props: StatesWorkspaceEntries<TSchema>;
+    readonly states: StatesWorkspaceEntries<TSchema>;
 }
 
 // @alpha @sealed

--- a/packages/framework/presence/src/presenceStates.ts
+++ b/packages/framework/presence/src/presenceStates.ts
@@ -293,7 +293,7 @@ class PresenceStatesImpl<TSchema extends StatesWorkspaceSchema>
 				}
 			}
 			this.nodes = nodes;
-			// props is the public view of nodes that limits the entries types to
+			// states is the public view of nodes that limits the entries types to
 			// the public interface of the State object with an additional type
 			// filter that beguiles the type system. So just reinterpret cast.
 			this.states = this.nodes as unknown as StatesWorkspace<TSchema>["states"];

--- a/packages/framework/presence/src/presenceStates.ts
+++ b/packages/framework/presence/src/presenceStates.ts
@@ -252,7 +252,7 @@ class PresenceStatesImpl<TSchema extends StatesWorkspaceSchema>
 		>
 {
 	private readonly nodes: MapEntries<TSchema>;
-	public readonly props: StatesWorkspace<TSchema>["props"];
+	public readonly states: StatesWorkspace<TSchema>["states"];
 
 	public readonly controls: RequiredBroadcastControl;
 
@@ -296,7 +296,7 @@ class PresenceStatesImpl<TSchema extends StatesWorkspaceSchema>
 			// props is the public view of nodes that limits the entries types to
 			// the public interface of the State object with an additional type
 			// filter that beguiles the type system. So just reinterpret cast.
-			this.props = this.nodes as unknown as StatesWorkspace<TSchema>["props"];
+			this.states = this.nodes as unknown as StatesWorkspace<TSchema>["states"];
 
 			if (anyInitialValues) {
 				this.runtime.localUpdate(newValues, {

--- a/packages/framework/presence/src/presenceStates.ts
+++ b/packages/framework/presence/src/presenceStates.ts
@@ -293,7 +293,7 @@ class PresenceStatesImpl<TSchema extends StatesWorkspaceSchema>
 				}
 			}
 			this.nodes = nodes;
-			// states is the public view of nodes that limits the entries types to
+			// `states` is the public view of nodes that limits the entries types to
 			// the public interface of the State object with an additional type
 			// filter that beguiles the type system. So just reinterpret cast.
 			this.states = this.nodes as unknown as StatesWorkspace<TSchema>["states"];

--- a/packages/framework/presence/src/test/batching.spec.ts
+++ b/packages/framework/presence/src/test/batching.spec.ts
@@ -147,7 +147,7 @@ describe("Presence", () => {
 					count: StateFactory.latest({ num: 0 }, { allowableUpdateLatencyMs: 0 }),
 				});
 
-				const { count } = stateWorkspace.props;
+				const { count } = stateWorkspace.states;
 
 				clock.tick(10); // Time is now 1020
 
@@ -270,7 +270,7 @@ describe("Presence", () => {
 					count: StateFactory.latest({ num: 0 } /* default allowableUpdateLatencyMs = 60 */),
 				}); // will be queued; deadline is now 1070
 
-				const { count } = stateWorkspace.props;
+				const { count } = stateWorkspace.states;
 
 				clock.tick(10); // Time is now 1020
 				count.local = { num: 12 }; // will be queued; deadline remains 1070
@@ -372,7 +372,7 @@ describe("Presence", () => {
 					count: StateFactory.latest({ num: 0 }, { allowableUpdateLatencyMs: 100 }),
 				});
 
-				const { count } = stateWorkspace.props;
+				const { count } = stateWorkspace.states;
 
 				clock.tick(10); // Time is now 1020
 				count.local = { num: 12 }; // will be queued; deadline is set to 1120
@@ -492,7 +492,7 @@ describe("Presence", () => {
 					immediateUpdate: StateFactory.latest({ num: 0 }, { allowableUpdateLatencyMs: 0 }),
 				});
 
-				const { count, immediateUpdate } = stateWorkspace.props;
+				const { count, immediateUpdate } = stateWorkspace.states;
 
 				clock.tick(10); // Time is now 1020
 				count.local = { num: 12 }; // will be queued; deadline is set to 1120
@@ -579,7 +579,7 @@ describe("Presence", () => {
 					note: StateFactory.latest({ message: "" }, { allowableUpdateLatencyMs: 50 }),
 				}); // will be queued, deadline is set to 1060
 
-				const { count, note } = stateWorkspace.props;
+				const { count, note } = stateWorkspace.states;
 
 				clock.tick(10); // Time is now 1020
 				note.local = { message: "will be queued" }; // will be queued, deadline remains 1060
@@ -654,8 +654,8 @@ describe("Presence", () => {
 					note: StateFactory.latest({ message: "" }, { allowableUpdateLatencyMs: 60 }),
 				}); // will be queued, deadline is 1070
 
-				const { count } = stateWorkspace.props;
-				const { note } = stateWorkspace2.props;
+				const { count } = stateWorkspace.states;
+				const { note } = stateWorkspace2.states;
 
 				clock.tick(10); // Time is now 1020
 				note.local = { message: "will be queued" }; // will be queued, deadline is 1070
@@ -748,7 +748,7 @@ describe("Presence", () => {
 					),
 				);
 
-				const { testEvents } = notificationsWorkspace.props;
+				const { testEvents } = notificationsWorkspace.states;
 
 				clock.tick(40); // Time is now 1050
 
@@ -861,8 +861,8 @@ describe("Presence", () => {
 					),
 				);
 
-				const { count } = stateWorkspace.props;
-				const { testEvents } = notificationsWorkspace.props;
+				const { count } = stateWorkspace.states;
+				const { testEvents } = notificationsWorkspace.states;
 
 				testEvents.notifications.on("newId", (attendee, newId) => {
 					// do nothing

--- a/packages/framework/presence/src/test/eventing.spec.ts
+++ b/packages/framework/presence/src/test/eventing.spec.ts
@@ -245,8 +245,8 @@ describe("Presence", () => {
 				latest: StateFactory.latest({ x: 0, y: 0, z: 0 }),
 				latestMap: StateFactory.latestMap({ key1: { a: 0, b: 0 }, key2: { c: 0, d: 0 } }),
 			});
-			latest = states.props.latest;
-			latestMap = states.props.latestMap;
+			latest = states.states.latest;
+			latestMap = states.states.latestMap;
 			if (notifications) {
 				const workspace: typeof states = states;
 				workspace.add(
@@ -255,7 +255,7 @@ describe("Presence", () => {
 						newId: (_attendee: Attendee, _id: number) => {},
 					}),
 				);
-				notificationManager = workspace.props.notifications;
+				notificationManager = workspace.states.notifications;
 			}
 		}
 
@@ -266,8 +266,8 @@ describe("Presence", () => {
 			const latesetMapStates = presence.states.getWorkspace("name:testWorkspace2", {
 				latestMap: StateFactory.latestMap({ key1: { a: 0, b: 0 }, key2: { c: 0, d: 0 } }),
 			});
-			latest = latestsStates.props.latest;
-			latestMap = latesetMapStates.props.latestMap;
+			latest = latestsStates.states.latest;
+			latestMap = latesetMapStates.states.latestMap;
 		}
 
 		function setupNotificationsWorkspace(): void {
@@ -279,7 +279,7 @@ describe("Presence", () => {
 					}),
 				},
 			);
-			notificationManager = notificationsWorkspace.props.notifications;
+			notificationManager = notificationsWorkspace.states.notifications;
 		}
 
 		function processUpdates(valueManagerUpdates: Record<string, UpdateContent>): void {
@@ -662,7 +662,7 @@ describe("Presence", () => {
 							}),
 						},
 					);
-					notificationsWorkspace.props.notifications.notifications.on(
+					notificationsWorkspace.states.notifications.notifications.on(
 						"newId",
 						notificationSpy,
 					);

--- a/packages/framework/presence/src/test/latestMapValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestMapValueManager.spec.ts
@@ -31,7 +31,7 @@ function createLatestMapManager(
 			valueControlSettings,
 		),
 	});
-	return states.props.fixedMap;
+	return states.states.fixedMap;
 }
 
 describe("Presence", () => {
@@ -54,7 +54,7 @@ describe("Presence", () => {
 			const states = presence.states.getWorkspace(testWorkspaceName, {
 				fixedMap: StateFactory.latestMap({ key1: { x: 0, y: 0 } }),
 			});
-			return states.props.fixedMap;
+			return states.states.fixedMap;
 		}
 
 		it("localItemUpdated event is fired with new value when local value is updated", () => {
@@ -94,7 +94,7 @@ describe("Presence", () => {
 				fixedMap: StateFactory.latestMap({ key1: { x: 0, y: 0 } }),
 			});
 
-			assert.strictEqual(states.props.fixedMap.presence, presence);
+			assert.strictEqual(states.states.fixedMap.presence, presence);
 		});
 	});
 });
@@ -118,7 +118,7 @@ export function checkCompiles(): void {
 	);
 	// Workaround ts(2775): Assertions require every name in the call target to be declared with an explicit type annotation.
 	const workspace: typeof statesWorkspace = statesWorkspace;
-	const props = workspace.props;
+	const props = workspace.states;
 
 	props.fixedMap.local.get("key1");
 	// @ts-expect-error with inferred keys only those named it init are accessible
@@ -147,7 +147,7 @@ export function checkCompiles(): void {
 
 	workspace.add("pointers", StateFactory.latestMap<PointerData>({}));
 
-	const pointers = workspace.props.pointers;
+	const pointers = workspace.states.pointers;
 	const localPointers = pointers.local;
 
 	function logClientValue<T>({

--- a/packages/framework/presence/src/test/latestMapValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestMapValueManager.spec.ts
@@ -202,7 +202,7 @@ export function checkCompiles(): void {
 		}),
 	);
 
-	const localPrimitiveMap = workspace.props.primitiveMap.local;
+	const localPrimitiveMap = workspace.states.primitiveMap.local;
 
 	// map value types are not matched to specific key
 	localPrimitiveMap.set("string", 1);

--- a/packages/framework/presence/src/test/latestValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestValueManager.spec.ts
@@ -27,7 +27,7 @@ function createLatestManager(
 	const states = presence.states.getWorkspace(testWorkspaceName, {
 		camera: StateFactory.latest({ x: 0, y: 0, z: 0 }, valueControlSettings),
 	});
-	return states.props.camera;
+	return states.states.camera;
 }
 
 describe("Presence", () => {
@@ -48,28 +48,28 @@ describe("Presence", () => {
 				const states = presence.states.getWorkspace(testWorkspaceName, {
 					obj: StateFactory.latest({}),
 				});
-				assert.deepStrictEqual(states.props.obj.local, {});
+				assert.deepStrictEqual(states.states.obj.local, {});
 			});
 
 			it("can set and get object with properties as initial value", () => {
 				const states = presence.states.getWorkspace(testWorkspaceName, {
 					obj: StateFactory.latest({ x: 0, y: 0, z: 0 }),
 				});
-				assert.deepStrictEqual(states.props.obj.local, { x: 0, y: 0, z: 0 });
+				assert.deepStrictEqual(states.states.obj.local, { x: 0, y: 0, z: 0 });
 			});
 
 			it("can set and get empty array as initial value", () => {
 				const states = presence.states.getWorkspace(testWorkspaceName, {
 					arr: StateFactory.latest([]),
 				});
-				assert.deepStrictEqual(states.props.arr.local, []);
+				assert.deepStrictEqual(states.states.arr.local, []);
 			});
 
 			it("can set and get array with elements as initial value", () => {
 				const states = presence.states.getWorkspace(testWorkspaceName, {
 					arr: StateFactory.latest([1, 2, 3]),
 				});
-				assert.deepStrictEqual(states.props.arr.local, [1, 2, 3]);
+				assert.deepStrictEqual(states.states.arr.local, [1, 2, 3]);
 			});
 
 			it(".presence provides Presence it was created under", () => {
@@ -77,7 +77,7 @@ describe("Presence", () => {
 					camera: StateFactory.latest({ x: 0, y: 0, z: 0 }),
 				});
 
-				assert.strictEqual(states.props.camera.presence, presence);
+				assert.strictEqual(states.states.camera.presence, presence);
 			});
 		});
 
@@ -89,7 +89,7 @@ describe("Presence", () => {
 			const states = presence.states.getWorkspace(testWorkspaceName, {
 				camera: StateFactory.latest({ x: 0, y: 0, z: 0 }),
 			});
-			const camera = states.props.camera;
+			const camera = states.states.camera;
 
 			let localUpdateCount = 0;
 			camera.events.on("localUpdated", (update) => {
@@ -118,16 +118,16 @@ export function checkCompiles(): void {
 	});
 	// Workaround ts(2775): Assertions require every name in the call target to be declared with an explicit type annotation.
 	const workspace: typeof statesWorkspace = statesWorkspace;
-	const props = workspace.props;
+	const props = workspace.states;
 
 	workspace.add("caret", StateFactory.latest({ id: "", pos: 0 }));
 
 	const fakeAdd =
-		workspace.props.caret.local.pos + props.camera.local.z + props.cursor.local.x;
+		workspace.states.caret.local.pos + props.camera.local.z + props.cursor.local.x;
 	console.log(fakeAdd);
 
 	// @ts-expect-error local may be set wholly, but partially it is readonly
-	workspace.props.caret.local.pos = 0;
+	workspace.states.caret.local.pos = 0;
 
 	function logClientValue<
 		T /* following extends should not be required: */ extends Record<string, unknown>,

--- a/packages/framework/presence/src/test/latestValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestValueManager.spec.ts
@@ -78,7 +78,7 @@ describe("Presence", () => {
 				const states = presence.states.getWorkspace(testWorkspaceName, {
 					arr: StateFactory.latest(null),
 				});
-				assert.deepStrictEqual(states.props.arr.local, null);
+				assert.deepStrictEqual(states.states.arr.local, null);
 			});
 
 			it(".presence provides Presence it was created under", () => {
@@ -96,8 +96,8 @@ describe("Presence", () => {
 				});
 
 				// Act and Verify
-				states.props.nullable.local = null;
-				assert.deepStrictEqual(states.props.nullable.local, null);
+				states.states.nullable.local = null;
+				assert.deepStrictEqual(states.states.nullable.local, null);
 			});
 		});
 

--- a/packages/framework/presence/src/test/notificationsManager.spec.ts
+++ b/packages/framework/presence/src/test/notificationsManager.spec.ts
@@ -85,9 +85,9 @@ describe("Presence", () => {
 			);
 
 			// Verify
-			assert.notEqual(notificationsWorkspace.props.testEvents, undefined);
+			assert.notEqual(notificationsWorkspace.states.testEvents, undefined);
 			assertIdenticalTypes(
-				notificationsWorkspace.props.testEvents,
+				notificationsWorkspace.states.testEvents,
 				createInstanceOf<NotificationsManager<{ newId: (id: number) => void }>>(),
 			);
 		});
@@ -107,7 +107,7 @@ describe("Presence", () => {
 				}),
 			);
 
-			const { testEvents } = notificationsWorkspace.props;
+			const { testEvents } = notificationsWorkspace.states;
 
 			clock.tick(10);
 
@@ -158,7 +158,7 @@ describe("Presence", () => {
 				}),
 			);
 
-			const { testEvents } = notificationsWorkspace.props;
+			const { testEvents } = notificationsWorkspace.states;
 
 			clock.tick(10);
 
@@ -222,7 +222,7 @@ describe("Presence", () => {
 				}),
 			);
 
-			const { testEvents } = notificationsWorkspace.props;
+			const { testEvents } = notificationsWorkspace.states;
 
 			testEvents.events.on("unattendedNotification", (name) => {
 				fail(`Unexpected unattendedNotification: ${name}`);
@@ -305,7 +305,7 @@ describe("Presence", () => {
 				}),
 			);
 
-			const { testEvents } = notificationsWorkspace.props;
+			const { testEvents } = notificationsWorkspace.states;
 
 			testEvents.events.on("unattendedNotification", (name, sender, ...content) => {
 				assert.equal(name, "oldId");
@@ -369,7 +369,7 @@ describe("Presence", () => {
 				}),
 			);
 
-			const { testEvents } = notificationsWorkspace.props;
+			const { testEvents } = notificationsWorkspace.states;
 
 			testEvents.events.on("unattendedNotification", (name, sender, ...content) => {
 				assert.equal(name, "newId");
@@ -438,7 +438,7 @@ describe("Presence", () => {
 				}),
 			);
 
-			const { testEvents } = notificationsWorkspace.props;
+			const { testEvents } = notificationsWorkspace.states;
 
 			testEvents.events.on("unattendedNotification", (name) => {
 				fail(`Unexpected unattendedNotification: ${name}`);
@@ -503,7 +503,7 @@ describe("Presence", () => {
 				),
 			);
 
-			assert.strictEqual(notificationsWorkspace.props.testEvents.presence, presence);
+			assert.strictEqual(notificationsWorkspace.states.testEvents.presence, presence);
 			assert.strictEqual(notificationsWorkspace.presence, presence);
 		});
 	});

--- a/packages/framework/presence/src/test/presenceStates.spec.ts
+++ b/packages/framework/presence/src/test/presenceStates.spec.ts
@@ -77,7 +77,7 @@ export function checkCompiles(): void {
 
 	const initialCaret = { id: "", pos: 0 };
 	states.add("caret", createValueManager(initialCaret));
-	const statesProps = states.props;
+	const statesProps = states.states;
 
 	const fakeAdd = statesProps.camera.z + statesProps.cursor.x + statesProps.caret.pos;
 	console.log(fakeAdd);

--- a/packages/framework/presence/src/types.ts
+++ b/packages/framework/presence/src/types.ts
@@ -101,7 +101,7 @@ export interface StatesWorkspace<
 	/**
 	 * Registry of State objects.
 	 */
-	readonly props: StatesWorkspaceEntries<TSchema>;
+	readonly states: StatesWorkspaceEntries<TSchema>;
 
 	/**
 	 * Default controls for management of broadcast updates.
@@ -166,7 +166,7 @@ export interface NotificationsWorkspace<TSchema extends NotificationsWorkspaceSc
 	/**
 	 * Registry of `NotificationsManager`s.
 	 */
-	readonly props: StatesWorkspaceEntries<TSchema>;
+	readonly states: StatesWorkspaceEntries<TSchema>;
 
 	/**
 	 * Containing {@link Presence}


### PR DESCRIPTION
## Description

Rename `StatesWorkspace.props` and `NotificationsWorkspace.props` to `StatesWorkspace.states` and `NotificationsWorkspace.states` respectively. 