### PR TITLE
Simplify, document and improve type safety and naming in hydration logic

### DIFF
--- a/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
+++ b/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
@@ -112,7 +112,7 @@ interface Root extends UpPath {
 }
 
 /**
- * The path from the included node to the to the root of the content tree it was inserted as part of.
+ * The path from the included node to the root of the content tree it was inserted as part of.
  */
 interface RelativeNodePath {
 	readonly path: UpPath;

--- a/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
+++ b/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
@@ -9,6 +9,9 @@ import type {
 	IForestSubscription,
 	MapTree,
 	UpPath,
+	NodeIndex,
+	FieldKey,
+	DetachedField,
 } from "../core/index.js";
 import {
 	type FlexTreeContext,
@@ -18,14 +21,14 @@ import {
 import type { ImplicitAllowedTypes, ImplicitFieldSchema } from "./schemaTypes.js";
 import { type InsertableContent, mapTreeFromNodeData } from "./toMapTree.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
-import { EmptyKey } from "../core/index.js";
-import { type Mutable, isReadonlyArray } from "../util/index.js";
+import { brand } from "../util/index.js";
 import {
 	getKernel,
 	type TreeNode,
 	tryUnhydratedFlexTreeNode,
 	unhydratedFlexTreeNodeToTreeNode,
 } from "./core/index.js";
+import { debugAssert } from "@fluidframework/core-utils/internal";
 
 /**
  * Prepare content from a user for insertion into a tree.
@@ -93,79 +96,75 @@ export function prepareForInsertionContextless<TIn extends InsertableContent | u
 	);
 
 	if (mapTree !== undefined && hydratedData !== undefined) {
-		prepareContentForHydration(mapTree, hydratedData.checkout.forest);
+		prepareContentForHydration([mapTree], hydratedData.checkout.forest);
 	}
 
 	return mapTree as TIn extends undefined ? undefined : ExclusiveMapTree;
 }
 
-// #region Content insertion and proxy binding
+/**
+ * An {@link UpPath} that is just index zero in a {@link DetachedField} which can be modified at a later time.
+ */
+interface Root extends UpPath {
+	readonly parent: undefined;
+	parentField: DetachedField & FieldKey;
+	readonly parentIndex: NodeIndex & 0;
+}
 
-/** The path of a proxy, relative to the root of the content tree that the proxy belongs to */
-interface RelativeProxyPath {
+/**
+ * The path from the included node to the to the root of the content tree it was inserted as part of.
+ */
+interface RelativeNodePath {
 	readonly path: UpPath;
-	readonly proxy: TreeNode;
+	readonly node: TreeNode;
 }
 
-/** All {@link RelativeProxyPath}s that are under the given root path */
-interface RootedProxyPaths {
-	readonly rootPath: UpPath;
-	readonly proxyPaths: RelativeProxyPath[];
+/**
+ * {@link RelativeNodePath}s for every {@link TreeNode} in the content tree inserted as an atomic operation.
+ */
+interface LocatedNodesBatch {
+	/**
+	 * UpPath shared by all {@link RelativeNodePath}s in this batch corresponding to the root of the inserted content.
+	 */
+	readonly rootPath: Root;
+	readonly paths: RelativeNodePath[];
 }
+
+/**
+ * A dummy key value used in {@link LocatedNodesBatch.rootPath} which will be replaced with the actual detached field once it is known.
+ */
+const placeholderKey: DetachedField & FieldKey = brand("placeholder" as const);
 
 /**
  * Records any proxies in the given content tree and does the necessary bookkeeping to ensure they are synchronized with subsequent reads of the tree.
  * @remarks If the content tree contains any proxies, this function must be called just prior to inserting the content into the tree.
  * Specifically, no other content may be inserted into the tree between the invocation of this function and the insertion of `content`.
  * The insertion of `content` must occur or else this function will cause memory leaks.
- * @param content - the tree of content to be inserted, of which any of its object/map/array nodes might be a proxy
- * @param anchors - the {@link AnchorSet} for the tree
- * @returns The content after having all proxies replaced inline with plain javascript objects.
+ * @param content - the content subsequence to be inserted, of which might deeply contain {@link TreeNode}s which need to be hydrated.
+ * @param forest - the forest the content is being inserted into.
  * See {@link extractFactoryContent} for more details.
  */
 function prepareContentForHydration(
-	content: MapTree | readonly MapTree[] | undefined,
-	forest: IForestSubscription,
-): void {
-	if (isReadonlyArray(content)) {
-		return prepareArrayContentForHydration(content, forest);
-	}
-
-	if (content !== undefined) {
-		const proxies: RootedProxyPaths = {
-			rootPath: { parent: undefined, parentField: EmptyKey, parentIndex: 0 },
-			proxyPaths: [],
-		};
-
-		walkMapTree(content, proxies.rootPath, (p, proxy) => {
-			proxies.proxyPaths.push({ path: p, proxy });
-		});
-
-		bindProxies([proxies], forest);
-	}
-}
-
-function prepareArrayContentForHydration(
 	content: readonly MapTree[],
 	forest: IForestSubscription,
 ): void {
-	const proxyPaths: RootedProxyPaths[] = [];
+	const batches: LocatedNodesBatch[] = [];
 	for (const item of content) {
-		const proxyPath: RootedProxyPaths = {
+		const batch: LocatedNodesBatch = {
 			rootPath: {
 				parent: undefined,
-				parentField: EmptyKey,
+				parentField: placeholderKey,
 				parentIndex: 0,
 			},
-			proxyPaths: [],
+			paths: [],
 		};
-		proxyPaths.push(proxyPath);
-		walkMapTree(item, proxyPath.rootPath, (p, proxy) => {
-			proxyPath.proxyPaths.push({ path: p, proxy });
+		batches.push(batch);
+		walkMapTree(item, batch.rootPath, (p, node) => {
+			batch.paths.push({ path: p, node });
 		});
 	}
 
-	bindProxies(proxyPaths, forest);
+	bindTreeNodes(batches, forest);
 }
 
 function walkMapTree(
@@ -206,25 +205,32 @@ function walkMapTree(
 	}
 }
 
-function bindProxies(proxies: readonly RootedProxyPaths[], forest: IForestSubscription): void {
-	// Only subscribe to the event if there is at least one proxy tree to hydrate - this is not the case when inserting an empty array [].
-	if (proxies.length > 0) {
+/**
+ * Register a collection of nodes with the forest so that they can be hydrated.
+ * @param locatedNodes - the nodes to register with the forest.
+ * Each index in this array expects its content to be added and produce its own `afterRootFieldCreated` event.
+ * If array subsequence insertion is optimized to produce a single event, this will not work correctly as is, and will need to be modified to take in a single {@link LocatedNodesBatch}.
+ */
+function bindTreeNodes(
+	locatedNodes: readonly LocatedNodesBatch[],
+	forest: IForestSubscription,
+): void {
+	// Only subscribe to the event if there is at least one TreeNode tree to hydrate - this is not the case when inserting an empty array [].
+	if (locatedNodes.length > 0) {
 		// Creating a new array emits one event per element in the array, so listen to the event once for each element
 		let i = 0;
 		const off = forest.events.on("afterRootFieldCreated", (fieldKey) => {
 			// Non null asserting here because of the length check above
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			(proxies[i]!.rootPath as Mutable<UpPath>).parentField = fieldKey;
-			// Non null asserting here because of the length check above
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			for (const { path, proxy } of proxies[i]!.proxyPaths) {
-				getKernel(proxy).anchorProxy(forest.anchors, path);
+			const batch = locatedNodes[i]!;
+			debugAssert(() => batch.rootPath.parentField === placeholderKey);
+			batch.rootPath.parentField = brand(fieldKey);
+			for (const { path, node } of batch.paths) {
+				getKernel(node).anchorProxy(forest.anchors, path);
 			}
-			if (++i === proxies.length) {
+			if (++i === locatedNodes.length) {
 				off();
 			}
 		});
 	}
 }
-
-// #endregion Content insertion and proxy binding


### PR DESCRIPTION
## Description

The hydration logic erroneously calls TreeNodes proxies. Not only are many tree nodes not implemented using proxies, but many other things are, so use the more specific and correct term, TreeNode (or node when not neeing to be specific).

Add documentation to many undocumented things.

Fix incorrect and out of date documentation.

Deduplicate the logic for single items and arrays by using an array of a single item.

Improve type safety for how the root of paths are edited.

Fixing up TreeNodeKernel.anchorProxy is out of scope: that has been left referring to proxy and will be looked at independently.

Moving/renaming the tests has also been skipped to help ensure the tests as is pass with these changes. They will also be moved and looked at independently.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
