### PR TITLE
improvement(tree): Table row insertion APIs now error if they contains cells with no matching column

### DIFF
--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1184,7 +1184,12 @@ export namespace TableSchema {
 		 * Inserts a column into the table.
 		 *
 		 * @throws
-		 * Throws an error if the column is already in the tree, or if the specified index is out of range.
+		 * Throws an error in the following cases:
+		 *
+		 * - The column, or a column with the same ID is already in the tree.
+		 *
+		 * - The specified index is out of range.
+		 *
 		 * No column is inserted in these cases.
 		 */
 		insertColumn(
@@ -1195,7 +1200,12 @@ export namespace TableSchema {
 		 * Inserts 0 or more columns into the table.
 		 *
 		 * @throws
-		 * Throws an error if any of the columns are already in the tree, or if the specified index is out of range.
+		 * Throws an error in the following cases:
+		 *
+		 * - At least one column, or a column with the same ID is already in the tree.
+		 *
+		 * - The specified index is out of range.
+		 *
 		 * No columns are inserted in these cases.
 		 */
 		insertColumns(
@@ -1203,11 +1213,18 @@ export namespace TableSchema {
 		): TreeNodeFromImplicitAllowedTypes<TColumn>[];
 
 		/**
-		 * Inserts a column into the table.
+		 * Inserts a row into the table.
 		 *
 		 * @throws
-		 * Throws an error if the column is already in the tree, or if the specified index is out of range.
-		 * No column is inserted in these cases.
+		 * Throws an error in the following cases:
+		 *
+		 * - The row, or a row with the same ID is already in the tree.
+		 *
+		 * - The row contains cells, but the table does not contain matching columns for one or more of those cells.
+		 *
+		 * - The specified index is out of range.
+		 *
+		 * No row is inserted in these cases.
 		 */
 		insertRow(params: InsertRowParameters<TRow>): TreeNodeFromImplicitAllowedTypes<TRow>;
 
@@ -1215,7 +1232,14 @@ export namespace TableSchema {
 		 * Inserts 0 or more rows into the table.
 		 *
 		 * @throws
-		 * Throws an error if any of the rows are already in the tree, or if the specified index is out of range.
+		 * Throws an error in the following cases:
+		 *
+		 * - At least one row, or a row with the same ID is already in the tree.
+		 *
+		 * - The row contains cells, but the table does not contain matching columns for one or more of those cells.
+		 *
+		 * - The specified index is out of range.
+		 *
 		 * No rows are inserted in these cases.
 		 */
 		insertRows(params: InsertRowsParameters<TRow>): TreeNodeFromImplicitAllowedTypes<TRow>[];

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -20,7 +20,7 @@ import { validateUsageError } from "./utils.js";
 
 const schemaFactory = new SchemaFactoryAlpha("test");
 
-describe.only("TableFactory unit tests", () => {
+describe("TableFactory unit tests", () => {
 	function createTableTree() {
 		class Cell extends schemaFactory.object("table-cell", {
 			value: schemaFactory.string,

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -20,7 +20,7 @@ import { validateUsageError } from "./utils.js";
 
 const schemaFactory = new SchemaFactoryAlpha("test");
 
-describe("TableFactory unit tests", () => {
+describe.only("TableFactory unit tests", () => {
 	function createTableTree() {
 		class Cell extends schemaFactory.object("table-cell", {
 			value: schemaFactory.string,
@@ -633,6 +633,33 @@ describe("TableFactory unit tests", () => {
 					}),
 				validateUsageError(/A row with ID "row-b" already exists in the table./),
 			);
+		});
+
+		it("Inserting a row with cells that have no matching column fails", () => {
+			const { treeView } = createTableTree();
+			treeView.initialize({
+				rows: [],
+				columns: [{ id: "column-a", props: {} }],
+			});
+
+			assert.throws(
+				() =>
+					treeView.root.insertRow({
+						row: {
+							id: "row-a",
+							cells: {
+								"column-a": { value: "Hello" },
+								"column-b": { value: "world!" },
+							},
+						},
+					}),
+				validateUsageError(
+					/Attempted to insert row a cell under column ID "column-b", but the table does not contain a column with that ID./,
+				),
+			);
+
+			// Ensure the row was not inserted
+			assert(treeView.root.rows.length === 0);
 		});
 	});
 


### PR DESCRIPTION
Updates `insertRow` and `insertRows` to throw if one or more rows contains any cells for which the specified column does not exist in the table.

Also updates corresponding API docs, as well as the docs for `insertColumn` and `insertColumns` to make the error cases clearer.