### PR TITLE
Cleanup tests using object forest

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkedForest.spec.ts
@@ -81,7 +81,6 @@ describe("ChunkedForest", () => {
 	for (const [name, chunker] of chunkers) {
 		describe(name, () => {
 			testForest({
-				suiteName: "ChunkedForest forest suite",
 				factory: (schema) => buildChunkedForest(chunker(schema)),
 				skipCursorErrorCheck: true,
 			});

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -101,7 +101,7 @@ describe("LazyField", () => {
 		// #region Tree and schema initialization
 
 		const builder = new SchemaFactory("test");
-		const rootSchema = builder.optional([builder.object("object", {})]);
+		const rootSchema = builder.optional(JsonAsTree.JsonObject);
 
 		// Note: this tree initialization is strictly to enable construction of the lazy field.
 		// The test cases below are strictly in terms of the schema of the created fields.
@@ -250,7 +250,7 @@ describe("LazyField", () => {
 
 		it("null-Leaf", () => {
 			const { context, cursor } = readonlyTreeWithContent({
-				schema: stringSchema,
+				schema: JsonAsTree.Tree,
 				initialTree: singleJsonCursor(null),
 			});
 			cursor.enterNode(0); // Root node field has 1 node; move into it
@@ -362,7 +362,7 @@ describe("LazyField", () => {
 
 		it("content", () => {
 			const view = flexTreeViewWithContent({
-				schema,
+				schema: SchemaFactory.optional(JsonAsTree.Tree),
 				initialTree: singleJsonCursor(5),
 			});
 			assert(view.flexTree.is(FieldKinds.optional));
@@ -377,7 +377,7 @@ describe("LazyField", () => {
 			view.flexTree.editor.set(
 				mapTreeFromCursor(
 					cursorForJsonableTreeNode({
-						type: brand(stringSchema.identifier),
+						type: brand(numberSchema.identifier),
 						value: 7,
 					}),
 				),

--- a/packages/dds/tree/src/test/feature-libraries/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/objectForest.spec.ts
@@ -18,9 +18,16 @@ import { testIdCompressor, testRevisionTagCodec } from "../utils.js";
 import { fieldJsonCursor } from "../json/index.js";
 
 describe("object-forest", () => {
-	testForest({
-		suiteName: "forest suite",
-		factory: (schema) => buildForest(),
+	describe("forest suite", () => {
+		testForest({
+			factory: (schema) => buildForest(),
+		});
+	});
+
+	describe("forest suite additional assertions", () => {
+		testForest({
+			factory: (schema) => buildForest(undefined, true),
+		});
 	});
 
 	const content: JsonCompatible = {

--- a/packages/dds/tree/src/test/forestTestSuite.ts
+++ b/packages/dds/tree/src/test/forestTestSuite.ts
@@ -389,7 +389,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		assert(forest.anchors.isEmpty());
 	});
 
-	it("using an anchor that went away returns NotFound", () => {
+	it("tryMoveCursorToNode with anchor to deleted node returns NotFound", () => {
 		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 
 		initializeForest(

--- a/packages/dds/tree/src/test/forestTestSuite.ts
+++ b/packages/dds/tree/src/test/forestTestSuite.ts
@@ -67,7 +67,6 @@ import { JsonAsTree } from "../jsonDomainSchema.js";
  * Configuration for the forest test suite.
  */
 export interface ForestTestConfiguration {
-	suiteName: string;
 	factory: (schema: TreeStoredSchemaSubscription) => IEditableForest;
 
 	/**
@@ -85,245 +84,205 @@ const buildId = { minor: 42 };
 const buildId2 = { minor: 442 };
 const detachId = { minor: 43 };
 
+const optionalArraySchema = toStoredSchema(SchemaFactory.optional(JsonAsTree.Array));
+
 /**
  * Generic forest test suite
  */
 export function testForest(config: ForestTestConfiguration): void {
 	const factory = config.factory;
-	describe(config.suiteName, () => {
-		const nestedContent: JsonCompatible = {
-			x: { foo: 2 },
-			y: 1,
-		};
-		const xField = brand<FieldKey>("x");
-		const yField = brand<FieldKey>("y");
-		const fooField: FieldKey = brand("foo");
 
-		// Use Json Cursor to insert and extract some Json data
-		describe("insert and extract json", () => {
-			// eslint-disable-next-line @typescript-eslint/ban-types
-			const testCases: [string, {} | number][] = [
-				["primitive", 5],
-				["array", [1, 2, 3]],
-				["object", { blah: "test" }],
-				["nested objects", { blah: { foo: 5 }, baz: [{}, { foo: 3 }] }],
-			];
-			for (const [name, data] of testCases) {
-				it(name, () => {
-					const schemaFactory = new SchemaFactory("forest test suite");
+	const nestedContent: JsonCompatible = {
+		x: { foo: 2 },
+		y: 1,
+	};
+	const xField = brand<FieldKey>("x");
+	const yField = brand<FieldKey>("y");
+	const fooField: FieldKey = brand("foo");
 
-					const rootSchema = schemaFactory.optional([JsonAsTree.Array]);
-					const schema = new TreeStoredSchemaRepository(toStoredSchema(rootSchema));
+	// Use Json Cursor to insert and extract some Json data
+	describe("insert and extract json", () => {
+		// eslint-disable-next-line @typescript-eslint/ban-types
+		const testCases: [string, {} | number][] = [
+			["primitive", 5],
+			["array", [1, 2, 3]],
+			["object", { blah: "test" }],
+			["nested objects", { blah: { foo: 5 }, baz: [{}, { foo: 3 }] }],
+		];
+		for (const [name, data] of testCases) {
+			it(name, () => {
+				const schemaFactory = new SchemaFactory("forest test suite");
 
-					const forest = factory(schema);
+				const rootSchema = schemaFactory.optional([JsonAsTree.Array]);
+				const schema = new TreeStoredSchemaRepository(toStoredSchema(rootSchema));
 
-					initializeForest(
-						forest,
-						fieldJsonCursor([data]),
-						testRevisionTagCodec,
-						testIdCompressor,
-					);
+				const forest = factory(schema);
 
-					const reader = forest.allocateCursor();
-					moveToDetachedField(forest, reader);
-
-					// copy data from reader into json object and compare to data.
-					const copy = mapCursorField(reader, cursorToJsonObject);
-					reader.free();
-					assert.deepEqual(copy, [data]);
-				});
-			}
-		});
-
-		it("cursor use", () => {
-			const forest = factory(new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)));
-			initializeForest(
-				forest,
-				fieldJsonCursor([[1, 2]]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
-
-			const reader = forest.allocateCursor();
-			moveToDetachedField(forest, reader);
-			const reader2 = reader.fork();
-			// Make sure fork is initialized properly
-			assert.deepEqual(reader.getFieldPath(), reader2.getFieldPath());
-			assert(reader.firstNode());
-			// Make sure forks can move independently
-			assert.deepEqual(reader.getPath()?.parent, reader2.getFieldPath().parent);
-			assert(reader2.firstNode());
-			assert.deepEqual(reader.getPath(), reader2.getPath());
-			reader.enterField(EmptyKey);
-			reader.enterNode(1);
-			assert.equal(reader.value, 2);
-			// Move reader two down to the same place, but by a different route.
-			reader2.enterField(EmptyKey);
-			reader2.enterNode(0);
-			assert.equal(reader2.value, 1);
-			assert.equal(reader.value, 2);
-			assert(reader2.nextNode());
-			assert.equal(reader2.value, 2);
-			// Test a fork with a longer path and at a node not a field.
-			const reader3 = reader2.fork();
-			assert.deepEqual(reader.getPath(), reader3.getPath());
-			reader.free();
-			reader2.free();
-		});
-
-		it("isEmpty: rootFieldKey", () => {
-			const forest = factory(new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)));
-			assert(forest.isEmpty);
-			initializeForest(forest, fieldJsonCursor([[]]), testRevisionTagCodec, testIdCompressor);
-			assert(!forest.isEmpty);
-		});
-
-		it("isEmpty: other root", () => {
-			const forest = factory(new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)));
-			assert(forest.isEmpty);
-
-			const insert: DeltaFieldChanges = [{ count: 1, attach: { minor: 1 } }];
-			applyTestDelta(new Map([[brand("different root"), insert]]), forest, {
-				build: [{ id: { minor: 1 }, trees: chunkFromJsonTrees([[]]) }],
-			});
-			assert(!forest.isEmpty);
-		});
-
-		it("moving a cursor to the root of an empty forest fails", () => {
-			const forest = factory(new TreeStoredSchemaRepository());
-			const cursor = forest.allocateCursor();
-			moveToDetachedField(forest, cursor);
-			assert.equal(cursor.firstNode(), false);
-		});
-
-		it("tryMoveCursorToNode", () => {
-			const forest = factory(new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)));
-
-			initializeForest(
-				forest,
-				fieldJsonCursor([[1, 2]]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
-
-			const parentPath: UpPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const childPath1: UpPath = {
-				parent: parentPath,
-				parentField: EmptyKey,
-				parentIndex: 0,
-			};
-
-			const childPath2: UpPath = {
-				parent: parentPath,
-				parentField: EmptyKey,
-				parentIndex: 1,
-			};
-
-			const parentAnchor = forest.anchors.track(parentPath);
-			const childAnchor1 = forest.anchors.track(childPath1);
-			const childAnchor2 = forest.anchors.track(childPath2);
-
-			const cursor = forest.allocateCursor();
-			assert.equal(forest.tryMoveCursorToNode(parentAnchor, cursor), TreeNavigationResult.Ok);
-			assert.equal(cursor.value, undefined);
-			assert.equal(forest.tryMoveCursorToNode(childAnchor1, cursor), TreeNavigationResult.Ok);
-			assert.equal(cursor.value, 1);
-			assert.equal(forest.tryMoveCursorToNode(childAnchor2, cursor), TreeNavigationResult.Ok);
-			assert.equal(cursor.value, 2);
-		});
-
-		it("tryMoveCursorToField", () => {
-			const forest = factory(new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)));
-
-			initializeForest(
-				forest,
-				fieldJsonCursor([[1, 2]]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
-
-			const parentPath: FieldUpPath = {
-				parent: undefined,
-				field: rootFieldKey,
-			};
-
-			const parentNodePath: UpPath = {
-				parent: undefined,
-				parentField: rootFieldKey,
-				parentIndex: 0,
-			};
-
-			const childPath: FieldUpPath = {
-				parent: parentNodePath,
-				field: EmptyKey,
-			};
-
-			const parentAnchor = forest.anchors.track(parentNodePath);
-
-			const cursor = forest.allocateCursor();
-			assert.equal(
-				forest.tryMoveCursorToField({ fieldKey: rootFieldKey, parent: undefined }, cursor),
-				TreeNavigationResult.Ok,
-			);
-
-			expectEqualFieldPaths(cursor.getFieldPath(), parentPath);
-			assert.equal(
-				forest.tryMoveCursorToField({ fieldKey: EmptyKey, parent: parentAnchor }, cursor),
-				TreeNavigationResult.Ok,
-			);
-			expectEqualFieldPaths(cursor.getFieldPath(), childPath);
-		});
-
-		describe("moveCursorToPath", () => {
-			it("moves cursor to specified path.", () => {
-				const forest = factory(
-					new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)),
-				);
 				initializeForest(
 					forest,
-					fieldJsonCursor([[1, 2]]),
+					fieldJsonCursor([data]),
 					testRevisionTagCodec,
 					testIdCompressor,
 				);
 
-				const cursor = forest.allocateCursor();
-				const path: UpPath = {
-					parent: undefined,
-					parentField: rootFieldKey,
-					parentIndex: 0,
-				};
+				const reader = forest.allocateCursor();
+				moveToDetachedField(forest, reader);
 
-				forest.moveCursorToPath(path, cursor);
-				expectEqualPaths(path, cursor.getPath());
+				// copy data from reader into json object and compare to data.
+				const copy = mapCursorField(reader, cursorToJsonObject);
+				reader.free();
+				assert.deepEqual(copy, [data]);
 			});
+		}
+	});
+
+	it("cursor use", () => {
+		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
+		initializeForest(
+			forest,
+			fieldJsonCursor([[1, 2]]),
+			testRevisionTagCodec,
+			testIdCompressor,
+		);
+
+		const reader = forest.allocateCursor();
+		moveToDetachedField(forest, reader);
+		const reader2 = reader.fork();
+		// Make sure fork is initialized properly
+		assert.deepEqual(reader.getFieldPath(), reader2.getFieldPath());
+		assert(reader.firstNode());
+		// Make sure forks can move independently
+		assert.deepEqual(reader.getPath()?.parent, reader2.getFieldPath().parent);
+		assert(reader2.firstNode());
+		assert.deepEqual(reader.getPath(), reader2.getPath());
+		reader.enterField(EmptyKey);
+		reader.enterNode(1);
+		assert.equal(reader.value, 2);
+		// Move reader two down to the same place, but by a different route.
+		reader2.enterField(EmptyKey);
+		reader2.enterNode(0);
+		assert.equal(reader2.value, 1);
+		assert.equal(reader.value, 2);
+		assert(reader2.nextNode());
+		assert.equal(reader2.value, 2);
+		// Test a fork with a longer path and at a node not a field.
+		const reader3 = reader2.fork();
+		assert.deepEqual(reader.getPath(), reader3.getPath());
+		reader.free();
+		reader2.free();
+	});
+
+	it("isEmpty: rootFieldKey", () => {
+		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
+		assert(forest.isEmpty);
+		initializeForest(forest, fieldJsonCursor([[]]), testRevisionTagCodec, testIdCompressor);
+		assert(!forest.isEmpty);
+	});
+
+	it("isEmpty: other root", () => {
+		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
+		assert(forest.isEmpty);
+
+		const insert: DeltaFieldChanges = [{ count: 1, attach: { minor: 1 } }];
+		applyTestDelta(new Map([[brand("different root"), insert]]), forest, {
+			build: [{ id: { minor: 1 }, trees: chunkFromJsonTrees([[]]) }],
 		});
+		assert(!forest.isEmpty);
+	});
 
-		it("getCursorAboveDetachedFields", () => {
-			const forest = factory(new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)));
-			initializeForest(
-				forest,
-				fieldJsonCursor([[1, 2]]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+	it("moving a cursor to the root of an empty forest fails", () => {
+		const forest = factory(new TreeStoredSchemaRepository());
+		const cursor = forest.allocateCursor();
+		moveToDetachedField(forest, cursor);
+		assert.equal(cursor.firstNode(), false);
+	});
 
-			const forestCursor = forest.allocateCursor();
-			moveToDetachedField(forest, forestCursor);
-			const expected = mapCursorField(forestCursor, jsonableTreeFromCursor);
+	it("tryMoveCursorToNode", () => {
+		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 
-			const cursor = forest.getCursorAboveDetachedFields();
-			cursor.enterField(rootFieldKey);
-			const actual = mapCursorField(cursor, jsonableTreeFromCursor);
-			assert.deepEqual(actual, expected);
-		});
+		initializeForest(
+			forest,
+			fieldJsonCursor([[1, 2]]),
+			testRevisionTagCodec,
+			testIdCompressor,
+		);
 
-		it("anchors creation and use", () => {
-			const forest = factory(new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)));
+		const parentPath: UpPath = {
+			parent: undefined,
+			parentField: rootFieldKey,
+			parentIndex: 0,
+		};
+
+		const childPath1: UpPath = {
+			parent: parentPath,
+			parentField: EmptyKey,
+			parentIndex: 0,
+		};
+
+		const childPath2: UpPath = {
+			parent: parentPath,
+			parentField: EmptyKey,
+			parentIndex: 1,
+		};
+
+		const parentAnchor = forest.anchors.track(parentPath);
+		const childAnchor1 = forest.anchors.track(childPath1);
+		const childAnchor2 = forest.anchors.track(childPath2);
+
+		const cursor = forest.allocateCursor();
+		assert.equal(forest.tryMoveCursorToNode(parentAnchor, cursor), TreeNavigationResult.Ok);
+		assert.equal(cursor.value, undefined);
+		assert.equal(forest.tryMoveCursorToNode(childAnchor1, cursor), TreeNavigationResult.Ok);
+		assert.equal(cursor.value, 1);
+		assert.equal(forest.tryMoveCursorToNode(childAnchor2, cursor), TreeNavigationResult.Ok);
+		assert.equal(cursor.value, 2);
+	});
+
+	it("tryMoveCursorToField", () => {
+		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
+
+		initializeForest(
+			forest,
+			fieldJsonCursor([[1, 2]]),
+			testRevisionTagCodec,
+			testIdCompressor,
+		);
+
+		const parentPath: FieldUpPath = {
+			parent: undefined,
+			field: rootFieldKey,
+		};
+
+		const parentNodePath: UpPath = {
+			parent: undefined,
+			parentField: rootFieldKey,
+			parentIndex: 0,
+		};
+
+		const childPath: FieldUpPath = {
+			parent: parentNodePath,
+			field: EmptyKey,
+		};
+
+		const parentAnchor = forest.anchors.track(parentNodePath);
+
+		const cursor = forest.allocateCursor();
+		assert.equal(
+			forest.tryMoveCursorToField({ fieldKey: rootFieldKey, parent: undefined }, cursor),
+			TreeNavigationResult.Ok,
+		);
+
+		expectEqualFieldPaths(cursor.getFieldPath(), parentPath);
+		assert.equal(
+			forest.tryMoveCursorToField({ fieldKey: EmptyKey, parent: parentAnchor }, cursor),
+			TreeNavigationResult.Ok,
+		);
+		expectEqualFieldPaths(cursor.getFieldPath(), childPath);
+	});
+
+	describe("moveCursorToPath", () => {
+		it("moves cursor to specified path.", () => {
+			const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 			initializeForest(
 				forest,
 				fieldJsonCursor([[1, 2]]),
@@ -332,95 +291,402 @@ export function testForest(config: ForestTestConfiguration): void {
 			);
 
 			const cursor = forest.allocateCursor();
-			moveToDetachedField(forest, cursor);
-			assert(cursor.firstNode());
-			const parentAnchor = cursor.buildAnchor();
-			cursor.enterField(EmptyKey);
-			cursor.enterNode(0);
-			assert.equal(cursor.value, 1);
-			const childAnchor1 = cursor.buildAnchor();
-			assert(cursor.nextNode());
-			const childAnchor2 = cursor.buildAnchor();
-			cursor.exitNode();
-			cursor.exitField();
-			const parentAnchor2 = cursor.buildAnchor();
-
-			const parentPath = clonePath(forest.anchors.locate(parentAnchor));
-			const childPath1 = clonePath(forest.anchors.locate(childAnchor1));
-			const childPath2 = clonePath(forest.anchors.locate(childAnchor2));
-			const parentPath2 = clonePath(forest.anchors.locate(parentAnchor2));
-
-			const expectedParent: UpPath = {
+			const path: UpPath = {
 				parent: undefined,
 				parentField: rootFieldKey,
 				parentIndex: 0,
 			};
 
-			assert.deepStrictEqual(parentPath, expectedParent);
-			assert.deepStrictEqual(parentPath2, expectedParent);
+			forest.moveCursorToPath(path, cursor);
+			expectEqualPaths(path, cursor.getPath());
+		});
+	});
 
-			const expectedChild1: UpPath = {
-				parent: expectedParent,
-				parentField: EmptyKey,
-				parentIndex: 0,
-			};
+	it("getCursorAboveDetachedFields", () => {
+		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
+		initializeForest(
+			forest,
+			fieldJsonCursor([[1, 2]]),
+			testRevisionTagCodec,
+			testIdCompressor,
+		);
 
-			const expectedChild2: UpPath = {
-				parent: expectedParent,
-				parentField: EmptyKey,
-				parentIndex: 1,
-			};
+		const forestCursor = forest.allocateCursor();
+		moveToDetachedField(forest, forestCursor);
+		const expected = mapCursorField(forestCursor, jsonableTreeFromCursor);
 
-			assert.deepStrictEqual(childPath1, expectedChild1);
-			assert.deepStrictEqual(childPath2, expectedChild2);
+		const cursor = forest.getCursorAboveDetachedFields();
+		cursor.enterField(rootFieldKey);
+		const actual = mapCursorField(cursor, jsonableTreeFromCursor);
+		assert.deepEqual(actual, expected);
+	});
 
-			assert.equal(forest.tryMoveCursorToNode(parentAnchor, cursor), TreeNavigationResult.Ok);
-			assert.equal(cursor.value, undefined);
-			assert.equal(forest.tryMoveCursorToNode(childAnchor1, cursor), TreeNavigationResult.Ok);
-			assert.equal(cursor.value, 1);
-			assert.equal(forest.tryMoveCursorToNode(childAnchor2, cursor), TreeNavigationResult.Ok);
-			assert.equal(cursor.value, 2);
+	it("anchors creation and use", () => {
+		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
+		initializeForest(
+			forest,
+			fieldJsonCursor([[1, 2]]),
+			testRevisionTagCodec,
+			testIdCompressor,
+		);
 
-			// Cleanup is not required for this test (since anchor set will go out of scope here),
-			// But make sure it works:
-			forest.anchors.forget(parentAnchor);
-			forest.anchors.forget(childAnchor1);
-			forest.anchors.forget(childAnchor2);
-			forest.anchors.forget(parentAnchor2);
-			assert(forest.anchors.isEmpty());
+		const cursor = forest.allocateCursor();
+		moveToDetachedField(forest, cursor);
+		assert(cursor.firstNode());
+		const parentAnchor = cursor.buildAnchor();
+		cursor.enterField(EmptyKey);
+		cursor.enterNode(0);
+		assert.equal(cursor.value, 1);
+		const childAnchor1 = cursor.buildAnchor();
+		assert(cursor.nextNode());
+		const childAnchor2 = cursor.buildAnchor();
+		cursor.exitNode();
+		cursor.exitField();
+		const parentAnchor2 = cursor.buildAnchor();
+
+		const parentPath = clonePath(forest.anchors.locate(parentAnchor));
+		const childPath1 = clonePath(forest.anchors.locate(childAnchor1));
+		const childPath2 = clonePath(forest.anchors.locate(childAnchor2));
+		const parentPath2 = clonePath(forest.anchors.locate(parentAnchor2));
+
+		const expectedParent: UpPath = {
+			parent: undefined,
+			parentField: rootFieldKey,
+			parentIndex: 0,
+		};
+
+		assert.deepStrictEqual(parentPath, expectedParent);
+		assert.deepStrictEqual(parentPath2, expectedParent);
+
+		const expectedChild1: UpPath = {
+			parent: expectedParent,
+			parentField: EmptyKey,
+			parentIndex: 0,
+		};
+
+		const expectedChild2: UpPath = {
+			parent: expectedParent,
+			parentField: EmptyKey,
+			parentIndex: 1,
+		};
+
+		assert.deepStrictEqual(childPath1, expectedChild1);
+		assert.deepStrictEqual(childPath2, expectedChild2);
+
+		assert.equal(forest.tryMoveCursorToNode(parentAnchor, cursor), TreeNavigationResult.Ok);
+		assert.equal(cursor.value, undefined);
+		assert.equal(forest.tryMoveCursorToNode(childAnchor1, cursor), TreeNavigationResult.Ok);
+		assert.equal(cursor.value, 1);
+		assert.equal(forest.tryMoveCursorToNode(childAnchor2, cursor), TreeNavigationResult.Ok);
+		assert.equal(cursor.value, 2);
+
+		// Cleanup is not required for this test (since anchor set will go out of scope here),
+		// But make sure it works:
+		forest.anchors.forget(parentAnchor);
+		forest.anchors.forget(childAnchor1);
+		forest.anchors.forget(childAnchor2);
+		forest.anchors.forget(parentAnchor2);
+		assert(forest.anchors.isEmpty());
+	});
+
+	it("using an anchor that went away returns NotFound", () => {
+		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
+
+		initializeForest(
+			forest,
+			fieldJsonCursor([[1, 2]]),
+			testRevisionTagCodec,
+			testIdCompressor,
+		);
+
+		const cursor = forest.allocateCursor();
+		moveToDetachedField(forest, cursor);
+		assert(cursor.firstNode());
+		cursor.enterField(EmptyKey);
+		cursor.enterNode(0);
+		const firstNodeAnchor = cursor.buildAnchor();
+		cursor.clear();
+
+		const mark: DeltaMark = { count: 1, detach: detachId };
+		const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+		applyTestDelta(delta, forest, { destroy: [{ id: detachId, count: 1 }] });
+		applyTestDelta(delta, forest.anchors, { destroy: [{ id: detachId, count: 1 }] });
+
+		assert.equal(
+			forest.tryMoveCursorToNode(firstNodeAnchor, cursor),
+			TreeNavigationResult.NotFound,
+		);
+	});
+
+	it("can destroy detached fields", () => {
+		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
+		const content: JsonCompatible[] = [1, 2];
+		initializeForest(forest, fieldJsonCursor(content), testRevisionTagCodec, testIdCompressor);
+
+		const mark: DeltaMark = {
+			count: 1,
+			detach: detachId,
+		};
+		const detachedFieldIndex = new DetachedFieldIndex(
+			"test",
+			idAllocatorFromMaxId() as IdAllocator<ForestRootId>,
+			testRevisionTagCodec,
+			testIdCompressor,
+			{ jsonValidator: typeboxValidator },
+		);
+		const delta: DeltaFieldMap = new Map<FieldKey, DeltaFieldChanges>([
+			[rootFieldKey, [mark]],
+		]);
+		applyTestDelta(delta, forest, { detachedFieldIndex });
+
+		const detachedField: DetachedField = brand(
+			detachedFieldIndex.toFieldKey(0 as ForestRootId),
+		);
+		// `1` should be under the detached field
+		const reader = forest.allocateCursor();
+		moveToDetachedField(forest, reader, detachedField);
+		assert(reader.firstNode());
+		assert.equal(reader.value, 1);
+		assert.equal(reader.nextNode(), false);
+		reader.clear();
+
+		forest.acquireVisitor().destroy(detachedFieldAsKey(detachedField), 1);
+
+		// check the detached field no longer exists
+		const detachedCursor = forest.allocateCursor();
+		moveToDetachedField(forest, detachedCursor, detachedField);
+		assert.equal(detachedCursor.getFieldLength(), 0);
+	});
+
+	describe("can clone", () => {
+		it("an empty forest", () => {
+			const schema = new TreeStoredSchemaRepository();
+			const forest = factory(schema);
+			const clone = forest.clone(schema, forest.anchors);
+			const reader = clone.allocateCursor();
+			moveToDetachedField(clone, reader);
+			// Expect no nodes under the detached field
+			assert.equal(reader.firstNode(), false);
 		});
 
-		it("using an anchor that went away returns NotFound", () => {
-			const forest = factory(new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)));
-
+		it("primitive nodes", () => {
+			const schema = new TreeStoredSchemaRepository(optionalArraySchema);
+			const forest = factory(schema);
+			const content: JsonCompatible[] = [1, true, "test"];
 			initializeForest(
 				forest,
-				fieldJsonCursor([[1, 2]]),
+				fieldJsonCursor(content),
 				testRevisionTagCodec,
 				testIdCompressor,
 			);
 
-			const cursor = forest.allocateCursor();
-			moveToDetachedField(forest, cursor);
-			assert(cursor.firstNode());
-			cursor.enterField(EmptyKey);
-			cursor.enterNode(0);
-			const firstNodeAnchor = cursor.buildAnchor();
-			cursor.clear();
+			const clone = forest.clone(schema, forest.anchors);
+			const reader = clone.allocateCursor();
+			moveToDetachedField(clone, reader);
+			assert(reader.firstNode());
+			assert.equal(reader.value, 1);
+			assert(reader.nextNode());
+			assert.equal(reader.value, true);
+			assert(reader.nextNode());
+			assert.equal(reader.value, "test");
+			assert.equal(reader.nextNode(), false);
+		});
+
+		it("multiple fields", () => {
+			const schema = new TreeStoredSchemaRepository(optionalArraySchema);
+			const forest = factory(schema);
+			initializeForest(
+				forest,
+				fieldJsonCursor([nestedContent]),
+				testRevisionTagCodec,
+				testIdCompressor,
+			);
+
+			const clone = forest.clone(schema, forest.anchors);
+			const reader = clone.allocateCursor();
+			moveToDetachedField(clone, reader);
+			assert(reader.firstNode());
+			const fromClone = cursorToJsonObject(reader);
+			assert.deepEqual(nestedContent, fromClone);
+		});
+
+		it("with anchors", () => {
+			const schema = new TreeStoredSchemaRepository(optionalArraySchema);
+			const forest = factory(schema);
+			initializeForest(
+				forest,
+				fieldJsonCursor([nestedContent]),
+				testRevisionTagCodec,
+				testIdCompressor,
+			);
+
+			const forestReader = forest.allocateCursor();
+			moveToDetachedField(forest, forestReader);
+			assert(forestReader.firstNode());
+			forestReader.enterField(xField);
+			assert(forestReader.firstNode());
+			const anchor = forestReader.buildAnchor();
+
+			const clone = forest.clone(schema, forest.anchors);
+			const reader = clone.allocateCursor();
+			clone.tryMoveCursorToNode(anchor, reader);
+			assert.equal(reader.value, undefined);
+		});
+	});
+
+	it("editing a cloned forest does not modify the original", () => {
+		const schema = new TreeStoredSchemaRepository(jsonSequenceRootSchema);
+		const forest = factory(schema);
+		const content: JsonableTree[] = [
+			{ type: brand(numberSchema.identifier), value: 1 },
+			{ type: brand(booleanSchema.identifier), value: true },
+			{ type: brand(stringSchema.identifier), value: "test" },
+		];
+		initializeForest(
+			forest,
+			cursorForJsonableTreeField(content),
+			testRevisionTagCodec,
+			testIdCompressor,
+		);
+
+		const clone = forest.clone(schema, forest.anchors);
+		const mark: DeltaMark = { count: 1, detach: detachId };
+		const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+		applyTestDelta(delta, clone);
+
+		// Check the clone has the new value
+		const cloneReader = clone.allocateCursor();
+		moveToDetachedField(clone, cloneReader);
+		assert(cloneReader.firstNode());
+		assert.equal(cloneReader.value, true);
+
+		// Check the original has the old value
+		const originalReader = forest.allocateCursor();
+		moveToDetachedField(forest, originalReader);
+		assert(originalReader.firstNode());
+		assert.equal(originalReader.value, 1);
+	});
+
+	describe("can apply deltas with", () => {
+		if (!config.skipCursorErrorCheck) {
+			it("ensures cursors are cleared before applying changes", () => {
+				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
+				initializeForest(forest, fieldJsonCursor([1]), testRevisionTagCodec, testIdCompressor);
+				const cursor = forest.allocateCursor();
+				moveToDetachedField(forest, cursor);
+
+				const mark: DeltaMark = { count: 1, detach: detachId };
+				const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+				assert.throws(() => applyTestDelta(delta, forest));
+			});
+
+			it("ensures cursors created in events during delta processing are cleared", () => {
+				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
+				initializeForest(forest, fieldJsonCursor([1]), testRevisionTagCodec, testIdCompressor);
+
+				const log: string[] = [];
+				forest.events.on("beforeChange", () => {
+					const cursor = forest.allocateCursor();
+					moveToDetachedField(forest, cursor);
+					log.push("beforeChange");
+				});
+
+				const mark: DeltaMark = { count: 1, detach: detachId };
+				const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+				assert.throws(() => applyTestDelta(delta, forest));
+				assert.deepEqual(log, ["beforeChange"]);
+			});
+		}
+
+		it("beforeChange events", () => {
+			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
+			initializeForest(forest, fieldJsonCursor([1]), testRevisionTagCodec, testIdCompressor);
+
+			const log: string[] = [];
+			forest.events.on("beforeChange", () => {
+				log.push("beforeChange");
+			});
 
 			const mark: DeltaMark = { count: 1, detach: detachId };
 			const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
-			applyTestDelta(delta, forest, { destroy: [{ id: detachId, count: 1 }] });
-			applyTestDelta(delta, forest.anchors, { destroy: [{ id: detachId, count: 1 }] });
-
-			assert.equal(
-				forest.tryMoveCursorToNode(firstNodeAnchor, cursor),
-				TreeNavigationResult.NotFound,
-			);
+			applyTestDelta(delta, forest);
+			assert.deepEqual(log, ["beforeChange"]);
 		});
 
-		it("can destroy detached fields", () => {
-			const forest = factory(new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)));
+		it("set fields as remove and insert", () => {
+			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
+			initializeForest(
+				forest,
+				fieldJsonCursor([nestedContent]),
+				testRevisionTagCodec,
+				testIdCompressor,
+			);
+
+			const setField: DeltaMark = {
+				count: 1,
+				fields: new Map([[xField, [{ count: 1, detach: detachId, attach: buildId }]]]),
+			};
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, [setField]]]);
+			applyTestDelta(delta, forest, {
+				build: [
+					{
+						id: buildId,
+						trees: chunkFromJsonableTrees([
+							{
+								type: brand(booleanSchema.identifier),
+								value: true,
+							},
+						]),
+					},
+				],
+			});
+
+			const reader = forest.allocateCursor();
+			moveToDetachedField(forest, reader);
+			assert(reader.firstNode());
+			reader.enterField(xField);
+			assert.equal(reader.firstNode(), true);
+			assert.equal(reader.value, true);
+		});
+
+		it("set fields as replace", () => {
+			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
+			initializeForest(
+				forest,
+				fieldJsonCursor([nestedContent]),
+				testRevisionTagCodec,
+				testIdCompressor,
+			);
+
+			const setField: DeltaMark = {
+				count: 1,
+				fields: new Map([[xField, [{ count: 1, detach: detachId, attach: buildId }]]]),
+			};
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, [setField]]]);
+			applyTestDelta(delta, forest, {
+				build: [
+					{
+						id: buildId,
+						trees: chunkFromJsonableTrees([
+							{
+								type: brand(booleanSchema.identifier),
+								value: true,
+							},
+						]),
+					},
+				],
+			});
+
+			const reader = forest.allocateCursor();
+			moveToDetachedField(forest, reader);
+			assert(reader.firstNode());
+			reader.enterField(xField);
+			assert.equal(reader.firstNode(), true);
+			assert.equal(reader.value, true);
+		});
+
+		it("remove", () => {
+			const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 			const content: JsonCompatible[] = [1, 2];
 			initializeForest(
 				forest,
@@ -433,663 +699,49 @@ export function testForest(config: ForestTestConfiguration): void {
 				count: 1,
 				detach: detachId,
 			};
-			const detachedFieldIndex = new DetachedFieldIndex(
-				"test",
-				idAllocatorFromMaxId() as IdAllocator<ForestRootId>,
-				testRevisionTagCodec,
-				testIdCompressor,
-				{ jsonValidator: typeboxValidator },
-			);
-			const delta: DeltaFieldMap = new Map<FieldKey, DeltaFieldChanges>([
-				[rootFieldKey, [mark]],
-			]);
-			applyTestDelta(delta, forest, { detachedFieldIndex });
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+			applyTestDelta(delta, forest);
 
-			const detachedField: DetachedField = brand(
-				detachedFieldIndex.toFieldKey(0 as ForestRootId),
-			);
-			// `1` should be under the detached field
+			// Inspect resulting tree: should just have `2`.
 			const reader = forest.allocateCursor();
-			moveToDetachedField(forest, reader, detachedField);
+			moveToDetachedField(forest, reader);
 			assert(reader.firstNode());
-			assert.equal(reader.value, 1);
+			assert.equal(reader.value, 2);
 			assert.equal(reader.nextNode(), false);
-			reader.clear();
-
-			forest.acquireVisitor().destroy(detachedFieldAsKey(detachedField), 1);
-
-			// check the detached field no longer exists
-			const detachedCursor = forest.allocateCursor();
-			moveToDetachedField(forest, detachedCursor, detachedField);
-			assert.equal(detachedCursor.getFieldLength(), 0);
 		});
 
-		describe("can clone", () => {
-			it("an empty forest", () => {
-				const schema = new TreeStoredSchemaRepository();
-				const forest = factory(schema);
-				const clone = forest.clone(schema, forest.anchors);
-				const reader = clone.allocateCursor();
-				moveToDetachedField(clone, reader);
-				// Expect no nodes under the detached field
-				assert.equal(reader.firstNode(), false);
-			});
-
-			it("primitive nodes", () => {
-				const schema = new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array));
-				const forest = factory(schema);
-				const content: JsonCompatible[] = [1, true, "test"];
-				initializeForest(
-					forest,
-					fieldJsonCursor(content),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-
-				const clone = forest.clone(schema, forest.anchors);
-				const reader = clone.allocateCursor();
-				moveToDetachedField(clone, reader);
-				assert(reader.firstNode());
-				assert.equal(reader.value, 1);
-				assert(reader.nextNode());
-				assert.equal(reader.value, true);
-				assert(reader.nextNode());
-				assert.equal(reader.value, "test");
-				assert.equal(reader.nextNode(), false);
-			});
-
-			it("multiple fields", () => {
-				const schema = new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array));
-				const forest = factory(schema);
-				initializeForest(
-					forest,
-					fieldJsonCursor([nestedContent]),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-
-				const clone = forest.clone(schema, forest.anchors);
-				const reader = clone.allocateCursor();
-				moveToDetachedField(clone, reader);
-				assert(reader.firstNode());
-				const fromClone = cursorToJsonObject(reader);
-				assert.deepEqual(nestedContent, fromClone);
-			});
-
-			it("with anchors", () => {
-				const schema = new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array));
-				const forest = factory(schema);
-				initializeForest(
-					forest,
-					fieldJsonCursor([nestedContent]),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-
-				const forestReader = forest.allocateCursor();
-				moveToDetachedField(forest, forestReader);
-				assert(forestReader.firstNode());
-				forestReader.enterField(xField);
-				assert(forestReader.firstNode());
-				const anchor = forestReader.buildAnchor();
-
-				const clone = forest.clone(schema, forest.anchors);
-				const reader = clone.allocateCursor();
-				clone.tryMoveCursorToNode(anchor, reader);
-				assert.equal(reader.value, undefined);
-			});
-		});
-
-		it("editing a cloned forest does not modify the original", () => {
-			const schema = new TreeStoredSchemaRepository(jsonSequenceRootSchema);
-			const forest = factory(schema);
-			const content: JsonableTree[] = [
-				{ type: brand(numberSchema.identifier), value: 1 },
-				{ type: brand(booleanSchema.identifier), value: true },
-				{ type: brand(stringSchema.identifier), value: "test" },
-			];
+		it("a skip", () => {
+			const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
+			const content: JsonCompatible[] = [1, 2];
 			initializeForest(
 				forest,
-				cursorForJsonableTreeField(content),
+				fieldJsonCursor(content),
 				testRevisionTagCodec,
 				testIdCompressor,
 			);
+			const cursor = forest.allocateCursor();
+			moveToDetachedField(forest, cursor);
+			cursor.firstNode();
+			const anchor = cursor.buildAnchor();
+			cursor.clear();
 
-			const clone = forest.clone(schema, forest.anchors);
-			const mark: DeltaMark = { count: 1, detach: detachId };
-			const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
-			applyTestDelta(delta, clone);
-
-			// Check the clone has the new value
-			const cloneReader = clone.allocateCursor();
-			moveToDetachedField(clone, cloneReader);
-			assert(cloneReader.firstNode());
-			assert.equal(cloneReader.value, true);
-
-			// Check the original has the old value
-			const originalReader = forest.allocateCursor();
-			moveToDetachedField(forest, originalReader);
-			assert(originalReader.firstNode());
-			assert.equal(originalReader.value, 1);
-		});
-
-		describe("can apply deltas with", () => {
-			if (!config.skipCursorErrorCheck) {
-				it("ensures cursors are cleared before applying changes", () => {
-					const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-					initializeForest(
-						forest,
-						fieldJsonCursor([1]),
-						testRevisionTagCodec,
-						testIdCompressor,
-					);
-					const cursor = forest.allocateCursor();
-					moveToDetachedField(forest, cursor);
-
-					const mark: DeltaMark = { count: 1, detach: detachId };
-					const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
-					assert.throws(() => applyTestDelta(delta, forest));
-				});
-
-				it("ensures cursors created in events during delta processing are cleared", () => {
-					const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-					initializeForest(
-						forest,
-						fieldJsonCursor([1]),
-						testRevisionTagCodec,
-						testIdCompressor,
-					);
-
-					const log: string[] = [];
-					forest.events.on("beforeChange", () => {
-						const cursor = forest.allocateCursor();
-						moveToDetachedField(forest, cursor);
-						log.push("beforeChange");
-					});
-
-					const mark: DeltaMark = { count: 1, detach: detachId };
-					const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
-					assert.throws(() => applyTestDelta(delta, forest));
-					assert.deepEqual(log, ["beforeChange"]);
-				});
-			}
-
-			it("beforeChange events", () => {
-				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-				initializeForest(forest, fieldJsonCursor([1]), testRevisionTagCodec, testIdCompressor);
-
-				const log: string[] = [];
-				forest.events.on("beforeChange", () => {
-					log.push("beforeChange");
-				});
-
-				const mark: DeltaMark = { count: 1, detach: detachId };
-				const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
-				applyTestDelta(delta, forest);
-				assert.deepEqual(log, ["beforeChange"]);
-			});
-
-			it("set fields as remove and insert", () => {
-				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-				initializeForest(
-					forest,
-					fieldJsonCursor([nestedContent]),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-
-				const setField: DeltaMark = {
-					count: 1,
-					fields: new Map([[xField, [{ count: 1, detach: detachId, attach: buildId }]]]),
-				};
-				const delta: DeltaFieldMap = new Map([[rootFieldKey, [setField]]]);
-				applyTestDelta(delta, forest, {
-					build: [
-						{
-							id: buildId,
-							trees: chunkFromJsonableTrees([
-								{
-									type: brand(booleanSchema.identifier),
-									value: true,
-								},
-							]),
-						},
-					],
-				});
-
-				const reader = forest.allocateCursor();
-				moveToDetachedField(forest, reader);
-				assert(reader.firstNode());
-				reader.enterField(xField);
-				assert.equal(reader.firstNode(), true);
-				assert.equal(reader.value, true);
-			});
-
-			it("set fields as replace", () => {
-				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-				initializeForest(
-					forest,
-					fieldJsonCursor([nestedContent]),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-
-				const setField: DeltaMark = {
-					count: 1,
-					fields: new Map([[xField, [{ count: 1, detach: detachId, attach: buildId }]]]),
-				};
-				const delta: DeltaFieldMap = new Map([[rootFieldKey, [setField]]]);
-				applyTestDelta(delta, forest, {
-					build: [
-						{
-							id: buildId,
-							trees: chunkFromJsonableTrees([
-								{
-									type: brand(booleanSchema.identifier),
-									value: true,
-								},
-							]),
-						},
-					],
-				});
-
-				const reader = forest.allocateCursor();
-				moveToDetachedField(forest, reader);
-				assert(reader.firstNode());
-				reader.enterField(xField);
-				assert.equal(reader.firstNode(), true);
-				assert.equal(reader.value, true);
-			});
-
-			it("remove", () => {
-				const forest = factory(
-					new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)),
-				);
-				const content: JsonCompatible[] = [1, 2];
-				initializeForest(
-					forest,
-					fieldJsonCursor(content),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-
-				const mark: DeltaMark = {
-					count: 1,
-					detach: detachId,
-				};
-				const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
-				applyTestDelta(delta, forest);
-
-				// Inspect resulting tree: should just have `2`.
-				const reader = forest.allocateCursor();
-				moveToDetachedField(forest, reader);
-				assert(reader.firstNode());
-				assert.equal(reader.value, 2);
-				assert.equal(reader.nextNode(), false);
-			});
-
-			it("a skip", () => {
-				const forest = factory(
-					new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)),
-				);
-				const content: JsonCompatible[] = [1, 2];
-				initializeForest(
-					forest,
-					fieldJsonCursor(content),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-				const cursor = forest.allocateCursor();
-				moveToDetachedField(forest, cursor);
-				cursor.firstNode();
-				const anchor = cursor.buildAnchor();
-				cursor.clear();
-
-				const skip: DeltaMark = { count: 1 };
-				const mark: DeltaMark = {
-					count: 1,
-					detach: detachId,
-				};
-				const delta: DeltaFieldMap = new Map([[rootFieldKey, [skip, mark]]]);
-				applyTestDelta(delta, forest);
-
-				// Inspect resulting tree: should just have `1`.
-				const reader = forest.allocateCursor();
-				assert.equal(forest.tryMoveCursorToNode(anchor, reader), TreeNavigationResult.Ok);
-				assert.equal(reader.value, 1);
-				assert.equal(reader.nextNode(), false);
-			});
-
-			it("insert", () => {
-				const forest = factory(
-					new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)),
-				);
-				const content: JsonCompatible[] = [1, 2];
-				initializeForest(
-					forest,
-					fieldJsonCursor(content),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-
-				const delta: DeltaFieldMap = new Map([
-					[rootFieldKey, [{ count: 1, attach: buildId }]],
-				]);
-				applyTestDelta(delta, forest, {
-					build: [{ id: buildId, trees: chunkFromJsonTrees([3]) }],
-				});
-
-				const reader = forest.allocateCursor();
-				moveToDetachedField(forest, reader);
-				assert(reader.firstNode());
-				assert.equal(reader.value, 3);
-				assert.equal(reader.nextNode(), true);
-				assert.equal(reader.value, 1);
-				assert.equal(reader.nextNode(), true);
-				assert.equal(reader.value, 2);
-				assert.equal(reader.nextNode(), false);
-			});
-
-			it("move-out under transient node", () => {
-				const forest = factory(
-					new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)),
-				);
-
-				const moveId = { minor: 1 };
-				const moveOut: DeltaMark = {
-					count: 1,
-					detach: moveId,
-				};
-				const moveIn: DeltaMark = {
-					count: 1,
-					attach: moveId,
-				};
-				const delta: DeltaFieldMap = new Map([[rootFieldKey, [moveIn]]]);
-				applyTestDelta(delta, forest, {
-					build: [{ id: buildId, trees: chunkFromJsonTrees([{ x: 0 }]) }],
-					global: [
-						{
-							id: buildId,
-							fields: new Map([[xField, [moveOut]]]),
-						},
-					],
-				});
-
-				const reader = forest.allocateCursor();
-				moveToDetachedField(forest, reader);
-				assert(reader.firstNode());
-				assert.equal(reader.value, 0);
-				assert.equal(reader.nextNode(), false);
-			});
-
-			it("move out and move in", () => {
-				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-				initializeForest(
-					forest,
-					fieldJsonCursor([nestedContent]),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-
-				const moveId = { minor: 0 };
-				const moveOut: DeltaMark = {
-					count: 1,
-					detach: moveId,
-				};
-				const moveIn: DeltaMark = {
-					count: 1,
-					attach: moveId,
-				};
-				const modify: DeltaMark = {
-					count: 1,
-					fields: new Map([
-						[xField, [moveOut]],
-						[yField, [{ count: 1 }, moveIn]],
-					]),
-				};
-				const delta: DeltaFieldMap = new Map([[rootFieldKey, [modify]]]);
-				applyTestDelta(delta, forest);
-				const reader = forest.allocateCursor();
-				moveToDetachedField(forest, reader);
-				assert(reader.firstNode());
-				reader.enterField(xField);
-				assert.equal(reader.getFieldLength(), 0);
-				reader.exitField();
-				reader.enterField(yField);
-				assert.equal(reader.getFieldLength(), 2);
-			});
-
-			it("insert and modify", () => {
-				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-				const content: JsonCompatible[] = [1, 2];
-				initializeForest(
-					forest,
-					fieldJsonCursor(content),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-
-				const delta: DeltaFieldMap = new Map([
-					[rootFieldKey, [{ count: 1, attach: buildId }]],
-				]);
-				applyTestDelta(delta, forest, {
-					build: [
-						{
-							id: buildId,
-							trees: chunkFromJsonableTrees([
-								{
-									type: brand(numberSchema.identifier),
-									value: 3,
-								},
-							]),
-						},
-						{
-							id: buildId2,
-							trees: chunkFromJsonableTrees([
-								{
-									type: brand(numberSchema.identifier),
-									value: 4,
-								},
-							]),
-						},
-					],
-					global: [
-						{
-							id: buildId,
-							fields: new Map([[brand("newField"), [{ count: 1, attach: buildId2 }]]]),
-						},
-					],
-				});
-
-				const reader = forest.allocateCursor();
-				moveToDetachedField(forest, reader);
-				assert(reader.firstNode());
-				assert.equal(reader.value, 3);
-				reader.enterField(brand("newField"));
-				assert(reader.firstNode());
-				assert.equal(reader.value, 4);
-				assert.equal(reader.nextNode(), false);
-				reader.exitField();
-				assert.equal(reader.nextNode(), true);
-				assert.equal(reader.value, 1);
-				assert.equal(reader.nextNode(), true);
-				assert.equal(reader.value, 2);
-				assert.equal(reader.nextNode(), false);
-			});
-
-			it("modify and remove", () => {
-				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-				initializeForest(
-					forest,
-					fieldJsonCursor([nestedContent]),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-
-				const moveId = { minor: 0 };
-				const mark: DeltaMark = {
-					count: 1,
-					detach: detachId,
-					fields: new Map([[xField, [{ count: 1, detach: moveId }]]]),
-				};
-				const delta: DeltaFieldMap = new Map([
-					[rootFieldKey, [mark, { count: 1, attach: moveId }]],
-				]);
-				applyTestDelta(delta, forest);
-
-				const reader = forest.allocateCursor();
-				moveToDetachedField(forest, reader);
-				assert.equal(reader.firstNode(), true);
-				assert.equal(reader.value, undefined);
-				assert.equal(reader.firstField(), true);
-				assert.equal(reader.getFieldKey(), fooField);
-			});
-
-			it("modify and move out", () => {
-				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-				initializeForest(
-					forest,
-					fieldJsonCursor([nestedContent]),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-
-				const moveId = { minor: 0 };
-				const mark: DeltaMark = {
-					count: 1,
-					fields: new Map([
-						[
-							xField,
-							[
-								{
-									count: 1,
-									detach: moveId,
-									fields: new Map([
-										[
-											fooField,
-											[
-												{
-													count: 1,
-													detach: detachId,
-													attach: buildId,
-												},
-											],
-										],
-									]),
-								},
-							],
-						],
-						[yField, [{ count: 1, attach: moveId }]],
-					]),
-				};
-				const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
-				applyTestDelta(delta, forest, {
-					build: [{ id: buildId, trees: chunkFromJsonTrees([3]) }],
-				});
-
-				const reader = forest.allocateCursor();
-				moveToDetachedField(forest, reader);
-				assert(reader.firstNode());
-				reader.enterField(xField);
-				assert.equal(reader.getFieldLength(), 0);
-				reader.exitField();
-				reader.enterField(yField);
-				assert(reader.firstNode());
-				reader.enterField(fooField);
-				assert(reader.firstNode());
-				assert.equal(reader.value, 3);
-				reader.exitNode();
-				reader.exitField();
-				assert.equal(reader.nextNode(), true);
-			});
-		});
-
-		describe("Does not leave an empty field", () => {
-			it("when removing the last node in the field", () => {
-				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-				const delta: DeltaFieldMap = new Map([
-					[
-						rootFieldKey,
-						[
-							{
-								count: 1,
-								fields: new Map([
-									[
-										xField,
-										[
-											{
-												count: 1,
-												detach: detachId,
-											},
-										],
-									],
-								]),
-							},
-						],
-					],
-				]);
-				const expected: JsonCompatible[] = [{ y: 1 }];
-				initializeForest(
-					forest,
-					fieldJsonCursor([nestedContent]),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-				applyTestDelta(delta, forest);
-				const readCursor = forest.allocateCursor();
-				moveToDetachedField(forest, readCursor);
-				const actual = mapCursorField(readCursor, cursorToJsonObject);
-				readCursor.free();
-				assert.deepEqual(actual, expected);
-			});
-			it("when moving the last node in the field", () => {
-				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-				initializeForest(
-					forest,
-					fieldJsonCursor([{ x: 2 }]),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
-				// Move from field x to y:
-				const moveId = { minor: 0 };
-				const moveOut: DeltaMark = {
-					count: 1,
-					detach: moveId,
-				};
-				const moveIn: DeltaMark = {
-					count: 1,
-					attach: moveId,
-				};
-				const modify: DeltaMark = {
-					count: 1,
-					fields: new Map([
-						[xField, [moveOut]],
-						[yField, [moveIn]],
-					]),
-				};
-				const delta: DeltaFieldMap = new Map([[rootFieldKey, [modify]]]);
-				applyTestDelta(delta, forest);
-				const expectedCursor = singleJsonCursor({ y: 2 });
-				const expected: JsonableTree[] = [jsonableTreeFromCursor(expectedCursor)];
-				const readCursor = forest.allocateCursor();
-				moveToDetachedField(forest, readCursor);
-				const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
-				readCursor.free();
-				assert.deepEqual(actual, expected);
-			});
-		});
-
-		it("can register and deregister announced visitors", () => {
-			let treesCreated = 0;
-			const acquireVisitor = () => {
-				return createAnnouncedVisitor({
-					afterCreate: () => {
-						treesCreated++;
-					},
-				});
+			const skip: DeltaMark = { count: 1 };
+			const mark: DeltaMark = {
+				count: 1,
+				detach: detachId,
 			};
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, [skip, mark]]]);
+			applyTestDelta(delta, forest);
 
-			const forest = factory(new TreeStoredSchemaRepository(toStoredSchema(JsonAsTree.Array)));
+			// Inspect resulting tree: should just have `1`.
+			const reader = forest.allocateCursor();
+			assert.equal(forest.tryMoveCursorToNode(anchor, reader), TreeNavigationResult.Ok);
+			assert.equal(reader.value, 1);
+			assert.equal(reader.nextNode(), false);
+		});
+
+		it("insert", () => {
+			const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 			const content: JsonCompatible[] = [1, 2];
 			initializeForest(
 				forest,
@@ -1098,19 +750,333 @@ export function testForest(config: ForestTestConfiguration): void {
 				testIdCompressor,
 			);
 
-			forest.registerAnnouncedVisitor(acquireVisitor);
 			const delta: DeltaFieldMap = new Map([[rootFieldKey, [{ count: 1, attach: buildId }]]]);
 			applyTestDelta(delta, forest, {
 				build: [{ id: buildId, trees: chunkFromJsonTrees([3]) }],
 			});
 
-			forest.deregisterAnnouncedVisitor(acquireVisitor);
+			const reader = forest.allocateCursor();
+			moveToDetachedField(forest, reader);
+			assert(reader.firstNode());
+			assert.equal(reader.value, 3);
+			assert.equal(reader.nextNode(), true);
+			assert.equal(reader.value, 1);
+			assert.equal(reader.nextNode(), true);
+			assert.equal(reader.value, 2);
+			assert.equal(reader.nextNode(), false);
+		});
+
+		it("move-out under transient node", () => {
+			const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
+
+			const moveId = { minor: 1 };
+			const moveOut: DeltaMark = {
+				count: 1,
+				detach: moveId,
+			};
+			const moveIn: DeltaMark = {
+				count: 1,
+				attach: moveId,
+			};
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, [moveIn]]]);
 			applyTestDelta(delta, forest, {
-				build: [{ id: buildId, trees: chunkFromJsonTrees([4]) }],
+				build: [{ id: buildId, trees: chunkFromJsonTrees([{ x: 0 }]) }],
+				global: [
+					{
+						id: buildId,
+						fields: new Map([[xField, [moveOut]]]),
+					},
+				],
 			});
 
-			assert.equal(treesCreated, 1);
+			const reader = forest.allocateCursor();
+			moveToDetachedField(forest, reader);
+			assert(reader.firstNode());
+			assert.equal(reader.value, 0);
+			assert.equal(reader.nextNode(), false);
 		});
+
+		it("move out and move in", () => {
+			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
+			initializeForest(
+				forest,
+				fieldJsonCursor([nestedContent]),
+				testRevisionTagCodec,
+				testIdCompressor,
+			);
+
+			const moveId = { minor: 0 };
+			const moveOut: DeltaMark = {
+				count: 1,
+				detach: moveId,
+			};
+			const moveIn: DeltaMark = {
+				count: 1,
+				attach: moveId,
+			};
+			const modify: DeltaMark = {
+				count: 1,
+				fields: new Map([
+					[xField, [moveOut]],
+					[yField, [{ count: 1 }, moveIn]],
+				]),
+			};
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, [modify]]]);
+			applyTestDelta(delta, forest);
+			const reader = forest.allocateCursor();
+			moveToDetachedField(forest, reader);
+			assert(reader.firstNode());
+			reader.enterField(xField);
+			assert.equal(reader.getFieldLength(), 0);
+			reader.exitField();
+			reader.enterField(yField);
+			assert.equal(reader.getFieldLength(), 2);
+		});
+
+		it("insert and modify", () => {
+			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
+			const content: JsonCompatible[] = [1, 2];
+			initializeForest(
+				forest,
+				fieldJsonCursor(content),
+				testRevisionTagCodec,
+				testIdCompressor,
+			);
+
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, [{ count: 1, attach: buildId }]]]);
+			applyTestDelta(delta, forest, {
+				build: [
+					{
+						id: buildId,
+						trees: chunkFromJsonableTrees([
+							{
+								type: brand(numberSchema.identifier),
+								value: 3,
+							},
+						]),
+					},
+					{
+						id: buildId2,
+						trees: chunkFromJsonableTrees([
+							{
+								type: brand(numberSchema.identifier),
+								value: 4,
+							},
+						]),
+					},
+				],
+				global: [
+					{
+						id: buildId,
+						fields: new Map([[brand("newField"), [{ count: 1, attach: buildId2 }]]]),
+					},
+				],
+			});
+
+			const reader = forest.allocateCursor();
+			moveToDetachedField(forest, reader);
+			assert(reader.firstNode());
+			assert.equal(reader.value, 3);
+			reader.enterField(brand("newField"));
+			assert(reader.firstNode());
+			assert.equal(reader.value, 4);
+			assert.equal(reader.nextNode(), false);
+			reader.exitField();
+			assert.equal(reader.nextNode(), true);
+			assert.equal(reader.value, 1);
+			assert.equal(reader.nextNode(), true);
+			assert.equal(reader.value, 2);
+			assert.equal(reader.nextNode(), false);
+		});
+
+		it("modify and remove", () => {
+			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
+			initializeForest(
+				forest,
+				fieldJsonCursor([nestedContent]),
+				testRevisionTagCodec,
+				testIdCompressor,
+			);
+
+			const moveId = { minor: 0 };
+			const mark: DeltaMark = {
+				count: 1,
+				detach: detachId,
+				fields: new Map([[xField, [{ count: 1, detach: moveId }]]]),
+			};
+			const delta: DeltaFieldMap = new Map([
+				[rootFieldKey, [mark, { count: 1, attach: moveId }]],
+			]);
+			applyTestDelta(delta, forest);
+
+			const reader = forest.allocateCursor();
+			moveToDetachedField(forest, reader);
+			assert.equal(reader.firstNode(), true);
+			assert.equal(reader.value, undefined);
+			assert.equal(reader.firstField(), true);
+			assert.equal(reader.getFieldKey(), fooField);
+		});
+
+		it("modify and move out", () => {
+			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
+			initializeForest(
+				forest,
+				fieldJsonCursor([nestedContent]),
+				testRevisionTagCodec,
+				testIdCompressor,
+			);
+
+			const moveId = { minor: 0 };
+			const mark: DeltaMark = {
+				count: 1,
+				fields: new Map([
+					[
+						xField,
+						[
+							{
+								count: 1,
+								detach: moveId,
+								fields: new Map([
+									[
+										fooField,
+										[
+											{
+												count: 1,
+												detach: detachId,
+												attach: buildId,
+											},
+										],
+									],
+								]),
+							},
+						],
+					],
+					[yField, [{ count: 1, attach: moveId }]],
+				]),
+			};
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, [mark]]]);
+			applyTestDelta(delta, forest, {
+				build: [{ id: buildId, trees: chunkFromJsonTrees([3]) }],
+			});
+
+			const reader = forest.allocateCursor();
+			moveToDetachedField(forest, reader);
+			assert(reader.firstNode());
+			reader.enterField(xField);
+			assert.equal(reader.getFieldLength(), 0);
+			reader.exitField();
+			reader.enterField(yField);
+			assert(reader.firstNode());
+			reader.enterField(fooField);
+			assert(reader.firstNode());
+			assert.equal(reader.value, 3);
+			reader.exitNode();
+			reader.exitField();
+			assert.equal(reader.nextNode(), true);
+		});
+	});
+
+	describe("Does not leave an empty field", () => {
+		it("when removing the last node in the field", () => {
+			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
+			const delta: DeltaFieldMap = new Map([
+				[
+					rootFieldKey,
+					[
+						{
+							count: 1,
+							fields: new Map([
+								[
+									xField,
+									[
+										{
+											count: 1,
+											detach: detachId,
+										},
+									],
+								],
+							]),
+						},
+					],
+				],
+			]);
+			const expected: JsonCompatible[] = [{ y: 1 }];
+			initializeForest(
+				forest,
+				fieldJsonCursor([nestedContent]),
+				testRevisionTagCodec,
+				testIdCompressor,
+			);
+			applyTestDelta(delta, forest);
+			const readCursor = forest.allocateCursor();
+			moveToDetachedField(forest, readCursor);
+			const actual = mapCursorField(readCursor, cursorToJsonObject);
+			readCursor.free();
+			assert.deepEqual(actual, expected);
+		});
+		it("when moving the last node in the field", () => {
+			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
+			initializeForest(
+				forest,
+				fieldJsonCursor([{ x: 2 }]),
+				testRevisionTagCodec,
+				testIdCompressor,
+			);
+			// Move from field x to y:
+			const moveId = { minor: 0 };
+			const moveOut: DeltaMark = {
+				count: 1,
+				detach: moveId,
+			};
+			const moveIn: DeltaMark = {
+				count: 1,
+				attach: moveId,
+			};
+			const modify: DeltaMark = {
+				count: 1,
+				fields: new Map([
+					[xField, [moveOut]],
+					[yField, [moveIn]],
+				]),
+			};
+			const delta: DeltaFieldMap = new Map([[rootFieldKey, [modify]]]);
+			applyTestDelta(delta, forest);
+			const expectedCursor = singleJsonCursor({ y: 2 });
+			const expected: JsonableTree[] = [jsonableTreeFromCursor(expectedCursor)];
+			const readCursor = forest.allocateCursor();
+			moveToDetachedField(forest, readCursor);
+			const actual = mapCursorField(readCursor, jsonableTreeFromCursor);
+			readCursor.free();
+			assert.deepEqual(actual, expected);
+		});
+	});
+
+	it("can register and deregister announced visitors", () => {
+		let treesCreated = 0;
+		const acquireVisitor = () => {
+			return createAnnouncedVisitor({
+				afterCreate: () => {
+					treesCreated++;
+				},
+			});
+		};
+
+		const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
+		const content: JsonCompatible[] = [1, 2];
+		initializeForest(forest, fieldJsonCursor(content), testRevisionTagCodec, testIdCompressor);
+
+		forest.registerAnnouncedVisitor(acquireVisitor);
+		const delta: DeltaFieldMap = new Map([[rootFieldKey, [{ count: 1, attach: buildId }]]]);
+		applyTestDelta(delta, forest, {
+			build: [{ id: buildId, trees: chunkFromJsonTrees([3]) }],
+		});
+
+		forest.deregisterAnnouncedVisitor(acquireVisitor);
+		applyTestDelta(delta, forest, {
+			build: [{ id: buildId, trees: chunkFromJsonTrees([4]) }],
+		});
+
+		assert.equal(treesCreated, 1);
 	});
 
 	testGeneralPurposeTreeCursor(

--- a/packages/dds/tree/src/test/sequenceRootUtils.ts
+++ b/packages/dds/tree/src/test/sequenceRootUtils.ts
@@ -10,13 +10,13 @@ import {
 	type JsonableTree,
 } from "../core/index.js";
 import { FieldKinds } from "../feature-libraries/index.js";
-import type { ITreeCheckout } from "../shared-tree/index.js";
+import type { ITreeCheckout, TreeCheckout } from "../shared-tree/index.js";
 import { stringSchema, toStoredSchema } from "../simple-tree/index.js";
 import { brand, type JsonCompatible } from "../util/index.js";
 import { checkoutWithContent, chunkFromJsonableTrees } from "./utils.js";
 // eslint-disable-next-line import/no-internal-modules
 import { normalizeAllowedTypes } from "../simple-tree/schemaTypes.js";
-import { singleJsonCursor } from "./json/index.js";
+import { fieldJsonCursor } from "./json/index.js";
 import { JsonAsTree } from "../jsonDomainSchema.js";
 
 // This file provides utilities for testing sequence fields using documents where the root is the sequence being tested.
@@ -67,11 +67,10 @@ export function remove(tree: ITreeCheckout, index: number, count: number): void 
 /**
  * Creates a sequence field at the root.
  */
-export function makeTreeFromJsonSequence(json: JsonCompatible[]): ITreeCheckout {
-	const cursors = json.map(singleJsonCursor);
+export function makeTreeFromJsonSequence(json: JsonCompatible[]): TreeCheckout {
 	const tree = checkoutWithContent({
 		schema: jsonSequenceRootSchema,
-		initialTree: cursors,
+		initialTree: fieldJsonCursor(json),
 	});
 	return tree;
 }

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -2004,15 +2004,12 @@ describe("Editing", () => {
 
 			const delAction = (peer: ITreeCheckout, idx: number) => remove(peer, idx, 1);
 			const srcField: NormalizedFieldUpPath = rootField;
-			let dstCounter = 0;
-			const moveAction = (peer: ITreeCheckout, idx: number) => {
-				const dstField: NormalizedFieldUpPath = {
-					parent: undefined,
-					// Produce a unique detached field for each move out to avoid collisions which result in multiple nodes in a single detached field, which currently violated schema assumptions.
-					field: brand(`dst${dstCounter++}`),
-				};
-				return peer.editor.move(srcField, idx, 1, dstField, 0);
+			const dstField: NormalizedFieldUpPath = {
+				parent: undefined,
+				field: brand("dst"),
 			};
+			const moveAction = (peer: ITreeCheckout, idx: number) =>
+				peer.editor.move(srcField, idx, 1, dstField, 0);
 
 			/**
 			 * Runs the given `scenario` using either remove or move operations.

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -3223,7 +3223,7 @@ describe("Editing", () => {
 
 	describe("Can abort transactions", () => {
 		/**
-		 * Takes a path to an field containing a single array node, and returns a path to the array node's field.
+		 * Takes a path to a field containing a single array node and returns a path to the array node's field.
 		 */
 		function getInnerSequenceFieldPath(outer: NormalizedFieldUpPath): NormalizedFieldUpPath {
 			return {

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -14,6 +14,7 @@ import {
 	rootFieldKey,
 	type NormalizedFieldUpPath,
 	type NormalizedUpPath,
+	type TreeNodeSchemaIdentifier,
 } from "../../core/index.js";
 import type { ITreeCheckout, TreeStoredContent } from "../../shared-tree/index.js";
 import { type JsonCompatible, brand, makeArray } from "../../util/index.js";
@@ -29,7 +30,7 @@ import {
 	validateUsageError,
 } from "../utils.js";
 import { insert, makeTreeFromJsonSequence, remove } from "../sequenceRootUtils.js";
-import { SchemaFactory, toStoredSchema } from "../../simple-tree/index.js";
+import { numberSchema, SchemaFactory, toStoredSchema } from "../../simple-tree/index.js";
 import { JsonAsTree } from "../../jsonDomainSchema.js";
 
 const rootField: NormalizedFieldUpPath = {
@@ -360,7 +361,7 @@ describe("Editing", () => {
 				parentField: brand("foo"),
 				parentIndex: 0,
 			};
-			const tree1 = makeTreeFromJson({ foo: ["A", "B", "C"] });
+			const tree1 = makeTreeFromJson({ foo: ["A", "B", "C"] }, true);
 			const tree2 = tree1.branch();
 
 			const { undoStack } = createTestUndoRedoStacks(tree1.events);
@@ -666,9 +667,7 @@ describe("Editing", () => {
 		});
 
 		it("can rebase node deletion over cross-field move of descendant", () => {
-			const tree1 = makeTreeFromJson({
-				foo: ["A"],
-			});
+			const tree1 = makeTreeFromJsonSequence([{ foo: ["A"] }]);
 			const tree2 = tree1.branch();
 
 			const fooList: NormalizedUpPath = {
@@ -2005,12 +2004,15 @@ describe("Editing", () => {
 
 			const delAction = (peer: ITreeCheckout, idx: number) => remove(peer, idx, 1);
 			const srcField: NormalizedFieldUpPath = rootField;
-			const dstField: NormalizedFieldUpPath = {
-				parent: undefined,
-				field: brand("dst"),
+			let dstCounter = 0;
+			const moveAction = (peer: ITreeCheckout, idx: number) => {
+				const dstField: NormalizedFieldUpPath = {
+					parent: undefined,
+					// Produce a unique detached field for each move out to avoid collisions which result in multiple nodes in a single detached field, which currently violated schema assumptions.
+					field: brand(`dst${dstCounter++}`),
+				};
+				return peer.editor.move(srcField, idx, 1, dstField, 0);
 			};
-			const moveAction = (peer: ITreeCheckout, idx: number) =>
-				peer.editor.move(srcField, idx, 1, dstField, 0);
 
 			/**
 			 * Runs the given `scenario` using either remove or move operations.
@@ -2423,7 +2425,7 @@ describe("Editing", () => {
 				describe(`reverting [${action.title}] restores A`, () => {
 					for (const disruption of disruptions) {
 						it(`even if it was ${disruption.title} before the revert`, () => {
-							const tree = makeTreeFromJson("A");
+							const tree = makeTreeFromJson("A", true);
 
 							const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
 							action.delegate(tree);
@@ -2437,7 +2439,7 @@ describe("Editing", () => {
 						});
 
 						it(`even if it was ${disruption.title} concurrently to (and sequenced before) the revert`, () => {
-							const tree1 = makeTreeFromJson("A");
+							const tree1 = makeTreeFromJson("A", true);
 							const tree2 = tree1.branch();
 
 							const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree1.events);
@@ -2459,7 +2461,7 @@ describe("Editing", () => {
 						});
 
 						it(`even if it was ${disruption.title} concurrently to (and sequenced before) the ${action.title}`, () => {
-							const tree1 = makeTreeFromJson("A");
+							const tree1 = makeTreeFromJson("A", true);
 							const tree2 = tree1.branch();
 
 							disruption.delegate(tree1, false);
@@ -2485,7 +2487,7 @@ describe("Editing", () => {
 		});
 
 		it("undo restores the removed node even when that node has been concurrently replaced", () => {
-			const tree = makeTreeFromJson("42");
+			const tree = makeTreeFromJson("42", true);
 			const tree2 = tree.branch();
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree2.events);
 
@@ -2571,7 +2573,7 @@ describe("Editing", () => {
 		});
 
 		it("simplified repro for 0x7cf from anchors-undo-redo fuzz seed 0", () => {
-			const tree = makeTreeFromJson(1);
+			const tree = makeTreeFromJson(1, true);
 			const fork = tree.branch();
 
 			tree.editor.optionalField(rootField).set(chunkFromJsonTrees([2]), false);
@@ -2590,7 +2592,7 @@ describe("Editing", () => {
 	describe("Constraints", () => {
 		describe("Node existence constraint", () => {
 			it("handles ancestor revive", () => {
-				const tree = checkoutWithContent(emptyJsonContent);
+				const tree = makeTreeFromJsonSequence([]);
 				const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
 
 				const rootSequence = tree.editor.sequenceField(rootField);
@@ -2628,37 +2630,31 @@ describe("Editing", () => {
 			});
 
 			it("handles ancestor remove", () => {
-				const tree = checkoutWithContent(emptyJsonContent);
-
-				const rootSequence = tree.editor.sequenceField(rootField);
-				rootSequence.insert(0, chunkFromJsonTrees([{}]));
-				const treeSequence = tree.editor.sequenceField({
-					parent: rootNode,
-					field: brand("foo"),
-				});
-				treeSequence.insert(0, chunkFromJsonTrees(["A"]));
+				const tree = makeTreeFromJsonSequence([{ foo: ["A"] }]);
 
 				const tree2 = tree.branch();
 
-				const fooPath: NormalizedFieldUpPath = {
+				const fooArrayNodePath: NormalizedUpPath = {
 					parent: rootNode,
-					field: brand("foo"),
+					parentField: brand("foo"),
+					parentIndex: 0,
+				};
+
+				const fooArrayFieldPath: NormalizedFieldUpPath = {
+					parent: fooArrayNodePath,
+					field: brand(""),
 				};
 
 				// Modify the field containing the node existence constraint then remove its ancestor
 				tree.transaction.start();
-				tree.editor.sequenceField(fooPath).insert(0, chunkFromJsonTrees(["C"]));
+				tree.editor.sequenceField(fooArrayFieldPath).insert(0, chunkFromJsonTrees(["C"]));
 				remove(tree, 0, 1);
 				tree.transaction.commit();
 
 				tree2.transaction.start();
 
 				// Put existence constraint on child of A
-				tree2.editor.addNodeExistsConstraint({
-					parent: rootNode,
-					parentField: brand("foo"),
-					parentIndex: 0,
-				});
+				tree2.editor.addNodeExistsConstraint(fooArrayNodePath);
 				const tree2Sequence = tree2.editor.sequenceField(rootField);
 
 				// Insert B if the child of A is still attached
@@ -2672,7 +2668,7 @@ describe("Editing", () => {
 			});
 
 			it("sequence field node exists constraint", () => {
-				const tree = checkoutWithContent(emptyJsonContent);
+				const tree = makeTreeFromJsonSequence([]);
 				const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
 
 				insert(tree, 0, "A", "D");
@@ -2719,7 +2715,7 @@ describe("Editing", () => {
 			});
 
 			it("optional field node exists constraint", () => {
-				const tree = checkoutWithContent(emptyJsonContent);
+				const tree = makeTreeFromJsonSequence([]);
 				const rootSequence = tree.editor.sequenceField(rootField);
 				rootSequence.insert(0, chunkFromJsonTrees([{}]));
 				const optional = tree.editor.optionalField({
@@ -2751,7 +2747,7 @@ describe("Editing", () => {
 			});
 
 			it("revived optional field node exists constraint", () => {
-				const tree = checkoutWithContent(emptyJsonContent);
+				const tree = makeTreeFromJsonSequence([]);
 				const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree.events);
 				const rootSequence = tree.editor.sequenceField(rootField);
 				rootSequence.insert(0, chunkFromJsonTrees([{}]));
@@ -2786,7 +2782,7 @@ describe("Editing", () => {
 			});
 
 			it("existence constraint on node inserted in prior transaction", () => {
-				const tree = checkoutWithContent(emptyJsonContent);
+				const tree = makeTreeFromJsonSequence([]);
 				const tree2 = tree.branch();
 
 				// Insert "a"
@@ -2847,7 +2843,7 @@ describe("Editing", () => {
 			});
 
 			it("a change can depend on the existence of a node that is built in a prior change whose constraint was violated", () => {
-				const tree = checkoutWithContent(emptyJsonContent);
+				const tree = makeTreeFromJsonSequence([]);
 				const rootSequence = tree.editor.sequenceField(rootField);
 				rootSequence.insert(0, chunkFromJsonTrees([{}]));
 				const optional = tree.editor.optionalField({
@@ -3229,6 +3225,9 @@ describe("Editing", () => {
 	});
 
 	describe("Can abort transactions", () => {
+		/**
+		 * Takes a path to an field containing a single array node, and returns a path to the array node's field.
+		 */
 		function getInnerSequenceFieldPath(outer: NormalizedFieldUpPath): NormalizedFieldUpPath {
 			return {
 				parent: {
@@ -3250,17 +3249,26 @@ describe("Editing", () => {
 			const foo1 = branch.editor.sequenceField(
 				getInnerSequenceFieldPath({ parent: rootNode2, field: brand("foo") }),
 			);
+
+			const Number: TreeNodeSchemaIdentifier = brand(numberSchema.identifier);
+
 			foo0.remove(1, 1);
-			foo0.insert(1, chunkFromJsonableTrees([{ type: brand("Number"), value: 41 }]));
+			foo0.insert(1, chunkFromJsonableTrees([{ type: Number, value: 41 }]));
 			foo0.remove(2, 1);
-			foo0.insert(1, chunkFromJsonableTrees([{ type: brand("Number"), value: 42 }]));
+			foo0.insert(1, chunkFromJsonableTrees([{ type: Number, value: 42 }]));
 			foo0.remove(0, 1);
-			rootSequence.insert(0, chunkFromJsonableTrees([{ type: brand("Test") }]));
+			rootSequence.insert(
+				0,
+				chunkFromJsonableTrees([{ type: brand(JsonAsTree.JsonObject.identifier) }]),
+			);
 			foo1.remove(0, 1);
-			foo1.insert(0, chunkFromJsonableTrees([{ type: brand("Number"), value: "RootValue2" }]));
-			foo1.insert(0, chunkFromJsonableTrees([{ type: brand("Test") }]));
+			foo1.insert(0, chunkFromJsonableTrees([{ type: Number, value: 123 }]));
+			foo1.insert(
+				0,
+				chunkFromJsonableTrees([{ type: brand(JsonAsTree.JsonObject.identifier) }]),
+			);
 			foo1.remove(1, 1);
-			foo1.insert(1, chunkFromJsonableTrees([{ type: brand("Number"), value: 82 }]));
+			foo1.insert(1, chunkFromJsonableTrees([{ type: Number, value: 82 }]));
 
 			// Aborting the transaction should restore the forest
 			branch.transaction.abort();
@@ -3270,19 +3278,19 @@ describe("Editing", () => {
 		}
 
 		it("on the main branch", () => {
-			const tree = makeTreeFromJson(initialState);
+			const tree = makeTreeFromJsonSequence([initialState]);
 			abortTransaction(tree);
 		});
 
 		it("on a child branch", () => {
-			const tree = makeTreeFromJson(initialState);
+			const tree = makeTreeFromJsonSequence([initialState]);
 			const child = tree.branch();
 			abortTransaction(child);
 		});
 	});
 
 	it("invert a composite change that include a mix of nested changes in a field that requires an amend pass", () => {
-		const tree = makeTreeFromJson({});
+		const tree = makeTreeFromJsonSequence([{}]);
 
 		tree.transaction.start();
 		tree.transaction.start();

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -33,7 +33,7 @@ import {
 	TestTreeProviderLite,
 	validateUsageError,
 } from "../utils.js";
-import { insert } from "../sequenceRootUtils.js";
+import { insert, makeTreeFromJsonSequence } from "../sequenceRootUtils.js";
 import {
 	CheckoutFlexTreeView,
 	type TreeCheckout,
@@ -481,11 +481,7 @@ describe("SchematizingSimpleTreeView", () => {
 	});
 
 	it("supports revertibles", () => {
-		const emptyContent = {
-			schema: emptySchema,
-			initialTree: undefined,
-		};
-		const checkout = checkoutWithContent(emptyContent);
+		const checkout = makeTreeFromJsonSequence([]);
 		const view = new SchematizingSimpleTreeView(
 			checkout,
 			config,
@@ -540,13 +536,13 @@ describe("SchematizingSimpleTreeView", () => {
 	describe("events", () => {
 		it("schemaChanged", () => {
 			const content = {
-				schema: toStoredSchema([]),
+				schema: toStoredSchema(SchemaFactory.optional([])),
 				initialTree: undefined,
 			};
 			const checkout = checkoutWithContent(content);
 			const view = new SchematizingSimpleTreeView(
 				checkout,
-				config,
+				new TreeViewConfiguration({ schema: SchemaFactory.optional(SchemaFactory.number) }),
 				new MockNodeIdentifierManager(),
 			);
 			const log: string[] = [];
@@ -557,16 +553,8 @@ describe("SchematizingSimpleTreeView", () => {
 		});
 
 		it("emits changed events for local edits", () => {
-			const emptyContent = {
-				schema: emptySchema,
-				initialTree: undefined,
-			};
-			const checkout = checkoutWithContent(emptyContent);
-			const view = new SchematizingSimpleTreeView(
-				checkout,
-				config,
-				new MockNodeIdentifierManager(),
-			);
+			const view = getView(config);
+			view.initialize(1);
 
 			let localChanges = 0;
 
@@ -576,7 +564,7 @@ describe("SchematizingSimpleTreeView", () => {
 				}
 			});
 
-			insert(checkout, 0, "a");
+			view.root = 2;
 			assert.equal(localChanges, 1);
 			unsubscribe();
 		});

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -868,7 +868,7 @@ export const IdentifierSchema = sf.object("identifier-object", {
 
 /**
  * Creates a tree using the Json domain.
- * 
+ *
  * @param json - The JSON-compatible object to initialize the tree with.
  * @param optionalRoot - If `true`, the root field is optional; otherwise, it is required. Defaults to `false`.
  */

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -869,9 +869,11 @@ export const IdentifierSchema = sf.object("identifier-object", {
 /**
  * Crates a tree using the Json domain with a required root field.
  */
-export function makeTreeFromJson(json: JsonCompatible): ITreeCheckout {
+export function makeTreeFromJson(json: JsonCompatible, optionalRoot = false): ITreeCheckout {
 	return checkoutWithContent({
-		schema: toStoredSchema(JsonAsTree.Tree),
+		schema: toStoredSchema(
+			optionalRoot ? SchemaFactory.optional(JsonAsTree.Tree) : JsonAsTree.Tree,
+		),
 		initialTree: singleJsonCursor(json),
 	});
 }

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -867,7 +867,10 @@ export const IdentifierSchema = sf.object("identifier-object", {
 });
 
 /**
- * Crates a tree using the Json domain with a required root field.
+ * Creates a tree using the Json domain.
+ * 
+ * @param json - The JSON-compatible object to initialize the tree with.
+ * @param optionalRoot - If `true`, the root field is optional; otherwise, it is required. Defaults to `false`.
  */
 export function makeTreeFromJson(json: JsonCompatible, optionalRoot = false): ITreeCheckout {
 	return checkoutWithContent({


### PR DESCRIPTION
## Description

Test cleanup split out from https://github.com/microsoft/FluidFramework/pull/24658

This does a few things:
- Make more tests actually in schema
- Make the users of the forest test suite handle putting it in a describe block instead of having the suite itself generate one (which fails to contain all of its content).
- Add a variant of the forest test suite for object forest which enables additional asserts.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
