### PR TITLE
Re-enable skipped conflicting ops test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -571,8 +571,7 @@ describeCompat("SharedInterval", "NoCompat", (getTestObjectProvider, apis) => {
 			}
 		});
 
-		// ! Disabled due to flakiness (see AB#29397)
-		it.skip("Conflicting ops", async () => {
+		it("Conflicting ops", async () => {
 			const stringId = "stringKey";
 			const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
 			const testContainerConfig: ITestContainerConfig = {


### PR DESCRIPTION
## Description

This test timed out once (maybe twice though we don't have the logs at this point) in the last few months on local-server, but upon scrutiny I don't believe it has any race conditions and the failure was more likely due to the CI machine's resources being overloaded. With the fixes in #24647, that problem should be mitigated.

I also ran this test repeatedly locally by looping it and didn't see any issues for some additional peace-of-mind.

AB#29237