### PR TITLE
Add deprecation comment to `Loader` class without @deprecation tag

### DIFF
--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -263,6 +263,7 @@ export type IDetachedBlobStorage = Pick<IDocumentStorageService, "createBlob" | 
 };
 
 /**
+ * @remarks The Loader class is deprecated and will be removed in a future release. Use the free-form functions instead (See issue #23882 for more details).
  * Manages Fluid resource loading
  * @legacy
  * @alpha

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -263,10 +263,11 @@ export type IDetachedBlobStorage = Pick<IDocumentStorageService, "createBlob" | 
 };
 
 /**
- * @remarks The Loader class is deprecated and will be removed in a future release. Use the free-form functions instead (See issue #23882 for more details).
  * Manages Fluid resource loading
  * @legacy
  * @alpha
+ *
+ * @remarks The Loader class is deprecated and will be removed in a future release. Use the free-form functions instead (See issue #23882 for more details).
  */
 export class Loader implements IHostLoader {
 	public readonly services: ILoaderServices;

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -267,7 +267,7 @@ export type IDetachedBlobStorage = Pick<IDocumentStorageService, "createBlob" | 
  * @legacy
  * @alpha
  *
- * @remarks The Loader class is deprecated and will be removed in a future release. Use the free-form functions instead (See issue #23882 for more details).
+ * @remarks The Loader class is deprecated and will be removed in a future release. Use the free-form functions instead (See issue #24450 for more details).
  */
 export class Loader implements IHostLoader {
 	public readonly services: ILoaderServices;


### PR DESCRIPTION
## Description

To make the `Loader` class internal, first we need to make sure to remove all of the uses of the class in external repositories.
This change is not meant to deprecate the loader class, but to make customers aware that it should no longer be used but instead use the free-form functions.

See [issue #24450](https://github.com/microsoft/FluidFramework/issues/24450) for more context.

## Reviewer Guidance

Please let me know if there's something I should change or be aware of.

Fixes [AB#36354](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/36354)
