### PR TITLE
Refactor tree content insertion handling

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/utilities.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/utilities.ts
@@ -11,8 +11,9 @@ import {
 	rootField,
 	type SchemaAndPolicy,
 } from "../../core/index.js";
+import type { FlexTreeContext } from "./context.js";
 
-import { TreeStatus, type FlexTreeEntity } from "./flexTreeTypes.js";
+import { TreeStatus } from "./flexTreeTypes.js";
 /**
  * Checks the detached field and returns the TreeStatus based on whether or not the detached field is a root field.
  * @param detachedField - the detached field you want to check.
@@ -80,10 +81,10 @@ export interface DetachedFieldCache {
  * @returns A {@link SchemaAndPolicy} object with the stored schema and policy from the node or field provided.
  * For {@link Unhydrated} nodes this schema may only describe the types allowed subtree for this particular entity.
  */
-export function getSchemaAndPolicy(nodeOrField: FlexTreeEntity): SchemaAndPolicy {
+export function getSchemaAndPolicy(context: FlexTreeContext): SchemaAndPolicy {
 	return {
-		schema: nodeOrField.context.schema,
-		policy: nodeOrField.context.schemaPolicy,
+		schema: context.schema,
+		policy: context.schemaPolicy,
 	};
 }
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/utilities.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/utilities.ts
@@ -76,10 +76,9 @@ export interface DetachedFieldCache {
 }
 
 /**
- * Utility function to get a {@link SchemaAndPolicy} object from a {@link FlexTreeNode} or {@link FlexTreeField}.
- * @param nodeOrField - {@link FlexTreeNode} or {@link FlexTreeField} to get the schema and policy from.
- * @returns A {@link SchemaAndPolicy} object with the stored schema and policy from the node or field provided.
- * For {@link Unhydrated} nodes this schema may only describe the types allowed subtree for this particular entity.
+ * Utility function to get a {@link SchemaAndPolicy} object from a {@link FlexTreeContext}.
+ * @returns A {@link SchemaAndPolicy} object with the stored schema and policy from the context provided.
+ * For {@link Unhydrated} contexts this schema may only describe the types allowed subtree for this particular entity.
  */
 export function getSchemaAndPolicy(context: FlexTreeContext): SchemaAndPolicy {
 	return {

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -33,8 +33,6 @@ import {
 	SchemaCompatibilityTester,
 	type InsertableContent,
 	type TreeViewConfiguration,
-	mapTreeFromNodeData,
-	prepareContentForHydration,
 	type TreeViewAlpha,
 	type InsertableField,
 	type ReadableField,
@@ -54,6 +52,7 @@ import {
 	SimpleContextSlot,
 	areImplicitFieldSchemaEqual,
 	createUnknownOptionalFieldPolicy,
+	prepareForInsertionContextless,
 } from "../simple-tree/index.js";
 import {
 	type Breakable,
@@ -176,17 +175,16 @@ export class SchematizingSimpleTreeView<
 
 		this.runSchemaEdit(() => {
 			const schema = this.viewSchema.viewSchemaAsStored;
-			const mapTree = mapTreeFromNodeData(
+			const mapTree = prepareForInsertionContextless(
 				content as InsertableContent | undefined,
 				this.rootFieldSchema,
-				this.nodeKeyManager,
 				{
 					schema,
 					policy: this.schemaPolicy,
 				},
+				this,
 			);
 
-			prepareContentForHydration(mapTree, this.checkout.forest);
 			initialize(this.checkout, {
 				schema,
 				initialTree: mapTree === undefined ? undefined : cursorForMapTreeNode(mapTree),

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -183,10 +183,7 @@ export {
 	type NodeSchemaMetadata,
 	evaluateLazySchema,
 } from "./schemaTypes.js";
-export {
-	getTreeNodeForField,
-	prepareContentForHydration,
-} from "./proxies.js";
+export { getTreeNodeForField } from "./proxies.js";
 export {
 	TreeArrayNode,
 	IterableTreeArrayContent,
@@ -219,6 +216,10 @@ export {
 	type FactoryContent,
 	type FactoryContentObject,
 } from "./toMapTree.js";
+export {
+	prepareForInsertion,
+	prepareForInsertionContextless,
+} from "./prepareForInsertion.js";
 export { toStoredSchema, getStoredSchema } from "./toStoredSchema.js";
 export {
 	numberSchema,

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -4,13 +4,12 @@
  */
 
 import { Lazy } from "@fluidframework/core-utils/internal";
-import {
-	type FlexTreeNode,
-	type FlexTreeOptionalField,
-	type OptionalFieldEditBuilder,
-	getSchemaAndPolicy,
+import type {
+	FlexTreeNode,
+	FlexTreeOptionalField,
+	OptionalFieldEditBuilder,
 } from "../feature-libraries/index.js";
-import { getTreeNodeForField, prepareContentForHydration } from "./proxies.js";
+import { getTreeNodeForField } from "./proxies.js";
 import {
 	createFieldSchema,
 	FieldKind,
@@ -42,6 +41,7 @@ import {
 	type FactoryContent,
 	type InsertableContent,
 } from "./toMapTree.js";
+import { prepareForInsertion } from "./prepareForInsertion.js";
 import { brand, count, type RestrictiveStringRecord } from "../util/index.js";
 import { TreeNodeValid, type MostDerivedData } from "./treeNodeValid.js";
 import type { ExclusiveMapTree } from "../core/index.js";
@@ -191,17 +191,13 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 	public set(key: string, value: InsertableTreeNodeFromImplicitAllowedTypes<T>): this {
 		const kernel = getKernel(this);
 		const node = this.innerNode;
-		const mapTree = mapTreeFromNodeData(
+		const mapTree = prepareForInsertion(
 			value as InsertableContent | undefined,
 			createFieldSchema(FieldKind.Optional, kernel.schema.info as ImplicitAllowedTypes),
-			node.context.isHydrated() ? node.context.nodeKeyManager : undefined,
-			getSchemaAndPolicy(node),
+			node.context,
 		);
 
 		const field = node.getBoxed(brand(key));
-		if (node.context.isHydrated()) {
-			prepareContentForHydration(mapTree, node.context.checkout.forest);
-		}
 
 		this.editor(key).set(mapTree, field.length === 0);
 		return this;

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -13,9 +13,8 @@ import {
 	type FlexTreeNode,
 	type FlexTreeOptionalField,
 	type FlexTreeRequiredField,
-	getSchemaAndPolicy,
 } from "../feature-libraries/index.js";
-import { getTreeNodeForField, prepareContentForHydration } from "./proxies.js";
+import { getTreeNodeForField } from "./proxies.js";
 import {
 	type ImplicitFieldSchema,
 	getStoredKey,
@@ -47,6 +46,7 @@ import {
 	getOrCreateInnerNode,
 } from "./core/index.js";
 import { mapTreeFromNodeData, type InsertableContent } from "./toMapTree.js";
+import { prepareForInsertion } from "./prepareForInsertion.js";
 import type { RestrictiveStringRecord, FlattenKeys } from "../util/index.js";
 import {
 	isObjectNodeSchema,
@@ -328,16 +328,7 @@ export function setField(
 	simpleFieldSchema: FieldSchema,
 	value: InsertableContent | undefined,
 ): void {
-	const mapTree = mapTreeFromNodeData(
-		value,
-		simpleFieldSchema,
-		field.context.isHydrated() ? field.context.nodeKeyManager : undefined,
-		getSchemaAndPolicy(field),
-	);
-
-	if (field.context.isHydrated()) {
-		prepareContentForHydration(mapTree, field.context.checkout.forest);
-	}
+	const mapTree = prepareForInsertion(value, simpleFieldSchema, field.context);
 
 	switch (field.schema) {
 		case FieldKinds.required.identifier: {

--- a/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
+++ b/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
@@ -1,0 +1,230 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type {
+	ExclusiveMapTree,
+	SchemaAndPolicy,
+	IForestSubscription,
+	MapTree,
+	UpPath,
+} from "../core/index.js";
+import {
+	type FlexTreeContext,
+	getSchemaAndPolicy,
+	type FlexTreeHydratedContext,
+} from "../feature-libraries/index.js";
+import type { ImplicitAllowedTypes, ImplicitFieldSchema } from "./schemaTypes.js";
+import { type InsertableContent, mapTreeFromNodeData } from "./toMapTree.js";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { EmptyKey } from "../core/index.js";
+import { type Mutable, isReadonlyArray } from "../util/index.js";
+import {
+	getKernel,
+	type TreeNode,
+	tryUnhydratedFlexTreeNode,
+	unhydratedFlexTreeNodeToTreeNode,
+} from "./core/index.js";
+
+/**
+ * Prepare content from a user for insertion into a tree.
+ * @remarks
+ * This validates and converts the input, and if necessary invokes {@link prepareContentForHydration}.
+ */
+export function prepareForInsertion<TIn extends InsertableContent | undefined>(
+	data: TIn,
+	schema: ImplicitFieldSchema,
+	destinationContext: FlexTreeContext,
+): ExclusiveMapTree | undefined extends TIn ? undefined : never {
+	return prepareForInsertionContextless(
+		data,
+		schema,
+		getSchemaAndPolicy(destinationContext),
+		destinationContext.isHydrated() ? destinationContext : undefined,
+	);
+}
+
+/**
+ * {@link prepareForInsertion} but batched for array content.
+ * @privateRemarks
+ * TODO:
+ * Experimentally it was determined that making separate calls to prepareContentForHydration for each array item did not work.
+ * This should be understood and fixed or have the factors that cause it clearly documented.
+ * If fixed, this function should be removed, and arrays can just map over prepareForInsertion.
+ */
+export function prepareArrayForInsertion(
+	data: readonly InsertableContent[],
+	schema: ImplicitAllowedTypes,
+	destinationContext: FlexTreeContext,
+): ExclusiveMapTree[] {
+	const mapTrees: ExclusiveMapTree[] = data.map((item) =>
+		mapTreeFromNodeData(
+			item,
+			schema,
+			destinationContext.isHydrated() ? destinationContext.nodeKeyManager : undefined,
+			getSchemaAndPolicy(destinationContext),
+		),
+	);
+
+	if (destinationContext.isHydrated()) {
+		prepareContentForHydration(mapTrees, destinationContext.checkout.forest);
+	}
+
+	return mapTrees;
+}
+
+/**
+ * Split out from {@link prepareForInsertion} as to allow use without a context.
+ * @remarks
+ * Adding this entry point is a workaround for initialize not currently having a context.
+ */
+export function prepareForInsertionContextless<TIn extends InsertableContent | undefined>(
+	data: TIn,
+	schema: ImplicitFieldSchema,
+	schemaAndPolicy: SchemaAndPolicy,
+	hydratedData: Pick<FlexTreeHydratedContext, "checkout" | "nodeKeyManager"> | undefined,
+): ExclusiveMapTree | undefined extends TIn ? undefined : never {
+	const mapTree = mapTreeFromNodeData(
+		data,
+		schema,
+		hydratedData?.nodeKeyManager,
+		schemaAndPolicy,
+	);
+
+	if (mapTree !== undefined && hydratedData !== undefined) {
+		prepareContentForHydration(mapTree, hydratedData.checkout.forest);
+	}
+
+	return mapTree as ExclusiveMapTree | undefined extends TIn ? undefined : never;
+}
+
+// #region Content insertion and proxy binding
+
+/** The path of a proxy, relative to the root of the content tree that the proxy belongs to */
+interface RelativeProxyPath {
+	readonly path: UpPath;
+	readonly proxy: TreeNode;
+}
+
+/** All {@link RelativeProxyPath}s that are under the given root path */
+interface RootedProxyPaths {
+	readonly rootPath: UpPath;
+	readonly proxyPaths: RelativeProxyPath[];
+}
+
+/**
+ * Records any proxies in the given content tree and does the necessary bookkeeping to ensure they are synchronized with subsequent reads of the tree.
+ * @remarks If the content tree contains any proxies, this function must be called just prior to inserting the content into the tree.
+ * Specifically, no other content may be inserted into the tree between the invocation of this function and the insertion of `content`.
+ * The insertion of `content` must occur or else this function will cause memory leaks.
+ * @param content - the tree of content to be inserted, of which any of its object/map/array nodes might be a proxy
+ * @param anchors - the {@link AnchorSet} for the tree
+ * @returns The content after having all proxies replaced inline with plain javascript objects.
+ * See {@link extractFactoryContent} for more details.
+ */
+function prepareContentForHydration(
+	content: MapTree | readonly MapTree[] | undefined,
+	forest: IForestSubscription,
+): void {
+	if (isReadonlyArray(content)) {
+		return prepareArrayContentForHydration(content, forest);
+	}
+
+	if (content !== undefined) {
+		const proxies: RootedProxyPaths = {
+			rootPath: { parent: undefined, parentField: EmptyKey, parentIndex: 0 },
+			proxyPaths: [],
+		};
+
+		walkMapTree(content, proxies.rootPath, (p, proxy) => {
+			proxies.proxyPaths.push({ path: p, proxy });
+		});
+
+		bindProxies([proxies], forest);
+	}
+}
+
+function prepareArrayContentForHydration(
+	content: readonly MapTree[],
+	forest: IForestSubscription,
+): void {
+	const proxyPaths: RootedProxyPaths[] = [];
+	for (const item of content) {
+		const proxyPath: RootedProxyPaths = {
+			rootPath: {
+				parent: undefined,
+				parentField: EmptyKey,
+				parentIndex: 0,
+			},
+			proxyPaths: [],
+		};
+		proxyPaths.push(proxyPath);
+		walkMapTree(item, proxyPath.rootPath, (p, proxy) => {
+			proxyPath.proxyPaths.push({ path: p, proxy });
+		});
+	}
+
+	bindProxies(proxyPaths, forest);
+}
+
+function walkMapTree(
+	mapTree: MapTree,
+	path: UpPath,
+	onVisitTreeNode: (path: UpPath, treeNode: TreeNode) => void,
+): void {
+	if (tryUnhydratedFlexTreeNode(mapTree)?.parentField.parent.parent !== undefined) {
+		throw new UsageError(
+			"Attempted to insert a node which is already under a parent. If this is desired, remove the node from its parent before inserting it elsewhere.",
+		);
+	}
+
+	type Next = [path: UpPath, tree: MapTree];
+	const nexts: Next[] = [];
+	for (let next: Next | undefined = [path, mapTree]; next !== undefined; next = nexts.pop()) {
+		const [p, m] = next;
+		const mapTreeNode = tryUnhydratedFlexTreeNode(m);
+		if (mapTreeNode !== undefined) {
+			const treeNode = unhydratedFlexTreeNodeToTreeNode.get(mapTreeNode);
+			if (treeNode !== undefined) {
+				onVisitTreeNode(p, treeNode);
+			}
+		}
+
+		for (const [key, field] of m.fields) {
+			for (const [i, child] of field.entries()) {
+				nexts.push([
+					{
+						parent: p,
+						parentField: key,
+						parentIndex: i,
+					},
+					child,
+				]);
+			}
+		}
+	}
+}
+
+function bindProxies(proxies: readonly RootedProxyPaths[], forest: IForestSubscription): void {
+	// Only subscribe to the event if there is at least one proxy tree to hydrate - this is not the case when inserting an empty array [].
+	if (proxies.length > 0) {
+		// Creating a new array emits one event per element in the array, so listen to the event once for each element
+		let i = 0;
+		const off = forest.events.on("afterRootFieldCreated", (fieldKey) => {
+			// Non null asserting here because of the length check above
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			(proxies[i]!.rootPath as Mutable<UpPath>).parentField = fieldKey;
+			// Non null asserting here because of the length check above
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			for (const { path, proxy } of proxies[i]!.proxyPaths) {
+				getKernel(proxy).anchorProxy(forest.anchors, path);
+			}
+			if (++i === proxies.length) {
+				off();
+			}
+		});
+	}
+}
+
+// #endregion Content insertion and proxy binding

--- a/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
+++ b/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
@@ -36,7 +36,7 @@ export function prepareForInsertion<TIn extends InsertableContent | undefined>(
 	data: TIn,
 	schema: ImplicitFieldSchema,
 	destinationContext: FlexTreeContext,
-): ExclusiveMapTree | undefined extends TIn ? undefined : never {
+): TIn extends undefined ? undefined : ExclusiveMapTree {
 	return prepareForInsertionContextless(
 		data,
 		schema,
@@ -84,7 +84,7 @@ export function prepareForInsertionContextless<TIn extends InsertableContent | u
 	schema: ImplicitFieldSchema,
 	schemaAndPolicy: SchemaAndPolicy,
 	hydratedData: Pick<FlexTreeHydratedContext, "checkout" | "nodeKeyManager"> | undefined,
-): ExclusiveMapTree | undefined extends TIn ? undefined : never {
+): TIn extends undefined ? undefined : ExclusiveMapTree {
 	const mapTree = mapTreeFromNodeData(
 		data,
 		schema,
@@ -96,7 +96,7 @@ export function prepareForInsertionContextless<TIn extends InsertableContent | u
 		prepareContentForHydration(mapTree, hydratedData.checkout.forest);
 	}
 
-	return mapTree as ExclusiveMapTree | undefined extends TIn ? undefined : never;
+	return mapTree as TIn extends undefined ? undefined : ExclusiveMapTree;
 }
 
 // #region Content insertion and proxy binding

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -3,16 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { fail } from "@fluidframework/core-utils/internal";
-import {
-	EmptyKey,
-	type IForestSubscription,
-	type MapTree,
-	type TreeValue,
-	type UpPath,
-} from "../core/index.js";
-
+import type { TreeValue } from "../core/index.js";
 import {
 	FieldKinds,
 	type FlexTreeField,
@@ -20,14 +12,7 @@ import {
 	type FlexTreeRequiredField,
 	type FlexTreeOptionalField,
 } from "../feature-libraries/index.js";
-import { type Mutable, isReadonlyArray } from "../util/index.js";
-import {
-	getKernel,
-	type TreeNode,
-	getOrCreateNodeFromInnerNode,
-	tryUnhydratedFlexTreeNode,
-	unhydratedFlexTreeNodeToTreeNode,
-} from "./core/index.js";
+import { type TreeNode, getOrCreateNodeFromInnerNode } from "./core/index.js";
 
 /**
  * Retrieve the associated {@link TreeNode} for the given field's content.
@@ -59,133 +44,3 @@ export function getTreeNodeForField(field: FlexTreeField): TreeNode | TreeValue 
 			fail(0xadf /* invalid field kind */);
 	}
 }
-
-// #region Content insertion and proxy binding
-
-/** The path of a proxy, relative to the root of the content tree that the proxy belongs to */
-interface RelativeProxyPath {
-	readonly path: UpPath;
-	readonly proxy: TreeNode;
-}
-
-/** All {@link RelativeProxyPath}s that are under the given root path */
-interface RootedProxyPaths {
-	readonly rootPath: UpPath;
-	readonly proxyPaths: RelativeProxyPath[];
-}
-
-/**
- * Records any proxies in the given content tree and does the necessary bookkeeping to ensure they are synchronized with subsequent reads of the tree.
- * @remarks If the content tree contains any proxies, this function must be called just prior to inserting the content into the tree.
- * Specifically, no other content may be inserted into the tree between the invocation of this function and the insertion of `content`.
- * The insertion of `content` must occur or else this function will cause memory leaks.
- * @param content - the tree of content to be inserted, of which any of its object/map/array nodes might be a proxy
- * @param anchors - the {@link AnchorSet} for the tree
- * @returns The content after having all proxies replaced inline with plain javascript objects.
- * See {@link extractFactoryContent} for more details.
- */
-export function prepareContentForHydration(
-	content: MapTree | readonly MapTree[] | undefined,
-	forest: IForestSubscription,
-): void {
-	if (isReadonlyArray(content)) {
-		return prepareArrayContentForHydration(content, forest);
-	}
-
-	if (content !== undefined) {
-		const proxies: RootedProxyPaths = {
-			rootPath: { parent: undefined, parentField: EmptyKey, parentIndex: 0 },
-			proxyPaths: [],
-		};
-
-		walkMapTree(content, proxies.rootPath, (p, proxy) => {
-			proxies.proxyPaths.push({ path: p, proxy });
-		});
-
-		bindProxies([proxies], forest);
-	}
-}
-
-function prepareArrayContentForHydration(
-	content: readonly MapTree[],
-	forest: IForestSubscription,
-): void {
-	const proxyPaths: RootedProxyPaths[] = [];
-	for (const item of content) {
-		const proxyPath: RootedProxyPaths = {
-			rootPath: {
-				parent: undefined,
-				parentField: EmptyKey,
-				parentIndex: 0,
-			},
-			proxyPaths: [],
-		};
-		proxyPaths.push(proxyPath);
-		walkMapTree(item, proxyPath.rootPath, (p, proxy) => {
-			proxyPath.proxyPaths.push({ path: p, proxy });
-		});
-	}
-
-	bindProxies(proxyPaths, forest);
-}
-
-function walkMapTree(
-	mapTree: MapTree,
-	path: UpPath,
-	onVisitTreeNode: (path: UpPath, treeNode: TreeNode) => void,
-): void {
-	if (tryUnhydratedFlexTreeNode(mapTree)?.parentField.parent.parent !== undefined) {
-		throw new UsageError(
-			"Attempted to insert a node which is already under a parent. If this is desired, remove the node from its parent before inserting it elsewhere.",
-		);
-	}
-
-	type Next = [path: UpPath, tree: MapTree];
-	const nexts: Next[] = [];
-	for (let next: Next | undefined = [path, mapTree]; next !== undefined; next = nexts.pop()) {
-		const [p, m] = next;
-		const mapTreeNode = tryUnhydratedFlexTreeNode(m);
-		if (mapTreeNode !== undefined) {
-			const treeNode = unhydratedFlexTreeNodeToTreeNode.get(mapTreeNode);
-			if (treeNode !== undefined) {
-				onVisitTreeNode(p, treeNode);
-			}
-		}
-
-		for (const [key, field] of m.fields) {
-			for (const [i, child] of field.entries()) {
-				nexts.push([
-					{
-						parent: p,
-						parentField: key,
-						parentIndex: i,
-					},
-					child,
-				]);
-			}
-		}
-	}
-}
-
-function bindProxies(proxies: readonly RootedProxyPaths[], forest: IForestSubscription): void {
-	// Only subscribe to the event if there is at least one proxy tree to hydrate - this is not the case when inserting an empty array [].
-	if (proxies.length > 0) {
-		// Creating a new array emits one event per element in the array, so listen to the event once for each element
-		let i = 0;
-		const off = forest.events.on("afterRootFieldCreated", (fieldKey) => {
-			// Non null asserting here because of the length check above
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			(proxies[i]!.rootPath as Mutable<UpPath>).parentField = fieldKey;
-			// Non null asserting here because of the length check above
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			for (const { path, proxy } of proxies[i]!.proxyPaths) {
-				getKernel(proxy).anchorProxy(forest.anchors, path);
-			}
-			if (++i === proxies.length) {
-				off();
-			}
-		});
-	}
-}
-
-// #endregion Content insertion and proxy binding

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -9,7 +9,6 @@ import {
 	buildForest,
 	cursorForMapTreeField,
 	defaultSchemaPolicy,
-	getSchemaAndPolicy,
 	initializeForest,
 	MockNodeIdentifierManager,
 } from "../../feature-libraries/index.js";
@@ -17,7 +16,6 @@ import {
 	HydratedContext,
 	isTreeNode,
 	isTreeNodeSchemaClass,
-	mapTreeFromNodeData,
 	normalizeFieldSchema,
 	SimpleContextSlot,
 	type ImplicitFieldSchema,
@@ -33,7 +31,6 @@ import {
 } from "../../simple-tree/index.js";
 import {
 	getTreeNodeForField,
-	prepareContentForHydration,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../simple-tree/proxies.js";
 // eslint-disable-next-line import/no-internal-modules
@@ -43,6 +40,7 @@ import type { TreeCheckout } from "../../shared-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { SchematizingSimpleTreeView } from "../../shared-tree/schematizingTreeView.js";
 import { CheckoutFlexTreeView, createTreeCheckout } from "../../shared-tree/index.js";
+import { prepareForInsertion } from "../../simple-tree/index.js";
 
 /**
  * Initializes a node with the given schema and content.
@@ -135,13 +133,8 @@ export function hydrate<const TSchema extends ImplicitFieldSchema>(
 		new HydratedContext(normalizeFieldSchema(schema).allowedTypeSet, checkout.context),
 	);
 	assert(field.context.isHydrated(), "Expected LazyField");
-	const mapTree = mapTreeFromNodeData(
-		initialTree as InsertableContent,
-		schema,
-		field.context.nodeKeyManager,
-		getSchemaAndPolicy(field),
-	);
-	prepareContentForHydration(mapTree, field.context.checkout.forest);
+	const mapTree = prepareForInsertion(initialTree as InsertableContent, schema, field.context);
+
 	if (mapTree === undefined) return undefined as TreeFieldFromImplicitField<TSchema>;
 	const cursor = cursorForMapTreeField([mapTree]);
 	initializeForest(forest, cursor, testRevisionTagCodec, testIdCompressor, true);


### PR DESCRIPTION
## Description

Refactor insertion handling logic to place all use of prepareContentForHydration behind prepareForInsertion which also does toMapTree and validation.

This helps ensure all code paths have uniform handling, making changes to validation, default generation etc. easier.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

