### PR TITLE
refactor(tree): Capitalize schema arguments to table schema factory functions

### DIFF
--- a/examples/data-objects/table-tree/src/Table/tableSchema.ts
+++ b/examples/data-objects/table-tree/src/Table/tableSchema.ts
@@ -97,21 +97,21 @@ export class ColumnProps extends schemaFactory.object("table-column-props", {
 }) {}
 export class Column extends TableSchema.column({
 	schemaFactory,
-	cell: Cell,
-	props: ColumnProps,
+	Cell,
+	Props: ColumnProps,
 }) {}
 export class RowProps extends schemaFactory.object("table-row-props", {
 	label: schemaFactory.optional(schemaFactory.string),
 }) {}
 export class Row extends TableSchema.row({
 	schemaFactory,
-	cell: Cell,
-	props: RowProps,
+	Cell,
+	Props: RowProps,
 }) {}
 
 export class Table extends TableSchema.table({
 	schemaFactory,
-	cell: Cell,
-	column: Column,
-	row: Row,
+	Cell,
+	Column,
+	Row,
 }) {}

--- a/examples/utils/import-testing/src/test/importer.spec.ts
+++ b/examples/utils/import-testing/src/test/importer.spec.ts
@@ -46,8 +46,8 @@ describe("import tests", () => {
 		}) {}
 		class Column extends TableSchema.column({
 			schemaFactory,
-			cell: Cell,
-			props: schemaFactory.optional(ColumnProps),
+			Cell,
+			Props: schemaFactory.optional(ColumnProps),
 		}) {}
 
 		class RowProps extends schemaFactory.object("table-row-props", {
@@ -55,15 +55,15 @@ describe("import tests", () => {
 		}) {}
 		class Row extends TableSchema.row({
 			schemaFactory,
-			cell: Cell,
-			props: RowProps,
+			Cell,
+			Props: RowProps,
 		}) {}
 
 		class Table extends TableSchema.table({
 			schemaFactory,
-			cell: Cell,
-			column: Column,
-			row: Row,
+			Cell,
+			Column,
+			Row,
 		}) {}
 
 		const _table = new Table({

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -136,7 +136,7 @@ export namespace System_TableSchema {
 		/**
 		 * Schema for the table's cells.
 		 */
-		readonly cell: TCellSchema;
+		readonly Cell: TCellSchema;
 	}
 
 	// #region Column
@@ -987,7 +987,7 @@ export namespace System_TableSchema {
  *
  * class Table extends TableSchema.table({
  * 	schemaFactory,
- * 	cell: Cell,
+ * 	Cell,
  * }) {}
  *
  * const table = new Table({
@@ -1012,20 +1012,20 @@ export namespace System_TableSchema {
  *
  * class Column extends TableSchema.column({
  * 	schemaFactory,
- * 	cell: Cell,
- * 	props: ColumnProps,
+ * 	Cell,
+ * 	Props: ColumnProps,
  * }) {}
  *
  * class Row extends TableSchema.row({
  * 	schemaFactory,
- * 	cell: Cell,
+ * 	Cell,
  * }) {}
  *
  * class Table extends TableSchema.table({
  * 	schemaFactory,
- * 	cell: Cell,
- * 	column: Column,
- * 	row: Row,
+ * 	Cell,
+ * 	Column,
+ * 	Row,
  * }) {}
  *
  * const table = new Table({
@@ -1114,7 +1114,7 @@ export namespace TableSchema {
 			/**
 			 * Optional column properties.
 			 */
-			readonly props: TProps;
+			readonly Props: TProps;
 		},
 	): System_TableSchema.ColumnSchemaBase<TScope, TCell, TProps>;
 	/**
@@ -1122,12 +1122,12 @@ export namespace TableSchema {
 	 */
 	export function column({
 		schemaFactory,
-		cell,
-		props = SchemaFactory.optional(SchemaFactory.null),
+		Cell,
+		Props = SchemaFactory.optional(SchemaFactory.null),
 	}: System_TableSchema.CreateColumnOptionsBase & {
-		readonly props?: ImplicitAnnotatedFieldSchema;
+		readonly Props?: ImplicitAnnotatedFieldSchema;
 	}): TreeNodeSchema {
-		return System_TableSchema.createColumnSchema(schemaFactory, cell, props);
+		return System_TableSchema.createColumnSchema(schemaFactory, Cell, Props);
 	}
 
 	// #endregion
@@ -1239,7 +1239,7 @@ export namespace TableSchema {
 			/**
 			 * Optional row properties.
 			 */
-			readonly props: TProps;
+			readonly Props: TProps;
 		},
 	): System_TableSchema.RowSchemaBase<TScope, TCell, TProps>;
 	/**
@@ -1247,12 +1247,12 @@ export namespace TableSchema {
 	 */
 	export function row({
 		schemaFactory,
-		cell,
-		props = SchemaFactory.optional(SchemaFactory.null),
+		Cell,
+		Props = SchemaFactory.optional(SchemaFactory.null),
 	}: System_TableSchema.CreateRowOptionsBase & {
-		readonly props?: ImplicitAnnotatedFieldSchema;
+		readonly Props?: ImplicitAnnotatedFieldSchema;
 	}): TreeNodeSchema {
-		return System_TableSchema.createRowSchema(schemaFactory, cell, props);
+		return System_TableSchema.createRowSchema(schemaFactory, Cell, Props);
 	}
 
 	// #endregion
@@ -1582,7 +1582,7 @@ export namespace TableSchema {
 		const TColumn extends System_TableSchema.ColumnSchemaBase<TScope, TCell>,
 	>(
 		params: System_TableSchema.TableFactoryOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
-			readonly column: TColumn;
+			readonly Column: TColumn;
 		},
 	): System_TableSchema.TableSchemaBase<
 		TScope,
@@ -1603,7 +1603,7 @@ export namespace TableSchema {
 		const TRow extends System_TableSchema.RowSchemaBase<TScope, TCell>,
 	>(
 		params: System_TableSchema.TableFactoryOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
-			readonly row: TRow;
+			readonly Row: TRow;
 		},
 	): System_TableSchema.TableSchemaBase<
 		TScope,
@@ -1626,8 +1626,8 @@ export namespace TableSchema {
 		const TRow extends System_TableSchema.RowSchemaBase<TScope, TCell>,
 	>(
 		params: System_TableSchema.TableFactoryOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
-			readonly column: TColumn;
-			readonly row: TRow;
+			readonly Column: TColumn;
+			readonly Row: TRow;
 		},
 	): System_TableSchema.TableSchemaBase<TScope, TCell, TColumn, TRow>;
 	/**
@@ -1635,24 +1635,24 @@ export namespace TableSchema {
 	 */
 	export function table({
 		schemaFactory,
-		cell: cellSchema,
-		column: columnSchema = column({
+		Cell: CellSchema,
+		Column: ColumnSchema = column({
 			schemaFactory,
-			cell: cellSchema,
+			Cell: CellSchema,
 		}),
-		row: rowSchema = row({
+		Row: RowSchema = row({
 			schemaFactory,
-			cell: cellSchema,
+			Cell: CellSchema,
 		}),
 	}: System_TableSchema.TableFactoryOptionsBase & {
-		readonly column?: System_TableSchema.ColumnSchemaBase;
-		readonly row?: System_TableSchema.RowSchemaBase;
+		readonly Column?: System_TableSchema.ColumnSchemaBase;
+		readonly Row?: System_TableSchema.RowSchemaBase;
 	}): TreeNodeSchema {
 		return System_TableSchema.createTableSchema(
 			schemaFactory,
-			cellSchema,
-			columnSchema,
-			rowSchema,
+			CellSchema,
+			ColumnSchema,
+			RowSchema,
 		);
 	}
 

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -35,8 +35,8 @@ describe("TableFactory unit tests", () => {
 		}) {}
 		class Column extends TableSchema.column({
 			schemaFactory,
-			cell: Cell,
-			props: ColumnProps,
+			Cell,
+			Props: ColumnProps,
 		}) {}
 
 		class RowProps extends schemaFactory.object("table-row-props", {
@@ -48,15 +48,15 @@ describe("TableFactory unit tests", () => {
 		}) {}
 		class Row extends TableSchema.row({
 			schemaFactory,
-			cell: Cell,
-			props: schemaFactory.optional(RowProps),
+			Cell,
+			Props: schemaFactory.optional(RowProps),
 		}) {}
 
 		class Table extends TableSchema.table({
 			schemaFactory,
-			cell: Cell,
-			column: Column,
-			row: Row,
+			Cell,
+			Column,
+			Row,
 		}) {}
 
 		const treeView = independentView(
@@ -87,7 +87,7 @@ describe("TableFactory unit tests", () => {
 
 	describe("Column Schema", () => {
 		it("Can create without props", () => {
-			class Column extends TableSchema.column({ schemaFactory, cell: schemaFactory.string }) {}
+			class Column extends TableSchema.column({ schemaFactory, Cell: schemaFactory.string }) {}
 			const column = new Column({ id: "column-0" });
 
 			// TODO: ideally the "props" property would not exist at all on the derived class.
@@ -99,8 +99,8 @@ describe("TableFactory unit tests", () => {
 		it("Can create with props", () => {
 			class Column extends TableSchema.column({
 				schemaFactory,
-				cell: schemaFactory.string,
-				props: schemaFactory.string,
+				Cell: schemaFactory.string,
+				Props: schemaFactory.string,
 			}) {}
 			const column = new Column({ id: "column-0", props: "Column 0" });
 			assert.equal(column.props, "Column 0");
@@ -159,7 +159,7 @@ describe("TableFactory unit tests", () => {
 			class Cell extends schemaFactory.object("table-cell", {
 				value: schemaFactory.string,
 			}) {}
-			class Row extends TableSchema.row({ schemaFactory, cell: Cell }) {}
+			class Row extends TableSchema.row({ schemaFactory, Cell }) {}
 			const row = new Row({ id: "row-0", cells: {} });
 
 			// TODO: ideally the "props" property would not exist at all on the derived class.
@@ -174,8 +174,8 @@ describe("TableFactory unit tests", () => {
 			}) {}
 			class Row extends TableSchema.row({
 				schemaFactory,
-				cell: Cell,
-				props: schemaFactory.string,
+				Cell,
+				Props: schemaFactory.string,
 			}) {}
 			const column = new Row({ id: "row-0", cells: {}, props: "Row 0" });
 			assert.equal(column.props, "Row 0");
@@ -227,7 +227,7 @@ describe("TableFactory unit tests", () => {
 		it("Can create without custom column/row schema", () => {
 			class Table extends TableSchema.table({
 				schemaFactory,
-				cell: schemaFactory.string,
+				Cell: schemaFactory.string,
 			}) {}
 
 			const _table = new Table({
@@ -240,15 +240,15 @@ describe("TableFactory unit tests", () => {
 			const Cell = schemaFactory.string;
 			class Column extends TableSchema.column({
 				schemaFactory,
-				cell: Cell,
-				props: schemaFactory.object("column-props", {
+				Cell,
+				Props: schemaFactory.object("column-props", {
 					label: schemaFactory.string,
 				}),
 			}) {}
 			class Table extends TableSchema.table({
 				schemaFactory,
-				cell: Cell,
-				column: Column,
+				Cell,
+				Column,
 			}) {}
 
 			const _table = new Table({
@@ -261,15 +261,15 @@ describe("TableFactory unit tests", () => {
 			const Cell = schemaFactory.string;
 			class Row extends TableSchema.row({
 				schemaFactory,
-				cell: Cell,
-				props: schemaFactory.object("row-props", {
+				Cell,
+				Props: schemaFactory.object("row-props", {
 					label: schemaFactory.string,
 				}),
 			}) {}
 			class Table extends TableSchema.table({
 				schemaFactory,
-				cell: schemaFactory.string,
-				row: Row,
+				Cell: schemaFactory.string,
+				Row,
 			}) {}
 
 			const _table = new Table({
@@ -282,23 +282,23 @@ describe("TableFactory unit tests", () => {
 			const Cell = schemaFactory.string;
 			class Column extends TableSchema.column({
 				schemaFactory,
-				cell: Cell,
-				props: schemaFactory.object("column-props", {
+				Cell,
+				Props: schemaFactory.object("column-props", {
 					label: schemaFactory.string,
 				}),
 			}) {}
 			class Row extends TableSchema.row({
 				schemaFactory,
-				cell: Cell,
-				props: schemaFactory.object("row-props", {
+				Cell,
+				Props: schemaFactory.object("row-props", {
 					label: schemaFactory.string,
 				}),
 			}) {}
 			class Table extends TableSchema.table({
 				schemaFactory,
-				cell: schemaFactory.string,
-				column: Column,
-				row: Row,
+				Cell: schemaFactory.string,
+				Column,
+				Row,
 			}) {}
 
 			const _table = new Table({
@@ -312,7 +312,7 @@ describe("TableFactory unit tests", () => {
 		it("Empty", () => {
 			class Table extends TableSchema.table({
 				schemaFactory,
-				cell: schemaFactory.string,
+				Cell: schemaFactory.string,
 			}) {
 				// Custom property on derived class included to verify that the
 				// return type of `Table.empty()` is correct.
@@ -1373,7 +1373,7 @@ describe("TableFactory unit tests", () => {
 
 			class Table extends TableSchema.table({
 				schemaFactory,
-				cell: Cell,
+				Cell,
 			}) {}
 
 			const table = new Table({
@@ -1399,20 +1399,20 @@ describe("TableFactory unit tests", () => {
 
 			class Column extends TableSchema.column({
 				schemaFactory,
-				cell: Cell,
-				props: ColumnProps,
+				Cell,
+				Props: ColumnProps,
 			}) {}
 
 			class Row extends TableSchema.row({
 				schemaFactory,
-				cell: Cell,
+				Cell,
 			}) {}
 
 			class Table extends TableSchema.table({
 				schemaFactory,
-				cell: Cell,
-				column: Column,
-				row: Row,
+				Cell,
+				Column,
+				Row,
 			}) {}
 
 			const table = new Table({


### PR DESCRIPTION
Makes the use of the factory functions a bit more ergonomic. E.g.

Before:

```ts
class Table extends TableSchema.table({
    schemaFactory,
    cell: Cell,
    column: Column,
    row: Row
}) {}
```

After:

```ts
class Table extends TableSchema.table({
    schemaFactory,
    Cell,
    Column,
    Row
}) {}
```