### PR TITLE
docs(getkeys): Add information on how to make getkeys work in WSL

### DIFF
--- a/tools/getkeys/index.js
+++ b/tools/getkeys/index.js
@@ -130,8 +130,12 @@ class AzCliKeyVaultClient {
 			if (error.message.includes("AADSTS530003")) {
 				console.log(
 					`\nAn error occurred running \`az ad signed-in-user show\` that suggests you might need to \`az logout\` and ` +
-						`\`az login\` again. One potential cause for this is having used \`az login --use-device-code\`. Error:\n\n` +
-						`${error.message}`,
+					`\`az login\` again. One potential cause for this is having used \`az login --use-device-code\`. ` +
+					`If you're using WSL, you might need to set the BROWSER environment variable to the path to a Windows-space ` +
+					`browser executable to run 'az login' in an interactive flow, e.g. ` +
+					`'BROWSER="/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe" az login'.\n\n` +
+					`Error:\n\n` +
+					`${error.message}`,
 				);
 				// eslint-disable-next-line unicorn/no-process-exit
 				process.exit(1);


### PR DESCRIPTION
## Description

Adds a note about how to get `getkeys` to run successfully in WSL in case of error `AADSTS530003: Your device is required to be managed to access this resource`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
