### PR TITLE
Fix schema validation for initialize

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
@@ -35,14 +35,6 @@ export function isNodeInSchema(
 	node: MapTree,
 	schemaAndPolicy: SchemaAndPolicy,
 ): SchemaValidationErrors {
-	// If the stored schema is completely empty it _probably_ (in almost all cases?) means the tree is brand new and we
-	// shouldn't validate the data.
-	// TODO: AB#8197
-	// See https://github.com/microsoft/FluidFramework/pull/21305#discussion_r1626595991 for further discussion.
-	if (schemaAndPolicy.schema.nodeSchema.size === 0) {
-		return SchemaValidationErrors.NoError;
-	}
-
 	// Validate the schema declared by the node exists
 	const schema = schemaAndPolicy.schema.nodeSchema.get(node.type);
 	if (schema === undefined) {

--- a/packages/dds/tree/src/shared-tree/schematizeTree.ts
+++ b/packages/dds/tree/src/shared-tree/schematizeTree.ts
@@ -159,7 +159,7 @@ function normalizeNewFieldContent(
  * This function should only be called when the tree is uninitialized (no schema or content).
  * @remarks
  *
- * If the proposed schema (from `treeContent`) is not compatible with the emptry tree, this function handles using an intermediate schema
+ * If the proposed schema (from `treeContent`) is not compatible with the empty tree, this function handles using an intermediate schema
  * which supports the empty tree as well as the final tree content.
  */
 export function initialize(checkout: ITreeCheckout, treeContent: TreeStoredContent): void {

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -173,19 +173,20 @@ export class SchematizingSimpleTreeView<
 		}
 
 		this.runSchemaEdit(() => {
+			const schema = this.viewSchema.viewSchemaAsStored;
 			const mapTree = mapTreeFromNodeData(
 				content as InsertableContent | undefined,
 				this.rootFieldSchema,
 				this.nodeKeyManager,
 				{
-					schema: this.checkout.storedSchema,
+					schema,
 					policy: this.schemaPolicy,
 				},
 			);
 
 			prepareContentForHydration(mapTree, this.checkout.forest);
 			initialize(this.checkout, {
-				schema: this.viewSchema.viewSchemaAsStored,
+				schema,
 				initialTree: mapTree === undefined ? undefined : cursorForMapTreeNode(mapTree),
 			});
 		});

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -322,7 +322,7 @@ const unparentedLocation: LocationInField = {
 	index: -1,
 };
 
-class UnhydratedFlexTreeField implements FlexTreeField {
+abstract class UnhydratedFlexTreeField implements FlexTreeField {
 	public [flexTreeMarker] = FlexTreeEntityKind.Field as const;
 
 	public get context(): FlexTreeContext {
@@ -597,7 +597,7 @@ function getOrCreateField(
 		return new UnhydratedTreeSequenceField(parent.simpleContext, schema, key, parent, onEdit);
 	}
 
-	return new UnhydratedFlexTreeField(parent.simpleContext, schema, key, parent, onEdit);
+	return fail("unsupported field kind");
 }
 
 // #endregion Caching and unboxing utilities

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -322,7 +322,7 @@ const unparentedLocation: LocationInField = {
 	index: -1,
 };
 
-abstract class UnhydratedFlexTreeField implements FlexTreeField {
+class UnhydratedFlexTreeField implements FlexTreeField {
 	public [flexTreeMarker] = FlexTreeEntityKind.Field as const;
 
 	public get context(): FlexTreeContext {
@@ -595,6 +595,11 @@ function getOrCreateField(
 
 	if (schema === FieldKinds.sequence.identifier) {
 		return new UnhydratedTreeSequenceField(parent.simpleContext, schema, key, parent, onEdit);
+	}
+
+	// TODO: this seems to used by unknown optional fields. They should probably use "optional" not "Forbidden" schema.
+	if (schema === FieldKinds.forbidden.identifier) {
+		return new UnhydratedFlexTreeField(parent.simpleContext, schema, key, parent, onEdit);
 	}
 
 	return fail("unsupported field kind");

--- a/packages/dds/tree/src/test/feature-libraries/default-schema/schemaChecker.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-schema/schemaChecker.spec.ts
@@ -134,13 +134,13 @@ describe("schema validation", () => {
 	});
 
 	describe("isNodeInSchema", () => {
-		it(`skips validation if stored schema is completely empty`, () => {
+		it(`does validation if stored schema is completely empty`, () => {
 			assert.equal(
 				isNodeInSchema(
 					createLeafNode("myNumberNode", 1, ValueSchema.Number).node,
 					createSchemaAndPolicy(), // Note this passes an empty stored schema
 				),
-				SchemaValidationErrors.NoError,
+				SchemaValidationErrors.Node_MissingSchema,
 			);
 		});
 

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -24,6 +24,7 @@ import {
 	type TransactionResult,
 	type TransactionResultExt,
 	toStoredSchema,
+	getKernel,
 } from "../../simple-tree/index.js";
 import {
 	checkoutWithContent,
@@ -38,6 +39,10 @@ import {
 	type TreeCheckout,
 	type TreeStoredContent,
 } from "../../shared-tree/index.js";
+import type { Mutable } from "../../util/index.js";
+import { brand } from "../../util/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { UnhydratedFlexTreeNode } from "../../simple-tree/core/unhydratedFlexTree.js";
 
 const schema = new SchemaFactory("com.example");
 const config = new TreeViewConfiguration({ schema: schema.number });
@@ -69,28 +74,87 @@ function checkoutWithInitialTree(
 const emptySchema = toStoredSchema(schema.optional([]));
 
 describe("SchematizingSimpleTreeView", () => {
-	it("Initialize document", () => {
-		const emptyContent = {
-			schema: emptySchema,
-			initialTree: undefined,
-		};
-		const checkout = checkoutWithContent(emptyContent);
-		const view = new SchematizingSimpleTreeView(
-			checkout,
-			config,
-			new MockNodeIdentifierManager(),
-		);
+	describe("initialize", () => {
+		it("Initialize document", () => {
+			const emptyContent = {
+				schema: emptySchema,
+				initialTree: undefined,
+			};
+			const checkout = checkoutWithContent(emptyContent);
+			const view = new SchematizingSimpleTreeView(
+				checkout,
+				config,
+				new MockNodeIdentifierManager(),
+			);
 
-		const { compatibility } = view;
-		assert.equal(compatibility.canView, false);
-		assert.equal(compatibility.canUpgrade, false);
-		assert.equal(compatibility.canInitialize, true);
+			const { compatibility } = view;
+			assert.equal(compatibility.canView, false);
+			assert.equal(compatibility.canUpgrade, false);
+			assert.equal(compatibility.canInitialize, true);
 
-		view.initialize(5);
-		assert.equal(view.root, 5);
+			view.initialize(5);
+			assert.equal(view.root, 5);
+
+			assert.throws(
+				() => view.initialize(5),
+				validateUsageError(/initialized more than once/),
+			);
+		});
+
+		for (const enableSchemaValidation of [true, false]) {
+			it(`Initialize invalid content: enableSchemaValidation: ${enableSchemaValidation}`, () => {
+				const emptyContent = {
+					schema: emptySchema,
+					initialTree: undefined,
+				};
+				const checkout = checkoutWithContent(emptyContent);
+
+				class Root extends schema.object("Root", {
+					content: schema.number,
+				}) {}
+
+				const config2 = new TreeViewConfiguration({
+					schema: Root,
+					enableSchemaValidation,
+				});
+
+				const view = new SchematizingSimpleTreeView(
+					checkout,
+					config2,
+					new MockNodeIdentifierManager(),
+				);
+
+				const root = new Root({ content: 5 });
+
+				const inner = getKernel(root).tryGetInnerNode() ?? assert.fail("Expected child");
+				const field = inner.getBoxed(brand("content"));
+				const child = field.boxedAt(0) ?? assert.fail("Expected child");
+				assert(child instanceof UnhydratedFlexTreeNode);
+
+				// Modify the tree so that it is out of schema.
+				// The public API is supposed to prevent out of schema trees,
+				// so this hack using internal APIs is needed a workaround to test the additional schema validation layer.
+				// In production cases this extra validation exists to help prevent corruption when bugs
+				// allow invalid data through the public API.
+				(child.mapTree as Mutable<typeof child.mapTree>).value = "invalid value";
+
+				// Attempt to initialize with invalid content
+				if (enableSchemaValidation) {
+					assert.throws(
+						() => view.initialize(root),
+						validateUsageError(/Tree does not conform to schema./),
+					);
+
+					assert.throws(() => view.root, validateUsageError(/invalid state by another error/));
+				} else {
+					view.initialize(root);
+					assert.equal(view.root.content, "invalid value");
+				}
+			});
+		}
 	});
 
-	it("Initialize errors", () => {
+	it("Broken state", () => {
 		const emptyContent = {
 			schema: emptySchema,
 			initialTree: undefined,
@@ -102,13 +166,18 @@ describe("SchematizingSimpleTreeView", () => {
 			new MockNodeIdentifierManager(),
 		);
 
-		assert.throws(() => view.root, validateUsageError(/compatibility/));
-
+		// Put into broken state by trying incompatible upgrade
 		assert.throws(() => view.upgradeSchema(), validateUsageError(/compatibility/));
+
 		assert.throws(
 			() => view.initialize(5),
 			validateUsageError(/invalid state by another error/),
 		);
+		assert.throws(
+			() => view.upgradeSchema(),
+			validateUsageError(/invalid state by another error/),
+		);
+		assert.throws(() => view.root, validateUsageError(/invalid state by another error/));
 	});
 
 	const getChangeData = <T extends ImplicitFieldSchema>(


### PR DESCRIPTION
## Description

Remove workaround which disabled schema validation when schema to validate against was empty.

Fix initialize to pass in the new schema not the old schema.

Improve testing in this area.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


