### PR TITLE
Eslint rule to prevent use of mocha's beforeEach

### DIFF
--- a/common/build/eslint-plugin-fluid/src/rules/no-before-each.js
+++ b/common/build/eslint-plugin-fluid/src/rules/no-before-each.js
@@ -1,0 +1,30 @@
+module.exports = {
+	meta: {
+		type: "problem",
+		docs: {
+			description: "Disallow calls to the 'beforeEach' function.",
+			category: "Best Practices",
+			recommended: false,
+		},
+		messages: {
+			noBeforeEach: "Calls to 'beforeEach' are not allowed.",
+		},
+		schema: [], // No options for this rule
+	},
+	create(context) {
+		return {
+			CallExpression(node) {
+				// Check if the callee is a function named "beforeEach"
+				if (
+					node.callee.type === "Identifier" &&
+					node.callee.name === "beforeEach"
+				) {
+					context.report({
+						node,
+						messageId: "noBeforeEach",
+					});
+				}
+			},
+		};
+	},
+};

--- a/common/build/eslint-plugin-fluid/src/test/enforce-no-unchecked-record-access/enforce-no-unchecked-record-access.test.js
+++ b/common/build/eslint-plugin-fluid/src/test/enforce-no-unchecked-record-access/enforce-no-unchecked-record-access.test.js
@@ -7,7 +7,7 @@ const assert = require("assert");
 const path = require("path");
 const { ESLint } = require("eslint");
 
-describe("ESLint Rule Tests", function () {
+describe("no-unchecked-record-access rule", function () {
 	async function lintFile(file) {
 		const eslint = new ESLint({
 			useEslintrc: false,

--- a/common/build/eslint-plugin-fluid/src/test/no-before-each/fixtures/with-before-each.js
+++ b/common/build/eslint-plugin-fluid/src/test/no-before-each/fixtures/with-before-each.js
@@ -1,0 +1,9 @@
+describe("Example test suite", function () {
+    beforeEach(function () {
+        // Example setup code
+    });
+
+    it("Example test", function () {
+        // Test code
+    });
+});

--- a/common/build/eslint-plugin-fluid/src/test/no-before-each/fixtures/without-before-each.js
+++ b/common/build/eslint-plugin-fluid/src/test/no-before-each/fixtures/without-before-each.js
@@ -1,0 +1,5 @@
+describe("Example test suite", function () {
+    it("Example test", function () {
+        // Test code
+    });
+});

--- a/common/build/eslint-plugin-fluid/src/test/no-before-each/no-before-each.test.js
+++ b/common/build/eslint-plugin-fluid/src/test/no-before-each/no-before-each.test.js
@@ -1,0 +1,38 @@
+const assert = require("assert");
+const path = require("path");
+const { ESLint } = require("eslint");
+
+describe("no-before-each rule", function () {
+	async function lintFile(file) {
+		const eslint = new ESLint({
+			useEslintrc: false,
+			overrideConfig: {
+				rules: {
+					"no-before-each": "error",
+				},
+				parser: "@typescript-eslint/parser",
+				parserOptions: {
+					project: path.join(__dirname, "../example/tsconfig.json"),
+				},
+			},
+			rulePaths: [path.join(__dirname, "../../rules")],
+		});
+		const fileToLint = path.join(__dirname, file);
+		const results = await eslint.lintFiles([fileToLint]);
+		return results[0];
+	}
+
+	it("Should report an error for using beforeEach", async function () {
+		const result = await lintFile("fixtures/with-before-each.js");
+		assert.strictEqual(result.errorCount, 1, "Should have 1 error");
+		assert.strictEqual(
+			result.messages[0].message,
+			"Calls to 'beforeEach' are not allowed.",
+		);
+	});
+
+	it("Should not report an error when beforeEach is not used", async function () {
+		const result = await lintFile("fixtures/without-before-each.js");
+		assert.strictEqual(result.errorCount, 0, "Should have no errors");
+	});
+});

--- a/packages/utils/telemetry-utils/src/test/test.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/test.spec.ts
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+describe.only("My test suite", () => {
+	beforeEach(() => {
+		throw new Error("Fake error");
+	});
+
+	it("Test 1", () => {
+		assert.equal(1, 1);
+	});
+
+	it("Test 2", () => {
+		assert.equal(2, 2);
+	});
+});
+
+describe.only("My second test suite", () => {
+	function setup(): void {
+		throw new Error("Fake error");
+	}
+
+	it("Test 1", () => {
+		setup();
+		assert.equal(1, 1);
+	});
+
+	it("Test 2", () => {
+		setup();
+		assert.equal(2, 2);
+	});
+});


### PR DESCRIPTION
## Description

This is an experiment that accompanies my proposal to stop using Mocha's `beforeEach()`. I asked Copilot to write the rule and haven't reviewed it in detail yet.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
