### PR TITLE
Improve TreeAlpha.create

### DIFF
--- a/.changeset/afraid-rice-feel.md
+++ b/.changeset/afraid-rice-feel.md
@@ -7,3 +7,6 @@ TreeAlpha.create now accepts unhydrated nodes
 
 [TreeAlpha.create](https://fluidframework.com/docs/api/fluid-framework/treealpha-interface#create-methodsignature) now accepts [unhydrated](https://fluidframework.com/docs/api/fluid-framework/unhydrated-typealias) nodes.
 `TreeAlpha.create`'s documentation has been fixed to indicate support instead of being self contradictory about it.
+
+Additionally `TreeAlpha.create` no longer throws a "Tree does not conform to schema" error when given a tree omitting an identifier.
+Instead the identifier behaves like it would for other ways to build unhydrated nodes: remaining unreadable until hydrated.

--- a/.changeset/afraid-rice-feel.md
+++ b/.changeset/afraid-rice-feel.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+TreeAlpha.create now accepts existing unhydrated nodes
+
+[TreeAlpha.create](https://fluidframework.com/docs/api/fluid-framework/treealpha-interface#create-methodsignature) now accepts existing [unhydrated](https://fluidframework.com/docs/api/fluid-framework/unhydrated-typealias) nodes.
+`TreeAlpha.create`'s documentation has been fixed to indicate support instead of being self contradictory about it.

--- a/.changeset/afraid-rice-feel.md
+++ b/.changeset/afraid-rice-feel.md
@@ -3,7 +3,7 @@
 "fluid-framework": minor
 "__section": tree
 ---
-TreeAlpha.create now accepts existing unhydrated nodes
+TreeAlpha.create now accepts unhydrated nodes
 
-[TreeAlpha.create](https://fluidframework.com/docs/api/fluid-framework/treealpha-interface#create-methodsignature) now accepts existing [unhydrated](https://fluidframework.com/docs/api/fluid-framework/unhydrated-typealias) nodes.
+[TreeAlpha.create](https://fluidframework.com/docs/api/fluid-framework/treealpha-interface#create-methodsignature) now accepts [unhydrated](https://fluidframework.com/docs/api/fluid-framework/unhydrated-typealias) nodes.
 `TreeAlpha.create`'s documentation has been fixed to indicate support instead of being self contradictory about it.

--- a/packages/dds/tree/src/simple-tree/api/create.ts
+++ b/packages/dds/tree/src/simple-tree/api/create.ts
@@ -28,12 +28,11 @@ import {
 import {
 	cursorForMapTreeNode,
 	defaultSchemaPolicy,
-	inSchemaOrThrow,
 	mapTreeFromCursor,
 	type NodeIdentifierManager,
 } from "../../feature-libraries/index.js";
 import { isFieldInSchema } from "../../feature-libraries/index.js";
-import { mapTreeFromNodeData } from "../toMapTree.js";
+import { inSchemaOrThrow, mapTreeFromNodeData } from "../toMapTree.js";
 import { getUnhydratedContext } from "../createContext.js";
 import { createUnknownOptionalFieldPolicy } from "../objectNode.js";
 

--- a/packages/dds/tree/src/simple-tree/api/create.ts
+++ b/packages/dds/tree/src/simple-tree/api/create.ts
@@ -5,7 +5,11 @@
 
 import { assert } from "@fluidframework/core-utils/internal";
 
-import type { ITreeCursorSynchronous, SchemaAndPolicy } from "../../core/index.js";
+import type {
+	ExclusiveMapTree,
+	ITreeCursorSynchronous,
+	SchemaAndPolicy,
+} from "../../core/index.js";
 import type {
 	ImplicitFieldSchema,
 	TreeFieldFromImplicitField,
@@ -24,13 +28,12 @@ import {
 import {
 	cursorForMapTreeNode,
 	defaultSchemaPolicy,
-	FieldKinds,
+	inSchemaOrThrow,
 	mapTreeFromCursor,
 	type NodeIdentifierManager,
 } from "../../feature-libraries/index.js";
 import { isFieldInSchema } from "../../feature-libraries/index.js";
-import { toStoredSchema } from "../toStoredSchema.js";
-import { inSchemaOrThrow, mapTreeFromNodeData } from "../toMapTree.js";
+import { mapTreeFromNodeData } from "../toMapTree.js";
 import { getUnhydratedContext } from "../createContext.js";
 import { createUnknownOptionalFieldPolicy } from "../objectNode.js";
 
@@ -88,24 +91,12 @@ export function cursorFromInsertable<
 ):
 	| ITreeCursorSynchronous
 	| (TSchema extends FieldSchema<FieldKind.Optional> ? undefined : never) {
-	const storedSchema = toStoredSchema(schema);
-	const schemaValidationPolicy: SchemaAndPolicy = {
-		policy: defaultSchemaPolicy,
-		// TODO: optimize: This isn't the most efficient operation since its not cached, and has to convert all the schema.
-		schema: storedSchema,
-	};
-
 	const mapTree = mapTreeFromNodeData(
 		data as InsertableField<UnsafeUnknownSchema>,
 		schema,
 		context,
-		schemaValidationPolicy,
 	);
 	if (mapTree === undefined) {
-		assert(
-			storedSchema.rootFieldSchema.kind === FieldKinds.optional.identifier,
-			0xa10 /* missing non-optional field */,
-		);
 		return undefined as TSchema extends FieldSchema<FieldKind.Optional> ? undefined : never;
 	}
 	return cursorForMapTreeNode(mapTree);
@@ -144,6 +135,16 @@ export function createFromCursor<const TSchema extends ImplicitFieldSchema>(
 	// Length asserted above, so this is safe. This assert is done instead of checking for undefined after indexing to ensure a length greater than 1 also errors.
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	const mapTree = mapTrees[0]!;
+	return createFromMapTree(schema, mapTree);
+}
+
+/**
+ * Creates an unhydrated simple-tree field from an ExclusiveMapTree.
+ */
+export function createFromMapTree<const TSchema extends ImplicitFieldSchema>(
+	schema: TSchema,
+	mapTree: ExclusiveMapTree,
+): Unhydrated<TreeFieldFromImplicitField<TSchema>> {
 	const mapTreeNode = UnhydratedFlexTreeNode.getOrCreate(
 		getUnhydratedContext(schema),
 		mapTree,

--- a/packages/dds/tree/src/simple-tree/api/index.ts
+++ b/packages/dds/tree/src/simple-tree/api/index.ts
@@ -45,7 +45,12 @@ export {
 	singletonSchema,
 } from "./schemaCreationUtilities.js";
 export { treeNodeApi, type TreeNodeApi, tryGetSchema } from "./treeNodeApi.js";
-export { createFromInsertable, cursorFromInsertable, createFromCursor } from "./create.js";
+export {
+	createFromInsertable,
+	cursorFromInsertable,
+	createFromCursor,
+	createFromMapTree,
+} from "./create.js";
 export {
 	type JsonSchemaId,
 	type JsonSchemaType,

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -69,7 +69,7 @@ interface LocationInField {
  * An unhydrated implementation of {@link FlexTreeNode} which wraps a {@link MapTree}.
  * @remarks
  * MapTreeNodes are unconditionally cached -
- * when retrieved via {@link getOrCreateNode}, the same {@link MapTree} object will always produce the same `UnhydratedFlexTreeNode` object.
+ * when retrieved via {@link getOrCreateNodeFromInnerNode}, the same {@link MapTree} object will always produce the same `UnhydratedFlexTreeNode` object.
  *
  * Create a `UnhydratedFlexTreeNode` by calling {@link getOrCreate}.
  */
@@ -112,9 +112,9 @@ export class UnhydratedFlexTreeNode implements FlexTreeNode {
 	 * Create a new UnhydratedFlexTreeNode.
 	 * @param location - the parentage of this node, if it is being created underneath an existing node and field, or undefined if not
 	 * @remarks This class (and its subclasses) should not be directly constructed outside of this module.
-	 * Instead, use {@link getOrCreateNode} to create a UnhydratedFlexTreeNode from a {@link MapTree}.
+	 * Instead, use {@link getOrCreateNodeFromInnerNode} to create a UnhydratedFlexTreeNode from a {@link MapTree}.
 	 * A `UnhydratedFlexTreeNode` may never be constructed more than once for the same {@link MapTree} object.
-	 * Instead, it should always be acquired via {@link getOrCreateNode}.
+	 * Instead, it should always be acquired via {@link getOrCreateNodeFromInnerNode}.
 	 */
 	public constructor(
 		public readonly simpleContext: Context,
@@ -548,7 +548,7 @@ function getFieldKeyCache(
 
 /**
  * If there exists a {@link UnhydratedFlexTreeNode} for the given {@link MapTree}, returns it, otherwise returns `undefined`.
- * @remarks {@link UnhydratedFlexTreeNode | UnhydratedFlexTreeNodes} are created via {@link getOrCreateNode}.
+ * @remarks {@link UnhydratedFlexTreeNode | UnhydratedFlexTreeNodes} are created via {@link getOrCreateNodeFromInnerNode}.
  */
 export function tryUnhydratedFlexTreeNode(
 	mapTree: MapTree,

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -122,6 +122,7 @@ export {
 	type FixRecursiveRecursionLimit,
 	schemaStatics,
 	type TreeChangeEvents,
+	createFromMapTree,
 } from "./api/index.js";
 export type {
 	SimpleTreeSchema,

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -8,6 +8,7 @@ import {
 	MockHandle,
 	validateAssertionError,
 } from "@fluidframework/test-runtime-utils/internal";
+import { isStableId } from "@fluidframework/id-compressor/internal";
 
 import { type NormalizedUpPath, rootFieldKey } from "../../../core/index.js";
 import {
@@ -51,7 +52,6 @@ import { testSimpleTrees } from "../../testTrees.js";
 import { FluidClientVersion } from "../../../codec/index.js";
 import { ajvValidator } from "../../codec/index.js";
 import { TreeAlpha } from "../../../shared-tree/index.js";
-import { isStableId } from "@fluidframework/id-compressor/internal";
 
 const schema = new SchemaFactory("com.example");
 


### PR DESCRIPTION
## Description

TreeAlpha.create now accepts existing unhydrated nodes and defaulted identifiers.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

