### PR TITLE
perf(client-container-runtime): reduce `semver` bundle regression

### DIFF
--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -184,7 +184,7 @@
 		"@tylerbu/sorted-btree-es6": "^1.8.0",
 		"double-ended-queue": "^2.1.0-0",
 		"lz4js": "^0.2.0",
-		"semver": "^7.7.1",
+		"semver-ts": "^1.0.3",
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
@@ -205,7 +205,6 @@
 		"@types/lz4js": "^0.2.0",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",
-		"@types/semver": "^7.7.0",
 		"@types/sinon": "^17.0.3",
 		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",

--- a/packages/runtime/container-runtime/src/compatUtils.ts
+++ b/packages/runtime/container-runtime/src/compatUtils.ts
@@ -4,13 +4,7 @@
  */
 
 import { FlushMode } from "@fluidframework/runtime-definitions/internal";
-// The semver package documents and encourages these imports for users that only need some of the semver functionality.
-// eslint-disable-next-line import/no-internal-modules
-import semverGte from "semver/functions/gte.js";
-// eslint-disable-next-line import/no-internal-modules
-import semverLte from "semver/functions/lte.js";
-// eslint-disable-next-line import/no-internal-modules
-import semverValid from "semver/functions/valid.js";
+import { compare, gte, lte, valid } from "semver-ts";
 
 import {
 	disabledCompressionConfig,
@@ -181,12 +175,12 @@ export function getConfigsForCompatMode<T extends Record<SemanticVersion, unknow
 	for (const key of Object.keys(configMap)) {
 		const config = configMap[key as keyof T];
 		// Sort the versions in ascending order so we can short circuit the loop.
-		const versions = Object.keys(config).sort((a, b) => (semverGte(b, a) ? -1 : 1));
+		const versions = Object.keys(config).sort(compare);
 		// For each config, we iterate over the keys and check if compatibilityVersion is greater than or equal to the version.
 		// If so, we set it as the default value for the option. At the end of the loop we should have the most recent default
 		// value that is compatible with the version specified as the compatibilityVersion.
 		for (const version of versions) {
-			if (semverGte(compatibilityVersion, version)) {
+			if (gte(compatibilityVersion, version)) {
 				defaultConfigs[key] = config[version as MinimumMinorSemanticVersion];
 			} else {
 				// If the compatibility mode is less than the version, we break out of the loop since we don't need to check
@@ -205,7 +199,7 @@ export function getConfigsForCompatMode<T extends Record<SemanticVersion, unknow
 export function isValidCompatVersion(compatibilityVersion: SemanticVersion): boolean {
 	return (
 		compatibilityVersion !== undefined &&
-		semverValid(compatibilityVersion) !== null &&
-		semverLte(compatibilityVersion, pkgVersion)
+		valid(compatibilityVersion) !== null &&
+		lte(compatibilityVersion, pkgVersion)
 	);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11961,9 +11961,9 @@ importers:
       lz4js:
         specifier: ^0.2.0
         version: 0.2.0
-      semver:
-        specifier: ^7.7.1
-        version: 7.7.1
+      semver-ts:
+        specifier: ^1.0.3
+        version: 1.0.3
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
@@ -12019,9 +12019,6 @@ importers:
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.67
-      '@types/semver':
-        specifier: ^7.7.0
-        version: 7.7.0
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
@@ -25660,6 +25657,10 @@ packages:
   semver-try-require@6.2.3:
     resolution: {integrity: sha512-6q1N/Vr/4/G0EcQ1k4svN5kwfh3MJs4Gfl+zBAVcKn+AeIjKLwTXQ143Y6YHu6xEeN5gSCbCD1/5+NwCipLY5A==}
     engines: {node: ^14||^16||>=18}
+
+  semver-ts@1.0.3:
+    resolution: {integrity: sha512-RMf2+Nbd0Hiq5u8LADzqnSRb09Vu1UKOLFw9P9nm8XY3JPeFjv3DLVYBZjPWFHUxBVz7ktIVGR3xFjYilHlXng==}
+    engines: {node: '>=0.10.0'}
 
   semver-utils@1.1.4:
     resolution: {integrity: sha512-EjnoLE5OGmDAVV/8YDoN5KiajNadjzIp9BAHOhYeQHt7j0UWxjmgsx4YD48wp4Ue1Qogq38F1GNUJNqF1kKKxA==}
@@ -41622,6 +41623,8 @@ snapshots:
   semver-try-require@6.2.3:
     dependencies:
       semver: 7.7.1
+
+  semver-ts@1.0.3: {}
 
   semver-utils@1.1.4: {}
 


### PR DESCRIPTION
using ESM and tree-shakable `semver-ts`.