### PR TITLE
DDS Fuzz: support numbers or iterable for all seed based test options

### DIFF
--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -448,7 +448,7 @@ export interface DDSFuzzSuiteOptions {
 	 * TODO: Improving workflows around fuzz test minimization, regression test generation for a particular seed,
 	 * or more flexibility around replay of test files would be a nice value add to this harness.
 	 */
-	replay?: number;
+	replay?: Iterable<number> | number;
 
 	/**
 	 * Runs only the provided seeds.
@@ -463,7 +463,7 @@ export interface DDSFuzzSuiteOptions {
 	 * @remarks
 	 * If you prefer, a variant of the standard `.only` syntax works. See {@link (createDDSFuzzSuite:namespace).only}.
 	 */
-	only: Iterable<number>;
+	only: Iterable<number> | number;
 
 	/**
 	 * Skips the provided seeds.
@@ -478,7 +478,7 @@ export interface DDSFuzzSuiteOptions {
 	 * @remarks
 	 * If you prefer, a variant of the standard `.skip` syntax works. See {@link (createDDSFuzzSuite:namespace).skip}.
 	 */
-	skip: Iterable<number>;
+	skip: Iterable<number> | number;
 
 	/**
 	 * Whether failure files should be saved to disk, and if so, the directory in which they should be saved.
@@ -1589,6 +1589,10 @@ type InternalOptions = InternalOnlyAndSkip & Omit<DDSFuzzSuiteOptions, "only" | 
  */
 export class ReducerPreconditionError extends Error {}
 
+const normalizeSeedOption = (
+	seeds: number | Iterable<number> | undefined,
+): Iterable<number> => (typeof seeds === "number" ? [seeds] : (seeds ?? []));
+
 /**
  * Performs the test again to verify if the DDS still fails with the same error message.
  *
@@ -1607,8 +1611,8 @@ export async function replayTest<
 	const options = {
 		...defaultDDSFuzzSuiteOptions,
 		...providedOptions,
-		only: new Set(providedOptions?.only ?? []),
-		skip: new Set(providedOptions?.skip ?? []),
+		only: new Set(normalizeSeedOption(providedOptions?.only)),
+		skip: new Set(normalizeSeedOption(providedOptions?.skip)),
 	};
 
 	const model = {
@@ -1623,8 +1627,8 @@ export async function replayTest<
 export function convertOnlyAndSkip<TOptions extends DDSFuzzSuiteOptions>(
 	options: TOptions,
 ): InternalOnlyAndSkip & Omit<TOptions, "only" | "skip"> {
-	const only = new Set(options.only);
-	const skip = new Set(options.skip);
+	const only = new Set(normalizeSeedOption(options.only));
+	const skip = new Set(normalizeSeedOption(options.skip));
 	Object.assign(options, { only, skip });
 	return options as unknown as InternalOnlyAndSkip & Omit<TOptions, "only" | "skip">;
 }
@@ -1663,24 +1667,25 @@ export function createSuite<
 		}
 
 		if (options.replay !== undefined) {
-			const seed = options.replay;
 			describe.only(`replay from file`, () => {
-				const saveInfo = getSaveInfo(model, options, seed);
-				assert(
-					saveInfo.saveOnFailure !== false,
-					"Cannot replay a file without a directory to save files in!",
-				);
-				const operations = options.parseOperations(
-					readFileSync(saveInfo.saveOnFailure.path).toString(),
-				);
+				for (const seed of normalizeSeedOption(options.replay)) {
+					const saveInfo = getSaveInfo(model, options, seed);
+					assert(
+						saveInfo.saveOnFailure !== false,
+						"Cannot replay a file without a directory to save files in!",
+					);
+					const operations = options.parseOperations(
+						readFileSync(saveInfo.saveOnFailure.path).toString(),
+					);
 
-				const replayModel = {
-					...model,
-					// We lose some type safety here because the options interface isn't generic
-					generatorFactory: (): AsyncGenerator<TOperation, unknown> =>
-						asyncGeneratorFromArray(operations as TOperation[]),
-				};
-				runTest(replayModel, options, seed, undefined);
+					const replayModel = {
+						...model,
+						// We lose some type safety here because the options interface isn't generic
+						generatorFactory: (): AsyncGenerator<TOperation, unknown> =>
+							asyncGeneratorFromArray(operations as TOperation[]),
+					};
+					runTest(replayModel, options, seed, undefined);
+				}
 			});
 		}
 	});
@@ -1752,7 +1757,7 @@ export namespace createDDSFuzzSuite {
 		): void =>
 			createDDSFuzzSuite(ddsModel, {
 				...providedOptions,
-				only: [...seeds, ...(providedOptions?.only ?? [])],
+				only: [...seeds, ...normalizeSeedOption(providedOptions?.only)],
 			});
 
 	/**
@@ -1774,6 +1779,6 @@ export namespace createDDSFuzzSuite {
 		): void =>
 			createDDSFuzzSuite(ddsModel, {
 				...providedOptions,
-				skip: [...seeds, ...(providedOptions?.skip ?? [])],
+				skip: [...seeds, ...normalizeSeedOption(providedOptions?.skip)],
 			});
 }

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -448,7 +448,7 @@ export interface DDSFuzzSuiteOptions {
 	 * TODO: Improving workflows around fuzz test minimization, regression test generation for a particular seed,
 	 * or more flexibility around replay of test files would be a nice value add to this harness.
 	 */
-	replay?: Iterable<number> | number;
+	replay?: number | Iterable<number>;
 
 	/**
 	 * Runs only the provided seeds.
@@ -1589,7 +1589,7 @@ type InternalOptions = InternalOnlyAndSkip & Omit<DDSFuzzSuiteOptions, "only" | 
  */
 export class ReducerPreconditionError extends Error {}
 
-const normalizeSeedOption = (
+export const normalizeSeedOption = (
 	seeds: number | Iterable<number> | undefined,
 ): Iterable<number> => (typeof seeds === "number" ? [seeds] : (seeds ?? []));
 

--- a/packages/dds/test-dds-utils/src/squashFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/squashFuzzHarness.ts
@@ -40,6 +40,7 @@ import {
 	defaultDDSFuzzSuiteOptions,
 	type CleanupFunction,
 	ReducerPreconditionError,
+	normalizeSeedOption,
 } from "./ddsFuzzHarness.js";
 import { makeUnreachableCodePathProxy } from "./utils.js";
 
@@ -384,7 +385,7 @@ export namespace createSquashFuzzSuite {
 		): void =>
 			createSquashFuzzSuite(ddsModel, {
 				...providedOptions,
-				only: [...seeds, ...(providedOptions?.only ?? [])],
+				only: [...seeds, ...normalizeSeedOption(providedOptions?.only)],
 			});
 
 	/**
@@ -406,6 +407,6 @@ export namespace createSquashFuzzSuite {
 		): void =>
 			createSquashFuzzSuite(ddsModel, {
 				...providedOptions,
-				skip: [...seeds, ...(providedOptions?.skip ?? [])],
+				skip: [...seeds, ...normalizeSeedOption(providedOptions?.skip)],
 			});
 }


### PR DESCRIPTION
This is really about ease of use. Supporting the same types of all options makes it easy to move between then as I run and debug the tests without requiring any re-formatting.

For instance, i can now change a `.skip` to a `.only` to rerun the skipped tests, and then i can change that to `.reply` to run the minimized forms.