### PR TITLE
Added dynamic S2S Axios timeouts

### DIFF
--- a/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
+++ b/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
@@ -461,6 +461,7 @@ export interface ITimeoutContext {
     bindTimeout(maxDurationMs: number, callback: () => void): void;
     bindTimeoutAsync<T>(maxDurationMs: number, callback: () => Promise<T>): Promise<T>;
     checkTimeout(): void;
+    getTimeRemainingMs(): number | undefined;
 }
 
 // @internal (undocumented)

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -106,6 +106,9 @@
 			},
 			"Interface_INetworkErrorDetails": {
 				"backCompat": false
+			},
+			"Interface_ITimeoutContext": {
+				"forwardCompat": false
 			}
 		},
 		"entrypoint": "public"

--- a/server/routerlicious/packages/services-client/src/test/types/validateServerServicesClientPrevious.generated.ts
+++ b/server/routerlicious/packages/services-client/src/test/types/validateServerServicesClientPrevious.generated.ts
@@ -800,6 +800,7 @@ declare type current_as_old_for_Interface_ISummaryUploadManager = requireAssigna
  * typeValidation.broken:
  * "Interface_ITimeoutContext": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ITimeoutContext = requireAssignableTo<TypeOnly<old.ITimeoutContext>, TypeOnly<current.ITimeoutContext>>
 
 /*

--- a/server/routerlicious/packages/services-client/src/timeoutContext.ts
+++ b/server/routerlicious/packages/services-client/src/timeoutContext.ts
@@ -24,6 +24,11 @@ export interface ITimeoutContext {
 	 * If exceeded, throws a 503 Timeout error
 	 */
 	checkTimeout(): void;
+	/**
+	 * Returns the time remaining before the timeout is exceeded.
+	 * If no timeout is set, returns undefined.
+	 */
+	getTimeRemainingMs(): number | undefined;
 }
 
 /**
@@ -38,6 +43,9 @@ class NullTimeoutContext implements ITimeoutContext {
 		return callback();
 	}
 	checkTimeout(): void {}
+	getTimeRemainingMs(): number | undefined {
+		return undefined;
+	}
 }
 const nullTimeoutContext = new NullTimeoutContext();
 

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -106,7 +106,11 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_AsyncLocalStorageTimeoutContext": {
+				"forwardCompat": false
+			}
+		},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/services-utils/src/asyncContext.ts
+++ b/server/routerlicious/packages/services-utils/src/asyncContext.ts
@@ -137,14 +137,14 @@ export class AsyncLocalStorageTimeoutContext implements ITimeoutContext {
 		if (!timeoutInfo) {
 			return undefined;
 		}
-		const timeElapsed = Date.now() - timeoutInfo.startTime;
-		const timeRemaining = timeoutInfo.maxDurationMs - timeElapsed;
+		const timeElapsedMs = Date.now() - timeoutInfo.startTime;
+		const timeRemainingMs = timeoutInfo.maxDurationMs - timeElapsedMs;
 		Lumberjack.debug("[TimeoutContext]: Time remaining.", {
-			timeRemaining,
+			timeRemainingMs,
 			startTime: timeoutInfo.startTime,
 			maxDurationMs: timeoutInfo.maxDurationMs,
-			timeElapsed,
+			timeElapsedMs,
 		});
-		return timeRemaining;
+		return timeRemainingMs;
 	}
 }

--- a/server/routerlicious/packages/services-utils/src/asyncContext.ts
+++ b/server/routerlicious/packages/services-utils/src/asyncContext.ts
@@ -129,4 +129,22 @@ export class AsyncLocalStorageTimeoutContext implements ITimeoutContext {
 			throw error;
 		}
 	}
+
+	public getTimeRemainingMs(): number | undefined {
+		// Check if there is any time still remaining. Throw an error if the timeout has been exceeded.
+		this.checkTimeout();
+		const timeoutInfo = this.contextProvider.getContext();
+		if (!timeoutInfo) {
+			return undefined;
+		}
+		const timeElapsed = Date.now() - timeoutInfo.startTime;
+		const timeRemaining = timeoutInfo.maxDurationMs - timeElapsed;
+		Lumberjack.debug("[TimeoutContext]: Time remaining.", {
+			timeRemaining,
+			startTime: timeoutInfo.startTime,
+			maxDurationMs: timeoutInfo.maxDurationMs,
+			timeElapsed,
+		});
+		return timeRemaining;
+	}
 }

--- a/server/routerlicious/packages/services-utils/src/test/types/validateServerServicesUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/services-utils/src/test/types/validateServerServicesUtilsPrevious.generated.ts
@@ -58,6 +58,7 @@ declare type current_as_old_for_Class_AsyncLocalStorageTelemetryContext = requir
  * typeValidation.broken:
  * "Class_AsyncLocalStorageTimeoutContext": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_AsyncLocalStorageTimeoutContext = requireAssignableTo<TypeOnly<old.AsyncLocalStorageTimeoutContext>, TypeOnly<current.AsyncLocalStorageTimeoutContext>>
 
 /*


### PR DESCRIPTION
## Description

This PR uses the already available `timeoutContext` to try and optimize S2S timeout values. Currently, all S2S requests have a static global timeout value of 30s. However, clients making requests to AFR timeout in 30s. Hence, there could be a condition where S2S calls end up taking longer than client to server calls. This is something we want to avoid. In this PR, we try to override this by doing the following:

Use the available timout context to compute the timeout value for every S2S request made using our `restWrapper`. This is done by adding a new method `getTimeRemainingMs()` which is used to get the max timeout value available based on the server max timeout defined. This function computes the available timeout using the following:

`Timeout = maxAvailableTimeout - (TimeNow - startTime)`

