### PR TITLE
ContainerRuntime: Ensure at least one layer of delta manager proxy

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1201,7 +1201,7 @@ export class ContainerRuntime
 		return this._deltaManager;
 	}
 
-	private readonly _deltaManager: IDeltaManagerFull;
+	private readonly _deltaManager: BaseDeltaManagerProxy;
 
 	/**
 	 * The delta manager provided by the container context. By default, using the default delta manager (proxy)
@@ -1597,11 +1597,10 @@ export class ContainerRuntime
 		}
 
 		// always wrap the exposed delta manager in at least on layer of proxying
-		if (outerDeltaManager instanceof BaseDeltaManagerProxy) {
-			outerDeltaManager = new BaseDeltaManagerProxy(this.innerDeltaManager);
-		}
-
-		this._deltaManager = outerDeltaManager;
+		this._deltaManager =
+			outerDeltaManager instanceof BaseDeltaManagerProxy
+				? outerDeltaManager
+				: new BaseDeltaManagerProxy(outerDeltaManager);
 
 		this.handleContext = new ContainerFluidHandleContext("", this);
 
@@ -2139,9 +2138,7 @@ export class ContainerRuntime
 		this.pendingStateManager.dispose();
 		this.inboundBatchAggregator.dispose();
 		this.deltaScheduler.dispose();
-		if (this._deltaManager instanceof BaseDeltaManagerProxy) {
-			this._deltaManager.dispose();
-		}
+		this._deltaManager.dispose();
 		this.emit("dispose");
 		this.removeAllListeners();
 	}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1596,6 +1596,11 @@ export class ContainerRuntime
 			outerDeltaManager = pendingOpsDeltaManagerProxy;
 		}
 
+		// always wrap the exposed delta manager in at least on layer of proxying
+		if (outerDeltaManager instanceof BaseDeltaManagerProxy) {
+			outerDeltaManager = new BaseDeltaManagerProxy(this.innerDeltaManager);
+		}
+
 		this._deltaManager = outerDeltaManager;
 
 		this.handleContext = new ContainerFluidHandleContext("", this);

--- a/packages/runtime/container-runtime/src/deltaManagerProxies.ts
+++ b/packages/runtime/container-runtime/src/deltaManagerProxies.ts
@@ -86,7 +86,7 @@ export interface BaseDeltaManagerProxyEventHandlers {
  * This class allows us to build proxy functionality without actually having to implement all the methods
  * of the DeltaManager.
  */
-export abstract class BaseDeltaManagerProxy
+export class BaseDeltaManagerProxy
 	extends TypedEventEmitter<IDeltaManagerEvents>
 	implements IDeltaManagerFull
 {


### PR DESCRIPTION
This was creating test failures due to listener count warnings. Adding the proxy back will resolve the listener warnings, as the proxy is a new event emitter.