### PR TITLE
fix(docs): Update release notes link

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -52,7 +52,7 @@ const sidebars: SidebarsConfig = {
 		{
 			type: "link",
 			label: "Release Notes",
-			href: "https://github.com/microsoft/FluidFramework/releases/tag/client_v2.0.0",
+			href: "https://github.com/microsoft/FluidFramework/releases?q=client",
 		},
 		{
 			type: "category",


### PR DESCRIPTION
The docs site was hard-coded to point to the v2.20 release notes. This updates the link to point to a query for all "client" releases instead.