### PR TITLE
refactor(docs): Update `ApiLink` to directly use `ApiItemKind`

### DIFF
--- a/docs/docs/build/container-states-events.mdx
+++ b/docs/docs/build/container-states-events.mdx
@@ -99,7 +99,7 @@ But the new container has a different ID from the deleted one and subsequent cli
 
 #### Handling publication status
 
-Your code can test for the publication status with the <ApiLink packageName="fluid-framework" apiName="IFluidContainer" apiType="interface" headingId="attachstate-propertysignature">container.AttachState</ApiLink> property which has an <ApiLink packageName="fluid-framework" apiName="AttachState" apiType="enum">AttachState</ApiLink> value.
+Your code can test for the publication status with the <ApiLink packageName="fluid-framework" apiName="IFluidContainer" apiType="Interface" headingId="attachstate-propertysignature">container.AttachState</ApiLink> property which has an <ApiLink packageName="fluid-framework" apiName="AttachState" apiType="Enum">AttachState</ApiLink> value.
 This can be useful if your application will publish the container in some code paths on the creating client, but not others.
 For example, on the creating computer, you don't want to call `container.attach` if it has already been called. In simple cases, you can know at coding time if that has happened, but when the creating client in complex code flows and calls of `container.attach` appear in more than one branch, you may need to test for this possibility. The following is a simple example.
 
@@ -269,7 +269,7 @@ The container transitions to this state automatically when it is fully caught up
 
 There are scenarios in which you need to control the connection status of the container. To assist, the `container` object has the following APIs:
 
--   A <ApiLink packageName="fluid-framework" apiName="IFluidContainer" apiType="interface" headingId="connectionstate-propertysignature">container.connectionState</ApiLink> property of type `ConnectionState`. There are four possible values for the property:
+-   A <ApiLink packageName="fluid-framework" apiName="IFluidContainer" apiType="Interface" headingId="connectionstate-propertysignature">container.connectionState</ApiLink> property of type `ConnectionState`. There are four possible values for the property:
 
     -   `Disconnected`
     -   `EstablishingConnection`: Your code should treat this state the same as it treats the disconnected state. See [Examples](#examples).

--- a/docs/docs/build/containers.mdx
+++ b/docs/docs/build/containers.mdx
@@ -8,7 +8,7 @@ import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
 The container is the primary unit of encapsulation in the Fluid Framework.
 It enables a group of clients to access the same set of shared objects and co-author changes on those objects.
 It is also a permission boundary ensuring visibility and access only to permitted clients.
-A container is represented by the <ApiLink packageName="fluid-framework" apiName="IFluidContainer" apiType="interface">FluidContainer</ApiLink> type and consists of a collection of shared objects and APIs to manage the life cycle of those objects.
+A container is represented by the <ApiLink packageName="fluid-framework" apiName="IFluidContainer" apiType="Interface">FluidContainer</ApiLink> type and consists of a collection of shared objects and APIs to manage the life cycle of those objects.
 
 This article explains:
 

--- a/docs/docs/build/experimental-features.mdx
+++ b/docs/docs/build/experimental-features.mdx
@@ -29,7 +29,7 @@ When a [container](./containers.mdx) is loaded, there will be several events log
 
 The following is an example of how to enable experimental features with `AzureClient`.
 
-1. First, implement <ApiLink packageName="core-interfaces" apiName="IConfigProviderBase" apiType="interface" />. For example:
+1. First, implement <ApiLink packageName="core-interfaces" apiName="IConfigProviderBase" apiType="Interface" />. For example:
 
     ```typescript
     const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({

--- a/docs/docs/start/tree-start.mdx
+++ b/docs/docs/start/tree-start.mdx
@@ -23,7 +23,7 @@ npm install fluid-framework@latest
 A `SharedTree` can be created by defining a `ContainerSchema` with an initial object of type `SharedTree` and using this schema to create and load your container.
 This example creates a container using an Azure specific client.
 
-**note**: `enableRuntimeIdCompressor` must be enabled in the <ApiLink packageName="container-runtime" apiName="IContainerRuntimeOptions" apiType="interface">container runtime options</ApiLink> in order to use `SharedTree`
+**note**: `enableRuntimeIdCompressor` must be enabled in the <ApiLink packageName="container-runtime" apiName="IContainerRuntimeOptions" apiType="TypeAlias">container runtime options</ApiLink> in order to use `SharedTree`
 
 See more info on creating and loading containers [here](../build/containers.mdx#creating-a-container).
 
@@ -93,7 +93,7 @@ This creates a `TodoList` class that is an object schema with two fields, `title
 
 Schemas can also be defined using plain old JavaScript object (POJO) mode.
 Generally, you should prefer customizable mode.
-See <ApiLink packageName="fluid-framework" apiName="SchemaFactory" apiType="class">the API docs</ApiLink> for more info on the differences between the two modes.
+See <ApiLink packageName="fluid-framework" apiName="SchemaFactory" apiType="Class">the API docs</ApiLink> for more info on the differences between the two modes.
 
 ## Initializing the Tree
 
@@ -154,7 +154,7 @@ useEffect(() => {
 
 `nodeChanged` fires whenever one or more properties of the specified node change while `treeChanged` also fires whenever any node in its subtree changes.
 
-See <ApiLink packageName="fluid-framework" apiName="TreeChangeEvents" apiType="interface">the API</ApiLink> docs for more details.
+See <ApiLink packageName="fluid-framework" apiName="TreeChangeEvents" apiType="Interface">the API</ApiLink> docs for more details.
 
 ## Editing Tree Data
 

--- a/docs/src/components/shortLinks.tsx
+++ b/docs/src/components/shortLinks.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useDoc } from "@docusaurus/plugin-content-docs/client";
+import type { ApiItemKind } from "@fluid-tools/api-markdown-documenter";
 import React from "react";
 
 // TODO: how will versioning interact with these?
@@ -41,9 +42,8 @@ export interface ApiLinkProps {
 	children?: React.ReactNode;
 	packageName: string;
 	apiName: string;
-	// TODO: import directly from `api-extractor-model`
 	// TODO: do we have enough context to determine this automatically when unambiguous?
-	apiType: "class" | "enum" | "function" | "interface" | "namespace" | "type" | "variable";
+	apiType: ApiItemKind;
 
 	/**
 	 * (Optional) heading ID on the target page to link to.
@@ -72,7 +72,7 @@ export function ApiLink({
 }: ApiLinkProps): JSX.Element {
 	const root = useLinkPathBase();
 	const headingPostfix = headingId === undefined ? "" : `#${headingId}`;
-	const path = `${root}${packageName}/${apiName.toLocaleLowerCase()}-${apiType}${headingPostfix}`;
+	const path = `${root}${packageName}/${apiName.toLocaleLowerCase()}-${apiType.toLocaleLowerCase()}${headingPostfix}`;
 	return <a href={path}>{children ?? apiName}</a>;
 }
 

--- a/docs/src/components/shortLinks.tsx
+++ b/docs/src/components/shortLinks.tsx
@@ -72,6 +72,8 @@ export function ApiLink({
 }: ApiLinkProps): JSX.Element {
 	const root = useLinkPathBase();
 	const headingPostfix = headingId === undefined ? "" : `#${headingId}`;
+	// `api-documenter` generates all lowercase entries for API item names and types.
+	// Convert input names and types to lowercase to match.
 	const path = `${root}${packageName}/${apiName.toLocaleLowerCase()}-${apiType.toLocaleLowerCase()}${headingPostfix}`;
 	return <a href={path}>{children ?? apiName}</a>;
 }

--- a/docs/versioned_docs/version-1/build/container-states-events.mdx
+++ b/docs/versioned_docs/version-1/build/container-states-events.mdx
@@ -97,7 +97,7 @@ But the new container has a different ID from the deleted one and subsequent cli
 
 #### Handling publication status
 
-Your code can test for the publication status with the <ApiLink packageName="fluid-static" apiName="IFluidContainer" apiType="interface" headingId="attachstate-propertysignature">container.AttachState</ApiLink> property which has an <ApiLink packageName="container-definitions" apiName="AttachState" apiType="enum">AttachState</ApiLink> value.
+Your code can test for the publication status with the <ApiLink packageName="fluid-static" apiName="IFluidContainer" apiType="Interface" headingId="attachstate-propertysignature">container.AttachState</ApiLink> property which has an <ApiLink packageName="container-definitions" apiName="AttachState" apiType="Enum">AttachState</ApiLink> value.
 This can be useful if your application will publish the container in some code paths on the creating client, but not others.
 For example, on the creating computer, you don't want to call `container.attach` if it has already been called. In simple cases, you can know at coding time if that has happened, but when the creating client in complex code flows and calls of `container.attach` appear in more than one branch, you may need to test for this possibility. The following is a simple example.
 
@@ -257,7 +257,7 @@ The container transitions to this state automatically when it is fully caught up
 
 There are scenarios in which you need to control the connection status of the container. To assist, the `container` object has the following APIs:
 
--   A <ApiLink packageName="fluid-static" apiName="IFluidContainer" apiType="interface" headingId="connectionstate-propertysignature">container.connectionState</ApiLink> property of type `ConnectionState`. There are four possible values for the property:
+-   A <ApiLink packageName="fluid-static" apiName="IFluidContainer" apiType="Interface" headingId="connectionstate-propertysignature">container.connectionState</ApiLink> property of type `ConnectionState`. There are four possible values for the property:
 
     -   `Disconnected`
     -   `EstablishingConnection`: Your code should treat this state the same as it treats the disconnected state. See [Examples](#examples).

--- a/docs/versioned_docs/version-1/build/containers.mdx
+++ b/docs/versioned_docs/version-1/build/containers.mdx
@@ -8,7 +8,7 @@ import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
 The container is the primary unit of encapsulation in the Fluid Framework.
 It enables a group of clients to access the same set of shared objects and co-author changes on those objects.
 It is also a permission boundary ensuring visibility and access only to permitted clients.
-A container is represented by the <ApiLink packageName="fluid-static" apiName="IFluidContainer" apiType="interface">FluidContainer</ApiLink> type and consists of a collection of shared objects and APIs to manage the life cycle of those objects.
+A container is represented by the <ApiLink packageName="fluid-static" apiName="IFluidContainer" apiType="Interface">FluidContainer</ApiLink> type and consists of a collection of shared objects and APIs to manage the life cycle of those objects.
 
 This article explains:
 

--- a/docs/versioned_docs/version-1/release-notes.mdx
+++ b/docs/versioned_docs/version-1/release-notes.mdx
@@ -23,11 +23,11 @@ We are now surfacing errors on FluidContainer "disposed" event, so the applicati
 
 ## fluid-framework
 
--   Add the missing <ApiLink packageName="container-loader" apiName="ConnectionState" apiType="enum" /> export to `fluid-framework`
+-   Add the missing <ApiLink packageName="container-loader" apiName="ConnectionState" apiType="Enum" /> export to `fluid-framework`
 
 ## @fluidframework/azure-client
 
--   Fix <ApiLink packageName="azure-client" apiName="AzureClient" apiType="class" /> issue where the second user could not connect in `local` mode
+-   Fix <ApiLink packageName="azure-client" apiName="AzureClient" apiType="Class" /> issue where the second user could not connect in `local` mode
 
 # 1.0.0
 
@@ -40,7 +40,7 @@ We've added two new methods to AzureClient that will enable developers to recove
 -   <ApiLink
     	packageName="azure-client"
     	apiName="AzureClient"
-    	apiType="class"
+    	apiType="Class"
     	headingId="getcontainerversions-method"
     >
     	`getContainerVersions(id, options)`
@@ -48,7 +48,7 @@ We've added two new methods to AzureClient that will enable developers to recove
 -   <ApiLink
     	packageName="azure-client"
     	apiName="AzureClient"
-    	apiType="class"
+    	apiType="Class"
     	headingId="copycontainer-method"
     >
     	`copyContainer(id, containerSchema)`

--- a/docs/versioned_docs/version-1/testing/telemetry.mdx
+++ b/docs/versioned_docs/version-1/testing/telemetry.mdx
@@ -35,7 +35,7 @@ interface as its constructor argument. `ILoaderProps` interface has an optional 
 <ApiLink
 	packageName="container-loader"
 	apiName="ILoaderProps"
-	apiType="interface"
+	apiType="Interface"
 	headingId="logger-propertysignature"
 >
 	ILoaderProps.logger


### PR DESCRIPTION
Updates `ApiLink` to directly use `ApiItemKind` instead of using a string union copy. The existing union contained a bug (the value for type alias items was "type" instead of "typealias", which is what `api-documenter` generates from `ApiItemKind`).

Also updates docs to use `PascalCase` "type" entries to match `ApiItemKind`'s values. This isn't strictly necessary, but gives a consistent pattern to follow.

Finally, this [fixes a broken link in the documentation](https://github.com/microsoft/FluidFramework/pull/24526/files#r2074392935).