### PR TITLE
skip snapshot refresh e2e tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/offline/refreshSerializerLifeCycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/refreshSerializerLifeCycle.spec.ts
@@ -101,7 +101,7 @@ describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider,
 	};
 
 	for (const testConfig of testConfigs) {
-		it(`Snapshot refresh life cycle: ${JSON.stringify(
+		it.skip(`Snapshot refresh life cycle: ${JSON.stringify(
 			testConfig ?? "undefined",
 		)}`, async () => {
 			const provider: ITestObjectProvider = getTestObjectProvider();


### PR DESCRIPTION
These tests are timing out even in local driver. Major refactoring is needed on them to test desired scenarios in a lighter and more controlled way. These tests only affect offline workflows which no one is using right now so it's safe to skip them for now.