### PR TITLE
Prototype Evaluation: Unify passing low volume state change through single method across layers

### DIFF
--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -35,11 +35,8 @@ import {
 	IFluidDataStoreChannel,
 	IFluidDataStoreContext,
 	IFluidDataStoreContextDetached,
-	IFluidDataStoreFactory,
-	IFluidDataStoreRegistry,
 	IFluidParentContext,
 	ISummarizeResult,
-	NamedFluidDataStoreRegistryEntries,
 	channelsTreeName,
 	IInboundSignalMessage,
 	gcDataBlobKey,
@@ -96,7 +93,6 @@ import {
 	createAttributesBlob,
 } from "./dataStoreContext.js";
 import { DataStoreContexts } from "./dataStoreContexts.js";
-import { FluidDataStoreRegistry } from "./dataStoreRegistry.js";
 import { GCNodeType, IGCNodeUpdatedProps, urlToGCNodePath } from "./gc/index.js";
 import { ContainerMessageType, LocalContainerRuntimeMessage } from "./messageTypes.js";
 import { StorageServiceWithAttachBlobs } from "./storageServiceWithAttachBlobs.js";
@@ -244,7 +240,7 @@ export function getLocalDataStoreType(localDataStore: LocalFluidDataStoreContext
  * but eventually could be hosted on any channel once we formalize the channel api boundary.
  * @internal
  */
-export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
+export class ChannelCollection implements IDisposable {
 	// Stores tracked by the Domain
 	private readonly pendingAttach = new Map<string, IAttachMessage>();
 	// 0.24 back-compat attachingBeforeSummary
@@ -421,7 +417,9 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 					this.pendingAttach.has(attachMessage.id),
 					0x15e /* "Local object does not have matching attach message id" */,
 				);
-				this.contexts.get(attachMessage.id)?.setAttachState(AttachState.Attached);
+				this.contexts
+					.get(attachMessage.id)
+					?.notifyStateChange({ attachState: AttachState.Attached });
 				this.pendingAttach.delete(attachMessage.id);
 				continue;
 			}
@@ -578,7 +576,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 		 */
 		if (this.parentContext.attachState !== AttachState.Detached) {
 			this.submitAttachChannelOp(localContext);
-			localContext.setAttachState(AttachState.Attaching);
+			localContext.notifyStateChange({ attachState: AttachState.Attaching });
 		}
 
 		this.contexts.bind(id);
@@ -1095,59 +1093,32 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 		context.processSignal(message, local);
 	}
 
-	public setConnectionState(connected: boolean, clientId?: string): void {
-		for (const [fluidDataStoreId, context] of this.contexts) {
-			try {
-				context.setConnectionState(connected, clientId);
-			} catch (error) {
-				this.mc.logger.sendErrorEvent(
-					{
-						eventName: "SetConnectionStateError",
-						clientId,
-						...tagCodeArtifacts({
-							fluidDataStoreId,
-						}),
-						details: JSON.stringify({
-							runtimeConnected: this.parentContext.connected,
-							connected,
-						}),
-					},
-					error,
-				);
-			}
-		}
-	}
-
 	/**
 	 * Enumerates the contexts and calls notifyReadOnlyState on them.
 	 */
-	public notifyReadOnlyState(readonly: boolean): void {
+	public notifyStateChange(changes: {
+		readonly?: boolean;
+		connected?: boolean;
+		clientId?: string;
+		attachState?: AttachState.Attached | AttachState.Attaching;
+	}): void {
 		for (const [fluidDataStoreId, context] of this.contexts) {
 			try {
-				context.notifyReadOnlyState(readonly);
+				context.notifyStateChange(changes);
 			} catch (error) {
 				this.mc.logger.sendErrorEvent(
 					{
-						eventName: "SetReadOnlyStateError",
+						eventName: "notifyStateChangeError",
 						...tagCodeArtifacts({
 							fluidDataStoreId,
 						}),
 						details: {
 							runtimeReadonly: this.parentContext.isReadOnly?.(),
-							readonly,
+							...changes,
 						},
 					},
 					error,
 				);
-			}
-		}
-	}
-
-	public setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void {
-		for (const [, context] of this.contexts) {
-			// Fire only for bounded stores.
-			if (!this.contexts.isNotBound(context.id)) {
-				context.setAttachState(attachState);
 			}
 		}
 	}
@@ -1435,7 +1406,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 
 		// Update the used routes in each data store. Used routes is empty for unused data stores.
 		for (const [contextId, context] of this.contexts) {
-			context.setTombstone(tombstonedDataStoresSet.has(contextId));
+			context.notifyStateChange({ tombstone: tombstonedDataStoresSet.has(contextId) });
 		}
 	}
 
@@ -1616,48 +1587,5 @@ export function detectOutboundReferences(
 	const fromPath = ["", address, ddsAddress].join("/");
 	for (const toPath of outboundPaths) {
 		addedOutboundReference(fromPath, toPath);
-	}
-}
-
-/**
- * @internal
- */
-export class ChannelCollectionFactory<T extends ChannelCollection = ChannelCollection>
-	implements IFluidDataStoreFactory
-{
-	public readonly type = "ChannelCollectionChannel";
-
-	public IFluidDataStoreRegistry: IFluidDataStoreRegistry;
-
-	constructor(
-		registryEntries: NamedFluidDataStoreRegistryEntries,
-		// ADO:7302 We need a better type here
-		private readonly provideEntryPoint: (
-			runtime: IFluidDataStoreChannel,
-		) => Promise<FluidObject>,
-		private readonly ctor: (...args: ConstructorParameters<typeof ChannelCollection>) => T,
-	) {
-		this.IFluidDataStoreRegistry = new FluidDataStoreRegistry(registryEntries);
-	}
-
-	public get IFluidDataStoreFactory(): ChannelCollectionFactory<T> {
-		return this;
-	}
-
-	public async instantiateDataStore(
-		context: IFluidDataStoreContext,
-		_existing: boolean,
-	): Promise<IFluidDataStoreChannel> {
-		const runtime = this.ctor(
-			context.baseSnapshot,
-			context, // parentContext
-			context.baseLogger,
-			() => {}, // gcNodeUpdated
-			(_nodePath: string) => false, // isDataStoreDeleted
-			new Map(), // aliasMap
-			this.provideEntryPoint,
-		);
-
-		return runtime;
 	}
 }

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -1131,7 +1131,10 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 	}): void {
 		for (const [fluidDataStoreId, context] of this.contexts) {
 			try {
-				context.notifyStateChange(changes);
+				context.notifyStateChange({
+					...changes,
+					attachState: this.contexts.isNotBound(context.id) ? undefined : changes.attachState,
+				});
 			} catch (error) {
 				this.mc.logger.sendErrorEvent(
 					{

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -28,7 +28,6 @@ export { IBlobManagerLoadInfo } from "./blobManager/index.js";
 export { FluidDataStoreRegistry } from "./dataStoreRegistry.js";
 export {
 	detectOutboundReferences,
-	ChannelCollectionFactory,
 	AllowTombstoneRequestHeaderKey,
 } from "./channelCollection.js";
 export {

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -28,6 +28,7 @@ export { IBlobManagerLoadInfo } from "./blobManager/index.js";
 export { FluidDataStoreRegistry } from "./dataStoreRegistry.js";
 export {
 	detectOutboundReferences,
+	ChannelCollectionFactory,
 	AllowTombstoneRequestHeaderKey,
 } from "./channelCollection.js";
 export {

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -157,7 +157,7 @@ function isSignalEnvelope(obj: unknown): obj is ISignalEnvelope {
 function defineResubmitAndSetConnectionState(containerRuntime: ContainerRuntime): void {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- Modifying private property
 	(containerRuntime as any).channelCollection = {
-		setConnectionState: (_connected: boolean, _clientId?: string) => {},
+		notifyStateChange: () => {},
 		// Pass data store op right back to ContainerRuntime
 		reSubmit: (type: string, envelope: IEnvelope, localOpMetadata: unknown) => {
 			submitDataStoreOp(
@@ -167,7 +167,7 @@ function defineResubmitAndSetConnectionState(containerRuntime: ContainerRuntime)
 				localOpMetadata,
 			);
 		},
-	} as ChannelCollection;
+	} as unknown as ChannelCollection;
 }
 
 describe("Runtime", () => {
@@ -985,7 +985,7 @@ describe("Runtime", () => {
 				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 				return {
 					processMessages: (..._args) => {},
-					setConnectionState: (..._args) => {},
+					notifyStateChange: (..._args) => {},
 				} as ChannelCollection;
 			};
 
@@ -1289,7 +1289,7 @@ describe("Runtime", () => {
 				};
 
 				patched.channelCollection = {
-					setConnectionState: (_connected: boolean, _clientId?: string) => {},
+					notifyStateChange: () => {},
 					// Pass data store op right back to ContainerRuntime
 					reSubmit: (type: string, envelope: IEnvelope, localOpMetadata: unknown) => {
 						submitDataStoreOp(

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -504,9 +504,9 @@ describe("Data Store Context Tests", () => {
 					snapshotTree: undefined,
 				});
 
-				localDataStoreContext.setTombstone(true);
+				localDataStoreContext.notifyStateChange({ tombstone: true });
 				assert(localDataStoreContext.tombstoned, `Local data store should be tombstoned!`);
-				localDataStoreContext.setTombstone(false);
+				localDataStoreContext.notifyStateChange({ tombstone: false });
 				assert(
 					!localDataStoreContext.tombstoned,
 					`Local data store should not be tombstoned!`,
@@ -963,9 +963,9 @@ describe("Data Store Context Tests", () => {
 					createSummarizerNodeFn,
 				});
 
-				remoteDataStoreContext.setTombstone(true);
+				remoteDataStoreContext.notifyStateChange({ tombstone: true });
 				assert(remoteDataStoreContext.tombstoned, `Local data store should be tombstoned!`);
-				remoteDataStoreContext.setTombstone(false);
+				remoteDataStoreContext.notifyStateChange({ tombstone: false });
 				assert(
 					!remoteDataStoreContext.tombstoned,
 					`Local data store should not be tombstoned!`,

--- a/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
@@ -64,12 +64,16 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     readonly ILayerCompatDetails?: unknown;
     // (undocumented)
     get isAttached(): boolean;
-    // (undocumented)
     readonly isReadOnly: () => boolean;
     // (undocumented)
     get logger(): ITelemetryLoggerExt;
     makeVisibleAndAttachGraph(): void;
-    notifyReadOnlyState(readonly: boolean): void;
+    notifyStateChange(changes: {
+        readonly?: boolean;
+        connected?: boolean;
+        clientId?: string;
+        attachState?: AttachState.Attaching | AttachState.Attached;
+    }): void;
     // (undocumented)
     get objectsRoutingContext(): this;
     // (undocumented)

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -296,7 +296,7 @@ export class FluidDataStoreRuntime
 		} else {
 			this._readonly = this.dataStoreContext.deltaManager.readOnlyInfo.readonly === true;
 			this.dataStoreContext.deltaManager.on("readonly", (readonly) =>
-				this.notifyReadOnlyState(readonly),
+				this.notifyStateChange({ readonly }),
 			);
 		}
 
@@ -693,11 +693,25 @@ export class FluidDataStoreRuntime
 	 * readonly state of this object. It should not be invoked by
 	 * any other callers.
 	 */
-	public notifyReadOnlyState(readonly: boolean): void {
+	public notifyStateChange(changes: {
+		readonly?: boolean;
+		connected?: boolean;
+		clientId?: string;
+		attachState?: AttachState.Attaching | AttachState.Attached;
+	}): void {
 		this.verifyNotClosed();
-		if (readonly !== this._readonly) {
-			this._readonly = readonly;
-			this.emit("readonly", readonly);
+		const { readonly, connected, clientId, attachState } = changes;
+		if (readonly !== undefined) {
+			if (readonly !== this._readonly) {
+				this._readonly = readonly;
+				this.emit("readonly", readonly);
+			}
+		}
+		if (connected !== undefined) {
+			this.setConnectionState(connected, clientId);
+		}
+		if (attachState !== undefined) {
+			this.setAttachState(attachState);
 		}
 	}
 

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -129,15 +129,21 @@ export interface IFluidDataStoreChannel extends IDisposable {
     getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     makeVisibleAndAttachGraph(): void;
-    notifyReadOnlyState?(readonly: boolean): void;
+    notifyStateChange?(changes: {
+        readonly?: boolean;
+        connected?: boolean;
+        clientId?: string;
+        attachState?: AttachState.Attached | AttachState.Attaching;
+    }): void;
     processMessages(messageCollection: IRuntimeMessageCollection): void;
     processSignal(message: IInboundSignalMessage, local: boolean): void;
     // (undocumented)
     request(request: IRequest): Promise<IResponse>;
     reSubmit(type: string, content: any, localOpMetadata: unknown): any;
     rollback?(type: string, content: any, localOpMetadata: unknown): void;
-    // (undocumented)
+    // @deprecated (undocumented)
     setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void;
+    // @deprecated
     setConnectionState(connected: boolean, clientId?: string): any;
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
     updateUsedRoutes(usedRoutes: string[]): void;

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -367,13 +367,19 @@ export interface IFluidDataStoreChannel extends IDisposable {
 	 * @param value - New connection state.
 	 * @param clientId - ID of the client. It's old ID when in disconnected state and
 	 * it's new client ID when we are connecting or connected.
+	 * @deprecated This is replaced by notifyStateChange
 	 */
 	setConnectionState(connected: boolean, clientId?: string);
 
 	/**
 	 * Notifies this object about changes in the readonly state
 	 */
-	notifyReadOnlyState?(readonly: boolean): void;
+	notifyStateChange?(changes: {
+		readonly?: boolean;
+		connected?: boolean;
+		clientId?: string;
+		attachState?: AttachState.Attached | AttachState.Attaching;
+	}): void;
 
 	/**
 	 * Ask the DDS to resubmit a message. This could be because we reconnected and this message was not acked.
@@ -404,6 +410,9 @@ export interface IFluidDataStoreChannel extends IDisposable {
 
 	request(request: IRequest): Promise<IResponse>;
 
+	/**
+	 * @deprecated This is replaced by notifyStateChange
+	 */
 	setAttachState(attachState: AttachState.Attaching | AttachState.Attached): void;
 }
 

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -460,7 +460,12 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     // (undocumented)
     makeVisibleAndAttachGraph(): void;
     // (undocumented)
-    notifyReadOnlyState(readonly: boolean): void;
+    notifyStateChange(changes: {
+        readonly?: boolean;
+        connected?: boolean;
+        clientId?: string;
+        attachState?: AttachState.Attaching | AttachState.Attached;
+    }): void;
     // (undocumented)
     get objectsRoutingContext(): IFluidHandleContext;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -1041,8 +1041,17 @@ export class MockFluidDataStoreRuntime
 		return;
 	}
 
-	public notifyReadOnlyState(readonly: boolean): void {
-		this.readonly = readonly;
+	public notifyStateChange(changes: {
+		readonly?: boolean;
+		connected?: boolean;
+		clientId?: string;
+		attachState?: AttachState.Attaching | AttachState.Attached;
+	}): void {
+		if (changes.readonly !== undefined) this.readonly = changes.readonly;
+		if (changes.connected !== undefined)
+			this.setConnectionState(this.connected, this.clientId);
+
+		if (changes.attachState) this.setAttachState(changes.attachState);
 	}
 
 	public async resolveHandle(request: IRequest): Promise<IResponse> {


### PR DESCRIPTION
Evaluating the idea of pushing all low volume state changes through a single method, rather than a method per state type. 

The main advantage is we don't need to add a new method to all layers for every state new state or augmentation, the disadvantage is it is harder to do api based feature detection.

The loss of api based feature detection may however be mitigated by the fact that we now have a layer compat contract. in fact, it is hard to deal with both layer compat and api as they don't interoperate well, so pushes more types are changes into the layer compat contract may actually make it easier to manage.

The basic premise here is replace `setConnectionState`, `setAttachState`, `noifyReadOnlyState`, and `setTombstone` with a single method, `notifyStateChange`.

I didn't do it in this PR, but we could also consider bringing a change like this to the loader layer.
