### PR TITLE
Re-enable unsummarized ops test with larger timeout

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/summaries.spec.ts
@@ -409,8 +409,7 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 		});
 	}
 
-	// AB#29483: This test is flaky on local server.
-	it.skip("Can summarize after hitting nack on unsummarized ops", async function () {
+	it("Can summarize after hitting nack on unsummarized ops", async function () {
 		if (provider.driver.type !== "local") {
 			this.skip();
 		}
@@ -481,7 +480,7 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 		await flushPromises();
 		assert.strictEqual(sharedString1.getLength(), 203);
 		assert.strictEqual(sharedString2.getLength(), 203);
-	});
+	}).timeout(5000);
 
 	itExpects(
 		"attempt last summary if parent container disconnects",


### PR DESCRIPTION
This test has been flaky in the test pipeline, and always related to timeouts. Running the test many times locally would eventually produce flakiness, but only after running the test almost 2000 times in a row. This leads me to believe this test is affected by service slowdowns more than usual, and flakiness is mainly coming from service latency. For example, after running the test about 3000 times, it starts to time out consistently.

The default timeout for local service is 2000ms, so I bumped this test to 5000ms for the time being. If the test still continues to be flaky, we can revisit if this test is still necessary to keep around.

### Test Data

| Number of runs | Timeout | Failures |
| -------- | ------- | ------- |
| 1000 | 2s | 0 |
| 2000 | 2s | 2 |
| 2500 | 2s | 10 |
| 2500 | 2s | 12 |
| 2500 | **3s** | 3 |
| 2500 | **5s** | 0 |

[AB#29483](https://dev.azure.com/fluidframework/internal/_workitems/edit/29483)