### PR TITLE
Fix local-server-stress-test's incremental build

### DIFF
--- a/packages/test/local-server-stress-tests/package.json
+++ b/packages/test/local-server-stress-tests/package.json
@@ -104,6 +104,7 @@
 			"build:test": [
 				"^tsc",
 				"^api-extractor:commonjs",
+				"@fluidframework/id-compressor#build:test",
 				"@fluidframework/sequence#build:test",
 				"@fluidframework/map#build:test"
 			]


### PR DESCRIPTION
## Description

Properly declares a dependency on id-compressor's test export.