### PR TITLE
feat(local-server-stress) Better error when DDS validation fails

### DIFF
--- a/packages/test/local-server-stress-tests/src/ddsOperations.ts
+++ b/packages/test/local-server-stress-tests/src/ddsOperations.ts
@@ -180,6 +180,13 @@ export const validateConsistencyOfAllDDS = async (clientA: Client, clientB: Clie
 		assert(aChannel.attributes.type === bChannel?.attributes.type, "channel types must match");
 		const model = ddsModelMap.get(aChannel.attributes.type);
 		assert(model !== undefined, "model must exist");
-		await model.validateConsistency(createDDSClient(aChannel), createDDSClient(bChannel));
+		try {
+			await model.validateConsistency(createDDSClient(aChannel), createDDSClient(bChannel));
+		} catch (error) {
+			if (error instanceof Error) {
+				error.message = `comparing ${clientA.tag} and ${clientB.tag}: ${error.message}`;
+			}
+			throw error;
+		}
 	}
 };


### PR DESCRIPTION
## Description

Wrap the thrown error with info about which DDSes are being compared.

This change originally made [here](https://github.com/microsoft/FluidFramework/pull/23783/files#diff-c349358d86e6b7e3daef04c90907fc84496d090ce05dec06d522bd0c5779e85b)