### PR TITLE
Enable pendingPayload blobs and test blobUpload for local-server-stress-tests

### DIFF
--- a/packages/test/local-server-stress-tests/src/baseModel.ts
+++ b/packages/test/local-server-stress-tests/src/baseModel.ts
@@ -59,7 +59,7 @@ export function makeGenerator<T extends BaseOperation>(
 				type: "uploadBlob",
 				tag: state.tag("blob"),
 			}),
-			0, // Blob Upload doesn't interact properly with Staging Mode
+			5,
 			// local server doesn't support detached blobs
 			(state) => state.client.container.attachState !== AttachState.Detached,
 		],

--- a/packages/test/local-server-stress-tests/src/stressDataObject.ts
+++ b/packages/test/local-server-stress-tests/src/stressDataObject.ts
@@ -344,6 +344,7 @@ export const createRuntimeFactory = (): IRuntimeFactory => {
 			} as any,
 		},
 		enableRuntimeIdCompressor: "on",
+		createBlobPayloadPending: true,
 	};
 
 	return {

--- a/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
@@ -29,13 +29,9 @@ describe("Local Server Stress", () => {
 		saveFailures,
 		// saveSuccesses,
 		skip: [
-			...[15], // 0x54e (IntervalCollection)
-			...[39], // 0xa6f (merge-tree PropertiesManager)
-			...[62], // 0x2f5 (Sequence interval createPositionReference)
-			...[5, 22, 31, 36], // Number of keys not same
-			...[6], // channel maps should be the same size
-			...[7], // Number of subDirectories not same,
-			...[12], // Rollback op does not match last pending
+			...[18, 65, 98], // Number of keys not same
+			...[5, 49, 57], // Number of subDirectories not same,
+			...[11, 39], // Rollback op does not match last pending
 		],
 	});
 });

--- a/packages/test/local-server-stress-tests/src/test/localServerStressOrderSequentially.spec.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStressOrderSequentially.spec.ts
@@ -92,10 +92,13 @@ describe("Local Server Stress with rollback", () => {
 		// saveSuccesses,
 		configurations: { "Fluid.ContainerRuntime.EnableRollback": true },
 		skip: [
-			...[1], // closed container: 0xb85
-			...[47], //  Mismatch in pending changes
-			...[15, 23, 51, 63, 65], //  Number of subDirectories/keys not same
-			...[13], // 0xb86 and 0xb89: exit staging mode logic failing due to id compressor allocation ops
+			...[12, 28, 30], // Key not found or value not matching key
+			...[15, 38, 51, 63], // Number of keys not same (directory)
+			...[24], // have different number of keys (map)
+			...[25], // Number of subDirectories not same
+			...[53], // SubDirectory with name ... not present in second directory
+			...[65], // closed or disposed: 0x2f5
+			...[72], // closed or disposed: 0x2fa
 		],
 	});
 });


### PR DESCRIPTION
The failures shifted of course, but nothing looks blob-specific.  Enabling payloadPending lets us avoid the `Can't rollback blobAttach` failings that we got without the feature, since the blobAttach op is not generated/sent until the handle is attached with the feature enabled.

[AB#32563](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/32563)