### PR TITLE
Add ODSP version attach to OdspContainerServices

### DIFF
--- a/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
@@ -45,6 +45,7 @@ export interface OdspConnectionConfig {
 
 // @beta
 export interface OdspContainerServices {
+    attach(odspProps?: ContainerAttachProps<OdspContainerAttachProps>): Promise<string>;
     audience: IOdspAudience;
 }
 

--- a/packages/service-clients/odsp-client/api-report/odsp-client.beta.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.beta.api.md
@@ -45,6 +45,7 @@ export interface OdspConnectionConfig {
 
 // @beta
 export interface OdspContainerServices {
+    attach(odspProps?: ContainerAttachProps<OdspContainerAttachProps>): Promise<string>;
     audience: IOdspAudience;
 }
 

--- a/packages/service-clients/odsp-client/src/interfaces.ts
+++ b/packages/service-clients/odsp-client/src/interfaces.ts
@@ -7,7 +7,11 @@ import type {
 	IConfigProviderBase,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import type { IMember, IServiceAudience } from "@fluidframework/fluid-static";
+import type {
+	IMember,
+	IServiceAudience,
+	ContainerAttachProps,
+} from "@fluidframework/fluid-static";
 
 import type { IOdspTokenProvider } from "./token.js";
 
@@ -87,6 +91,11 @@ export interface OdspContainerServices {
 	 * Provides an object that facilitates obtaining information about users present in the Fluid session, as well as listeners for roster changes triggered by users joining or leaving the session.
 	 */
 	audience: IOdspAudience;
+
+	/**
+	 * Attach function that is used to attach the container to the ODSP service. This function is specific to the ODSP service and accepts some ODSP specific properties.
+	 */
+	attach(odspProps?: ContainerAttachProps<OdspContainerAttachProps>): Promise<string>;
 }
 
 /**

--- a/packages/service-clients/odsp-client/src/odspClient.ts
+++ b/packages/service-clients/odsp-client/src/odspClient.ts
@@ -137,7 +137,7 @@ export class OdspClient {
 
 		const fluidContainer = await this.createFluidContainer(container, this.connectionConfig);
 
-		const services = await this.getContainerServices(container);
+		const services = await this.getContainerServices(container, fluidContainer);
 
 		return { container: fluidContainer as IFluidContainer<T>, services };
 	}
@@ -162,7 +162,7 @@ export class OdspClient {
 			container,
 			rootDataObject: await this.getContainerEntryPoint(container),
 		});
-		const services = await this.getContainerServices(container);
+		const services = await this.getContainerServices(container, fluidContainer);
 		return { container: fluidContainer as IFluidContainer<T>, services };
 	}
 
@@ -242,12 +242,18 @@ export class OdspClient {
 		return fluidContainer;
 	}
 
-	private async getContainerServices(container: IContainer): Promise<OdspContainerServices> {
+	private async getContainerServices(
+		container: IContainer,
+		fluidContaienr: IFluidContainer,
+	): Promise<OdspContainerServices> {
 		return {
 			audience: createServiceAudience({
 				container,
 				createServiceMember: createOdspAudienceMember,
 			}),
+			attach: async (odspProps?: ContainerAttachProps<OdspContainerAttachProps>) => {
+				return fluidContaienr.attach(odspProps);
+			},
 		};
 	}
 

--- a/packages/service-clients/odsp-client/src/odspClient.ts
+++ b/packages/service-clients/odsp-client/src/odspClient.ts
@@ -244,7 +244,7 @@ export class OdspClient {
 
 	private async getContainerServices(
 		container: IContainer,
-		fluidContaienr: IFluidContainer,
+		fluidContainer: IFluidContainer,
 	): Promise<OdspContainerServices> {
 		return {
 			audience: createServiceAudience({
@@ -252,7 +252,7 @@ export class OdspClient {
 				createServiceMember: createOdspAudienceMember,
 			}),
 			attach: async (odspProps?: ContainerAttachProps<OdspContainerAttachProps>) => {
-				return fluidContaienr.attach(odspProps);
+				return fluidContainer.attach(odspProps);
 			},
 		};
 	}


### PR DESCRIPTION
## Description
Add attach function to OdspContainerServices. It is more like exposing the ODSP specific arguments to ODSP client. Previously, the attach is at the IFluidContainer level which is a generic interface. Some arguments like filePath and fileName are not available in the function. But internally, we already support these arguments, through an internal logic by reassigning the attach function at ODSPClient. This change is just to expose it at ODSP interface.

User will be aware of the available args for ODSP specifically and can call OdspContainerServices.attach(odspArgs) to use the ODSP version of the attach function. It will just call the same function as before.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).