### PR TITLE
Simplify .npmrc download configuration to single-feed

### DIFF
--- a/tools/pipelines/templates/include-setup-npmrc-for-download.yml
+++ b/tools/pipelines/templates/include-setup-npmrc-for-download.yml
@@ -36,11 +36,6 @@ steps:
         exit 1
       fi
 
-      if [ -z "$(ado-feeds-office)" ]; then
-        echo "##vso[task.logissue type=error]Runtime variable 'ado-feeds-office' must have a value. Make sure the 'ado-feeds' variable group is in scope."
-        exit 1
-      fi
-
 - task: Bash@3
   displayName: Initialize .npmrc
   inputs:
@@ -55,10 +50,6 @@ steps:
 
       # Default feed that contains all our internal builds and mirrors external sources like npm.
       echo "registry=$(ado-feeds-ff-download-only)" >> ./.npmrc
-      echo "always-auth=true" >> ./.npmrc
-
-      # For some internal dependencies in the @microsoft scope
-      echo "@microsoft:registry=$(ado-feeds-office)" >> ./.npmrc
       echo "always-auth=true" >> ./.npmrc
       cat .npmrc
 


### PR DESCRIPTION
## Description

We recently restructured upstreams on the feeds we use in internal pipelines which now make it possible to reference only one feed for downloading packages. This PR updates the `.npmrc` we generate for such pipeline runs to do so.