### PR TITLE
improvement(tree): Update table schema error policies

### DIFF
--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -608,6 +608,8 @@ export namespace System_TableSchema {
 					for (const rowToRemove of rowsToRemove) {
 						const index = this.rows.indexOf(rowToRemove);
 						if (index === -1) {
+							// Note, throwing an error within a transaction will abort the entire transaction.
+							// So if we throw an error here for any row, no rows will be removed.
 							throw new UsageError(
 								`Specified row with ID "${rowToRemove.id}" does not exist in the table.`,
 							);

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1057,7 +1057,7 @@ export namespace TableSchema {
 		 * In this case, no rows are removed.
 		 * @privateRemarks
 		 * TODO:
-		 * - Add overload that takes an ID.
+		 * - Add overload that takes IDs.
 		 * - Return removed rows.
 		 * - Throw an error if any row(s) aren't in the table.
 		 */
@@ -1073,9 +1073,7 @@ export namespace TableSchema {
 		 * Removes the cell at the specified location in the table.
 		 * @returns The cell if it exists, otherwise undefined.
 		 * @throws Throws an error if the location does not exist in the table.
-		 * @privateRemarks
-		 * TODO:
-		 * - Add overload that takes column/row nodes?
+		 * @privateRemarks TODO: Add overload that takes column/row nodes.
 		 */
 		removeCell(key: CellKey): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
 	}

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -491,12 +491,18 @@ export namespace System_TableSchema {
 				column,
 				index,
 			}: TableSchema.InsertColumnParameters<TColumnSchema>): ColumnValueType {
+				// #region Input validation
+
 				// TypeScript is unable to narrow the type of the column node correctly here, hence the cast.
 				// See: https://github.com/microsoft/TypeScript/issues/52144
 				const maybeId = (column as TableSchema.IColumn).id;
+
+				// Ensure that no column with the same ID already exists in the table.
 				if (maybeId !== undefined && this.containsColumnWithId(maybeId)) {
 					throw new UsageError(`A column with ID "${maybeId}" already exists in the table.`);
 				}
+
+				// #endregion
 
 				if (index === undefined) {
 					// TypeScript is unable to narrow the types correctly here, hence the cast.
@@ -518,7 +524,9 @@ export namespace System_TableSchema {
 				index,
 				rows,
 			}: TableSchema.InsertRowsParameters<TRowSchema>): RowValueType[] {
-				// Check all of the rows being inserted an make sure the table does not already contain any with the same ID.
+				// #region Input validation
+
+				// Check all of the rows being inserted an ensure the table does not already contain any with the same ID.
 				for (const newRow of rows) {
 					// TypeScript is unable to narrow the type of the row node correctly here, hence the cast.
 					// See: https://github.com/microsoft/TypeScript/issues/52144
@@ -529,6 +537,8 @@ export namespace System_TableSchema {
 						);
 					}
 				}
+
+				// #endregion
 
 				if (index === undefined) {
 					// TypeScript is unable to narrow the types correctly here, hence the cast.

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -826,9 +826,7 @@ export namespace TableSchema {
 		/**
 		 * Removes the cell in the specified column.
 		 * @returns The cell if it exists, otherwise undefined.
-		 * @privateRemarks
-		 * TODO:
-		 * - Throw if the column does not belong to the same table as the row.
+		 * @privateRemarks TODO: Throw if the column does not belong to the same table as the row.
 		 */
 		removeCell(column: IColumn): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
 		/**

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1035,10 +1035,7 @@ export namespace TableSchema {
 		/**
 		 * Sets the cell at the specified location in the table.
 		 * @remarks To remove a cell, call {@link TableSchema.ITable.removeCell} instead.
-		 * @privateRemarks
-		 * TODO:
-		 * - Add overload that takes column/row nodes.
-		 * - Throw an error if the location is invalid.
+		 * @privateRemarks TODO: Add overload that takes column/row nodes.
 		 */
 		setCell(params: SetCellParameters<TCell>): void;
 
@@ -1052,7 +1049,7 @@ export namespace TableSchema {
 		 * - Throw an error if the column isn't in the table.
 		 * - (future) Actually remove corresponding cells from table rows.
 		 */
-		removeColumn: (column: TreeNodeFromImplicitAllowedTypes<TColumn>) => void;
+		removeColumn(column: TreeNodeFromImplicitAllowedTypes<TColumn>): void;
 
 		/**
 		 * Removes 0 or more rows from the table.

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -808,7 +808,6 @@ export namespace TableSchema {
 		/**
 		 * Gets the cell in the specified column, denoted by column ID.
 		 * @returns The cell if it exists, otherwise undefined.
-		 * @privateRemarks TODO: throw if the column does not belong to the same table as the row.
 		 */
 		getCell(columnId: string): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
 
@@ -821,7 +820,6 @@ export namespace TableSchema {
 		/**
 		 * Sets the cell in the specified column, denoted by column ID.
 		 * @remarks To remove a cell, call {@link TableSchema.IRow.(removeCell:2)} instead.
-		 * @privateRemarks TODO: Throw an error if the column does not exist in the table.
 		 */
 		setCell(columnId: string, value: InsertableTreeNodeFromImplicitAllowedTypes<TCell>): void;
 

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1020,8 +1020,8 @@ export namespace TableSchema {
 		 * @privateRemarks
 		 * TODO:
 		 * - Add overload that takes an ID.
-		 * - Return removed column (if any).
-		 * - Throw an error if the column belongs to a different table.
+		 * - Return removed column.
+		 * - Throw an error if the column isn't in the table.
 		 * - (future) Actually remove corresponding cells from table rows.
 		 */
 		removeColumn: (column: TreeNodeFromImplicitAllowedTypes<TColumn>) => void;
@@ -1031,8 +1031,8 @@ export namespace TableSchema {
 		 * @privateRemarks
 		 * TODO:
 		 * - Add overload that takes an ID.
-		 * - Return removed rows (if any).
-		 * - Throw an error if any row(s) belong to a different table.
+		 * - Return removed rows.
+		 * - Throw an error if any row(s) aren't in the table.
 		 */
 		removeRows(rows: readonly TreeNodeFromImplicitAllowedTypes<TRow>[]): void;
 

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -592,7 +592,7 @@ export namespace System_TableSchema {
 					const rowToRemove = rowsToRemove[0] ?? oob();
 					const index = this.rows.indexOf(rowToRemove);
 
-					// If the row
+					// If the row does not exist in the table, throw an error.
 					if (index === -1) {
 						throw new UsageError(
 							`Specified row with ID "${rowToRemove.id}" does not exist in the table.`,
@@ -607,6 +607,8 @@ export namespace System_TableSchema {
 				Tree.runTransaction(this, () => {
 					for (const rowToRemove of rowsToRemove) {
 						const index = this.rows.indexOf(rowToRemove);
+
+						// If any of the rows do not exist in the table, throw an error.
 						if (index === -1) {
 							// Note, throwing an error within a transaction will abort the entire transaction.
 							// So if we throw an error here for any row, no rows will be removed.

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -547,12 +547,16 @@ export namespace System_TableSchema {
 			public setCell({ key, cell }: TableSchema.SetCellParameters<CellInsertableType>): void {
 				const { columnId, rowId } = key;
 				const row = this.getRow(rowId);
-				if (row !== undefined) {
-					const column = this.getColumn(columnId);
-					if (column !== undefined) {
-						row.setCell(column.id, cell);
-					}
+				if (row === undefined) {
+					throw new UsageError(`Row with ID "${rowId}" does not exist in the table.`);
 				}
+
+				const column = this.getColumn(columnId);
+				if (column === undefined) {
+					throw new UsageError(`Column with ID "${columnId}" does not exist in the table.`);
+				}
+
+				row.setCell(column.id, cell);
 			}
 
 			public removeColumn(column: ColumnValueType): void {
@@ -762,33 +766,40 @@ export namespace TableSchema {
 		/**
 		 * Gets the cell in the specified column.
 		 * @returns The cell if it exists, otherwise undefined.
+		 * @privateRemarks TODO: throw if the column does not belong to the same table as the row.
 		 */
 		getCell(column: IColumn): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
 		/**
 		 * Gets the cell in the specified column, denoted by column ID.
 		 * @returns The cell if it exists, otherwise undefined.
+		 * @privateRemarks TODO: throw if the column does not belong to the same table as the row.
 		 */
 		getCell(columnId: string): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
 
 		/**
 		 * Sets the cell in the specified column.
 		 * @remarks To remove a cell, call {@link TableSchema.IRow.(removeCell:1)} instead.
+		 * @privateRemarks TODO: Throw an error if the column does not exist in the table.
 		 */
 		setCell(column: IColumn, value: InsertableTreeNodeFromImplicitAllowedTypes<TCell>): void;
 		/**
 		 * Sets the cell in the specified column, denoted by column ID.
 		 * @remarks To remove a cell, call {@link TableSchema.IRow.(removeCell:2)} instead.
+		 * @privateRemarks TODO: Throw an error if the column does not exist in the table.
 		 */
 		setCell(columnId: string, value: InsertableTreeNodeFromImplicitAllowedTypes<TCell>): void;
 
 		/**
 		 * Removes the cell in the specified column.
-		 * @privateRemarks TODO: return removed cell
+		 * @privateRemarks
+		 * TODO:
+		 * - Return the removed cell (if any)
+		 * - Throw if the column does not belong to the same table as the row.
 		 */
 		removeCell(column: IColumn): void;
 		/**
 		 * Removes the cell in the specified column, denoted by column ID.
-		 * @privateRemarks TODO: return removed cell
+		 * @privateRemarks TODO: Return the removed cell (if any)
 		 */
 		removeCell(columnId: string): void;
 
@@ -943,7 +954,7 @@ export namespace TableSchema {
 		readonly rows: TreeArrayNode<TRow>;
 
 		/**
-		 * Gets a table column by its {@link TableSchema.IRow.id}.
+		 * Gets a table column by its {@link TableSchema.IColumn.id}.
 		 */
 		getColumn(id: string): TreeNodeFromImplicitAllowedTypes<TColumn> | undefined;
 
@@ -978,7 +989,10 @@ export namespace TableSchema {
 		/**
 		 * Sets the cell at the specified location in the table.
 		 * @remarks To remove a cell, call {@link TableSchema.ITable.removeCell} instead.
-		 * @privateRemarks TODO: add overload that takes column/row nodes?
+		 * @privateRemarks
+		 * TODO:
+		 * - Add overload that takes column/row nodes.
+		 * - Throw an error if the location is invalid.
 		 */
 		setCell(
 			params: SetCellParameters<InsertableTreeNodeFromImplicitAllowedTypes<TCell>>,
@@ -989,25 +1003,35 @@ export namespace TableSchema {
 		 * @remarks Note: this does not remove any cells from the table's rows.
 		 * @privateRemarks
 		 * TODO:
-		 * - Policy for when the column is not in the table.
-		 * - Actually remove corresponding cells from table rows.
+		 * - Add overload that takes an ID.
+		 * - Return removed column (if any).
+		 * - Throw an error if the column belongs to a different table.
+		 * - (future) Actually remove corresponding cells from table rows.
 		 */
 		removeColumn: (column: TreeNodeFromImplicitAllowedTypes<TColumn>) => void;
 
 		/**
 		 * Removes 0 or more rows from the table.
-		 * @privateRemarks TODO: policy for when 1 or more rows are not in the table.
+		 * @privateRemarks
+		 * TODO:
+		 * - Add overload that takes an ID.
+		 * - Return removed rows (if any).
+		 * - Throw an error if any row(s) belong to a different table.
 		 */
 		removeRows: (rows: readonly TreeNodeFromImplicitAllowedTypes<TRow>[]) => void;
 
 		/**
 		 * Removes all rows from the table.
+		 * @privateRemarks TODO: Return removed rows (if any).
 		 */
 		removeAllRows: () => void;
 
 		/**
 		 * Removes the cell at the specified location in the table.
-		 * @privateRemarks TODO: add overload that takes column/row nodes?
+		 * @privateRemarks
+		 * TODO:
+		 * - Add overload that takes column/row nodes?
+		 * - Return removed cell (if any)
 		 */
 		removeCell: (key: CellKey) => void;
 	}

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -573,7 +573,6 @@ export namespace System_TableSchema {
 
 			public removeColumn(columnToRemove: ColumnValueType): void {
 				const index = this.columns.indexOf(columnToRemove);
-				// If the column is not in the table, do nothing
 				if (index === -1) {
 					throw new UsageError(
 						`Specified column with ID "${columnToRemove.id}" does not exist in the table.`,

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -20,7 +20,7 @@ import { validateUsageError } from "./utils.js";
 
 const schemaFactory = new SchemaFactoryAlpha("test");
 
-describe.only("TableFactory unit tests", () => {
+describe("TableFactory unit tests", () => {
 	function createTableTree() {
 		class Cell extends schemaFactory.object("table-cell", {
 			value: schemaFactory.string,

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -299,7 +299,7 @@ describe.only("TableFactory unit tests", () => {
 					treeView.root.insertColumn({
 						column: { id: "column-b", props: {} },
 					}),
-				validateUsageError(/Column "column-b" already exists in the table./),
+				validateUsageError(/Column with ID "column-b" already exists in the table./),
 			);
 		});
 	});
@@ -494,7 +494,7 @@ describe.only("TableFactory unit tests", () => {
 							},
 						],
 					}),
-				validateUsageError(/Row "row-a" already exists in the table./),
+				validateUsageError(/Row with ID "row-a" already exists in the table./),
 			);
 		});
 	});
@@ -834,9 +834,7 @@ describe.only("TableFactory unit tests", () => {
 			});
 		});
 
-		// TODO: There is currently no usage error for deleting invalid cells.
-		// Once that work is finished, the usage error in this test should be updated, and the test can be un-skipped.
-		it.skip("removing cell from nonexistent row and column errors", () => {
+		it("removing cell from nonexistent row and column errors", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
 				columns: [
@@ -853,14 +851,25 @@ describe.only("TableFactory unit tests", () => {
 					},
 				],
 			});
-			const invalidCellKey = {
-				rowId: "invalid-row",
-				columnId: "invalid-column",
-			};
 
+			// Invalid row
 			assert.throws(
-				() => treeView.root.removeCell(invalidCellKey),
-				validateUsageError(/Placeholder usage error./),
+				() =>
+					treeView.root.removeCell({
+						rowId: "row-1",
+						columnId: "column-0",
+					}),
+				validateUsageError(/Row with ID "row-1" does not exist in the table./),
+			);
+
+			// Invalid column
+			assert.throws(
+				() =>
+					treeView.root.removeCell({
+						rowId: "row-0",
+						columnId: "column-1",
+					}),
+				validateUsageError(/Column with ID "column-1" does not exist in the table./),
 			);
 		});
 	});

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -20,7 +20,7 @@ import { validateUsageError } from "./utils.js";
 
 const schemaFactory = new SchemaFactoryAlpha("test");
 
-describe("TableFactory unit tests", () => {
+describe.only("TableFactory unit tests", () => {
 	function createTableTree() {
 		class Cell extends schemaFactory.object("table-cell", {
 			value: schemaFactory.string,
@@ -284,9 +284,7 @@ describe("TableFactory unit tests", () => {
 			});
 		});
 
-		// TODO: There is currently no policy from prohibiting insertion of a column that already exists.
-		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
-		it.skip("Appending existing column errors", () => {
+		it("Inserting existing column fails", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
 				rows: [],
@@ -301,7 +299,7 @@ describe("TableFactory unit tests", () => {
 					treeView.root.insertColumn({
 						column: { id: "column-b", props: {} },
 					}),
-				validateUsageError(/Placeholder usage error/),
+				validateUsageError(/Column "column-b" already exists in the table./),
 			);
 		});
 	});
@@ -467,9 +465,7 @@ describe("TableFactory unit tests", () => {
 			});
 		});
 
-		// TODO: There is currently no policy from prohibiting insertion of a row that already exists.
-		// Once that work is finished, the usage error in this test should be updated, and the test can be unskipped.
-		it.skip("Inserting row that already exists fails", () => {
+		it("Inserting existing row fails", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
 				rows: [
@@ -498,7 +494,7 @@ describe("TableFactory unit tests", () => {
 							},
 						],
 					}),
-				validateUsageError(/Placeholder usage error/),
+				validateUsageError(/Row "row-a" already exists in the table./),
 			);
 		});
 	});

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -548,9 +548,7 @@ describe.only("TableFactory unit tests", () => {
 			});
 		});
 
-		// TODO: There is currently no policy from prohibiting insertion of an invalid cell.
-		// Once that work is finished, the usage error in this test should be updated, and the test can be un-skipped.
-		it.skip("setting cell in an invalid location errors", () => {
+		it("setting cell in an invalid location errors", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
 				columns: [
@@ -568,16 +566,30 @@ describe.only("TableFactory unit tests", () => {
 				],
 			});
 
+			// Invalid row
 			assert.throws(
 				() =>
 					treeView.root.setCell({
 						key: {
 							rowId: "row-1",
+							columnId: "column-0",
+						},
+						cell: { value: "Hello world!" },
+					}),
+				validateUsageError(/Row with ID "row-1" does not exist in the table./),
+			);
+
+			// Invalid column
+			assert.throws(
+				() =>
+					treeView.root.setCell({
+						key: {
+							rowId: "row-0",
 							columnId: "column-1",
 						},
 						cell: { value: "Hello world!" },
 					}),
-				validateUsageError(/Placeholder usage error/),
+				validateUsageError(/Column with ID "column-1" does not exist in the table./),
 			);
 		});
 	});


### PR DESCRIPTION
Adds error policies for various table operations (cell/column/row set and remove operations, specifically).

Also...
- Updates `removeCell` methods to return the removed cell (if any)
- adds some TODO comments for future API improvements.