### PR TITLE
docs: Update README to reference Biome as repo formatter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,6 @@ Then:
 ### Biome
 
 This repository uses [biome](https://biomejs.dev/formatter/) as its code formatter.
-# figure out what to do about shared config
 Right now, this is implemented on a per-package basis, with a [shared base configuration](./biome.jsonc).
 
 -   To run `biome` on your code, run `npm run format` from the appropriate package or release group, or run

--- a/README.md
+++ b/README.md
@@ -295,22 +295,22 @@ Then:
 
 ## Tools
 
-### Prettier
+### Biome
 
-This repository uses [prettier](https://prettier.io/) as its code formatter.
-Right now, this is implemented on a per-package basis, with a [shared base configuration](./common/build/build-common/prettier.config.cjs).
+This repository uses [biome](https://biomejs.dev/formatter/) as its code formatter.
+# figure out what to do about shared config
+Right now, this is implemented on a per-package basis, with a [shared base configuration](./biome.jsonc).
 
--   To run `prettier` on your code, run `npm run format` from the appropriate package or release group, or run
+-   To run `biome` on your code, run `npm run format` from the appropriate package or release group, or run
     `npm run format:changed` from the root of the repo to format only files changed since the main branch.
-    If your change is for the next branch instead, you can run `npm run format:changed:next`.
--   To run `prettier` with [fluid-build](./build-tools/packages/build-tools/README.md), you can specify "format" via the
+-   To run `biome` with [fluid-build](./build-tools/packages/build-tools/README.md), you can specify "format" via the
     script argument: `fluid-build -t format` or `npm run build:fast -- -t format`
 
 To ensure our formatting remains consistent, we run a formatting check as a part of each package's `lint` script.
 
 #### VSCode Options
 
-Our [workspace configuration](./.vscode/settings.json) specifies `prettier` as the default formatter.
+Our [workspace configuration](./.vscode/settings.json) specifies `biome` as the default formatter.
 Please do not change this.
 
 It is not configured to do any formatting automatically, however.


### PR DESCRIPTION
The main README had outdated information about the formatter that we use. Update the Tools section to reference Biome instead of Prettier. 