### PR TITLE
improvement(tree): Make "props" default strictly `undefined`

### DIFF
--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -54,9 +54,7 @@ export namespace System_TableSchema {
 	 * Default type used for column and row "props" fields.
 	 * @system @internal
 	 */
-	export type DefaultPropsType = ReturnType<
-		typeof SchemaFactory.optional<[]>
-	>;
+	export type DefaultPropsType = ReturnType<typeof SchemaFactory.optional<[]>>;
 
 	/**
 	 * A base interface for factory input options which include an schema factory.

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -52,6 +52,10 @@ const tableSchemaFactorySubScope = "table";
 export namespace System_TableSchema {
 	/**
 	 * Default type used for column and row "props" fields.
+	 * @privateRemarks
+	 * Longer term, it would be better to simply omit "props" altogether by default.
+	 * For now, this ensures that the user doesn't have to specify a "props" entry when initializing column/row nodes
+	 * and ensures that they cannot set anything that might conflict with future evolutions of the schema.
 	 * @system @internal
 	 */
 	export type DefaultPropsType = ReturnType<typeof SchemaFactory.optional<[]>>;

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -55,7 +55,7 @@ export namespace System_TableSchema {
 	 * @system @internal
 	 */
 	export type DefaultPropsType = ReturnType<
-		typeof SchemaFactory.optional<typeof SchemaFactory.null>
+		typeof SchemaFactory.optional<[]>
 	>;
 
 	/**

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -16,7 +16,7 @@ import {
 	type TreeNode,
 } from "../simple-tree/index.js";
 import { TableSchema } from "../tableSchema.js";
-import type { requireAssignableTo } from "../util/index.js";
+import type { areSafelyAssignable, requireTrue } from "../util/index.js";
 import { validateUsageError } from "./utils.js";
 
 const schemaFactory = new SchemaFactoryAlpha("test");
@@ -91,7 +91,7 @@ describe("TableFactory unit tests", () => {
 
 			// TODO: ideally the "props" property would not exist at all on the derived class.
 			// For now, it is at least an optional property and cannot be set to anything meaningful.
-			type _test = requireAssignableTo<undefined, Column["props"]>;
+			type _test = requireTrue<areSafelyAssignable<undefined, Column["props"]>>;
 			assert.equal(column.props, undefined);
 		});
 
@@ -115,7 +115,7 @@ describe("TableFactory unit tests", () => {
 
 			// TODO: ideally the "props" property would not exist at all on the derived class.
 			// For now, it is at least an optional property and cannot be set to anything meaningful.
-			type _test = requireAssignableTo<undefined, Row["props"]>;
+			type _test = requireTrue<areSafelyAssignable<undefined, Row["props"]>>;
 			assert.equal(row.props, undefined);
 		});
 

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -91,7 +91,7 @@ describe("TableFactory unit tests", () => {
 
 			// TODO: ideally the "props" property would not exist at all on the derived class.
 			// For now, it is at least an optional property and cannot be set to anything meaningful.
-			type _test = requireAssignableTo<null | undefined, Column["props"]>;
+			type _test = requireAssignableTo<undefined, Column["props"]>;
 			assert.equal(column.props, undefined);
 		});
 
@@ -115,7 +115,7 @@ describe("TableFactory unit tests", () => {
 
 			// TODO: ideally the "props" property would not exist at all on the derived class.
 			// For now, it is at least an optional property and cannot be set to anything meaningful.
-			type _test = requireAssignableTo<null | undefined, Row["props"]>;
+			type _test = requireAssignableTo<undefined, Row["props"]>;
 			assert.equal(row.props, undefined);
 		});
 


### PR DESCRIPTION
Make the default typing of column/row "props" `undefined` instead of `null | undefined`. `null` is unnecessary (we don't expect users to specify "props" in default cases), and including it makes future schema evolution more difficult for the user (they have to handle back-compat with `null`).