### PR TITLE
Fix various e2e test memory leaks

### DIFF
--- a/packages/test/test-driver-definitions/src/interfaces.ts
+++ b/packages/test/test-driver-definitions/src/interfaces.ts
@@ -116,6 +116,8 @@ export interface ITestDriver {
 	 * when resolving the container  URL.
 	 */
 	createContainerUrl(testId: string, containerUrl?: IResolvedUrl): Promise<string>;
+
+	dispose?(): void;
 }
 
 /**

--- a/packages/test/test-drivers/src/localServerTestDriver.ts
+++ b/packages/test/test-drivers/src/localServerTestDriver.ts
@@ -69,4 +69,11 @@ export class LocalServerTestDriver implements ITestDriver {
 	async createContainerUrl(testId: string): Promise<string> {
 		return `http://localhost/${testId}`;
 	}
+
+	/**
+	 * Local server dispose flows are especially important to avoid leaking memory over the course of a test run.
+	 */
+	dispose() {
+		this._server.close();
+	}
 }

--- a/packages/test/test-drivers/src/localServerTestDriver.ts
+++ b/packages/test/test-drivers/src/localServerTestDriver.ts
@@ -74,6 +74,8 @@ export class LocalServerTestDriver implements ITestDriver {
 	 * Local server dispose flows are especially important to avoid leaking memory over the course of a test run.
 	 */
 	dispose() {
-		this._server.close();
+		this._server.close().catch(() => {
+			// TODO: We may want to log the error in the future.
+		});
 	}
 }

--- a/packages/test/test-utils/src/loaderContainerTracker.ts
+++ b/packages/test/test-utils/src/loaderContainerTracker.ts
@@ -200,6 +200,9 @@ export class LoaderContainerTracker implements IOpProcessingController {
 		this.lastProposalSeqNum = 0;
 		for (const container of this.containers.keys()) {
 			container.close();
+			// Optional chaining here is because containers made with LTS loaders don't have a dispose method or process
+			// and this package is used with various previous versions of Fluid layers in our compat testing.
+			container.dispose?.();
 		}
 		this.containers.clear();
 

--- a/packages/test/test-utils/src/test/timeoutUtils.spec.ts
+++ b/packages/test/test-utils/src/test/timeoutUtils.spec.ts
@@ -12,7 +12,7 @@ import { timeoutPromise } from "../timeoutUtils.js";
  * is running in a mocha test that is about to time out.
  * Keep that in mind as you read/update the tests below.
  */
-describe.only("TimeoutPromise", () => {
+describe("TimeoutPromise", () => {
 	beforeEach(async () => {
 		// Make sure there are no setTimeouts left behind from previous tests,
 		// by waiting longer than the timeout we use for tests.

--- a/packages/test/test-utils/src/test/timeoutUtils.spec.ts
+++ b/packages/test/test-utils/src/test/timeoutUtils.spec.ts
@@ -12,7 +12,7 @@ import { timeoutPromise } from "../timeoutUtils.js";
  * is running in a mocha test that is about to time out.
  * Keep that in mind as you read/update the tests below.
  */
-describe("TimeoutPromise", () => {
+describe.only("TimeoutPromise", () => {
 	beforeEach(async () => {
 		// Make sure there are no setTimeouts left behind from previous tests,
 		// by waiting longer than the timeout we use for tests.

--- a/packages/test/test-utils/src/timeoutUtils.ts
+++ b/packages/test/test-utils/src/timeoutUtils.ts
@@ -20,12 +20,15 @@ class TestTimeout {
 
 	private static instance: TestTimeout = new TestTimeout();
 	public static reset(runnable: Mocha.Runnable) {
-		TestTimeout.clear();
+		TestTimeout.instance.clearTimer();
+		TestTimeout.instance = new TestTimeout();
 		TestTimeout.instance.resetTimer(runnable);
 	}
 
 	public static clear() {
+		// TODO: Check general setup here to see if we want tweaks.
 		if (TestTimeout.instance.deferred.isCompleted) {
+			// Problem was that this line basically never happened because clearTimer resets the deffered state!
 			TestTimeout.instance = new TestTimeout();
 		} else {
 			TestTimeout.instance.clearTimer();
@@ -174,6 +177,7 @@ export async function timeoutPromise<T = void>(
 	) => void,
 	timeoutOptions: TimeoutWithError | TimeoutWithValue<T> = {},
 ): Promise<T> {
+	// return new Promise(executor);
 	// create the timeout error outside the async task, so its callstack includes
 	// the original call site, this makes it easier to debug
 	const err =

--- a/packages/test/test-utils/src/timeoutUtils.ts
+++ b/packages/test/test-utils/src/timeoutUtils.ts
@@ -182,7 +182,6 @@ export async function timeoutPromise<T = void>(
 	) => void,
 	timeoutOptions: TimeoutWithError | TimeoutWithValue<T> = {},
 ): Promise<T> {
-	// return new Promise(executor);
 	// create the timeout error outside the async task, so its callstack includes
 	// the original call site, this makes it easier to debug
 	const err =

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -127,7 +127,7 @@ function createCompatSuite(
 					return provider;
 				}, apis);
 
-				afterEach("Reset TestObjectProvider", function () {
+				afterEach("Reset TestObjectProvider", () => {
 					if (provider === undefined) {
 						throw new Error("Expected provider to be set up by before hook");
 					}

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -60,6 +60,7 @@ function createCompatSuite(
 		if (compatFilter !== undefined) {
 			configs = configs.filter((value) => compatFilter.includes(value.kind));
 		}
+
 		for (const config of configs) {
 			if (minVersion && isCompatVersionBelowMinVersion(minVersion, config)) {
 				// skip current config if compat version is below min version supported for test suite
@@ -69,11 +70,11 @@ function createCompatSuite(
 				continue;
 			}
 			describe(config.name, function () {
-				let provider: ITestObjectProvider;
+				let provider: ITestObjectProvider | undefined;
 				let resetAfterEach: boolean;
 				const apis: CompatApis = getVersionedApis(config);
 
-				before(async function () {
+				before("Create TestObjectProvider", async function () {
 					try {
 						provider =
 							config.kind === CompatKind.CrossVersion
@@ -106,11 +107,17 @@ function createCompatSuite(
 						throw error;
 					}
 
-					Object.defineProperty(this, "__fluidTestProvider", { get: () => provider });
+					Object.defineProperty(this, "__fluidTestProvider", {
+						get: () => provider,
+						configurable: true,
+					});
 				});
 
 				tests.bind(this)((options?: ITestObjectProviderOptions) => {
 					resetAfterEach = options?.resetAfterEach ?? true;
+					if (provider === undefined) {
+						throw new Error("Expected provider to be set up by before hook");
+					}
 					if (options?.syncSummarizer === true) {
 						provider.resetLoaderContainerTracker(true /* syncSummarizerClients */);
 					}
@@ -120,7 +127,19 @@ function createCompatSuite(
 					return provider;
 				}, apis);
 
-				afterEach(function (done: Mocha.Done) {
+				afterEach("Reset TestObjectProvider", function () {
+					if (provider === undefined) {
+						throw new Error("Expected provider to be set up by before hook");
+					}
+					if (resetAfterEach) {
+						provider.reset();
+					}
+				});
+
+				afterEach("Verify container telemetry", function (done: Mocha.Done) {
+					if (provider === undefined) {
+						throw new Error("Expected provider to be set up by before hook");
+					}
 					const logErrors = getUnexpectedLogErrorException(provider.tracker);
 					// if the test failed for another reason
 					// then we don't need to check errors
@@ -130,9 +149,35 @@ function createCompatSuite(
 					} else {
 						done();
 					}
-					if (resetAfterEach) {
-						provider.reset();
+				});
+
+				// Mocha contexts are long-lived, and leaking the testObjectProvider on them severely eats into
+				// memory over the course of our e2e tests. This is especially the case for local server, where the
+				// server ends up retaining direct references to containers. This hook resolves that issue by explicitly
+				// removing retainers for the test object provider from the context.
+				// A good way to test memory impact of changes here is by doing one of:
+				// - Put an existing e2e test's `it` block in a loop to create many copies of it and run only this test
+				// - Put a single test in a `describeCompat` block and put the `describeCompat` block in a loop
+				// then taking heap snapshots over the course of various runs.
+				// Because of things like the summarizer process, container cleanup as soon as tests are done executing is not reasonable,
+				// but you should see the total number of retained containers as well as server objects stabilize over time rather than grow.
+				// Snapshots for a large number of tests within a single suite help detect bugs with leaking objects while a suite executes,
+				// which is problematic for suites that run a large number of test cases (usually combintorially generated).
+				// Snapshots for a large number of suites help detect bugs with leaking objects across suites,
+				// which is problematic for issues that tend to get hit "later in the overall test run".
+				after("Cleanup TestObjectProvider", function () {
+					if (provider === undefined) {
+						throw new Error("Expected provider to be set up by before hook");
 					}
+					provider.driver.dispose?.();
+					provider = undefined;
+					Object.defineProperty(this, "__fluidTestProvider", {
+						get: () => {
+							throw new Error(
+								"Attempted to use __fluidTestProvider after test suite disposed.",
+							);
+						},
+					});
 				});
 			});
 		}

--- a/packages/test/test-version-utils/src/describeWithVersions.ts
+++ b/packages/test/test-version-utils/src/describeWithVersions.ts
@@ -114,7 +114,7 @@ function createTestSuiteWithInstalledVersion(
 			return provider;
 		});
 
-		afterEach("Reset TestObjectProvider", function () {
+		afterEach("Reset TestObjectProvider", () => {
 			if (provider === undefined) {
 				throw new Error("Expected provider to be set up by before hook");
 			}

--- a/packages/test/test-version-utils/src/describeWithVersions.ts
+++ b/packages/test/test-version-utils/src/describeWithVersions.ts
@@ -74,13 +74,13 @@ function createTestSuiteWithInstalledVersion(
 	timeoutMs: number = defaultTimeoutMs,
 ) {
 	return function (this: Mocha.Suite) {
-		let defaultProvider: TestObjectProvider;
+		let provider: TestObjectProvider | undefined;
 		let resetAfterEach: boolean;
-		before(async function () {
+		before("Create TestObjectProvider", async function () {
 			this.timeout(Math.max(defaultTimeoutMs, timeoutMs));
 
 			await installRequiredVersions(requiredVersions);
-			defaultProvider = await getVersionedTestObjectProvider(
+			provider = await getVersionedTestObjectProvider(
 				pkgVersion, // baseVersion
 				pkgVersion, // loaderVersion
 				{
@@ -95,20 +95,39 @@ function createTestSuiteWithInstalledVersion(
 				pkgVersion, // dataRuntimeVersion
 			);
 
-			Object.defineProperty(this, "__fluidTestProvider", { get: () => defaultProvider });
+			Object.defineProperty(this, "__fluidTestProvider", {
+				get: () => provider,
+				configurable: true,
+			});
 		});
 
 		tests.bind(this)((options?: ITestObjectProviderOptions) => {
 			resetAfterEach = options?.resetAfterEach ?? true;
-			if (options?.syncSummarizer === true) {
-				defaultProvider.resetLoaderContainerTracker(true /* syncSummarizerClients */);
+			if (provider === undefined) {
+				throw new Error("Expected provider to be set up by before hook");
 			}
 
-			return defaultProvider;
+			if (options?.syncSummarizer === true) {
+				provider.resetLoaderContainerTracker(true /* syncSummarizerClients */);
+			}
+
+			return provider;
 		});
 
-		afterEach(function (done: Mocha.Done) {
-			const logErrors = getUnexpectedLogErrorException(defaultProvider.tracker);
+		afterEach("Reset TestObjectProvider", function () {
+			if (provider === undefined) {
+				throw new Error("Expected provider to be set up by before hook");
+			}
+			if (resetAfterEach) {
+				provider.reset();
+			}
+		});
+
+		afterEach("Verify Container Telemetry", function (done: Mocha.Done) {
+			if (provider === undefined) {
+				throw new Error("Expected provider to be set up by before hook");
+			}
+			const logErrors = getUnexpectedLogErrorException(provider.tracker);
 			// if the test failed for another reason
 			// then we don't need to check errors
 			// and fail the after each as well
@@ -117,10 +136,20 @@ function createTestSuiteWithInstalledVersion(
 			} else {
 				done();
 			}
+		});
 
-			if (resetAfterEach) {
-				defaultProvider.reset();
+		// See remarks in `createCompatSuite` for cleanup justification + tips on debugging memory leaks
+		after("Cleanup TestObjectProvider", function () {
+			if (provider === undefined) {
+				throw new Error("Expected provider to be set up by before hook");
 			}
+			provider.driver.dispose?.();
+			provider = undefined;
+			Object.defineProperty(this, "__fluidTestProvider", {
+				get: () => {
+					throw new Error("Attempted to use __fluidTestProvider after test suite disposed.");
+				},
+			});
 		});
 	};
 }


### PR DESCRIPTION
## Description

This fixes several issues that caused our e2e tests to memory leak.

- `Container.dispose` was not called between tests after closing containers.
- LocalServer objects were not cleaned up across test suites. This ended up leaking at least some of the containers they talked to.
- TestObjectProviders were retained by mocha context objects set up via `createCompatSuite` and variants.
- The changes made in #24116 were most of the way there toward fixing the memory leak, but the logic to actually create a new `TestTimeout` wasn't invoked enough as most of the time, tests wouldn't timeout and therefore the created deferred object would just be reset. So they weren't fully effective

There are still some lingering leaks that could use tracking down eventually, but a quick sniff test of "watch the memory usage over the course of the full e2e test run" shows that peak memory usage before changes is ~2.5 GB whereas after it's just shy of 1 GB, and remaining resource leaks are happening *way* slower over the course of the test run.

This change also gets us closer to being able to enable the `--exit` flag in mocha: that works for NoCompat suites whereas it didn't work before. I suspect remaining leaks may be tied to certain compat configurations.