### PR TITLE
Fix shared-tree-demo app

### DIFF
--- a/examples/service-clients/odsp-client/shared-tree-demo/.env.template
+++ b/examples/service-clients/odsp-client/shared-tree-demo/.env.template
@@ -1,0 +1,6 @@
+
+# If using SharePoint embedded, set these variables.
+SPE_CLIENT_ID=<client-id-of-the-Entra-App-for-SPE>
+SPE_ENTRA_TENANT_ID=<id-of-the-Entra-tenant-where-the-app-registration-lives>
+SITE_URL=<site-url>
+DRIVE_ID=<id-of-the-SPE-container>

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
@@ -13,8 +13,8 @@ export interface OdspTestCredentials {
 }
 
 export const props: OdspTestCredentials = {
-	siteUrl: process.env.SITE_URL,
-	driveId: process.env.DRIVE_ID,
+	siteUrl: process.env.SITE_URL as string,
+	driveId: process.env.DRIVE_ID as string,
 };
 
 const connectionConfig: OdspConnectionConfig = {

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
@@ -10,17 +10,15 @@ import { OdspTestTokenProvider } from "./tokenProvider.js";
 export interface OdspTestCredentials {
 	siteUrl: string;
 	driveId: string;
-	clientId: string;
 }
 
 export const props: OdspTestCredentials = {
 	siteUrl: "<site__url>",
 	driveId: "<drive__id>",
-	clientId: "<client__id>",
 };
 
 const connectionConfig: OdspConnectionConfig = {
-	tokenProvider: new OdspTestTokenProvider(props.clientId),
+	tokenProvider: new OdspTestTokenProvider(),
 	siteUrl: props.siteUrl,
 	driveId: props.driveId,
 	filePath: "",

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
@@ -8,19 +8,22 @@ import { OdspClientProps, OdspConnectionConfig } from "@fluidframework/odsp-clie
 import { OdspTestTokenProvider } from "./tokenProvider.js";
 
 export interface OdspTestCredentials {
-	siteUrl: string;
-	driveId: string;
+	SITE_URL: string;
+	SPE_DRIVE_ID: string;
+	SPE_CLIENT_ID: string;
+	SPE_ENTRA_TENANT_ID: string;
 }
 
-export const props: OdspTestCredentials = {
-	siteUrl: process.env.SITE_URL as string,
-	driveId: process.env.DRIVE_ID as string,
-};
+declare global {
+	const process: {
+		env: OdspTestCredentials;
+	};
+}
 
 const connectionConfig: OdspConnectionConfig = {
 	tokenProvider: new OdspTestTokenProvider(),
-	siteUrl: props.siteUrl,
-	driveId: props.driveId,
+	siteUrl: process.env.SITE_URL,
+	driveId: process.env.SPE_DRIVE_ID,
 	filePath: "",
 };
 

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
@@ -13,8 +13,8 @@ export interface OdspTestCredentials {
 }
 
 export const props: OdspTestCredentials = {
-	siteUrl: "<site__url>",
-	driveId: "<drive__id>",
+	siteUrl: process.env.SITE_URL,
+	driveId: process.env.DRIVE_ID,
 };
 
 const connectionConfig: OdspConnectionConfig = {

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/tokenProvider.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/tokenProvider.ts
@@ -6,17 +6,38 @@
 import { PublicClientApplication } from "@azure/msal-browser";
 import { IOdspTokenProvider, TokenResponse } from "@fluidframework/odsp-client/beta";
 
-export class OdspTestTokenProvider implements IOdspTokenProvider {
-	private readonly msalInstance: PublicClientApplication;
-	constructor(clientId: string) {
-		const msalConfig = {
-			auth: {
-				clientId,
-				authority: "https://login.microsoftonline.com/common/",
-			},
-		};
-		this.msalInstance = new PublicClientApplication(msalConfig);
+// Helper function to authenticate the user
+export async function createMsalInstance(): Promise<PublicClientApplication> {
+	// Get the client id (app id) from the environment variables
+	const clientId = process.env.NEXT_PUBLIC_SPE_CLIENT_ID;
+
+	if (clientId === undefined) {
+		throw new Error("NEXT_PUBLIC_SPE_CLIENT_ID is not defined");
 	}
+
+	const tenantId = process.env.NEXT_PUBLIC_SPE_ENTRA_TENANT_ID;
+	if (tenantId === undefined) {
+		throw new Error("NEXT_PUBLIC_SPE_ENTRA_TENANT_ID is not defined");
+	}
+
+	// Create the MSAL instance
+	const msalConfig = {
+		auth: {
+			clientId,
+			authority: `https://login.microsoftonline.com/${tenantId}/`,
+			tenantId,
+		},
+	};
+
+	// Initialize the MSAL instance
+	const msalInstance = new PublicClientApplication(msalConfig);
+	await msalInstance.initialize();
+
+	return msalInstance;
+}
+
+export class OdspTestTokenProvider implements IOdspTokenProvider {
+	private readonly msalInstance: Promise<PublicClientApplication> = createMsalInstance();
 
 	public async fetchWebsocketToken(siteUrl: string, refresh: boolean): Promise<TokenResponse> {
 		const pushScope = ["offline_access https://pushchannel.1drv.ms/PushChannel.ReadWrite.All"];
@@ -39,13 +60,14 @@ export class OdspTestTokenProvider implements IOdspTokenProvider {
 	}
 
 	private async fetchTokens(scope: string[]): Promise<string> {
-		const accounts = this.msalInstance.getAllAccounts();
+		const msal = await this.msalInstance;
+		const accounts = msal.getAllAccounts();
 		let response;
 
 		if (accounts.length === 0) {
 			try {
 				// This will only work if loginPopup is synchronous, otherwise, you may need to handle the response in a different way
-				response = await this.msalInstance.loginPopup({
+				response = await msal.loginPopup({
 					scopes: ["FileStorageContainer.Selected"],
 				});
 			} catch (error) {
@@ -56,10 +78,10 @@ export class OdspTestTokenProvider implements IOdspTokenProvider {
 		}
 
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-		this.msalInstance.setActiveAccount(response.account);
+		msal.setActiveAccount(response.account);
 
 		try {
-			const result = await this.msalInstance.acquireTokenSilent({ scopes: scope });
+			const result = await msal.acquireTokenSilent({ scopes: scope });
 			return result.accessToken;
 		} catch (error) {
 			throw new Error(`MSAL error: ${error}`);

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/tokenProvider.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/tokenProvider.ts
@@ -9,15 +9,15 @@ import { IOdspTokenProvider, TokenResponse } from "@fluidframework/odsp-client/b
 // Helper function to authenticate the user
 export async function createMsalInstance(): Promise<PublicClientApplication> {
 	// Get the client id (app id) from the environment variables
-	const clientId = process.env.NEXT_PUBLIC_SPE_CLIENT_ID;
+	const clientId = process.env.SPE_CLIENT_ID;
 
 	if (clientId === undefined) {
-		throw new Error("NEXT_PUBLIC_SPE_CLIENT_ID is not defined");
+		throw new Error("SPE_CLIENT_ID is not defined");
 	}
 
-	const tenantId = process.env.NEXT_PUBLIC_SPE_ENTRA_TENANT_ID;
+	const tenantId = process.env.SPE_ENTRA_TENANT_ID;
 	if (tenantId === undefined) {
-		throw new Error("NEXT_PUBLIC_SPE_ENTRA_TENANT_ID is not defined");
+		throw new Error("SPE_ENTRA_TENANT_ID is not defined");
 	}
 
 	// Create the MSAL instance

--- a/examples/service-clients/odsp-client/shared-tree-demo/tsconfig.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
 	"compilerOptions": {
 		"outDir": "./lib",
-		"types": ["react", "react-dom", "node"],
+		"types": ["react", "react-dom"],
 		"exactOptionalPropertyTypes": false,
 	},
 	"include": ["src/**/*", "tests/**/*"],

--- a/examples/service-clients/odsp-client/shared-tree-demo/tsconfig.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
 	"compilerOptions": {
 		"outDir": "./lib",
-		"types": ["react", "react-dom"],
+		"types": ["react", "react-dom", "node"],
 		"exactOptionalPropertyTypes": false,
 	},
 	"include": ["src/**/*", "tests/**/*"],


### PR DESCRIPTION
`shared-tree-demo` app wasn't working with the credentials. To fix this, the authority field in the MSAL configuration is updated to include the tenant ID, following this guidance: https://learn.microsoft.com/en-us/entra/identity-platform/msal-js-initializing-client-applications#initialize-msaljs-2x-apps