### PR TITLE
improvement(test-end-to-end-tests): Add minVersionForCollab to test infrastructure

### DIFF
--- a/packages/test/test-utils/src/containerRuntimeFactories.ts
+++ b/packages/test/test-utils/src/containerRuntimeFactories.ts
@@ -11,6 +11,7 @@ import {
 	FluidDataStoreRegistry,
 	loadContainerRuntime,
 	type IContainerRuntimeOptions,
+	type MinimumVersionForCollab,
 } from "@fluidframework/container-runtime/internal";
 import type {
 	IContainerRuntime,
@@ -65,6 +66,12 @@ export interface ContainerRuntimeFactoryWithDefaultDataStoreProps {
 	 * created with this factory
 	 */
 	readonly provideEntryPoint?: (runtime: IContainerRuntime) => Promise<FluidObject>;
+
+	/**
+	 * The minVersionForCollab passed to the IContainerRuntime when instantiating it
+	 * See {@link @fluidframework/container-runtime#LoadContainerRuntimeParams} for additional details.
+	 */
+	readonly minVersionForCollab?: MinimumVersionForCollab;
 }
 
 /**
@@ -110,6 +117,11 @@ export class ContainerRuntimeFactoryWithDefaultDataStore
 	 */
 	private readonly provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
 
+	/**
+	 * {@inheritDoc ContainerRuntimeFactoryWithDefaultDataStoreProps.minVersionForCollab}
+	 */
+	private readonly minVersionForCollab: MinimumVersionForCollab | undefined;
+
 	public constructor(props: ContainerRuntimeFactoryWithDefaultDataStoreProps) {
 		super();
 
@@ -135,6 +147,7 @@ export class ContainerRuntimeFactoryWithDefaultDataStore
 		this.provideEntryPoint = props.provideEntryPoint ?? getDefaultFluidObject;
 		this.requestHandlers = [getDefaultObject];
 		this.registry = new FluidDataStoreRegistry(this.registryEntries);
+		this.minVersionForCollab = props.minVersionForCollab;
 	}
 
 	public async instantiateFirstTime(runtime: IContainerRuntime): Promise<void> {
@@ -159,6 +172,7 @@ export class ContainerRuntimeFactoryWithDefaultDataStore
 			// eslint-disable-next-line import/no-deprecated
 			requestHandler: buildRuntimeRequestHandler(...this.requestHandlers),
 			provideEntryPoint: this.provideEntryPoint,
+			minVersionForCollab: this.minVersionForCollab,
 		});
 	}
 

--- a/packages/test/test-utils/src/testContainerRuntimeFactory.ts
+++ b/packages/test/test-utils/src/testContainerRuntimeFactory.ts
@@ -8,6 +8,8 @@ import {
 	ContainerRuntime,
 	DefaultSummaryConfiguration,
 	type IContainerRuntimeOptionsInternal,
+	type LoadContainerRuntimeParams,
+	type MinimumVersionForCollab,
 } from "@fluidframework/container-runtime/internal";
 import {
 	IContainerRuntime,
@@ -82,6 +84,7 @@ export const createTestContainerRuntimeFactory = (
 					},
 				},
 			},
+			public minVersionForCollab: MinimumVersionForCollab | undefined = undefined,
 			// eslint-disable-next-line import/no-deprecated
 			public requestHandlers: RuntimeRequestHandler[] = [],
 		) {
@@ -170,12 +173,11 @@ export const createTestContainerRuntimeFactory = (
 				// eslint-disable-next-line import/no-deprecated
 				requestHandler: buildRuntimeRequestHandler(getDefaultObject, ...this.requestHandlers),
 				provideEntryPoint,
-				// ! This prop is needed for back-compat. Can be removed in 2.0.0-internal.8.0.0
-				initializeEntryPoint: provideEntryPoint,
 				runtimeOptions: this.runtimeOptions,
 				containerScope: context.scope,
 				existing,
-			} as any);
+				minVersionForCollab: this.minVersionForCollab,
+			} satisfies LoadContainerRuntimeParams);
 		}
 	};
 };

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -15,7 +15,10 @@ import {
 	Loader,
 	waitContainerToCatchUp as waitContainerToCatchUp_original,
 } from "@fluidframework/container-loader/internal";
-import { type IContainerRuntimeOptionsInternal } from "@fluidframework/container-runtime/internal";
+import {
+	type IContainerRuntimeOptionsInternal,
+	type MinimumVersionForCollab,
+} from "@fluidframework/container-runtime/internal";
 import {
 	IRequestHeader,
 	ITelemetryBaseEvent,
@@ -265,6 +268,12 @@ export interface ITestContainerConfig {
 
 	/** Loader options for the loader used to create containers */
 	loaderProps?: Partial<ILoaderProps>;
+
+	/**
+	 * The minVersionForCollab passed to the ContainerRuntime when instantiating it.
+	 * See {@link @fluidframework/container-runtime#LoadContainerRuntimeParams} for more details on this property.
+	 */
+	minVersionForCollab?: MinimumVersionForCollab | undefined;
 }
 
 /**

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -251,6 +251,7 @@ export async function getVersionedTestObjectProviderFromApis(
 				containerOptions?.runtimeOptions,
 				type,
 			),
+			containerOptions?.minVersionForCollab,
 		);
 	};
 
@@ -363,6 +364,7 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 				containerOptions?.runtimeOptions,
 				driverConfig.type,
 			),
+			containerOptions?.minVersionForCollab,
 			[innerRequestHandler],
 		);
 	};
@@ -387,6 +389,7 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 				containerOptions?.runtimeOptions,
 				driverConfig.type,
 			),
+			containerOptions?.minVersionForCollab,
 			[innerRequestHandler],
 		);
 	};


### PR DESCRIPTION
## Description

This PR adds `minVersionForCollab` to the e2e test infrastructure (ported from https://github.com/microsoft/FluidFramework/pull/24566). This lets us pass in a `minVersionForCollab` through `ITestContainerConfig` that gets passed to the runtime factory.