### PR TITLE
Add consumer seek failure log

### DIFF
--- a/server/routerlicious/packages/lambdas/src/utils/circuitBreaker.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/circuitBreaker.ts
@@ -110,8 +110,8 @@ export class LambdaCircuitBreaker {
 			state: this.circuitBreaker.toJSON()?.state,
 		};
 		if (this.circuitBreakerMetric && !this.circuitBreakerMetric.isCompleted()) {
-			this.circuitBreakerMetric?.setProperties(metricProperties);
-			this.circuitBreakerMetric?.success("Circuit breaker shutdown"); // could be due to rebalancing
+			this.circuitBreakerMetric.setProperties(metricProperties);
+			this.circuitBreakerMetric.success("Circuit breaker shutdown"); // could be due to rebalancing
 		} else {
 			Lumberjack.info("Circuit breaker shutdown", metricProperties);
 		}

--- a/server/routerlicious/packages/lambdas/src/utils/circuitBreaker.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/circuitBreaker.ts
@@ -109,7 +109,7 @@ export class LambdaCircuitBreaker {
 			openCount: this.circuitBreakerOpenCount,
 			state: this.circuitBreaker.toJSON()?.state,
 		};
-		if (this.circuitBreakerMetric) {
+		if (this.circuitBreakerMetric && !this.circuitBreakerMetric.isCompleted()) {
 			this.circuitBreakerMetric?.setProperties(metricProperties);
 			this.circuitBreakerMetric?.success("Circuit breaker shutdown"); // could be due to rebalancing
 		} else {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -582,6 +582,18 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 				seekTimeout,
 				(err) => {
 					if (err) {
+						Lumberjack.error(
+							`Consumer seek failed`,
+							{
+								topic: this.topic,
+								partitionId,
+								offset,
+								isConsumerConnected: this.consumer?.isConnected(),
+								isConsumerRebalancing: this.isRebalancing,
+								consumerAssignments: this.consumer?.assignments()?.length,
+							},
+							err,
+						);
 						this.error(err, {
 							restart: true,
 							errorLabel: "rdkafkaConsumer:pauseFetching.seek",


### PR DESCRIPTION
## Description

- Added an error log when consumer.seek() fails.
- Added a check to ensure that the circuit breaker metric is not completed before completing it.