### PR TITLE
improvement(client-runtime): type createBlobPayloadPending as true | undefined

### DIFF
--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -36,7 +36,7 @@ export enum ContainerMessageType {
 export interface ContainerRuntimeOptions {
     readonly chunkSizeInBytes: number;
     readonly compressionOptions: ICompressionRuntimeOptions;
-    readonly createBlobPayloadPending: boolean;
+    readonly createBlobPayloadPending: true | undefined;
     // @deprecated
     readonly enableGroupedBatching: boolean;
     readonly enableRuntimeIdCompressor: IdCompressorMode;

--- a/packages/runtime/container-runtime/src/compatUtils.ts
+++ b/packages/runtime/container-runtime/src/compatUtils.ts
@@ -150,8 +150,8 @@ const runtimeOptionsAffectingDocSchemaConfigMap = {
 	createBlobPayloadPending: {
 		// This feature is new and disabled by default. In the future we will enable it by default, but we have not
 		// closed on the version where that will happen yet.  Probably a .10 release since blob functionality is not
-		// exposed on the public API surface.
-		"1.0.0": false,
+		// exposed on the `@public` API surface.
+		"1.0.0": undefined,
 	} as const,
 } as const satisfies ConfigMap<RuntimeOptionsAffectingDocSchema>;
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -413,10 +413,10 @@ export interface ContainerRuntimeOptions {
 	readonly explicitSchemaControl: boolean;
 
 	/**
-	 * Create blob handles with pending payloads when calling createBlob (default is false).
-	 * When enabled, createBlob will return a handle before the blob upload completes.
+	 * Create blob handles with pending payloads when calling createBlob (default is `undefined` (disabled)).
+	 * When enabled (`true`), createBlob will return a handle before the blob upload completes.
 	 */
-	readonly createBlobPayloadPending: boolean;
+	readonly createBlobPayloadPending: true | undefined;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -96,7 +96,7 @@ export interface IDocumentSchemaFeatures {
 	compressionLz4: boolean;
 	idCompressorMode: IdCompressorMode;
 	opGroupingEnabled: boolean;
-	createBlobPayloadPending: boolean;
+	createBlobPayloadPending: true | undefined;
 
 	/**
 	 * List of disallowed versions of the runtime.
@@ -484,7 +484,7 @@ export class DocumentsSchemaController {
 				compressionLz4: boolToProp(features.compressionLz4),
 				idCompressorMode: features.idCompressorMode,
 				opGroupingEnabled: boolToProp(features.opGroupingEnabled),
-				createBlobPayloadPending: boolToProp(features.createBlobPayloadPending),
+				createBlobPayloadPending: features.createBlobPayloadPending,
 				disallowedVersions: arrayToProp(features.disallowedVersions),
 			},
 		};

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -81,6 +81,7 @@ import {
 	IPendingRuntimeState,
 	defaultPendingOpsWaitTimeoutMs,
 	getSingleUseLegacyLogCallback,
+	type ContainerRuntimeOptionsInternal,
 	type IContainerRuntimeOptionsInternal,
 } from "../containerRuntime.js";
 import {
@@ -1565,7 +1566,7 @@ describe("Runtime", () => {
 				mockLogger = new MockLogger();
 			});
 
-			const runtimeOptions: IContainerRuntimeOptionsInternal = {
+			const runtimeOptions = {
 				compressionOptions: {
 					minimumBatchSizeInBytes: 1024 * 1024,
 					compressionAlgorithm: CompressionAlgorithms.lz4,
@@ -1573,9 +1574,9 @@ describe("Runtime", () => {
 				chunkSizeInBytes: 800 * 1024,
 				flushMode: FlushModeExperimental.Async as unknown as FlushMode,
 				enableGroupedBatching: true,
-			};
+			} as const satisfies IContainerRuntimeOptionsInternal;
 
-			const defaultRuntimeOptions: IContainerRuntimeOptionsInternal = {
+			const defaultRuntimeOptions = {
 				summaryOptions: {},
 				gcOptions: {},
 				loadSequenceNumberVerification: "close",
@@ -1589,8 +1590,8 @@ describe("Runtime", () => {
 				enableRuntimeIdCompressor: undefined,
 				enableGroupedBatching: true, // Redundant, but makes the JSON.stringify yield the same result as the logs
 				explicitSchemaControl: false,
-				createBlobPayloadPending: false, // Redundant, but makes the JSON.stringify yield the same result as the logs
-			};
+				createBlobPayloadPending: undefined,
+			} as const satisfies ContainerRuntimeOptionsInternal;
 			const mergedRuntimeOptions = { ...defaultRuntimeOptions, ...runtimeOptions };
 
 			it("Container load stats", async () => {
@@ -3654,7 +3655,6 @@ describe("Runtime", () => {
 					enableRuntimeIdCompressor: undefined,
 					enableGroupedBatching: true,
 					explicitSchemaControl: false,
-					createBlobPayloadPending: false,
 				};
 
 				logger.assertMatchAny([
@@ -3692,7 +3692,6 @@ describe("Runtime", () => {
 					enableRuntimeIdCompressor: undefined,
 					enableGroupedBatching: false,
 					explicitSchemaControl: false,
-					createBlobPayloadPending: false,
 				};
 
 				logger.assertMatchAny([
@@ -3730,7 +3729,6 @@ describe("Runtime", () => {
 					enableRuntimeIdCompressor: undefined,
 					enableGroupedBatching: true,
 					explicitSchemaControl: false,
-					createBlobPayloadPending: false,
 				};
 
 				logger.assertMatchAny([
@@ -3768,7 +3766,6 @@ describe("Runtime", () => {
 					enableRuntimeIdCompressor: undefined,
 					enableGroupedBatching: true,
 					explicitSchemaControl: true,
-					createBlobPayloadPending: false,
 				};
 
 				logger.assertMatchAny([
@@ -3806,7 +3803,6 @@ describe("Runtime", () => {
 					enableRuntimeIdCompressor: undefined,
 					enableGroupedBatching: true,
 					explicitSchemaControl: true,
-					createBlobPayloadPending: false,
 				};
 
 				logger.assertMatchAny([
@@ -3834,7 +3830,6 @@ describe("Runtime", () => {
 						enableRuntimeIdCompressor: "on",
 						enableGroupedBatching: false, // By turning off batching, we will also disable compression automatically
 						explicitSchemaControl: true,
-						createBlobPayloadPending: false,
 					},
 					provideEntryPoint: mockProvideEntryPoint,
 				});
@@ -3853,7 +3848,6 @@ describe("Runtime", () => {
 					enableRuntimeIdCompressor: "on",
 					enableGroupedBatching: false,
 					explicitSchemaControl: true,
-					createBlobPayloadPending: false,
 				};
 
 				logger.assertMatchAny([
@@ -3912,7 +3906,6 @@ describe("Runtime", () => {
 						enableRuntimeIdCompressor: undefined, // idCompressor is undefined, since that represents a logical state (off)
 						enableGroupedBatching: true,
 						explicitSchemaControl: false,
-						createBlobPayloadPending: false,
 					};
 
 					logger.assertMatchAny([
@@ -3949,7 +3942,6 @@ describe("Runtime", () => {
 					enableRuntimeIdCompressor: undefined,
 					enableGroupedBatching: true,
 					explicitSchemaControl: true,
-					createBlobPayloadPending: false,
 				};
 
 				logger.assertMatchAny([

--- a/packages/runtime/container-runtime/src/test/documentSchema.spec.ts
+++ b/packages/runtime/container-runtime/src/test/documentSchema.spec.ts
@@ -12,7 +12,7 @@ import {
 	type IDocumentSchemaFeatures,
 } from "../summary/index.js";
 
-function boolToProp(b: boolean) {
+function boolToProp(b: boolean | undefined) {
 	return b ? true : undefined;
 }
 
@@ -33,14 +33,14 @@ describe("Runtime", () => {
 		},
 	};
 
-	const features: IDocumentSchemaFeatures = {
+	const features = {
 		explicitSchemaControl: true,
 		compressionLz4: true,
 		opGroupingEnabled: false,
 		idCompressorMode: "delayed",
-		createBlobPayloadPending: false,
+		createBlobPayloadPending: undefined,
 		disallowedVersions: [],
-	};
+	} as const satisfies IDocumentSchemaFeatures;
 
 	function createController(config: unknown) {
 		return new DocumentsSchemaController(
@@ -303,7 +303,7 @@ describe("Runtime", () => {
 					compressionLz4: boolToProp(featuresModified.compressionLz4),
 					idCompressorMode: featuresModified.idCompressorMode,
 					opGroupingEnabled: boolToProp(featuresModified.opGroupingEnabled),
-					createBlobPayloadPending: boolToProp(featuresModified.createBlobPayloadPending),
+					createBlobPayloadPending: featuresModified.createBlobPayloadPending,
 					disallowedVersions: arrayToProp(featuresModified.disallowedVersions),
 				},
 			};

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -116,7 +116,7 @@ export function generateRuntimeOptions(
 		chunkSizeInBytes: [204800],
 		enableRuntimeIdCompressor: ["on", undefined, "delayed"],
 		enableGroupedBatching: [true, false],
-		createBlobPayloadPending: [true, false],
+		createBlobPayloadPending: [true, undefined],
 		explicitSchemaControl: [true, false],
 	};
 


### PR DESCRIPTION
matching IDocumentSchemaCurrent.runtime
and eliminating telemetry noise

Follow-up for #24320 before released for use. Document schema is unchanged; only change is runtime option requirements.