### PR TITLE
Fix a few undocumented API warnings

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -2651,6 +2651,8 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 	}
 
 	/**
+	 * Builds a new tree to use in an edit.
+	 *
 	 * @param firstId - The ID to associate with the first node
 	 * @param content - The node(s) to build.
 	 * @param revision - The revision to use for the build.

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -542,7 +542,7 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
 // When other forest implementations are created (ex: optimized ones),
 // this function should likely be moved and updated to (at least conditionally) use them.
 /**
- * @returns an implementation of {@link IEditableForest} with no data or schema.
+ * Returns an implementation of {@link IEditableForest} with no content.
  */
 export function buildForest(
 	anchors?: AnchorSet,

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -107,6 +107,7 @@ function assertDeltasEqual(actual: DeltaRoot[], expected: DeltaRoot[]): void {
 }
 
 /**
+ * Initialize an editable forest.
  * @param data - The data to initialize the forest with.
  */
 function initializeEditableForest(data?: JsonableTree): {


### PR DESCRIPTION
## Description

We get warnings if APIs have no documentation thats not part of a specific tag, This fixes 3 such warnings.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
