### PR TITLE
Adding calling service name in S2S request headers

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -26,7 +26,7 @@ import express from "express";
 import shajs from "sha.js";
 import { Provider } from "nconf";
 import type { Emitter as RedisEmitter } from "@socket.io/redis-emitter";
-import { DriverVersionHeaderName, IAlfredTenant } from "@fluidframework/server-services-client";
+import { CallingServiceHeaderName, DriverVersionHeaderName, IAlfredTenant } from "@fluidframework/server-services-client";
 import {
 	alternativeMorganLoggerMiddleware,
 	bindTelemetryContext,
@@ -34,7 +34,7 @@ import {
 	jsonMorganLoggerMiddleware,
 } from "@fluidframework/server-services-utils";
 import { RestLessServer, IHttpServerConfig } from "@fluidframework/server-services";
-import { BaseTelemetryProperties, HttpProperties } from "@fluidframework/server-services-telemetry";
+import { BaseTelemetryProperties, CommonProperties, HttpProperties } from "@fluidframework/server-services-telemetry";
 import { catch404, getIdFromRequest, getTenantIdFromRequest, handleError } from "../utils";
 import { IDocumentDeleteService } from "./services";
 import * as alfredRoutes from "./routes";
@@ -87,7 +87,7 @@ export function create(
 	app.set("trust proxy", 1);
 
 	app.use(compression());
-	app.use(bindTelemetryContext());
+	app.use(bindTelemetryContext("alfred"));
 	if (httpServerConfig?.connectionTimeoutMs) {
 		// If connectionTimeoutMs configured and not 0, bind timeout context.
 		app.use(bindTimeoutContext(httpServerConfig.connectionTimeoutMs));
@@ -106,6 +106,7 @@ export function create(
 						),
 						[BaseTelemetryProperties.tenantId]: getTenantIdFromRequest(req.params),
 						[BaseTelemetryProperties.documentId]: getIdFromRequest(req.params),
+						[CommonProperties.callingServiceName]: req.headers[CallingServiceHeaderName] ?? "",
 					};
 					if (enableClientIPLogging === true) {
 						const hashedClientIP = req.ip

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -26,7 +26,11 @@ import express from "express";
 import shajs from "sha.js";
 import { Provider } from "nconf";
 import type { Emitter as RedisEmitter } from "@socket.io/redis-emitter";
-import { CallingServiceHeaderName, DriverVersionHeaderName, IAlfredTenant } from "@fluidframework/server-services-client";
+import {
+	CallingServiceHeaderName,
+	DriverVersionHeaderName,
+	IAlfredTenant,
+} from "@fluidframework/server-services-client";
 import {
 	alternativeMorganLoggerMiddleware,
 	bindTelemetryContext,
@@ -34,7 +38,11 @@ import {
 	jsonMorganLoggerMiddleware,
 } from "@fluidframework/server-services-utils";
 import { RestLessServer, IHttpServerConfig } from "@fluidframework/server-services";
-import { BaseTelemetryProperties, CommonProperties, HttpProperties } from "@fluidframework/server-services-telemetry";
+import {
+	BaseTelemetryProperties,
+	CommonProperties,
+	HttpProperties,
+} from "@fluidframework/server-services-telemetry";
 import { catch404, getIdFromRequest, getTenantIdFromRequest, handleError } from "../utils";
 import { IDocumentDeleteService } from "./services";
 import * as alfredRoutes from "./routes";
@@ -106,7 +114,8 @@ export function create(
 						),
 						[BaseTelemetryProperties.tenantId]: getTenantIdFromRequest(req.params),
 						[BaseTelemetryProperties.documentId]: getIdFromRequest(req.params),
-						[CommonProperties.callingServiceName]: req.headers[CallingServiceHeaderName] ?? "",
+						[CommonProperties.callingServiceName]:
+							req.headers[CallingServiceHeaderName] ?? "",
 					};
 					if (enableClientIPLogging === true) {
 						const hashedClientIP = req.ip

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -391,6 +391,7 @@ const uploadBlob = async (
 		() => getGlobalTelemetryContext().getProperties() /* getTelemetryContextProperties */,
 		undefined /* refreshTokenIfNeeded */,
 		logHttpMetrics /* logHttpMetrics */,
+		() => getGlobalTelemetryContext().getProperties().serviceName ?? "" /* serviceName */,
 	);
 	return restWrapper.post(uri, blobData, undefined, {
 		"Content-Type": "application/json",

--- a/server/routerlicious/packages/routerlicious-base/src/nexus/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/nexus/app.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BaseTelemetryProperties } from "@fluidframework/server-services-telemetry";
+import { BaseTelemetryProperties, CommonProperties } from "@fluidframework/server-services-telemetry";
 import * as bodyParser from "body-parser";
 import express from "express";
 import {
@@ -15,6 +15,7 @@ import { catch404, getTenantIdFromRequest, handleError } from "../utils";
 import { createHealthCheckEndpoints } from "@fluidframework/server-services-shared";
 import type { Provider } from "nconf";
 import { IReadinessCheck } from "@fluidframework/server-services-core";
+import { CallingServiceHeaderName } from "@fluidframework/server-services-client";
 
 export function create(
 	config: Provider,
@@ -27,13 +28,14 @@ export function create(
 	// Running behind iisnode
 	app.set("trust proxy", 1);
 
-	app.use(bindTelemetryContext());
+	app.use(bindTelemetryContext("nexus"));
 	const loggerFormat = config.get("logger:morganFormat");
 	if (loggerFormat === "json") {
 		app.use(
 			jsonMorganLoggerMiddleware("nexus", (tokens, req, res) => {
 				return {
 					[BaseTelemetryProperties.tenantId]: getTenantIdFromRequest(req.params),
+					[CommonProperties.callingServiceName]: req.headers[CallingServiceHeaderName] ?? "",
 				};
 			}),
 		);

--- a/server/routerlicious/packages/routerlicious-base/src/nexus/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/nexus/app.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { BaseTelemetryProperties, CommonProperties } from "@fluidframework/server-services-telemetry";
+import {
+	BaseTelemetryProperties,
+	CommonProperties,
+} from "@fluidframework/server-services-telemetry";
 import * as bodyParser from "body-parser";
 import express from "express";
 import {
@@ -35,7 +38,8 @@ export function create(
 			jsonMorganLoggerMiddleware("nexus", (tokens, req, res) => {
 				return {
 					[BaseTelemetryProperties.tenantId]: getTenantIdFromRequest(req.params),
-					[CommonProperties.callingServiceName]: req.headers[CallingServiceHeaderName] ?? "",
+					[CommonProperties.callingServiceName]:
+						req.headers[CallingServiceHeaderName] ?? "",
 				};
 			}),
 		);

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
@@ -4,7 +4,7 @@
  */
 
 import { ISecretManager, ICache, IReadinessCheck } from "@fluidframework/server-services-core";
-import { BaseTelemetryProperties } from "@fluidframework/server-services-telemetry";
+import { BaseTelemetryProperties, CommonProperties } from "@fluidframework/server-services-telemetry";
 import * as bodyParser from "body-parser";
 import express from "express";
 import {
@@ -17,6 +17,7 @@ import { catch404, getTenantIdFromRequest, handleError } from "../utils";
 import * as api from "./api";
 import { ITenantRepository } from "./mongoTenantRepository";
 import { createHealthCheckEndpoints } from "@fluidframework/server-services-shared";
+import { CallingServiceHeaderName } from "@fluidframework/server-services-client";
 
 export function create(
 	tenantRepository: ITenantRepository,
@@ -38,12 +39,13 @@ export function create(
 	// Running behind iisnode
 	app.set("trust proxy", 1);
 
-	app.use(bindTelemetryContext());
+	app.use(bindTelemetryContext("riddler"));
 	if (loggerFormat === "json") {
 		app.use(
 			jsonMorganLoggerMiddleware("riddler", (tokens, req, res) => {
 				return {
 					[BaseTelemetryProperties.tenantId]: getTenantIdFromRequest(req.params),
+					[CommonProperties.callingServiceName]: req.headers[CallingServiceHeaderName] ?? "",
 				};
 			}),
 		);

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
@@ -4,7 +4,10 @@
  */
 
 import { ISecretManager, ICache, IReadinessCheck } from "@fluidframework/server-services-core";
-import { BaseTelemetryProperties, CommonProperties } from "@fluidframework/server-services-telemetry";
+import {
+	BaseTelemetryProperties,
+	CommonProperties,
+} from "@fluidframework/server-services-telemetry";
 import * as bodyParser from "body-parser";
 import express from "express";
 import {
@@ -45,7 +48,8 @@ export function create(
 			jsonMorganLoggerMiddleware("riddler", (tokens, req, res) => {
 				return {
 					[BaseTelemetryProperties.tenantId]: getTenantIdFromRequest(req.params),
-					[CommonProperties.callingServiceName]: req.headers[CallingServiceHeaderName] ?? "",
+					[CommonProperties.callingServiceName]:
+						req.headers[CallingServiceHeaderName] ?? "",
 				};
 			}),
 		);

--- a/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
+++ b/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
@@ -26,13 +26,16 @@ import { SummaryObject } from '@fluidframework/protocol-definitions';
 
 // @internal (undocumented)
 export class BasicRestWrapper extends RestWrapper {
-    constructor(baseurl?: string, defaultQueryString?: Record<string, string | number | boolean>, maxBodyLength?: number, maxContentLength?: number, defaultHeaders?: RawAxiosRequestHeaders, axios?: AxiosInstance, refreshDefaultQueryString?: (() => Record<string, string | number | boolean>) | undefined, refreshDefaultHeaders?: (() => RawAxiosRequestHeaders) | undefined, getCorrelationId?: (() => string | undefined) | undefined, getTelemetryContextProperties?: (() => Record<string, string | number | boolean> | undefined) | undefined, refreshTokenIfNeeded?: ((authorizationHeader: RawAxiosRequestHeaders) => Promise<RawAxiosRequestHeaders | undefined>) | undefined, logHttpMetrics?: ((requestProps: IBasicRestWrapperMetricProps) => void) | undefined);
+    constructor(baseurl?: string, defaultQueryString?: Record<string, string | number | boolean>, maxBodyLength?: number, maxContentLength?: number, defaultHeaders?: RawAxiosRequestHeaders, axios?: AxiosInstance, refreshDefaultQueryString?: (() => Record<string, string | number | boolean>) | undefined, refreshDefaultHeaders?: (() => RawAxiosRequestHeaders) | undefined, getCorrelationId?: (() => string | undefined) | undefined, getTelemetryContextProperties?: (() => Record<string, string | number | boolean> | undefined) | undefined, refreshTokenIfNeeded?: ((authorizationHeader: RawAxiosRequestHeaders) => Promise<RawAxiosRequestHeaders | undefined>) | undefined, logHttpMetrics?: ((requestProps: IBasicRestWrapperMetricProps) => void) | undefined, getCallingServiceName?: (() => string | undefined) | undefined);
     // (undocumented)
     protected request<T>(requestConfig: AxiosRequestConfig, statusCode: number, canRetry?: boolean): Promise<T>;
 }
 
 // @internal
 export const buildTreePath: (...nodeNames: string[]) => string;
+
+// @internal
+export const CallingServiceHeaderName = "x-calling-service";
 
 // @internal
 export const canDeleteDoc: (scopes: string[]) => boolean;

--- a/server/routerlicious/packages/services-client/src/constants.ts
+++ b/server/routerlicious/packages/services-client/src/constants.ts
@@ -24,3 +24,9 @@ export const TelemetryContextHeaderName = "x-telemetry-context";
  * @internal
  */
 export const LatestSummaryId = "latest";
+
+/**
+ * HTTP Header name for the calling service to be sent to the service for telemetry purposes.
+ * @internal
+ */
+export const CallingServiceHeaderName = "x-calling-service";

--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -20,6 +20,7 @@ export {
 	DriverVersionHeaderName,
 	LatestSummaryId,
 	TelemetryContextHeaderName,
+	CallingServiceHeaderName,
 } from "./constants";
 export {
 	createFluidServiceNetworkError,

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -93,6 +93,9 @@
 			},
 			"Interface_ITelemetryContextProperties": {
 				"forwardCompat": false
+			},
+			"Enum_CommonProperties": {
+				"backCompat": false
 			}
 		},
 		"entrypoint": "public"

--- a/server/routerlicious/packages/services-telemetry/src/resources.ts
+++ b/server/routerlicious/packages/services-telemetry/src/resources.ts
@@ -125,6 +125,7 @@ export enum CommonProperties {
 	errorLabel = "errorLabel",
 	isGlobalDb = "isGlobalDb",
 	internalErrorCode = "internalErrorCode",
+	callingServiceName = "callingServiceName",
 }
 
 /**

--- a/server/routerlicious/packages/services-telemetry/src/telemetryContext.ts
+++ b/server/routerlicious/packages/services-telemetry/src/telemetryContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { BaseTelemetryProperties } from "./resources";
+import { BaseTelemetryProperties, type CommonProperties } from "./resources";
 
 /**
  * @internal
@@ -13,6 +13,7 @@ export interface ITelemetryContextProperties {
 	[BaseTelemetryProperties.documentId]: string;
 	[BaseTelemetryProperties.correlationId]: string;
 	[BaseTelemetryProperties.requestSource]: string;
+	[CommonProperties.serviceName]: string;
 }
 
 /**

--- a/server/routerlicious/packages/services-telemetry/src/test/types/validateServerServicesTelemetryPrevious.generated.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/types/validateServerServicesTelemetryPrevious.generated.ts
@@ -375,6 +375,7 @@ declare type old_as_current_for_Enum_CommonProperties = requireAssignableTo<Type
  * typeValidation.broken:
  * "Enum_CommonProperties": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Enum_CommonProperties = requireAssignableTo<TypeOnly<current.CommonProperties>, TypeOnly<old.CommonProperties>>
 
 /*

--- a/server/routerlicious/packages/services-utils/src/telemetryContext.ts
+++ b/server/routerlicious/packages/services-utils/src/telemetryContext.ts
@@ -92,7 +92,7 @@ export function getTelemetryContextPropertiesWithHttpInfo(
  * Requests from the Fluid client may not include a correlationId, so one is generated when unavailable.
  * @internal
  */
-export const bindTelemetryContext = (): RequestHandler => {
+export const bindTelemetryContext = (serviceName: string): RequestHandler => {
 	return (req, res, next) => {
 		const telemetryContext = getGlobalTelemetryContext();
 		// Bind incoming telemetry properties to async context.
@@ -101,6 +101,7 @@ export const bindTelemetryContext = (): RequestHandler => {
 		if (!telemetryContextProperties.correlationId) {
 			telemetryContextProperties.correlationId = uuid();
 		}
+		telemetryContextProperties.serviceName = serviceName;
 		// Assign response headers for client telemetry purposes.
 		res.setHeader(CorrelationIdHeaderName, telemetryContextProperties.correlationId);
 		telemetryContext.bindProperties(telemetryContextProperties, () => next());

--- a/server/routerlicious/packages/services/src/deltaManager.ts
+++ b/server/routerlicious/packages/services/src/deltaManager.ts
@@ -118,6 +118,7 @@ export class DeltaManager implements IDeltaService {
 			() => getGlobalTelemetryContext().getProperties() /* getTelemetryContextProperties */,
 			refreshTokenIfNeeded,
 			logHttpMetrics,
+			() => getGlobalTelemetryContext().getProperties().serviceName ?? "" /* serviceName */,
 		);
 		return restWrapper;
 	}

--- a/server/routerlicious/packages/services/src/documentManager.ts
+++ b/server/routerlicious/packages/services/src/documentManager.ts
@@ -152,6 +152,7 @@ export class DocumentManager implements IDocumentManager {
 			() => getGlobalTelemetryContext().getProperties() /* getTelemetryContextProperties */,
 			refreshTokenIfNeeded /* refreshTokenIfNeeded */,
 			logHttpMetrics,
+			() => getGlobalTelemetryContext().getProperties().serviceName ?? "" /* serviceName */,
 		);
 		return restWrapper;
 	}

--- a/server/routerlicious/packages/services/src/tenant.ts
+++ b/server/routerlicious/packages/services/src/tenant.ts
@@ -123,6 +123,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			() => getGlobalTelemetryContext().getProperties(),
 			undefined /* refreshTokenIfNeeded */,
 			logHttpMetrics,
+			() => getGlobalTelemetryContext().getProperties().serviceName ?? "" /* serviceName */,
 		);
 		const result = await restWrapper.post<core.ITenantConfig & { key: string }>(
 			`/api/tenants/${encodeURIComponent(tenantId || "")}`,
@@ -242,6 +243,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			() => getGlobalTelemetryContext().getProperties(),
 			refreshTokenIfNeeded,
 			logHttpMetrics,
+			() => getGlobalTelemetryContext().getProperties().serviceName ?? "" /* serviceName */,
 		);
 		const historian = new Historian(baseUrl, true, false, tenantRestWrapper);
 		const gitManager = new GitManager(historian);
@@ -290,6 +292,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			() => getGlobalTelemetryContext().getProperties(),
 			undefined /* refreshTokenIfNeeded */,
 			logHttpMetrics,
+			() => getGlobalTelemetryContext().getProperties().serviceName ?? "" /* serviceName */,
 		);
 		try {
 			await restWrapper.post(`/api/tenants/${encodeURIComponent(tenantId)}/validate`, {
@@ -335,6 +338,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			() => getGlobalTelemetryContext().getProperties(),
 			undefined /* refreshTokenIfNeeded */,
 			logHttpMetrics,
+			() => getGlobalTelemetryContext().getProperties().serviceName ?? "" /* serviceName */,
 		);
 		const result = await restWrapper.get<core.ITenantKeys>(
 			`/api/tenants/${encodeURIComponent(tenantId)}/keys`,
@@ -366,6 +370,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			() => getGlobalTelemetryContext().getProperties(),
 			undefined /* refreshTokenIfNeeded */,
 			logHttpMetrics,
+			() => getGlobalTelemetryContext().getProperties().serviceName ?? "" /* serviceName */,
 		);
 		const result = await restWrapper.post<core.IFluidAccessToken>(
 			`/api/tenants/${encodeURIComponent(tenantId)}/accesstoken`,
@@ -407,6 +412,7 @@ export class TenantManager implements core.ITenantManager, core.ITenantConfigMan
 			() => getGlobalTelemetryContext().getProperties(),
 			undefined /* refreshTokenIfNeeded */,
 			logHttpMetrics,
+			() => getGlobalTelemetryContext().getProperties().serviceName ?? "" /* serviceName */,
 		);
 		return restWrapper.get<core.ITenantConfig>(`/api/tenants/${tenantId}`, {
 			includeDisabledTenant,


### PR DESCRIPTION
## Description

This PR adds the following support for internal S2S API calls:

1) All requests sent within the server will now have the caller name in the headers with header name `x-calling-service`.
2) The receiving logging middleware logs the calling service name

## Breaking Changes

This is a breaking change as it introduces a new arg in the `bindTelemetryContext()` function - `serviceName`. I will be implementing this change as part of a r11 bump in Historian and also in AFR.

