### PR TITLE
Better schema validation errors

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/index.ts
@@ -27,7 +27,7 @@ export {
 } from "./defaultEditBuilder.js";
 
 export {
-	SchemaValidationErrors,
+	SchemaValidationError,
 	isNodeInSchema,
 	isFieldInSchema,
 	inSchemaOrThrow,

--- a/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
@@ -17,25 +17,27 @@ import {
 import { allowsValue } from "../valueUtilities.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-export const enum SchemaValidationErrors {
-	NoError,
+export enum SchemaValidationError {
 	Field_KindNotInSchemaPolicy,
-	Field_IncorrectMultiplicity,
+	Field_MissingRequiredChild,
+	Field_MultipleChildrenNotAllowed,
+	Field_ChildInForbiddenField,
 	Field_NodeTypeNotAllowed,
 	LeafNode_InvalidValue,
 	LeafNode_FieldsNotAllowed,
 	ObjectNode_FieldNotInSchema,
 	NonLeafNode_ValueNotAllowed,
 	Node_MissingSchema,
-	UnknownError,
 }
 
 /**
  * Throws a UsageError if maybeError indicates a tree is out of schema.
  */
-export function inSchemaOrThrow(maybeError: SchemaValidationErrors): void {
-	if (maybeError !== SchemaValidationErrors.NoError) {
-		throw new UsageError("Tree does not conform to schema.");
+export function inSchemaOrThrow(maybeError: SchemaValidationError | undefined): void {
+	if (maybeError !== undefined) {
+		throw new UsageError(
+			`Tree does not conform to schema: ${SchemaValidationError[maybeError]}`,
+		);
 	}
 }
 
@@ -45,25 +47,25 @@ export function inSchemaOrThrow(maybeError: SchemaValidationErrors): void {
 export function isNodeInSchema(
 	node: MapTree,
 	schemaAndPolicy: SchemaAndPolicy,
-): SchemaValidationErrors {
+): SchemaValidationError | undefined {
 	// Validate the schema declared by the node exists
 	const schema = schemaAndPolicy.schema.nodeSchema.get(node.type);
 	if (schema === undefined) {
-		return SchemaValidationErrors.Node_MissingSchema;
+		return SchemaValidationError.Node_MissingSchema;
 	}
 
 	// Validate the node is well formed according to its schema
 
 	if (schema instanceof LeafNodeStoredSchema) {
 		if (node.fields.size !== 0) {
-			return SchemaValidationErrors.LeafNode_FieldsNotAllowed;
+			return SchemaValidationError.LeafNode_FieldsNotAllowed;
 		}
 		if (!allowsValue(schema.leafValue, node.value)) {
-			return SchemaValidationErrors.LeafNode_InvalidValue;
+			return SchemaValidationError.LeafNode_InvalidValue;
 		}
 	} else {
 		if (node.value !== undefined) {
-			return SchemaValidationErrors.NonLeafNode_ValueNotAllowed;
+			return SchemaValidationError.NonLeafNode_ValueNotAllowed;
 		}
 
 		if (schema instanceof ObjectNodeStoredSchema) {
@@ -71,7 +73,7 @@ export function isNodeInSchema(
 			for (const [fieldKey, fieldSchema] of schema.objectNodeFields) {
 				const nodeField = node.fields.get(fieldKey) ?? [];
 				const fieldInSchemaResult = isFieldInSchema(nodeField, fieldSchema, schemaAndPolicy);
-				if (fieldInSchemaResult !== SchemaValidationErrors.NoError) {
+				if (fieldInSchemaResult !== undefined) {
 					return fieldInSchemaResult;
 				}
 				uncheckedFieldsFromNode.delete(fieldKey);
@@ -81,12 +83,12 @@ export function isNodeInSchema(
 				uncheckedFieldsFromNode.size !== 0 &&
 				!schemaAndPolicy.policy.allowUnknownOptionalFields(node.type)
 			) {
-				return SchemaValidationErrors.ObjectNode_FieldNotInSchema;
+				return SchemaValidationError.ObjectNode_FieldNotInSchema;
 			}
 		} else if (schema instanceof MapNodeStoredSchema) {
 			for (const field of node.fields.values()) {
 				const fieldInSchemaResult = isFieldInSchema(field, schema.mapFields, schemaAndPolicy);
-				if (fieldInSchemaResult !== SchemaValidationErrors.NoError) {
+				if (fieldInSchemaResult !== undefined) {
 					return fieldInSchemaResult;
 				}
 			}
@@ -95,7 +97,7 @@ export function isNodeInSchema(
 		}
 	}
 
-	return SchemaValidationErrors.NoError;
+	return undefined;
 }
 
 /**
@@ -105,32 +107,35 @@ export function isFieldInSchema(
 	childNodes: readonly MapTree[],
 	schema: TreeFieldStoredSchema,
 	schemaAndPolicy: SchemaAndPolicy,
-): SchemaValidationErrors {
+): SchemaValidationError | undefined {
 	// Validate that the field kind is handled by the schema policy
 	const kind = schemaAndPolicy.policy.fieldKinds.get(schema.kind);
 	if (kind === undefined) {
-		return SchemaValidationErrors.Field_KindNotInSchemaPolicy;
+		return SchemaValidationError.Field_KindNotInSchemaPolicy;
 	}
 
 	// Validate that the field doesn't contain more nodes than its type supports
-	if (!compliesWithMultiplicity(childNodes.length, kind.multiplicity)) {
-		return SchemaValidationErrors.Field_IncorrectMultiplicity;
+	{
+		const multiplicityCheck = compliesWithMultiplicity(childNodes.length, kind.multiplicity);
+		if (multiplicityCheck !== undefined) {
+			return multiplicityCheck;
+		}
 	}
 
 	for (const node of childNodes) {
 		// Validate the type declared by the node is allowed in this field
 		if (schema.types !== undefined && !schema.types.has(node.type)) {
-			return SchemaValidationErrors.Field_NodeTypeNotAllowed;
+			return SchemaValidationError.Field_NodeTypeNotAllowed;
 		}
 
 		// Validate the node complies with the type it declares to be.
 		const nodeInSchemaResult = isNodeInSchema(node, schemaAndPolicy);
-		if (nodeInSchemaResult !== SchemaValidationErrors.NoError) {
+		if (nodeInSchemaResult !== undefined) {
 			return nodeInSchemaResult;
 		}
 	}
 
-	return SchemaValidationErrors.NoError;
+	return undefined;
 }
 
 /**
@@ -142,16 +147,26 @@ export function isFieldInSchema(
 export function compliesWithMultiplicity(
 	numberOfItems: number,
 	multiplicity: Multiplicity,
-): boolean {
+): SchemaValidationError | undefined {
 	switch (multiplicity) {
 		case Multiplicity.Single:
-			return numberOfItems === 1;
+			if (numberOfItems < 1) {
+				return SchemaValidationError.Field_MissingRequiredChild;
+			} else if (numberOfItems > 1) {
+				return SchemaValidationError.Field_MultipleChildrenNotAllowed;
+			} else {
+				return undefined;
+			}
 		case Multiplicity.Optional:
-			return numberOfItems <= 1;
+			return numberOfItems > 1
+				? SchemaValidationError.Field_MultipleChildrenNotAllowed
+				: undefined;
 		case Multiplicity.Sequence:
-			return true;
+			return undefined;
 		case Multiplicity.Forbidden:
-			return numberOfItems === 0;
+			return numberOfItems === 0
+				? undefined
+				: SchemaValidationError.Field_ChildInForbiddenField;
 		default:
 			unreachableCase(multiplicity);
 	}

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -142,7 +142,7 @@ export {
 	fieldKindConfigurations,
 	intoDelta,
 	relevantRemovedRoots,
-	SchemaValidationErrors,
+	SchemaValidationError,
 	isNodeInSchema,
 	isFieldInSchema,
 	inSchemaOrThrow,

--- a/packages/dds/tree/src/test/feature-libraries/default-schema/schemaChecker.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-schema/schemaChecker.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "node:assert";
 
 // Reaching into internal module just to test it
 import {
-	SchemaValidationErrors,
+	SchemaValidationError,
 	compliesWithMultiplicity,
 	isFieldInSchema,
 	isNodeInSchema,
@@ -111,19 +111,19 @@ describe("schema validation", () => {
 		const multiplicityTestCases: [
 			kind: Multiplicity,
 			numberToTest: number,
-			expectedResult: boolean,
+			expectedResult: undefined | SchemaValidationError,
 		][] = [
-			[Multiplicity.Forbidden, 0, true],
-			[Multiplicity.Forbidden, 1, false],
-			[Multiplicity.Single, 0, false],
-			[Multiplicity.Single, 1, true],
-			[Multiplicity.Single, 2, false],
-			[Multiplicity.Sequence, 0, true],
-			[Multiplicity.Sequence, 1, true],
-			[Multiplicity.Sequence, 2, true],
-			[Multiplicity.Optional, 0, true],
-			[Multiplicity.Optional, 1, true],
-			[Multiplicity.Optional, 2, false],
+			[Multiplicity.Forbidden, 0, undefined],
+			[Multiplicity.Forbidden, 1, SchemaValidationError.Field_ChildInForbiddenField],
+			[Multiplicity.Single, 0, SchemaValidationError.Field_MissingRequiredChild],
+			[Multiplicity.Single, 1, undefined],
+			[Multiplicity.Single, 2, SchemaValidationError.Field_MultipleChildrenNotAllowed],
+			[Multiplicity.Sequence, 0, undefined],
+			[Multiplicity.Sequence, 1, undefined],
+			[Multiplicity.Sequence, 2, undefined],
+			[Multiplicity.Optional, 0, undefined],
+			[Multiplicity.Optional, 1, undefined],
+			[Multiplicity.Optional, 2, SchemaValidationError.Field_MultipleChildrenNotAllowed],
 		];
 		for (const [kind, numberToTest, expectedResult] of multiplicityTestCases) {
 			it(`compliesWithMultiplicity(${numberToTest}, ${Multiplicity[kind]}) === ${expectedResult}`, () => {
@@ -140,7 +140,7 @@ describe("schema validation", () => {
 					createLeafNode("myNumberNode", 1, ValueSchema.Number).node,
 					createSchemaAndPolicy(), // Note this passes an empty stored schema
 				),
-				SchemaValidationErrors.Node_MissingSchema,
+				SchemaValidationError.Node_MissingSchema,
 			);
 		});
 
@@ -157,7 +157,7 @@ describe("schema validation", () => {
 					// So just putting a schema for a node that is not the one we pass in for validation.
 					createSchemaAndPolicy(new Map([[stringNode.type, stringSchema]])),
 				),
-				SchemaValidationErrors.Node_MissingSchema,
+				SchemaValidationError.Node_MissingSchema,
 			);
 		});
 
@@ -165,7 +165,7 @@ describe("schema validation", () => {
 			it("in schema", () => {
 				const { node, schema } = createLeafNode("myNode", 1, ValueSchema.Number);
 				const schemaAndPolicy = createSchemaAndPolicy(new Map([[node.type, schema]]));
-				assert.equal(isNodeInSchema(node, schemaAndPolicy), SchemaValidationErrors.NoError);
+				assert.equal(isNodeInSchema(node, schemaAndPolicy), undefined);
 			});
 
 			it("not in schema due to invalid value", () => {
@@ -173,7 +173,7 @@ describe("schema validation", () => {
 				const schemaAndPolicy = createSchemaAndPolicy(new Map([[node.type, schema]]));
 				assert.equal(
 					isNodeInSchema(node, schemaAndPolicy),
-					SchemaValidationErrors.LeafNode_InvalidValue,
+					SchemaValidationError.LeafNode_InvalidValue,
 				);
 			});
 
@@ -182,7 +182,7 @@ describe("schema validation", () => {
 				const schemaAndPolicy = createSchemaAndPolicy(new Map([[node.type, schema]]));
 				assert.equal(
 					isNodeInSchema(node, schemaAndPolicy),
-					SchemaValidationErrors.LeafNode_InvalidValue,
+					SchemaValidationError.LeafNode_InvalidValue,
 				);
 			});
 
@@ -198,7 +198,7 @@ describe("schema validation", () => {
 
 				assert.equal(
 					isNodeInSchema(outOfSchemaNode, schemaAndPolicy),
-					SchemaValidationErrors.LeafNode_FieldsNotAllowed,
+					SchemaValidationError.LeafNode_FieldsNotAllowed,
 				);
 			});
 		});
@@ -229,10 +229,7 @@ describe("schema validation", () => {
 					new Map([[fieldSchema.kind, FieldKinds.required]]),
 				);
 
-				assert.equal(
-					isNodeInSchema(mapNode.node, schemaAndPolicy),
-					SchemaValidationErrors.NoError,
-				);
+				assert.equal(isNodeInSchema(mapNode.node, schemaAndPolicy), undefined);
 			});
 
 			it("in schema while empty", () => {
@@ -250,10 +247,7 @@ describe("schema validation", () => {
 					new Map([[fieldSchema.kind, FieldKinds.required]]),
 				);
 
-				assert.equal(
-					isNodeInSchema(mapNode.node, schemaAndPolicy),
-					SchemaValidationErrors.NoError,
-				);
+				assert.equal(isNodeInSchema(mapNode.node, schemaAndPolicy), undefined);
 			});
 
 			it("not in schema due to having a value", () => {
@@ -280,7 +274,7 @@ describe("schema validation", () => {
 
 				assert.equal(
 					isNodeInSchema(outOfSchemaNode, schemaAndPolicy),
-					SchemaValidationErrors.NonLeafNode_ValueNotAllowed,
+					SchemaValidationError.NonLeafNode_ValueNotAllowed,
 				);
 			});
 		});
@@ -302,10 +296,7 @@ describe("schema validation", () => {
 					new Map([[fieldSchema.kind, FieldKinds.required]]),
 				);
 
-				assert.equal(
-					isNodeInSchema(objectNode.node, schemaAndPolicy),
-					SchemaValidationErrors.NoError,
-				);
+				assert.equal(isNodeInSchema(objectNode.node, schemaAndPolicy), undefined);
 			});
 
 			it(`in schema with empty optional field`, () => {
@@ -324,10 +315,7 @@ describe("schema validation", () => {
 					new Map([[fieldSchema.kind, FieldKinds.optional]]),
 				);
 
-				assert.equal(
-					isNodeInSchema(objectNode.node, schemaAndPolicy),
-					SchemaValidationErrors.NoError,
-				);
+				assert.equal(isNodeInSchema(objectNode.node, schemaAndPolicy), undefined);
 			});
 
 			it(`not in schema due to having a field not present in its defined schema`, () => {
@@ -351,7 +339,7 @@ describe("schema validation", () => {
 
 				assert.equal(
 					isNodeInSchema(objectNode.node, schemaAndPolicy),
-					SchemaValidationErrors.ObjectNode_FieldNotInSchema,
+					SchemaValidationError.ObjectNode_FieldNotInSchema,
 				);
 			});
 
@@ -375,7 +363,7 @@ describe("schema validation", () => {
 
 				assert.equal(
 					isNodeInSchema(objectNode.node, schemaAndPolicy),
-					SchemaValidationErrors.Field_IncorrectMultiplicity,
+					SchemaValidationError.Field_MissingRequiredChild,
 				);
 			});
 
@@ -404,7 +392,7 @@ describe("schema validation", () => {
 
 				assert.equal(
 					isNodeInSchema(outOfSchemaNode, schemaAndPolicy),
-					SchemaValidationErrors.NonLeafNode_ValueNotAllowed,
+					SchemaValidationError.NonLeafNode_ValueNotAllowed,
 				);
 			});
 
@@ -427,7 +415,7 @@ describe("schema validation", () => {
 
 				assert.equal(
 					isNodeInSchema(objectNode.node, schemaAndPolicy),
-					SchemaValidationErrors.Field_KindNotInSchemaPolicy,
+					SchemaValidationError.Field_KindNotInSchemaPolicy,
 				);
 			});
 		});
@@ -444,10 +432,7 @@ describe("schema validation", () => {
 
 			const field: MapTree[] = [numberNode.node];
 
-			assert.equal(
-				isFieldInSchema(field, fieldSchema, schemaAndPolicy),
-				SchemaValidationErrors.NoError,
-			);
+			assert.equal(isFieldInSchema(field, fieldSchema, schemaAndPolicy), undefined);
 		});
 
 		it(`not in schema if field kind not supported by schema policy`, () => {
@@ -460,7 +445,7 @@ describe("schema validation", () => {
 			// FieldKinds.required is used above but missing in the schema policy
 			assert.equal(
 				isFieldInSchema([numberNode.node], fieldSchema, schemaAndPolicy),
-				SchemaValidationErrors.Field_KindNotInSchemaPolicy,
+				SchemaValidationError.Field_KindNotInSchemaPolicy,
 			);
 		});
 
@@ -479,7 +464,7 @@ describe("schema validation", () => {
 					fieldSchema,
 					schemaAndPolicy,
 				),
-				SchemaValidationErrors.Field_NodeTypeNotAllowed,
+				SchemaValidationError.Field_NodeTypeNotAllowed,
 			);
 		});
 
@@ -495,7 +480,7 @@ describe("schema validation", () => {
 
 			assert.equal(
 				isFieldInSchema(emptyField, fieldSchema, schemaAndPolicy),
-				SchemaValidationErrors.Field_IncorrectMultiplicity,
+				SchemaValidationError.Field_MissingRequiredChild,
 			);
 		});
 	});
@@ -512,7 +497,7 @@ describe("schema validation", () => {
 						schema,
 						policy: defaultSchemaPolicy,
 					}),
-					SchemaValidationErrors.NoError,
+					undefined,
 				);
 			});
 		}

--- a/packages/dds/tree/src/test/simple-tree/prepareForInsertion.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/prepareForInsertion.spec.ts
@@ -25,7 +25,7 @@ import {
 	type TreeNodeStoredSchema,
 } from "../../core/index.js";
 import { brand } from "../../util/index.js";
-import { checkoutWithContent } from "../utils.js";
+import { checkoutWithContent, validateUsageError } from "../utils.js";
 import {
 	defaultSchemaPolicy,
 	FieldKinds,
@@ -120,9 +120,7 @@ describe("prepareForInsertion", () => {
 			] as const;
 		}
 
-		const outOfSchemaExpectedError: Partial<Error> = {
-			message: "Tree does not conform to schema.",
-		};
+		const outOfSchemaExpectedError = validateUsageError(/Tree does not conform to schema/);
 
 		const schemaFactory = new SchemaFactory("test");
 
@@ -175,7 +173,7 @@ describe("prepareForInsertion", () => {
 								[schemaFactory.string],
 								...schemaValidationPolicy,
 							),
-						outOfSchemaExpectedError,
+						validateUsageError(/LeafNode_InvalidValue/),
 					);
 				});
 			});


### PR DESCRIPTION
## Description

Improve messages from schema validation errors.

Note that these are not the user facing errors people typically see (those are from toMapTree) but instead the secondary validation which users should usually not see.

If however toMapTree misses something, these errors will be user facing, and this gives them much better messages.

This is also really nice for developers.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

