### PR TITLE
improvement(client-container-runtime): fix required runtime option typing

### DIFF
--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -32,6 +32,22 @@ export enum ContainerMessageType {
     Rejoin = "rejoin"
 }
 
+// @alpha
+export interface ContainerRuntimeOptions {
+    readonly chunkSizeInBytes: number;
+    readonly compressionOptions: ICompressionRuntimeOptions;
+    // @deprecated
+    readonly enableGroupedBatching: boolean;
+    readonly enableRuntimeIdCompressor: IdCompressorMode;
+    readonly explicitSchemaControl: boolean;
+    // (undocumented)
+    readonly gcOptions: IGCRuntimeOptions;
+    readonly loadSequenceNumberVerification: "close" | "log" | "bypass";
+    readonly maxBatchSizeInBytes: number;
+    // (undocumented)
+    readonly summaryOptions: ISummaryRuntimeOptions;
+}
+
 // @alpha (undocumented)
 export const DefaultSummaryConfiguration: ISummaryConfiguration;
 
@@ -98,19 +114,7 @@ export interface ICompressionRuntimeOptions {
 }
 
 // @alpha
-export interface IContainerRuntimeOptions {
-    readonly chunkSizeInBytes?: number;
-    readonly compressionOptions?: ICompressionRuntimeOptions;
-    // @deprecated
-    readonly enableGroupedBatching?: boolean;
-    readonly enableRuntimeIdCompressor?: IdCompressorMode;
-    readonly explicitSchemaControl?: boolean;
-    // (undocumented)
-    readonly gcOptions?: IGCRuntimeOptions;
-    readonly loadSequenceNumberVerification?: "close" | "log" | "bypass";
-    readonly maxBatchSizeInBytes?: number;
-    // (undocumented)
-    readonly summaryOptions?: ISummaryRuntimeOptions;
+export interface IContainerRuntimeOptions extends Partial<ContainerRuntimeOptions> {
 }
 
 // @alpha

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -114,8 +114,7 @@ export interface ICompressionRuntimeOptions {
 }
 
 // @alpha
-export interface IContainerRuntimeOptions extends Partial<ContainerRuntimeOptions> {
-}
+export type IContainerRuntimeOptions = Partial<ContainerRuntimeOptions>;
 
 // @alpha
 export type IdCompressorMode = "on" | "delayed" | undefined;

--- a/packages/runtime/container-runtime/src/compatUtils.ts
+++ b/packages/runtime/container-runtime/src/compatUtils.ts
@@ -16,9 +16,8 @@ import {
 	disabledCompressionConfig,
 	enabledCompressionConfig,
 } from "./compressionDefinitions.js";
-import type { IContainerRuntimeOptionsInternal } from "./containerRuntime.js";
+import type { ContainerRuntimeOptionsInternal } from "./containerRuntime.js";
 import { pkgVersion } from "./packageVersion.js";
-import type { IdCompressorMode } from "./summary/index.js";
 
 /**
  * Our policy is to support N/N-1 compatibility by default, where N is the most
@@ -65,29 +64,27 @@ export type ConfigMap<T extends Record<string, unknown>> = {
 };
 
 /**
- * Subset of the {@link IContainerRuntimeOptionsInternal} properties which
+ * Subset of the {@link ContainerRuntimeOptionsInternal} properties which
  * affect {@link IDocumentSchemaFeatures}.
  *
  * @remarks
- * When a new option is added to {@link IContainerRuntimeOptionsInternal}, we
+ * When a new option is added to {@link ContainerRuntimeOptionsInternal}, we
  * must consider if it changes the DocumentSchema. If so, then a corresponding
  * entry must be added to {@link runtimeOptionsAffectingDocSchemaConfigMap}
  * below. If not, then it must be omitted from this type.
  *
  * Note: `Omit` is used instead of `Pick` to ensure that all new options are
  * included in this type by default. If any new properties are added to
- * {@link IContainerRuntimeOptionsInternal}, they will be included in this
+ * {@link ContainerRuntimeOptionsInternal}, they will be included in this
  * type unless explicitly omitted. This will prevent us from forgetting to
  * account for any new properties in the future.
  */
-export type RuntimeOptionsAffectingDocSchema = Required<
-	Omit<
-		IContainerRuntimeOptionsInternal,
-		| "chunkSizeInBytes"
-		| "maxBatchSizeInBytes"
-		| "loadSequenceNumberVerification"
-		| "summaryOptions"
-	>
+export type RuntimeOptionsAffectingDocSchema = Omit<
+	ContainerRuntimeOptionsInternal,
+	| "chunkSizeInBytes"
+	| "maxBatchSizeInBytes"
+	| "loadSequenceNumberVerification"
+	| "summaryOptions"
 >;
 
 /**
@@ -117,7 +114,7 @@ const runtimeOptionsAffectingDocSchemaConfigMap = {
 		// However, to satisfy the Required<> constraint while
 		// `exactOptionalPropertyTypes` is `false` (TODO: AB#8215), we need
 		// to have it defined, so we trick the type checker here.
-		"1.0.0": undefined as unknown as Exclude<IdCompressorMode, undefined>,
+		"1.0.0": undefined,
 		// We do not yet want to enable idCompressor by default since it will
 		// increase bundle sizes, and not all customers will benefit from it.
 		// Therefore, we will require customers to explicitly enable it. We

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -320,7 +320,10 @@ export interface ISummaryRuntimeOptions {
 }
 
 /**
- * Options for container runtime.
+ * Full set of options for container runtime as "required".
+ *
+ * @remarks
+ * {@link IContainerRuntimeOptions} is expected to be used by consumers.
  *
  * @privateRemarks If any new properties are added to this interface (or
  * {@link IContainerRuntimeOptionsInternal}), then we will also need to make
@@ -335,9 +338,9 @@ export interface ISummaryRuntimeOptions {
  * @legacy
  * @alpha
  */
-export interface IContainerRuntimeOptions {
-	readonly summaryOptions?: ISummaryRuntimeOptions;
-	readonly gcOptions?: IGCRuntimeOptions;
+export interface ContainerRuntimeOptions {
+	readonly summaryOptions: ISummaryRuntimeOptions;
+	readonly gcOptions: IGCRuntimeOptions;
 	/**
 	 * Affects the behavior while loading the runtime when the data verification check which
 	 * compares the DeltaManager sequence number (obtained from protocol in summary) to the
@@ -346,12 +349,12 @@ export interface IContainerRuntimeOptions {
 	 * 2. "log" will log an error event to telemetry, but still continue to load.
 	 * 3. "bypass" will skip the check entirely. This is not recommended.
 	 */
-	readonly loadSequenceNumberVerification?: "close" | "log" | "bypass";
+	readonly loadSequenceNumberVerification: "close" | "log" | "bypass";
 
 	/**
 	 * Enables the runtime to compress ops. See {@link ICompressionRuntimeOptions}.
 	 */
-	readonly compressionOptions?: ICompressionRuntimeOptions;
+	readonly compressionOptions: ICompressionRuntimeOptions;
 	/**
 	 * If specified, when in FlushMode.TurnBased, if the size of the ops between JS turns exceeds this value,
 	 * an error will be thrown and the container will close.
@@ -362,27 +365,27 @@ export interface IContainerRuntimeOptions {
 	 *
 	 * @experimental This config should be driven by the connection with the service and will be moved in the future.
 	 */
-	readonly maxBatchSizeInBytes?: number;
+	readonly maxBatchSizeInBytes: number;
 	/**
 	 * If the op payload needs to be chunked in order to work around the maximum size of the batch, this value represents
 	 * how large the individual chunks will be. This is only supported when compression is enabled. If after compression, the
 	 * batch content size exceeds this value, it will be chunked into smaller ops of this exact size.
 	 *
 	 * This value is a trade-off between having many small chunks vs fewer larger chunks and by default, the runtime is configured to use
-	 * 200 * 1024 = 204800 bytes. This default value ensures that no compressed payload's content is able to exceed {@link IContainerRuntimeOptions.maxBatchSizeInBytes}
+	 * 200 * 1024 = 204800 bytes. This default value ensures that no compressed payload's content is able to exceed {@link ContainerRuntimeOptions.maxBatchSizeInBytes}
 	 * regardless of the overhead of an individual op.
 	 *
-	 * Any value of `chunkSizeInBytes` exceeding {@link IContainerRuntimeOptions.maxBatchSizeInBytes} will disable this feature, therefore if a compressed batch's content
-	 * size exceeds {@link IContainerRuntimeOptions.maxBatchSizeInBytes} after compression, the container will close with an instance of `DataProcessingError` with
+	 * Any value of `chunkSizeInBytes` exceeding {@link ContainerRuntimeOptions.maxBatchSizeInBytes} will disable this feature, therefore if a compressed batch's content
+	 * size exceeds {@link ContainerRuntimeOptions.maxBatchSizeInBytes} after compression, the container will close with an instance of `DataProcessingError` with
 	 * the `BatchTooLarge` message.
 	 */
-	readonly chunkSizeInBytes?: number;
+	readonly chunkSizeInBytes: number;
 
 	/**
 	 * Enable the IdCompressor in the runtime.
 	 * @experimental Not ready for use.
 	 */
-	readonly enableRuntimeIdCompressor?: IdCompressorMode;
+	readonly enableRuntimeIdCompressor: IdCompressorMode;
 
 	/**
 	 * If enabled, the runtime will group messages within a batch into a single
@@ -392,7 +395,7 @@ export interface IContainerRuntimeOptions {
 	 * By default, the feature is enabled. This feature can only be disabled when compression is also disabled.
 	 * @deprecated  The ability to disable Grouped Batching is deprecated and will be removed in a future release. This feature is required for the proper functioning of the Fluid Framework.
 	 */
-	readonly enableGroupedBatching?: boolean;
+	readonly enableGroupedBatching: boolean;
 
 	/**
 	 * When this property is set to true, it requires runtime to control is document schema properly through ops
@@ -401,33 +404,53 @@ export interface IContainerRuntimeOptions {
 	 * When this property is not set (or set to false), runtime operates in legacy mode, where new features (modifying document schema)
 	 * are engaged as they become available, without giving legacy clients any chance to fail predictably.
 	 */
-	readonly explicitSchemaControl?: boolean;
+	readonly explicitSchemaControl: boolean;
 }
 
 /**
- * Internal extension of @see IContainerRuntimeOptions
+ * Options for container runtime.
+ *
+ * @legacy
+ * @alpha
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IContainerRuntimeOptions extends Partial<ContainerRuntimeOptions> {}
+
+/**
+ * Internal extension of @see ContainerRuntimeOptions
  *
  * These options are not available to consumers when creating a new container runtime,
  * but we do need to expose them for internal use, e.g. when configuring the container runtime
  * to ensure compatibility with older versions.
  *
+ * This is defined as a fully required set of options as this package does not yet
+ * use `exactOptionalPropertyTypes` and `Required<>` applied to optional type allowing
+ * `undefined` like {@link IdCompressorMode} will exclude `undefined`.
+ *
  * @internal
  */
-export interface IContainerRuntimeOptionsInternal extends IContainerRuntimeOptions {
+export interface ContainerRuntimeOptionsInternal extends ContainerRuntimeOptions {
 	/**
 	 * Sets the flush mode for the runtime. In Immediate flush mode the runtime will immediately
 	 * send all operations to the driver layer, while in TurnBased the operations will be buffered
 	 * and then sent them as a single batch at the end of the turn.
 	 * By default, flush mode is TurnBased.
 	 */
-	readonly flushMode?: FlushMode;
+	readonly flushMode: FlushMode;
 
 	/**
 	 * Allows Grouped Batching to be disabled by setting to false (default is true).
 	 * In that case, batched messages will be sent individually (but still all at the same time).
 	 */
-	readonly enableGroupedBatching?: boolean;
+	readonly enableGroupedBatching: boolean;
 }
+
+/**
+ * Internal extension of @see IContainerRuntimeOptions
+ *
+ * @internal
+ */
+export type IContainerRuntimeOptionsInternal = Partial<ContainerRuntimeOptionsInternal>;
 
 /**
  * Error responses when requesting a deleted object will have this header set to true
@@ -1002,7 +1025,7 @@ export class ContainerRuntime
 		const featureGatesForTelemetry: Record<string, boolean | number | undefined> = {};
 
 		// Make sure we've got all the options including internal ones
-		const internalRuntimeOptions: Readonly<Required<IContainerRuntimeOptionsInternal>> = {
+		const internalRuntimeOptions: Readonly<ContainerRuntimeOptionsInternal> = {
 			summaryOptions,
 			gcOptions,
 			loadSequenceNumberVerification,
@@ -1010,8 +1033,7 @@ export class ContainerRuntime
 			compressionOptions,
 			maxBatchSizeInBytes,
 			chunkSizeInBytes,
-			// Requires<> drops undefined from IdCompressorType
-			enableRuntimeIdCompressor: enableRuntimeIdCompressor as "on" | "delayed",
+			enableRuntimeIdCompressor,
 			enableGroupedBatching,
 			explicitSchemaControl,
 		};
@@ -1352,7 +1374,7 @@ export class ContainerRuntime
 		private readonly electedSummarizerData: ISerializedElection | undefined,
 		chunks: [string, string[]][],
 		dataStoreAliasMap: [string, string][],
-		private readonly runtimeOptions: Readonly<Required<IContainerRuntimeOptionsInternal>>,
+		private readonly runtimeOptions: Readonly<ContainerRuntimeOptionsInternal>,
 		private readonly containerScope: FluidObject,
 		// Create a custom ITelemetryBaseLogger to output telemetry events.
 		public readonly baseLogger: ITelemetryBaseLogger,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -413,12 +413,12 @@ export interface ContainerRuntimeOptions {
  * @legacy
  * @alpha
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IContainerRuntimeOptions extends Partial<ContainerRuntimeOptions> {}
+export type IContainerRuntimeOptions = Partial<ContainerRuntimeOptions>;
 
 /**
- * Internal extension of @see ContainerRuntimeOptions
+ * Internal extension of {@link ContainerRuntimeOptions}
  *
+ * @privateRemarks
  * These options are not available to consumers when creating a new container runtime,
  * but we do need to expose them for internal use, e.g. when configuring the container runtime
  * to ensure compatibility with older versions.
@@ -446,7 +446,7 @@ export interface ContainerRuntimeOptionsInternal extends ContainerRuntimeOptions
 }
 
 /**
- * Internal extension of @see IContainerRuntimeOptions
+ * Internal extension of {@link IContainerRuntimeOptions}
  *
  * @internal
  */

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -4,6 +4,8 @@
  */
 
 export {
+	ContainerRuntimeOptions,
+	ContainerRuntimeOptionsInternal,
 	ISummaryRuntimeOptions,
 	IContainerRuntimeOptions,
 	IContainerRuntimeOptionsInternal,

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -16,6 +16,7 @@ import {
 	disabledCompressionConfig,
 	IGCRuntimeOptions,
 	ISummaryRuntimeOptions,
+	type ContainerRuntimeOptionsInternal,
 	type IContainerRuntimeOptionsInternal,
 } from "@fluidframework/container-runtime/internal";
 import { ConfigTypes } from "@fluidframework/core-interfaces";
@@ -86,7 +87,7 @@ const summaryOptionsMatrix: OptionsMatrix<ISummaryRuntimeOptions> = {
 
 export function generateRuntimeOptions(
 	seed: number,
-	overrides: Partial<OptionsMatrix<IContainerRuntimeOptionsInternal>> | undefined,
+	overrides: Partial<OptionsMatrix<ContainerRuntimeOptionsInternal>> | undefined,
 ) {
 	const gcOptions = generatePairwiseOptions(
 		applyOverrides(gcOptionsMatrix, overrides?.gcOptions as any),
@@ -98,6 +99,10 @@ export function generateRuntimeOptions(
 		seed,
 	);
 
+	// Warning: this appears to incorrectly use `undefined` as a value in the options matrix
+	// with `exactOptionalPropertyTypes` disabled and thus not complaining. Note that `undefined`
+	// is a valid option for `enableRuntimeIdCompressor`. Probably should replace `undefined`
+	// with a sentinel symbol assuming `undefined` does mean something to overall processing.
 	const runtimeOptionsMatrix: OptionsMatrix<IContainerRuntimeOptionsInternal> = {
 		gcOptions: [undefined, ...gcOptions],
 		summaryOptions: [undefined, ...summaryOptions],
@@ -129,7 +134,7 @@ export function generateRuntimeOptions(
 			(
 				options as {
 					// Remove readonly modifier to allow overriding
-					-readonly [P in keyof IContainerRuntimeOptionsInternal]: IContainerRuntimeOptionsInternal[P];
+					-readonly [P in keyof ContainerRuntimeOptionsInternal]: ContainerRuntimeOptionsInternal[P];
 				}
 			).compressionOptions = disabledCompressionConfig;
 		}

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -5,7 +5,7 @@
 
 import { OptionsMatrix } from "@fluid-private/test-pairwise-generator";
 import { ILoaderOptions } from "@fluidframework/container-definitions/internal";
-import { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
+import type { ContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
 import { ConfigTypes } from "@fluidframework/core-interfaces";
 
 /** Type modeling the structure of the testConfig.json file */
@@ -125,6 +125,6 @@ export interface TestConfiguration {
 
 export interface OptionOverride {
 	loader?: Partial<OptionsMatrix<ILoaderOptions>>;
-	container?: Partial<OptionsMatrix<IContainerRuntimeOptions>>;
+	container?: Partial<OptionsMatrix<ContainerRuntimeOptions>>;
 	configurations?: OptionsMatrix<Record<string, ConfigTypes>>;
 }


### PR DESCRIPTION
While container-runtime still disables `exactOptionalPropertyTypes` applying `Required` incorrectly alters possible types that might support `undefined`.
Create underlying options types without optional (`?`) and use those where `Required<>` was applied or already supported.