### PR TITLE
AzureClient: Fix test issue

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
@@ -20,7 +20,7 @@ class TestDataObjectClass extends DataObject {
 	public static readonly Name = "@fluid-example/test-data-object";
 
 	public static readonly factory = new DataObjectFactory({
-		type: "TestDataObject",
+		type: TestDataObjectClass.Name,
 		ctor: TestDataObjectClass,
 	});
 


### PR DESCRIPTION
In #24527 a test issue was identified in the AzureClient. The problem was the rename of a string, which shouldn't necessarily matter, but in this case the string is also hard coded in another file: [packages\service-clients\end-to-end-tests\azure-client\src\test\ephemeralSummaryTrees.ts](https://github.com/microsoft/FluidFramework/blob/main/packages/service-clients/end-to-end-tests/azure-client/src/test/ephemeralSummaryTrees.ts)