### PR TITLE
fix(server): NexusSessionResult timestamp and duration bugs

### DIFF
--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -48,6 +48,24 @@ services:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules
     restart: on-failure
+  nexus2:
+    platform: linux/amd64
+    build:
+      context: ./routerlicious
+      target: runner
+      additional_contexts:
+        root: ..
+    expose:
+      - "3000"
+    command: node packages/routerlicious/dist/nexus/www.js
+    environment:
+      - DEBUG=fluid:*
+      - NODE_ENV=development
+      - IS_FLUID_SERVER=true
+    volumes:
+      - ./routerlicious:/usr/src/server
+      - /usr/src/server/node_modules
+    restart: on-failure
   deli:
     platform: linux/amd64
     build:

--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -48,24 +48,26 @@ services:
       - ./routerlicious:/usr/src/server
       - /usr/src/server/node_modules
     restart: on-failure
-  nexus2:
-    platform: linux/amd64
-    build:
-      context: ./routerlicious
-      target: runner
-      additional_contexts:
-        root: ..
-    expose:
-      - "3000"
-    command: node packages/routerlicious/dist/nexus/www.js
-    environment:
-      - DEBUG=fluid:*
-      - NODE_ENV=development
-      - IS_FLUID_SERVER=true
-    volumes:
-      - ./routerlicious:/usr/src/server
-      - /usr/src/server/node_modules
-    restart: on-failure
+  # Uncomment to enable 2 Nexus instances
+  # Uncomment the matching line in server/routerlicious/nginx.conf
+  # nexus2:
+  #   platform: linux/amd64
+  #   build:
+  #     context: ./routerlicious
+  #     target: runner
+  #     additional_contexts:
+  #       root: ..
+  #   expose:
+  #     - "3000"
+  #   command: node packages/routerlicious/dist/nexus/www.js
+  #   environment:
+  #     - DEBUG=fluid:*
+  #     - NODE_ENV=development
+  #     - IS_FLUID_SERVER=true
+  #   volumes:
+  #     - ./routerlicious:/usr/src/server
+  #     - /usr/src/server/node_modules
+  #   restart: on-failure
   deli:
     platform: linux/amd64
     build:

--- a/server/routerlicious/nginx.conf
+++ b/server/routerlicious/nginx.conf
@@ -15,6 +15,7 @@ http {
 
     upstream docker-nexus {
         server nexus:3000;
+        server nexus2:3000;
     }
 
     upstream docker-historian {

--- a/server/routerlicious/nginx.conf
+++ b/server/routerlicious/nginx.conf
@@ -15,7 +15,9 @@ http {
 
     upstream docker-nexus {
         server nexus:3000;
-        server nexus2:3000;
+        # Uncomment to enable 2 Nexus instances
+        # Uncomment the matching server instance in server/docker-compose.dev.yml
+        # server nexus2:3000;
     }
 
     upstream docker-historian {

--- a/server/routerlicious/packages/lambdas/src/nexus/connect.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/connect.ts
@@ -302,13 +302,14 @@ function trackCollaborationSession(
 	tenantId: string,
 	documentId: string,
 	connectedClients: ISignalClient[],
+	connectedTimestamp: number,
 	{ collaborationSessionTracker }: INexusLambdaDependencies,
 ): void {
 	// Track the collaboration session for this connection
 	if (collaborationSessionTracker) {
 		const sessionClient: ICollaborationSessionClient = {
 			clientId,
-			joinedTime: clientDetails.timestamp ?? Date.now(),
+			joinedTime: connectedTimestamp,
 			isWriteClient,
 			isSummarizerClient: isSummarizer(clientDetails.details),
 		};
@@ -738,6 +739,7 @@ export async function connectDocument(
 			tenantId,
 			documentId,
 			clients,
+			connectedTimestamp,
 			lambdaDependencies,
 		);
 

--- a/server/routerlicious/packages/lambdas/src/nexus/disconnect.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/disconnect.ts
@@ -125,13 +125,11 @@ function removeClientAndSendNotifications(
 		// Update session tracker upon disconnection
 		if (collaborationSessionTracker) {
 			const client = clientMap.get(clientId);
-			const connectionTimestamp = connectionTimeMap.get(clientId);
 			if (client) {
 				collaborationSessionTracker
 					.endClientSession(
 						{
 							clientId,
-							joinedTime: connectionTimestamp ?? 0,
 							isSummarizerClient: isSummarizer(client.details),
 							isWriteClient: isWriter(client.scopes, client.mode),
 						},

--- a/server/routerlicious/packages/services-core/src/collabSession.ts
+++ b/server/routerlicious/packages/services-core/src/collabSession.ts
@@ -75,6 +75,14 @@ export interface ICollaborationSession {
 	 */
 	firstClientJoinTime: number;
 	/**
+	 * Time when the most recent client joined the session.
+	 *
+	 * @remarks
+	 * Use this value to determine if/when a session should expire.
+	 * Possibly undefined for backwards compatibility.
+	 */
+	latestClientJoinTime: number | undefined;
+	/**
 	 * Time when the last client left the session.
 	 * Undefined if the session is still active and the last client has not left
 	 * or a new client re-joined the session before it expired.
@@ -165,7 +173,7 @@ export interface ICollaborationSessionTracker {
 	 * @param otherConnectedClients - Optional list of other clients currently connected to the document session.
 	 */
 	endClientSession(
-		client: ICollaborationSessionClient,
+		client: Omit<ICollaborationSessionClient, "joinedTime">,
 		sessionId: Pick<ICollaborationSession, "tenantId" | "documentId">,
 		knownConnectedClients?: ISignalClient[],
 	): Promise<void>;

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -80,7 +80,8 @@
 	"typeValidation": {
 		"broken": {
 			"Class_Lumber": {
-				"backCompat": false
+				"backCompat": false,
+				"forwardCompat": false
 			},
 			"Enum_BaseTelemetryProperties": {
 				"backCompat": false

--- a/server/routerlicious/packages/services-telemetry/src/lumber.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumber.ts
@@ -34,7 +34,8 @@ export class Lumber<T extends string = LumberEventName> {
 	private _exception?: Error;
 	private _logLevel?: LogLevel;
 	private _completed = false;
-	public readonly timestamp = Date.now();
+	private _timestamp = Date.now();
+	public readonly timestamp = this._timestamp;
 	public readonly id = uuid();
 
 	public get properties(): Map<string, any> {
@@ -101,6 +102,17 @@ export class Lumber<T extends string = LumberEventName> {
 			});
 		}
 		return this;
+	}
+
+	/**
+	 * Overrides the timestamp of the telemetry event.
+	 * @param msSinceEpoch - The timestamp in milliseconds since the epoch (1970-01-01T00:00:00Z), i.e. `Date.now()`
+	 * @remarks
+	 * This is useful when a Metric's start time needs to be set retroactively, such as when an event's duration is
+	 * tracked across several service instances, then logged in a single instance where the event may not have started.
+	 */
+	public overrideTimestamp(msSinceEpoch: number): void {
+		this._timestamp = msSinceEpoch;
 	}
 
 	public success(message: string, logLevel: LogLevel = LogLevel.Info) {

--- a/server/routerlicious/packages/services-telemetry/src/lumber.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumber.ts
@@ -35,7 +35,9 @@ export class Lumber<T extends string = LumberEventName> {
 	private _logLevel?: LogLevel;
 	private _completed = false;
 	private _timestamp = Date.now();
-	public readonly timestamp = this._timestamp;
+	public get timestamp(): number {
+		return this._timestamp;
+	}
 	public readonly id = uuid();
 
 	public get properties(): Map<string, any> {

--- a/server/routerlicious/packages/services-telemetry/src/test/types/validateServerServicesTelemetryPrevious.generated.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/types/validateServerServicesTelemetryPrevious.generated.ts
@@ -94,6 +94,7 @@ declare type current_as_old_for_Class_LambdaSchemaValidator = requireAssignableT
  * typeValidation.broken:
  * "Class_Lumber": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_Lumber = requireAssignableTo<TypeOnly<old.Lumber>, TypeOnly<current.Lumber>>
 
 /*

--- a/server/routerlicious/packages/services/src/redisSessionManager.ts
+++ b/server/routerlicious/packages/services/src/redisSessionManager.ts
@@ -25,6 +25,10 @@ interface IShortCollaborationSession {
 	 */
 	fjt: number;
 	/**
+	 * {@link ICollaborationSession.latestClientJoinTime}
+	 */
+	ljt: number | undefined;
+	/**
 	 * {@link ICollaborationSession.lastClientLeaveTime}
 	 */
 	llt: number | undefined;
@@ -157,6 +161,7 @@ export class RedisCollaborationSessionManager implements ICollaborationSessionMa
 		return {
 			fjt: session.firstClientJoinTime,
 			llt: session.lastClientLeaveTime,
+			ljt: session.latestClientJoinTime,
 			tp: {
 				hwc: session.telemetryProperties.hadWriteClient,
 				tlj: session.telemetryProperties.totalClientsJoined,
@@ -172,6 +177,7 @@ export class RedisCollaborationSessionManager implements ICollaborationSessionMa
 		return {
 			...this.getTenantIdDocumentIdFromFieldKey(fieldKey),
 			firstClientJoinTime: shortSession.fjt,
+			latestClientJoinTime: shortSession.ljt,
 			lastClientLeaveTime: shortSession.llt,
 			telemetryProperties: {
 				hadWriteClient: shortSession.tp.hwc,

--- a/server/routerlicious/packages/services/src/sessionTracker.ts
+++ b/server/routerlicious/packages/services/src/sessionTracker.ts
@@ -99,6 +99,7 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 			tenantId: existingSession?.tenantId ?? sessionId.tenantId,
 			documentId: existingSession?.documentId ?? sessionId.documentId,
 			firstClientJoinTime: existingSession?.firstClientJoinTime ?? client.joinedTime,
+			latestClientJoinTime: client.joinedTime,
 			lastClientLeaveTime: undefined,
 			telemetryProperties: {
 				hadWriteClient:
@@ -195,19 +196,38 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 		});
 	}
 
+	private isSessionExpired(session: ICollaborationSession, timeoutBuffer = 0): boolean {
+		const now = Date.now();
+		if (session.lastClientLeaveTime === undefined) {
+			// Session has not ended yet, so it can't be expired
+			return false;
+		}
+		if (now - session.lastClientLeaveTime <= this.sessionActivityTimeoutMs + timeoutBuffer) {
+			// Session has not been inactive long enough to be expired
+			return false;
+		}
+		if (session.latestClientJoinTime !== undefined) {
+			if (
+				session.latestClientJoinTime > session.lastClientLeaveTime ||
+				now - session.latestClientJoinTime <= this.sessionActivityTimeoutMs + timeoutBuffer
+			) {
+				// Session has been rejoined since the last client leave, so it can't be expired.
+				// This can happen if a client rejoins before the session end timer expires, but
+				// the session end timer is not cleared on this instance due to the new client
+				// being on a different instance.
+				return false;
+			}
+		}
+		return true;
+	}
+
 	private async pruneInactiveSessionsCore(): Promise<void> {
 		const allSessions = await this.sessionManager.getAllSessions();
-		const now = Date.now();
 		// Add a buffer to the session activity timeout to prevent pruning sessions that are already
 		// being closed or have just been closed normally.
-		const inactiveSessionPruningBuffer = Math.round(1.1 * this.sessionActivityTimeoutMs);
-		const inactiveSessionsToPrune = allSessions.filter(
-			(session) =>
-				// Check if the session has ended due to inactivity
-				session.lastClientLeaveTime !== undefined &&
-				// Check if the session has been inactive for longer than the timeout + buffer
-				now - session.lastClientLeaveTime >
-					this.sessionActivityTimeoutMs + inactiveSessionPruningBuffer,
+		const inactiveSessionPruningBuffer = Math.round(0.1 * this.sessionActivityTimeoutMs);
+		const inactiveSessionsToPrune = allSessions.filter((session) =>
+			this.isSessionExpired(session, inactiveSessionPruningBuffer),
 		);
 		const clientSessionTimeoutPs: Promise<void>[] = inactiveSessionsToPrune.map(
 			async (session) =>
@@ -231,7 +251,7 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 	}
 
 	private async getSessionAndClients(
-		client: ICollaborationSessionClient,
+		client: Pick<ICollaborationSessionClient, "clientId">,
 		sessionId: Pick<ICollaborationSession, "tenantId" | "documentId">,
 		knownConnectedClients?: ISignalClient[],
 	): Promise<{
@@ -250,6 +270,36 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 		session: ICollaborationSession,
 		reason = "inactivity",
 	): Promise<void> {
+		const connectedClientsAfterTimeout = await this.clientManager.getClients(
+			session.tenantId,
+			session.documentId,
+		);
+		if (connectedClientsAfterTimeout.length > 0) {
+			// If there are still clients connected, don't end the session.
+			// This can happen if the session end timer expires but a client reconnects before the session is ended.
+			// When that happens on a different or new Nexus instance, the session end timer is not cleared.
+			Lumberjack.verbose("Session end timer expired but clients are still connected", {
+				...getLumberBaseProperties(session.documentId, session.tenantId),
+				...session.telemetryProperties,
+				numConnectedClients: connectedClientsAfterTimeout.length,
+			});
+			return;
+		}
+		const latestSessionInformation = await this.sessionManager.getSession({
+			tenantId: session.tenantId,
+			documentId: session.documentId,
+		});
+		if (latestSessionInformation !== undefined && this.isSessionExpired(session)) {
+			// Session information on this instance is stale, so don't end the session.
+			Lumberjack.verbose("Session end timer expired but session is still active", {
+				...getLumberBaseProperties(session.documentId, session.tenantId),
+				...latestSessionInformation.telemetryProperties,
+				lastClientLeaveTime: latestSessionInformation.lastClientLeaveTime,
+				latestClientJoinTime: latestSessionInformation.latestClientJoinTime,
+				numConnectedClients: connectedClientsAfterTimeout.length,
+			});
+		}
+		// Session end timer expired and no clients are connected, so end the session.
 		const now = Date.now();
 		const sessionDurationInMs = now - session.firstClientJoinTime;
 		const metric = Lumberjack.newLumberMetric(LumberEventName.NexusSessionResult, {
@@ -268,6 +318,9 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 					: undefined,
 			...session.telemetryProperties,
 		});
+		// The lumber metric is created at the end of the session, so "timestamp" is the end time, rather than the usual "start time".
+		// Override the timestamp to be the start time of the session.
+		metric.overrideTimestamp(session.firstClientJoinTime);
 
 		// For now, always a "success" result
 		metric.success(`Session ended due to ${reason}`);

--- a/server/routerlicious/packages/services/src/sessionTracker.ts
+++ b/server/routerlicious/packages/services/src/sessionTracker.ts
@@ -150,13 +150,18 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 			sessionId,
 			knownConnectedClients,
 		);
-		if (!existingSession) {
-			throw new Error("Existing session not found in endClientSessionCore");
-		}
 
 		// Clear the session end timer if it exists. This shouldn't be necessary if the timer is
 		// properly cleared when the last client reconnects, but this is a safety measure.
 		clearTimeout(this.sessionEndTimers.get(sessionTimerKey));
+		if (!existingSession) {
+			// Session doesn't exist, so we can't end it.
+			Lumberjack.verbose("Session not found in endClientSessionCore", {
+				...getLumberBaseProperties(sessionId.documentId, sessionId.tenantId),
+				numConnectedClients: knownConnectedClients?.length,
+			});
+			return;
+		}
 		if (otherConnectedClients.length === 0) {
 			// Start a timer to end the session after a period of inactivity
 			const timer = setTimeout(() => {

--- a/server/routerlicious/packages/services/src/sessionTracker.ts
+++ b/server/routerlicious/packages/services/src/sessionTracker.ts
@@ -303,6 +303,7 @@ export class CollaborationSessionTracker implements ICollaborationSessionTracker
 				latestClientJoinTime: latestSessionInformation.latestClientJoinTime,
 				numConnectedClients: connectedClientsAfterTimeout.length,
 			});
+			return;
 		}
 		// Session end timer expired and no clients are connected, so end the session.
 		const now = Date.now();

--- a/server/routerlicious/packages/services/src/test/redisSessionManager.spec.ts
+++ b/server/routerlicious/packages/services/src/test/redisSessionManager.spec.ts
@@ -33,6 +33,7 @@ describe("RedisCollaborationSessionManager", () => {
 			documentId: "test-doc-id",
 			tenantId: "test-tenant-id",
 			firstClientJoinTime: Date.now(),
+			latestClientJoinTime: Date.now(),
 			lastClientLeaveTime: undefined,
 			telemetryProperties: {
 				hadWriteClient: true,
@@ -58,6 +59,7 @@ describe("RedisCollaborationSessionManager", () => {
 			documentId: "test-doc-id",
 			tenantId: "test-tenant-id",
 			firstClientJoinTime: Date.now(),
+			latestClientJoinTime: Date.now(),
 			lastClientLeaveTime: undefined,
 			telemetryProperties: {
 				hadWriteClient: false,
@@ -103,6 +105,7 @@ describe("RedisCollaborationSessionManager", () => {
 			documentId: "test-doc-id-1",
 			tenantId: "test-tenant-id",
 			firstClientJoinTime: Date.now(),
+			latestClientJoinTime: Date.now(),
 			lastClientLeaveTime: undefined,
 			telemetryProperties: {
 				hadWriteClient: true,
@@ -114,6 +117,7 @@ describe("RedisCollaborationSessionManager", () => {
 			documentId: "test-doc-id-2",
 			tenantId: "test-tenant-id",
 			firstClientJoinTime: Date.now(),
+			latestClientJoinTime: Date.now(),
 			lastClientLeaveTime: undefined,
 			telemetryProperties: {
 				hadWriteClient: false,
@@ -153,6 +157,7 @@ describe("RedisCollaborationSessionManager", () => {
 				documentId: `test-doc-id-${i}`,
 				tenantId: `test-tenant-id-${i % 3}`,
 				firstClientJoinTime: Date.now() - 100 * i,
+				latestClientJoinTime: Date.now() - 50 * i,
 				lastClientLeaveTime: i % 4 === 0 ? Date.now() : undefined,
 				telemetryProperties: {
 					hadWriteClient: i % 2 === 0,

--- a/server/routerlicious/packages/services/src/test/sessionTracker.spec.ts
+++ b/server/routerlicious/packages/services/src/test/sessionTracker.spec.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import sinon from "sinon";
 import { strict as assert } from "node:assert";
 import { CollaborationSessionTracker } from "../sessionTracker";

--- a/server/routerlicious/packages/services/src/test/sessionTracker.spec.ts
+++ b/server/routerlicious/packages/services/src/test/sessionTracker.spec.ts
@@ -1,0 +1,223 @@
+import sinon from "sinon";
+import { strict as assert } from "node:assert";
+import { CollaborationSessionTracker } from "../sessionTracker";
+import {
+	ICollaborationSessionClient,
+	ICollaborationSessionManager,
+	IClientManager,
+	ICollaborationSession,
+} from "@fluidframework/server-services-core";
+
+describe("CollaborationSessionTracker", () => {
+	let clientManager: sinon.SinonStubbedInstance<IClientManager>;
+	let sessionManager: sinon.SinonStubbedInstance<ICollaborationSessionManager>;
+	let sessionTracker: CollaborationSessionTracker;
+
+	beforeEach(() => {
+		sinon.useFakeTimers();
+		clientManager = {
+			getClients: sinon.stub(),
+		} as unknown as sinon.SinonStubbedInstance<IClientManager>;
+
+		sessionManager = {
+			getSession: sinon.stub(),
+			addOrUpdateSession: sinon.stub(),
+			removeSession: sinon.stub(),
+			getAllSessions: sinon.stub(),
+		} as unknown as sinon.SinonStubbedInstance<ICollaborationSessionManager>;
+
+		sessionTracker = new CollaborationSessionTracker(clientManager, sessionManager);
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	describe("startClientSession", () => {
+		it("should start a client session and update the session manager", async () => {
+			const client: ICollaborationSessionClient = {
+				clientId: "client1",
+				joinedTime: Date.now(),
+				isWriteClient: true,
+				isSummarizerClient: false,
+			};
+			const sessionId = { tenantId: "tenant1", documentId: "doc1" };
+
+			sessionManager.getSession.resolves(undefined);
+			clientManager.getClients.resolves([]);
+
+			await sessionTracker.startClientSession(client, sessionId);
+
+			assert.equal(sessionManager.addOrUpdateSession.calledOnce, true);
+			const updatedSession = sessionManager.addOrUpdateSession.getCall(0).args[0];
+			assert.equal(updatedSession.tenantId, sessionId.tenantId);
+			assert.equal(updatedSession.documentId, sessionId.documentId);
+			assert.equal(updatedSession.firstClientJoinTime, client.joinedTime);
+		});
+
+		it("should handle errors and log them", async () => {
+			const client: ICollaborationSessionClient = {
+				clientId: "client1",
+				joinedTime: Date.now(),
+				isWriteClient: true,
+				isSummarizerClient: false,
+			};
+			const sessionId = { tenantId: "tenant1", documentId: "doc1" };
+
+			sessionManager.addOrUpdateSession.rejects(new Error("Test error"));
+			clientManager.getClients.resolves([]);
+
+			try {
+				await sessionTracker.startClientSession(client, sessionId);
+			} catch (error) {
+				assert.equal((error as Error).message, "Test error");
+			}
+		});
+	});
+
+	describe("endClientSession", () => {
+		it("should end a client session and start a session end timer", async () => {
+			const client: ICollaborationSessionClient = {
+				clientId: "client1",
+				joinedTime: Date.now(),
+				isWriteClient: true,
+				isSummarizerClient: false,
+			};
+			const sessionId = { tenantId: "tenant1", documentId: "doc1" };
+
+			sessionManager.getSession.resolves({
+				tenantId: sessionId.tenantId,
+				documentId: sessionId.documentId,
+				firstClientJoinTime: Date.now(),
+				latestClientJoinTime: Date.now(),
+				lastClientLeaveTime: undefined,
+				telemetryProperties: {
+					hadWriteClient: true,
+					totalClientsJoined: 1,
+					maxConcurrentClients: 1,
+				},
+			});
+			clientManager.getClients.resolves([]);
+
+			await sessionTracker.endClientSession(client, sessionId);
+
+			assert.equal(sessionManager.addOrUpdateSession.calledOnce, true);
+			const updatedSession = sessionManager.addOrUpdateSession.getCall(0).args[0];
+			assert.equal(typeof updatedSession.lastClientLeaveTime, "number");
+		});
+
+		it("should handle errors and log them", async () => {
+			const client: ICollaborationSessionClient = {
+				clientId: "client1",
+				joinedTime: Date.now(),
+				isWriteClient: true,
+				isSummarizerClient: false,
+			};
+			const sessionId = { tenantId: "tenant1", documentId: "doc1" };
+
+			sessionManager.getSession.resolves({
+				tenantId: sessionId.tenantId,
+				documentId: sessionId.documentId,
+				firstClientJoinTime: Date.now(),
+				latestClientJoinTime: Date.now(),
+				lastClientLeaveTime: undefined,
+				telemetryProperties: {
+					hadWriteClient: true,
+					totalClientsJoined: 1,
+					maxConcurrentClients: 1,
+				},
+			});
+			sessionManager.addOrUpdateSession.rejects(new Error("Test error"));
+			clientManager.getClients.resolves([]);
+
+			try {
+				await sessionTracker.endClientSession(client, sessionId);
+			} catch (error) {
+				assert.equal((error as Error).message, "Test error");
+			}
+		});
+
+		it("should handle session not found case", async () => {
+			const client: ICollaborationSessionClient = {
+				clientId: "client1",
+				joinedTime: Date.now(),
+				isWriteClient: true,
+				isSummarizerClient: false,
+			};
+			const sessionId = { tenantId: "tenant1", documentId: "doc1" };
+
+			sessionManager.getSession.resolves(undefined);
+			clientManager.getClients.resolves([]);
+
+			await sessionTracker.endClientSession(client, sessionId);
+
+			assert.equal(sessionManager.addOrUpdateSession.notCalled, true);
+		});
+
+		it("should handle session updated on another instance", async () => {
+			const client: ICollaborationSessionClient = {
+				clientId: "client1",
+				joinedTime: Date.now(),
+				isWriteClient: true,
+				isSummarizerClient: false,
+			};
+			const sessionId = { tenantId: "tenant1", documentId: "doc1" };
+
+			const existingSession: ICollaborationSession = {
+				tenantId: sessionId.tenantId,
+				documentId: sessionId.documentId,
+				firstClientJoinTime: Date.now() - 20 * 60 * 1000,
+				latestClientJoinTime: Date.now() - 10 * 60 * 1000,
+				lastClientLeaveTime: Date.now() - 15 * 60 * 1000,
+				telemetryProperties: {
+					hadWriteClient: true,
+					totalClientsJoined: 1,
+					maxConcurrentClients: 1,
+				},
+			};
+
+			sessionManager.getSession.resolves(existingSession);
+			clientManager.getClients.resolves([]);
+
+			await sessionTracker.endClientSession(client, sessionId);
+		});
+	});
+
+	describe("pruneInactiveSessions", () => {
+		it("should prune inactive sessions", async () => {
+			const session: ICollaborationSession = {
+				tenantId: "tenant1",
+				documentId: "doc1",
+				firstClientJoinTime: Date.now() - 20 * 60 * 1000,
+				latestClientJoinTime: Date.now() - 20 * 60 * 1000,
+				lastClientLeaveTime: Date.now() - 15 * 60 * 1000,
+				telemetryProperties: {
+					hadWriteClient: true,
+					totalClientsJoined: 1,
+					maxConcurrentClients: 1,
+				},
+			};
+
+			sessionManager.getAllSessions.resolves([session]);
+			clientManager.getClients.resolves([]);
+
+			await sessionTracker.pruneInactiveSessions();
+
+			assert.equal(sessionManager.removeSession.calledOnce, true);
+			const removedSession = sessionManager.removeSession.getCall(0).args[0];
+			assert.equal(removedSession.tenantId, session.tenantId);
+			assert.equal(removedSession.documentId, session.documentId);
+		});
+
+		it("should handle errors during pruning", async () => {
+			sessionManager.getAllSessions.rejects(new Error("Test error"));
+			clientManager.getClients.resolves([]);
+
+			try {
+				await sessionTracker.pruneInactiveSessions();
+			} catch (error) {
+				assert.equal((error as Error).message, "Test error");
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Description

Recently, a few bugs/issues were found in the NexusSessionResult telemetry event.

1. DurationInMs could sometimes be ~1.7Trillion, which is roughly equal to `Date.now()` or "mx since epoch."
    - It appears that in some cases, `IClient.timestamp` was possibly `0`. We shouldn't have been relying on this anyways, since we already have `connectedTimestamp` tracked in the service.
    - There was also a suspicious `joinedTime ?? 0` which didn't seem to be in the path for telemetry use, but I removed it completely just to make sure.
2. Duplicate, overlapping "sessions" were possible because a client could re-connect to a new instance within the session activity timeout window, but on a new Nexus instance. This would allow the old instance's timer to remain uncleared.
    - A quick "make sure the session wasn't updated recently" check on timer firing was sufficient for this bug
3. The timestamp for `NexusSessionResult` telemetry event aligned with the _end_ of the event, rather than the _start_ of the event. All other telemetry events' timestamps align with the start of the event.
    - A new `overrideTimestamp` method was added to the `Lumber` class.

## Breaking Changes

A few internal classes/methods have new/altered/reduced parameters. These are internal, though, and shouldn't cause any issues.

## Reviewer Guidance

I locally made some alterations for testing this code using multiple Nexus instances within the Docker Compose behind NGINX with Round Robin loadbalancing. This fairly accurately simulates having multiple Nexus instances in our production setup. I did not include this change in the PR, as there is not a good way to enable/disable it.

## WIP

- [x] UTs
