### PR TITLE
Add framework for fuzz testing DDS squash behavior

### DIFF
--- a/packages/dds/sequence/src/test/fuzz/sharedString.squash.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/fuzz/sharedString.squash.fuzz.spec.ts
@@ -156,14 +156,14 @@ emitter.on("clientCreate", (client) => {
 	channel.poisonedHandleLocations = [];
 });
 
-describe("SharedString fuzz testing", () => {
+describe.skip("SharedString fuzz testing", () => {
 	createSquashFuzzSuite(
 		{
 			...baseSharedStringModel,
 			generatorFactory: () => takeAsync(100, makeSquashOperationGenerator()),
 			exitingStagingModeGeneratorFactory: makeExitingStagingModeGenerator,
 			reducer: makeSquashReducer(),
-			workloadName: "SharedString squashing",
+			workloadName: "squashing",
 			minimizationTransforms: [
 				// Apply all base transformations to op types we inherit from the base model
 				...(baseSharedStringModel.minimizationTransforms?.map(

--- a/packages/dds/sequence/src/test/fuzz/sharedString.squash.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/fuzz/sharedString.squash.fuzz.spec.ts
@@ -1,0 +1,207 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { TypedEventEmitter } from "@fluid-internal/client-utils";
+import {
+	createWeightedAsyncGenerator,
+	takeAsync,
+	done,
+} from "@fluid-private/stochastic-test-utils";
+import {
+	createSquashFuzzSuite,
+	type DDSFuzzHarnessEvents,
+	type SquashFuzzTestState,
+} from "@fluid-private/test-dds-utils";
+import {
+	ReferenceType,
+	type LocalReferencePosition,
+} from "@fluidframework/merge-tree/internal";
+import { segmentIsRemoved } from "@fluidframework/merge-tree/internal";
+
+import type { SharedStringFactory } from "../../sequenceFactory.js";
+import type { ISharedString } from "../../sharedString.js";
+
+import {
+	baseSharedStringModel,
+	defaultFuzzOptions,
+	defaultIntervalOperationGenerationConfig,
+	makeSharedStringOperationGenerator,
+	type AddPoisonedText,
+	type Operation,
+	type SharedStringOperationGenerationConfig,
+} from "./fuzzUtils.js";
+
+export type PoisonedSharedString = ISharedString & {
+	poisonedHandleLocations: LocalReferencePosition[];
+};
+
+export function isPoisonedSharedString(s: ISharedString): s is PoisonedSharedString {
+	return (
+		(s as PoisonedSharedString).poisonedHandleLocations !== undefined &&
+		Array.isArray((s as PoisonedSharedString).poisonedHandleLocations)
+	);
+}
+
+type FuzzTestState = SquashFuzzTestState<SharedStringFactory>;
+
+type SquashOperation = AddPoisonedText | Operation;
+
+interface SquashOperationGenerationConfig extends SharedStringOperationGenerationConfig {
+	weights: SharedStringOperationGenerationConfig["weights"] & {
+		addPoisonedHandleText: number;
+	};
+}
+
+const defaultSquashOperationGenerationConfig: SquashOperationGenerationConfig = {
+	...defaultIntervalOperationGenerationConfig,
+	weights: {
+		...defaultIntervalOperationGenerationConfig.weights,
+		addPoisonedHandleText: 1,
+	},
+};
+
+function makeExitingStagingModeGenerator() {
+	return (state: FuzzTestState): Operation | typeof done => {
+		// Rather than generate a normal op, only generate ops which remove existing poisoned handles.
+		const {
+			client: { channel: sharedString },
+		} = state;
+		assert(isPoisonedSharedString(sharedString));
+		const { poisonedHandleLocations } = sharedString;
+		// Mutating in the generator like this is not great practice, but it avoids having to define a special op type for 'removing poisoned content'
+		// which also handles removing values from `poisonedHandleLocations`.
+		// If debugging a situation where this test has strange behavior, consider adding that separate op type instead.
+		while (poisonedHandleLocations.length > 0) {
+			// safe due to length check above
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			const lastPoisonedHandleLocation = poisonedHandleLocations.pop()!;
+			const pos = sharedString.localReferencePositionToPosition(lastPoisonedHandleLocation);
+			const segment = lastPoisonedHandleLocation.getSegment();
+			sharedString.removeLocalReferencePosition(lastPoisonedHandleLocation);
+			if (segment !== undefined && !segmentIsRemoved(segment)) {
+				return {
+					type: "removeRange",
+					start: pos,
+					end: pos + 1,
+				};
+			}
+		}
+
+		return done;
+	};
+}
+
+function makeSquashOperationGenerator(optionsParam?: SquashOperationGenerationConfig) {
+	const baseGenerator = makeSharedStringOperationGenerator(optionsParam);
+
+	async function addPoisonedHandleText(state: FuzzTestState): Promise<AddPoisonedText> {
+		const { random, client } = state;
+		return {
+			type: "addPoisonedText",
+			index: random.integer(0, client.channel.getLength()),
+			content: random.string(1),
+			properties: { poison: state.random.poisonedHandle() },
+		};
+	}
+
+	const isInStagingMode = (state: FuzzTestState): boolean =>
+		state.client.stagingModeStatus === "staging";
+
+	const usableWeights =
+		optionsParam?.weights ?? defaultSquashOperationGenerationConfig.weights;
+	return createWeightedAsyncGenerator<SquashOperation, FuzzTestState>([
+		[
+			baseGenerator,
+			usableWeights.addText +
+				usableWeights.removeRange +
+				usableWeights.obliterateRange +
+				usableWeights.annotateRange,
+		],
+		[addPoisonedHandleText, usableWeights.addPoisonedHandleText, isInStagingMode],
+	]);
+}
+
+function makeSquashReducer() {
+	const baseFuzzReducer = baseSharedStringModel.reducer;
+	return (state: FuzzTestState, op: SquashOperation): void => {
+		if (op.type === "addPoisonedText") {
+			const { client } = state;
+			const { content, index, properties } = op;
+			assert(isPoisonedSharedString(client.channel));
+			assert(content.length === 1);
+			client.channel.insertText(index, content, properties);
+			const { segment, offset } = client.channel.getContainingSegment(index);
+			assert(segment !== undefined && offset !== undefined);
+			const ref = client.channel.createLocalReferencePosition(
+				segment,
+				offset,
+				ReferenceType.Simple,
+				undefined,
+			);
+			client.channel.poisonedHandleLocations.push(ref);
+		} else {
+			baseFuzzReducer(state, op);
+		}
+	};
+}
+
+const emitter = new TypedEventEmitter<DDSFuzzHarnessEvents>();
+
+emitter.on("clientCreate", (client) => {
+	const channel = client.channel as PoisonedSharedString;
+	channel.poisonedHandleLocations = [];
+});
+
+describe("SharedString fuzz testing", () => {
+	createSquashFuzzSuite(
+		{
+			...baseSharedStringModel,
+			generatorFactory: () => takeAsync(100, makeSquashOperationGenerator()),
+			exitingStagingModeGeneratorFactory: makeExitingStagingModeGenerator,
+			reducer: makeSquashReducer(),
+			workloadName: "SharedString squashing",
+			minimizationTransforms: [
+				// Apply all base transformations to op types we inherit from the base model
+				...(baseSharedStringModel.minimizationTransforms?.map(
+					(transform) => (op: SquashOperation) => {
+						if (op.type !== "addPoisonedText") {
+							transform(op);
+						}
+					},
+				) ?? []),
+				// ...and a simple one for poisoned handle ops.
+				(op: SquashOperation) => {
+					if (op.type === "addPoisonedText") {
+						op.index--;
+					}
+				},
+			],
+			validatePoisonedContentRemoved: (client) => {
+				assert(isPoisonedSharedString(client.channel));
+				const { poisonedHandleLocations } = client.channel;
+				if (poisonedHandleLocations.length > 0) {
+					for (const handle of poisonedHandleLocations) {
+						const segment = handle.getSegment();
+						assert(
+							segment === undefined || segmentIsRemoved(segment),
+							"Content with poisoned handle not removed from shared string.",
+						);
+					}
+				}
+			},
+		},
+		{
+			...defaultFuzzOptions,
+			emitter,
+			stagingMode: {
+				changeStagingModeProbability: 0.1,
+			},
+			// Uncomment this line to replay a specific seed from its failure file:
+			// replay: 0,
+		},
+	);
+});

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -88,7 +88,7 @@ export class FluidSerializer implements IFluidSerializer {
 		// return the result of 'recursivelyReplace()'.
 		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 		return !!input && typeof input === "object"
-			? this.recursivelyReplace(input, this.encodeValue, bind)
+			? this.recursivelyReplace(input, this.encodeValue.bind(this), bind)
 			: input;
 	}
 
@@ -106,7 +106,7 @@ export class FluidSerializer implements IFluidSerializer {
 		// return the result of 'recursivelyReplace()'.
 		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 		return !!input && typeof input === "object"
-			? this.recursivelyReplace(input, this.decodeValue)
+			? this.recursivelyReplace(input, this.decodeValue.bind(this))
 			: input;
 	}
 
@@ -131,20 +131,20 @@ export class FluidSerializer implements IFluidSerializer {
 	 * If the given 'value' is an IFluidHandle, returns the encoded IFluidHandle.
 	 * Otherwise returns the original 'value'.  Used by 'encode()' and 'stringify()'.
 	 */
-	private readonly encodeValue = (value: unknown, bind?: IFluidHandleInternal): unknown => {
+	protected encodeValue(value: unknown, bind?: IFluidHandleInternal): unknown {
 		// If 'value' is an IFluidHandle return its encoded form.
 		if (isFluidHandle(value)) {
 			assert(bind !== undefined, 0xa93 /* Cannot encode a handle without a bind context */);
 			return this.bindAndEncodeHandle(toFluidHandleInternal(value), bind);
 		}
 		return value;
-	};
+	}
 
 	/**
 	 * If the given 'value' is an encoded IFluidHandle, returns the decoded IFluidHandle.
 	 * Otherwise returns the original 'value'.  Used by 'decode()' and 'parse()'.
 	 */
-	private readonly decodeValue = (value: unknown): unknown => {
+	protected decodeValue(value: unknown): unknown {
 		// If 'value' is a serialized IFluidHandle return the deserialized result.
 		if (isSerializedHandle(value)) {
 			// Old documents may have handles with relative path in their summaries. Convert these to absolute
@@ -157,7 +157,7 @@ export class FluidSerializer implements IFluidSerializer {
 		} else {
 			return value;
 		}
-	};
+	}
 
 	/**
 	 * Invoked for non-null objects to recursively replace references to IFluidHandles.

--- a/packages/dds/test-dds-utils/src/clientLoading.ts
+++ b/packages/dds/test-dds-utils/src/clientLoading.ts
@@ -21,6 +21,16 @@ export interface Client<TChannelFactory extends IChannelFactory> {
 	channel: ReturnType<TChannelFactory["create"]>;
 	dataStoreRuntime: MockFluidDataStoreRuntime;
 	containerRuntime: MockContainerRuntimeForReconnection;
+	/**
+	 * TODO: When real API for this is more settled, it probably makes more sense for something like this
+	 * to be on the container runtime (and mock container runtime above) rather than a separate property here.
+	 */
+	// isInStagingMode: boolean;
+	/**
+	 * 'exiting' means "it's up to the DDS to apply edits which remove any poisoned handles from the document".
+	 * They should use TODO to do so
+	 */
+	stagingModeStatus: "off" | "staging" | "exiting";
 }
 
 /**

--- a/packages/dds/test-dds-utils/src/clientLoading.ts
+++ b/packages/dds/test-dds-utils/src/clientLoading.ts
@@ -21,16 +21,6 @@ export interface Client<TChannelFactory extends IChannelFactory> {
 	channel: ReturnType<TChannelFactory["create"]>;
 	dataStoreRuntime: MockFluidDataStoreRuntime;
 	containerRuntime: MockContainerRuntimeForReconnection;
-	/**
-	 * TODO: When real API for this is more settled, it probably makes more sense for something like this
-	 * to be on the container runtime (and mock container runtime above) rather than a separate property here.
-	 */
-	// isInStagingMode: boolean;
-	/**
-	 * 'exiting' means "it's up to the DDS to apply edits which remove any poisoned handles from the document".
-	 * They should use TODO to do so
-	 */
-	stagingModeStatus: "off" | "staging" | "exiting";
 }
 
 /**

--- a/packages/dds/test-dds-utils/src/ddsFuzzHandle.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHandle.ts
@@ -10,6 +10,8 @@ import {
 	generateHandleContextPath,
 } from "@fluidframework/runtime-utils/internal";
 
+import type { IPoisonedHandle } from "./fuzzSerializer.js";
+
 /**
  * @internal
  */
@@ -25,6 +27,40 @@ export class DDSFuzzHandle extends FluidHandleBase<string> {
 	constructor(
 		public readonly id: string,
 		public readonly routeContext: IFluidHandleContext,
+	) {
+		super();
+		this.absolutePath = generateHandleContextPath(id, this.routeContext);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	public async get(): Promise<any> {
+		return this.absolutePath;
+	}
+
+	public attachGraph(): void {
+		if (!this.attached) {
+			this.attached = true;
+		}
+	}
+
+	public bind(handle: IFluidHandle): void {}
+}
+
+export class PoisonedDDSFuzzHandle extends FluidHandleBase<string> implements IPoisonedHandle {
+	private attached: boolean = false;
+
+	public get isAttached(): boolean {
+		return this.routeContext.isAttached && this.attached;
+	}
+
+	public readonly absolutePath: string;
+
+	public readonly poisoned = true;
+
+	constructor(
+		public readonly id: string,
+		public readonly routeContext: IFluidHandleContext,
+		public readonly creatingClientId: string,
 	) {
 		super();
 		this.absolutePath = generateHandleContextPath(id, this.routeContext);

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -41,19 +41,19 @@ import { AttachState } from "@fluidframework/container-definitions";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import { unreachableCase } from "@fluidframework/core-utils/internal";
 import type {
+	IChannel,
 	IChannelFactory,
 	IChannelServices,
 } from "@fluidframework/datastore-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type { IIdCompressorCore } from "@fluidframework/id-compressor/internal";
-import { FluidSerializer } from "@fluidframework/shared-object-base/internal";
+import type { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
 import {
 	MockContainerRuntimeFactoryForReconnection,
 	MockFluidDataStoreRuntime,
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 import type { IMockContainerRuntimeOptions } from "@fluidframework/test-runtime-utils/internal";
-import { v4 as uuid } from "uuid";
 
 import {
 	type Client,
@@ -65,6 +65,8 @@ import {
 	hasStashData,
 } from "./clientLoading.js";
 import { DDSFuzzHandle } from "./ddsFuzzHandle.js";
+import { DDSFuzzSerializer } from "./fuzzSerializer.js";
+import { makeUnreachableCodePathProxy } from "./utils.js";
 
 /**
  * @internal
@@ -123,14 +125,6 @@ export interface StashClient {
 /**
  * @internal
  */
-export interface HandlePicked {
-	type: "handlePicked";
-	handleId: string;
-}
-
-/**
- * @internal
- */
 export interface Attach {
 	type: "attach";
 }
@@ -173,6 +167,16 @@ export interface Synchronize {
 	type: "synchronize";
 	clients?: string[];
 }
+
+export type HarnessOperation =
+	| AddClient
+	| Attach
+	| Attaching
+	| Rehydrate
+	| ChangeConnectionState
+	| TriggerRebase
+	| Synchronize
+	| StashClient;
 
 /**
  * Represents a generic fuzz model for testing eventual consistency of a DDS.
@@ -629,18 +633,17 @@ export function mixinReconnect<
 >(
 	model: DDSFuzzHarnessModel<TChannelFactory, TOperation, TState>,
 	options: DDSFuzzSuiteOptions,
+	isReconnectAllowed = (state: TState): boolean => !state.isDetached,
 ): DDSFuzzHarnessModel<TChannelFactory, TOperation | ChangeConnectionState, TState> {
 	const generatorFactory: () => AsyncGenerator<TOperation | ChangeConnectionState, TState> =
 		() => {
 			const baseGenerator = model.generatorFactory();
 			return async (state): Promise<TOperation | ChangeConnectionState | typeof done> => {
 				const baseOp = baseGenerator(state);
-				if (!state.isDetached && state.random.bool(options.reconnectProbability)) {
-					const client = state.clients.find((c) => c.channel.id === state.client.channel.id);
-					assert(client !== undefined);
+				if (isReconnectAllowed(state) && state.random.bool(options.reconnectProbability)) {
 					return {
 						type: "changeConnectionState",
-						connected: !client.containerRuntime.connected,
+						connected: !state.client.containerRuntime.connected,
 					};
 				}
 
@@ -1017,6 +1020,23 @@ export function mixinSynchronization<
 const isClientSpec = (op: unknown): op is ClientSpec =>
 	(op as ClientSpec).clientId !== undefined;
 
+export function addClientContext(
+	state: DDSFuzzTestState<IChannelFactory>,
+	client: Client<IChannelFactory>,
+): CleanupFunction {
+	const { client: oldClient, random } = state;
+	// eslint-disable-next-line @typescript-eslint/unbound-method
+	const { handle: oldHandle } = random;
+
+	state.client = client;
+	random.handle = () => new DDSFuzzHandle(random.pick(handles), client.dataStoreRuntime);
+	return () => {
+		state.client = oldClient;
+		// eslint-disable-next-line unicorn/consistent-destructuring
+		state.random.handle = oldHandle;
+	};
+}
+
 /**
  * Mixes in the ability to select a client to perform an operation on.
  * Makes this available to existing generators and reducers in the passed-in model via {@link DDSFuzzTestState.client}
@@ -1033,6 +1053,10 @@ export function mixinClientSelection<
 >(
 	model: DDSFuzzHarnessModel<TChannelFactory, TOperation, TState>,
 	_: DDSFuzzSuiteOptions,
+	setupClientState: (
+		state: TState,
+		client: TState["client"],
+	) => CleanupFunction = addClientContext,
 ): DDSFuzzHarnessModel<TChannelFactory, TOperation, TState> {
 	const generatorFactory: () => AsyncGenerator<TOperation, TState> = () => {
 		const baseGenerator = model.generatorFactory();
@@ -1043,7 +1067,7 @@ export function mixinClientSelection<
 			// 2. Make it available to the subsequent reducer logic we're going to inject
 			// (so that we can recover the channel from serialized data)
 			const client = state.random.pick(state.clients);
-			const baseOp = await runInStateWithClient(state, client, async () =>
+			const baseOp = await runInStateWithClient(state, client, setupClientState, async () =>
 				baseGenerator(state),
 			);
 			return baseOp === done
@@ -1059,7 +1083,7 @@ export function mixinClientSelection<
 		assert(isClientSpec(operation), "operation should have been given a client");
 		const client = state.clients.find((c) => c.channel.id === operation.clientId);
 		assert(client !== undefined);
-		await runInStateWithClient(state, client, async () =>
+		await runInStateWithClient(state, client, setupClientState, async () =>
 			model.reducer(state, operation as TOperation),
 		);
 	};
@@ -1146,6 +1170,15 @@ export function mixinStashedClient<
 	};
 }
 
+export const handles = Array.from({ length: 100 }, (_, index) => `handle_${index}`);
+
+/**
+ * Callback invoked on "cleanup" of some associated operation.
+ *
+ * This is the same dispose callback pattern used by our eventing library in common-utils.
+ */
+export type CleanupFunction = () => void;
+
 /**
  * This modifies the value of "client" while callback is running, then restores it.
  * This is does instead of copying the state since the state object is mutable, and running callback might make changes to state (like add new members) which are lost if state is just copied.
@@ -1155,28 +1188,15 @@ export function mixinStashedClient<
 async function runInStateWithClient<TState extends DDSFuzzTestState<IChannelFactory>, Result>(
 	state: TState,
 	client: TState["client"],
+	setupClientState: (state: TState, client: TState["client"]) => CleanupFunction,
 	callback: (state: TState) => Promise<Result>,
 ): Promise<Result> {
-	const oldClient = state.client;
-	state.client = client;
+	const cleanup = setupClientState(state, client);
 	try {
 		return await callback(state);
 	} finally {
-		// This code is explicitly trying to "update" to the old value.
-		// eslint-disable-next-line require-atomic-updates
-		state.client = oldClient;
+		cleanup();
 	}
-}
-
-function makeUnreachableCodePathProxy<T extends object>(name: string): T {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-	return new Proxy({} as T, {
-		get: (): never => {
-			throw new Error(
-				`Unexpected read of '${name}:' this indicates a bug in the DDS eventual consistency harness.`,
-			);
-		},
-	});
 }
 
 function createDetachedClient<TChannelFactory extends IChannelFactory>(
@@ -1199,6 +1219,7 @@ function createDetachedClient<TChannelFactory extends IChannelFactory>(
 		dataStoreRuntime,
 		clientId,
 	);
+	setupFuzzSerializer(channel, dataStoreRuntime);
 
 	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime, {
 		// only track remote ops(which enables initialize from stashed ops), if rehydrate is enabled
@@ -1210,6 +1231,7 @@ function createDetachedClient<TChannelFactory extends IChannelFactory>(
 		containerRuntime,
 		dataStoreRuntime,
 		channel: channel as ReturnType<TChannelFactory["create"]>,
+		stagingModeStatus: "off",
 	};
 	options.emitter.emit("clientCreate", newClient);
 	return newClient;
@@ -1235,6 +1257,15 @@ async function loadClient<TChannelFactory extends IChannelFactory>(
 		options,
 		supportStashing,
 	);
+}
+
+function setupFuzzSerializer(
+	channel: IChannel,
+	dataStoreRuntime: MockFluidDataStoreRuntime,
+): void {
+	// TODO: More legitimate way to inject this alternative serialization strategy
+	(channel as unknown as { _serializer: IFluidSerializer })._serializer =
+		new DDSFuzzSerializer(dataStoreRuntime.channelsRoutingContext, dataStoreRuntime.id);
 }
 
 async function loadClientFromSummaries<TChannelFactory extends IChannelFactory>(
@@ -1270,6 +1301,7 @@ async function loadClientFromSummaries<TChannelFactory extends IChannelFactory>(
 		services,
 		factory.attributes,
 	)) as ReturnType<TChannelFactory["create"]>;
+	setupFuzzSerializer(channel, dataStoreRuntime);
 	channel.connect(services);
 
 	const newClient: ClientWithStashData<TChannelFactory> = {
@@ -1277,6 +1309,7 @@ async function loadClientFromSummaries<TChannelFactory extends IChannelFactory>(
 		containerRuntime,
 		dataStoreRuntime,
 		stashData,
+		stagingModeStatus: "off",
 	};
 
 	options.emitter.emit("clientCreate", newClient);
@@ -1326,6 +1359,7 @@ async function loadDetached<TChannelFactory extends IChannelFactory>(
 		channel,
 		containerRuntime,
 		dataStoreRuntime,
+		stagingModeStatus: "off",
 	};
 	options.emitter.emit("clientCreate", newClient);
 	return newClient;
@@ -1405,29 +1439,15 @@ export async function runTestForSeed<
 				),
 			);
 	const summarizerClient = initialClient;
-	const handles = Array.from({ length: 5 }).map(() => uuid());
-	let handleGenerated = false;
 	const initialState: DDSFuzzTestState<TChannelFactory> = {
 		clients,
 		summarizerClient,
 		containerRuntimeFactory,
 		random: {
 			...random,
-			handle: () => {
-				handleGenerated = true;
-				return new DDSFuzzHandle(
-					random.pick(handles),
-					// this is wonky, as get on this handle will always resolve via
-					// the summarizer client, but since we just return the absolute path
-					// it doesn't really matter, and remote handles will use
-					// the right handle context when they are deserialized
-					// by the dds.
-					//
-					// we re-used this hack a few time below, because
-					// we don't have the real client
-					initialState.summarizerClient.dataStoreRuntime,
-				);
-			},
+			// This is injected by client selection logic, which allows binding the handle
+			// to an appropriate client context.
+			handle: makeUnreachableCodePathProxy("random.handle"),
 		},
 		client: makeUnreachableCodePathProxy("client"),
 		isDetached: startDetached,
@@ -1435,13 +1455,23 @@ export async function runTestForSeed<
 
 	options.emitter.emit("testStart", initialState);
 
-	const serializer = new FluidSerializer(initialState.summarizerClient.dataStoreRuntime);
-	const bind = new DDSFuzzHandle("", initialState.summarizerClient.dataStoreRuntime);
+	const serializer = new DDSFuzzSerializer(
+		initialState.summarizerClient.dataStoreRuntime,
+		initialState.summarizerClient.dataStoreRuntime.id,
+		false,
+	);
+	const rootHandle = new DDSFuzzHandle("", initialState.summarizerClient.dataStoreRuntime);
 
 	let operationCount = 0;
 	const generator = model.generatorFactory();
 	const finalState = await performFuzzActionsAsync(
-		async (state) => serializer.encode(await generator(state), bind) as TOperation,
+		// performFuzzActionsAsync expects generators to return JSON-serializable objects.
+		// To make this work with handles that the DDS model may have generated, we use the FluidSerializer above
+		// to encode here and decode in the reducer.
+		async (state) => {
+			const operation = await generator(state);
+			return serializer.encode(operation, rootHandle) as TOperation;
+		},
 		async (state, operation) => {
 			const decodedHandles = serializer.decode(operation) as TOperation;
 			options.emitter.emit("operation", decodedHandles);
@@ -1455,14 +1485,6 @@ export async function runTestForSeed<
 	// Sanity-check that the generator produced at least one operation. If it failed to do so,
 	// this usually indicates an error on the part of the test author.
 	assert(operationCount > 0, "Generator should have produced at least one operation.");
-
-	if (options.handleGenerationDisabled !== true) {
-		assert(
-			handleGenerated,
-			"no handles were generated; tests should generate and use handle via random.handle, or disable handles for the test",
-		);
-	}
-
 	options.emitter.emit("testEnd", finalState);
 
 	return finalState;
@@ -1523,14 +1545,12 @@ function runTest<TChannelFactory extends IChannelFactory, TOperation extends Bas
 	});
 }
 
-type InternalOptions = Omit<DDSFuzzSuiteOptions, "only" | "skip"> & {
+interface InternalOnlyAndSkip {
 	only: Set<number>;
 	skip: Set<number>;
-};
-
-function isInternalOptions(options: DDSFuzzSuiteOptions): options is InternalOptions {
-	return options.only instanceof Set && options.skip instanceof Set;
 }
+
+type InternalOptions = InternalOnlyAndSkip & Omit<DDSFuzzSuiteOptions, "only" | "skip">;
 
 /**
  * Some reducers require preconditions be met which are validated by their generator.
@@ -1573,29 +1593,19 @@ export async function replayTest<
 	await runTestForSeed(model, options, seed, saveInfo);
 }
 
-/**
- * Creates a suite of eventual consistency tests for a particular DDS model.
- * @internal
- */
-export function createDDSFuzzSuite<
-	TChannelFactory extends IChannelFactory,
-	TOperation extends BaseOperation,
->(
-	ddsModel: DDSFuzzModel<TChannelFactory, TOperation>,
-	providedOptions?: Partial<DDSFuzzSuiteOptions>,
-): void {
-	const options = {
-		...defaultDDSFuzzSuiteOptions,
-		...providedOptions,
-	};
-
+export function convertOnlyAndSkip<TOptions extends DDSFuzzSuiteOptions>(
+	options: TOptions,
+): InternalOnlyAndSkip & Omit<TOptions, "only" | "skip"> {
 	const only = new Set(options.only);
 	const skip = new Set(options.skip);
 	Object.assign(options, { only, skip });
-	assert(isInternalOptions(options));
+	return options as unknown as InternalOnlyAndSkip & Omit<TOptions, "only" | "skip">;
+}
 
-	const model = getFullModel(ddsModel, options);
-
+export function createSuite<
+	TChannelFactory extends IChannelFactory,
+	TOperation extends BaseOperation,
+>(model: DDSFuzzHarnessModel<TChannelFactory, TOperation>, options: InternalOptions): void {
 	const describeFuzz = createFuzzDescribe({ defaultTestCount: options.defaultTestCount });
 	describeFuzz(model.workloadName, ({ testCount, stressMode }) => {
 		before(() => {
@@ -1646,18 +1656,7 @@ const getFullModel = <
 >(
 	ddsModel: DDSFuzzModel<TChannelFactory, TOperation>,
 	options: DDSFuzzSuiteOptions,
-): DDSFuzzHarnessModel<
-	TChannelFactory,
-	| TOperation
-	| AddClient
-	| Attach
-	| Attaching
-	| Rehydrate
-	| ChangeConnectionState
-	| TriggerRebase
-	| Synchronize
-	| StashClient
-> =>
+): DDSFuzzHarnessModel<TChannelFactory, TOperation | HarnessOperation> =>
 	mixinAttach(
 		mixinSynchronization(
 			mixinNewClient(
@@ -1674,6 +1673,22 @@ const getFullModel = <
 		),
 		options,
 	);
+
+/**
+ * Creates a suite of eventual consistency tests for a particular DDS model.
+ * @internal
+ */
+export function createDDSFuzzSuite<
+	TChannelFactory extends IChannelFactory,
+	TOperation extends BaseOperation,
+>(
+	ddsModel: DDSFuzzModel<TChannelFactory, TOperation>,
+	providedOptions?: Partial<DDSFuzzSuiteOptions>,
+): void {
+	const options = convertOnlyAndSkip({ ...defaultDDSFuzzSuiteOptions, ...providedOptions });
+	const model = getFullModel(ddsModel, options);
+	createSuite(model, options);
+}
 
 /**
  * {@inheritDoc (createDDSFuzzSuite:function)}

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -1231,7 +1231,6 @@ function createDetachedClient<TChannelFactory extends IChannelFactory>(
 		containerRuntime,
 		dataStoreRuntime,
 		channel: channel as ReturnType<TChannelFactory["create"]>,
-		stagingModeStatus: "off",
 	};
 	options.emitter.emit("clientCreate", newClient);
 	return newClient;
@@ -1309,7 +1308,6 @@ async function loadClientFromSummaries<TChannelFactory extends IChannelFactory>(
 		containerRuntime,
 		dataStoreRuntime,
 		stashData,
-		stagingModeStatus: "off",
 	};
 
 	options.emitter.emit("clientCreate", newClient);
@@ -1359,7 +1357,6 @@ async function loadDetached<TChannelFactory extends IChannelFactory>(
 		channel,
 		containerRuntime,
 		dataStoreRuntime,
-		stagingModeStatus: "off",
 	};
 	options.emitter.emit("clientCreate", newClient);
 	return newClient;

--- a/packages/dds/test-dds-utils/src/fuzzSerializer.ts
+++ b/packages/dds/test-dds-utils/src/fuzzSerializer.ts
@@ -1,0 +1,223 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import {
+	IFluidHandleContext,
+	type IFluidHandleInternal,
+} from "@fluidframework/core-interfaces/internal";
+import { assert, shallowCloneObject } from "@fluidframework/core-utils/internal";
+import {
+	encodeHandleForSerialization,
+	generateHandleContextPath,
+	isSerializedHandle,
+	isFluidHandle,
+	toFluidHandleInternal,
+	type ISerializedHandle,
+	RemoteFluidObjectHandle,
+} from "@fluidframework/runtime-utils/internal";
+import type { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
+
+import { PoisonedDDSFuzzHandle } from "./ddsFuzzHandle.js";
+
+/**
+ * Data Store serializer implementation
+ * @internal
+ */
+export class DDSFuzzSerializer implements IFluidSerializer {
+	private readonly root: IFluidHandleContext;
+
+	public constructor(
+		private readonly context: IFluidHandleContext,
+		public readonly clientId: string,
+		private readonly strict: boolean = true,
+	) {
+		this.root = this.context;
+		while (this.root.routeContext !== undefined) {
+			this.root = this.root.routeContext;
+		}
+	}
+
+	public get IFluidSerializer(): IFluidSerializer {
+		return this;
+	}
+
+	/**
+	 * Given a mostly-jsonable object tree that may have handle objects embedded within, will return a
+	 * fully-jsonable object tree where any embedded IFluidHandles have been replaced with a serializable form.
+	 *
+	 * The original `input` object is not mutated.  This method will shallowly clone all objects in the path from
+	 * the root to any replaced handles.  (If no handles are found, returns the original object.)
+	 *
+	 * Any unbound handles encountered are bound to the provided IFluidHandle.
+	 */
+	public encode(input: unknown, bind: IFluidHandleInternal): unknown {
+		// If the given 'input' cannot contain handles, return it immediately.  Otherwise,
+		// return the result of 'recursivelyReplace()'.
+		return !!input && typeof input === "object"
+			? this.recursivelyReplace(input, this.encodeValue, bind)
+			: input;
+	}
+
+	/**
+	 * Given a fully-jsonable object tree that may have encoded handle objects embedded within, will return an
+	 * equivalent object tree where any encoded IFluidHandles have been replaced with their decoded form.
+	 *
+	 * The original `input` object is not mutated.  This method will shallowly clone all objects in the path from
+	 * the root to any replaced handles.  (If no handles are found, returns the original object.)
+	 *
+	 * The decoded handles are implicitly bound to the handle context of this serializer.
+	 */
+	public decode(input: unknown): unknown {
+		// If the given 'input' cannot contain handles, return it immediately.  Otherwise,
+		// return the result of 'recursivelyReplace()'.
+		return !!input && typeof input === "object"
+			? this.recursivelyReplace(input, this.decodeValue)
+			: input;
+	}
+
+	/**
+	 * Serializes the input object into a JSON string.
+	 * Any IFluidHandles in the object will be replaced with their serialized form before stringify,
+	 * being bound to the given bind context in the process.
+	 */
+	public stringify(input: unknown, bind: IFluidHandle): string {
+		const bindInternal = toFluidHandleInternal(bind);
+		return JSON.stringify(input, (key, value) => this.encodeValue(value, bindInternal));
+	}
+
+	/**
+	 * Parses the serialized data - context must match the context with which the JSON was stringified
+	 */
+	public parse(input: string): unknown {
+		return JSON.parse(input, (key, value) => this.decodeValue(value));
+	}
+
+	/**
+	 * If the given 'value' is an IFluidHandle, returns the encoded IFluidHandle.
+	 * Otherwise returns the original 'value'.  Used by 'encode()' and 'stringify()'.
+	 */
+	private readonly encodeValue = (value: unknown, bind?: IFluidHandleInternal): unknown => {
+		// If 'value' is an IFluidHandle return its encoded form.
+		if (isFluidHandle(value)) {
+			assert(bind !== undefined, 0xa93 /* Cannot encode a handle without a bind context */);
+			return this.bindAndEncodeHandle(toFluidHandleInternal(value), bind);
+		}
+		return value;
+	};
+
+	/**
+	 * If the given 'value' is an encoded IFluidHandle, returns the decoded IFluidHandle.
+	 * Otherwise returns the original 'value'.  Used by 'decode()' and 'parse()'.
+	 */
+	private readonly decodeValue = (value: unknown): unknown => {
+		// If 'value' is a serialized IFluidHandle return the deserialized result.
+		if (isSerializedHandle(value)) {
+			// Old documents may have handles with relative path in their summaries. Convert these to absolute
+			// paths. This will ensure that future summaries will have absolute paths for these handles.
+			const absolutePath = value.url.startsWith("/")
+				? value.url
+				: generateHandleContextPath(value.url, this.context);
+
+			if (isPoisonedHandle(value)) {
+				if (this.strict && this.clientId !== value.creatingClientId) {
+					throw new Error(
+						`Poisoned handle created by client ${value.creatingClientId} should not be referenced by client ${this.clientId}, but was found at deserialization time!`,
+					);
+				}
+
+				return new PoisonedDDSFuzzHandle(absolutePath, this.root, value.creatingClientId);
+			}
+			return new RemoteFluidObjectHandle(absolutePath, this.root);
+		} else {
+			return value;
+		}
+	};
+
+	/**
+	 * Invoked for non-null objects to recursively replace references to IFluidHandles.
+	 * Clones as-needed to avoid mutating the `input` object.  If no IFluidHandles are present,
+	 * returns the original `input`.
+	 */
+	private recursivelyReplace<TContext = unknown>(
+		input: object,
+		replacer: (input: unknown, context?: TContext) => unknown,
+		context?: TContext,
+	): unknown {
+		// Note: Caller is responsible for ensuring that `input` is defined / non-null.
+		//       (Required for Object.keys() below.)
+
+		// Execute the `replace` on the current input.  Note that Caller is responsible for ensuring that `input`
+		// is a non-null object.
+		const maybeReplaced = replacer(input, context);
+
+		// If either input or the replaced result is a Fluid Handle, there is no need to descend further.
+		// IFluidHandles are always leaves in the object graph, and the code below cannot deal with IFluidHandle's structure.
+		if (isFluidHandle(input) || isFluidHandle(maybeReplaced)) {
+			return maybeReplaced;
+		}
+
+		// Otherwise descend into the object graph looking for IFluidHandle instances.
+		let clone: object | undefined;
+		for (const key of Object.keys(input)) {
+			const value: unknown = input[key];
+			if (!!value && typeof value === "object") {
+				// Note: Except for IFluidHandle, `input` must not contain circular references (as object must
+				//       be JSON serializable.)  Therefore, guarding against infinite recursion here would only
+				//       lead to a later error when attempting to stringify().
+				const replaced = this.recursivelyReplace(value, replacer, context);
+
+				// If the `replaced` object is different than the original `value` then the subgraph contained one
+				// or more handles.  If this happens, we need to return a clone of the `input` object where the
+				// current property is replaced by the `replaced` value.
+				if (replaced !== value) {
+					// Lazily create a shallow clone of the `input` object if we haven't done so already.
+					clone ??= shallowCloneObject(input);
+
+					// Overwrite the current property `key` in the clone with the `replaced` value.
+					clone[key] = replaced;
+				}
+			}
+		}
+		return clone ?? input;
+	}
+
+	/**
+	 * Encodes the given IFluidHandle into a JSON-serializable form,
+	 * also binding it to another node to ensure it attaches at the right time.
+	 * @param handle - The IFluidHandle to serialize.
+	 * @param bind - The binding context for the handle (the handle will become attached whenever this context is attached).
+	 * @returns The serialized handle.
+	 */
+	protected bindAndEncodeHandle(
+		handle: IFluidHandleInternal,
+		bind: IFluidHandleInternal,
+	): ISerializedHandle & Partial<IPoisonedHandle> {
+		bind.bind(handle);
+		const baseEncoding = encodeHandleForSerialization(handle);
+		if (isPoisonedHandle(handle)) {
+			return {
+				...baseEncoding,
+				poisoned: true,
+				creatingClientId: handle.creatingClientId,
+			};
+		}
+		return baseEncoding;
+	}
+}
+
+/**
+ * NOTE: used in both serialized and non-serialized form.
+ */
+export interface IPoisonedHandle {
+	poisoned: boolean;
+	creatingClientId: string;
+}
+
+function isPoisonedHandle<T extends ISerializedHandle | IFluidHandleInternal>(
+	value: T,
+): value is T & IPoisonedHandle {
+	return "poisoned" in value && value.poisoned === true;
+}

--- a/packages/dds/test-dds-utils/src/fuzzSerializer.ts
+++ b/packages/dds/test-dds-utils/src/fuzzSerializer.ts
@@ -3,22 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidHandle } from "@fluidframework/core-interfaces";
 import {
 	IFluidHandleContext,
 	type IFluidHandleInternal,
 } from "@fluidframework/core-interfaces/internal";
-import { assert, shallowCloneObject } from "@fluidframework/core-utils/internal";
+import { assert } from "@fluidframework/core-utils/internal";
 import {
-	encodeHandleForSerialization,
-	generateHandleContextPath,
 	isSerializedHandle,
-	isFluidHandle,
-	toFluidHandleInternal,
 	type ISerializedHandle,
 	RemoteFluidObjectHandle,
 } from "@fluidframework/runtime-utils/internal";
-import type { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
+import { FluidSerializer } from "@fluidframework/shared-object-base/internal";
 
 import { PoisonedDDSFuzzHandle } from "./ddsFuzzHandle.js";
 
@@ -26,100 +21,27 @@ import { PoisonedDDSFuzzHandle } from "./ddsFuzzHandle.js";
  * Data Store serializer implementation
  * @internal
  */
-export class DDSFuzzSerializer implements IFluidSerializer {
-	private readonly root: IFluidHandleContext;
-
+export class DDSFuzzSerializer extends FluidSerializer {
 	public constructor(
-		private readonly context: IFluidHandleContext,
-		public readonly clientId: string,
+		context: IFluidHandleContext,
+		private readonly clientId: string,
 		private readonly strict: boolean = true,
 	) {
-		this.root = this.context;
-		while (this.root.routeContext !== undefined) {
-			this.root = this.root.routeContext;
-		}
+		super(context);
 	}
-
-	public get IFluidSerializer(): IFluidSerializer {
-		return this;
-	}
-
-	/**
-	 * Given a mostly-jsonable object tree that may have handle objects embedded within, will return a
-	 * fully-jsonable object tree where any embedded IFluidHandles have been replaced with a serializable form.
-	 *
-	 * The original `input` object is not mutated.  This method will shallowly clone all objects in the path from
-	 * the root to any replaced handles.  (If no handles are found, returns the original object.)
-	 *
-	 * Any unbound handles encountered are bound to the provided IFluidHandle.
-	 */
-	public encode(input: unknown, bind: IFluidHandleInternal): unknown {
-		// If the given 'input' cannot contain handles, return it immediately.  Otherwise,
-		// return the result of 'recursivelyReplace()'.
-		return !!input && typeof input === "object"
-			? this.recursivelyReplace(input, this.encodeValue, bind)
-			: input;
-	}
-
-	/**
-	 * Given a fully-jsonable object tree that may have encoded handle objects embedded within, will return an
-	 * equivalent object tree where any encoded IFluidHandles have been replaced with their decoded form.
-	 *
-	 * The original `input` object is not mutated.  This method will shallowly clone all objects in the path from
-	 * the root to any replaced handles.  (If no handles are found, returns the original object.)
-	 *
-	 * The decoded handles are implicitly bound to the handle context of this serializer.
-	 */
-	public decode(input: unknown): unknown {
-		// If the given 'input' cannot contain handles, return it immediately.  Otherwise,
-		// return the result of 'recursivelyReplace()'.
-		return !!input && typeof input === "object"
-			? this.recursivelyReplace(input, this.decodeValue)
-			: input;
-	}
-
-	/**
-	 * Serializes the input object into a JSON string.
-	 * Any IFluidHandles in the object will be replaced with their serialized form before stringify,
-	 * being bound to the given bind context in the process.
-	 */
-	public stringify(input: unknown, bind: IFluidHandle): string {
-		const bindInternal = toFluidHandleInternal(bind);
-		return JSON.stringify(input, (key, value) => this.encodeValue(value, bindInternal));
-	}
-
-	/**
-	 * Parses the serialized data - context must match the context with which the JSON was stringified
-	 */
-	public parse(input: string): unknown {
-		return JSON.parse(input, (key, value) => this.decodeValue(value));
-	}
-
-	/**
-	 * If the given 'value' is an IFluidHandle, returns the encoded IFluidHandle.
-	 * Otherwise returns the original 'value'.  Used by 'encode()' and 'stringify()'.
-	 */
-	private readonly encodeValue = (value: unknown, bind?: IFluidHandleInternal): unknown => {
-		// If 'value' is an IFluidHandle return its encoded form.
-		if (isFluidHandle(value)) {
-			assert(bind !== undefined, 0xa93 /* Cannot encode a handle without a bind context */);
-			return this.bindAndEncodeHandle(toFluidHandleInternal(value), bind);
-		}
-		return value;
-	};
 
 	/**
 	 * If the given 'value' is an encoded IFluidHandle, returns the decoded IFluidHandle.
 	 * Otherwise returns the original 'value'.  Used by 'decode()' and 'parse()'.
 	 */
-	private readonly decodeValue = (value: unknown): unknown => {
+	protected readonly decodeValue = (value: unknown): unknown => {
+		const baseResult = super.decodeValue(value);
 		// If 'value' is a serialized IFluidHandle return the deserialized result.
 		if (isSerializedHandle(value)) {
-			// Old documents may have handles with relative path in their summaries. Convert these to absolute
-			// paths. This will ensure that future summaries will have absolute paths for these handles.
-			const absolutePath = value.url.startsWith("/")
-				? value.url
-				: generateHandleContextPath(value.url, this.context);
+			assert(
+				baseResult instanceof RemoteFluidObjectHandle,
+				"Expected serialized handle to decode to a handle by FluidSerializer",
+			);
 
 			if (isPoisonedHandle(value)) {
 				if (this.strict && this.clientId !== value.creatingClientId) {
@@ -128,61 +50,16 @@ export class DDSFuzzSerializer implements IFluidSerializer {
 					);
 				}
 
-				return new PoisonedDDSFuzzHandle(absolutePath, this.root, value.creatingClientId);
+				return new PoisonedDDSFuzzHandle(
+					baseResult.absolutePath,
+					baseResult.routeContext,
+					value.creatingClientId,
+				);
 			}
-			return new RemoteFluidObjectHandle(absolutePath, this.root);
-		} else {
-			return value;
 		}
+
+		return baseResult;
 	};
-
-	/**
-	 * Invoked for non-null objects to recursively replace references to IFluidHandles.
-	 * Clones as-needed to avoid mutating the `input` object.  If no IFluidHandles are present,
-	 * returns the original `input`.
-	 */
-	private recursivelyReplace<TContext = unknown>(
-		input: object,
-		replacer: (input: unknown, context?: TContext) => unknown,
-		context?: TContext,
-	): unknown {
-		// Note: Caller is responsible for ensuring that `input` is defined / non-null.
-		//       (Required for Object.keys() below.)
-
-		// Execute the `replace` on the current input.  Note that Caller is responsible for ensuring that `input`
-		// is a non-null object.
-		const maybeReplaced = replacer(input, context);
-
-		// If either input or the replaced result is a Fluid Handle, there is no need to descend further.
-		// IFluidHandles are always leaves in the object graph, and the code below cannot deal with IFluidHandle's structure.
-		if (isFluidHandle(input) || isFluidHandle(maybeReplaced)) {
-			return maybeReplaced;
-		}
-
-		// Otherwise descend into the object graph looking for IFluidHandle instances.
-		let clone: object | undefined;
-		for (const key of Object.keys(input)) {
-			const value: unknown = input[key];
-			if (!!value && typeof value === "object") {
-				// Note: Except for IFluidHandle, `input` must not contain circular references (as object must
-				//       be JSON serializable.)  Therefore, guarding against infinite recursion here would only
-				//       lead to a later error when attempting to stringify().
-				const replaced = this.recursivelyReplace(value, replacer, context);
-
-				// If the `replaced` object is different than the original `value` then the subgraph contained one
-				// or more handles.  If this happens, we need to return a clone of the `input` object where the
-				// current property is replaced by the `replaced` value.
-				if (replaced !== value) {
-					// Lazily create a shallow clone of the `input` object if we haven't done so already.
-					clone ??= shallowCloneObject(input);
-
-					// Overwrite the current property `key` in the clone with the `replaced` value.
-					clone[key] = replaced;
-				}
-			}
-		}
-		return clone ?? input;
-	}
 
 	/**
 	 * Encodes the given IFluidHandle into a JSON-serializable form,
@@ -195,8 +72,7 @@ export class DDSFuzzSerializer implements IFluidSerializer {
 		handle: IFluidHandleInternal,
 		bind: IFluidHandleInternal,
 	): ISerializedHandle & Partial<IPoisonedHandle> {
-		bind.bind(handle);
-		const baseEncoding = encodeHandleForSerialization(handle);
+		const baseEncoding = super.bindAndEncodeHandle(handle, bind);
 		if (isPoisonedHandle(handle)) {
 			return {
 				...baseEncoding,

--- a/packages/dds/test-dds-utils/src/index.ts
+++ b/packages/dds/test-dds-utils/src/index.ts
@@ -22,6 +22,15 @@ export {
 	defaultDDSFuzzSuiteOptions,
 	replayTest,
 } from "./ddsFuzzHarness.js";
+export {
+	createSquashFuzzSuite,
+	type SquashClient,
+	type SquashRandom,
+	type SquashFuzzHarnessModel,
+	type SquashFuzzSuiteOptions,
+	type SquashFuzzTestState,
+	type SquashFuzzModel,
+} from "./squashFuzzHarness.js";
 export type { ISnapshotSuite } from "./ddsSnapshotHarness.js";
 export { createSnapshotSuite } from "./ddsSnapshotHarness.js";
 export type { Client, FuzzSerializedIdCompressor } from "./clientLoading.js";

--- a/packages/dds/test-dds-utils/src/squashFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/squashFuzzHarness.ts
@@ -66,7 +66,7 @@ export interface SquashClient<TChannelFactory extends IChannelFactory>
 	 * 'exiting' phase means "it's up to the DDS to apply edits which remove any poisoned handles from the document".
 	 *
 	 * During this phase, a generator produced by `exitingStagingModeGeneratorFactory` will be invoked to create operations.
-	 * See {@link createSquashFuzzSuite} for more details.
+	 * See `createSquashFuzzSuite` for more details.
 	 */
 	stagingModeStatus: "off" | "staging" | "exiting";
 }
@@ -353,6 +353,9 @@ export function createSquashFuzzSuite<
 	options.emitter.on("testStart", (state) => {
 		(state.random as SquashRandom).poisonedHandle =
 			makeUnreachableCodePathProxy("random.poisonedHandle");
+	});
+	options.emitter.on("clientCreate", (client) => {
+		(client as SquashClient<TChannelFactory>).stagingModeStatus = "off";
 	});
 	const model = getFullModel(ddsModel, options);
 	createSuite(model as unknown as DDSFuzzHarnessModel<TChannelFactory, TOperation>, options);

--- a/packages/dds/test-dds-utils/src/squashFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/squashFuzzHarness.ts
@@ -1,0 +1,411 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import type {
+	AsyncGenerator,
+	AsyncReducer,
+	BaseOperation,
+	Generator,
+	MinimizationTransform,
+	Reducer,
+} from "@fluid-private/stochastic-test-utils";
+import { done } from "@fluid-private/stochastic-test-utils";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IChannelFactory } from "@fluidframework/datastore-definitions/internal";
+
+import { type Client } from "./clientLoading.js";
+import { PoisonedDDSFuzzHandle } from "./ddsFuzzHandle.js";
+import {
+	addClientContext,
+	createSuite,
+	handles,
+	mixinAttach,
+	mixinClientSelection,
+	mixinNewClient,
+	mixinRebase,
+	mixinReconnect,
+	mixinStashedClient,
+	mixinSynchronization,
+	convertOnlyAndSkip,
+	type DDSFuzzHarnessModel,
+	type DDSFuzzModel,
+	type DDSFuzzSuiteOptions,
+	type DDSFuzzTestState,
+	type DDSRandom,
+	type HarnessOperation,
+	defaultDDSFuzzSuiteOptions,
+	type CleanupFunction,
+	ReducerPreconditionError,
+} from "./ddsFuzzHarness.js";
+import { makeUnreachableCodePathProxy } from "./utils.js";
+
+/**
+ * @internal
+ */
+export interface SquashRandom extends DDSRandom {
+	/**
+	 * Generate a handle which should never be sent to other clients.
+	 * This is used to simulate data that should be squashed when exiting staging mode / resubmitting ops,
+	 * and it is up to the test author to ensure that all such handles are removed before resubmission occurs.
+	 * A suggested approach to implement this is to store information about the location of all poisoned handles
+	 * in the test state while in staging mode, then listening to the "exitStaging" event to issue remove ops.
+	 */
+	poisonedHandle(): IFluidHandle;
+}
+
+/**
+ * @internal
+ */
+export interface SquashClient<TChannelFactory extends IChannelFactory>
+	extends Client<TChannelFactory> {
+	/**
+	 * 'exiting' phase means "it's up to the DDS to apply edits which remove any poisoned handles from the document".
+	 *
+	 * During this phase, a generator produced by `exitingStagingModeGeneratorFactory` will be invoked to create operations.
+	 * See {@link createSquashFuzzSuite} for more details.
+	 */
+	stagingModeStatus: "off" | "staging" | "exiting";
+}
+
+/**
+ * @internal
+ */
+export interface SquashFuzzModel<
+	TChannelFactory extends IChannelFactory,
+	TOperation extends BaseOperation,
+	TState extends DDSFuzzTestState<TChannelFactory> = SquashFuzzTestState<TChannelFactory>,
+> extends DDSFuzzModel<TChannelFactory, TOperation, TState> {
+	/**
+	 * This generator will be invoked when the selected client is exiting staging mode.
+	 * It is the responsibility of the DDS model to generate one or more operations which remove references to poisoned content
+	 * from the document.
+	 *
+	 * Once all poisoned content is removed, this generator should return "done" to indicate to the harness that it is safe to reconnect.
+	 */
+	exitingStagingModeGeneratorFactory: () => Generator<TOperation, TState>;
+
+	/**
+	 * Invoked whenever a client is about to exit squash mode (and therefore reconnect).
+	 * DDS model authors should use this to validate that the client has already undergone edits which should remove all poisoned content from this
+	 * client's view.
+	 * @throws - if the provided client has poisoned content still in its view of the document
+	 * @remarks
+	 * When a DDS does not correctly squash edits that insert and remove a piece of poisoned content, this generates the same sort of error
+	 * as if the edits removing the content had never been generated.
+	 *
+	 * Whereas the first is a valid bug that the model caught, the second is an invalid test case. Fuzz minimization logic tries to remove ops
+	 * that are not necessary to reproduce the error. When doing so, without this piece of validation, it could transform what was originally a
+	 * valid test case demonstrating a squashing bug into an invalid test case.
+	 */
+	validatePoisonedContentRemoved: (client: SquashClient<TChannelFactory>) => void;
+}
+
+/**
+ * This model is used within the harness to wrap the provided {@link SquashFuzzModel}.
+ *
+ * This model's reducer differs from the {@link SquashFuzzModel} in that it can be an asynchronous
+ * reducer. This is necessary for the harness to support asynchronous operations
+ * like loading new clients, and doing synchronization.
+ *
+ * @internal
+ */
+export interface SquashFuzzHarnessModel<
+	TChannelFactory extends IChannelFactory,
+	TOperation extends BaseOperation,
+	TState extends SquashFuzzTestState<TChannelFactory> = SquashFuzzTestState<TChannelFactory>,
+> extends Omit<
+		SquashFuzzModel<TChannelFactory, TOperation, TState>,
+		"reducer" | "exitingStagingModeGeneratorFactory"
+	> {
+	/**
+	 * Reducer capable of updating the test state according to the operations generated.
+	 */
+	reducer: AsyncReducer<TOperation, TState> | Reducer<TOperation, TState>;
+}
+
+/**
+ * @internal
+ */
+export interface SquashFuzzSuiteOptions extends DDSFuzzSuiteOptions {
+	/**
+	 * TODO: Document expectations / consider reworking the API. Weird decisions right now.
+	 */
+	stagingMode: {
+		changeStagingModeProbability: number;
+	};
+}
+
+/**
+ * @internal
+ */
+export interface SquashFuzzTestState<TChannelFactory extends IChannelFactory>
+	extends DDSFuzzTestState<TChannelFactory> {
+	random: SquashRandom;
+	clients: SquashClient<TChannelFactory>[];
+	client: SquashClient<TChannelFactory>;
+}
+
+export interface ChangeStagingMode {
+	type: "changeStagingMode";
+	newStatus: "off" | "staging" | "exiting";
+}
+
+export type SquashHarnessOperation = HarnessOperation | ChangeStagingMode;
+
+export function mixinStagingMode<
+	TChannelFactory extends IChannelFactory,
+	TOperation extends BaseOperation,
+	TState extends SquashFuzzTestState<TChannelFactory>,
+>(
+	model: SquashFuzzModel<TChannelFactory, TOperation, TState>,
+	options: SquashFuzzSuiteOptions,
+): SquashFuzzHarnessModel<TChannelFactory, TOperation | ChangeStagingMode, TState> {
+	const generatorFactory: () => AsyncGenerator<TOperation | ChangeStagingMode, TState> =
+		() => {
+			const baseGenerator = model.generatorFactory();
+			const exitingStagingModeGenerator = model.exitingStagingModeGeneratorFactory();
+			return async (state): Promise<TOperation | ChangeStagingMode | typeof done> => {
+				if (state.client.stagingModeStatus === "exiting") {
+					const op = exitingStagingModeGenerator(state);
+					return op === done
+						? {
+								type: "changeStagingMode",
+								newStatus: "off",
+							}
+						: op;
+				}
+				if (
+					!state.isDetached &&
+					state.random.bool(options.stagingMode.changeStagingModeProbability)
+				) {
+					return {
+						type: "changeStagingMode",
+						newStatus: state.client.stagingModeStatus === "off" ? "staging" : "exiting",
+					};
+				}
+
+				return baseGenerator(state);
+			};
+		};
+
+	const minimizationTransforms = model.minimizationTransforms as
+		| MinimizationTransform<TOperation | ChangeStagingMode>[]
+		| undefined;
+
+	const stageToNextStage = {
+		off: "staging",
+		staging: "exiting",
+		exiting: "off",
+	} as const;
+
+	const reducer: AsyncReducer<TOperation | ChangeStagingMode, TState> = async (
+		state,
+		operation,
+	) => {
+		if (operation.type === "changeStagingMode") {
+			const currentStatus = state.client.stagingModeStatus;
+			const newStatus = (operation as ChangeStagingMode).newStatus;
+
+			state.client.stagingModeStatus = newStatus;
+			if (stageToNextStage[currentStatus] !== newStatus) {
+				// Minimization may attempt to remove changeStagingMode ops. Doing so usually causes the test case to become invalid,
+				// since this can cause poisoned content to be sent immediately.
+				// We guard against this with this precondition error.
+				throw new ReducerPreconditionError(
+					"changeStagingMode must cycle clients between off, staging, and exiting.",
+				);
+			}
+			if (newStatus === "off") {
+				model.validatePoisonedContentRemoved(state.client);
+				state.client.containerRuntime.connected = true;
+			} else if (newStatus === "staging") {
+				state.client.containerRuntime.connected = false;
+			}
+			return state;
+		} else {
+			return model.reducer(state, operation as TOperation);
+		}
+	};
+	return {
+		...model,
+		minimizationTransforms,
+		generatorFactory,
+		reducer,
+	};
+}
+
+function setupClientState<TChannelFactory extends IChannelFactory>(
+	state: SquashFuzzTestState<TChannelFactory>,
+	client: SquashClient<TChannelFactory>,
+): CleanupFunction {
+	const baseCleanup = addClientContext(state, client);
+	// eslint-disable-next-line @typescript-eslint/unbound-method
+	const { poisonedHandle: oldPoisonedHandle } = state.random;
+	// eslint-disable-next-line unicorn/prefer-ternary
+	if (state.client.stagingModeStatus === "staging") {
+		state.random.poisonedHandle = () =>
+			new PoisonedDDSFuzzHandle(
+				state.random.pick(handles),
+				client.dataStoreRuntime,
+				client.channel.id,
+			);
+	} else {
+		state.random.poisonedHandle = () => {
+			// If you encounter this error, you probably need to check `state.client.stagingModeStatus` before generating poisoned handles.
+			// If you're generating poisoned handles using `createWeightedGenerator`, you might consider using an acceptance condition on the weights object.
+			throw new Error(
+				`Poisoned handles should only be generated while in staging mode, but state is currently: ${state.client.stagingModeStatus}. This indicates a bug in the DDS's model.`,
+			);
+		};
+	}
+	return () => {
+		baseCleanup();
+		state.random.poisonedHandle = oldPoisonedHandle;
+	};
+}
+
+const getFullModel = <
+	TChannelFactory extends IChannelFactory,
+	TOperation extends BaseOperation,
+>(
+	ddsModel: SquashFuzzModel<TChannelFactory, TOperation>,
+	options: SquashFuzzSuiteOptions,
+): SquashFuzzHarnessModel<TChannelFactory, TOperation | SquashHarnessOperation> => {
+	const isReconnectAllowed = (state: SquashFuzzTestState<TChannelFactory>): boolean =>
+		// When staging mode is active, we don't want to generate any reconnect ops as they could result in poisoned handles being sent to other clients
+		// without the DDS model having a chance to remove their content.
+		state.client.stagingModeStatus === "off" && !state.isDetached;
+	const modelPartsRequiringClientSelection = mixinReconnect(
+		mixinRebase(mixinStagingMode(ddsModel, options), options),
+		options,
+		isReconnectAllowed,
+	);
+
+	const model = mixinAttach(
+		mixinSynchronization(
+			mixinNewClient(
+				mixinStashedClient(
+					mixinClientSelection(modelPartsRequiringClientSelection, options, setupClientState),
+					options,
+				),
+				options,
+			),
+			options,
+		),
+		options,
+	);
+
+	// Sanity check that using base mixins didn't remove squash-specific properties--this also helps validate
+	// the cast on return is ok.
+	assert(
+		(model as SquashFuzzHarnessModel<TChannelFactory, TOperation | SquashHarnessOperation>)
+			.validatePoisonedContentRemoved !== undefined,
+		"model should still have validatePoisonedContentRemoved",
+	);
+
+	return model as SquashFuzzHarnessModel<TChannelFactory, TOperation | SquashHarnessOperation>;
+};
+
+const defaultSquashFuzzOptions: SquashFuzzSuiteOptions = {
+	...defaultDDSFuzzSuiteOptions,
+	stagingMode: {
+		changeStagingModeProbability: 0,
+	},
+};
+
+/**
+ * Creates a fuzz test targetting correctness of a DDS's "squash" functionality while resubmitting ops.
+ *
+ * This model is an extension of `createDDSFuzzSuite`. In addition to whatever set of operations are defined in the DDS's
+ * eventual consistency model, this harness also injects the notion of each client entering/exiting a "staging mode".
+ *
+ * While in staging mode, DDS models should sometimes opt to add "poisoned content" to the document. They do so by generating a
+ * 'poisoned handle' using {@link SquashRandom.poisonedHandle}. If this handle is ever sent to another client, the harness will
+ * detect this and fail the test.
+ *
+ * This model helps fuzz test correctness of squash functionality, as before a client exits staging mode, the harness will place it
+ * in an "exiting" state and invoke {@link SquashFuzzModel.exitingStagingModeGeneratorFactory} to allow the model to remove any poisoned content from the document.
+ * If the DDS's resubmit implementation correctly squashes this insertion+removal of content, this means that other clients should never see it.
+ *
+ * To do this incrementally, typically a model would want to augment its per-client state with information about where the poisoned content lives in a way that is
+ * stable across edits. The {@link DDSFuzzHarnessEvents} event "clientCreate" is a good place to set up any initial state, and specific operations which add poisoned content
+ * can augment this state. Other implementations (such as exhaustively walking the DDS contents to look for poisoned content) are also possible, but less efficient.
+ *
+ * Models should not generate poisoned handles while staging mode is off. This harness will also detect this and report an error indicating
+ * the model author has a bug.
+ *
+ * Model authors should attempt to cover all possible notions by which content may be "added then removed" from their DDS.
+ *
+ * @internal
+ */
+export function createSquashFuzzSuite<
+	TChannelFactory extends IChannelFactory,
+	TOperation extends BaseOperation,
+>(
+	ddsModel: SquashFuzzModel<TChannelFactory, TOperation>,
+	providedOptions?: Partial<SquashFuzzSuiteOptions>,
+): void {
+	const options = convertOnlyAndSkip({ ...defaultSquashFuzzOptions, ...providedOptions });
+	options.emitter.on("testStart", (state) => {
+		(state.random as SquashRandom).poisonedHandle =
+			makeUnreachableCodePathProxy("random.poisonedHandle");
+	});
+	const model = getFullModel(ddsModel, options);
+	createSuite(model as unknown as DDSFuzzHarnessModel<TChannelFactory, TOperation>, options);
+}
+
+/**
+ * {@inheritDoc (createSquashFuzzSuite:function)}
+ * @internal
+ */
+// Explicit usage of namespace needed for api-extractor.
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace createSquashFuzzSuite {
+	/**
+	 * Runs only the provided seeds.
+	 *
+	 * @example
+	 *
+	 * ```typescript
+	 * // Runs only seed 42 for the given model.
+	 * createSquashFuzzSuite.only(42)(model);
+	 * ```
+	 * @internal
+	 */
+	export const only =
+		(...seeds: number[]) =>
+		<TChannelFactory extends IChannelFactory, TOperation extends BaseOperation>(
+			ddsModel: SquashFuzzModel<TChannelFactory, TOperation>,
+			providedOptions?: Partial<SquashFuzzSuiteOptions>,
+		): void =>
+			createSquashFuzzSuite(ddsModel, {
+				...providedOptions,
+				only: [...seeds, ...(providedOptions?.only ?? [])],
+			});
+
+	/**
+	 * Skips the provided seeds.
+	 *
+	 * @example
+	 *
+	 * ```typescript
+	 * // Skips seed 42 for the given model.
+	 * createSquashFuzzSuite.skip(42)(model);
+	 * ```
+	 * @internal
+	 */
+	export const skip =
+		(...seeds: number[]) =>
+		<TChannelFactory extends IChannelFactory, TOperation extends BaseOperation>(
+			ddsModel: SquashFuzzModel<TChannelFactory, TOperation>,
+			providedOptions?: Partial<SquashFuzzSuiteOptions>,
+		): void =>
+			createSquashFuzzSuite(ddsModel, {
+				...providedOptions,
+				skip: [...seeds, ...(providedOptions?.skip ?? [])],
+			});
+}

--- a/packages/dds/test-dds-utils/src/squashFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/squashFuzzHarness.ts
@@ -20,7 +20,7 @@ import type { IChannelFactory } from "@fluidframework/datastore-definitions/inte
 import { type Client } from "./clientLoading.js";
 import { PoisonedDDSFuzzHandle } from "./ddsFuzzHandle.js";
 import {
-	addClientContext,
+	setupClientContext,
 	createSuite,
 	handles,
 	mixinAttach,
@@ -77,7 +77,7 @@ export interface SquashClient<TChannelFactory extends IChannelFactory>
 export interface SquashFuzzModel<
 	TChannelFactory extends IChannelFactory,
 	TOperation extends BaseOperation,
-	TState extends DDSFuzzTestState<TChannelFactory> = SquashFuzzTestState<TChannelFactory>,
+	TState extends SquashFuzzTestState<TChannelFactory> = SquashFuzzTestState<TChannelFactory>,
 > extends DDSFuzzModel<TChannelFactory, TOperation, TState> {
 	/**
 	 * This generator will be invoked when the selected client is exiting staging mode.
@@ -131,9 +131,6 @@ export interface SquashFuzzHarnessModel<
  * @internal
  */
 export interface SquashFuzzSuiteOptions extends DDSFuzzSuiteOptions {
-	/**
-	 * TODO: Document expectations / consider reworking the API. Weird decisions right now.
-	 */
 	stagingMode: {
 		changeStagingModeProbability: number;
 	};
@@ -242,7 +239,7 @@ function setupClientState<TChannelFactory extends IChannelFactory>(
 	state: SquashFuzzTestState<TChannelFactory>,
 	client: SquashClient<TChannelFactory>,
 ): CleanupFunction {
-	const baseCleanup = addClientContext(state, client);
+	const baseCleanup = setupClientContext(state, client);
 	// eslint-disable-next-line @typescript-eslint/unbound-method
 	const { poisonedHandle: oldPoisonedHandle } = state.random;
 	// eslint-disable-next-line unicorn/prefer-ternary

--- a/packages/dds/test-dds-utils/src/utils.ts
+++ b/packages/dds/test-dds-utils/src/utils.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export function makeUnreachableCodePathProxy<T extends object>(name: string): T {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+	return new Proxy({} as T, {
+		get: (): never => {
+			throw new Error(
+				`Unexpected read of '${name}:' this indicates a bug in the DDS eventual consistency harness.`,
+			);
+		},
+	});
+}


### PR DESCRIPTION
## Description

Adds a variant of `createDDSFuzz` that verifies a DDS's squash behavior. See documentation on `createSquashFuzzSuite` for details of how this works (which should also be a good entrypoint for review purposes).

This setup successfully detects lack of squashing support in existing SharedString but passes with the changes in #24424.

