### PR TITLE
Make failProxy fail on unrecognized properties

### DIFF
--- a/packages/loader/container-loader/src/test/failProxy.ts
+++ b/packages/loader/container-loader/src/test/failProxy.ts
@@ -24,7 +24,7 @@ export const failSometimeProxy = <T extends object>(handler: Partial<T>): T => {
 			if (p in handler) {
 				return Reflect.get(t, p, r);
 			}
-			return failProxy();
+			throw new Error(`${p.toString()} not implemented`);
 		},
 	});
 	return proxy;

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -62,6 +62,8 @@ const createCodeLoader = (props?: { createDetachedBlob?: boolean }): ICodeDetail
 									pending: [],
 								}),
 								ILayerCompatDetails: undefined,
+								disposed: false,
+								setConnectionState: () => {},
 							});
 						},
 					},

--- a/packages/loader/container-loader/src/test/loaderLayerCompatValidation.spec.ts
+++ b/packages/loader/container-loader/src/test/loaderLayerCompatValidation.spec.ts
@@ -239,6 +239,8 @@ describe("Runtime Layer compatibility", () => {
 												pending: [],
 											}),
 											ILayerCompatDetails: compatibilityDetails,
+											disposed: false,
+											setConnectionState: () => {},
 										});
 									},
 								},

--- a/packages/runtime/container-runtime/src/test/blobHandles.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobHandles.spec.ts
@@ -25,8 +25,7 @@ export const failProxy = <T extends object>(handler: Partial<T> = {}): T => {
 			if (handler !== undefined && p in handler) {
 				return Reflect.get(t, p, r);
 			}
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-			return failProxy();
+			throw new Error(`${p.toString()} not implemented`);
 		},
 	});
 	return proxy;

--- a/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
@@ -51,7 +51,7 @@ function createBlobManager(overrides?: Partial<ConstructorParameters<typeof Blob
 			blobManagerLoadInfo: {},
 			stashedBlobs: undefined,
 			localBlobIdGenerator: undefined,
-			storage: failProxy() as unknown as IDocumentStorageService,
+			storage: failProxy<IDocumentStorageService>(),
 			sendBlobAttachOp: () => {},
 			blobRequested: () => {},
 			isBlobDeleted: () => false,

--- a/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
@@ -28,8 +28,7 @@ export const failProxy = <T extends object>(handler: Partial<T> = {}): T => {
 			if (handler !== undefined && p in handler) {
 				return Reflect.get(t, p, r);
 			}
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-			return failProxy();
+			throw new Error(`${p.toString()} not implemented`);
 		},
 	});
 	return proxy;
@@ -52,6 +51,10 @@ function createBlobManager(overrides?: Partial<ConstructorParameters<typeof Blob
 			blobManagerLoadInfo: {},
 			stashedBlobs: undefined,
 			localBlobIdGenerator: undefined,
+			storage: failProxy() as unknown as IDocumentStorageService,
+			sendBlobAttachOp: () => {},
+			blobRequested: () => {},
+			isBlobDeleted: () => false,
 			createBlobPlaceholders: false,
 
 			// overrides


### PR DESCRIPTION
Guessing this was the original intent and just a bug.  Otherwise it returns an object on unrecognized properties, which is particularly bad for boolean properties since it looks truthy.  E.g. notably it was sending loader.spec.ts down the `disposed == true` paths which probably wasn't intended.