### PR TITLE
Rename ViewSchema to SchemaCompatibilityTester

### DIFF
--- a/packages/dds/tree/src/shared-tree/schematizeTree.ts
+++ b/packages/dds/tree/src/shared-tree/schematizeTree.ts
@@ -23,7 +23,7 @@ import {
 import { isReadonlyArray } from "../util/index.js";
 
 import type { ITreeCheckout } from "./treeCheckout.js";
-import { toStoredSchema, type ViewSchema } from "../simple-tree/index.js";
+import type { SchemaCompatibilityTester } from "../simple-tree/index.js";
 
 /**
  * Modify `storedSchema` and invoke `setInitialTree` when it's time to set the tree content.
@@ -113,7 +113,7 @@ export enum UpdateType {
 }
 
 export function evaluateUpdate(
-	viewSchema: ViewSchema,
+	viewSchema: SchemaCompatibilityTester,
 	allowedSchemaModifications: AllowedUpdateType,
 	checkout: ITreeCheckout,
 ): UpdateType {
@@ -209,7 +209,7 @@ export function initialize(checkout: ITreeCheckout, treeContent: TreeStoredConte
 }
 
 /**
- * Ensure a {@link ITreeCheckout} can be used with a given {@link ViewSchema}.
+ * Ensure a {@link ITreeCheckout} can be used with a given {@link SchemaCompatibilityTester}.
  *
  * @remarks
  * It is up to the caller to ensure that compatibility is reevaluated if the checkout's stored schema is edited in the future.
@@ -221,7 +221,7 @@ export function initialize(checkout: ITreeCheckout, treeContent: TreeStoredConte
  * @returns true iff checkout now is compatible with `viewSchema`.
  */
 export function ensureSchema(
-	viewSchema: ViewSchema,
+	viewSchema: SchemaCompatibilityTester,
 	allowedSchemaModifications: AllowedUpdateType,
 	checkout: ITreeCheckout,
 	treeContent: TreeStoredContent | undefined,
@@ -241,7 +241,7 @@ export function ensureSchema(
 			return false;
 		}
 		case UpdateType.SchemaCompatible: {
-			checkout.updateSchema(toStoredSchema(viewSchema.schema));
+			checkout.updateSchema(viewSchema.viewSchemaAsStored);
 			return true;
 		}
 		case UpdateType.Initialize: {

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -30,13 +30,12 @@ import {
 	getTreeNodeForField,
 	setField,
 	normalizeFieldSchema,
-	ViewSchema,
+	SchemaCompatibilityTester,
 	type InsertableContent,
 	type TreeViewConfiguration,
 	mapTreeFromNodeData,
 	prepareContentForHydration,
 	comparePersistedSchemaInternal,
-	toStoredSchema,
 	type TreeViewAlpha,
 	type InsertableField,
 	type ReadableField,
@@ -98,7 +97,7 @@ export class SchematizingSimpleTreeView<
 		IEmitter<TreeViewEvents & TreeBranchEvents> &
 		HasListeners<TreeViewEvents & TreeBranchEvents> = createEmitter();
 
-	private readonly viewSchema: ViewSchema;
+	private readonly viewSchema: SchemaCompatibilityTester;
 
 	private readonly unregisterCallbacks = new Set<() => void>();
 
@@ -133,7 +132,11 @@ export class SchematizingSimpleTreeView<
 			allowUnknownOptionalFields: createUnknownOptionalFieldPolicy(this.rootFieldSchema),
 		};
 
-		this.viewSchema = new ViewSchema(this.schemaPolicy, {}, this.rootFieldSchema);
+		this.viewSchema = new SchemaCompatibilityTester(
+			this.schemaPolicy,
+			{},
+			this.rootFieldSchema,
+		);
 		// This must be initialized before `update` can be called.
 		this.currentCompatibility = {
 			canView: false,
@@ -182,7 +185,7 @@ export class SchematizingSimpleTreeView<
 
 			prepareContentForHydration(mapTree, this.checkout.forest);
 			initialize(this.checkout, {
-				schema: toStoredSchema(this.viewSchema.schema),
+				schema: this.viewSchema.viewSchemaAsStored,
 				initialTree: mapTree === undefined ? undefined : cursorForMapTreeNode(mapTree),
 			});
 		});
@@ -209,7 +212,7 @@ export class SchematizingSimpleTreeView<
 				AllowedUpdateType.SchemaCompatible,
 				this.checkout,
 				{
-					schema: toStoredSchema(this.viewSchema.schema),
+					schema: this.viewSchema.viewSchemaAsStored,
 					initialTree: undefined,
 				},
 			);
@@ -502,12 +505,12 @@ export function getCheckout(context: TreeBranch): TreeCheckout {
 }
 
 /**
- * Creates a view that self-disposes whenenever the stored schema changes.
+ * Creates a view that self-disposes whenever the stored schema changes.
  * This may only be called when the schema is already known to be compatible (typically via ensureSchema).
  */
 export function requireSchema(
 	checkout: ITreeCheckout,
-	viewSchema: ViewSchema,
+	viewSchema: SchemaCompatibilityTester,
 	onDispose: () => void,
 	nodeKeyManager: NodeIdentifierManager,
 	schemaPolicy: FullSchemaPolicy,

--- a/packages/dds/tree/src/simple-tree/api/index.ts
+++ b/packages/dds/tree/src/simple-tree/api/index.ts
@@ -59,7 +59,7 @@ export {
 export type { TreeSchemaEncodingOptions } from "./getJsonSchema.js";
 export { getJsonSchema } from "./getJsonSchema.js";
 export { getSimpleSchema } from "./getSimpleSchema.js";
-export { ViewSchema } from "./view.js";
+export { SchemaCompatibilityTester } from "./schemaCompatibilityTester.js";
 export type {
 	Unenforced,
 	FieldSchemaAlphaUnsafe,

--- a/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
@@ -22,37 +22,30 @@ import {
 	fieldRealizer,
 	comparePosetElements,
 } from "../../feature-libraries/index.js";
-import {
-	normalizeFieldSchema,
-	type FieldSchema,
-	type ImplicitFieldSchema,
-} from "../schemaTypes.js";
+import type { FieldSchema } from "../schemaTypes.js";
 import { toStoredSchema } from "../toStoredSchema.js";
 import type { SchemaCompatibilityStatus } from "./tree.js";
 
 /**
  * A collection of View information for schema, including policy.
+ * @remarks
+ * This contains everything needed to determine compatibility with a given stored schema.
  */
-export class ViewSchema {
+export class SchemaCompatibilityTester {
 	/**
 	 * Cached conversion of the view schema in the stored schema format.
 	 */
-	private readonly viewSchemaAsStored: TreeStoredSchema;
-	/**
-	 * Normalized view schema (implicitly allowed view schema types are converted to their canonical form).
-	 */
-	public readonly schema: FieldSchema;
+	public readonly viewSchemaAsStored: TreeStoredSchema;
 
 	/**
-	 * @param viewSchema - Schema for the root field of this view.
+	 * @param viewSchemaRoot - Schema for the root field.
 	 */
 	public constructor(
 		public readonly policy: FullSchemaPolicy,
 		public readonly adapters: Adapters,
-		viewSchema: ImplicitFieldSchema,
+		viewSchemaRoot: FieldSchema,
 	) {
-		this.schema = normalizeFieldSchema(viewSchema);
-		this.viewSchemaAsStored = toStoredSchema(this.schema);
+		this.viewSchemaAsStored = toStoredSchema(viewSchemaRoot);
 	}
 
 	/**

--- a/packages/dds/tree/src/simple-tree/api/storedSchema.ts
+++ b/packages/dds/tree/src/simple-tree/api/storedSchema.ts
@@ -13,10 +13,10 @@ import {
 // eslint-disable-next-line import/no-internal-modules
 import type { Format } from "../../feature-libraries/schema-index/index.js";
 import type { JsonCompatible } from "../../util/index.js";
-import type { ImplicitFieldSchema } from "../schemaTypes.js";
+import { normalizeFieldSchema, type ImplicitFieldSchema } from "../schemaTypes.js";
 import { toStoredSchema } from "../toStoredSchema.js";
 import type { SchemaCompatibilityStatus } from "./tree.js";
-import { ViewSchema } from "./view.js";
+import { SchemaCompatibilityTester } from "./schemaCompatibilityTester.js";
 
 /**
  * Dumps the "persisted" schema subset of the provided `schema` into a deterministic JSON-compatible, semi-human-readable, but unspecified format.
@@ -91,7 +91,11 @@ export function comparePersistedSchema(
 ): SchemaCompatibilityStatus {
 	const schemaCodec = makeSchemaCodec(options);
 	const stored = schemaCodec.decode(persisted as Format);
-	const viewSchema = new ViewSchema(defaultSchemaPolicy, {}, view);
+	const viewSchema = new SchemaCompatibilityTester(
+		defaultSchemaPolicy,
+		{},
+		normalizeFieldSchema(view),
+	);
 	return comparePersistedSchemaInternal(stored, viewSchema, canInitialize);
 }
 
@@ -101,7 +105,7 @@ export function comparePersistedSchema(
  */
 export function comparePersistedSchemaInternal(
 	stored: TreeStoredSchema,
-	viewSchema: ViewSchema,
+	viewSchema: SchemaCompatibilityTester,
 	canInitialize: boolean,
 ): SchemaCompatibilityStatus {
 	return {

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -81,7 +81,7 @@ export {
 	comparePersistedSchema,
 	type ConciseTree,
 	comparePersistedSchemaInternal,
-	ViewSchema,
+	SchemaCompatibilityTester,
 	type Unenforced,
 	type System_Unsafe,
 	type ArrayNodeCustomizableSchemaUnsafe,

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -28,7 +28,7 @@ import {
 	getStoredSchema,
 	SchemaFactory,
 	toStoredSchema,
-	ViewSchema,
+	SchemaCompatibilityTester,
 	type TreeNodeSchema,
 } from "../../../simple-tree/index.js";
 import { brand } from "../../../util/index.js";
@@ -118,7 +118,7 @@ describe("Schema Evolution Examples", () => {
 		// This is where legacy schema handling logic for schematize.
 		const adapters: Adapters = {};
 		// Compose all the view information together.
-		const view = new ViewSchema(defaultSchemaPolicy, adapters, root);
+		const view = new SchemaCompatibilityTester(defaultSchemaPolicy, adapters, root);
 
 		// Now lets imagine using this application on a new empty document.
 		// TreeStoredSchemaRepository defaults to a state that permits no document states at all.
@@ -150,7 +150,7 @@ describe("Schema Evolution Examples", () => {
 
 			// This example picks the first approach.
 			// Lets simulate the developers of the app making this change by modifying the view schema:
-			const view2 = new ViewSchema(defaultSchemaPolicy, adapters, tolerantRoot);
+			const view2 = new SchemaCompatibilityTester(defaultSchemaPolicy, adapters, tolerantRoot);
 			// When we open this document, we should check it's compatibility with our application:
 			const compat = view2.checkCompatibility(stored);
 
@@ -208,7 +208,11 @@ describe("Schema Evolution Examples", () => {
 			// And canvas is still the same storage wise, but its view schema references the updated positionedCanvasItem2:
 			const canvas2 = builder.array("Canvas", positionedCanvasItem2);
 			// Once again we will simulate reloading the app with different schema by modifying the view schema.
-			const view3 = new ViewSchema(defaultSchemaPolicy, adapters, builder.optional(canvas2));
+			const view3 = new SchemaCompatibilityTester(
+				defaultSchemaPolicy,
+				adapters,
+				builder.optional(canvas2),
+			);
 
 			// With this new schema, we can load the document just like before:
 			const compat2 = view3.checkCompatibility(stored);

--- a/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
@@ -40,10 +40,11 @@ import { checkoutWithContent, validateViewConsistency } from "../utils.js";
 import type { Listenable } from "@fluidframework/core-interfaces";
 import {
 	SchemaFactory,
-	ViewSchema,
+	SchemaCompatibilityTester,
 	type ImplicitFieldSchema,
 	type TreeView,
 	type TreeViewConfiguration,
+	normalizeFieldSchema,
 } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { toStoredSchema } from "../../simple-tree/toStoredSchema.js";
@@ -207,14 +208,22 @@ describe("schematizeTree", () => {
 			for (const [name, data, isEmpty] of testCases) {
 				it(name, () => {
 					const checkout = mockCheckout(data, isEmpty);
-					const viewSchema = new ViewSchema(defaultSchemaPolicy, {}, data);
+					const viewSchema = new SchemaCompatibilityTester(
+						defaultSchemaPolicy,
+						{},
+						normalizeFieldSchema(data),
+					);
 					const result = evaluateUpdate(viewSchema, AllowedUpdateType.None, checkout);
 					assert.equal(result, UpdateType.None);
 				});
 
 				it(`${name} initialize`, () => {
 					const checkout = mockCheckout(emptySchema, isEmpty);
-					const viewSchema = new ViewSchema(defaultSchemaPolicy, {}, data);
+					const viewSchema = new SchemaCompatibilityTester(
+						defaultSchemaPolicy,
+						{},
+						normalizeFieldSchema(data),
+					);
 					const result = evaluateUpdate(viewSchema, AllowedUpdateType.Initialize, checkout);
 					if (data === emptySchema) {
 						assert.equal(result, UpdateType.None);
@@ -227,7 +236,11 @@ describe("schematizeTree", () => {
 
 		it("AllowedUpdateType works", () => {
 			const checkout = mockCheckout(schema, false);
-			const viewSchema = new ViewSchema(defaultSchemaPolicy, {}, schemaGeneralized);
+			const viewSchema = new SchemaCompatibilityTester(
+				defaultSchemaPolicy,
+				{},
+				schemaGeneralized,
+			);
 			{
 				const result = evaluateUpdate(
 					viewSchema,
@@ -262,7 +275,7 @@ describe("schematizeTree", () => {
 				schema: toStoredSchema(emptySchema),
 				initialTree: undefined,
 			});
-			const viewSchema = new ViewSchema(defaultSchemaPolicy, {}, emptySchema);
+			const viewSchema = new SchemaCompatibilityTester(defaultSchemaPolicy, {}, emptySchema);
 			assert(ensureSchema(viewSchema, AllowedUpdateType.None, checkout, undefined));
 		});
 
@@ -282,7 +295,11 @@ describe("schematizeTree", () => {
 				schema: toStoredSchema(schemaGeneralized),
 				initialTree: undefined,
 			});
-			const viewSchema = new ViewSchema(defaultSchemaPolicy, {}, schemaGeneralized);
+			const viewSchema = new SchemaCompatibilityTester(
+				defaultSchemaPolicy,
+				{},
+				schemaGeneralized,
+			);
 
 			// Non updating cases
 			{
@@ -360,7 +377,11 @@ describe("schematizeTree", () => {
 			};
 			const initializedCheckout = checkoutWithContent(content);
 
-			const viewSchema = new ViewSchema(defaultSchemaPolicy, {}, schemaValueRoot);
+			const viewSchema = new SchemaCompatibilityTester(
+				defaultSchemaPolicy,
+				{},
+				normalizeFieldSchema(schemaValueRoot),
+			);
 
 			// Non updating cases
 			{
@@ -425,7 +446,11 @@ describe("schematizeTree", () => {
 				initialTree: initialContent.initialTree,
 			});
 
-			const viewSchema = new ViewSchema(defaultSchemaPolicy, {}, schemaGeneralized);
+			const viewSchema = new SchemaCompatibilityTester(
+				defaultSchemaPolicy,
+				{},
+				schemaGeneralized,
+			);
 
 			// Non updating case
 			{

--- a/packages/dds/tree/src/test/simple-tree/api/schemaCompatibilityTester.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaCompatibilityTester.spec.ts
@@ -8,18 +8,24 @@ import {
 	storedEmptyFieldSchema,
 	type Adapters,
 	type TreeStoredSchema,
-} from "../../core/index.js";
-import { defaultSchemaPolicy, type FullSchemaPolicy } from "../../feature-libraries/index.js";
+} from "../../../core/index.js";
+import {
+	defaultSchemaPolicy,
+	type FullSchemaPolicy,
+} from "../../../feature-libraries/index.js";
 import {
 	toStoredSchema,
-	ViewSchema,
 	type ImplicitFieldSchema,
 	type SchemaCompatibilityStatus,
-} from "../../simple-tree/index.js";
+	normalizeFieldSchema,
+} from "../../../simple-tree/index.js";
 import {
 	createUnknownOptionalFieldPolicy,
 	SchemaFactoryAlpha,
-} from "../../simple-tree/index.js";
+} from "../../../simple-tree/index.js";
+
+// eslint-disable-next-line import/no-internal-modules
+import { SchemaCompatibilityTester } from "../../../simple-tree/api/schemaCompatibilityTester.js";
 
 const noAdapters: Adapters = {};
 const emptySchema: TreeStoredSchema = {
@@ -31,18 +37,22 @@ const factory = new SchemaFactoryAlpha("");
 
 function expectCompatibility(
 	{ view, stored }: { view: ImplicitFieldSchema; stored: TreeStoredSchema },
-	expected: ReturnType<ViewSchema["checkCompatibility"]>,
+	expected: ReturnType<SchemaCompatibilityTester["checkCompatibility"]>,
 	policy: FullSchemaPolicy = {
 		...defaultSchemaPolicy,
 		allowUnknownOptionalFields: createUnknownOptionalFieldPolicy(view),
 	},
 ) {
-	const viewSchema = new ViewSchema(policy, noAdapters, view);
+	const viewSchema = new SchemaCompatibilityTester(
+		policy,
+		noAdapters,
+		normalizeFieldSchema(view),
+	);
 	const compatibility = viewSchema.checkCompatibility(stored);
 	assert.deepEqual(compatibility, expected);
 }
 
-describe("viewSchema", () => {
+describe("SchemaCompatibilityTester", () => {
 	describe(".checkCompatibility", () => {
 		it("works with never trees", () => {
 			class NeverObject extends factory.objectRecursive("NeverObject", {


### PR DESCRIPTION
## Description

"view.ts" and "ViewSchema" were not very useful names, so rename them to SchemaCompatibilityTester.

This frees up view file names for use by TreeView.

Also fix that test file was incorrectly named and in the wrong directory.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
