### PR TITLE
refactor(tree): Simplify type parameters and fix links in comments in table schema APIs

### DIFF
--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1096,14 +1096,16 @@ export namespace TableSchema {
 		 * @throws Throws an error if any of the rows are not in the table.
 		 * In this case, no rows are removed.
 		 */
-		removeRows(rows: readonly TreeNodeFromImplicitAllowedTypes<TRow>[]): void;
+		removeRows(
+			rows: readonly TreeNodeFromImplicitAllowedTypes<TRow>[],
+		): TreeNodeFromImplicitAllowedTypes<TRow>[];
 		/**
 		 * Removes 0 or more rows from the table.
 		 * @param rows - The rows to remove, specified by their {@link IRow.id}.
 		 * @throws Throws an error if any of the rows are not in the table.
 		 * In this case, no rows are removed.
 		 */
-		removeRows(rows: readonly string[]): void;
+		removeRows(rows: readonly string[]): TreeNodeFromImplicitAllowedTypes<TRow>[];
 
 		/**
 		 * Removes all rows from the table.

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -770,6 +770,10 @@ export namespace System_TableSchema {
 				return this.rows.find((row) => (row as TableSchema.IRow).id === rowId) !== undefined;
 			}
 
+			/**
+			 * Ensure that the specified index is a valid location for item insertion in the destination list.
+			 * @throws Throws a usage error if the destination is invalid.
+			 */
 			private static validateInsertionIndex(
 				index: number,
 				destinationList: readonly unknown[],

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1213,7 +1213,7 @@ export namespace TableSchema {
 
 		/**
 		 * Removes the specified column from the table.
-		 * @param column - The {@link IColumn | column} or {@link IColumn.id | column ID} to remove.
+		 * @param column - The {@link TableSchema.IColumn | column} or {@link TableSchema.IColumn.id | column ID} to remove.
 		 * @remarks Note: this does not remove any cells from the table's rows.
 		 * @throws Throws an error if the column is not in the table.
 		 * @privateRemarks TODO (future): Actually remove corresponding cells from table rows.
@@ -1233,7 +1233,7 @@ export namespace TableSchema {
 		): TreeNodeFromImplicitAllowedTypes<TColumn>[];
 		/**
 		 * Removes 0 or more columns from the table.
-		 * @param columns - The columns to remove, specified by their {@link IColumn.id}.
+		 * @param columns - The columns to remove, specified by their {@link TableSchema.IColumn.id}.
 		 * @throws Throws an error if any of the columns are not in the table.
 		 * In this case, no columns are removed.
 		 */
@@ -1247,7 +1247,7 @@ export namespace TableSchema {
 
 		/**
 		 * Removes the specified row from the table.
-		 * @param row - The {@link IRow | row} or {@link IRow.id | row ID} to remove.
+		 * @param row - The {@link TableSchema.IRow | row} or {@link TableSchema.IRow.id | row ID} to remove.
 		 * @throws Throws an error if the row is not in the table.
 		 */
 		removeRow(
@@ -1265,7 +1265,7 @@ export namespace TableSchema {
 		): TreeNodeFromImplicitAllowedTypes<TRow>[];
 		/**
 		 * Removes 0 or more rows from the table.
-		 * @param rows - The rows to remove, specified by their {@link IRow.id}.
+		 * @param rows - The rows to remove, specified by their {@link TableSchema.IRow.id}.
 		 * @throws Throws an error if any of the rows are not in the table.
 		 * In this case, no rows are removed.
 		 */

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -627,8 +627,10 @@ export namespace System_TableSchema {
 				return column as ColumnValueType;
 			}
 
-			public removeAllColumns(): void {
-				this.columns.removeRange();
+			public removeAllColumns(): ColumnValueType[] {
+				// TypeScript is unable to narrow the row type correctly here, hence the cast.
+				// See: https://github.com/microsoft/TypeScript/issues/52144
+				return this.removeColumns(this.columns as unknown as ColumnValueType[]);
 			}
 
 			public removeRows(rows: readonly string[] | readonly RowValueType[]): RowValueType[] {
@@ -672,8 +674,10 @@ export namespace System_TableSchema {
 				return rowToRemove as RowValueType;
 			}
 
-			public removeAllRows(): void {
-				this.rows.removeRange();
+			public removeAllRows(): RowValueType[] {
+				// TypeScript is unable to narrow the row type correctly here, hence the cast.
+				// See: https://github.com/microsoft/TypeScript/issues/52144
+				return this.removeRows(this.rows as unknown as RowValueType[]);
 			}
 
 			public removeCell(
@@ -1141,9 +1145,9 @@ export namespace TableSchema {
 
 		/**
 		 * Removes all columns from the table.
-		 * @privateRemarks TODO: Return removed columns (if any).
+		 * @returns The removed columns.
 		 */
-		removeAllColumns(): void;
+		removeAllColumns(): TreeNodeFromImplicitAllowedTypes<TColumn>[];
 
 		/**
 		 * Removes the specified row from the table.
@@ -1173,9 +1177,9 @@ export namespace TableSchema {
 
 		/**
 		 * Removes all rows from the table.
-		 * @privateRemarks TODO: Return removed rows (if any).
+		 * @returns The removed rows.
 		 */
-		removeAllRows(): void;
+		removeAllRows(): TreeNodeFromImplicitAllowedTypes<TRow>[];
 
 		/**
 		 * Removes the cell at the specified location in the table.

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -512,14 +512,12 @@ export namespace System_TableSchema {
 
 				// #endregion
 
+				// TypeScript is unable to narrow the column type correctly here, hence the casts below.
+				// See: https://github.com/microsoft/TypeScript/issues/52144
 				if (index === undefined) {
-					// TypeScript is unable to narrow the types correctly here, hence the cast.
-					// See: https://github.com/microsoft/TypeScript/issues/52144
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					this.columns.insertAtEnd(column as any);
 				} else {
-					// TypeScript is unable to narrow the types correctly here, hence the cast.
-					// See: https://github.com/microsoft/TypeScript/issues/52144
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					this.columns.insertAt(index, column as any);
 				}
@@ -548,14 +546,12 @@ export namespace System_TableSchema {
 
 				// #endregion
 
+				// TypeScript is unable to narrow the row type correctly here, hence the casts below.
+				// See: https://github.com/microsoft/TypeScript/issues/52144
 				if (index === undefined) {
-					// TypeScript is unable to narrow the types correctly here, hence the cast.
-					// See: https://github.com/microsoft/TypeScript/issues/52144
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					this.rows.insertAtEnd(TreeArrayNode.spread(rows) as any);
 				} else {
-					// TypeScript is unable to narrow the types correctly here, hence the cast.
-					// See: https://github.com/microsoft/TypeScript/issues/52144
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					this.rows.insertAt(index, TreeArrayNode.spread(rows) as any);
 				}

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1117,7 +1117,6 @@ export namespace TableSchema {
 		 * Removes the cell at the specified location in the table.
 		 * @returns The cell if it exists, otherwise undefined.
 		 * @throws Throws an error if the location does not exist in the table.
-		 * @privateRemarks TODO: Add overload that takes column/row nodes.
 		 */
 		removeCell(key: CellKey): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
 	}

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -780,10 +780,14 @@ export namespace System_TableSchema {
 			): void {
 				if (index < 0) {
 					throw new UsageError("The index must be greater than or equal to 0.");
-				} else if (!Number.isInteger(index)) {
-					throw new UsageError("The index must be an integer.");
-				} else if (index > destinationList.length) {
+				}
+
+				if (index > destinationList.length) {
 					throw new UsageError("The index specified for insertion is out of bounds.");
+				}
+
+				if (!Number.isInteger(index)) {
+					throw new UsageError("The index must be an integer.");
 				}
 			}
 		}

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -32,10 +32,15 @@ import {
 	type UnannotateImplicitFieldSchema,
 } from "./simple-tree/index.js";
 
-// Future improvement TODOs (ideally to be done before promoting these APIs to `@alpha`):
+// Future improvement TODOs:
+// - Omit `cells` property from Row insertion type.
+//     -
 // - Record-like type parameters / input parameters?
 // - Omit `props` properties from Row and Column schemas when not provided?
 
+/**
+ * The sub-scope applied to user-provided {@link SchemaFactory}s by table schema factories.
+ */
 const tableSchemaFactorySubScope = "table";
 
 /**

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -589,14 +589,18 @@ export namespace System_TableSchema {
 				row.setCell(column, cell);
 			}
 
-			public removeColumn(columnToRemove: ColumnValueType): void {
-				const index = this.columns.indexOf(columnToRemove);
+			public removeColumn(columnOrId: string | ColumnValueType): ColumnValueType {
+				const column: ColumnValueType | undefined =
+					typeof columnOrId === "string" ? this.getColumn(columnOrId) : columnOrId;
+				const index = column === undefined ? -1 : this.columns.indexOf(column);
 				if (index === -1) {
+					const columnId = typeof columnOrId === "string" ? columnOrId : columnOrId.id;
 					throw new UsageError(
-						`Specified column with ID "${columnToRemove.id}" does not exist in the table.`,
+						`Specified column with ID "${columnId}" does not exist in the table.`,
 					);
 				}
 				this.columns.removeAt(index);
+				return column as ColumnValueType;
 			}
 
 			public removeRows(rowsToRemove: readonly RowValueType[]): void {
@@ -1065,15 +1069,13 @@ export namespace TableSchema {
 
 		/**
 		 * Removes the specified column from the table.
+		 * @param column - The {@link IColumn | column} or {@link IColumn.id | column ID} to remove.
 		 * @remarks Note: this does not remove any cells from the table's rows.
-		 * @privateRemarks
-		 * TODO:
-		 * - Add overload that takes an ID.
-		 * - Return removed column.
-		 * - Throw an error if the column isn't in the table.
-		 * - (future) Actually remove corresponding cells from table rows.
+		 * @privateRemarks TODO (future): Actually remove corresponding cells from table rows.
 		 */
-		removeColumn(column: TreeNodeFromImplicitAllowedTypes<TColumn>): void;
+		removeColumn(
+			column: string | TreeNodeFromImplicitAllowedTypes<TColumn>,
+		): TreeNodeFromImplicitAllowedTypes<TColumn>;
 
 		/**
 		 * Removes 0 or more rows from the table.

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1084,11 +1084,21 @@ export namespace TableSchema {
 		 * Removes the specified column from the table.
 		 * @param column - The {@link IColumn | column} or {@link IColumn.id | column ID} to remove.
 		 * @remarks Note: this does not remove any cells from the table's rows.
+		 * @throws Throws an error if the column is not in the table.
 		 * @privateRemarks TODO (future): Actually remove corresponding cells from table rows.
 		 */
 		removeColumn(
 			column: string | TreeNodeFromImplicitAllowedTypes<TColumn>,
 		): TreeNodeFromImplicitAllowedTypes<TColumn>;
+
+		/**
+		 * Removes the specified row from the table.
+		 * @param row - The {@link IRow | row} or {@link IRow.id | row ID} to remove.
+		 * @throws Throws an error if the row is not in the table.
+		 */
+		removeRow(
+			row: string | TreeNodeFromImplicitAllowedTypes<TRow>,
+		): TreeNodeFromImplicitAllowedTypes<TRow>;
 
 		/**
 		 * Removes 0 or more rows from the table.

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -514,13 +514,7 @@ export namespace System_TableSchema {
 
 				// Ensure index is valid
 				if (index !== undefined) {
-					if (index < 0) {
-						throw new UsageError("The index must be greater than or equal to 0.");
-					} else if (!Number.isInteger(index)) {
-						throw new UsageError("The index must be an integer.");
-					} else if (index > this.columns.length) {
-						throw new UsageError("The index specified for column insertion is out of bounds.");
-					}
+					Table.validateInsertionIndex(index, this.rows);
 				}
 
 				// Check all of the columns being inserted an ensure the table does not already contain any with the same ID.
@@ -570,13 +564,7 @@ export namespace System_TableSchema {
 
 				// Ensure index is valid
 				if (index !== undefined) {
-					if (index < 0) {
-						throw new UsageError("The index must be greater than or equal to 0.");
-					} else if (!Number.isInteger(index)) {
-						throw new UsageError("The index must be an integer.");
-					} else if (index > this.rows.length) {
-						throw new UsageError("The index specified for row insertion is out of bounds.");
-					}
+					Table.validateInsertionIndex(index, this.rows);
 				}
 
 				// Check all of the rows being inserted an ensure the table does not already contain any with the same ID.
@@ -780,6 +768,19 @@ export namespace System_TableSchema {
 				// TypeScript is unable to narrow the types correctly here, hence the cast.
 				// See: https://github.com/microsoft/TypeScript/issues/52144
 				return this.rows.find((row) => (row as TableSchema.IRow).id === rowId) !== undefined;
+			}
+
+			private static validateInsertionIndex(
+				index: number,
+				destinationList: readonly unknown[],
+			): void {
+				if (index < 0) {
+					throw new UsageError("The index must be greater than or equal to 0.");
+				} else if (!Number.isInteger(index)) {
+					throw new UsageError("The index must be an integer.");
+				} else if (index > destinationList.length) {
+					throw new UsageError("The index specified for insertion is out of bounds.");
+				}
 			}
 		}
 

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -627,6 +627,10 @@ export namespace System_TableSchema {
 				return column as ColumnValueType;
 			}
 
+			public removeAllColumns(): void {
+				this.columns.removeRange();
+			}
+
 			public removeRows(rows: readonly string[] | readonly RowValueType[]): RowValueType[] {
 				// If there are no rows to remove, do nothing
 				if (rows.length === 0) {
@@ -1134,6 +1138,12 @@ export namespace TableSchema {
 		 * In this case, no columns are removed.
 		 */
 		removeColumns(columns: readonly string[]): TreeNodeFromImplicitAllowedTypes<TColumn>[];
+
+		/**
+		 * Removes all columns from the table.
+		 * @privateRemarks TODO: Return removed columns (if any).
+		 */
+		removeAllColumns(): void;
 
 		/**
 		 * Removes the specified row from the table.

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -59,14 +59,12 @@ export namespace System_TableSchema {
 	 * @privateRemarks This interface primarily exists to provide a single home for property documentation.
 	 * @system @internal
 	 */
-	export interface OptionsWithSchemaFactory<
-		TScope extends string | undefined = string | undefined,
-	> {
+	export interface OptionsWithSchemaFactory<TSchemaFactory extends SchemaFactoryAlpha> {
 		/**
 		 * Schema factory with which the Column schema will be associated.
 		 * @remarks Can be used to associate the resulting schema with an existing {@link SchemaFactory.scope|scope}.
 		 */
-		readonly schemaFactory: SchemaFactoryAlpha<TScope>;
+		readonly schemaFactory: TSchemaFactory;
 	}
 
 	/**
@@ -92,8 +90,8 @@ export namespace System_TableSchema {
 	 * @system @internal
 	 */
 	export type CreateColumnOptionsBase<
-		TInputScope extends string | undefined = string | undefined,
-	> = OptionsWithSchemaFactory<TInputScope>;
+		TSchemaFactory extends SchemaFactoryAlpha = SchemaFactoryAlpha,
+	> = OptionsWithSchemaFactory<TSchemaFactory>;
 
 	/**
 	 * Factory for creating new table column schema.
@@ -233,9 +231,9 @@ export namespace System_TableSchema {
 	 * @system @internal
 	 */
 	export type CreateRowOptionsBase<
-		TScope extends string | undefined = string | undefined,
+		TSchemaFactory extends SchemaFactoryAlpha = SchemaFactoryAlpha,
 		TCell extends ImplicitAllowedTypes = ImplicitAllowedTypes,
-	> = OptionsWithSchemaFactory<TScope> & OptionsWithCellSchema<TCell>;
+	> = OptionsWithSchemaFactory<TSchemaFactory> & OptionsWithCellSchema<TCell>;
 
 	/**
 	 * Factory for creating new table row schema.
@@ -412,9 +410,9 @@ export namespace System_TableSchema {
 	 * @system @internal
 	 */
 	export type TableFactoryOptionsBase<
-		TScope extends string | undefined = string | undefined,
+		TSchemaFactory extends SchemaFactoryAlpha = SchemaFactoryAlpha,
 		TCell extends ImplicitAllowedTypes = ImplicitAllowedTypes,
-	> = OptionsWithSchemaFactory<TScope> & OptionsWithCellSchema<TCell>;
+	> = OptionsWithSchemaFactory<TSchemaFactory> & OptionsWithCellSchema<TCell>;
 
 	/**
 	 * Factory for creating new table schema.
@@ -874,7 +872,7 @@ export namespace TableSchema {
 	 */
 	export function createColumn<const TScope extends string | undefined>({
 		schemaFactory,
-	}: System_TableSchema.CreateColumnOptionsBase<TScope>): ReturnType<
+	}: System_TableSchema.CreateColumnOptionsBase<SchemaFactoryAlpha<TScope>>): ReturnType<
 		typeof System_TableSchema.createColumnInternal<
 			TScope,
 			FieldSchema<FieldKind.Optional, typeof SchemaFactoryAlpha.null>
@@ -890,7 +888,7 @@ export namespace TableSchema {
 	>({
 		schemaFactory,
 		props,
-	}: System_TableSchema.CreateColumnOptionsBase<TScope> & {
+	}: System_TableSchema.CreateColumnOptionsBase<SchemaFactoryAlpha<TScope>> & {
 		/**
 		 * Optional column properties.
 		 */
@@ -986,7 +984,7 @@ export namespace TableSchema {
 	>({
 		schemaFactory,
 		cell,
-	}: System_TableSchema.CreateRowOptionsBase<TScope, TCell>): ReturnType<
+	}: System_TableSchema.CreateRowOptionsBase<SchemaFactoryAlpha<TScope>, TCell>): ReturnType<
 		typeof System_TableSchema.createRowInternal<
 			TScope,
 			TCell,
@@ -1005,7 +1003,7 @@ export namespace TableSchema {
 		schemaFactory,
 		cell,
 		props,
-	}: System_TableSchema.CreateRowOptionsBase<TScope, TCell> & {
+	}: System_TableSchema.CreateRowOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
 		/**
 		 * Optional row properties.
 		 */
@@ -1308,9 +1306,10 @@ export namespace TableSchema {
 	>({
 		schemaFactory,
 		cell,
-	}: System_TableSchema.TableFactoryOptionsBase<TScope, TCell>): ReturnType<
-		typeof System_TableSchema.createTableInternal<TScope, TCell>
-	>;
+	}: System_TableSchema.TableFactoryOptionsBase<
+		SchemaFactoryAlpha<TScope>,
+		TCell
+	>): ReturnType<typeof System_TableSchema.createTableInternal<TScope, TCell>>;
 	/**
 	 * Factory for creating new table schema without specifying row schema.
 	 * @internal
@@ -1323,7 +1322,7 @@ export namespace TableSchema {
 		schemaFactory,
 		cell,
 		column,
-	}: System_TableSchema.TableFactoryOptionsBase<TScope, TCell> & {
+	}: System_TableSchema.TableFactoryOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
 		readonly column: TColumn;
 	}): ReturnType<typeof System_TableSchema.createTableInternal<TScope, TCell, TColumn>>;
 	/**
@@ -1340,7 +1339,7 @@ export namespace TableSchema {
 		cell,
 		column,
 		row,
-	}: System_TableSchema.TableFactoryOptionsBase<TScope, TCell> & {
+	}: System_TableSchema.TableFactoryOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
 		readonly column: TColumn;
 		readonly row: TRow;
 	}): ReturnType<typeof System_TableSchema.createTableInternal<TScope, TCell, TColumn, TRow>>;

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -512,6 +512,17 @@ export namespace System_TableSchema {
 			}: TableSchema.InsertColumnsParameters<TColumnSchema>): ColumnValueType[] {
 				// #region Input validation
 
+				// Ensure index is valid
+				if (index !== undefined) {
+					if (index < 0) {
+						throw new UsageError("The index must be greater than or equal to 0.");
+					} else if (!Number.isInteger(index)) {
+						throw new UsageError("The index must be an integer.");
+					} else if (index > this.columns.length) {
+						throw new UsageError("The index specified for column insertion is out of bounds.");
+					}
+				}
+
 				// Check all of the columns being inserted an ensure the table does not already contain any with the same ID.
 				for (const column of columns) {
 					// TypeScript is unable to narrow the type of the column type correctly here, hence the casts below.
@@ -556,6 +567,17 @@ export namespace System_TableSchema {
 				rows,
 			}: TableSchema.InsertRowsParameters<TRowSchema>): RowValueType[] {
 				// #region Input validation
+
+				// Ensure index is valid
+				if (index !== undefined) {
+					if (index < 0) {
+						throw new UsageError("The index must be greater than or equal to 0.");
+					} else if (!Number.isInteger(index)) {
+						throw new UsageError("The index must be an integer.");
+					} else if (index > this.rows.length) {
+						throw new UsageError("The index specified for row insertion is out of bounds.");
+					}
+				}
 
 				// Check all of the rows being inserted an ensure the table does not already contain any with the same ID.
 				for (const newRow of rows) {

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -514,7 +514,7 @@ export namespace System_TableSchema {
 
 				// Ensure index is valid
 				if (index !== undefined) {
-					Table.validateInsertionIndex(index, this.rows);
+					Table.validateInsertionIndex(index, this.columns);
 				}
 
 				// Check all of the columns being inserted an ensure the table does not already contain any with the same ID.

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -73,9 +73,7 @@ export namespace System_TableSchema {
 	 * @privateRemarks This interface primarily exists to provide a single home for property documentation.
 	 * @system @internal
 	 */
-	export interface OptionsWithCellSchema<
-		TCellSchema extends ImplicitAllowedTypes = ImplicitAllowedTypes,
-	> {
+	export interface OptionsWithCellSchema<TCellSchema extends ImplicitAllowedTypes> {
 		/**
 		 * Schema for the table's cells.
 		 */
@@ -593,22 +591,21 @@ export namespace System_TableSchema {
 				return rows as unknown as RowValueType[];
 			}
 
-			public setCell({ key, cell }: TableSchema.SetCellParameters<TCellSchema>): void {
+			public setCell({
+				key,
+				cell,
+			}: TableSchema.SetCellParameters<TCellSchema, TColumnSchema, TRowSchema>): void {
 				const { column: columnOrId, row: rowOrId } = key;
 
-				// TypeScript is unable to narrow the row type correctly here, hence the casts below.
-				// See: https://github.com/microsoft/TypeScript/issues/52144
-				const row = this._getRow(rowOrId as RowValueType | string);
+				const row = this._getRow(rowOrId);
 				if (row === undefined) {
-					const rowId = this._getRowId(rowOrId as RowValueType | string);
+					const rowId = this._getRowId(rowOrId);
 					throw new UsageError(`No row with ID "${rowId}" exists in the table.`);
 				}
 
-				// TypeScript is unable to narrow the column type correctly here, hence the casts below.
-				// See: https://github.com/microsoft/TypeScript/issues/52144
-				const column = this._getColumn(columnOrId as ColumnValueType | string);
+				const column = this._getColumn(columnOrId);
 				if (column === undefined) {
-					const columnId = this._getColumnId(columnOrId as ColumnValueType | string);
+					const columnId = this._getColumnId(columnOrId);
 					throw new UsageError(`No column with ID "${columnId}" exists in the table.`);
 				}
 
@@ -1031,8 +1028,8 @@ export namespace TableSchema {
 	 * @internal
 	 */
 	export interface CellKey<
-		TColumn extends ImplicitAllowedTypes = ImplicitAllowedTypes,
-		TRow extends ImplicitAllowedTypes = ImplicitAllowedTypes,
+		TColumn extends ImplicitAllowedTypes,
+		TRow extends ImplicitAllowedTypes,
 	> {
 		/**
 		 * {@link TableSchema.IColumn} or {@link TableSchema.IColumn.id} at which the cell is located.
@@ -1049,9 +1046,7 @@ export namespace TableSchema {
 	 * {@link TableSchema.ITable.insertColumn} parameters.
 	 * @internal
 	 */
-	export interface InsertColumnParameters<
-		TColumn extends ImplicitAllowedTypes = ImplicitAllowedTypes,
-	> {
+	export interface InsertColumnParameters<TColumn extends ImplicitAllowedTypes> {
 		/**
 		 * The index at which to insert the new column.
 		 * @remarks If not provided, the column will be appended to the end of the table.
@@ -1068,9 +1063,7 @@ export namespace TableSchema {
 	 * {@link TableSchema.ITable.insertColumns} parameters.
 	 * @internal
 	 */
-	export interface InsertColumnsParameters<
-		TColumn extends ImplicitAllowedTypes = ImplicitAllowedTypes,
-	> {
+	export interface InsertColumnsParameters<TColumn extends ImplicitAllowedTypes> {
 		/**
 		 * The index at which to insert the new columns.
 		 * @remarks If not provided, the columns will be appended to the end of the table.
@@ -1087,9 +1080,7 @@ export namespace TableSchema {
 	 * {@link TableSchema.ITable.insertRow} parameters.
 	 * @internal
 	 */
-	export interface InsertRowParameters<
-		TRow extends ImplicitAllowedTypes = ImplicitAllowedTypes,
-	> {
+	export interface InsertRowParameters<TRow extends ImplicitAllowedTypes> {
 		/**
 		 * The index at which to insert the new row.
 		 * @remarks If not provided, the row will be appended to the end of the table.
@@ -1106,9 +1097,7 @@ export namespace TableSchema {
 	 * {@link TableSchema.ITable.insertRows} parameters.
 	 * @internal
 	 */
-	export interface InsertRowsParameters<
-		TRow extends ImplicitAllowedTypes = ImplicitAllowedTypes,
-	> {
+	export interface InsertRowsParameters<TRow extends ImplicitAllowedTypes> {
 		/**
 		 * The index at which to insert the new rows.
 		 * @remarks If not provided, the rows will be appended to the end of the table.
@@ -1126,9 +1115,9 @@ export namespace TableSchema {
 	 * @internal
 	 */
 	export interface SetCellParameters<
-		TCell extends ImplicitAllowedTypes = ImplicitAllowedTypes,
-		TColumn extends ImplicitAllowedTypes = ImplicitAllowedTypes,
-		TRow extends ImplicitAllowedTypes = ImplicitAllowedTypes,
+		TCell extends ImplicitAllowedTypes,
+		TColumn extends ImplicitAllowedTypes,
+		TRow extends ImplicitAllowedTypes,
 	> {
 		/**
 		 * The key to uniquely identify a cell in a table.
@@ -1146,9 +1135,9 @@ export namespace TableSchema {
 	 * @sealed @internal
 	 */
 	export interface ITable<
-		TCell extends ImplicitAllowedTypes = ImplicitAllowedTypes,
-		TColumn extends ImplicitAllowedTypes = ImplicitAllowedTypes,
-		TRow extends ImplicitAllowedTypes = ImplicitAllowedTypes,
+		TCell extends ImplicitAllowedTypes,
+		TColumn extends ImplicitAllowedTypes,
+		TRow extends ImplicitAllowedTypes,
 	> {
 		/**
 		 * The table's columns.
@@ -1293,7 +1282,9 @@ export namespace TableSchema {
 		 * @returns The cell if it exists, otherwise undefined.
 		 * @throws Throws an error if the location does not exist in the table.
 		 */
-		removeCell(key: CellKey): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
+		removeCell(
+			key: CellKey<TColumn, TRow>,
+		): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
 	}
 
 	/**

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -34,7 +34,6 @@ import {
 
 // Future improvement TODOs:
 // - Omit `cells` property from Row insertion type.
-//     -
 // - Record-like type parameters / input parameters?
 // - Omit `props` properties from Row and Column schemas when not provided?
 

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -20,7 +20,7 @@ import { validateUsageError } from "./utils.js";
 
 const schemaFactory = new SchemaFactoryAlpha("test");
 
-describe.only("TableFactory unit tests", () => {
+describe("TableFactory unit tests", () => {
 	function createTableTree() {
 		class Cell extends schemaFactory.object("table-cell", {
 			value: schemaFactory.string,

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -595,7 +595,7 @@ describe.only("TableFactory unit tests", () => {
 	});
 
 	describe("Remove column", () => {
-		it("Remove existing column", () => {
+		it("Remove column by ID", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
 				columns: [
@@ -613,7 +613,46 @@ describe.only("TableFactory unit tests", () => {
 				],
 			});
 
-			treeView.root.removeColumn(treeView.root.columns[0]);
+			const removed = treeView.root.removeColumn("column-0");
+			assertEqualTrees(removed, {
+				id: "column-0",
+				props: { label: "Column 0" },
+			});
+			assertEqualTrees(treeView.root, {
+				columns: [],
+				rows: [
+					{
+						id: "row-0",
+						cells: {},
+						props: {},
+					},
+				],
+			});
+		});
+
+		it("Remove column by node", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({
+				columns: [
+					{
+						id: "column-0",
+						props: { label: "Column 0" },
+					},
+				],
+				rows: [
+					{
+						id: "row-0",
+						cells: {},
+						props: {},
+					},
+				],
+			});
+
+			const removed = treeView.root.removeColumn(treeView.root.columns[0]);
+			assertEqualTrees(removed, {
+				id: "column-0",
+				props: { label: "Column 0" },
+			});
 			assertEqualTrees(treeView.root, {
 				columns: [],
 				rows: [

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -284,6 +284,23 @@ describe.only("TableFactory unit tests", () => {
 			});
 		});
 
+		it("Inserting column at out-of-bounds index fails", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({
+				columns: [],
+				rows: [],
+			});
+
+			assert.throws(
+				() =>
+					treeView.root.insertColumn({
+						index: 1,
+						column: { props: {} },
+					}),
+				validateUsageError(/The index specified for column insertion is out of bounds./),
+			);
+		});
+
 		it("Inserting existing column fails", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
@@ -580,6 +597,23 @@ describe.only("TableFactory unit tests", () => {
 					},
 				],
 			});
+		});
+
+		it("Inserting row at out-of-bounds index fails", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({
+				columns: [],
+				rows: [],
+			});
+
+			assert.throws(
+				() =>
+					treeView.root.insertRow({
+						index: 1,
+						row: { cells: {}, props: {} },
+					}),
+				validateUsageError(/The index specified for row insertion is out of bounds./),
+			);
 		});
 
 		it("Inserting existing row fails", () => {

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -20,7 +20,7 @@ import { validateUsageError } from "./utils.js";
 
 const schemaFactory = new SchemaFactoryAlpha("test");
 
-describe("TableFactory unit tests", () => {
+describe.only("TableFactory unit tests", () => {
 	function createTableTree() {
 		class Cell extends schemaFactory.object("table-cell", {
 			value: schemaFactory.string,
@@ -521,8 +521,8 @@ describe("TableFactory unit tests", () => {
 			// By not specifying an index, the column should be appended to the end of the list.
 			treeView.root.setCell({
 				key: {
-					rowId: "row-0",
-					columnId: "column-0",
+					row: "row-0",
+					column: "column-0",
 				},
 				cell: { value: "Hello world!" },
 			});
@@ -571,8 +571,8 @@ describe("TableFactory unit tests", () => {
 				() =>
 					treeView.root.setCell({
 						key: {
-							rowId: "row-1",
-							columnId: "column-0",
+							row: "row-1",
+							column: "column-0",
 						},
 						cell: { value: "Hello world!" },
 					}),
@@ -584,8 +584,8 @@ describe("TableFactory unit tests", () => {
 				() =>
 					treeView.root.setCell({
 						key: {
-							rowId: "row-0",
-							columnId: "column-1",
+							row: "row-0",
+							column: "column-1",
 						},
 						cell: { value: "Hello world!" },
 					}),
@@ -768,8 +768,8 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 			const cellKey = {
-				rowId: "row-0",
-				columnId: "column-0",
+				row: "row-0",
+				column: "column-0",
 			};
 			treeView.root.setCell({
 				key: cellKey,
@@ -811,8 +811,8 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 			const cellKey = {
-				rowId: "row-0",
-				columnId: "column-0",
+				row: "row-0",
+				column: "column-0",
 			};
 			treeView.root.removeCell(cellKey);
 			assertEqualTrees(treeView.root, {
@@ -854,8 +854,8 @@ describe("TableFactory unit tests", () => {
 			assert.throws(
 				() =>
 					treeView.root.removeCell({
-						rowId: "row-1",
-						columnId: "column-0",
+						row: "row-1",
+						column: "column-0",
 					}),
 				validateUsageError(/Specified row with ID "row-1" does not exist in the table./),
 			);
@@ -864,8 +864,8 @@ describe("TableFactory unit tests", () => {
 			assert.throws(
 				() =>
 					treeView.root.removeCell({
-						rowId: "row-0",
-						columnId: "column-1",
+						row: "row-0",
+						column: "column-1",
 					}),
 				validateUsageError(/Specified column with ID "column-1" does not exist in the table./),
 			);
@@ -884,7 +884,7 @@ describe("TableFactory unit tests", () => {
 			rows: [row0],
 		});
 
-		const cell = treeView.root.getCell({ columnId: "column-0", rowId: "row-0" });
+		const cell = treeView.root.getCell({ column: "column-0", row: "row-0" });
 		const column = treeView.root.getColumn("column-0");
 		const row = treeView.root.getRow("row-0");
 

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -20,7 +20,7 @@ import { validateUsageError } from "./utils.js";
 
 const schemaFactory = new SchemaFactoryAlpha("test");
 
-describe("TableFactory unit tests", () => {
+describe.only("TableFactory unit tests", () => {
 	function createTableTree() {
 		class Cell extends schemaFactory.object("table-cell", {
 			value: schemaFactory.string,
@@ -304,6 +304,188 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
+	describe("insertColumns", () => {
+		it("Insert empty columns list", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({ rows: [], columns: [] });
+
+			treeView.root.insertColumns({ index: 0, columns: [] });
+
+			assertEqualTrees(treeView.root, {
+				columns: [],
+				rows: [],
+			});
+		});
+
+		it("Insert single column into empty list", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({ rows: [], columns: [] });
+
+			treeView.root.insertColumns({
+				index: 0,
+				columns: [
+					{
+						id: "column-0",
+						props: {},
+					},
+				],
+			});
+
+			assertEqualTrees(treeView.root, {
+				columns: [
+					{
+						id: "column-0",
+						props: {},
+					},
+				],
+				rows: [],
+			});
+		});
+
+		it("Insert columns into non-empty list", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({
+				columns: [
+					{
+						id: "column-a",
+						props: {},
+					},
+					{
+						id: "column-b",
+						props: {},
+					},
+				],
+				rows: [],
+			});
+
+			treeView.root.insertColumns({
+				index: 1,
+				columns: [
+					{
+						id: "column-c",
+						props: {},
+					},
+					{
+						id: "column-d",
+						props: {},
+					},
+				],
+			});
+
+			assertEqualTrees(treeView.root, {
+				columns: [
+					{
+						id: "column-a",
+						props: {},
+					},
+					{
+						id: "column-c",
+						props: {},
+					},
+					{
+						id: "column-d",
+						props: {},
+					},
+					{
+						id: "column-b",
+						props: {},
+					},
+				],
+				rows: [],
+			});
+		});
+
+		it("Append columns", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({
+				columns: [
+					{
+						id: "column-a",
+						props: {},
+					},
+					{
+						id: "column-b",
+						props: {},
+					},
+				],
+				rows: [],
+			});
+
+			treeView.root.insertColumns({
+				columns: [
+					{
+						id: "column-c",
+						props: {},
+					},
+					{
+						id: "column-d",
+						props: {},
+					},
+				],
+			});
+
+			assertEqualTrees(treeView.root, {
+				columns: [
+					{
+						id: "column-a",
+						props: {},
+					},
+					{
+						id: "column-b",
+						props: {},
+					},
+					{
+						id: "column-c",
+						props: {},
+					},
+					{
+						id: "column-d",
+						props: {},
+					},
+				],
+				rows: [],
+			});
+		});
+
+		it("Inserting existing column fails", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({
+				columns: [
+					{
+						id: "column-a",
+						props: {},
+					},
+					{
+						id: "column-b",
+						props: {},
+					},
+				],
+				rows: [],
+			});
+
+			assert.throws(
+				() =>
+					treeView.root.insertColumns({
+						columns: [
+							{
+								id: "column-c",
+								props: {},
+							},
+							{
+								// A column with this ID already exists in the table
+								id: "column-a",
+								props: {},
+							},
+						],
+					}),
+				validateUsageError(/A column with ID "column-a" already exists in the table./),
+			);
+
+			// Ensure no columns were inserted
+			assert(treeView.root.columns.length === 2);
+		});
+	});
+
 	describe("insertRows", () => {
 		it("Insert empty rows list", () => {
 			const { treeView } = createTableTree();
@@ -488,6 +670,12 @@ describe("TableFactory unit tests", () => {
 					treeView.root.insertRows({
 						rows: [
 							{
+								id: "row-c",
+								cells: {},
+								props: {},
+							},
+							{
+								// A row with this ID already exists in the table
 								id: "row-a",
 								cells: {},
 								props: {},
@@ -496,6 +684,9 @@ describe("TableFactory unit tests", () => {
 					}),
 				validateUsageError(/A row with ID "row-a" already exists in the table./),
 			);
+
+			// Ensure no rows were inserted
+			assert(treeView.root.rows.length === 2);
 		});
 	});
 

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -297,7 +297,7 @@ describe("TableFactory unit tests", () => {
 						index: 1,
 						column: { props: {} },
 					}),
-				validateUsageError(/The index specified for column insertion is out of bounds./),
+				validateUsageError(/The index specified for insertion is out of bounds./),
 			);
 		});
 
@@ -612,7 +612,7 @@ describe("TableFactory unit tests", () => {
 						index: 1,
 						row: { cells: {}, props: {} },
 					}),
-				validateUsageError(/The index specified for row insertion is out of bounds./),
+				validateUsageError(/The index specified for insertion is out of bounds./),
 			);
 		});
 

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -195,7 +195,7 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("Insert column", () => {
+	describe("insertColumn", () => {
 		it("Insert new column into empty list", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({ rows: [], columns: [] });
@@ -304,7 +304,7 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("Insert rows", () => {
+	describe("insertRows", () => {
 		it("Insert empty rows list", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({ rows: [], columns: [] });
@@ -499,7 +499,7 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("Set cell", () => {
+	describe("setCell", () => {
 		it("Set cell in a valid location", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
@@ -594,7 +594,7 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("Remove column", () => {
+	describe("removeColumn", () => {
 		it("Remove column by ID", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
@@ -681,7 +681,7 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("Remove rows", () => {
+	describe("removeRows", () => {
 		it("Remove empty list", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({
@@ -788,7 +788,7 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("Remove cell", () => {
+	describe("removeCell", () => {
 		it("Remove cell in valid location with existing data", () => {
 			const { treeView } = createTableTree();
 			treeView.initialize({

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -486,6 +486,122 @@ describe.only("TableFactory unit tests", () => {
 		});
 	});
 
+	describe("insertRow", () => {
+		it("Insert new row into empty list", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({ rows: [], columns: [] });
+
+			treeView.root.insertRow({
+				index: 0,
+				row: { id: "row-0", cells: {}, props: {} },
+			});
+
+			assertEqualTrees(treeView.root, {
+				columns: [],
+				rows: [
+					{
+						id: "row-0",
+						cells: {},
+						props: {},
+					},
+				],
+			});
+		});
+
+		it("Insert new row into non-empty list", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({
+				columns: [],
+				rows: [
+					{ id: "row-a", cells: {}, props: {} },
+					{ id: "row-b", cells: {}, props: {} },
+				],
+			});
+
+			treeView.root.insertRow({
+				index: 1,
+				row: { id: "row-c", cells: {}, props: {} },
+			});
+
+			assertEqualTrees(treeView.root, {
+				columns: [],
+				rows: [
+					{
+						id: "row-a",
+						cells: {},
+						props: {},
+					},
+					{
+						id: "row-c",
+						cells: {},
+						props: {},
+					},
+					{
+						id: "row-b",
+						cells: {},
+						props: {},
+					},
+				],
+			});
+		});
+
+		it("Append new row", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({
+				columns: [],
+				rows: [
+					{ id: "row-a", cells: {}, props: {} },
+					{ id: "row-b", cells: {}, props: {} },
+				],
+			});
+
+			// By not specifying an index, the column should be appended to the end of the list.
+			treeView.root.insertRow({
+				row: { id: "row-c", cells: {}, props: {} },
+			});
+
+			assertEqualTrees(treeView.root, {
+				columns: [],
+				rows: [
+					{
+						id: "row-a",
+						cells: {},
+						props: {},
+					},
+					{
+						id: "row-b",
+						cells: {},
+						props: {},
+					},
+					{
+						id: "row-c",
+						cells: {},
+						props: {},
+					},
+				],
+			});
+		});
+
+		it("Inserting existing row fails", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({
+				columns: [],
+				rows: [
+					{ id: "row-a", cells: {}, props: {} },
+					{ id: "row-b", cells: {}, props: {} },
+				],
+			});
+
+			assert.throws(
+				() =>
+					treeView.root.insertRow({
+						row: { id: "row-b", cells: {}, props: {} },
+					}),
+				validateUsageError(/A row with ID "row-b" already exists in the table./),
+			);
+		});
+	});
+
 	describe("insertRows", () => {
 		it("Insert empty rows list", () => {
 			const { treeView } = createTableTree();


### PR DESCRIPTION
Simplifies generic type parameters in the table schema APIs, and removes defaults where possible (which caught a couple of type bugs).

Also fixes some broken `{@link }`s in doc comments.