### PR TITLE
Remove Deprecated IDetachedBlobStorage from Loader

### DIFF
--- a/.changeset/empty-lions-flow.md
+++ b/.changeset/empty-lions-flow.md
@@ -2,6 +2,6 @@
 "@fluidframework/container-loader": minor
 "__section": legacy
 ---
-Remove Deprecated IDetachedBlobStorage from Loader
+Remove deprecated IDetachedBlobStorage from Loader
 
 It is no longer necessary or supported to provide detachedBlobStorage to the Loader. This functionality is now provided by default, and the deprecated IDetachedBlobStorage has been removed.

--- a/.changeset/empty-lions-flow.md
+++ b/.changeset/empty-lions-flow.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/container-loader": minor
+"__section": legacy
+---
+Remove Deprecated IDetachedBlobStorage from Loader
+
+It is no longer necessary or supported to provide detachedBlobStorage to the Loader. This functionality is now provided by default, and the deprecated IDetachedBlobStorage has been removed.

--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -57,13 +57,6 @@ export interface ICreateDetachedContainerProps extends ICreateAndLoadContainerPr
     readonly codeDetails: IFluidCodeDetails;
 }
 
-// @alpha @deprecated @legacy
-export type IDetachedBlobStorage = Pick<IDocumentStorageService, "createBlob" | "readBlob"> & {
-    size: number;
-    getBlobIds(): string[];
-    dispose?(): void;
-};
-
 // @alpha @deprecated @legacy (undocumented)
 export interface IFluidModuleWithDetails {
     details: IFluidCodeDetails;
@@ -74,7 +67,6 @@ export interface IFluidModuleWithDetails {
 export interface ILoaderProps {
     readonly codeLoader: ICodeDetailsLoader;
     readonly configProvider?: IConfigProviderBase;
-    readonly detachedBlobStorage?: IDetachedBlobStorage;
     readonly documentServiceFactory: IDocumentServiceFactory;
     readonly logger?: ITelemetryBaseLogger;
     readonly options?: ILoaderOptions;
@@ -86,8 +78,6 @@ export interface ILoaderProps {
 // @alpha @legacy
 export interface ILoaderServices {
     readonly codeLoader: ICodeDetailsLoader;
-    // @deprecated
-    readonly detachedBlobStorage?: IDetachedBlobStorage;
     readonly documentServiceFactory: IDocumentServiceFactory;
     readonly options: ILoaderOptions;
     readonly protocolHandlerBuilder?: ProtocolHandlerBuilder;

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -212,7 +212,12 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"TypeAlias_IDetachedBlobStorage": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/loader/container-loader/src/attachment.ts
+++ b/packages/loader/container-loader/src/attachment.ts
@@ -9,8 +9,7 @@ import { ISummaryTree } from "@fluidframework/driver-definitions";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
 import { CombinedAppAndProtocolSummary } from "@fluidframework/driver-utils/internal";
 
-// eslint-disable-next-line import/no-deprecated
-import { IDetachedBlobStorage } from "./loader.js";
+import type { MemoryDetachedBlobStorage } from "./memoryBlobStorage.js";
 import type { SnapshotWithBlobs } from "./serializedStateManager.js";
 import { getSnapshotTreeAndBlobsFromSerializedContainer } from "./utils.js";
 
@@ -113,8 +112,7 @@ export interface AttachProcessProps {
 	 * The detached blob storage if it exists.
 	 */
 	readonly detachedBlobStorage?: Pick<
-		// eslint-disable-next-line import/no-deprecated
-		IDetachedBlobStorage,
+		MemoryDetachedBlobStorage,
 		"getBlobIds" | "readBlob" | "size"
 	>;
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -128,14 +128,12 @@ import {
 	getPackageName,
 } from "./contracts.js";
 import { DeltaManager, IConnectionArgs } from "./deltaManager.js";
-// eslint-disable-next-line import/no-deprecated
-import { IDetachedBlobStorage } from "./loader.js";
 import { RelativeLoader } from "./loader.js";
 import { validateRuntimeCompatibility } from "./loaderLayerCompatState.js";
 import {
-	serializeMemoryDetachedBlobStorage,
 	createMemoryDetachedBlobStorage,
 	tryInitializeMemoryDetachedBlobStorage,
+	type MemoryDetachedBlobStorage,
 } from "./memoryBlobStorage.js";
 import { NoopHeuristic } from "./noopHeuristic.js";
 import { pkgVersion } from "./packageVersion.js";
@@ -240,12 +238,6 @@ export interface IContainerCreateProps {
 	 * The logger downstream consumers should construct their loggers from
 	 */
 	readonly subLogger: ITelemetryLoggerExt;
-
-	/**
-	 * Blobs storage for detached containers.
-	 */
-	// eslint-disable-next-line import/no-deprecated
-	readonly detachedBlobStorage?: IDetachedBlobStorage;
 
 	/**
 	 * Optional property for allowing the container to use a custom
@@ -492,8 +484,7 @@ export class Container
 	private readonly options: ILoaderOptions;
 	private readonly scope: FluidObject;
 	private readonly subLogger: ITelemetryLoggerExt;
-	// eslint-disable-next-line import/no-deprecated
-	private readonly detachedBlobStorage: IDetachedBlobStorage | undefined;
+	private readonly detachedBlobStorage: MemoryDetachedBlobStorage | undefined;
 	private readonly protocolHandlerBuilder: ProtocolHandlerBuilder;
 	private readonly client: IClient;
 
@@ -807,7 +798,6 @@ export class Container
 			options,
 			scope,
 			subLogger,
-			detachedBlobStorage,
 			protocolHandlerBuilder,
 		} = createProps;
 
@@ -1006,10 +996,7 @@ export class Container
 		this.detachedBlobStorage =
 			this.attachState === AttachState.Attached
 				? undefined
-				: (detachedBlobStorage ??
-					(this.mc.config.getBoolean("Fluid.Container.MemoryBlobStorageEnabled") === false
-						? undefined
-						: createMemoryDetachedBlobStorage()));
+				: createMemoryDetachedBlobStorage();
 
 		this.storageAdapter = new ContainerStorageAdapter(
 			this.detachedBlobStorage,
@@ -1284,7 +1271,7 @@ export class Container
 			pendingRuntimeState,
 			hasAttachmentBlobs:
 				this.detachedBlobStorage !== undefined && this.detachedBlobStorage.size > 0,
-			attachmentBlobs: serializeMemoryDetachedBlobStorage(this.detachedBlobStorage),
+			attachmentBlobs: this.detachedBlobStorage?.serialize(),
 		};
 		return JSON.stringify(detachedContainerState);
 	}
@@ -1846,7 +1833,8 @@ export class Container
 	}: IPendingDetachedContainerState): Promise<void> {
 		if (hasAttachmentBlobs) {
 			if (attachmentBlobs !== undefined) {
-				tryInitializeMemoryDetachedBlobStorage(this.detachedBlobStorage, attachmentBlobs);
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				tryInitializeMemoryDetachedBlobStorage(this.detachedBlobStorage!, attachmentBlobs);
 			}
 			assert(
 				this.detachedBlobStorage !== undefined && this.detachedBlobStorage.size > 0,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1833,8 +1833,11 @@ export class Container
 	}: IPendingDetachedContainerState): Promise<void> {
 		if (hasAttachmentBlobs) {
 			if (attachmentBlobs !== undefined) {
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				tryInitializeMemoryDetachedBlobStorage(this.detachedBlobStorage!, attachmentBlobs);
+				assert(
+					this.detachedBlobStorage !== undefined,
+					"detached blob storage should always exist when detached",
+				);
+				tryInitializeMemoryDetachedBlobStorage(this.detachedBlobStorage, attachmentBlobs);
 			}
 			assert(
 				this.detachedBlobStorage !== undefined && this.detachedBlobStorage.size > 0,

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -23,8 +23,7 @@ import {
 import { isInstanceOfISnapshot, UsageError } from "@fluidframework/driver-utils/internal";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
-// eslint-disable-next-line import/no-deprecated
-import { IDetachedBlobStorage } from "./loader.js";
+import type { MemoryDetachedBlobStorage } from "./memoryBlobStorage.js";
 import { ProtocolTreeStorageService } from "./protocolTreeDocumentStorageService.js";
 import { RetriableDocumentStorageService } from "./retriableDocumentStorageService.js";
 import type {
@@ -80,8 +79,7 @@ export class ContainerStorageAdapter
 	 * @param enableSummarizeProtocolTree - Enable uploading a protocol summary. Note: preference is given to service policy's "summarizeProtocolTree" before this value.
 	 */
 	public constructor(
-		// eslint-disable-next-line import/no-deprecated
-		detachedBlobStorage: IDetachedBlobStorage | undefined,
+		detachedBlobStorage: MemoryDetachedBlobStorage | undefined,
 		private readonly logger: ITelemetryLoggerExt,
 		/**
 		 * ArrayBufferLikes or utf8 encoded strings, containing blobs from a snapshot
@@ -258,8 +256,7 @@ export class ContainerStorageAdapter
  */
 class BlobOnlyStorage implements IDocumentStorageService {
 	constructor(
-		// eslint-disable-next-line import/no-deprecated
-		private readonly detachedStorage: IDetachedBlobStorage | undefined,
+		private readonly detachedStorage: MemoryDetachedBlobStorage | undefined,
 		private readonly logger: ITelemetryLoggerExt,
 	) {}
 
@@ -271,8 +268,7 @@ class BlobOnlyStorage implements IDocumentStorageService {
 		return this.verifyStorage().readBlob(blobId);
 	}
 
-	// eslint-disable-next-line import/no-deprecated
-	private verifyStorage(): IDetachedBlobStorage {
+	private verifyStorage(): MemoryDetachedBlobStorage {
 		if (this.detachedStorage === undefined) {
 			throw new UsageError("Real storage calls not allowed in Unattached container");
 		}

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -16,7 +16,6 @@ export {
 } from "./createAndLoadContainerUtils.js";
 export {
 	ICodeDetailsLoader,
-	IDetachedBlobStorage,
 	IFluidModuleWithDetails,
 	ILoaderProps,
 	ILoaderServices,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -22,7 +22,6 @@ import {
 import { IClientDetails } from "@fluidframework/driver-definitions";
 import {
 	IDocumentServiceFactory,
-	IDocumentStorageService,
 	IResolvedUrl,
 	IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
@@ -171,11 +170,6 @@ export interface ILoaderProps {
 	readonly logger?: ITelemetryBaseLogger;
 
 	/**
-	 * Blobs storage for detached containers.
-	 */
-	readonly detachedBlobStorage?: IDetachedBlobStorage;
-
-	/**
 	 * The configuration provider which may be used to control features.
 	 */
 	readonly configProvider?: IConfigProviderBase;
@@ -229,38 +223,11 @@ export interface ILoaderServices {
 	readonly subLogger: ITelemetryLoggerExt;
 
 	/**
-	 * Blobs storage for detached containers.
-	 * @deprecated - IDetachedBlobStorage will be removed in a future release without a replacement. Blobs created while detached will be stored in memory to align with attached container behavior. AB#8049
-	 */
-	readonly detachedBlobStorage?: IDetachedBlobStorage;
-
-	/**
 	 * Optional property for allowing the container to use a custom
 	 * protocol implementation for handling the quorum and/or the audience.
 	 */
 	readonly protocolHandlerBuilder?: ProtocolHandlerBuilder;
 }
-
-/**
- * Subset of IDocumentStorageService which only supports createBlob() and readBlob(). This is used to support
- * blobs in detached containers.
- * @legacy
- * @alpha
- *
- * @deprecated - IDetachedBlobStorage will be removed in a future release without a replacement. Blobs created while detached will be stored in memory to align with attached container behavior. AB#8049
- */
-export type IDetachedBlobStorage = Pick<IDocumentStorageService, "createBlob" | "readBlob"> & {
-	size: number;
-	/**
-	 * Return an array of all blob IDs present in storage
-	 */
-	getBlobIds(): string[];
-
-	/**
-	 * After the container is attached, the detached blob storage is no longer needed and will be disposed.
-	 */
-	dispose?(): void;
-};
 
 /**
  * Manages Fluid resource loading
@@ -281,7 +248,6 @@ export class Loader implements IHostLoader {
 			options,
 			scope,
 			logger,
-			detachedBlobStorage,
 			configProvider,
 			protocolHandlerBuilder,
 		} = loaderProps;
@@ -306,7 +272,6 @@ export class Loader implements IHostLoader {
 			options: options ?? {},
 			scope:
 				options?.provideScopeLoader === false ? { ...scope } : { ...scope, ILoader: this },
-			detachedBlobStorage,
 			protocolHandlerBuilder,
 			subLogger: subMc.logger,
 		};

--- a/packages/loader/container-loader/src/memoryBlobStorage.ts
+++ b/packages/loader/container-loader/src/memoryBlobStorage.ts
@@ -12,6 +12,8 @@ import type {
 
 /**
  * An interface used to manage blobs in memory for detached containers.
+ * 
+ * @remarks
  * On attach of the container the blobs are read, and uploaded to the server.
  * The interface also supports serialization and initialization which is
  * used when serializing and rehydrating a detached container with blobs.

--- a/packages/loader/container-loader/src/memoryBlobStorage.ts
+++ b/packages/loader/container-loader/src/memoryBlobStorage.ts
@@ -10,6 +10,12 @@ import type {
 	IDocumentStorageService,
 } from "@fluidframework/driver-definitions/internal";
 
+/**
+ * An interface used to manage blobs in memory for detached containers.
+ * On attach of the container the blobs are read, and uploaded to the server.
+ * The interface also supports serialization and initialization which is
+ * used when serializing and rehydrating a detached container with blobs.
+ */
 export interface MemoryDetachedBlobStorage
 	extends Pick<IDocumentStorageService, "createBlob" | "readBlob"> {
 	size: number;

--- a/packages/loader/container-loader/src/memoryBlobStorage.ts
+++ b/packages/loader/container-loader/src/memoryBlobStorage.ts
@@ -4,57 +4,32 @@
  */
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
-import { assert, isObject } from "@fluidframework/core-utils/internal";
-import type { ICreateBlobResponse } from "@fluidframework/driver-definitions/internal";
+import { assert } from "@fluidframework/core-utils/internal";
+import type {
+	ICreateBlobResponse,
+	IDocumentStorageService,
+} from "@fluidframework/driver-definitions/internal";
 
-// eslint-disable-next-line import/no-deprecated
-import type { IDetachedBlobStorage } from "./loader.js";
+export interface MemoryDetachedBlobStorage
+	extends Pick<IDocumentStorageService, "createBlob" | "readBlob"> {
+	size: number;
+	/**
+	 * Return an array of all blob IDs present in storage
+	 */
+	getBlobIds(): string[];
 
-const MemoryDetachedBlobStorageIdentifier = Symbol();
-
-// eslint-disable-next-line import/no-deprecated
-interface MemoryDetachedBlobStorage extends IDetachedBlobStorage {
-	[MemoryDetachedBlobStorageIdentifier]: typeof MemoryDetachedBlobStorageIdentifier;
+	/**
+	 * After the container is attached, the detached blob storage is no longer needed and will be disposed.
+	 */
+	dispose?(): void;
 	initialize(attachmentBlobs: string[]): void;
 	serialize(): string | undefined;
 }
 
-function isMemoryDetachedBlobStorage(
-	// eslint-disable-next-line import/no-deprecated
-	detachedStorage: IDetachedBlobStorage | undefined,
-): detachedStorage is MemoryDetachedBlobStorage {
-	return (
-		isObject(detachedStorage) &&
-		MemoryDetachedBlobStorageIdentifier in detachedStorage &&
-		detachedStorage[MemoryDetachedBlobStorageIdentifier] ===
-			MemoryDetachedBlobStorageIdentifier
-	);
-}
-
-export function serializeMemoryDetachedBlobStorage(
-	// eslint-disable-next-line import/no-deprecated
-	detachedStorage: IDetachedBlobStorage | undefined,
-): string | undefined {
-	if (
-		detachedStorage !== undefined &&
-		detachedStorage.size > 0 &&
-		isMemoryDetachedBlobStorage(detachedStorage)
-	) {
-		return detachedStorage.serialize();
-	}
-}
-
 export function tryInitializeMemoryDetachedBlobStorage(
-	// eslint-disable-next-line import/no-deprecated
-	detachedStorage: IDetachedBlobStorage | undefined,
+	detachedStorage: MemoryDetachedBlobStorage,
 	attachmentBlobs: string,
 ): void {
-	if (!isMemoryDetachedBlobStorage(detachedStorage)) {
-		throw new Error(
-			"DetachedBlobStorage was not provided to the loader during serialize so cannot be provided during rehydrate.",
-		);
-	}
-
 	assert(detachedStorage.size === 0, 0x99e /* Blob storage already initialized */);
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	const maybeAttachmentBlobs = JSON.parse(attachmentBlobs);
@@ -65,10 +40,9 @@ export function tryInitializeMemoryDetachedBlobStorage(
 }
 
 // eslint-disable-next-line import/no-deprecated
-export function createMemoryDetachedBlobStorage(): IDetachedBlobStorage {
+export function createMemoryDetachedBlobStorage(): MemoryDetachedBlobStorage {
 	const blobs: ArrayBufferLike[] = [];
 	const storage: MemoryDetachedBlobStorage = {
-		[MemoryDetachedBlobStorageIdentifier]: MemoryDetachedBlobStorageIdentifier,
 		createBlob: async (file: ArrayBufferLike): Promise<ICreateBlobResponse> => ({
 			id: `${blobs.push(file) - 1}`,
 		}),

--- a/packages/loader/container-loader/src/memoryBlobStorage.ts
+++ b/packages/loader/container-loader/src/memoryBlobStorage.ts
@@ -12,7 +12,7 @@ import type {
 
 /**
  * An interface used to manage blobs in memory for detached containers.
- * 
+ *
  * @remarks
  * On attach of the container the blobs are read, and uploaded to the server.
  * The interface also supports serialization and initialization which is

--- a/packages/loader/container-loader/src/memoryBlobStorage.ts
+++ b/packages/loader/container-loader/src/memoryBlobStorage.ts
@@ -67,7 +67,10 @@ export function createMemoryDetachedBlobStorage(): MemoryDetachedBlobStorage {
 		},
 		getBlobIds: (): string[] => blobs.map((_, i) => `${i}`),
 		dispose: () => blobs.splice(0),
-		serialize: () => JSON.stringify(blobs.map((b) => bufferToString(b, "utf8"))),
+		serialize: () =>
+			blobs.length > 0
+				? JSON.stringify(blobs.map((b) => bufferToString(b, "utf8")))
+				: undefined,
 		initialize: (attachmentBlobs: string[]) =>
 			blobs.push(...attachmentBlobs.map((maybeBlob) => stringToBuffer(maybeBlob, "utf8"))),
 	};

--- a/packages/loader/container-loader/src/memoryBlobStorage.ts
+++ b/packages/loader/container-loader/src/memoryBlobStorage.ts
@@ -39,6 +39,12 @@ export function tryInitializeMemoryDetachedBlobStorage(
 	detachedStorage.initialize(maybeAttachmentBlobs);
 }
 
+/**
+ * Creates a new instance of `MemoryDetachedBlobStorage`.
+ * The returned storage allows for creating, reading, and managing blobs in memory.
+ * It also provides methods for serialization and initialization with attachment blobs.
+ * @returns A new `MemoryDetachedBlobStorage` instance.
+ */
 // eslint-disable-next-line import/no-deprecated
 export function createMemoryDetachedBlobStorage(): MemoryDetachedBlobStorage {
 	const blobs: ArrayBufferLike[] = [];

--- a/packages/loader/container-loader/src/test/memoryBlobStorage.spec.ts
+++ b/packages/loader/container-loader/src/test/memoryBlobStorage.spec.ts
@@ -7,10 +7,8 @@ import { strict as assert } from "node:assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
 
-import type { IDetachedBlobStorage } from "../loader.js";
 import {
 	createMemoryDetachedBlobStorage,
-	serializeMemoryDetachedBlobStorage,
 	tryInitializeMemoryDetachedBlobStorage,
 } from "../memoryBlobStorage.js";
 
@@ -69,7 +67,7 @@ describe("MemoryBlobStorage", () => {
 		const blobResponse = await storage.createBlob(blobContent);
 
 		// Serialize the storage
-		const serializedStorage = serializeMemoryDetachedBlobStorage(storage);
+		const serializedStorage = storage.serialize();
 		assert(serializedStorage !== undefined, "Serialized storage is undefined");
 
 		const newStorage = createMemoryDetachedBlobStorage();
@@ -102,7 +100,7 @@ describe("MemoryBlobStorage", () => {
 		await storage.createBlob(blobContent);
 
 		// Serialize the storage
-		const serializedStorage = serializeMemoryDetachedBlobStorage(storage);
+		const serializedStorage = storage.serialize();
 
 		assert(serializedStorage !== undefined, "Serialized storage is undefined");
 
@@ -113,32 +111,9 @@ describe("MemoryBlobStorage", () => {
 			tryInitializeMemoryDetachedBlobStorage(newStorage, serializedStorage);
 		}, "Expected an error when initializing storage that already has blobs");
 	});
-
-	it("Throws error when tryInitializeMemoryDetachedBlobStorage is called on non-MemoryBlobStorage", () => {
-		const notMemoryBlobStorage: IDetachedBlobStorage = {
-			size: 0,
-			createBlob: async () => {
-				throw new Error("createBlob not implemented");
-			},
-			readBlob: async () => {
-				throw new Error("readBlob not implemented");
-			},
-			getBlobIds: () => {
-				throw new Error("getBlobIds not implemented");
-			},
-			dispose: () => {
-				throw new Error("dispose not implemented");
-			},
-		};
-
-		assert.throws(() => {
-			tryInitializeMemoryDetachedBlobStorage(notMemoryBlobStorage, "");
-		}, "Expected an error when initializing non-MemoryBlobStorage");
-	});
-
 	it("Returns undefined when serializing empty storage", () => {
 		const storage = createMemoryDetachedBlobStorage();
-		const serializedStorage = serializeMemoryDetachedBlobStorage(storage);
+		const serializedStorage = storage.serialize();
 		assert.strictEqual(
 			serializedStorage,
 			undefined,

--- a/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
+++ b/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
@@ -355,6 +355,7 @@ declare type current_as_old_for_Interface_IScribeProtocolState = requireAssignab
  * typeValidation.broken:
  * "TypeAlias_IDetachedBlobStorage": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_IDetachedBlobStorage = requireAssignableTo<TypeOnly<old.IDetachedBlobStorage>, TypeOnly<current.IDetachedBlobStorage>>
 
 /*
@@ -364,6 +365,7 @@ declare type old_as_current_for_TypeAlias_IDetachedBlobStorage = requireAssignab
  * typeValidation.broken:
  * "TypeAlias_IDetachedBlobStorage": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_IDetachedBlobStorage = requireAssignableTo<TypeOnly<current.IDetachedBlobStorage>, TypeOnly<old.IDetachedBlobStorage>>
 
 /*

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -39,7 +39,6 @@ import { wrapObjectAndOverride } from "../mocking.js";
 import { TestPersistedCache } from "../testPersistedCache.js";
 
 import {
-	MockDetachedBlobStorage,
 	driverSupportsBlobs,
 	getUrlFromDetachedBlobStorage,
 } from "./mockDetachedBlobStorage.js";
@@ -773,7 +772,6 @@ function serializationTests({
 			it("rehydrating without detached blob storage results in error", async function () {
 				const loader = provider.makeTestLoader({
 					...testContainerConfig,
-					loaderProps: { detachedBlobStorage: new MockDetachedBlobStorage() },
 				});
 				const serializeContainer = await loader.createDetachedContainer(
 					provider.defaultCodeDetails,

--- a/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
@@ -31,7 +31,7 @@ import {
 	createAndAttachContainer,
 } from "@fluidframework/test-utils/internal";
 
-import { MockDetachedBlobStorage, driverSupportsBlobs } from "./mockDetachedBlobStorage.js";
+import { driverSupportsBlobs } from "./mockDetachedBlobStorage.js";
 
 const mapId = "map";
 const directoryId = "directoryKey";
@@ -183,7 +183,6 @@ describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, api
 		let provider: ITestObjectProvider;
 		let loader: IHostLoader;
 		let container: IContainer;
-		let detachedBlobStorage: MockDetachedBlobStorage;
 		let detachedDataStore: ITestFluidObject;
 		let map: ISharedMap;
 		let directory: ISharedDirectory;
@@ -195,10 +194,8 @@ describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, api
 			if (!driverSupportsBlobs(provider.driver)) {
 				this.skip();
 			}
-			detachedBlobStorage = new MockDetachedBlobStorage();
 			loader = provider.makeTestLoader({
 				...testContainerConfig,
-				loaderProps: { detachedBlobStorage },
 			});
 			container = await loader.createDetachedContainer(provider.defaultCodeDetails);
 			provider.updateDocumentId(container.resolvedUrl);
@@ -270,7 +267,6 @@ describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, api
 			detachedDataStore.root.set("map", map.handle);
 			map.set("my blob", blobHandle);
 			await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-			detachedBlobStorage.dispose();
 			checkForAttachedHandles(map);
 		});
 
@@ -278,7 +274,6 @@ describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, api
 			detachedDataStore.root.set(directoryId, directory.handle);
 			directory.set("my blob", blobHandle);
 			await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-			detachedBlobStorage.dispose();
 			checkForAttachedHandles(directory);
 		});
 
@@ -295,7 +290,6 @@ describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, api
 				false,
 				"blob should be detached in a detached dds and attached container",
 			);
-			detachedBlobStorage.dispose();
 			detachedDataStore.root.set(mapId, map.handle);
 			assert.strictEqual(
 				map.handle.isAttached,
@@ -322,7 +316,6 @@ describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, api
 				false,
 				"blob should be detached in a detached dds and attached container",
 			);
-			detachedBlobStorage.dispose();
 			detachedDataStore.root.set(directoryId, directory.handle);
 			assert.strictEqual(
 				directory.handle.isAttached,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
@@ -19,7 +19,6 @@ import {
 } from "@fluidframework/test-utils/internal";
 
 import {
-	MockDetachedBlobStorage,
 	driverSupportsBlobs,
 	getUrlFromDetachedBlobStorage,
 } from "../mockDetachedBlobStorage.js";
@@ -107,10 +106,8 @@ describeCompat("Garbage collection of blobs", "NoCompat", (getTestObjectProvider
 			if (!driverSupportsBlobs(provider.driver)) {
 				this.skip();
 			}
-			const detachedBlobStorage = new MockDetachedBlobStorage();
 			const loader = provider.makeTestLoader({
 				...gcContainerConfig,
-				loaderProps: { detachedBlobStorage },
 			});
 			container = await loader.createDetachedContainer(provider.defaultCodeDetails);
 			defaultDataStore = (await container.getEntryPoint()) as ITestDataObject;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -43,7 +43,6 @@ import {
 } from "@fluidframework/test-utils/internal";
 
 import {
-	MockDetachedBlobStorage,
 	driverSupportsBlobs,
 	getUrlFromDetachedBlobStorage,
 } from "../mockDetachedBlobStorage.js";
@@ -446,10 +445,9 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 		 * Creates a detached container and returns it along with the default data store.
 		 */
 		async function createDetachedContainerAndDataStore() {
-			const detachedBlobStorage = new MockDetachedBlobStorage();
 			const loader = provider.makeTestLoader({
 				...testContainerConfig,
-				loaderProps: { ...testContainerConfig.loaderProps, detachedBlobStorage },
+				loaderProps: { ...testContainerConfig.loaderProps },
 			});
 			const mainContainer = await loader.createDetachedContainer(provider.defaultCodeDetails);
 			const mainDataStore = (await mainContainer.getEntryPoint()) as ITestDataObject;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -24,7 +24,6 @@ import {
 } from "@fluidframework/test-utils/internal";
 
 import {
-	MockDetachedBlobStorage,
 	driverSupportsBlobs,
 	getUrlFromDetachedBlobStorage,
 } from "../mockDetachedBlobStorage.js";
@@ -458,10 +457,9 @@ describeCompat("GC attachment blob tombstone tests", "NoCompat", (getTestObjectP
 		 * Creates a detached container and returns it along with the default data store.
 		 */
 		async function createDetachedContainerAndDataStore() {
-			const detachedBlobStorage = new MockDetachedBlobStorage();
 			const loader = provider.makeTestLoader({
 				...testContainerConfig,
-				loaderProps: { ...testContainerConfig.loaderProps, detachedBlobStorage },
+				loaderProps: { ...testContainerConfig.loaderProps },
 			});
 			const mainContainer = await loader.createDetachedContainer(provider.defaultCodeDetails);
 			const mainDataStore = (await mainContainer.getEntryPoint()) as ITestDataObject;

--- a/packages/test/test-end-to-end-tests/src/test/mockDetachedBlobStorage.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mockDetachedBlobStorage.ts
@@ -7,38 +7,8 @@ import { strict as assert } from "assert";
 
 import { ITestDriver } from "@fluid-internal/test-driver-definitions";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import { IDetachedBlobStorage } from "@fluidframework/container-loader/internal";
-import { ICreateBlobResponse } from "@fluidframework/driver-definitions/internal";
 import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
 import { ITestObjectProvider } from "@fluidframework/test-utils/internal";
-
-export class MockDetachedBlobStorage implements IDetachedBlobStorage {
-	private readonly blobs = new Map<string, ArrayBufferLike>();
-
-	public get size() {
-		return this.blobs.size;
-	}
-
-	public getBlobIds(): string[] {
-		return Array.from(this.blobs.keys());
-	}
-
-	public async createBlob(content: ArrayBufferLike): Promise<ICreateBlobResponse> {
-		const id = this.size.toString();
-		this.blobs.set(id, content);
-		return { id };
-	}
-
-	public async readBlob(blobId: string): Promise<ArrayBufferLike> {
-		const blob = this.blobs.get(blobId);
-		assert(blob);
-		return blob;
-	}
-
-	dispose(): void {
-		this.blobs.clear();
-	}
-}
 
 const driversThatSupportBlobs: string[] = ["local", "odsp"];
 export function driverSupportsBlobs(driver: ITestDriver): boolean {

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -17,14 +17,11 @@ import {
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
 import {
 	createDetachedContainer,
-	// eslint-disable-next-line import/no-deprecated
-	type IDetachedBlobStorage,
 	type ILoaderProps,
 } from "@fluidframework/container-loader/internal";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { ICreateBlobResponse } from "@fluidframework/driver-definitions/internal";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import { LocalCodeLoader } from "@fluidframework/test-utils/internal";
 
@@ -47,31 +44,6 @@ const codeDetails: IFluidCodeDetails = {
 
 export const createCodeLoader = (options?: IContainerRuntimeOptions | undefined) =>
 	new LocalCodeLoader([[codeDetails, createFluidExport(options)]]);
-
-// eslint-disable-next-line import/no-deprecated
-class MockDetachedBlobStorage implements IDetachedBlobStorage {
-	public readonly blobs = new Map<string, ArrayBufferLike>();
-
-	public get size() {
-		return this.blobs.size;
-	}
-
-	public getBlobIds(): string[] {
-		return Array.from(this.blobs.keys());
-	}
-
-	public async createBlob(content: ArrayBufferLike): Promise<ICreateBlobResponse> {
-		const id = this.size.toString();
-		this.blobs.set(id, content);
-		return { id };
-	}
-
-	public async readBlob(blobId: string): Promise<ArrayBufferLike> {
-		const blob = this.blobs.get(blobId);
-		assert(!!blob, "blob not found");
-		return blob;
-	}
-}
 
 export async function initialize(
 	testDriver: ITestDriver,
@@ -112,7 +84,6 @@ export async function initialize(
 		codeLoader: createCodeLoader(containerRuntimeOptions),
 		logger,
 		options: loaderOptions,
-		detachedBlobStorage: new MockDetachedBlobStorage(),
 		configProvider: configProvider(configurations),
 	};
 


### PR DESCRIPTION
It is no longer necessary or supported to provide detachedBlobStorage to the Loader. This functionality is now provided by default, and the deprecated IDetachedBlobStorage has been removed.

fixes #24120