### PR TITLE
fix(tree): combineVisitors handling of nested combinations

### DIFF
--- a/packages/dds/tree/src/core/tree/visitorUtils.ts
+++ b/packages/dds/tree/src/core/tree/visitorUtils.ts
@@ -53,25 +53,16 @@ export function announceDelta(
 	visitor.free();
 }
 
-function isAnnouncedVisitor(
-	visitor: DeltaVisitor | AnnouncedVisitor,
-): visitor is AnnouncedVisitor {
-	return (visitor as AnnouncedVisitor).isAnnouncedVisitor === true;
-}
-
-function isCombinedVisitor(
-	visitor: CombinableVisitor | CombinedVisitor,
-): visitor is CombinedVisitor {
-	return (visitor as CombinedVisitor).isCombinedVisitor === true;
-}
-
 export interface CombinedVisitor extends DeltaVisitor {
-	readonly isCombinedVisitor: true;
+	readonly type: "Combined";
 
-	visitors: readonly CombinableVisitor[];
+	readonly visitors: readonly CombinableVisitor[];
 }
 
-export type CombinableVisitor = DeltaVisitor | AnnouncedVisitor;
+export type CombinableVisitor =
+	| (DeltaVisitor & { type?: never })
+	| AnnouncedVisitor
+	| CombinedVisitor;
 
 /**
  * Combines multiple visitors into a single visitor.
@@ -79,10 +70,12 @@ export type CombinableVisitor = DeltaVisitor | AnnouncedVisitor;
  * @returns a DeltaVisitor combining all `visitors`.
  */
 export function combineVisitors(visitors: readonly CombinableVisitor[]): CombinedVisitor {
-	const allVisitors = visitors.flatMap((v) => (isCombinedVisitor(v) ? v.visitors : [v]));
-	const announcedVisitors = allVisitors.filter(isAnnouncedVisitor);
+	const allVisitors = visitors.flatMap((v) => (v.type === "Combined" ? v.visitors : [v]));
+	const announcedVisitors = allVisitors.filter(
+		(v): v is AnnouncedVisitor => v.type === "Announced",
+	);
 	return {
-		isCombinedVisitor: true,
+		type: "Combined",
 		visitors: allVisitors,
 		free: () => visitors.forEach((v) => v.free()),
 		create: (...args) => {
@@ -138,7 +131,7 @@ export function combineVisitors(visitors: readonly CombinableVisitor[]): Combine
  * Must be freed after use.
  */
 export interface AnnouncedVisitor extends DeltaVisitor {
-	readonly isAnnouncedVisitor: true;
+	readonly type: "Announced";
 	/**
 	 * A hook that is called after all nodes have been created.
 	 */
@@ -165,7 +158,7 @@ export function createAnnouncedVisitor(
 ): AnnouncedVisitor {
 	const noOp = (): void => {};
 	return {
-		isAnnouncedVisitor: true,
+		type: "Announced",
 		free: visitorFunctions.free ?? noOp,
 		create: visitorFunctions.create ?? noOp,
 		afterCreate: visitorFunctions.afterCreate ?? noOp,

--- a/packages/dds/tree/src/core/tree/visitorUtils.ts
+++ b/packages/dds/tree/src/core/tree/visitorUtils.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
-
 import type { ICodecOptions } from "../../codec/index.js";
 import { type IdAllocator, idAllocatorFromMaxId } from "../../util/index.js";
 import type { RevisionTag, RevisionTagCodec } from "../rebase/index.js";
@@ -51,41 +49,53 @@ export function announceDelta(
 	detachedFieldIndex: DetachedFieldIndex,
 ): void {
 	const visitor = deltaProcessor.acquireVisitor();
-	visitDelta(delta, combineVisitors([visitor], [visitor]), detachedFieldIndex, latestRevision);
+	visitDelta(delta, combineVisitors([visitor]), detachedFieldIndex, latestRevision);
 	visitor.free();
 }
 
+function isAnnouncedVisitor(
+	visitor: DeltaVisitor | AnnouncedVisitor,
+): visitor is AnnouncedVisitor {
+	return (visitor as AnnouncedVisitor).isAnnouncedVisitor === true;
+}
+
+function isCombinedVisitor(
+	visitor: CombinableVisitor | CombinedVisitor,
+): visitor is CombinedVisitor {
+	return (visitor as CombinedVisitor).isCombinedVisitor === true;
+}
+
+export interface CombinedVisitor extends DeltaVisitor {
+	readonly isCombinedVisitor: true;
+
+	visitors: readonly CombinableVisitor[];
+}
+
+export type CombinableVisitor = DeltaVisitor | AnnouncedVisitor;
+
 /**
+ * Combines multiple visitors into a single visitor.
  * @param visitors - The returned visitor invokes the corresponding events for all these visitors, in order.
- * @param announcedVisitors - Subset of `visitors` to also call {@link AnnouncedVisitor} methods on.
- * This must be a subset of `visitors`: if not the visitor will not have its path correctly set when the events are triggered.
- * When `visitors` are making changes to data, `announcedVisitors` can be used to get extra events before or after all the changes from all the visitors have been made.
- * This can, for example, enable visitors to have access to the tree in these extra events despite multiple separate visitors updating different tree related data-structures.
  * @returns a DeltaVisitor combining all `visitors`.
  */
-export function combineVisitors(
-	visitors: readonly DeltaVisitor[],
-	announcedVisitors: readonly AnnouncedVisitor[] = [],
-): DeltaVisitor {
-	{
-		const set = new Set(visitors);
-		for (const item of announcedVisitors) {
-			assert(set.has(item), 0x8c8 /* AnnouncedVisitor would not get traversed */);
-		}
-	}
+export function combineVisitors(visitors: readonly CombinableVisitor[]): CombinedVisitor {
+	const allVisitors = visitors.flatMap((v) => (isCombinedVisitor(v) ? v.visitors : [v]));
+	const announcedVisitors = allVisitors.filter(isAnnouncedVisitor);
 	return {
+		isCombinedVisitor: true,
+		visitors: allVisitors,
 		free: () => visitors.forEach((v) => v.free()),
 		create: (...args) => {
-			visitors.forEach((v) => v.create(...args));
+			allVisitors.forEach((v) => v.create(...args));
 			announcedVisitors.forEach((v) => v.afterCreate(...args));
 		},
 		destroy: (...args) => {
 			announcedVisitors.forEach((v) => v.beforeDestroy(...args));
-			visitors.forEach((v) => v.destroy(...args));
+			allVisitors.forEach((v) => v.destroy(...args));
 		},
 		attach: (source: FieldKey, count: number, destination: PlaceIndex) => {
 			announcedVisitors.forEach((v) => v.beforeAttach(source, count, destination));
-			visitors.forEach((v) => v.attach(source, count, destination));
+			allVisitors.forEach((v) => v.attach(source, count, destination));
 			announcedVisitors.forEach((v) =>
 				v.afterAttach(source, {
 					start: destination,
@@ -95,7 +105,7 @@ export function combineVisitors(
 		},
 		detach: (source: Range, destination: FieldKey, id: DetachedNodeId) => {
 			announcedVisitors.forEach((v) => v.beforeDetach(source, destination));
-			visitors.forEach((v) => v.detach(source, destination, id));
+			allVisitors.forEach((v) => v.detach(source, destination, id));
 			announcedVisitors.forEach((v) =>
 				v.afterDetach(source.start, source.end - source.start, destination),
 			);
@@ -109,17 +119,17 @@ export function combineVisitors(
 			announcedVisitors.forEach((v) =>
 				v.beforeReplace(newContent, oldContent, oldContentDestination),
 			);
-			visitors.forEach((v) =>
+			allVisitors.forEach((v) =>
 				v.replace(newContent, oldContent, oldContentDestination, oldContentId),
 			);
 			announcedVisitors.forEach((v) =>
 				v.afterReplace(newContent, oldContent, oldContentDestination),
 			);
 		},
-		enterNode: (...args) => visitors.forEach((v) => v.enterNode(...args)),
-		exitNode: (...args) => visitors.forEach((v) => v.exitNode(...args)),
-		enterField: (...args) => visitors.forEach((v) => v.enterField(...args)),
-		exitField: (...args) => visitors.forEach((v) => v.exitField(...args)),
+		enterNode: (...args) => allVisitors.forEach((v) => v.enterNode(...args)),
+		exitNode: (...args) => allVisitors.forEach((v) => v.exitNode(...args)),
+		enterField: (...args) => allVisitors.forEach((v) => v.enterField(...args)),
+		exitField: (...args) => allVisitors.forEach((v) => v.exitField(...args)),
 	};
 }
 
@@ -128,6 +138,7 @@ export function combineVisitors(
  * Must be freed after use.
  */
 export interface AnnouncedVisitor extends DeltaVisitor {
+	readonly isAnnouncedVisitor: true;
 	/**
 	 * A hook that is called after all nodes have been created.
 	 */
@@ -154,6 +165,7 @@ export function createAnnouncedVisitor(
 ): AnnouncedVisitor {
 	const noOp = (): void => {};
 	return {
+		isAnnouncedVisitor: true,
 		free: visitorFunctions.free ?? noOp,
 		create: visitorFunctions.create ?? noOp,
 		afterCreate: visitorFunctions.afterCreate ?? noOp,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -289,10 +289,7 @@ export class ChunkedForest implements IEditableForest {
 
 		const announcedVisitors: AnnouncedVisitor[] = [];
 		this.deltaVisitors.forEach((getVisitor) => announcedVisitors.push(getVisitor()));
-		const combinedVisitor = combineVisitors(
-			[forestVisitor, ...announcedVisitors],
-			announcedVisitors,
-		);
+		const combinedVisitor = combineVisitors([forestVisitor, ...announcedVisitors]);
 		this.activeVisitor = combinedVisitor;
 		return combinedVisitor;
 	}

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -267,10 +267,7 @@ export class ObjectForest implements IEditableForest {
 		const forestVisitor = new Visitor(this);
 		const announcedVisitors: AnnouncedVisitor[] = [];
 		this.deltaVisitors.forEach((getVisitor) => announcedVisitors.push(getVisitor()));
-		const combinedVisitor = combineVisitors(
-			[forestVisitor, ...announcedVisitors],
-			announcedVisitors,
-		);
+		const combinedVisitor = combineVisitors([forestVisitor, ...announcedVisitors]);
 		this.activeVisitor = combinedVisitor;
 		return combinedVisitor;
 	}

--- a/packages/dds/tree/src/test/tree/visitorUtils.spec.ts
+++ b/packages/dds/tree/src/test/tree/visitorUtils.spec.ts
@@ -56,7 +56,7 @@ class LoggingVisitor implements DeltaVisitor {
 }
 
 class LoggingAnnouncedVisitor extends LoggingVisitor implements AnnouncedVisitor {
-	public readonly isAnnouncedVisitor = true;
+	public readonly type = "Announced";
 	public afterCreate(): void {
 		this.log("afterCreate");
 	}

--- a/packages/dds/tree/src/test/tree/visitorUtils.spec.ts
+++ b/packages/dds/tree/src/test/tree/visitorUtils.spec.ts
@@ -1,0 +1,167 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import {
+	type AnnouncedVisitor,
+	type DeltaVisitor,
+	type FieldKey,
+	combineVisitors,
+} from "../../core/index.js";
+import { brand } from "../../util/index.js";
+
+class LoggingVisitor implements DeltaVisitor {
+	public readonly name: string;
+	public readonly callLog: string[];
+	public constructor(name: string, callLog: string[] = []) {
+		this.name = name;
+		this.callLog = callLog;
+	}
+	protected log(message: string): void {
+		this.callLog.push(`${this.name}: ${message}`);
+	}
+	public free(): void {
+		this.log("free");
+	}
+	public create(): void {
+		this.log("create");
+	}
+	public destroy(): void {
+		this.log("destroy");
+	}
+	public attach(): void {
+		this.log("attach");
+	}
+	public detach(): void {
+		this.log("detach");
+	}
+	public replace(): void {
+		this.log("replace");
+	}
+	public enterNode(): void {
+		this.log("enterNode");
+	}
+	public exitNode(): void {
+		this.log("exitNode");
+	}
+	public enterField(): void {
+		this.log("enterField");
+	}
+	public exitField(): void {
+		this.log("exitField");
+	}
+}
+
+class LoggingAnnouncedVisitor extends LoggingVisitor implements AnnouncedVisitor {
+	public readonly isAnnouncedVisitor = true;
+	public afterCreate(): void {
+		this.log("afterCreate");
+	}
+	public beforeDestroy(): void {
+		this.log("beforeDestroy");
+	}
+	public beforeAttach(): void {
+		this.log("beforeAttach");
+	}
+	public afterAttach(): void {
+		this.log("afterAttach");
+	}
+	public beforeDetach(): void {
+		this.log("beforeDetach");
+	}
+	public afterDetach(): void {
+		this.log("afterDetach");
+	}
+	public beforeReplace(): void {
+		this.log("beforeReplace");
+	}
+	public afterReplace(): void {
+		this.log("afterReplace");
+	}
+}
+
+const fieldKey: FieldKey = brand("field");
+
+describe("combineVisitors", () => {
+	it("calls all visitors in order", () => {
+		const actual: string[] = [];
+		const combined = combineVisitors([
+			new LoggingVisitor("1", actual),
+			new LoggingAnnouncedVisitor("2", actual),
+			new LoggingVisitor("3", actual),
+		]);
+		combined.free();
+		const expected = ["1: free", "2: free", "3: free"];
+		assert.deepEqual(actual, expected);
+	});
+	it(`calls announced visitors "before" methods before visitor methods`, () => {
+		const actual: string[] = [];
+		const combined = combineVisitors([
+			new LoggingVisitor("v1", actual),
+			new LoggingAnnouncedVisitor("av1", actual),
+			new LoggingVisitor("v2", actual),
+			new LoggingAnnouncedVisitor("av2", actual),
+		]);
+		combined.destroy(fieldKey, 1);
+		const expected = [
+			"av1: beforeDestroy",
+			"av2: beforeDestroy",
+			"v1: destroy",
+			"av1: destroy",
+			"v2: destroy",
+			"av2: destroy",
+		];
+		assert.deepEqual(actual, expected);
+	});
+	it(`calls announced visitors "after" methods after visitor methods`, () => {
+		const actual: string[] = [];
+		const combined = combineVisitors([
+			new LoggingVisitor("v1", actual),
+			new LoggingAnnouncedVisitor("av1", actual),
+			new LoggingVisitor("v2", actual),
+			new LoggingAnnouncedVisitor("av2", actual),
+		]);
+		combined.create([], fieldKey);
+		const expected = [
+			"v1: create",
+			"av1: create",
+			"v2: create",
+			"av2: create",
+			"av1: afterCreate",
+			"av2: afterCreate",
+		];
+		assert.deepEqual(actual, expected);
+	});
+	it("combines CombinedVisitor instances in a way that preserves before/after ordering", () => {
+		const actual: string[] = [];
+		const combined = combineVisitors([
+			combineVisitors([new LoggingAnnouncedVisitor("av1", actual)]),
+			new LoggingVisitor("v", actual),
+			combineVisitors([new LoggingAnnouncedVisitor("av2", actual)]),
+		]);
+		combined.detach({ start: 0, end: 1 }, fieldKey, { minor: 42 });
+		actual.push("---");
+		combined.attach(fieldKey, 1, 42);
+		const expected = [
+			"av1: beforeDetach",
+			"av2: beforeDetach",
+			"av1: detach",
+			"v: detach",
+			"av2: detach",
+			"av1: afterDetach",
+			"av2: afterDetach",
+			"---",
+			"av1: beforeAttach",
+			"av2: beforeAttach",
+			"av1: attach",
+			"v: attach",
+			"av2: attach",
+			"av1: afterAttach",
+			"av2: afterAttach",
+		];
+		assert.deepEqual(actual, expected);
+	});
+});


### PR DESCRIPTION
## Description

Before this change, the `combineVisitors` function was oblivious to the possibility that one of the visitors it is passed may itself be a combined visitor. This made `combineVisitors` impractical in scenarios where such nesting occurs because it could lead to "afterFoo" methods being invoked on some visitors before the corresponding "foo" method was called on some other visitor.

This issue was occurring in the presence of tree indexes: `TreeCheckout` would combine the forest visitor and the `AnchorSet` visitor, but the forest visitor was itself a combination of its own internal visitor and tree indexes visitors. This lead to the following patterns of calls:
* `visitDelta` calls `attach(...)` on the combined visitor created by `TreeCheckout`. As part of that...
  *  the combined visitor created by `TreeCheckout` calls `attach(...)` on the combined visitor created by the forest. As part of that...
     * the combined visitor created by the forest calls `afterAttach(...)` on the tree index visitor.
  * then then combined visitor created by `TreeCheckout` calls `attach(...)` on the `AnchorSet` visitor.

This change also refactors the signature of `combineVisitors` so it takes a single list of visitors instead of two. This removes the possibility of an `AnnouncedVisitor` being passed only in the `announcedVisitors` list, which used to throw a runtime error.

This change also changes the `AnnouncedVisitor` interface.

## Breaking Changes

None for users of the tree package.

Within the tree package, this is a breaking change for users of `combineVisitors` and implementers of the `AnnouncedVisitor` interface. All know usages have been updated but existing branches that are merging in this commit may need to update their usage of the function.
