### PR TITLE
docs(shared-object-base): Improve property docs

### DIFF
--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
@@ -39,7 +39,8 @@ export function parseHandles(value: unknown, serializer: IFluidSerializer): unkn
 
 // @alpha @legacy
 export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends SharedObjectCore<TEvent> {
-    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes, telemetryContextPrefix: string);
+    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes,
+    telemetryContextPrefix: string);
     getAttachSummary(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): IGarbageCollectionData;
     protected processGCDataCore(serializer: IFluidSerializer): void;
@@ -51,9 +52,11 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
 
 // @alpha @legacy
 export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends EventEmitterWithErrorHandling<TEvent> implements ISharedObject<TEvent> {
-    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
+    constructor(
+    id: string,
+    runtime: IFluidDataStoreRuntime,
+    attributes: IChannelAttributes);
     protected abstract applyStashedOp(content: unknown): void;
-    // (undocumented)
     readonly attributes: IChannelAttributes;
     bindToContext(): void;
     connect(services: IChannelServices): void;
@@ -65,7 +68,6 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     abstract getAttachSummary(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     abstract getGCData(fullGC?: boolean): IGarbageCollectionData;
     readonly handle: IFluidHandleInternal;
-    // (undocumented)
     id: string;
     // (undocumented)
     get IFluidLoadable(): this;
@@ -83,7 +85,6 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     protected processMessagesCore?(messagesCollection: IRuntimeMessageCollection): void;
     protected reSubmitCore(content: unknown, localOpMetadata: unknown): void;
     protected rollback(content: unknown, localOpMetadata: unknown): void;
-    // (undocumented)
     protected runtime: IFluidDataStoreRuntime;
     protected abstract get serializer(): IFluidSerializer;
     protected submitLocalMessage(content: unknown, localOpMetadata?: unknown): void;

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -129,14 +129,18 @@ export abstract class SharedObjectCore<
 		return this._connected;
 	}
 
-	/**
-	 * @param id - The id of the shared object
-	 * @param runtime - The IFluidDataStoreRuntime which contains the shared object
-	 * @param attributes - Attributes of the shared object
-	 */
 	constructor(
+		/**
+		 * The ID of the shared object.
+		 */
 		public id: string,
+		/**
+		 * The runtime instance that contains the Shared Object.
+		 */
 		protected runtime: IFluidDataStoreRuntime,
+		/**
+		 * The attributes of the Shared Object.
+		 */
 		public readonly attributes: IChannelAttributes,
 	) {
 		super((event: EventEmitterEventType, e: unknown) =>
@@ -762,15 +766,13 @@ export abstract class SharedObject<
 		return this._serializer;
 	}
 
-	/**
-	 * @param id - The id of the shared object
-	 * @param runtime - The IFluidDataStoreRuntime which contains the shared object
-	 * @param attributes - Attributes of the shared object
-	 */
 	constructor(
 		id: string,
 		runtime: IFluidDataStoreRuntime,
 		attributes: IChannelAttributes,
+		/**
+		 * The prefix to use for telemetry events emitted by this object.
+		 */
 		private readonly telemetryContextPrefix: string,
 	) {
 		super(id, runtime, attributes);


### PR DESCRIPTION
Better leverages TSDoc syntax, and will result in a better generated API docs experience (for our internal docs feed).