### PR TITLE
breaking change(client-azure-client): Remove ITokenClaims and ScopeType re-exports

### DIFF
--- a/.changeset/swift-signs-move.md
+++ b/.changeset/swift-signs-move.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/azure-client": minor
+"__section": breaking
+---
+Remove ITokenClaims and ScopeType re-exports
+
+Import from `@fluidframework/driver-definitions/legacy` as needed. See issue [#23702](https://github.com/microsoft/FluidFramework/issues/23702).

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.alpha.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.alpha.api.md
@@ -82,19 +82,10 @@ export { ITelemetryBaseEvent }
 
 export { ITelemetryBaseLogger }
 
-// @alpha @deprecated @legacy
-export type ITokenClaims = ITokenClaims_2;
-
 export { ITokenProvider }
 
 export { ITokenResponse }
 
 export { IUser }
-
-// @alpha @deprecated @legacy
-export const ScopeType: typeof ScopeType_2;
-
-// @alpha @deprecated @legacy
-export type ScopeType = ScopeType_2;
 
 ```

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -130,7 +130,20 @@
 		"uuid": "^9.0.0"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"TypeAlias_ITokenClaims": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"TypeAlias_ScopeType": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"Variable_ScopeType": {
+				"backCompat": false,
+				"forwardCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/service-clients/azure-client/src/index.ts
+++ b/packages/service-clients/azure-client/src/index.ts
@@ -26,33 +26,6 @@ export type {
 
 export type { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
 export type { IUser } from "@fluidframework/driver-definitions";
-import {
-	type ITokenClaims as ITokenClaimsBase,
-	ScopeType as ScopeTypeBase,
-} from "@fluidframework/driver-definitions/internal";
-
-/**
- * {@inheritdoc @fluidframework/driver-definitions/legacy#ITokenClaims}
- * @legacy
- * @alpha
- * @deprecated Consider importing from `@fluidframework/driver-definitions/legacy` - to be removed in 2.40
- */
-export type ITokenClaims = ITokenClaimsBase;
-
-/**
- * {@inheritdoc @fluidframework/driver-definitions/legacy#ScopeType}
- * @legacy
- * @alpha
- * @deprecated Use ScopeType from \@fluidframework/driver-definitions/legacy - to be removed in 2.40
- */
-export const ScopeType = ScopeTypeBase;
-/**
- * {@inheritdoc @fluidframework/driver-definitions/legacy#ScopeType}
- * @legacy
- * @alpha
- * @deprecated Use ScopeType from \@fluidframework/driver-definitions/legacy - to be removed in 2.40
- */
-export type ScopeType = ScopeTypeBase;
 
 // Re-export so developers can build loggers without pulling in core-interfaces
 export type {

--- a/packages/service-clients/azure-client/src/test/types/validateAzureClientPrevious.generated.ts
+++ b/packages/service-clients/azure-client/src/test/types/validateAzureClientPrevious.generated.ts
@@ -337,6 +337,7 @@ declare type current_as_old_for_TypeAlias_IAzureAudience = requireAssignableTo<T
  * typeValidation.broken:
  * "TypeAlias_ITokenClaims": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_ITokenClaims = requireAssignableTo<TypeOnly<old.ITokenClaims>, TypeOnly<current.ITokenClaims>>
 
 /*
@@ -346,6 +347,7 @@ declare type old_as_current_for_TypeAlias_ITokenClaims = requireAssignableTo<Typ
  * typeValidation.broken:
  * "TypeAlias_ITokenClaims": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_ITokenClaims = requireAssignableTo<TypeOnly<current.ITokenClaims>, TypeOnly<old.ITokenClaims>>
 
 /*
@@ -355,6 +357,7 @@ declare type current_as_old_for_TypeAlias_ITokenClaims = requireAssignableTo<Typ
  * typeValidation.broken:
  * "TypeAlias_ScopeType": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_ScopeType = requireAssignableTo<TypeOnly<old.ScopeType>, TypeOnly<current.ScopeType>>
 
 /*
@@ -364,6 +367,7 @@ declare type old_as_current_for_TypeAlias_ScopeType = requireAssignableTo<TypeOn
  * typeValidation.broken:
  * "TypeAlias_ScopeType": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_ScopeType = requireAssignableTo<TypeOnly<current.ScopeType>, TypeOnly<old.ScopeType>>
 
 /*
@@ -373,4 +377,5 @@ declare type current_as_old_for_TypeAlias_ScopeType = requireAssignableTo<TypeOn
  * typeValidation.broken:
  * "Variable_ScopeType": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Variable_ScopeType = requireAssignableTo<TypeOnly<typeof current.ScopeType>, TypeOnly<typeof old.ScopeType>>


### PR DESCRIPTION
Users should import from `@fluidframework/driver-definitions/legacy` directly as needed.