### PR TITLE
Fix build of NotificationsWorkspaceAdapter for ES2022

### DIFF
--- a/packages/framework/presence/src/notificationsAdapter.ts
+++ b/packages/framework/presence/src/notificationsAdapter.ts
@@ -23,9 +23,13 @@ export class NotificationsWorkspaceAdapter<TSchema extends NotificationsWorkspac
 {
 	public constructor(private readonly statesWorkspace: StatesWorkspace<TSchema>) {}
 
-	public readonly notifications: StatesWorkspaceEntries<TSchema> = this.statesWorkspace.states;
+	public get notifications(): StatesWorkspaceEntries<TSchema> {
+		return this.statesWorkspace.states;
+	}
 
-	public readonly presence: Presence = this.statesWorkspace.presence;
+	public get presence(): Presence {
+		return this.statesWorkspace.presence;
+	}
 
 	public add<
 		TKey extends string,


### PR DESCRIPTION
## Description

`NotificationsWorkspaceAdapter` relied on the initialization of `notifications` and `presence` running after `statesWorkspace` is initialized. This worked when TypeScript targeted ES2021 due to that initialization logic getting placed in the constructor. In ES2022 this logic is part of the JS properties, which do not allow this case of initialization order dependence among properties.

There were two easy fixes: either loop up the values lazily with getters, or move the initializers to the constructor. I went with getters as that reduces the own properties: only a single copy of the getters has to exist on the prototype. It also avoids having multipel different ways to reach the same values and thus avoids any possible bugs that could occur due to things like statesWorkspace.states changing and the property having a stale value.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

