### PR TITLE
Refactor: Move validation of inserted trees

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/index.ts
@@ -26,7 +26,12 @@ export {
 	relevantRemovedRoots,
 } from "./defaultEditBuilder.js";
 
-export { SchemaValidationErrors, isNodeInSchema, isFieldInSchema } from "./schemaChecker.js";
+export {
+	SchemaValidationErrors,
+	isNodeInSchema,
+	isFieldInSchema,
+	inSchemaOrThrow,
+} from "./schemaChecker.js";
 
 export { defaultSchemaPolicy } from "./defaultSchema.js";
 

--- a/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
@@ -14,6 +14,7 @@ import {
 	type SchemaAndPolicy,
 } from "../../core/index.js";
 import { allowsValue } from "../valueUtilities.js";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 export const enum SchemaValidationErrors {
 	NoError,
@@ -26,6 +27,15 @@ export const enum SchemaValidationErrors {
 	NonLeafNode_ValueNotAllowed,
 	Node_MissingSchema,
 	UnknownError,
+}
+
+/**
+ * Throws a UsageError if maybeError indicates a tree is out of schema.
+ */
+export function inSchemaOrThrow(maybeError: SchemaValidationErrors): void {
+	if (maybeError !== SchemaValidationErrors.NoError) {
+		throw new UsageError("Tree does not conform to schema.");
+	}
 }
 
 /**
@@ -50,38 +60,38 @@ export function isNodeInSchema(
 		if (!allowsValue(schema.leafValue, node.value)) {
 			return SchemaValidationErrors.LeafNode_InvalidValue;
 		}
-	} else if (schema instanceof ObjectNodeStoredSchema) {
-		if (node.value !== undefined) {
-			return SchemaValidationErrors.NonLeafNode_ValueNotAllowed;
-		}
-		const uncheckedFieldsFromNode = new Set(node.fields.keys());
-		for (const [fieldKey, fieldSchema] of schema.objectNodeFields) {
-			const nodeField = node.fields.get(fieldKey) ?? [];
-			const fieldInSchemaResult = isFieldInSchema(nodeField, fieldSchema, schemaAndPolicy);
-			if (fieldInSchemaResult !== SchemaValidationErrors.NoError) {
-				return fieldInSchemaResult;
-			}
-			uncheckedFieldsFromNode.delete(fieldKey);
-		}
-		// The node has fields that we did not check as part of looking at every field defined in the node's schema
-		if (
-			uncheckedFieldsFromNode.size !== 0 &&
-			!schemaAndPolicy.policy.allowUnknownOptionalFields(node.type)
-		) {
-			return SchemaValidationErrors.ObjectNode_FieldNotInSchema;
-		}
-	} else if (schema instanceof MapNodeStoredSchema) {
-		if (node.value !== undefined) {
-			return SchemaValidationErrors.NonLeafNode_ValueNotAllowed;
-		}
-		for (const field of node.fields.values()) {
-			const fieldInSchemaResult = isFieldInSchema(field, schema.mapFields, schemaAndPolicy);
-			if (fieldInSchemaResult !== SchemaValidationErrors.NoError) {
-				return fieldInSchemaResult;
-			}
-		}
 	} else {
-		fail(0xb0e /* Unknown TreeNodeStoredSchema type */);
+		if (node.value !== undefined) {
+			return SchemaValidationErrors.NonLeafNode_ValueNotAllowed;
+		}
+
+		if (schema instanceof ObjectNodeStoredSchema) {
+			const uncheckedFieldsFromNode = new Set(node.fields.keys());
+			for (const [fieldKey, fieldSchema] of schema.objectNodeFields) {
+				const nodeField = node.fields.get(fieldKey) ?? [];
+				const fieldInSchemaResult = isFieldInSchema(nodeField, fieldSchema, schemaAndPolicy);
+				if (fieldInSchemaResult !== SchemaValidationErrors.NoError) {
+					return fieldInSchemaResult;
+				}
+				uncheckedFieldsFromNode.delete(fieldKey);
+			}
+			// The node has fields that we did not check as part of looking at every field defined in the node's schema
+			if (
+				uncheckedFieldsFromNode.size !== 0 &&
+				!schemaAndPolicy.policy.allowUnknownOptionalFields(node.type)
+			) {
+				return SchemaValidationErrors.ObjectNode_FieldNotInSchema;
+			}
+		} else if (schema instanceof MapNodeStoredSchema) {
+			for (const field of node.fields.values()) {
+				const fieldInSchemaResult = isFieldInSchema(field, schema.mapFields, schemaAndPolicy);
+				if (fieldInSchemaResult !== SchemaValidationErrors.NoError) {
+					return fieldInSchemaResult;
+				}
+			}
+		} else {
+			fail(0xb0e /* Unknown TreeNodeStoredSchema type */);
+		}
 	}
 
 	return SchemaValidationErrors.NoError;

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -145,6 +145,7 @@ export {
 	SchemaValidationErrors,
 	isNodeInSchema,
 	isFieldInSchema,
+	inSchemaOrThrow,
 } from "./default-schema/index.js";
 
 export {

--- a/packages/dds/tree/src/simple-tree/api/create.ts
+++ b/packages/dds/tree/src/simple-tree/api/create.ts
@@ -28,11 +28,12 @@ import {
 import {
 	cursorForMapTreeNode,
 	defaultSchemaPolicy,
+	inSchemaOrThrow,
 	mapTreeFromCursor,
 	type NodeIdentifierManager,
 } from "../../feature-libraries/index.js";
 import { isFieldInSchema } from "../../feature-libraries/index.js";
-import { inSchemaOrThrow, mapTreeFromNodeData } from "../toMapTree.js";
+import { mapTreeFromNodeData } from "../toMapTree.js";
 import { getUnhydratedContext } from "../createContext.js";
 import { createUnknownOptionalFieldPolicy } from "../objectNode.js";
 

--- a/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
+++ b/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
@@ -99,6 +99,10 @@ export function prepareArrayContentForInsertion(
 
 /**
  * Split out from {@link prepareForInsertion} as to allow use without a context.
+ *
+ * @param hydratedData - If specified, the `mapTrees` will be prepared for hydration into this context.
+ * `undefined` when `mapTrees` are being inserted into an {@link Unhydrated} tree.
+ *
  * @remarks
  * Adding this entry point is a workaround for initialize not currently having a context.
  */
@@ -119,6 +123,9 @@ export function prepareForInsertionContextless<TIn extends InsertableContent | u
 
 /**
  * If hydrating, do a final validation against the schema and prepare the content for hydration.
+ *
+ * @param hydratedData - If specified, the `mapTrees` will be prepared for hydration into this context.
+ * `undefined` when `mapTrees` are being inserted into an {@link Unhydrated} tree.
  */
 function validateAndPrepare(
 	schemaAndPolicy: SchemaAndPolicy,

--- a/packages/dds/tree/src/test/core/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/anchorSet.spec.ts
@@ -26,16 +26,16 @@ import {
 	keyAsDetachedField,
 	makeDetachedFieldIndex,
 	rootFieldKey,
-} from "../../core/index.js";
-import { brand } from "../../util/index.js";
+} from "../../../core/index.js";
+import { brand } from "../../../util/index.js";
 import {
 	applyTestDelta,
 	chunkFromJsonableTrees,
 	expectEqualPaths,
 	testIdCompressor,
 	testRevisionTagCodec,
-} from "../utils.js";
-import { stringSchema } from "../../simple-tree/index.js";
+} from "../../utils.js";
+import { stringSchema } from "../../../simple-tree/index.js";
 
 const fieldFoo: FieldKey = brand("foo");
 const fieldBar: FieldKey = brand("bar");

--- a/packages/dds/tree/src/test/core/tree/detachedFieldIndex.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/detachedFieldIndex.spec.ts
@@ -8,22 +8,30 @@ import { strict as assert } from "node:assert";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import { createIdCompressor } from "@fluidframework/id-compressor/internal";
 
-import { DetachedFieldIndex, type ForestRootId, RevisionTagCodec } from "../../core/index.js";
+import {
+	DetachedFieldIndex,
+	type ForestRootId,
+	RevisionTagCodec,
+} from "../../../core/index.js";
 // eslint-disable-next-line import/no-internal-modules
-import { makeDetachedNodeToFieldCodec } from "../../core/tree/detachedFieldIndexCodec.js";
+import { makeDetachedNodeToFieldCodec } from "../../../core/tree/detachedFieldIndexCodec.js";
 // eslint-disable-next-line import/no-internal-modules
-import type { Format } from "../../core/tree/detachedFieldIndexFormat.js";
+import type { Format } from "../../../core/tree/detachedFieldIndexFormat.js";
 // eslint-disable-next-line import/no-internal-modules
-import type { DetachedFieldSummaryData } from "../../core/tree/detachedFieldIndexTypes.js";
-import { typeboxValidator } from "../../external-utilities/index.js";
+import type { DetachedFieldSummaryData } from "../../../core/tree/detachedFieldIndexTypes.js";
+import { typeboxValidator } from "../../../external-utilities/index.js";
 import {
 	type IdAllocator,
 	type JsonCompatibleReadOnly,
 	brand,
 	idAllocatorFromMaxId,
-} from "../../util/index.js";
-import { takeJsonSnapshot, useSnapshotDirectory } from "../snapshots/index.js";
-import { testIdCompressor, testRevisionTagCodec, createSnapshotCompressor } from "../utils.js";
+} from "../../../util/index.js";
+import { takeJsonSnapshot, useSnapshotDirectory } from "../../snapshots/index.js";
+import {
+	testIdCompressor,
+	testRevisionTagCodec,
+	createSnapshotCompressor,
+} from "../../utils.js";
 
 const mintedTag = testIdCompressor.generateCompressedId();
 const finalizedTag = testIdCompressor.normalizeToOpSpace(mintedTag);

--- a/packages/dds/tree/src/test/core/tree/mapTree.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/mapTree.spec.ts
@@ -1,0 +1,44 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { deepCopyMapTree, type ExclusiveMapTree } from "../../../core/index.js";
+import { brand } from "../../../util/index.js";
+
+describe("mapTree", () => {
+	// Used by `generateMapTree` to give unique types and values to each MapTree
+	let mapTreeGeneration = 0;
+	function generateMapTree(depth: number): ExclusiveMapTree {
+		const generation = mapTreeGeneration++;
+		return {
+			type: brand(String(generation)),
+			value: generation,
+			fields: new Map(
+				depth === 0
+					? []
+					: [
+							[brand("a"), [generateMapTree(depth - 1), generateMapTree(depth - 1)]],
+							[brand("b"), [generateMapTree(depth - 1), generateMapTree(depth - 1)]],
+						],
+			),
+		};
+	}
+
+	it("empty tree", () => {
+		const mapTree = generateMapTree(0);
+		assert.deepEqual(deepCopyMapTree(mapTree), mapTree);
+	});
+
+	it("shallow tree", () => {
+		const mapTree = generateMapTree(1);
+		assert.deepEqual(deepCopyMapTree(mapTree), mapTree);
+	});
+
+	it("deep tree", () => {
+		const mapTree = generateMapTree(2);
+		assert.deepEqual(deepCopyMapTree(mapTree), mapTree);
+	});
+});

--- a/packages/dds/tree/src/test/core/tree/pathTree.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/pathTree.spec.ts
@@ -14,11 +14,11 @@ import {
 	getDepth,
 	rootField,
 	rootFieldKey,
-} from "../../core/index.js";
+} from "../../../core/index.js";
 // This import is targeting the code being tested
 // eslint-disable-next-line import/no-internal-modules
-import { getDetachedFieldContainingPath } from "../../core/tree/pathTree.js";
-import { brand } from "../../util/index.js";
+import { getDetachedFieldContainingPath } from "../../../core/tree/pathTree.js";
+import { brand } from "../../../util/index.js";
 
 const rootKey = brand<FieldKey>("root");
 const fooKey = brand<FieldKey>("foo");

--- a/packages/dds/tree/src/test/core/tree/visitDelta.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/visitDelta.spec.ts
@@ -18,8 +18,8 @@ import {
 	type RevisionTag,
 	makeDetachedFieldIndex,
 	visitDelta,
-} from "../../core/index.js";
-import { brand } from "../../util/index.js";
+} from "../../../core/index.js";
+import { brand } from "../../../util/index.js";
 import {
 	chunkFromJsonTrees,
 	chunkToMapTreeField,
@@ -28,9 +28,9 @@ import {
 	testIdCompressor,
 	testRevisionTagCodec,
 	type DeltaParams,
-} from "../utils.js";
+} from "../../utils.js";
 import { deepFreeze } from "@fluidframework/test-runtime-utils/internal";
-import { mapTreeFromCursor } from "../../feature-libraries/index.js";
+import { mapTreeFromCursor } from "../../../feature-libraries/index.js";
 
 function visit(
 	delta: DeltaRoot,

--- a/packages/dds/tree/src/test/core/tree/visitorUtils.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/visitorUtils.spec.ts
@@ -10,8 +10,8 @@ import {
 	type DeltaVisitor,
 	type FieldKey,
 	combineVisitors,
-} from "../../core/index.js";
-import { brand } from "../../util/index.js";
+} from "../../../core/index.js";
+import { brand } from "../../../util/index.js";
 
 class LoggingVisitor implements DeltaVisitor {
 	public readonly name: string;

--- a/packages/dds/tree/src/test/simple-tree/api/create.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/create.spec.ts
@@ -5,8 +5,16 @@
 
 import { strict as assert } from "node:assert";
 
-import { createFromInsertable, SchemaFactory } from "../../../simple-tree/index.js";
+import {
+	createFromInsertable,
+	cursorFromInsertable,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../../simple-tree/api/create.js";
+
 import { TreeAlpha } from "../../../shared-tree/index.js";
+import { SchemaFactory } from "../../../simple-tree/index.js";
+import { MockNodeIdentifierManager } from "../../../feature-libraries/index.js";
+import { validateUsageError } from "../../utils.js";
 
 const schema = new SchemaFactory("com.example");
 
@@ -30,5 +38,24 @@ describe("simple-tree create", () => {
 		});
 		const canvas2 = new Canvas({ stuff: [] });
 		assert.deepEqual(canvas1, canvas2);
+	});
+
+	describe("cursorFromInsertable", () => {
+		it("Success", () => {
+			cursorFromInsertable(schema.string, "Hello world", new MockNodeIdentifierManager());
+		});
+
+		it("Failure", () => {
+			assert.throws(
+				() =>
+					cursorFromInsertable(
+						schema.number,
+						// @ts-expect-error invalid data for schema
+						"Hello world",
+						new MockNodeIdentifierManager(),
+					),
+				validateUsageError(/incompatible/),
+			);
+		});
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/prepareForInsertion.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/prepareForInsertion.spec.ts
@@ -18,7 +18,6 @@ import {
 	storedEmptyFieldSchema,
 	ValueSchema,
 	type FieldKey,
-	type FieldKindData,
 	type FieldKindIdentifier,
 	type SchemaAndPolicy,
 	type TreeFieldStoredSchema,
@@ -28,6 +27,7 @@ import {
 import { brand } from "../../util/index.js";
 import { checkoutWithContent } from "../utils.js";
 import {
+	defaultSchemaPolicy,
 	FieldKinds,
 	MockNodeIdentifierManager,
 	type FlexTreeHydratedContext,
@@ -91,14 +91,13 @@ describe("prepareForInsertion", () => {
 		 */
 		function createSchemaAndPolicy(
 			nodeSchema: Map<TreeNodeSchemaIdentifier, TreeNodeStoredSchema> = new Map(),
-			fieldKinds: Map<FieldKindIdentifier, FieldKindData> = new Map(),
 		): [SchemaAndPolicy, Pick<FlexTreeHydratedContext, "checkout" | "nodeKeyManager">] {
 			const schemaAndPolicy = {
 				schema: {
 					nodeSchema,
 				},
 				policy: {
-					fieldKinds,
+					fieldKinds: defaultSchemaPolicy.fieldKinds,
 					validateSchema: true,
 					// toMapTree drops all extra fields, so varying this policy is unnecessary
 					// (schema validation only occurs after converting to a MapTree)
@@ -142,7 +141,7 @@ describe("prepareForInsertion", () => {
 			}
 
 			describe("Leaf node", () => {
-				function createSchemaAndPolicyForLeafNode(invalid: boolean = false) {
+				function createSchemaAndPolicyForString(invalid: boolean = false) {
 					return createSchemaAndPolicy(
 						new Map([
 							[
@@ -153,13 +152,12 @@ describe("prepareForInsertion", () => {
 									: new LeafNodeStoredSchema(ValueSchema.String),
 							],
 						]),
-						new Map(),
 					);
 				}
 
 				it("Success", () => {
 					const content = "Hello world";
-					const schemaValidationPolicy = createSchemaAndPolicyForLeafNode();
+					const schemaValidationPolicy = createSchemaAndPolicyForString();
 					prepareForInsertionContextless(
 						content,
 						schemaFactory.string,
@@ -169,7 +167,7 @@ describe("prepareForInsertion", () => {
 
 				it("Failure", () => {
 					const content = "Hello world";
-					const schemaValidationPolicy = createSchemaAndPolicyForLeafNode(true);
+					const schemaValidationPolicy = createSchemaAndPolicyForString(true);
 					assert.throws(
 						() =>
 							prepareForInsertionContextless(
@@ -208,7 +206,6 @@ describe("prepareForInsertion", () => {
 								),
 							],
 						]),
-						new Map([[fieldSchema.kind, FieldKinds.required]]),
 					);
 				}
 				it("Success", () => {
@@ -266,7 +263,6 @@ describe("prepareForInsertion", () => {
 							],
 							[brand(myMapSchema.identifier), new MapNodeStoredSchema(fieldSchema)],
 						]),
-						new Map([[fieldSchema.kind, FieldKinds.required]]),
 					);
 				}
 				it("Success", () => {
@@ -311,7 +307,6 @@ describe("prepareForInsertion", () => {
 							],
 							[brand(myArrayNodeSchema.identifier), new MapNodeStoredSchema(fieldSchema)],
 						]),
-						new Map([[fieldSchema.kind, FieldKinds.required]]),
 					);
 				}
 				it("Success", () => {

--- a/packages/dds/tree/src/test/simple-tree/prepareForInsertion.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/prepareForInsertion.spec.ts
@@ -6,7 +6,32 @@
 import { strict as assert } from "node:assert";
 
 import { hydrate } from "./utils.js";
-import { SchemaFactory, TreeArrayNode } from "../../simple-tree/index.js";
+import {
+	prepareForInsertionContextless,
+	SchemaFactory,
+	TreeArrayNode,
+} from "../../simple-tree/index.js";
+import {
+	LeafNodeStoredSchema,
+	MapNodeStoredSchema,
+	ObjectNodeStoredSchema,
+	storedEmptyFieldSchema,
+	ValueSchema,
+	type FieldKey,
+	type FieldKindData,
+	type FieldKindIdentifier,
+	type SchemaAndPolicy,
+	type TreeFieldStoredSchema,
+	type TreeNodeSchemaIdentifier,
+	type TreeNodeStoredSchema,
+} from "../../core/index.js";
+import { brand } from "../../util/index.js";
+import { checkoutWithContent } from "../utils.js";
+import {
+	FieldKinds,
+	MockNodeIdentifierManager,
+	type FlexTreeHydratedContext,
+} from "../../feature-libraries/index.js";
 
 // proxies.spec.ts has a lot of coverage for this code, but is focused on other things, and more integration test oriented.
 // Here are a few key tests for prepareForInsertion covering cases which are known to be likely to have issues.
@@ -58,5 +83,259 @@ describe("prepareForInsertion", () => {
 
 		assert.equal(deep1, root[0]);
 		assert.equal(deep2, root[1]);
+	});
+
+	describe("Stored schema validation", () => {
+		/**
+		 * Creates a schema and policy and indicates stored schema validation should be performed.
+		 */
+		function createSchemaAndPolicy(
+			nodeSchema: Map<TreeNodeSchemaIdentifier, TreeNodeStoredSchema> = new Map(),
+			fieldKinds: Map<FieldKindIdentifier, FieldKindData> = new Map(),
+		): [SchemaAndPolicy, Pick<FlexTreeHydratedContext, "checkout" | "nodeKeyManager">] {
+			const schemaAndPolicy = {
+				schema: {
+					nodeSchema,
+				},
+				policy: {
+					fieldKinds,
+					validateSchema: true,
+					// toMapTree drops all extra fields, so varying this policy is unnecessary
+					// (schema validation only occurs after converting to a MapTree)
+					allowUnknownOptionalFields: () => false,
+				},
+			};
+
+			return [
+				schemaAndPolicy,
+				{
+					checkout: checkoutWithContent({
+						schema: {
+							...schemaAndPolicy.schema,
+							rootFieldSchema: storedEmptyFieldSchema,
+						},
+						initialTree: undefined,
+					}),
+					nodeKeyManager: new MockNodeIdentifierManager(),
+				},
+			] as const;
+		}
+
+		const outOfSchemaExpectedError: Partial<Error> = {
+			message: "Tree does not conform to schema.",
+		};
+
+		const schemaFactory = new SchemaFactory("test");
+
+		describe("mapTreeFromNodeData", () => {
+			/**
+			 * Helper for building {@link TreeFieldStoredSchema}.
+			 */
+			function getFieldSchema(
+				kind: { identifier: FieldKindIdentifier },
+				allowedTypes: Iterable<TreeNodeSchemaIdentifier>,
+			): TreeFieldStoredSchema {
+				return {
+					kind: kind.identifier,
+					types: new Set(allowedTypes),
+				};
+			}
+
+			describe("Leaf node", () => {
+				function createSchemaAndPolicyForLeafNode(invalid: boolean = false) {
+					return createSchemaAndPolicy(
+						new Map([
+							[
+								// An invalid stored schema will associate the string identifier to a number schema
+								brand(schemaFactory.string.identifier),
+								invalid
+									? new LeafNodeStoredSchema(ValueSchema.Number)
+									: new LeafNodeStoredSchema(ValueSchema.String),
+							],
+						]),
+						new Map(),
+					);
+				}
+
+				it("Success", () => {
+					const content = "Hello world";
+					const schemaValidationPolicy = createSchemaAndPolicyForLeafNode();
+					prepareForInsertionContextless(
+						content,
+						schemaFactory.string,
+						...schemaValidationPolicy,
+					);
+				});
+
+				it("Failure", () => {
+					const content = "Hello world";
+					const schemaValidationPolicy = createSchemaAndPolicyForLeafNode(true);
+					assert.throws(
+						() =>
+							prepareForInsertionContextless(
+								content,
+								[schemaFactory.string],
+								...schemaValidationPolicy,
+							),
+						outOfSchemaExpectedError,
+					);
+				});
+			});
+
+			describe("Object node", () => {
+				const content = { foo: "Hello world" };
+				const fieldSchema = getFieldSchema(FieldKinds.required, [
+					brand(schemaFactory.string.identifier),
+				]);
+				const myObjectSchema = schemaFactory.object("myObject", {
+					foo: schemaFactory.string,
+				});
+
+				function createSchemaAndPolicyForObjectNode(invalid: boolean = false) {
+					return createSchemaAndPolicy(
+						new Map<TreeNodeSchemaIdentifier, TreeNodeStoredSchema>([
+							[
+								// An invalid stored schema will associate the string identifier to a number schema
+								brand(schemaFactory.string.identifier),
+								invalid
+									? new LeafNodeStoredSchema(ValueSchema.Number)
+									: new LeafNodeStoredSchema(ValueSchema.String),
+							],
+							[
+								brand(myObjectSchema.identifier),
+								new ObjectNodeStoredSchema(
+									new Map<FieldKey, TreeFieldStoredSchema>([[brand("foo"), fieldSchema]]),
+								),
+							],
+						]),
+						new Map([[fieldSchema.kind, FieldKinds.required]]),
+					);
+				}
+				it("Success", () => {
+					const schemaValidationPolicy = createSchemaAndPolicyForObjectNode();
+					prepareForInsertionContextless(
+						content,
+						[myObjectSchema, schemaFactory.string],
+						...schemaValidationPolicy,
+					);
+				});
+
+				it("Failure", () => {
+					const schemaValidationPolicy = createSchemaAndPolicyForObjectNode(true);
+					assert.throws(
+						() =>
+							prepareForInsertionContextless(
+								content,
+								[myObjectSchema, schemaFactory.string],
+								...schemaValidationPolicy,
+							),
+						outOfSchemaExpectedError,
+					);
+				});
+
+				it("Only imports data in the schema", () => {
+					const schemaValidationPolicy = createSchemaAndPolicyForObjectNode();
+					// Note that despite the content containing keys not in the object schema, this test passes.
+					// This is by design: if an app author wants to preserve data that isn't in the schema (ex: to
+					// collaborate with other clients that have newer schema without erasing auxiliary data), they
+					// can use import/export tree APIs as noted in `SchemaFactoryObjectOptions`.
+					prepareForInsertionContextless(
+						{ foo: "Hello world", notInSchemaKey: 5, anotherNotInSchemaKey: false },
+						[myObjectSchema, schemaFactory.string],
+						...schemaValidationPolicy,
+					);
+				});
+			});
+
+			describe("Map node", () => {
+				const content = new Map([["foo", "Hello world"]]);
+				const fieldSchema = getFieldSchema(FieldKinds.required, [
+					brand(schemaFactory.string.identifier),
+				]);
+				const myMapSchema = schemaFactory.map("myMap", [schemaFactory.string]);
+
+				function createSchemaAndPolicyForMapNode(invalid: boolean = false) {
+					return createSchemaAndPolicy(
+						new Map<TreeNodeSchemaIdentifier, TreeNodeStoredSchema>([
+							[
+								// An invalid stored schema will associate the string identifier to a number schema
+								brand(schemaFactory.string.identifier),
+								invalid
+									? new LeafNodeStoredSchema(ValueSchema.Number)
+									: new LeafNodeStoredSchema(ValueSchema.String),
+							],
+							[brand(myMapSchema.identifier), new MapNodeStoredSchema(fieldSchema)],
+						]),
+						new Map([[fieldSchema.kind, FieldKinds.required]]),
+					);
+				}
+				it("Success", () => {
+					const schemaValidationPolicy = createSchemaAndPolicyForMapNode();
+					prepareForInsertionContextless(
+						content,
+						[myMapSchema, schemaFactory.string],
+						...schemaValidationPolicy,
+					);
+				});
+
+				it("Failure", () => {
+					const schemaValidationPolicy = createSchemaAndPolicyForMapNode(true);
+					assert.throws(
+						() =>
+							prepareForInsertionContextless(
+								content,
+								[myMapSchema, schemaFactory.string],
+								...schemaValidationPolicy,
+							),
+						outOfSchemaExpectedError,
+					);
+				});
+			});
+
+			describe("Array node", () => {
+				const content = ["foo"];
+				const fieldSchema = getFieldSchema(FieldKinds.required, [
+					brand(schemaFactory.string.identifier),
+				]);
+				const myArrayNodeSchema = schemaFactory.array("myArrayNode", [schemaFactory.string]);
+
+				function createSchemaAndPolicyForMapNode(invalid: boolean = false) {
+					return createSchemaAndPolicy(
+						new Map<TreeNodeSchemaIdentifier, TreeNodeStoredSchema>([
+							[
+								// An invalid stored schema will associate the string identifier to a number schema
+								brand(schemaFactory.string.identifier),
+								invalid
+									? new LeafNodeStoredSchema(ValueSchema.Number)
+									: new LeafNodeStoredSchema(ValueSchema.String),
+							],
+							[brand(myArrayNodeSchema.identifier), new MapNodeStoredSchema(fieldSchema)],
+						]),
+						new Map([[fieldSchema.kind, FieldKinds.required]]),
+					);
+				}
+				it("Success", () => {
+					const schemaValidationPolicy = createSchemaAndPolicyForMapNode();
+					prepareForInsertionContextless(
+						content,
+						[myArrayNodeSchema, schemaFactory.string],
+						...schemaValidationPolicy,
+					);
+				});
+
+				it("Failure", () => {
+					const schemaValidationPolicy = createSchemaAndPolicyForMapNode(true);
+					assert.throws(
+						() =>
+							prepareForInsertionContextless(
+								content,
+								[myArrayNodeSchema, schemaFactory.string],
+								...schemaValidationPolicy,
+							),
+						outOfSchemaExpectedError,
+					);
+				});
+			});
+		});
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/toMapTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/toMapTree.spec.ts
@@ -11,25 +11,13 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 
 import {
-	deepCopyMapTree,
 	EmptyKey,
-	LeafNodeStoredSchema,
-	MapNodeStoredSchema,
-	ObjectNodeStoredSchema,
-	ValueSchema,
 	type ExclusiveMapTree,
 	type FieldKey,
-	type FieldKindData,
-	type FieldKindIdentifier,
 	type MapTree,
-	type SchemaAndPolicy,
-	type TreeFieldStoredSchema,
-	type TreeNodeSchemaIdentifier,
-	type TreeNodeStoredSchema,
 } from "../../core/index.js";
 import {
 	booleanSchema,
-	cursorFromInsertable,
 	handleSchema,
 	nullSchema,
 	numberSchema,
@@ -57,24 +45,10 @@ import {
 } from "../../simple-tree/toMapTree.js";
 import { brand } from "../../util/index.js";
 import {
-	FieldKinds,
 	MockNodeIdentifierManager,
 	type NodeIdentifierManager,
 } from "../../feature-libraries/index.js";
 import { validateUsageError } from "../utils.js";
-
-/**
- * Helper for building {@link TreeFieldStoredSchema}.
- */
-function getFieldSchema(
-	kind: { identifier: FieldKindIdentifier },
-	allowedTypes?: Iterable<TreeNodeSchemaIdentifier>,
-): TreeFieldStoredSchema {
-	return {
-		kind: kind.identifier,
-		types: new Set(allowedTypes),
-	};
-}
 
 describe("toMapTree", () => {
 	let nodeKeyManager: MockNodeIdentifierManager;
@@ -1283,403 +1257,96 @@ describe("toMapTree", () => {
 		});
 	});
 
-	describe("Stored schema validation", () => {
-		/**
-		 * Creates a schema and policy and indicates stored schema validation should be performed.
-		 */
-		function createSchemaAndPolicy(
-			nodeSchema: Map<TreeNodeSchemaIdentifier, TreeNodeStoredSchema> = new Map(),
-			fieldKinds: Map<FieldKindIdentifier, FieldKindData> = new Map(),
-		): SchemaAndPolicy {
-			return {
-				schema: {
-					nodeSchema,
-				},
-				policy: {
-					fieldKinds,
-					validateSchema: true,
-					// toMapTree drops all extra fields, so varying this policy is unnecessary
-					// (schema validation only occurs after converting to a MapTree)
-					allowUnknownOptionalFields: () => false,
-				},
-			};
-		}
-
-		const outOfSchemaExpectedError: Partial<Error> = {
-			message: "Tree does not conform to schema.",
-		};
-
-		const schemaFactory = new SchemaFactory("test");
-
-		describe("mapTreeFromNodeData", () => {
-			describe("Leaf node", () => {
-				function createSchemaAndPolicyForLeafNode(invalid: boolean = false) {
-					return createSchemaAndPolicy(
-						new Map([
-							[
-								// An invalid stored schema will associate the string identifier to a number schema
-								brand(schemaFactory.string.identifier),
-								invalid
-									? new LeafNodeStoredSchema(ValueSchema.Number)
-									: new LeafNodeStoredSchema(ValueSchema.String),
-							],
-						]),
-						new Map(),
-					);
-				}
-
-				it("Success", () => {
-					const content = "Hello world";
-					const schemaValidationPolicy = createSchemaAndPolicyForLeafNode();
-					mapTreeFromNodeData(
-						content,
-						[schemaFactory.string],
-						new MockNodeIdentifierManager(),
-						schemaValidationPolicy,
-					);
-				});
-
-				it("Failure", () => {
-					const content = "Hello world";
-					const schemaValidationPolicy = createSchemaAndPolicyForLeafNode(true);
-					assert.throws(
-						() =>
-							mapTreeFromNodeData(
-								content,
-								[schemaFactory.string],
-								new MockNodeIdentifierManager(),
-								schemaValidationPolicy,
-							),
-						outOfSchemaExpectedError,
-					);
-				});
-			});
-
-			describe("Object node", () => {
-				const content = { foo: "Hello world" };
-				const fieldSchema = getFieldSchema(FieldKinds.required, [
-					brand(schemaFactory.string.identifier),
-				]);
-				const myObjectSchema = schemaFactory.object("myObject", {
-					foo: schemaFactory.string,
-				});
-
-				function createSchemaAndPolicyForObjectNode(invalid: boolean = false) {
-					return createSchemaAndPolicy(
-						new Map<TreeNodeSchemaIdentifier, TreeNodeStoredSchema>([
-							[
-								// An invalid stored schema will associate the string identifier to a number schema
-								brand(schemaFactory.string.identifier),
-								invalid
-									? new LeafNodeStoredSchema(ValueSchema.Number)
-									: new LeafNodeStoredSchema(ValueSchema.String),
-							],
-							[
-								brand(myObjectSchema.identifier),
-								new ObjectNodeStoredSchema(
-									new Map<FieldKey, TreeFieldStoredSchema>([[brand("foo"), fieldSchema]]),
-								),
-							],
-						]),
-						new Map([[fieldSchema.kind, FieldKinds.required]]),
-					);
-				}
-				it("Success", () => {
-					const schemaValidationPolicy = createSchemaAndPolicyForObjectNode();
-					mapTreeFromNodeData(
-						content,
-						[myObjectSchema, schemaFactory.string],
-						new MockNodeIdentifierManager(),
-						schemaValidationPolicy,
-					);
-				});
-
-				it("Failure", () => {
-					const schemaValidationPolicy = createSchemaAndPolicyForObjectNode(true);
-					assert.throws(
-						() =>
-							mapTreeFromNodeData(
-								content,
-								[myObjectSchema, schemaFactory.string],
-								new MockNodeIdentifierManager(),
-								schemaValidationPolicy,
-							),
-						outOfSchemaExpectedError,
-					);
-				});
-
-				it("Only imports data in the schema", () => {
-					const schemaValidationPolicy = createSchemaAndPolicyForObjectNode();
-					// Note that despite the content containing keys not in the object schema, this test passes.
-					// This is by design: if an app author wants to preserve data that isn't in the schema (ex: to
-					// collaborate with other clients that have newer schema without erasing auxiliary data), they
-					// can use import/export tree APIs as noted in `SchemaFactoryObjectOptions`.
-					mapTreeFromNodeData(
-						{ foo: "Hello world", notInSchemaKey: 5, anotherNotInSchemaKey: false },
-						[myObjectSchema, schemaFactory.string],
-						new MockNodeIdentifierManager(),
-						schemaValidationPolicy,
-					);
-				});
-			});
-
-			describe("Map node", () => {
-				const content = new Map([["foo", "Hello world"]]);
-				const fieldSchema = getFieldSchema(FieldKinds.required, [
-					brand(schemaFactory.string.identifier),
-				]);
-				const myMapSchema = schemaFactory.map("myMap", [schemaFactory.string]);
-
-				function createSchemaAndPolicyForMapNode(invalid: boolean = false) {
-					return createSchemaAndPolicy(
-						new Map<TreeNodeSchemaIdentifier, TreeNodeStoredSchema>([
-							[
-								// An invalid stored schema will associate the string identifier to a number schema
-								brand(schemaFactory.string.identifier),
-								invalid
-									? new LeafNodeStoredSchema(ValueSchema.Number)
-									: new LeafNodeStoredSchema(ValueSchema.String),
-							],
-							[brand(myMapSchema.identifier), new MapNodeStoredSchema(fieldSchema)],
-						]),
-						new Map([[fieldSchema.kind, FieldKinds.required]]),
-					);
-				}
-				it("Success", () => {
-					const schemaValidationPolicy = createSchemaAndPolicyForMapNode();
-					mapTreeFromNodeData(
-						content,
-						[myMapSchema, schemaFactory.string],
-						new MockNodeIdentifierManager(),
-						schemaValidationPolicy,
-					);
-				});
-
-				it("Failure", () => {
-					const schemaValidationPolicy = createSchemaAndPolicyForMapNode(true);
-					assert.throws(
-						() =>
-							mapTreeFromNodeData(
-								content,
-								[myMapSchema, schemaFactory.string],
-								new MockNodeIdentifierManager(),
-								schemaValidationPolicy,
-							),
-						outOfSchemaExpectedError,
-					);
-				});
-			});
-
-			describe("Array node", () => {
-				const content = ["foo"];
-				const fieldSchema = getFieldSchema(FieldKinds.required, [
-					brand(schemaFactory.string.identifier),
-				]);
-				const myArrayNodeSchema = schemaFactory.array("myArrayNode", [schemaFactory.string]);
-
-				function createSchemaAndPolicyForMapNode(invalid: boolean = false) {
-					return createSchemaAndPolicy(
-						new Map<TreeNodeSchemaIdentifier, TreeNodeStoredSchema>([
-							[
-								// An invalid stored schema will associate the string identifier to a number schema
-								brand(schemaFactory.string.identifier),
-								invalid
-									? new LeafNodeStoredSchema(ValueSchema.Number)
-									: new LeafNodeStoredSchema(ValueSchema.String),
-							],
-							[brand(myArrayNodeSchema.identifier), new MapNodeStoredSchema(fieldSchema)],
-						]),
-						new Map([[fieldSchema.kind, FieldKinds.required]]),
-					);
-				}
-				it("Success", () => {
-					const schemaValidationPolicy = createSchemaAndPolicyForMapNode();
-					mapTreeFromNodeData(
-						content,
-						[myArrayNodeSchema, schemaFactory.string],
-						new MockNodeIdentifierManager(),
-						schemaValidationPolicy,
-					);
-				});
-
-				it("Failure", () => {
-					const schemaValidationPolicy = createSchemaAndPolicyForMapNode(true);
-					assert.throws(
-						() =>
-							mapTreeFromNodeData(
-								content,
-								[myArrayNodeSchema, schemaFactory.string],
-								new MockNodeIdentifierManager(),
-								schemaValidationPolicy,
-							),
-						outOfSchemaExpectedError,
-					);
-				});
-			});
+	describe("getPossibleTypes", () => {
+		it("array vs map", () => {
+			const f = new SchemaFactory("test");
+			const arraySchema = f.array([f.null]);
+			const mapSchema = f.map([f.null]);
+			// Array makes array
+			assert.deepEqual(getPossibleTypes(new Set([mapSchema, arraySchema]), []), [arraySchema]);
+			// Map makes map
+			assert.deepEqual(getPossibleTypes(new Set([mapSchema, arraySchema]), new Map()), [
+				mapSchema,
+			]);
+			// Iterator can make map or array.
+			assert.deepEqual(getPossibleTypes(new Set([mapSchema, arraySchema]), new Map().keys()), [
+				mapSchema,
+				arraySchema,
+			]);
 		});
 
-		const schemaValidationPolicyForSuccess = createSchemaAndPolicy(
-			new Map([
-				[brand(schemaFactory.string.identifier), new LeafNodeStoredSchema(ValueSchema.String)],
-			]),
-			new Map(),
-		);
-		const schemaValidationPolicyForFailure = createSchemaAndPolicy(
-			new Map([
-				[
-					// Fake a stored schema that associates the string identifier to a number schema
-					brand(schemaFactory.string.identifier),
-					new LeafNodeStoredSchema(ValueSchema.Number),
-				],
-			]),
-			new Map(),
-		);
-
-		describe("cursorFromInsertable", () => {
-			it("Success", () => {
-				cursorFromInsertable(schemaFactory.string, "Hello world", nodeKeyManager);
-			});
-
-			it("Failure", () => {
-				assert.throws(
-					() =>
-						// @ts-expect-error invalid data for schema
-						cursorFromInsertable(schemaFactory.number, "Hello world", nodeKeyManager),
-					validateUsageError(/incompatible/),
-				);
-			});
+		it("array vs map low priority matching", () => {
+			const f = new SchemaFactory("test");
+			const arraySchema = f.array([f.null]);
+			const mapSchema = f.map([f.null]);
+			// Array makes map
+			assert.deepEqual(getPossibleTypes(new Set([mapSchema]), []), [mapSchema]);
+			// Map makes array
+			assert.deepEqual(getPossibleTypes(new Set([arraySchema]), new Map()), [arraySchema]);
 		});
 
-		describe("getPossibleTypes", () => {
-			it("array vs map", () => {
-				const f = new SchemaFactory("test");
-				const arraySchema = f.array([f.null]);
-				const mapSchema = f.map([f.null]);
-				// Array makes array
-				assert.deepEqual(getPossibleTypes(new Set([mapSchema, arraySchema]), []), [
-					arraySchema,
-				]);
-				// Map makes map
-				assert.deepEqual(getPossibleTypes(new Set([mapSchema, arraySchema]), new Map()), [
-					mapSchema,
-				]);
-				// Iterator can make map or array.
-				assert.deepEqual(
-					getPossibleTypes(new Set([mapSchema, arraySchema]), new Map().keys()),
-					[mapSchema, arraySchema],
-				);
-			});
-
-			it("array vs map low priority matching", () => {
-				const f = new SchemaFactory("test");
-				const arraySchema = f.array([f.null]);
-				const mapSchema = f.map([f.null]);
-				// Array makes map
-				assert.deepEqual(getPossibleTypes(new Set([mapSchema]), []), [mapSchema]);
-				// Map makes array
-				assert.deepEqual(getPossibleTypes(new Set([arraySchema]), new Map()), [arraySchema]);
-			});
-
-			it("inherited properties types", () => {
-				const f = new SchemaFactory("test");
-				class Optional extends f.object("x", {
-					constructor: f.optional(f.number),
-				}) {}
-				class Required extends f.object("x", {
-					constructor: f.number,
-				}) {}
-				class Other extends f.object("y", {
-					other: f.number,
-				}) {}
-				// Ignore inherited constructor field
-				assert.deepEqual(getPossibleTypes(new Set([Optional, Required, Other]), {}), [
-					Optional,
-				]);
-				// Allow overridden field
-				assert.deepEqual(
-					getPossibleTypes(new Set([Optional, Required, Other]), { constructor: 5 }),
-					[Optional, Required],
-				);
-				// Allow overridden undefined
-				assert.deepEqual(
-					getPossibleTypes(new Set([Optional, Required, Other]), { constructor: undefined }),
-					[Optional],
-				);
-				// Multiple Fields
-				assert.deepEqual(
-					getPossibleTypes(new Set([Optional, Required, Other]), {
-						constructor: undefined,
-						other: 6,
-					}),
-					[Optional, Other],
-				);
-				assert.deepEqual(
-					getPossibleTypes(new Set([Optional, Required, Other]), {
-						constructor: 5,
-						other: 6,
-					}),
-					[Optional, Required, Other],
-				);
-				// No properties
-				assert.deepEqual(
-					getPossibleTypes(new Set([Optional, Required, Other]), Object.create(null)),
-					[Optional],
-				);
-			});
-		});
-
-		describe("addDefaultsToMapTree", () => {
-			it("custom stored key", () => {
-				const f = new SchemaFactory("test");
-
-				class Test extends f.object("test", {
-					api: createFieldSchema(FieldKind.Required, [f.number], {
-						key: "stored",
-						defaultProvider: getDefaultProvider(() => 5),
-					}),
-				}) {}
-				const m: ExclusiveMapTree = { type: brand(Test.identifier), fields: new Map() };
-				addDefaultsToMapTree(m, Test, undefined);
-				assert.deepEqual(
-					m.fields,
-					new Map([["stored", [{ type: f.number.identifier, fields: new Map(), value: 5 }]]]),
-				);
-			});
+		it("inherited properties types", () => {
+			const f = new SchemaFactory("test");
+			class Optional extends f.object("x", {
+				constructor: f.optional(f.number),
+			}) {}
+			class Required extends f.object("x", {
+				constructor: f.number,
+			}) {}
+			class Other extends f.object("y", {
+				other: f.number,
+			}) {}
+			// Ignore inherited constructor field
+			assert.deepEqual(getPossibleTypes(new Set([Optional, Required, Other]), {}), [Optional]);
+			// Allow overridden field
+			assert.deepEqual(
+				getPossibleTypes(new Set([Optional, Required, Other]), { constructor: 5 }),
+				[Optional, Required],
+			);
+			// Allow overridden undefined
+			assert.deepEqual(
+				getPossibleTypes(new Set([Optional, Required, Other]), { constructor: undefined }),
+				[Optional],
+			);
+			// Multiple Fields
+			assert.deepEqual(
+				getPossibleTypes(new Set([Optional, Required, Other]), {
+					constructor: undefined,
+					other: 6,
+				}),
+				[Optional, Other],
+			);
+			assert.deepEqual(
+				getPossibleTypes(new Set([Optional, Required, Other]), {
+					constructor: 5,
+					other: 6,
+				}),
+				[Optional, Required, Other],
+			);
+			// No properties
+			assert.deepEqual(
+				getPossibleTypes(new Set([Optional, Required, Other]), Object.create(null)),
+				[Optional],
+			);
 		});
 	});
-});
 
-describe("deepCopyMapTree", () => {
-	// Used by `generateMapTree` to give unique types and values to each MapTree
-	let mapTreeGeneration = 0;
-	function generateMapTree(depth: number): ExclusiveMapTree {
-		const generation = mapTreeGeneration++;
-		return {
-			type: brand(String(generation)),
-			value: generation,
-			fields: new Map(
-				depth === 0
-					? []
-					: [
-							[brand("a"), [generateMapTree(depth - 1), generateMapTree(depth - 1)]],
-							[brand("b"), [generateMapTree(depth - 1), generateMapTree(depth - 1)]],
-						],
-			),
-		};
-	}
+	describe("addDefaultsToMapTree", () => {
+		it("custom stored key", () => {
+			const f = new SchemaFactory("test");
 
-	it("empty tree", () => {
-		const mapTree = generateMapTree(0);
-		assert.deepEqual(deepCopyMapTree(mapTree), mapTree);
-	});
-
-	it("shallow tree", () => {
-		const mapTree = generateMapTree(1);
-		assert.deepEqual(deepCopyMapTree(mapTree), mapTree);
-	});
-
-	it("deep tree", () => {
-		const mapTree = generateMapTree(2);
-		assert.deepEqual(deepCopyMapTree(mapTree), mapTree);
+			class Test extends f.object("test", {
+				api: createFieldSchema(FieldKind.Required, [f.number], {
+					key: "stored",
+					defaultProvider: getDefaultProvider(() => 5),
+				}),
+			}) {}
+			const m: ExclusiveMapTree = { type: brand(Test.identifier), fields: new Map() };
+			addDefaultsToMapTree(m, Test, undefined);
+			assert.deepEqual(
+				m.fields,
+				new Map([["stored", [{ type: f.number.identifier, fields: new Map(), value: 5 }]]]),
+			);
+		});
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/treeContext.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/treeContext.spec.ts
@@ -29,12 +29,11 @@ describe("TreeBranch", () => {
 		return view;
 	}
 
-	{
-		// Test that branching from a TreeView returns a typed view (as opposed to an untyped context).
+	it("Test that branching from a TreeView returns a typed view (as opposed to an untyped context)", () => {
 		const view = init([]);
 		const branch = view.fork();
 		type _check = requireAssignableTo<typeof branch, typeof view>;
-	}
+	});
 
 	it("can downcast to a view", () => {
 		const view = init(["a", "b", "c"]);


### PR DESCRIPTION
## Description

The last chance schema validation to guard against document corruption is now done on the insertion code-path together with the other logic we run before final document insertion.

Moving this logic also involved moving its tests, which resulted in a significant amount of test cleanup since many tests in toMapTree.spec.ts were misplaced.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

