### PR TITLE
refactor(tree): Extract `@system` table schema APIs into their own "System" namespace

### DIFF
--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -288,4 +288,4 @@ export type { MapNodeInsertableData } from "./simple-tree/index.js";
 
 export { JsonAsTree } from "./jsonDomainSchema.js";
 export { FluidSerializableAsTree } from "./serializableDomainSchema.js";
-export { TableSchema } from "./tableSchema.js";
+export { TableSchema, type System_TableSchema } from "./tableSchema.js";

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -32,7 +32,7 @@ describe("TableFactory unit tests", () => {
 			 */
 			label: schemaFactory.optional(schemaFactory.string),
 		}) {}
-		class Column extends TableSchema.createColumnInternal(schemaFactory, ColumnProps) {}
+		class Column extends TableSchema.createColumn(schemaFactory, ColumnProps) {}
 
 		class RowProps extends schemaFactory.object("table-row-props", {
 			/**


### PR DESCRIPTION
This namespace is type-exported to prevent users from directly consuming the internal factory function implementations.