### PR TITLE
Vermadhr/modify timeout context to fetch timeout values

### DIFF
--- a/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
+++ b/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
@@ -461,6 +461,7 @@ export interface ITimeoutContext {
     bindTimeout(maxDurationMs: number, callback: () => void): void;
     bindTimeoutAsync<T>(maxDurationMs: number, callback: () => Promise<T>): Promise<T>;
     checkTimeout(): void;
+    getTimeRemainingMs(): number | undefined;
 }
 
 // @internal (undocumented)

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -106,6 +106,9 @@
 			},
 			"Interface_INetworkErrorDetails": {
 				"backCompat": false
+			},
+			"Interface_ITimeoutContext": {
+				"forwardCompat": false
 			}
 		},
 		"entrypoint": "public"

--- a/server/routerlicious/packages/services-client/src/test/types/validateServerServicesClientPrevious.generated.ts
+++ b/server/routerlicious/packages/services-client/src/test/types/validateServerServicesClientPrevious.generated.ts
@@ -800,6 +800,7 @@ declare type current_as_old_for_Interface_ISummaryUploadManager = requireAssigna
  * typeValidation.broken:
  * "Interface_ITimeoutContext": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ITimeoutContext = requireAssignableTo<TypeOnly<old.ITimeoutContext>, TypeOnly<current.ITimeoutContext>>
 
 /*

--- a/server/routerlicious/packages/services-client/src/timeoutContext.ts
+++ b/server/routerlicious/packages/services-client/src/timeoutContext.ts
@@ -24,6 +24,11 @@ export interface ITimeoutContext {
 	 * If exceeded, throws a 503 Timeout error
 	 */
 	checkTimeout(): void;
+	/**
+	 * Returns the time remaining before the timeout is exceeded.
+	 * If no timeout is set, returns undefined.
+	 */
+	getTimeRemainingMs(): number | undefined;
 }
 
 /**
@@ -38,6 +43,9 @@ class NullTimeoutContext implements ITimeoutContext {
 		return callback();
 	}
 	checkTimeout(): void {}
+	getTimeRemainingMs(): number | undefined {
+		return undefined;
+	}
 }
 const nullTimeoutContext = new NullTimeoutContext();
 

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -106,7 +106,11 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_AsyncLocalStorageTimeoutContext": {
+				"forwardCompat": false
+			}
+		},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/services-utils/src/asyncContext.ts
+++ b/server/routerlicious/packages/services-utils/src/asyncContext.ts
@@ -129,4 +129,22 @@ export class AsyncLocalStorageTimeoutContext implements ITimeoutContext {
 			throw error;
 		}
 	}
+
+	public getTimeRemainingMs(): number | undefined {
+		// Check if there is any time still remaining. Throw an error if the timeout has been exceeded.
+		this.checkTimeout();
+		const timeoutInfo = this.contextProvider.getContext();
+		if (!timeoutInfo) {
+			return undefined;
+		}
+		const timeElapsed = Date.now() - timeoutInfo.startTime;
+		const timeRemaining = timeoutInfo.maxDurationMs - timeElapsed;
+		Lumberjack.debug("[TimeoutContext]: Time remaining.", {
+			timeRemaining,
+			startTime: timeoutInfo.startTime,
+			maxDurationMs: timeoutInfo.maxDurationMs,
+			timeElapsed,
+		});
+		return timeRemaining;
+	}
 }

--- a/server/routerlicious/packages/services-utils/src/test/types/validateServerServicesUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/services-utils/src/test/types/validateServerServicesUtilsPrevious.generated.ts
@@ -58,6 +58,7 @@ declare type current_as_old_for_Class_AsyncLocalStorageTelemetryContext = requir
  * typeValidation.broken:
  * "Class_AsyncLocalStorageTimeoutContext": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_AsyncLocalStorageTimeoutContext = requireAssignableTo<TypeOnly<old.AsyncLocalStorageTimeoutContext>, TypeOnly<current.AsyncLocalStorageTimeoutContext>>
 
 /*


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The sections included below are suggestions for what you may want to include.
Feel free to remove or alter parts of this template that do not offer value for your specific change.

## Description

> A concise description of the changes (bug or feature) and their impact/motivation.
> If this description is short enough to be used as the title, delete this section and just use the title.

> For bug fixes, also include specifics of how to reproduce it / confirm it is fixed.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

## Breaking Changes

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.
> See [Breaking-vs-Non-breaking-Changes](https://github.com/microsoft/FluidFramework/wiki/Breaking-vs-Non-breaking-Changes) for details.
> If there are no breaking changes, delete this section.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

> List any specific things you want to get reviewer opinions on, and anything a reviewer would need to know to review this PR effectively.
> Things you might want to include:
>
> -   Questions about how to properly make automated tests for your changes.
> -   Questions about design choices you made.
> -   Descriptions of how to manually test the changes (and how much of that you have done).
> -   etc.
>
> If you have any questions in this section, consider making the PR a draft until all questions have been resolved.
