### PR TITLE
Revert "Bumped packages using @fluid-tools/benchmark to 0.51 (#24573)"

### DIFF
--- a/examples/benchmarks/tablebench/package.json
+++ b/examples/benchmarks/tablebench/package.json
@@ -61,7 +61,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.3",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -103,7 +103,7 @@
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -84,7 +84,7 @@
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-drivers": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/container-definitions": "workspace:~",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -118,7 +118,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -151,7 +151,7 @@
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -142,7 +142,7 @@
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -149,7 +149,7 @@
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-pairwise-generator": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -164,7 +164,7 @@
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -175,7 +175,7 @@
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",
 		"@fluid-private/test-drivers": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -193,7 +193,7 @@
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-pairwise-generator": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -140,7 +140,7 @@
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -99,7 +99,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -86,7 +86,7 @@
 		"@fluid-private/test-loader-utils": "workspace:~",
 		"@fluid-private/test-pairwise-generator": "workspace:~",
 		"@fluid-private/test-version-utils": "workspace:~",
-		"@fluid-tools/benchmark": "^0.51.0",
+		"@fluid-tools/benchmark": "^0.50.0",
 		"@fluidframework/agent-scheduler": "workspace:~",
 		"@fluidframework/aqueduct": "workspace:~",
 		"@fluidframework/cell": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2253,8 +2253,8 @@ importers:
         specifier: workspace:~
         version: link:../../../packages/test/mocha-test-setup
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -6700,8 +6700,8 @@ importers:
         specifier: workspace:~
         version: link:../../../packages/dds/test-dds-utils
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluid-tools/build-cli':
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
@@ -7103,8 +7103,8 @@ importers:
         specifier: workspace:~
         version: link:../../../packages/test/test-drivers
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -7666,8 +7666,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/mocha-test-setup
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluid-tools/build-cli':
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
@@ -8106,8 +8106,8 @@ importers:
         specifier: workspace:~
         version: link:../test-dds-utils
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluid-tools/build-cli':
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
@@ -8230,8 +8230,8 @@ importers:
         specifier: workspace:~
         version: link:../test-dds-utils
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluid-tools/build-cli':
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
@@ -8354,8 +8354,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-pairwise-generator
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluid-tools/build-cli':
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
@@ -8760,8 +8760,8 @@ importers:
         specifier: workspace:~
         version: link:../test-dds-utils
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluid-tools/build-cli':
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
@@ -9329,8 +9329,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-drivers
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluid-tools/build-cli':
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
@@ -12117,8 +12117,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-pairwise-generator
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluid-tools/build-cli':
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
@@ -12451,8 +12451,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/stochastic-test-utils
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluid-tools/build-cli':
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
@@ -13921,8 +13921,8 @@ importers:
         specifier: workspace:~
         version: link:../mocha-test-setup
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluid-tools/build-cli':
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
@@ -14163,8 +14163,8 @@ importers:
         specifier: workspace:~
         version: link:../test-version-utils
       '@fluid-tools/benchmark':
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.50.0
+        version: 0.50.0
       '@fluidframework/agent-scheduler':
         specifier: workspace:~
         version: link:../../framework/agent-scheduler
@@ -17349,8 +17349,8 @@ packages:
   '@fluid-internal/test-driver-definitions@2.33.0':
     resolution: {integrity: sha512-Vx5aN1a/IhuNa1X8kBCcWYsjzWdKeUxSfgj4K7bqRlaODkUm9hhAQKEvoG/yu1mlmUxyMoRvX1/iXkOWUdGS6Q==}
 
-  '@fluid-tools/benchmark@0.51.0':
-    resolution: {integrity: sha512-Hych9VQu9RrBlYwBHvb2J20GHIs8abpzx1TgypHHIsYDxqK7IVrQ/NRYTE+e8XvXwVHbiuBWQrtpK9oB9bGm2Q==}
+  '@fluid-tools/benchmark@0.50.0':
+    resolution: {integrity: sha512-UGvRHYYGp0aRI90oDA8CFT2d8SdJMZMrDqQAJ9Qbw6VSGR3L9ii9xc43NWU33+qGrt3p1NpAzBppX1sVT55rag==}
 
   '@fluid-tools/build-cli@0.55.0':
     resolution: {integrity: sha512-PnPoJx/7Fzz/jO8/0+QyYARtiJRIsj1NE79DPWbrBGdeSAacok/UgrEJ3JC1Kr68KKgnoIU3Zo7DnLPfBWx1PQ==}
@@ -24167,6 +24167,12 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  mocha-json-output-reporter@2.1.0:
+    resolution: {integrity: sha512-FF2BItlMo8nK9+SgN/WAD01ue7G+qI1Po0U3JCZXQiiyTJ5OV3KcT1mSoZKirjYP73JFZznaaPC6Mp052PF3Vw==}
+    peerDependencies:
+      mocha: ^10.0.0
+      moment: ^2.21.0
+
   mocha-multi-reporters@1.5.1:
     resolution: {integrity: sha512-Yb4QJOaGLIcmB0VY7Wif5AjvLMUFAdV57D2TWEva1Y0kU/3LjKpeRVmlMIfuO1SVbauve459kgtIizADqxMWPg==}
     engines: {node: '>=6.0.0'}
@@ -29456,12 +29462,13 @@ snapshots:
       '@fluidframework/core-interfaces': 2.33.0
       '@fluidframework/driver-definitions': 2.33.0
 
-  '@fluid-tools/benchmark@0.51.0':
+  '@fluid-tools/benchmark@0.50.0':
     dependencies:
       chai: 4.5.0
       chalk: 4.1.2
       easy-table: 1.2.0
       mocha: 10.8.2
+      mocha-json-output-reporter: 2.1.0(mocha@10.8.2)(moment@2.30.1)
       mocha-multi-reporters: 1.5.1(mocha@10.8.2)
       moment: 2.30.1
     transitivePeerDependencies:
@@ -39710,6 +39717,11 @@ snapshots:
   mkdirp@2.1.6: {}
 
   mkdirp@3.0.1: {}
+
+  mocha-json-output-reporter@2.1.0(mocha@10.8.2)(moment@2.30.1):
+    dependencies:
+      mocha: 10.8.2
+      moment: 2.30.1
 
   mocha-multi-reporters@1.5.1(mocha@10.8.2):
     dependencies:


### PR DESCRIPTION
Our internal "Performance benchmarks" pipeline started timing out consistently after this commit. Reverting to allow time for investigation.

https://github.com/microsoft/FluidFramework/pull/24573