### PR TITLE
Simplify ensureSchema

### DIFF
--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -208,7 +208,6 @@ export {
 	type Adapters,
 	AdaptedViewSchema,
 	type TreeAdapter,
-	AllowedUpdateType,
 } from "./schema-view/index.js";
 
 export {

--- a/packages/dds/tree/src/core/schema-view/index.ts
+++ b/packages/dds/tree/src/core/schema-view/index.ts
@@ -7,5 +7,4 @@ export {
 	type Adapters,
 	type TreeAdapter,
 	AdaptedViewSchema,
-	AllowedUpdateType,
 } from "./view.js";

--- a/packages/dds/tree/src/core/schema-view/view.ts
+++ b/packages/dds/tree/src/core/schema-view/view.ts
@@ -10,37 +10,6 @@ import type { TreeNodeSchemaIdentifier, TreeStoredSchema } from "../schema-store
  */
 
 /**
- * What kinds of updates to stored schema to permit.
- *
- * Bit flags enum.
- */
-export enum AllowedUpdateType {
-	/**
-	 * Do not update the stored schema to match view schema.
-	 */
-	None = 0,
-	/**
-	 * Update the stored schema as part of initializing an empty document.
-	 *
-	 * Includes "Initialize".
-	 */
-	// eslint-disable-next-line no-bitwise
-	Initialize = 1 << 0,
-	/**
-	 * Update the stored schema to match the view schema if the current document contents are compatible with the view schema.
-	 * TODO: support this option.
-	 */
-	// DataCompatible,
-	/**
-	 * Update the stored schema to match view schema if all possible documents based on the current stored schema would be compatible with the view schema.
-	 *
-	 * Includes "Initialize".
-	 */
-	// eslint-disable-next-line no-bitwise
-	SchemaCompatible = 1 << 1,
-}
-
-/**
  */
 export interface TreeAdapter {
 	readonly output: TreeNodeSchemaIdentifier;

--- a/packages/dds/tree/src/shared-tree/schematizeTree.ts
+++ b/packages/dds/tree/src/shared-tree/schematizeTree.ts
@@ -6,7 +6,6 @@
 import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 
 import {
-	AllowedUpdateType,
 	CursorLocationType,
 	type ITreeCursorSynchronous,
 	type TreeStoredSchema,
@@ -21,7 +20,6 @@ import {
 	mapTreeFromCursor,
 } from "../feature-libraries/index.js";
 import { isReadonlyArray } from "../util/index.js";
-
 import type { ITreeCheckout } from "./treeCheckout.js";
 import type { SchemaCompatibilityTester } from "../simple-tree/index.js";
 
@@ -99,10 +97,6 @@ export enum UpdateType {
 	 */
 	None,
 	/**
-	 * Empty: needs initializing.
-	 */
-	Initialize,
-	/**
 	 * Schema can be upgraded leaving tree as is.
 	 */
 	SchemaCompatible,
@@ -112,9 +106,11 @@ export enum UpdateType {
 	Incompatible,
 }
 
+/**
+ * Returns how compatible updating checkout's schema is with the viewSchema.
+ */
 export function evaluateUpdate(
 	viewSchema: SchemaCompatibilityTester,
-	allowedSchemaModifications: AllowedUpdateType,
 	checkout: ITreeCheckout,
 ): UpdateType {
 	const compatibility = viewSchema.checkCompatibility(checkout.storedSchema);
@@ -122,11 +118,6 @@ export function evaluateUpdate(
 	if (compatibility.canUpgrade && compatibility.canView) {
 		// Compatible as is
 		return UpdateType.None;
-	}
-
-	// eslint-disable-next-line no-bitwise
-	if (allowedSchemaModifications & AllowedUpdateType.Initialize && canInitialize(checkout)) {
-		return UpdateType.Initialize;
 	}
 
 	if (!compatibility.canUpgrade) {
@@ -137,10 +128,7 @@ export function evaluateUpdate(
 	assert(!compatibility.canView, 0x8bd /* unexpected case */);
 	assert(compatibility.canUpgrade, 0x8be /* unexpected case */);
 
-	// eslint-disable-next-line no-bitwise
-	return allowedSchemaModifications & AllowedUpdateType.SchemaCompatible
-		? UpdateType.SchemaCompatible
-		: UpdateType.Incompatible;
+	return UpdateType.SchemaCompatible;
 }
 
 export function canInitialize(checkout: ITreeCheckout): boolean {
@@ -222,17 +210,9 @@ export function initialize(checkout: ITreeCheckout, treeContent: TreeStoredConte
  */
 export function ensureSchema(
 	viewSchema: SchemaCompatibilityTester,
-	allowedSchemaModifications: AllowedUpdateType,
 	checkout: ITreeCheckout,
-	treeContent: TreeStoredContent | undefined,
 ): boolean {
-	let possibleModifications = allowedSchemaModifications;
-	if (treeContent === undefined) {
-		// Clear bit for Initialize if initial tree is not provided.
-		// eslint-disable-next-line no-bitwise
-		possibleModifications &= ~AllowedUpdateType.Initialize;
-	}
-	const updatedNeeded = evaluateUpdate(viewSchema, possibleModifications, checkout);
+	const updatedNeeded = evaluateUpdate(viewSchema, checkout);
 	switch (updatedNeeded) {
 		case UpdateType.None: {
 			return true;
@@ -242,16 +222,6 @@ export function ensureSchema(
 		}
 		case UpdateType.SchemaCompatible: {
 			checkout.updateSchema(viewSchema.viewSchemaAsStored);
-			return true;
-		}
-		case UpdateType.Initialize: {
-			if (treeContent === undefined) {
-				return false;
-			}
-			// TODO:
-			// When this becomes a more proper out of schema adapter, editing should be made lazy.
-			// This will improve support for readonly documents, cross version collaboration and attribution.
-			initialize(checkout, treeContent);
 			return true;
 		}
 		default: {

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -12,7 +12,7 @@ import { createEmitter } from "@fluid-internal/client-utils";
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import { AllowedUpdateType, anchorSlot, type SchemaPolicy } from "../core/index.js";
+import { anchorSlot, type SchemaPolicy } from "../core/index.js";
 import {
 	type NodeIdentifierManager,
 	defaultSchemaPolicy,
@@ -207,15 +207,7 @@ export class SchematizingSimpleTreeView<
 		}
 
 		this.runSchemaEdit(() => {
-			const result = ensureSchema(
-				this.viewSchema,
-				AllowedUpdateType.SchemaCompatible,
-				this.checkout,
-				{
-					schema: this.viewSchema.viewSchemaAsStored,
-					initialTree: undefined,
-				},
-			);
+			const result = ensureSchema(this.viewSchema, this.checkout);
 			assert(result, 0x8bf /* Schema upgrade should always work if canUpgrade is set. */);
 		});
 	}

--- a/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "node:assert";
 
 import {
-	AllowedUpdateType,
 	type Anchor,
 	type AnchorNode,
 	type IForestSubscription,
@@ -213,28 +212,13 @@ describe("schematizeTree", () => {
 						{},
 						normalizeFieldSchema(data),
 					);
-					const result = evaluateUpdate(viewSchema, AllowedUpdateType.None, checkout);
+					const result = evaluateUpdate(viewSchema, checkout);
 					assert.equal(result, UpdateType.None);
-				});
-
-				it(`${name} initialize`, () => {
-					const checkout = mockCheckout(emptySchema, isEmpty);
-					const viewSchema = new SchemaCompatibilityTester(
-						defaultSchemaPolicy,
-						{},
-						normalizeFieldSchema(data),
-					);
-					const result = evaluateUpdate(viewSchema, AllowedUpdateType.Initialize, checkout);
-					if (data === emptySchema) {
-						assert.equal(result, UpdateType.None);
-					} else {
-						assert.equal(result, isEmpty ? UpdateType.Initialize : UpdateType.Incompatible);
-					}
 				});
 			}
 		});
 
-		it("AllowedUpdateType works", () => {
+		it("UpdateType.SchemaCompatible", () => {
 			const checkout = mockCheckout(schema, false);
 			const viewSchema = new SchemaCompatibilityTester(
 				defaultSchemaPolicy,
@@ -242,20 +226,8 @@ describe("schematizeTree", () => {
 				schemaGeneralized,
 			);
 			{
-				const result = evaluateUpdate(
-					viewSchema,
-					AllowedUpdateType.SchemaCompatible,
-					checkout,
-				);
+				const result = evaluateUpdate(viewSchema, checkout);
 				assert.equal(result, UpdateType.SchemaCompatible);
-			}
-			{
-				const result = evaluateUpdate(viewSchema, AllowedUpdateType.Initialize, checkout);
-				assert.equal(result, UpdateType.Incompatible);
-			}
-			{
-				const result = evaluateUpdate(viewSchema, AllowedUpdateType.None, checkout);
-				assert.equal(result, UpdateType.Incompatible);
 			}
 		});
 	});
@@ -276,20 +248,15 @@ describe("schematizeTree", () => {
 				initialTree: undefined,
 			});
 			const viewSchema = new SchemaCompatibilityTester(defaultSchemaPolicy, {}, emptySchema);
-			assert(ensureSchema(viewSchema, AllowedUpdateType.None, checkout, undefined));
+			assert(ensureSchema(viewSchema, checkout));
 		});
 
-		it("initialize optional root", () => {
+		it("compatible: upgrade optional root", () => {
 			const emptyContent: TreeStoredContent = {
 				schema: toStoredSchema(emptySchema),
 				initialTree: undefined,
 			};
-			const emptyCheckout = checkoutWithContent(emptyContent);
-			const content: TreeStoredContent = {
-				schema: toStoredSchema(schemaGeneralized),
-				initialTree: singleJsonCursor(5),
-			};
-			const initializedCheckout = checkoutWithContent(content);
+
 			// Schema upgraded, but content not initialized
 			const upgradedCheckout = checkoutWithContent({
 				schema: toStoredSchema(schemaGeneralized),
@@ -301,81 +268,20 @@ describe("schematizeTree", () => {
 				schemaGeneralized,
 			);
 
-			// Non updating cases
+			// Schema upgrade
 			{
 				const checkout = checkoutWithContent(emptyContent);
-				assert(!ensureSchema(viewSchema, AllowedUpdateType.None, checkout, undefined));
-				validateViewConsistency(checkout, emptyCheckout);
-			}
-			{
-				const checkout = checkoutWithContent(emptyContent);
-				assert(!ensureSchema(viewSchema, AllowedUpdateType.None, checkout, content));
-				validateViewConsistency(checkout, emptyCheckout);
-			}
-			{
-				const checkout = checkoutWithContent(emptyContent);
-				assert(!ensureSchema(viewSchema, AllowedUpdateType.Initialize, checkout, undefined));
-				validateViewConsistency(checkout, emptyCheckout);
-			}
-
-			// Initialize
-			{
-				const checkout = checkoutWithContent(emptyContent);
-				assert(ensureSchema(viewSchema, AllowedUpdateType.Initialize, checkout, content));
-				validateViewConsistency(checkout, initializedCheckout);
-			}
-
-			// Schema upgrade but not initialize
-			{
-				const checkout = checkoutWithContent(emptyContent);
-				assert(
-					ensureSchema(viewSchema, AllowedUpdateType.SchemaCompatible, checkout, content),
-				);
-				validateViewConsistency(checkout, upgradedCheckout);
-			}
-
-			// Prefer initialize over schema upgrade when both are allowed
-			{
-				const checkout = checkoutWithContent(emptyContent);
-				assert(
-					ensureSchema(
-						viewSchema,
-						// eslint-disable-next-line no-bitwise
-						AllowedUpdateType.SchemaCompatible | AllowedUpdateType.Initialize,
-						checkout,
-						content,
-					),
-				);
-				validateViewConsistency(checkout, initializedCheckout);
-			}
-
-			//  Schema upgrade when no content is provided
-			{
-				const checkout = checkoutWithContent(emptyContent);
-				assert(
-					ensureSchema(
-						viewSchema,
-						// eslint-disable-next-line no-bitwise
-						AllowedUpdateType.SchemaCompatible | AllowedUpdateType.Initialize,
-						checkout,
-						undefined,
-					),
-				);
+				assert(ensureSchema(viewSchema, checkout));
 				validateViewConsistency(checkout, upgradedCheckout);
 			}
 		});
 
-		it("initialize required root", () => {
+		it("incompatible: empty to required root", () => {
 			const emptyContent: TreeStoredContent = {
 				schema: toStoredSchema(emptySchema),
 				initialTree: undefined,
 			};
 			const emptyCheckout = checkoutWithContent(emptyContent);
-			const content: TreeStoredContent = {
-				schema: toStoredSchema(schemaValueRoot),
-				initialTree: singleJsonCursor(5),
-			};
-			const initializedCheckout = checkoutWithContent(content);
 
 			const viewSchema = new SchemaCompatibilityTester(
 				defaultSchemaPolicy,
@@ -383,50 +289,10 @@ describe("schematizeTree", () => {
 				normalizeFieldSchema(schemaValueRoot),
 			);
 
-			// Non updating cases
-			{
-				const checkout = checkoutWithContent(emptyContent);
-				assert(!ensureSchema(viewSchema, AllowedUpdateType.None, checkout, undefined));
-				validateViewConsistency(checkout, emptyCheckout);
-			}
-			{
-				const checkout = checkoutWithContent(emptyContent);
-				assert(!ensureSchema(viewSchema, AllowedUpdateType.None, checkout, content));
-				validateViewConsistency(checkout, emptyCheckout);
-			}
-			{
-				const checkout = checkoutWithContent(emptyContent);
-				assert(!ensureSchema(viewSchema, AllowedUpdateType.Initialize, checkout, undefined));
-				validateViewConsistency(checkout, emptyCheckout);
-			}
-			// Cases which don't update due to root being required
-			{
-				const checkout = checkoutWithContent(emptyContent);
-				assert(
-					!ensureSchema(
-						viewSchema,
-						// eslint-disable-next-line no-bitwise
-						AllowedUpdateType.SchemaCompatible | AllowedUpdateType.Initialize,
-						checkout,
-						undefined,
-					),
-				);
-				validateViewConsistency(checkout, emptyCheckout);
-			}
-			{
-				const checkout = checkoutWithContent(emptyContent);
-				assert(
-					!ensureSchema(viewSchema, AllowedUpdateType.SchemaCompatible, checkout, content),
-				);
-				validateViewConsistency(checkout, emptyCheckout);
-			}
-
-			// Initialize
-			{
-				const checkout = checkoutWithContent(emptyContent);
-				assert(ensureSchema(viewSchema, AllowedUpdateType.Initialize, checkout, content));
-				validateViewConsistency(checkout, initializedCheckout);
-			}
+			// Case which doesn't update due to root being required
+			const checkout = checkoutWithContent(emptyContent);
+			assert(!ensureSchema(viewSchema, checkout));
+			validateViewConsistency(checkout, emptyCheckout);
 		});
 
 		it("update non-empty", () => {
@@ -452,20 +318,9 @@ describe("schematizeTree", () => {
 				schemaGeneralized,
 			);
 
-			// Non updating case
-			{
-				const checkout = checkoutWithContent(initialContent);
-				assert(!ensureSchema(viewSchema, AllowedUpdateType.Initialize, checkout, content));
-				validateViewConsistency(checkout, initialCheckout);
-			}
-			// Updating case
-			{
-				const checkout = checkoutWithContent(initialContent);
-				assert(
-					ensureSchema(viewSchema, AllowedUpdateType.SchemaCompatible, checkout, undefined),
-				);
-				validateViewConsistency(checkout, updatedCheckout);
-			}
+			const checkout = checkoutWithContent(initialContent);
+			assert(ensureSchema(viewSchema, checkout));
+			validateViewConsistency(checkout, updatedCheckout);
 		});
 	});
 });


### PR DESCRIPTION
## Description

Simplify ensureSchema to only support the case that is actually used.

ensureSchema was written back when schema upgrades and initialize were combined, so it had many more cases it needed to handle. This change removes these extra cases and their tests.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
