### PR TITLE
Update DiceRoller tutorial to match the current FluidHelloWorld main

### DIFF
--- a/docs/docs/start/tutorial.mdx
+++ b/docs/docs/start/tutorial.mdx
@@ -117,26 +117,28 @@ start().catch((error) => console.error(error));
 The Fluid Framework is agnostic about view frameworks and works well with React, Vue, Angular and web components.
 This example uses standard HTML/DOM methods to render a view.
 
-The `renderDiceRoller` function runs only when the container is created or loaded. It appends the `diceTemplate` to the passed in HTML element, and creates a working dice roller with a random dice value each time the "Roll" button is clicked on a client.
+The `renderDiceRoller` function runs only when the container is created or loaded. It appends the `template` to the passed in HTML element, and creates a working dice roller with a random dice value each time the "Roll" button is clicked on a client.
 
 ```js
-const diceTemplate = document.createElement("template");
+const template = document.createElement("template");
 
-diceTemplate.innerHTML = `
+template.innerHTML = `
   <style>
-    .wrapper { text-align: center }
-    .dice { font-size: 200px }
-    .roll { font-size: 50px;}
+    .wrapper { display: flex; flex-direction: column; align-items: center; }
+    .dice { width: 200px; }
+    .rollButton { width: 118px; height: 48px; background: #0078D4; border-style: none; border-radius: 8px; }
+    .rollText { font-size: 20px; color: #FFFFFF; }
   </style>
   <div class="wrapper">
-    <div class="dice"></div>
-    <button class="roll"> Roll </button>
+    <img class="dice"/>
+    <button class="rollButton"><span class="rollText">Roll</span></button>
   </div>
 `;
+
 const renderDiceRoller = (dice, elem) => {
 	elem.appendChild(template.content.cloneNode(true));
 
-	const rollButton = elem.querySelector(".roll");
+	const rollButton = elem.querySelector(".rollButton");
 	const diceElem = elem.querySelector(".dice");
 
 	/* REMAINDER OF THE FUNCTION IS DESCRIBED BELOW */
@@ -149,7 +151,7 @@ Let's go through the rest of the `renderDiceRoller` function line-by-line.
 
 ### Create the Roll button handler
 
-The next line of the `renderDiceRoller` function assigns a handler to the click event of the "Roll" button. Instead of updating the local state directly, the button updates the number stored in the `value` property of the `dice` object. Because `dice` is the root object of Fluid `SharedTree`, changes will be distributed to all clients. Any changes to `dice` will cause a `afterChanged` event to be emitted, and an event handler, defined below, can trigger an update of the view.
+The next line of the `renderDiceRoller` function assigns a handler to the click event of the "rollButton" button. Instead of updating the local state directly, the button updates the number stored in the `value` property of the `dice` object. Because `dice` is the root object of Fluid `SharedTree`, changes will be distributed to all clients. Any changes to `dice` will cause a `nodeChanged` event to be emitted, and an event handler, defined below, can trigger an update of the view.
 
 This pattern is common in Fluid because it enables the view to behave the same way for both local and remote changes.
 
@@ -166,14 +168,13 @@ The next line creates the function that will rerender the local view with the la
 -   When the container is created or loaded.
 -   When the dice value changes on any client.
 
-Note that the current value is retrieved from the `SharedMap` each time `updateDice` is called. It is _not_ read from the `textContent` of the local `dice` HTML element.
+Note that the current value is retrieved from the `SharedTree` each time `updateDice` is called. It is _not_ read from the `textContent` of the local `dice` HTML element.
 
 ```js
 const updateDice = () => {
 	const diceValue = dice.value;
-	// Unicode 0x2680-0x2685 are the sides of a dice (⚀⚁⚂⚃⚄⚅)
-	diceElem.textContent = String.fromCodePoint(0x267f + diceValue);
-	diceElem.style.color = `hsl(${diceValue * 60}, 70%, 30%)`;
+	diceElem.src = `/images/dice-${diceValue}.png`;
+	diceElem.alt = diceValue.toString();
 };
 ```
 
@@ -187,10 +188,10 @@ updateDice();
 
 ### Handling remote changes
 
-To keep the data up to date as it changes, an event handler must be set on the `dice` object to call `updateDice` each time that the `afterChanged` event is sent. Use the built-in `Tree` object to subscribe to the event. Note that the `afterChanged` event fires whenever the `dice` object changes on _any_ client; that is, when the "Roll" button is clicked on any client.
+To keep the data up to date as it changes, an event handler must be set on the `dice` object to call `updateDice` each time that the `nodeChanged` event is sent. Use the built-in `Tree` object to subscribe to the event. Note that the `nodeChanged` event fires whenever the `dice` object changes on _any_ client; that is, when the "rollButton" button is clicked on any client.
 
 ```js
-Tree.on(dice, "afterChange", updateDice);
+Tree.on(dice, "nodeChanged", updateDice);
 ```
 
 ## Run the app

--- a/docs/docs/start/tutorial.mdx
+++ b/docs/docs/start/tutorial.mdx
@@ -117,7 +117,8 @@ start().catch((error) => console.error(error));
 The Fluid Framework is agnostic about view frameworks and works well with React, Vue, Angular and web components.
 This example uses standard HTML/DOM methods to render a view.
 
-The `renderDiceRoller` function runs only when the container is created or loaded. It appends the `template` to the passed in HTML element, and creates a working dice roller with a random dice value each time the "Roll" button is clicked on a client.
+The `renderDiceRoller` function runs only when the container is created or loaded.
+It appends the `template` to the passed in HTML element, and creates a working dice roller with a random dice value each time the "Roll" button is clicked on a client.
 
 ```js
 const template = document.createElement("template");

--- a/docs/docs/start/tutorial.mdx
+++ b/docs/docs/start/tutorial.mdx
@@ -151,7 +151,10 @@ Let's go through the rest of the `renderDiceRoller` function line-by-line.
 
 ### Create the Roll button handler
 
-The next line of the `renderDiceRoller` function assigns a handler to the click event of the "rollButton" button. Instead of updating the local state directly, the button updates the number stored in the `value` property of the `dice` object. Because `dice` is the root object of Fluid `SharedTree`, changes will be distributed to all clients. Any changes to `dice` will cause a `nodeChanged` event to be emitted, and an event handler, defined below, can trigger an update of the view.
+The next line of the `renderDiceRoller` function assigns a handler to the click event of the "rollButton" button.
+Instead of updating the local state directly, the button updates the number stored in the `value` property of the `dice` object.
+Because `dice` is the root object of Fluid `SharedTree`, changes will be distributed to all clients. 
+Any changes to `dice` will cause a `nodeChanged` event to be emitted, and an event handler, defined below, can trigger an update of the view.
 
 This pattern is common in Fluid because it enables the view to behave the same way for both local and remote changes.
 

--- a/docs/docs/start/tutorial.mdx
+++ b/docs/docs/start/tutorial.mdx
@@ -191,7 +191,9 @@ updateDice();
 
 ### Handling remote changes
 
-To keep the data up to date as it changes, an event handler must be set on the `dice` object to call `updateDice` each time that the `nodeChanged` event is sent. Use the built-in `Tree` object to subscribe to the event. Note that the `nodeChanged` event fires whenever the `dice` object changes on _any_ client; that is, when the "rollButton" button is clicked on any client.
+To keep the data up to date as it changes, an event handler must be set on the `dice` object to call `updateDice` each time that the `nodeChanged` event is sent.
+Use the built-in `Tree` object to subscribe to the event.
+Note that the `nodeChanged` event fires whenever the `dice` object changes on _any_ client; that is, when the "rollButton" button is clicked on any client.
 
 ```js
 Tree.on(dice, "nodeChanged", updateDice);

--- a/docs/docs/start/tutorial.mdx
+++ b/docs/docs/start/tutorial.mdx
@@ -172,7 +172,8 @@ The next line creates the function that will rerender the local view with the la
 -   When the container is created or loaded.
 -   When the dice value changes on any client.
 
-Note that the current value is retrieved from the `SharedTree` each time `updateDice` is called. It is _not_ read from the `textContent` of the local `dice` HTML element.
+Note that the current value is retrieved from the `SharedTree` each time `updateDice` is called.
+It is _not_ read from the `textContent` of the local `dice` HTML element.
 
 ```js
 const updateDice = () => {

--- a/docs/docs/start/tutorial.mdx
+++ b/docs/docs/start/tutorial.mdx
@@ -5,7 +5,8 @@ sidebar_position: 3
 
 import { MockDiceRollerSample } from "@site/src/components/mockDiceRoller";
 
-In this walkthrough, you'll learn about using the Fluid Framework by examining the DiceRoller application at https://github.com/microsoft/FluidHelloWorld. To get started, go through the [Quick Start](./quick-start.mdx) guide.
+In this walkthrough, you'll learn about using the Fluid Framework by examining the DiceRoller application at https://github.com/microsoft/FluidHelloWorld.
+To get started, go through the [Quick Start](./quick-start.mdx) guide.
 
 <MockDiceRollerSample
 	style={{
@@ -18,7 +19,9 @@ In this walkthrough, you'll learn about using the Fluid Framework by examining t
 />
 <br />
 
-In the DiceRoller app, users are shown a die with a button to roll it. When the die is rolled, the Fluid Framework syncs the data across clients so everyone sees the same result. To do this, complete the following steps:
+In the DiceRoller app, users are shown a die with a button to roll it.
+When the die is rolled, the Fluid Framework syncs the data across clients so everyone sees the same result.
+To do this, complete the following steps:
 
 1. [Set up the application](#set-up-the-application).
 2. [Create a Fluid container](#create-a-fluid-container).
@@ -29,9 +32,11 @@ All of the work in this demo will be done in the [app.js](https://github.com/mic
 
 ## Set up the application
 
-Start by creating a new instance of the Tinylicious client. Tinylicious is the Fluid Framework's local testing server, and a client is responsible for creating and loading containers.
+Start by creating a new instance of the Tinylicious client.
+Tinylicious is the Fluid Framework's local testing server, and a client is responsible for creating and loading containers.
 
-The app creates Fluid containers using a schema that defines a set of _initial objects_ that will be available in the container. Learn more about initial objects in [Data modeling](../build/data-modeling.mdx).
+The app creates Fluid containers using a schema that defines a set of _initial objects_ that will be available in the container.
+Learn more about initial objects in [Data modeling](../build/data-modeling.mdx).
 
 Lastly, `root` defines the HTML element that the Dice will render on.
 
@@ -55,16 +60,22 @@ To create a Fluid application that can be deployed to Azure, check out the [Azur
 
 ## Create a Fluid container
 
-Fluid data is stored within containers, and these containers need to be created before other users can load them. Since creation and loading of containers both happen in the browser, a Fluid application needs to be capable of handling both paths.
+Fluid data is stored within containers, and these containers need to be created before other users can load them.
+Since creation and loading of containers both happen in the browser, a Fluid application needs to be capable of handling both paths.
 
 ### Create a new container
 
-The creation section of the application starts with calling `createContainer` and passing in a schema defining which shared objects will be available on the new `container`. After a new container is created, default data can be set on the shared objects before the container is attached to the Tinylicious service. Note, we are passing the parameter "2" in the createContainer call to indicate the version of Fluid Framework that the data
-is compatible with. For new apps always use "2". Use "1" if you have apps running Fluid Framework 1.X until you've migrated all the apps to version 2.X.
+The creation section of the application starts with calling `createContainer` and passing in a schema defining which shared objects will be available on the new `container`.
+After a new container is created, default data can be set on the shared objects before the container is attached to the Tinylicious service.
+Note, we are passing the parameter "2" in the createContainer call to indicate the version of Fluid Framework that the data is compatible with.
+For new apps always use "2".
+Use "1" if you have apps running Fluid Framework 1.X until you've migrated all the apps to version 2.X.
 
-The `attach` call publishes the container to the Tinylicious service and returns the `id` of the container, which the app can use to load this container on other clients (or this client in a future session). Once attached, any further changes to the shared objects, made by the rendered app, will be communicated to all collaborators.
+The `attach` call publishes the container to the Tinylicious service and returns the `id` of the container, which the app can use to load this container on other clients (or this client in a future session).
+Once attached, any further changes to the shared objects, made by the rendered app, will be communicated to all collaborators.
 
-The `renderDiceRoller` function is created in a later step. It renders the UI of the app on the local client.
+The `renderDiceRoller` function is created in a later step.
+It renders the UI of the app on the local client.
 
 ```js
 const createNewDice = async () => {
@@ -78,7 +89,9 @@ const createNewDice = async () => {
 
 ### Loading an existing container
 
-Loading a container is more straightforward than creating a new one. When loading, the container already contains data, and is already attached, so those steps are irrelevant. You need only to pass the `id` of the container you wish to load in the `getContainer()` function along with the same schema used when creating the container.
+Loading a container is more straightforward than creating a new one.
+When loading, the container already contains data, and is already attached, so those steps are irrelevant.
+You need only to pass the `id` of the container you wish to load in the `getContainer()` function along with the same schema used when creating the container.
 
 ```js
 const loadExistingDice = async (id) => {
@@ -91,8 +104,8 @@ const loadExistingDice = async (id) => {
 ### Switching between loading and creating
 
 The app supports both creating a new container and loading an existing container using its `id`.
-But, the app needs to know whether the container already exists. There are many ways of
-determining this.
+But, the app needs to know whether the container already exists.
+There are many ways of determining this.
 This sample app stores the container ID in the URL hash.
 If the URL has a hash, the app will load that existing container.
 Otherwise, the app creates a new container, attaches it, and sets the returned `id` as the hash.
@@ -154,7 +167,7 @@ Let's go through the rest of the `renderDiceRoller` function line-by-line.
 
 The next line of the `renderDiceRoller` function assigns a handler to the click event of the "rollButton" button.
 Instead of updating the local state directly, the button updates the number stored in the `value` property of the `dice` object.
-Because `dice` is the root object of Fluid `SharedTree`, changes will be distributed to all clients. 
+Because `dice` is the root object of Fluid `SharedTree`, changes will be distributed to all clients.
 Any changes to `dice` will cause a `nodeChanged` event to be emitted, and an event handler, defined below, can trigger an update of the view.
 
 This pattern is common in Fluid because it enables the view to behave the same way for both local and remote changes.
@@ -167,13 +180,13 @@ rollButton.onclick = () => {
 
 ### Relying on Fluid data
 
-The next line creates the function that will rerender the local view with the lastest dice value. This function will be called:
+The next line creates the function that will rerender the local view with the latest dice value.
+This function will be called:
 
 -   When the container is created or loaded.
 -   When the dice value changes on any client.
 
-Note that the current value is retrieved from the `SharedTree` each time `updateDice` is called.
-It is _not_ read from the `textContent` of the local `dice` HTML element.
+Note that the current value is retrieved from the `SharedTree` each time `updateDice` is called. It is _not_ read from the `textContent` of the local `dice` HTML element.
 
 ```js
 const updateDice = () => {
@@ -203,4 +216,5 @@ Tree.on(dice, "nodeChanged", updateDice);
 
 ## Run the app
 
-The [full code for this application is available](https://github.com/microsoft/FluidHelloWorld) for you to try out. Try opening it in multiple browser windows to see the changes reflected between clients.
+The [full code for this application is available](https://github.com/microsoft/FluidHelloWorld) for you to try out.
+Try opening it in multiple browser windows to see the changes reflected between clients.


### PR DESCRIPTION
## Description

The DiceRoller Tutorial <https://fluidframework.com/docs/start/tutorial> currently lists code that doesn't match the `main` branch of <https://github.com/microsoft/FluidHelloWorld> any more. This PR addresses that by updating the tutorial website to match the current `main` branch.