### PR TITLE
refactor(tree): Rename table schema APIs

### DIFF
--- a/examples/data-objects/table-tree/src/Table/tableSchema.ts
+++ b/examples/data-objects/table-tree/src/Table/tableSchema.ts
@@ -95,20 +95,20 @@ export class ColumnProps extends schemaFactory.object("table-column-props", {
 	label: schemaFactory.optional(schemaFactory.string),
 	hint: schemaFactory.optional(schemaFactory.string),
 }) {}
-export class Column extends TableSchema.createColumn({
+export class Column extends TableSchema.column({
 	schemaFactory,
 	props: ColumnProps,
 }) {}
 export class RowProps extends schemaFactory.object("table-row-props", {
 	label: schemaFactory.optional(schemaFactory.string),
 }) {}
-export class Row extends TableSchema.createRow({
+export class Row extends TableSchema.row({
 	schemaFactory,
 	cell: Cell,
 	props: RowProps,
 }) {}
 
-export class Table extends TableSchema.createTable({
+export class Table extends TableSchema.table({
 	schemaFactory,
 	cell: Cell,
 	column: Column,

--- a/examples/utils/import-testing/src/test/importer.spec.ts
+++ b/examples/utils/import-testing/src/test/importer.spec.ts
@@ -39,14 +39,12 @@ describe("import tests", () => {
 	it("TableSchema", () => {
 		const schemaFactory = new SchemaFactoryAlpha("com.example");
 
-		class Cell extends schemaFactory.object("table-cell", {
-			value: schemaFactory.string,
-		}) {}
+		const Cell = schemaFactory.string;
 
 		class ColumnProps extends schemaFactory.object("table-column-props", {
 			label: schemaFactory.optional(schemaFactory.string),
 		}) {}
-		class Column extends TableSchema.createColumn({
+		class Column extends TableSchema.column({
 			schemaFactory,
 			props: schemaFactory.optional(ColumnProps),
 		}) {}
@@ -54,13 +52,13 @@ describe("import tests", () => {
 		class RowProps extends schemaFactory.object("table-row-props", {
 			label: schemaFactory.optional(schemaFactory.string),
 		}) {}
-		class Row extends TableSchema.createRow({
+		class Row extends TableSchema.row({
 			schemaFactory,
 			cell: Cell,
 			props: RowProps,
 		}) {}
 
-		class Table extends TableSchema.createTable({
+		class Table extends TableSchema.table({
 			schemaFactory,
 			cell: Cell,
 			column: Column,

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -102,11 +102,11 @@ export namespace System_TableSchema {
 	> = OptionsWithSchemaFactory<TSchemaFactory>;
 
 	/**
-	 * Factory for creating new table column schema.
+	 * Factory for creating column schema.
 	 * @system @internal
 	 */
 	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Return type is too complex to be reasonable to specify
-	export function createColumnInternal<
+	export function createColumnSchema<
 		const TInputScope extends string | undefined,
 		const TPropsSchema extends ImplicitAnnotatedFieldSchema,
 	>(inputSchemaFactory: SchemaFactoryAlpha<TInputScope>, propsSchema: TPropsSchema) {
@@ -227,7 +227,7 @@ export namespace System_TableSchema {
 	export type ColumnSchemaBase<
 		TScope extends string | undefined = string | undefined,
 		TPropsSchema extends ImplicitAnnotatedFieldSchema = ImplicitAnnotatedFieldSchema,
-	> = ReturnType<typeof createColumnInternal<TScope, TPropsSchema>>;
+	> = ReturnType<typeof createColumnSchema<TScope, TPropsSchema>>;
 
 	// #endregion
 
@@ -244,12 +244,11 @@ export namespace System_TableSchema {
 	> = OptionsWithSchemaFactory<TSchemaFactory> & OptionsWithCellSchema<TCell>;
 
 	/**
-	 * Factory for creating new table row schema.
-	 *
+	 * Factory for creating row schema.
 	 * @sealed @internal
 	 */
 	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Return type is too complex to be reasonable to specify
-	export function createRowInternal<
+	export function createRowSchema<
 		const TInputScope extends string | undefined,
 		const TCellSchema extends ImplicitAllowedTypes,
 		const TPropsSchema extends ImplicitAnnotatedFieldSchema,
@@ -412,7 +411,7 @@ export namespace System_TableSchema {
 		TScope extends string | undefined = string | undefined,
 		TCellSchema extends ImplicitAllowedTypes = ImplicitAllowedTypes,
 		TPropsSchema extends ImplicitAnnotatedFieldSchema = ImplicitAnnotatedFieldSchema,
-	> = ReturnType<typeof createRowInternal<TScope, TCellSchema, TPropsSchema>>;
+	> = ReturnType<typeof createRowSchema<TScope, TCellSchema, TPropsSchema>>;
 
 	// #endregion
 
@@ -429,11 +428,11 @@ export namespace System_TableSchema {
 	> = OptionsWithSchemaFactory<TSchemaFactory> & OptionsWithCellSchema<TCell>;
 
 	/**
-	 * Factory for creating new table schema.
+	 * Factory for creating table schema.
 	 * @system @internal
 	 */
 	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Return type is too complex to be reasonable to specify
-	export function createTableInternal<
+	export function createTableSchema<
 		const TInputScope extends string | undefined,
 		const TCellSchema extends ImplicitAllowedTypes,
 		const TColumnSchema extends ColumnSchemaBase<TInputScope>,
@@ -847,7 +846,7 @@ export namespace System_TableSchema {
 		TCell extends ImplicitAllowedTypes,
 		TColumn extends ColumnSchemaBase<TScope>,
 		TRow extends RowSchemaBase<TScope, TCell>,
-	> = ReturnType<typeof createTableInternal<TScope, TCell, TColumn, TRow>>;
+	> = ReturnType<typeof createTableSchema<TScope, TCell, TColumn, TRow>>;
 
 	// #endregion
 }
@@ -883,7 +882,7 @@ export namespace System_TableSchema {
  * 	value: schemaFactory.string,
  * }) {}
  *
- * class Table extends TableSchema.createTable({
+ * class Table extends TableSchema.table({
  * 	schemaFactory,
  * 	cell: Cell,
  * }) {}
@@ -908,17 +907,17 @@ export namespace System_TableSchema {
  * 	dataType: schemaFactory.optional(schemaFactory.string),
  * }) {}
  *
- * class Column extends TableSchema.createColumn({
+ * class Column extends TableSchema.column({
  * 	schemaFactory,
  * 	props: ColumnProps,
  * }) {}
  *
- * class Row extends TableSchema.createRow({
+ * class Row extends TableSchema.row({
  * 	schemaFactory,
  * 	cell: Cell,
  * }) {}
  *
- * class Table extends TableSchema.createTable({
+ * class Table extends TableSchema.table({
  * 	schemaFactory,
  * 	cell: Cell,
  * 	column: Column,
@@ -946,7 +945,7 @@ export namespace TableSchema {
 
 	/**
 	 * A column in a table.
-	 * @remarks Implemented by the schema class returned from {@link TableSchema.(createColumn:2)}.
+	 * @remarks Implemented by the schema class returned from {@link TableSchema.(column:2)}.
 	 * @sealed @internal
 	 */
 	export interface Column<
@@ -962,7 +961,7 @@ export namespace TableSchema {
 		 * The column's properties.
 		 * @remarks This is a user-defined schema that can be used to store additional information about the column.
 		 * @privateRemarks
-		 * Note: these docs are duplicated on the inline type definitions in {@link createColumn}.
+		 * Note: these docs are duplicated on the inline type definitions in {@link System_TableSchema.createColumnSchema}.
 		 * If you update the docs here, please also update the inline type definitions.
 		 */
 		get props(): TreeFieldFromImplicitField<UnannotateImplicitFieldSchema<TProps>>;
@@ -975,37 +974,34 @@ export namespace TableSchema {
 	 * Factory for creating new table column schema.
 	 * @internal
 	 */
-	export function createColumn<const TScope extends string | undefined>({
-		schemaFactory,
-	}: System_TableSchema.CreateColumnOptionsBase<
-		SchemaFactoryAlpha<TScope>
-	>): System_TableSchema.ColumnSchemaBase<TScope, System_TableSchema.DefaultPropsType>;
+	export function column<const TScope extends string | undefined>(
+		params: System_TableSchema.CreateColumnOptionsBase<SchemaFactoryAlpha<TScope>>,
+	): System_TableSchema.ColumnSchemaBase<TScope, System_TableSchema.DefaultPropsType>;
 	/**
 	 * Factory for creating new table column schema.
 	 * @internal
 	 */
-	export function createColumn<
+	export function column<
 		const TScope extends string | undefined,
 		const TProps extends ImplicitAnnotatedFieldSchema,
-	>({
-		schemaFactory,
-		props,
-	}: System_TableSchema.CreateColumnOptionsBase<SchemaFactoryAlpha<TScope>> & {
-		/**
-		 * Optional column properties.
-		 */
-		readonly props: TProps;
-	}): System_TableSchema.ColumnSchemaBase<TScope, TProps>;
+	>(
+		params: System_TableSchema.CreateColumnOptionsBase<SchemaFactoryAlpha<TScope>> & {
+			/**
+			 * Optional column properties.
+			 */
+			readonly props: TProps;
+		},
+	): System_TableSchema.ColumnSchemaBase<TScope, TProps>;
 	/**
 	 * Overload implementation
 	 */
-	export function createColumn({
+	export function column({
 		schemaFactory,
 		props = SchemaFactory.optional(SchemaFactory.null),
 	}: System_TableSchema.CreateColumnOptionsBase & {
 		readonly props?: ImplicitAnnotatedFieldSchema;
 	}): TreeNodeSchema {
-		return System_TableSchema.createColumnInternal(schemaFactory, props);
+		return System_TableSchema.createColumnSchema(schemaFactory, props);
 	}
 
 	// #endregion
@@ -1067,7 +1063,7 @@ export namespace TableSchema {
 		 * The row's properties.
 		 * @remarks This is a user-defined schema that can be used to store additional information about the row.
 		 * @privateRemarks
-		 * Note: these docs are duplicated on the inline type definitions in {@link createColumn}.
+		 * Note: these docs are duplicated on the inline type definitions in {@link System_TableSchema.createRowSchema}.
 		 * If you update the docs here, please also update the inline type definitions.
 		 */
 		get props(): TreeFieldFromImplicitField<UnannotateImplicitFieldSchema<TProps>>;
@@ -1080,45 +1076,39 @@ export namespace TableSchema {
 	 * Factory for creating new table column schema.
 	 * @internal
 	 */
-	export function createRow<
+	export function row<
 		const TScope extends string | undefined,
 		const TCell extends ImplicitAllowedTypes,
-	>({
-		schemaFactory,
-		cell,
-	}: System_TableSchema.CreateRowOptionsBase<
-		SchemaFactoryAlpha<TScope>,
-		TCell
-	>): System_TableSchema.RowSchemaBase<TScope, TCell, System_TableSchema.DefaultPropsType>;
+	>(
+		params: System_TableSchema.CreateRowOptionsBase<SchemaFactoryAlpha<TScope>, TCell>,
+	): System_TableSchema.RowSchemaBase<TScope, TCell, System_TableSchema.DefaultPropsType>;
 	/**
 	 * Factory for creating new table column schema.
 	 * @internal
 	 */
-	export function createRow<
+	export function row<
 		const TScope extends string | undefined,
 		const TCell extends ImplicitAllowedTypes,
 		const TProps extends ImplicitAnnotatedFieldSchema,
-	>({
-		schemaFactory,
-		cell,
-		props,
-	}: System_TableSchema.CreateRowOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
-		/**
-		 * Optional row properties.
-		 */
-		readonly props: TProps;
-	}): System_TableSchema.RowSchemaBase<TScope, TCell, TProps>;
+	>(
+		params: System_TableSchema.CreateRowOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
+			/**
+			 * Optional row properties.
+			 */
+			readonly props: TProps;
+		},
+	): System_TableSchema.RowSchemaBase<TScope, TCell, TProps>;
 	/**
 	 * Overload implementation
 	 */
-	export function createRow({
+	export function row({
 		schemaFactory,
 		cell,
 		props = SchemaFactory.optional(SchemaFactory.null),
 	}: System_TableSchema.CreateRowOptionsBase & {
 		readonly props?: ImplicitAnnotatedFieldSchema;
 	}): TreeNodeSchema {
-		return System_TableSchema.createRowInternal(schemaFactory, cell, props);
+		return System_TableSchema.createRowSchema(schemaFactory, cell, props);
 	}
 
 	// #endregion
@@ -1431,16 +1421,12 @@ export namespace TableSchema {
 	 * Factory for creating new table schema without specifying row or column schema.
 	 * @internal
 	 */
-	export function createTable<
+	export function table<
 		const TScope extends string | undefined,
 		const TCell extends ImplicitAllowedTypes,
-	>({
-		schemaFactory,
-		cell,
-	}: System_TableSchema.TableFactoryOptionsBase<
-		SchemaFactoryAlpha<TScope>,
-		TCell
-	>): System_TableSchema.TableSchemaBase<
+	>(
+		params: System_TableSchema.TableFactoryOptionsBase<SchemaFactoryAlpha<TScope>, TCell>,
+	): System_TableSchema.TableSchemaBase<
 		TScope,
 		TCell,
 		System_TableSchema.ColumnSchemaBase<TScope, System_TableSchema.DefaultPropsType>,
@@ -1450,17 +1436,15 @@ export namespace TableSchema {
 	 * Factory for creating new table schema without specifying row schema.
 	 * @internal
 	 */
-	export function createTable<
+	export function table<
 		const TScope extends string | undefined,
 		const TCell extends ImplicitAllowedTypes,
 		const TColumn extends System_TableSchema.ColumnSchemaBase<TScope>,
-	>({
-		schemaFactory,
-		cell,
-		column,
-	}: System_TableSchema.TableFactoryOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
-		readonly column: TColumn;
-	}): System_TableSchema.TableSchemaBase<
+	>(
+		params: System_TableSchema.TableFactoryOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
+			readonly column: TColumn;
+		},
+	): System_TableSchema.TableSchemaBase<
 		TScope,
 		TCell,
 		TColumn,
@@ -1470,38 +1454,40 @@ export namespace TableSchema {
 	 * Factory for creating new table schema.
 	 * @internal
 	 */
-	export function createTable<
+	export function table<
 		const TScope extends string | undefined,
 		const TCell extends ImplicitAllowedTypes,
 		const TColumn extends System_TableSchema.ColumnSchemaBase<TScope>,
 		const TRow extends System_TableSchema.RowSchemaBase<TScope, TCell>,
-	>({
-		schemaFactory,
-		cell,
-		column,
-		row,
-	}: System_TableSchema.TableFactoryOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
-		readonly column: TColumn;
-		readonly row: TRow;
-	}): System_TableSchema.TableSchemaBase<TScope, TCell, TColumn, TRow>;
+	>(
+		params: System_TableSchema.TableFactoryOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
+			readonly column: TColumn;
+			readonly row: TRow;
+		},
+	): System_TableSchema.TableSchemaBase<TScope, TCell, TColumn, TRow>;
 	/**
 	 * Overload implementation
 	 */
-	export function createTable({
+	export function table({
 		schemaFactory,
-		cell,
-		column = createColumn({
+		cell: cellSchema,
+		column: columnSchema = column({
 			schemaFactory,
 		}),
-		row = createRow({
+		row: rowSchema = row({
 			schemaFactory,
-			cell,
+			cell: cellSchema,
 		}),
 	}: System_TableSchema.TableFactoryOptionsBase & {
 		readonly column?: System_TableSchema.ColumnSchemaBase;
 		readonly row?: System_TableSchema.RowSchemaBase;
 	}): TreeNodeSchema {
-		return System_TableSchema.createTableInternal(schemaFactory, cell, column, row);
+		return System_TableSchema.createTableSchema(
+			schemaFactory,
+			cellSchema,
+			columnSchema,
+			rowSchema,
+		);
 	}
 
 	// #endregion

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1083,7 +1083,7 @@ export namespace TableSchema {
 		params: System_TableSchema.CreateRowOptionsBase<SchemaFactoryAlpha<TScope>, TCell>,
 	): System_TableSchema.RowSchemaBase<TScope, TCell, System_TableSchema.DefaultPropsType>;
 	/**
-	 * Factory for creating new table column schema.
+	 * Factory for creating new table row schema.
 	 * @internal
 	 */
 	export function row<

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -33,7 +33,7 @@ describe("TableFactory unit tests", () => {
 			 */
 			label: schemaFactory.optional(schemaFactory.string),
 		}) {}
-		class Column extends TableSchema.createColumn({
+		class Column extends TableSchema.column({
 			schemaFactory,
 			props: ColumnProps,
 		}) {}
@@ -45,13 +45,13 @@ describe("TableFactory unit tests", () => {
 			 */
 			selectable: schemaFactory.optional(schemaFactory.boolean),
 		}) {}
-		class Row extends TableSchema.createRow({
+		class Row extends TableSchema.row({
 			schemaFactory,
 			cell: Cell,
 			props: schemaFactory.optional(RowProps),
 		}) {}
 
-		class Table extends TableSchema.createTable({
+		class Table extends TableSchema.table({
 			schemaFactory,
 			cell: Cell,
 			column: Column,
@@ -86,7 +86,7 @@ describe("TableFactory unit tests", () => {
 
 	describe("Column Schema", () => {
 		it("Can create without props", () => {
-			class Column extends TableSchema.createColumn({ schemaFactory }) {}
+			class Column extends TableSchema.column({ schemaFactory }) {}
 			const column = new Column({ id: "column-0" });
 
 			// TODO: ideally the "props" property would not exist at all on the derived class.
@@ -96,7 +96,7 @@ describe("TableFactory unit tests", () => {
 		});
 
 		it("Can create with props", () => {
-			class Column extends TableSchema.createColumn({
+			class Column extends TableSchema.column({
 				schemaFactory,
 				props: schemaFactory.string,
 			}) {}
@@ -110,7 +110,7 @@ describe("TableFactory unit tests", () => {
 			class Cell extends schemaFactory.object("table-cell", {
 				value: schemaFactory.string,
 			}) {}
-			class Row extends TableSchema.createRow({ schemaFactory, cell: Cell }) {}
+			class Row extends TableSchema.row({ schemaFactory, cell: Cell }) {}
 			const row = new Row({ id: "row-0", cells: {} });
 
 			// TODO: ideally the "props" property would not exist at all on the derived class.
@@ -123,7 +123,7 @@ describe("TableFactory unit tests", () => {
 			class Cell extends schemaFactory.object("table-cell", {
 				value: schemaFactory.string,
 			}) {}
-			class Row extends TableSchema.createRow({
+			class Row extends TableSchema.row({
 				schemaFactory,
 				cell: Cell,
 				props: schemaFactory.string,
@@ -1309,7 +1309,7 @@ describe("TableFactory unit tests", () => {
 				value: schemaFactory.string,
 			}) {}
 
-			class Table extends TableSchema.createTable({
+			class Table extends TableSchema.table({
 				schemaFactory,
 				cell: Cell,
 			}) {}
@@ -1335,17 +1335,17 @@ describe("TableFactory unit tests", () => {
 				dataType: schemaFactory.optional(schemaFactory.string),
 			}) {}
 
-			class Column extends TableSchema.createColumn({
+			class Column extends TableSchema.column({
 				schemaFactory,
 				props: ColumnProps,
 			}) {}
 
-			class Row extends TableSchema.createRow({
+			class Row extends TableSchema.row({
 				schemaFactory,
 				cell: Cell,
 			}) {}
 
-			class Table extends TableSchema.createTable({
+			class Table extends TableSchema.table({
 				schemaFactory,
 				cell: Cell,
 				column: Column,


### PR DESCRIPTION
Renames the public-facing APIs as follows:
- `TableSchema.createColumn` -> `TableSchema.column`
- `TableSchema.createRow` -> `TableSchema.row`
- `TableSchema.createTable` -> `TableSchema.table`