### PR TITLE
Simplify hydrate util

### DIFF
--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -19,6 +19,7 @@ import {
 } from "../../simple-tree/index.js";
 import { getView } from "../utils.js";
 import type { TreeCheckout } from "../../shared-tree/index.js";
+import { SchematizingSimpleTreeView } from "../../shared-tree/index.js";
 
 /**
  * Initializes a node with the given schema and content.

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -19,6 +19,7 @@ import {
 } from "../../simple-tree/index.js";
 import { getView } from "../utils.js";
 import type { TreeCheckout } from "../../shared-tree/index.js";
+
 /**
  * Initializes a node with the given schema and content.
  * @param schema - The schema of the node being initialized

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -19,8 +19,6 @@ import {
 } from "../../simple-tree/index.js";
 import { getView } from "../utils.js";
 import type { TreeCheckout } from "../../shared-tree/index.js";
-import { SchematizingSimpleTreeView } from "../../shared-tree/index.js";
-
 /**
  * Initializes a node with the given schema and content.
  * @param schema - The schema of the node being initialized
@@ -92,7 +90,7 @@ export function describeHydration(
  * @remarks
  * For minimal/concise targeted unit testing of specific simple-tree content.
  *
- * This this produces "marinated" nodes, meaning hydrated nodes which may not have an inner node cached yet.
+ * This produces "marinated" nodes, meaning hydrated nodes which may not have an inner node cached yet.
  */
 export function hydrate<const TSchema extends ImplicitFieldSchema>(
 	schema: TSchema,


### PR DESCRIPTION
## Description

Now that independentView exists, there is a reasonable way using more production APi to hydrate nodes without involving fluid runtimes. Refactor `hydrate` test util to use it via `getView`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

