### PR TITLE
fix(server): LocalOrdererManager removeOrderer to no-op

### DIFF
--- a/server/routerlicious/packages/local-server/src/localOrdererManager.ts
+++ b/server/routerlicious/packages/local-server/src/localOrdererManager.ts
@@ -150,12 +150,7 @@ export class LocalOrdererManager implements IOrdererManager {
 	}
 
 	public async removeOrderer(tenantId: string, documentId: string): Promise<void> {
-		const key = this.getOrdererMapKey(tenantId, documentId);
-		const orderer = this.ordererMap.get(key);
-		if (orderer !== undefined) {
-			this.ordererMap.delete(key);
-			await (await orderer).close();
-		}
+		// No-op for local orderer. Orderer connections are managed separately.
 	}
 
 	private getOrdererMapKey(tenantId: string, documentId: string) {


### PR DESCRIPTION
## Description

Fixes [AB#35445](https://dev.azure.com/fluidframework/internal/_workitems/edit/35445).

LocalOrdererManager handles connection cleanup differently from Nexus' OrdererManager. #21528 incorrectly caused disconnect socket connection to sever all current orderer connections.

<details>
<summary>Note on memory use</summary>

I had a much longer PR in progress to share logic between the Nexus OrdererManager and LocalOrdererManager, but it got way too complicated, and really the number of connections held by T9s shouldn't apply memory pressure like it would in Nexus

</details>
