### PR TITLE
tree: Remove unnecessary rollback tagging

### DIFF
--- a/packages/dds/tree/src/core/rebase/utils.ts
+++ b/packages/dds/tree/src/core/rebase/utils.ts
@@ -440,19 +440,21 @@ function rollbackFromCommit<TChange>(
 	mintRevisionTag: () => RevisionTag,
 	cache?: boolean,
 ): TaggedChange<TChange, RevisionTag> {
-	const rollback = Rollback.get(commit);
-	if (rollback !== undefined) {
-		return rollback;
+	const cachedRollback = Rollback.get(commit);
+	if (cachedRollback !== undefined) {
+		return cachedRollback;
 	}
 	const tag = mintRevisionTag();
-	const untagged = changeRebaser.invert(commit, true, tag);
-	const deeplyTaggedRollback = changeRebaser.changeRevision(untagged, tag, commit.revision);
-	const fullyTaggedRollback = tagRollbackInverse(deeplyTaggedRollback, tag, commit.revision);
+	const rollback = tagRollbackInverse(
+		changeRebaser.invert(commit, true, tag),
+		tag,
+		commit.revision,
+	);
 
 	if (cache === true) {
-		Rollback.set(commit, fullyTaggedRollback);
+		Rollback.set(commit, rollback);
 	}
-	return fullyTaggedRollback;
+	return rollback;
 }
 
 /**


### PR DESCRIPTION
## Description

Removed a call to `changeRevision` when creating inverses. This is no longer necessary as the revision is now passed in when creating the inverse.