### PR TITLE
Invert when warning text is provided for bundle-size test

### DIFF
--- a/examples/utils/bundle-size-tests/webpack.config.cjs
+++ b/examples/utils/bundle-size-tests/webpack.config.cjs
@@ -46,9 +46,8 @@ if (isInternalVersionScheme(verString, true, true)) {
 			strict: false,
 		},
 	});
-} else {
 	console.warn(
-		`The version string ${verString} is not a Fluid internal version string. The version string in the bundled code will not be replaced.`,
+		`The version string ${verString} is a Fluid internal version string. The version string in the bundled code will be replaced with ${newVersion}.`,
 	);
 }
 

--- a/examples/utils/bundle-size-tests/webpack.config.cjs
+++ b/examples/utils/bundle-size-tests/webpack.config.cjs
@@ -47,7 +47,7 @@ if (isInternalVersionScheme(verString, true, true)) {
 		},
 	});
 	console.warn(
-		`The version string ${verString} is a Fluid internal version string. The version string in the bundled code will be replaced with ${newVersion}.`,
+		`The version string '${verString}' is a Fluid internal version string. The version string in the bundled code will be replaced with '${newVersion}'.`,
 	);
 }
 


### PR DESCRIPTION
I think we've left the internal naming scheme behind, and this text seems a little alarming in the normal case.  Figured it would make more sense to at least be silent for normal numbering schemes and raise the alert for when a replacement actually happens.