### PR TITLE
Expose ability to modify cluster size in id-compressor test export

### DIFF
--- a/packages/runtime/id-compressor/.eslintrc.cjs
+++ b/packages/runtime/id-compressor/.eslintrc.cjs
@@ -19,7 +19,7 @@ module.exports = {
 				// Test files are run in node only so additional node libraries can be used.
 				"import/no-nodejs-modules": [
 					"error",
-					{ allow: ["node:assert", "node:crypto", "node:util/types", "node:fs", "node:path"] },
+					{ allow: ["node:assert", "node:crypto", "node:fs", "node:path"] },
 				],
 			},
 		},

--- a/packages/runtime/id-compressor/.eslintrc.cjs
+++ b/packages/runtime/id-compressor/.eslintrc.cjs
@@ -14,10 +14,13 @@ module.exports = {
 	overrides: [
 		{
 			// Rules only for test files
-			files: ["*.spec.ts", "src/test/**"],
+			files: ["*.spec.ts", "src/test/**/*.ts"],
 			rules: {
 				// Test files are run in node only so additional node libraries can be used.
-				"import/no-nodejs-modules": ["error", { allow: ["assert", "crypto"] }],
+				"import/no-nodejs-modules": [
+					"error",
+					{ allow: ["node:assert", "node:crypto", "node:util/types", "node:fs", "node:path"] },
+				],
 			},
 		},
 	],

--- a/packages/runtime/id-compressor/src/test/appendOnlySortedMap.spec.ts
+++ b/packages/runtime/id-compressor/src/test/appendOnlySortedMap.spec.ts
@@ -5,7 +5,6 @@
 
 /* eslint-disable no-bitwise */
 
-// eslint-disable-next-line import/no-nodejs-modules
 import { strict as assert } from "node:assert";
 
 import { AppendOnlySortedMap } from "../appendOnlySortedMap.js";

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable import/no-nodejs-modules */
 import { strict as assert } from "node:assert";
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
@@ -27,6 +26,7 @@ import {
 	IdCompressorTestNetwork,
 	MetaClient,
 	expectSerializes,
+	getClusterSize,
 	makeOpGenerator,
 	performFuzzActions,
 	roundtrip,
@@ -1214,20 +1214,14 @@ describe("IdCompressor", () => {
 				network.allocateAndSendIds(Client.Client1, 3);
 				network.allocateAndSendIds(
 					Client.Client2,
-
-					// eslint-disable-next-line @typescript-eslint/dot-notation
-					network.getCompressor(Client.Client2)["nextRequestedClusterSize"] * 2,
+					2 * getClusterSize(network.getCompressor(Client.Client2)),
 				);
 				network.allocateAndSendIds(Client.Client3, 5);
 				expectSequencedLogsAlign(network, Client.Client1, Client.Client2);
 			});
 
 			itNetwork("can finalize a range when the current cluster is full", 5, (network) => {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				const clusterCapacity: number = network.getCompressor(
-					Client.Client1,
-					// eslint-disable-next-line @typescript-eslint/dot-notation
-				)["nextRequestedClusterSize"];
+				const clusterCapacity: number = getClusterSize(network.getCompressor(Client.Client1));
 				network.allocateAndSendIds(Client.Client1, clusterCapacity);
 				network.allocateAndSendIds(Client.Client2, clusterCapacity);
 				network.allocateAndSendIds(Client.Client1, clusterCapacity);
@@ -1235,11 +1229,7 @@ describe("IdCompressor", () => {
 			});
 
 			itNetwork("can finalize a range that spans multiple clusters", 5, (network) => {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				const clusterCapacity: number = network.getCompressor(
-					Client.Client1,
-					// eslint-disable-next-line @typescript-eslint/dot-notation
-				)["nextRequestedClusterSize"];
+				const clusterCapacity: number = getClusterSize(network.getCompressor(Client.Client1));
 				network.allocateAndSendIds(Client.Client1, 1);
 				network.allocateAndSendIds(Client.Client2, 1);
 				network.allocateAndSendIds(Client.Client1, clusterCapacity * 3);
@@ -1317,11 +1307,7 @@ describe("IdCompressor", () => {
 				"can resume a session and interact with multiple other clients",
 				3,
 				(network) => {
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-					const clusterSize: number = network.getCompressor(
-						Client.Client1,
-						// eslint-disable-next-line @typescript-eslint/dot-notation
-					)["nextRequestedClusterSize"];
+					const clusterSize: number = getClusterSize(network.getCompressor(Client.Client1));
 					network.allocateAndSendIds(Client.Client1, clusterSize);
 					network.allocateAndSendIds(Client.Client2, clusterSize);
 					network.allocateAndSendIds(Client.Client3, clusterSize);

--- a/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
@@ -145,10 +145,12 @@ export function getClusterSize(compressor: ReadonlyIdCompressor): number {
 
 function verifyCompressorLike(compressor: ReadonlyIdCompressor | IIdCompressor): void {
 	assert(
-		// Some IdCompressor tests wrap underlying compressors with proxies--allow this for now
+		// Some IdCompressor tests wrap underlying compressors with proxies--allow this for now.
+		// Because of id-compressor's dynamic import in container-runtime, instanceof checks for IdCompressor
+		// also won't necessarily work nicely. Get a small amount of validation that this function should work
+		// as intended by at least verifying the property name exists.
 		// eslint-disable-next-line @typescript-eslint/dot-notation
-		(isProxy(compressor) && typeof compressor["nextRequestedClusterSize"] === "number") ||
-			compressor instanceof IdCompressor,
+		typeof compressor["nextRequestedClusterSize"] === "number",
 	);
 }
 

--- a/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "node:assert";
-import { isProxy } from "node:util/types";
 
 import {
 	BaseFuzzTestState,

--- a/packages/runtime/id-compressor/src/test/index.ts
+++ b/packages/runtime/id-compressor/src/test/index.ts
@@ -7,4 +7,7 @@
  * Exports for test utilities for `id-compressor`
  */
 
-export { createAlwaysFinalizedIdCompressor } from "./idCompressorTestUtilities.js";
+export {
+	createAlwaysFinalizedIdCompressor,
+	modifyClusterSize,
+} from "./idCompressorTestUtilities.js";

--- a/packages/runtime/id-compressor/src/test/numericUuid.spec.ts
+++ b/packages/runtime/id-compressor/src/test/numericUuid.spec.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-nodejs-modules
 import { strict as assert } from "node:assert";
 
 import { StableId } from "../index.js";

--- a/packages/runtime/id-compressor/src/test/sessionSpaceNormalizer.spec.ts
+++ b/packages/runtime/id-compressor/src/test/sessionSpaceNormalizer.spec.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable import/no-nodejs-modules */
 import { strict as assert } from "node:assert";
 
 import { SessionSpaceNormalizer } from "../sessionSpaceNormalizer.js";

--- a/packages/runtime/id-compressor/src/test/snapshots/summary.spec.ts
+++ b/packages/runtime/id-compressor/src/test/snapshots/summary.spec.ts
@@ -3,13 +3,12 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable import/no-nodejs-modules */
-
 import { strict as assert } from "node:assert";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import { SessionId, createIdCompressor } from "../../index.js";
+import { modifyClusterSize } from "../idCompressorTestUtilities.js";
 
 import { _dirname } from "./dirname.cjs";
 
@@ -136,8 +135,7 @@ describe("snapshot tests", () => {
 	it("expansion semantics", () => {
 		const compressor = createIdCompressor(client1);
 		const compressor2 = createIdCompressor(client2);
-		// eslint-disable-next-line @typescript-eslint/dot-notation
-		compressor["nextRequestedClusterSize"] = 2;
+		modifyClusterSize(compressor, 2);
 		compressor.generateCompressedId();
 		const idRange = compressor.takeNextCreationRange();
 		compressor.finalizeCreationRange(idRange);


### PR DESCRIPTION
## Description

Moves around some test code in id-compressor which modifies the next reserved cluster size so that we use access violation in less places. This also exports the functionality under id-compressor's test export, as we have plans to use it for better coverage in stress tests.
