### PR TITLE
Fix docs for TreeAlpha

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -961,21 +961,38 @@ export interface TransactionResultSuccess<TSuccessValue> {
 export const Tree: TreeApi;
 
 // @alpha @sealed
-export const TreeAlpha: {
+export interface TreeAlpha {
     branch(node: TreeNode): TreeBranch | undefined;
     create<const TSchema extends ImplicitFieldSchema | UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: InsertableField<TSchema>): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
-    importConcise<const TSchema extends ImplicitFieldSchema | UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: ConciseTree | undefined): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
-    importVerbose<const TSchema extends ImplicitFieldSchema>(schema: TSchema, data: VerboseTree | undefined, options?: Partial<TreeEncodingOptions>): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
-    exportConcise(node: TreeNode | TreeLeafValue, options?: TreeEncodingOptions): ConciseTree;
-    exportConcise(node: TreeNode | TreeLeafValue | undefined, options?: TreeEncodingOptions): ConciseTree | undefined;
-    exportVerbose(node: TreeNode | TreeLeafValue, options?: TreeEncodingOptions): VerboseTree;
     exportCompressed(tree: TreeNode | TreeLeafValue, options: {
         oldestCompatibleClient: FluidClientVersion;
         idCompressor?: IIdCompressor;
     }): JsonCompatible<IFluidHandle>;
+    exportConcise(node: TreeNode | TreeLeafValue, options?: TreeEncodingOptions): ConciseTree;
+    exportConcise(node: TreeNode | TreeLeafValue | undefined, options?: TreeEncodingOptions): ConciseTree | undefined;
+    exportVerbose(node: TreeNode | TreeLeafValue, options?: TreeEncodingOptions): VerboseTree;
     importCompressed<const TSchema extends ImplicitFieldSchema>(schema: TSchema, compressedData: JsonCompatible<IFluidHandle>, options: {
         idCompressor?: IIdCompressor;
     } & ICodecOptions): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
+    importConcise<const TSchema extends ImplicitFieldSchema | UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: ConciseTree | undefined): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
+    importVerbose<const TSchema extends ImplicitFieldSchema>(schema: TSchema, data: VerboseTree | undefined, options?: Partial<TreeEncodingOptions>): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
+}
+
+// @alpha @sealed (undocumented)
+export const TreeAlpha: {
+    branch(node: TreeNode): TreeBranch | undefined;
+    create: typeof createFromInsertable;
+    importConcise<TSchema extends ImplicitFieldSchema | typeof UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: ConciseTree | undefined): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
+    importVerbose<const TSchema_1 extends ImplicitFieldSchema>(schema: TSchema_1, data: VerboseTree | undefined, options?: TreeEncodingOptions): TreeFieldFromImplicitField<TSchema_1>;
+    exportConcise: typeof exportConcise;
+    exportVerbose(node: TreeNode | TreeLeafValue, options?: TreeEncodingOptions): VerboseTree;
+    exportCompressed(node: TreeNode | TreeLeafValue, options: {
+        oldestCompatibleClient: FluidClientVersion;
+        idCompressor?: IIdCompressor;
+    }): JsonCompatible<IFluidHandle>;
+    importCompressed<const TSchema_2 extends ImplicitFieldSchema>(schema: TSchema_2, compressedData: JsonCompatible<IFluidHandle>, options: {
+        idCompressor?: IIdCompressor;
+    } & ICodecOptions): TreeFieldFromImplicitField<TSchema_2>;
 };
 
 // @public @sealed @system

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -978,22 +978,8 @@ export interface TreeAlpha {
     importVerbose<const TSchema extends ImplicitFieldSchema>(schema: TSchema, data: VerboseTree | undefined, options?: Partial<TreeEncodingOptions>): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
 }
 
-// @alpha @sealed (undocumented)
-export const TreeAlpha: {
-    branch(node: TreeNode): TreeBranch | undefined;
-    create: typeof createFromInsertable;
-    importConcise<TSchema extends ImplicitFieldSchema | typeof UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: ConciseTree | undefined): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
-    importVerbose<const TSchema_1 extends ImplicitFieldSchema>(schema: TSchema_1, data: VerboseTree | undefined, options?: TreeEncodingOptions): TreeFieldFromImplicitField<TSchema_1>;
-    exportConcise: typeof exportConcise;
-    exportVerbose(node: TreeNode | TreeLeafValue, options?: TreeEncodingOptions): VerboseTree;
-    exportCompressed(node: TreeNode | TreeLeafValue, options: {
-        oldestCompatibleClient: FluidClientVersion;
-        idCompressor?: IIdCompressor;
-    }): JsonCompatible<IFluidHandle>;
-    importCompressed<const TSchema_2 extends ImplicitFieldSchema>(schema: TSchema_2, compressedData: JsonCompatible<IFluidHandle>, options: {
-        idCompressor?: IIdCompressor;
-    } & ICodecOptions): TreeFieldFromImplicitField<TSchema_2>;
-};
+// @alpha @sealed
+export const TreeAlpha: TreeAlpha;
 
 // @public @sealed @system
 interface TreeApi extends TreeNodeApi {

--- a/packages/dds/tree/src/jsonDomainSchema.ts
+++ b/packages/dds/tree/src/jsonDomainSchema.ts
@@ -36,7 +36,7 @@ const sf = new SchemaFactory("com.fluidframework.json");
  *
  * 2. The order of fields on an object is not preserved. The resulting order is arbitrary.
  *
- * JSON data can be imported from JSON into this format using `JSON.parse` then {@link TreeAlpha.importConcise} with the {@link JsonAsTree.(Tree:variable)} schema.
+ * JSON data can be imported from JSON into this format using `JSON.parse` then {@link (TreeAlpha:interface).importConcise} with the {@link JsonAsTree.(Tree:variable)} schema.
  *
  * @alpha
  */
@@ -125,7 +125,7 @@ export namespace JsonAsTree {
 	/**
 	 * Arbitrary JSON array as a {@link TreeNode}.
 	 * @remarks
-	 * This can be imported using {@link TreeAlpha.importConcise}.
+	 * This can be imported using {@link (TreeAlpha:interface).importConcise}.
 	 * @example
 	 * ```typescript
 	 * // Due to TypeScript restrictions on recursive types, the constructor can be somewhat limiting.

--- a/packages/dds/tree/src/serializableDomainSchema.ts
+++ b/packages/dds/tree/src/serializableDomainSchema.ts
@@ -21,14 +21,14 @@ const sf = new SchemaFactory("com.fluidframework.serializable");
  * @remarks
  * Schema which replicate the Fluid Serializable data model with {@link TreeNode}s.
  *
- * Fluid Serializable data can be imported from the {@link FluidSerializableAsTree.Data|Fluid Serializable format} into this format using {@link TreeAlpha.importConcise} with the {@link FluidSerializableAsTree.(Tree:variable)} schema.
+ * Fluid Serializable data can be imported from the {@link FluidSerializableAsTree.Data|Fluid Serializable format} into this format using {@link (TreeAlpha:interface).importConcise} with the {@link FluidSerializableAsTree.(Tree:variable)} schema.
  * @internal
  */
 export namespace FluidSerializableAsTree {
 	/**
 	 * Data which can be serialized by Fluid.
 	 * @remarks
-	 * Can be encoded as a {@link FluidSerializableAsTree.(Tree:type)} using {@link TreeAlpha.importConcise}.
+	 * Can be encoded as a {@link FluidSerializableAsTree.(Tree:type)} using {@link (TreeAlpha:interface).importConcise}.
 	 * @internal
 	 */
 	export type Data = JsonCompatible<IFluidHandle>;
@@ -100,7 +100,7 @@ export namespace FluidSerializableAsTree {
 	/**
 	 * Arbitrary Fluid Serializable array as a {@link TreeNode}.
 	 * @remarks
-	 * This can be imported using {@link TreeAlpha.importConcise}.
+	 * This can be imported using {@link (TreeAlpha:interface).importConcise}.
 	 * @example
 	 * ```typescript
 	 * // Due to TypeScript restrictions on recursive types, the constructor can be somewhat limiting.

--- a/packages/dds/tree/src/shared-tree/independentView.ts
+++ b/packages/dds/tree/src/shared-tree/independentView.ts
@@ -134,7 +134,7 @@ export function independentInitializedView<const TSchema extends ImplicitFieldSc
  */
 export interface ViewContent {
 	/**
-	 * Compressed tree from {@link TreeAlpha.exportCompressed}.
+	 * Compressed tree from {@link (TreeAlpha:interface).exportCompressed}.
 	 * @remarks
 	 * This is an owning reference:
 	 * consumers of this content might modify this data in place (for example when applying edits) to avoid copying.

--- a/packages/dds/tree/src/shared-tree/treeApiAlpha.ts
+++ b/packages/dds/tree/src/shared-tree/treeApiAlpha.ts
@@ -209,8 +209,7 @@ export interface TreeAlpha {
 
 /**
  * Extensions to {@link Tree} and {@link TreeBeta} which are not yet stable.
- * @remarks
- * See {@link (TreeAlpha:interface)}.
+ * @see {@link (TreeAlpha:interface)}.
  * @sealed @alpha
  */
 export const TreeAlpha: TreeAlpha = {

--- a/packages/dds/tree/src/shared-tree/treeApiAlpha.ts
+++ b/packages/dds/tree/src/shared-tree/treeApiAlpha.ts
@@ -55,6 +55,8 @@ import { SchematizingSimpleTreeView, ViewSlot } from "./schematizingTreeView.js"
 
 /**
  * Extensions to {@link Tree} and {@link TreeBeta} which are not yet stable.
+ * @remarks
+ * Use via the {@link (TreeAlpha:variable)} singleton.
  * @sealed @alpha
  */
 export interface TreeAlpha {
@@ -206,6 +208,9 @@ export interface TreeAlpha {
 }
 
 /**
+ * Extensions to {@link Tree} and {@link TreeBeta} which are not yet stable.
+ * @remarks
+ * See {@link (TreeAlpha:interface)}.
  * @sealed @alpha
  */
 export const TreeAlpha = {

--- a/packages/dds/tree/src/shared-tree/treeApiAlpha.ts
+++ b/packages/dds/tree/src/shared-tree/treeApiAlpha.ts
@@ -213,7 +213,7 @@ export interface TreeAlpha {
  * See {@link (TreeAlpha:interface)}.
  * @sealed @alpha
  */
-export const TreeAlpha = {
+export const TreeAlpha: TreeAlpha = {
 	branch(node: TreeNode): TreeBranch | undefined {
 		const kernel = getKernel(node);
 		if (!kernel.isHydrated()) {

--- a/packages/dds/tree/src/shared-tree/treeApiAlpha.ts
+++ b/packages/dds/tree/src/shared-tree/treeApiAlpha.ts
@@ -57,7 +57,7 @@ import { SchematizingSimpleTreeView, ViewSlot } from "./schematizingTreeView.js"
  * Extensions to {@link Tree} and {@link TreeBeta} which are not yet stable.
  * @sealed @alpha
  */
-export const TreeAlpha: {
+export interface TreeAlpha {
 	/**
 	 * Retrieve the {@link TreeBranch | branch}, if any, for the given node.
 	 * @param node - The node to query
@@ -95,7 +95,7 @@ export const TreeAlpha: {
 	>;
 
 	/**
-	 * Less type safe version of {@link TreeAlpha.create}, suitable for importing data.
+	 * Less type safe version of {@link (TreeAlpha:interface).create}, suitable for importing data.
 	 * @remarks
 	 * Due to {@link ConciseTree} relying on type inference from the data, its use is somewhat limited.
 	 * This does not support {@link ConciseTree|ConciseTrees} with customized handle encodings or using persisted keys.
@@ -103,8 +103,8 @@ export const TreeAlpha: {
 	 *
 	 * When using this function,
 	 * it is recommend to ensure your schema is unambiguous with {@link ITreeConfigurationOptions.preventAmbiguity}.
-	 * If the schema is ambiguous, consider using {@link TreeAlpha.create} and {@link Unhydrated} nodes where needed,
-	 * or using {@link TreeAlpha.(importVerbose:1)} and specify all types.
+	 * If the schema is ambiguous, consider using {@link (TreeAlpha:interface).create} and {@link Unhydrated} nodes where needed,
+	 * or using {@link (TreeAlpha:interface).(importVerbose:1)} and specify all types.
 	 *
 	 * Documented (and thus recoverable) error handling/reporting for this is not yet implemented,
 	 * but for now most invalid inputs will throw a recoverable error.
@@ -123,7 +123,7 @@ export const TreeAlpha: {
 	/**
 	 * Construct tree content compatible with a field defined by the provided `schema`.
 	 * @param schema - The schema for what to construct. As this is an {@link ImplicitFieldSchema}, a {@link FieldSchema}, {@link TreeNodeSchema} or {@link AllowedTypes} array can be provided.
-	 * @param data - The data used to construct the field content. See {@link TreeAlpha.(exportVerbose:1)}.
+	 * @param data - The data used to construct the field content. See {@link (TreeAlpha:interface).(exportVerbose:1)}.
 	 */
 	importVerbose<const TSchema extends ImplicitFieldSchema>(
 		schema: TSchema,
@@ -149,7 +149,7 @@ export const TreeAlpha: {
 	 * Uses the {@link VerboseTree} format, with an explicit type on every node.
 	 *
 	 * @remarks
-	 * There are several cases this may be preferred to {@link TreeAlpha.(exportConcise:1)}:
+	 * There are several cases this may be preferred to {@link (TreeAlpha:interface).(exportConcise:1)}:
 	 *
 	 * 1. When not using {@link ITreeConfigurationOptions.preventAmbiguity} (or when using `useStableFieldKeys`), `exportConcise` can produce ambiguous data (the type may be unclear on some nodes).
 	 * `exportVerbose` will always be unambiguous and thus lossless.
@@ -182,11 +182,11 @@ export const TreeAlpha: {
 	): JsonCompatible<IFluidHandle>;
 
 	/**
-	 * Import data encoded by {@link TreeAlpha.exportCompressed}.
+	 * Import data encoded by {@link (TreeAlpha:interface).exportCompressed}.
 	 *
 	 * @param schema - Schema with which the data must be compatible. This compatibility is not verified and must be ensured by the caller.
-	 * @param compressedData - Data compressed by {@link TreeAlpha.exportCompressed}.
-	 * @param options - If {@link TreeAlpha.exportCompressed} was given an `idCompressor`, it must be provided here.
+	 * @param compressedData - Data compressed by {@link (TreeAlpha:interface).exportCompressed}.
+	 * @param options - If {@link (TreeAlpha:interface).exportCompressed} was given an `idCompressor`, it must be provided here.
 	 *
 	 * @remarks
 	 * If the data could have been encoded with a different schema, consider encoding the schema along side it using {@link extractPersistedSchema} and loading the data using {@link independentView}.
@@ -203,7 +203,12 @@ export const TreeAlpha: {
 		compressedData: JsonCompatible<IFluidHandle>,
 		options: { idCompressor?: IIdCompressor } & ICodecOptions,
 	): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
-} = {
+}
+
+/**
+ * @sealed @alpha
+ */
+export const TreeAlpha = {
 	branch(node: TreeNode): TreeBranch | undefined {
 		const kernel = getKernel(node);
 		if (!kernel.isHydrated()) {

--- a/packages/dds/tree/src/simple-tree/api/conciseTree.ts
+++ b/packages/dds/tree/src/simple-tree/api/conciseTree.ts
@@ -21,7 +21,7 @@ import { getUnhydratedContext } from "../createContext.js";
  * @remarks
  * This is "concise" meaning that explicit type information is omitted.
  * If the schema is compatible with {@link ITreeConfigurationOptions.preventAmbiguity},
- * types will be lossless and compatible with {@link TreeAlpha.create} (unless the options are used to customize it).
+ * types will be lossless and compatible with {@link (TreeAlpha:interface).create} (unless the options are used to customize it).
  *
  * Every {@link TreeNode} is an array or object.
  * Any IFluidHandle values have been replaced by `THandle`.

--- a/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
@@ -125,7 +125,7 @@ export interface SchemaFactoryObjectOptions<TCustomMetadata = unknown>
 	 * ```
 	 *
 	 * If an application wants to be particularly careful to preserve all data on a node when editing it, it can use
-	 * {@link TreeAlpha.importVerbose|import}/{@link TreeAlpha.exportVerbose|export} APIs with persistent keys.
+	 * {@link (TreeAlpha:interface).importVerbose|import}/{@link (TreeAlpha:interface).exportVerbose|export} APIs with persistent keys.
 	 *
 	 * Note that public API methods which operate on entire nodes (such as `moveTo`, `moveToEnd`, etc. on arrays) do not encounter
 	 * this problem as SharedTree's implementation stores the entire node in its lower layers. It's only when application code

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -53,7 +53,7 @@ import type {
  *
  * @privateRemarks
  * TODO:
- * Add stored key versions of {@link TreeAlpha.(exportVerbose:2)}, {@link TreeAlpha.(exportConcise:2)} and {@link TreeAlpha.exportCompressed} here so tree content can be accessed without a view schema.
+ * Add stored key versions of {@link (TreeAlpha:interface).(exportVerbose:2)}, {@link (TreeAlpha:interface).(exportConcise:2)} and {@link (TreeAlpha:interface).exportCompressed} here so tree content can be accessed without a view schema.
  * Add exportSimpleSchema and exportJsonSchema methods (which should exactly match the concise format, and match the free functions for exporting view schema).
  * Maybe rename "exportJsonSchema" to align on "concise" terminology.
  * Ensure schema exporting APIs here align and reference APIs for exporting view schema to the same formats (which should include stored vs property key choice).
@@ -99,7 +99,7 @@ export interface ITree extends ViewableTree, IFluidLoadable {}
  */
 export interface ITreeAlpha extends ITree {
 	/**
-	 * Exports root in the same format as {@link TreeAlpha.(exportVerbose:1)} using stored keys.
+	 * Exports root in the same format as {@link (TreeAlpha:interface).(exportVerbose:1)} using stored keys.
 	 * @remarks
 	 * This is `undefined` if and only if the root field is empty (this can only happen if the root field is optional).
 	 */

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -59,7 +59,7 @@ import type { SimpleObjectFieldSchema } from "./simpleSchema.js";
  * @remarks
  * Due to {@link https://github.com/microsoft/TypeScript/issues/43826}, we can't enable implicit construction of {@link TreeNode|TreeNodes} for setters.
  * Therefore code assigning to these fields must explicitly construct nodes using the schema's constructor or create method,
- * or using some other method like {@link TreeAlpha.create}.
+ * or using some other method like {@link (TreeAlpha:interface).create}.
  * @system @public
  */
 export type ObjectFromSchemaRecord<T extends RestrictiveStringRecord<ImplicitFieldSchema>> =

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1344,21 +1344,38 @@ export type TransformedEvent<TThis, E, A extends any[]> = (event: E, listener: (
 export const Tree: TreeApi;
 
 // @alpha @sealed
-export const TreeAlpha: {
+export interface TreeAlpha {
     branch(node: TreeNode): TreeBranch | undefined;
     create<const TSchema extends ImplicitFieldSchema | UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: InsertableField<TSchema>): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
-    importConcise<const TSchema extends ImplicitFieldSchema | UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: ConciseTree | undefined): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
-    importVerbose<const TSchema extends ImplicitFieldSchema>(schema: TSchema, data: VerboseTree | undefined, options?: Partial<TreeEncodingOptions>): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
-    exportConcise(node: TreeNode | TreeLeafValue, options?: TreeEncodingOptions): ConciseTree;
-    exportConcise(node: TreeNode | TreeLeafValue | undefined, options?: TreeEncodingOptions): ConciseTree | undefined;
-    exportVerbose(node: TreeNode | TreeLeafValue, options?: TreeEncodingOptions): VerboseTree;
     exportCompressed(tree: TreeNode | TreeLeafValue, options: {
         oldestCompatibleClient: FluidClientVersion;
         idCompressor?: IIdCompressor;
     }): JsonCompatible<IFluidHandle>;
+    exportConcise(node: TreeNode | TreeLeafValue, options?: TreeEncodingOptions): ConciseTree;
+    exportConcise(node: TreeNode | TreeLeafValue | undefined, options?: TreeEncodingOptions): ConciseTree | undefined;
+    exportVerbose(node: TreeNode | TreeLeafValue, options?: TreeEncodingOptions): VerboseTree;
     importCompressed<const TSchema extends ImplicitFieldSchema>(schema: TSchema, compressedData: JsonCompatible<IFluidHandle>, options: {
         idCompressor?: IIdCompressor;
     } & ICodecOptions): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
+    importConcise<const TSchema extends ImplicitFieldSchema | UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: ConciseTree | undefined): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
+    importVerbose<const TSchema extends ImplicitFieldSchema>(schema: TSchema, data: VerboseTree | undefined, options?: Partial<TreeEncodingOptions>): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
+}
+
+// @alpha @sealed (undocumented)
+export const TreeAlpha: {
+    branch(node: TreeNode): TreeBranch | undefined;
+    create: typeof createFromInsertable;
+    importConcise<TSchema extends ImplicitFieldSchema | typeof UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: ConciseTree | undefined): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
+    importVerbose<const TSchema_1 extends ImplicitFieldSchema>(schema: TSchema_1, data: VerboseTree | undefined, options?: TreeEncodingOptions): TreeFieldFromImplicitField<TSchema_1>;
+    exportConcise: typeof exportConcise;
+    exportVerbose(node: TreeNode | TreeLeafValue, options?: TreeEncodingOptions): VerboseTree;
+    exportCompressed(node: TreeNode | TreeLeafValue, options: {
+        oldestCompatibleClient: FluidClientVersion;
+        idCompressor?: IIdCompressor;
+    }): JsonCompatible<IFluidHandle>;
+    importCompressed<const TSchema_2 extends ImplicitFieldSchema>(schema: TSchema_2, compressedData: JsonCompatible<IFluidHandle>, options: {
+        idCompressor?: IIdCompressor;
+    } & ICodecOptions): TreeFieldFromImplicitField<TSchema_2>;
 };
 
 // @public @sealed @system

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1361,22 +1361,8 @@ export interface TreeAlpha {
     importVerbose<const TSchema extends ImplicitFieldSchema>(schema: TSchema, data: VerboseTree | undefined, options?: Partial<TreeEncodingOptions>): Unhydrated<TreeFieldFromImplicitField<TSchema>>;
 }
 
-// @alpha @sealed (undocumented)
-export const TreeAlpha: {
-    branch(node: TreeNode): TreeBranch | undefined;
-    create: typeof createFromInsertable;
-    importConcise<TSchema extends ImplicitFieldSchema | typeof UnsafeUnknownSchema>(schema: UnsafeUnknownSchema extends TSchema ? ImplicitFieldSchema : TSchema & ImplicitFieldSchema, data: ConciseTree | undefined): Unhydrated<TSchema extends ImplicitFieldSchema ? TreeFieldFromImplicitField<TSchema> : TreeNode | TreeLeafValue | undefined>;
-    importVerbose<const TSchema_1 extends ImplicitFieldSchema>(schema: TSchema_1, data: VerboseTree | undefined, options?: TreeEncodingOptions): TreeFieldFromImplicitField<TSchema_1>;
-    exportConcise: typeof exportConcise;
-    exportVerbose(node: TreeNode | TreeLeafValue, options?: TreeEncodingOptions): VerboseTree;
-    exportCompressed(node: TreeNode | TreeLeafValue, options: {
-        oldestCompatibleClient: FluidClientVersion;
-        idCompressor?: IIdCompressor;
-    }): JsonCompatible<IFluidHandle>;
-    importCompressed<const TSchema_2 extends ImplicitFieldSchema>(schema: TSchema_2, compressedData: JsonCompatible<IFluidHandle>, options: {
-        idCompressor?: IIdCompressor;
-    } & ICodecOptions): TreeFieldFromImplicitField<TSchema_2>;
-};
+// @alpha @sealed
+export const TreeAlpha: TreeAlpha;
 
 // @public @sealed @system
 interface TreeApi extends TreeNodeApi {


### PR DESCRIPTION
## Description

Our generated API docs for [TreeAlpha](https://fluidframework.com/docs/api/tree/#treealpha-variable) are bad. This change should fix that by splitting out the type into an interface.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
