### PR TITLE
fix(tree): Remove invalid input validation in table APIs

### DIFF
--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -524,26 +524,10 @@ export namespace System_TableSchema {
 				columns,
 				index,
 			}: TableSchema.InsertColumnsParameters<TColumnSchema>): ColumnValueType[] {
-				// #region Input validation
-
 				// Ensure index is valid
 				if (index !== undefined) {
 					Table.validateInsertionIndex(index, this.columns);
 				}
-
-				// Check all of the columns being inserted an ensure the table does not already contain any with the same ID.
-				for (const column of columns) {
-					// TypeScript is unable to narrow the type of the column type correctly here, hence the casts below.
-					// See: https://github.com/microsoft/TypeScript/issues/52144
-					const maybeId = (column as ColumnValueType).id;
-					if (maybeId !== undefined && this.containsColumnWithId(maybeId)) {
-						throw new UsageError(
-							`A column with ID "${(column as ColumnValueType).id}" already exists in the table.`,
-						);
-					}
-				}
-
-				// #endregion
 
 				// TypeScript is unable to narrow the column type correctly here, hence the casts below.
 				// See: https://github.com/microsoft/TypeScript/issues/52144
@@ -584,14 +568,6 @@ export namespace System_TableSchema {
 				// Note: TypeScript is unable to narrow the type of the row type correctly here, hence the casts below.
 				// See: https://github.com/microsoft/TypeScript/issues/52144
 				for (const newRow of rows) {
-					// Check all of the rows being inserted an ensure the table does not already contain any with the same ID.
-					const maybeId = (newRow as RowValueType).id;
-					if (maybeId !== undefined && this.containsRowWithId(maybeId)) {
-						throw new UsageError(
-							`A row with ID "${(newRow as RowValueType).id}" already exists in the table.`,
-						);
-					}
-
 					// If the row contains cells, verify that the table contains the columns for those cells.
 					// Note: we intentionally hide `cells` on `IRow` to avoid leaking the internal data representation as much as possible, so we have to cast here.
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1272,12 +1248,7 @@ export namespace TableSchema {
 		/**
 		 * Inserts a column into the table.
 		 *
-		 * @throws
-		 * Throws an error in the following cases:
-		 *
-		 * - The column, or a column with the same ID is already in the tree.
-		 *
-		 * - The specified index is out of range.
+		 * @throws Throws an error if the specified index is out of range.
 		 *
 		 * No column is inserted in these cases.
 		 */
@@ -1288,12 +1259,7 @@ export namespace TableSchema {
 		/**
 		 * Inserts 0 or more columns into the table.
 		 *
-		 * @throws
-		 * Throws an error in the following cases:
-		 *
-		 * - At least one column, or a column with the same ID is already in the tree.
-		 *
-		 * - The specified index is out of range.
+		 * @throws Throws an error if the specified index is out of range.
 		 *
 		 * No columns are inserted in these cases.
 		 */
@@ -1306,8 +1272,6 @@ export namespace TableSchema {
 		 *
 		 * @throws
 		 * Throws an error in the following cases:
-		 *
-		 * - The row, or a row with the same ID is already in the tree.
 		 *
 		 * - The row contains cells, but the table does not contain matching columns for one or more of those cells.
 		 *
@@ -1322,8 +1286,6 @@ export namespace TableSchema {
 		 *
 		 * @throws
 		 * Throws an error in the following cases:
-		 *
-		 * - At least one row, or a row with the same ID is already in the tree.
 		 *
 		 * - The row contains cells, but the table does not contain matching columns for one or more of those cells.
 		 *

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1250,7 +1250,7 @@ export namespace TableSchema {
 		 *
 		 * @throws Throws an error if the specified index is out of range.
 		 *
-		 * No column is inserted in these cases.
+		 * No column is inserted in this case.
 		 */
 		insertColumn(
 			params: InsertColumnParameters<TColumn>,
@@ -1261,7 +1261,7 @@ export namespace TableSchema {
 		 *
 		 * @throws Throws an error if the specified index is out of range.
 		 *
-		 * No columns are inserted in these cases.
+		 * No columns are inserted in this case.
 		 */
 		insertColumns(
 			params: InsertColumnsParameters<TColumn>,

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -388,25 +388,6 @@ describe("TableFactory unit tests", () => {
 				validateUsageError(/The index specified for insertion is out of bounds./),
 			);
 		});
-
-		it("Inserting existing column fails", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
-				rows: [],
-				columns: [
-					{ id: "column-a", props: {} },
-					{ id: "column-b", props: {} },
-				],
-			});
-
-			assert.throws(
-				() =>
-					treeView.root.insertColumn({
-						column: { id: "column-b", props: {} },
-					}),
-				validateUsageError(/A column with ID "column-b" already exists in the table./),
-			);
-		});
 	});
 
 	describe("insertColumns", () => {
@@ -551,44 +532,6 @@ describe("TableFactory unit tests", () => {
 				rows: [],
 			});
 		});
-
-		it("Inserting existing column fails", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
-				columns: [
-					{
-						id: "column-a",
-						props: {},
-					},
-					{
-						id: "column-b",
-						props: {},
-					},
-				],
-				rows: [],
-			});
-
-			assert.throws(
-				() =>
-					treeView.root.insertColumns({
-						columns: [
-							{
-								id: "column-c",
-								props: {},
-							},
-							{
-								// A column with this ID already exists in the table
-								id: "column-a",
-								props: {},
-							},
-						],
-					}),
-				validateUsageError(/A column with ID "column-a" already exists in the table./),
-			);
-
-			// Ensure no columns were inserted
-			assert(treeView.root.columns.length === 2);
-		});
 	});
 
 	describe("insertRow", () => {
@@ -701,25 +644,6 @@ describe("TableFactory unit tests", () => {
 						row: { cells: {}, props: {} },
 					}),
 				validateUsageError(/The index specified for insertion is out of bounds./),
-			);
-		});
-
-		it("Inserting existing row fails", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
-				columns: [],
-				rows: [
-					{ id: "row-a", cells: {}, props: {} },
-					{ id: "row-b", cells: {}, props: {} },
-				],
-			});
-
-			assert.throws(
-				() =>
-					treeView.root.insertRow({
-						row: { id: "row-b", cells: {}, props: {} },
-					}),
-				validateUsageError(/A row with ID "row-b" already exists in the table./),
 			);
 		});
 
@@ -910,48 +834,6 @@ describe("TableFactory unit tests", () => {
 					},
 				],
 			});
-		});
-
-		it("Inserting existing row fails", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
-				rows: [
-					{
-						id: "row-a",
-						cells: {},
-						props: {},
-					},
-					{
-						id: "row-b",
-						cells: {},
-						props: {},
-					},
-				],
-				columns: [],
-			});
-
-			assert.throws(
-				() =>
-					treeView.root.insertRows({
-						rows: [
-							{
-								id: "row-c",
-								cells: {},
-								props: {},
-							},
-							{
-								// A row with this ID already exists in the table
-								id: "row-a",
-								cells: {},
-								props: {},
-							},
-						],
-					}),
-				validateUsageError(/A row with ID "row-a" already exists in the table./),
-			);
-
-			// Ensure no rows were inserted
-			assert(treeView.root.rows.length === 2);
 		});
 	});
 


### PR DESCRIPTION
Checking the `id` field of node input is not possible, because the `id` property is not observable until _after_ the associated node has been inserted into the tree.