### PR TITLE
improvement(devtools-view): Fix incorrect `useEffect` dependencies in `FluidHandleView`

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidHandleView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidHandleView.tsx
@@ -81,7 +81,7 @@ export function FluidHandleView(props: FluidHandleViewProps): React.ReactElement
 		return (): void => {
 			messageRelay.off("message", messageHandler);
 		};
-	}, [containerKey, setVisualTree, fluidObjectId, messageRelay]);
+	}, [containerKey, visualTree, fluidObjectId, messageRelay]);
 
 	if (visualTree === undefined) {
 		const header = <TreeHeader label={label} inlineValue={<Spinner size="tiny" />} />;


### PR DESCRIPTION
This PR removes `setVisualTree` and adds `visualTree` to the `useEffect` dependency array in the `FluidHandleView` component.

- `setVisualTree` is a stable setter function from `useState` and does not need to be included in the dependency array.
- Adds `visualTree` to the dependency array to ensure that the `FluidHandleView` component reacts to changes in the underlying visual tree.