### PR TITLE
Enable trusted types policy in enforcement mode.

### DIFF
--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
 	"globalHeaders": {
 		"cache-control": "must-revalidate, max-age=3600",
-		"Content-Security-Policy-Report-Only": "require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
+		"Content-Security-Policy": "require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
 	},
 	"navigationFallback": {
 		"rewrite": "/api/fallback"


### PR DESCRIPTION
Enabling this policy in enforcement mode will help us prevent cross-site scripting attacks by enforcing a strong policy that only allows trusted types to be loaded. After testing in our staging environment, no bugs or block functionality was found. 