### PR TITLE
fix(outbox): Fix typo in telemetry property name

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -267,7 +267,7 @@ export class Outbox {
 							? "generic"
 							: "error",
 					eventName: "ReferenceSequenceNumberMismatch",
-					Data_details: {
+					details: {
 						expectedDueToReentrancy,
 						mainReferenceSequenceNumber: mainBatchSeqNums.referenceSequenceNumber,
 						mainClientSequenceNumber: mainBatchSeqNums.clientSequenceNumber,


### PR DESCRIPTION
## Description

I'm so used to talked about `Data_details` which is how our internal telemetry database names the `details` property we put on events, I named a new property event `Data_details` by accident. 🤪  So it showed up in telemetry as `Data_Data_details`.