### PR TITLE
refactor(api-markdown-documenter): Simplify DocumentationNode domain

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -7,6 +7,19 @@
 Updates default transformation logic for `ApiInterface` items to generate headings that read "Constructor" rather than "Construct Signature" for constructor-like members.
 This better aligns with similar policies for members like interface methods which are labeled "Method" and not "Method Signature", despite the underlying TypeScript AST entry being a "method signature".
 
+### Simplify `DocumentationNode` types
+
+Removes:
+
+- `MultiLineDocumentationNode`
+- `SingleLineDocumentationNode`
+- `SingleLineSpanNode`
+
+Updates `DocumentationNode` types that were constrained to single-line nodes to allow any `DocumentationNode` children.
+Rendering to Markdown falls back to HTML syntax in cases where multi-line content appears in relevant contexts (lists).
+
+Also updates `CodeSpanNode` to only allow plain text content, which is in line with how it is used, and how it is constrained in Markdown.
+
 ## 0.19.0
 
 ### Add the ability to filter out individual API items (and their descendants) from documentation generation

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -158,7 +158,7 @@ export { ApiPackage }
 export type ApiSignatureLike = ApiCallSignature | ApiIndexSignature;
 
 // @public
-export class BlockQuoteNode extends DocumentationParentNodeBase implements MultiLineDocumentationNode {
+export class BlockQuoteNode extends DocumentationParentNodeBase {
     constructor(children: DocumentationNode[]);
     static createFromPlainText(text: string): BlockQuoteNode;
     static readonly Empty: BlockQuoteNode;
@@ -167,8 +167,8 @@ export class BlockQuoteNode extends DocumentationParentNodeBase implements Multi
 }
 
 // @public
-export class CodeSpanNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements SingleLineDocumentationNode {
-    constructor(children: SingleLineDocumentationNode[]);
+export class CodeSpanNode extends DocumentationParentNodeBase<PlainTextNode> {
+    constructor(children: PlainTextNode[]);
     static createFromPlainText(text: string): CodeSpanNode;
     static readonly Empty: CodeSpanNode;
     get singleLine(): true;
@@ -374,7 +374,7 @@ export namespace DocumentWriter {
 }
 
 // @public
-export class FencedCodeBlockNode extends DocumentationParentNodeBase implements MultiLineDocumentationNode {
+export class FencedCodeBlockNode extends DocumentationParentNodeBase {
     constructor(children: DocumentationNode[], language?: string);
     static createFromPlainText(text: string, language?: string): FencedCodeBlockNode;
     readonly language?: string;
@@ -462,8 +462,8 @@ export interface Heading {
 }
 
 // @public
-export class HeadingNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements Omit<Heading, "title">, MultiLineDocumentationNode {
-    constructor(content: SingleLineDocumentationNode[], id?: string);
+export class HeadingNode extends DocumentationParentNodeBase implements Omit<Heading, "title"> {
+    constructor(content: DocumentationNode[], id?: string);
     static createFromPlainText(text: string, id?: string): HeadingNode;
     static createFromPlainTextHeading(heading: Heading): HeadingNode;
     readonly id?: string;
@@ -507,7 +507,7 @@ export type HierarchyOptions = {
 };
 
 // @public
-export class HorizontalRuleNode implements MultiLineDocumentationNode {
+export class HorizontalRuleNode implements DocumentationNode {
     constructor();
     readonly isEmpty = false;
     readonly isLiteral = true;
@@ -559,7 +559,7 @@ declare namespace LayoutUtilities {
 export { LayoutUtilities }
 
 // @public
-export class LineBreakNode implements MultiLineDocumentationNode {
+export class LineBreakNode implements DocumentationNode {
     constructor();
     readonly isEmpty = false;
     readonly isLiteral = true;
@@ -576,8 +576,8 @@ export interface Link {
 }
 
 // @public
-export class LinkNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements SingleLineDocumentationNode, Omit<Link, "text"> {
-    constructor(content: SingleLineDocumentationNode[], target: UrlTarget);
+export class LinkNode extends DocumentationParentNodeBase implements Omit<Link, "text"> {
+    constructor(content: DocumentationNode[], target: UrlTarget);
     static createFromPlainText(text: string, target: UrlTarget): LinkNode;
     static createFromPlainTextLink(link: Link): LinkNode;
     get singleLine(): true;
@@ -664,16 +664,11 @@ export interface MarkdownRenderers {
     readonly [documentationNodeKind: string]: (node: DocumentationNode, writer: DocumentWriter, context: MarkdownRenderContext) => void;
 }
 
-// @public
-export interface MultiLineDocumentationNode<TData extends object = Data> extends DocumentationNode<TData> {
-    readonly singleLine: false;
-}
-
 export { NewlineKind }
 
 // @public
-export class OrderedListNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements MultiLineDocumentationNode {
-    constructor(children: SingleLineDocumentationNode[]);
+export class OrderedListNode extends DocumentationParentNodeBase {
+    constructor(children: DocumentationNode[]);
     static createFromPlainTextEntries(entries: string[]): OrderedListNode;
     static readonly Empty: OrderedListNode;
     get singleLine(): false;
@@ -681,7 +676,7 @@ export class OrderedListNode extends DocumentationParentNodeBase<SingleLineDocum
 }
 
 // @public
-export class ParagraphNode extends DocumentationParentNodeBase implements MultiLineDocumentationNode {
+export class ParagraphNode extends DocumentationParentNodeBase {
     constructor(children: DocumentationNode[]);
     static createFromPlainText(text: string): ParagraphNode;
     static readonly Empty: ParagraphNode;
@@ -690,7 +685,7 @@ export class ParagraphNode extends DocumentationParentNodeBase implements MultiL
 }
 
 // @public
-export class PlainTextNode extends DocumentationLiteralNodeBase<string> implements SingleLineDocumentationNode {
+export class PlainTextNode extends DocumentationLiteralNodeBase<string> {
     constructor(text: string, escaped?: boolean);
     static readonly Empty: PlainTextNode;
     readonly escaped: boolean;
@@ -763,7 +758,7 @@ export interface SectionHierarchyConfiguration extends DocumentationHierarchyCon
 }
 
 // @public
-export class SectionNode extends DocumentationParentNodeBase implements MultiLineDocumentationNode {
+export class SectionNode extends DocumentationParentNodeBase {
     constructor(children: DocumentationNode[], heading?: HeadingNode);
     static combine(...sections: SectionNode[]): SectionNode;
     static readonly Empty: SectionNode;
@@ -776,20 +771,8 @@ export class SectionNode extends DocumentationParentNodeBase implements MultiLin
 function shouldItemBeIncluded(apiItem: ApiItem, config: ApiItemTransformationConfiguration): boolean;
 
 // @public
-export interface SingleLineDocumentationNode<TData extends object = Data> extends DocumentationNode<TData> {
-    readonly singleLine: true;
-}
-
-// @public
-export class SingleLineSpanNode extends SpanNode<SingleLineDocumentationNode> implements SingleLineDocumentationNode {
-    constructor(children: SingleLineDocumentationNode[], formatting?: TextFormatting);
-    static createFromPlainText(text: string, formatting?: TextFormatting): SingleLineSpanNode;
-    get singleLine(): true;
-}
-
-// @public
-export class SpanNode<TDocumentationNode extends DocumentationNode = DocumentationNode> extends DocumentationParentNodeBase<TDocumentationNode> {
-    constructor(children: TDocumentationNode[], formatting?: TextFormatting);
+export class SpanNode extends DocumentationParentNodeBase {
+    constructor(children: DocumentationNode[], formatting?: TextFormatting);
     static createFromPlainText(text: string, formatting?: TextFormatting): SpanNode;
     static readonly Empty: SpanNode;
     readonly textFormatting?: TextFormatting;
@@ -836,7 +819,7 @@ export class TableHeaderRowNode extends TableRowNode {
 }
 
 // @public
-export class TableNode extends DocumentationParentNodeBase<TableBodyRowNode> implements MultiLineDocumentationNode {
+export class TableNode extends DocumentationParentNodeBase<TableBodyRowNode> {
     constructor(bodyRows: TableBodyRowNode[], headingRow?: TableHeaderRowNode);
     static readonly Empty: TableNode;
     readonly headerRow?: TableHeaderRowNode;
@@ -900,8 +883,8 @@ export function transformApiModel(options: ApiItemTransformationOptions): Docume
 export function transformTsdocNode(node: DocNode, contextApiItem: ApiItem, config: ApiItemTransformationConfiguration): DocumentationNode | undefined;
 
 // @public
-export class UnorderedListNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements MultiLineDocumentationNode {
-    constructor(children: SingleLineDocumentationNode[]);
+export class UnorderedListNode extends DocumentationParentNodeBase {
+    constructor(children: DocumentationNode[]);
     static createFromPlainTextEntries(entries: string[]): UnorderedListNode;
     static readonly Empty: UnorderedListNode;
     get singleLine(): false;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -158,7 +158,7 @@ export { ApiPackage }
 export type ApiSignatureLike = ApiCallSignature | ApiIndexSignature;
 
 // @public
-export class BlockQuoteNode extends DocumentationParentNodeBase implements MultiLineDocumentationNode {
+export class BlockQuoteNode extends DocumentationParentNodeBase {
     constructor(children: DocumentationNode[]);
     static createFromPlainText(text: string): BlockQuoteNode;
     static readonly Empty: BlockQuoteNode;
@@ -167,8 +167,8 @@ export class BlockQuoteNode extends DocumentationParentNodeBase implements Multi
 }
 
 // @public
-export class CodeSpanNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements SingleLineDocumentationNode {
-    constructor(children: SingleLineDocumentationNode[]);
+export class CodeSpanNode extends DocumentationParentNodeBase<PlainTextNode> {
+    constructor(children: PlainTextNode[]);
     static createFromPlainText(text: string): CodeSpanNode;
     static readonly Empty: CodeSpanNode;
     get singleLine(): true;
@@ -374,7 +374,7 @@ export namespace DocumentWriter {
 }
 
 // @public
-export class FencedCodeBlockNode extends DocumentationParentNodeBase implements MultiLineDocumentationNode {
+export class FencedCodeBlockNode extends DocumentationParentNodeBase {
     constructor(children: DocumentationNode[], language?: string);
     static createFromPlainText(text: string, language?: string): FencedCodeBlockNode;
     readonly language?: string;
@@ -462,8 +462,8 @@ export interface Heading {
 }
 
 // @public
-export class HeadingNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements Omit<Heading, "title">, MultiLineDocumentationNode {
-    constructor(content: SingleLineDocumentationNode[], id?: string);
+export class HeadingNode extends DocumentationParentNodeBase implements Omit<Heading, "title"> {
+    constructor(content: DocumentationNode[], id?: string);
     static createFromPlainText(text: string, id?: string): HeadingNode;
     static createFromPlainTextHeading(heading: Heading): HeadingNode;
     readonly id?: string;
@@ -507,7 +507,7 @@ export type HierarchyOptions = {
 };
 
 // @public
-export class HorizontalRuleNode implements MultiLineDocumentationNode {
+export class HorizontalRuleNode implements DocumentationNode {
     constructor();
     readonly isEmpty = false;
     readonly isLiteral = true;
@@ -559,7 +559,7 @@ declare namespace LayoutUtilities {
 export { LayoutUtilities }
 
 // @public
-export class LineBreakNode implements MultiLineDocumentationNode {
+export class LineBreakNode implements DocumentationNode {
     constructor();
     readonly isEmpty = false;
     readonly isLiteral = true;
@@ -576,8 +576,8 @@ export interface Link {
 }
 
 // @public
-export class LinkNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements SingleLineDocumentationNode, Omit<Link, "text"> {
-    constructor(content: SingleLineDocumentationNode[], target: UrlTarget);
+export class LinkNode extends DocumentationParentNodeBase implements Omit<Link, "text"> {
+    constructor(content: DocumentationNode[], target: UrlTarget);
     static createFromPlainText(text: string, target: UrlTarget): LinkNode;
     static createFromPlainTextLink(link: Link): LinkNode;
     get singleLine(): true;
@@ -664,16 +664,11 @@ export interface MarkdownRenderers {
     readonly [documentationNodeKind: string]: (node: DocumentationNode, writer: DocumentWriter, context: MarkdownRenderContext) => void;
 }
 
-// @public
-export interface MultiLineDocumentationNode<TData extends object = Data> extends DocumentationNode<TData> {
-    readonly singleLine: false;
-}
-
 export { NewlineKind }
 
 // @public
-export class OrderedListNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements MultiLineDocumentationNode {
-    constructor(children: SingleLineDocumentationNode[]);
+export class OrderedListNode extends DocumentationParentNodeBase {
+    constructor(children: DocumentationNode[]);
     static createFromPlainTextEntries(entries: string[]): OrderedListNode;
     static readonly Empty: OrderedListNode;
     get singleLine(): false;
@@ -681,7 +676,7 @@ export class OrderedListNode extends DocumentationParentNodeBase<SingleLineDocum
 }
 
 // @public
-export class ParagraphNode extends DocumentationParentNodeBase implements MultiLineDocumentationNode {
+export class ParagraphNode extends DocumentationParentNodeBase {
     constructor(children: DocumentationNode[]);
     static createFromPlainText(text: string): ParagraphNode;
     static readonly Empty: ParagraphNode;
@@ -690,7 +685,7 @@ export class ParagraphNode extends DocumentationParentNodeBase implements MultiL
 }
 
 // @public
-export class PlainTextNode extends DocumentationLiteralNodeBase<string> implements SingleLineDocumentationNode {
+export class PlainTextNode extends DocumentationLiteralNodeBase<string> {
     constructor(text: string, escaped?: boolean);
     static readonly Empty: PlainTextNode;
     readonly escaped: boolean;
@@ -749,7 +744,7 @@ export interface SectionHierarchyConfiguration extends DocumentationHierarchyCon
 }
 
 // @public
-export class SectionNode extends DocumentationParentNodeBase implements MultiLineDocumentationNode {
+export class SectionNode extends DocumentationParentNodeBase {
     constructor(children: DocumentationNode[], heading?: HeadingNode);
     static combine(...sections: SectionNode[]): SectionNode;
     static readonly Empty: SectionNode;
@@ -762,20 +757,8 @@ export class SectionNode extends DocumentationParentNodeBase implements MultiLin
 function shouldItemBeIncluded(apiItem: ApiItem, config: ApiItemTransformationConfiguration): boolean;
 
 // @public
-export interface SingleLineDocumentationNode<TData extends object = Data> extends DocumentationNode<TData> {
-    readonly singleLine: true;
-}
-
-// @public
-export class SingleLineSpanNode extends SpanNode<SingleLineDocumentationNode> implements SingleLineDocumentationNode {
-    constructor(children: SingleLineDocumentationNode[], formatting?: TextFormatting);
-    static createFromPlainText(text: string, formatting?: TextFormatting): SingleLineSpanNode;
-    get singleLine(): true;
-}
-
-// @public
-export class SpanNode<TDocumentationNode extends DocumentationNode = DocumentationNode> extends DocumentationParentNodeBase<TDocumentationNode> {
-    constructor(children: TDocumentationNode[], formatting?: TextFormatting);
+export class SpanNode extends DocumentationParentNodeBase {
+    constructor(children: DocumentationNode[], formatting?: TextFormatting);
     static createFromPlainText(text: string, formatting?: TextFormatting): SpanNode;
     static readonly Empty: SpanNode;
     readonly textFormatting?: TextFormatting;
@@ -822,7 +805,7 @@ export class TableHeaderRowNode extends TableRowNode {
 }
 
 // @public
-export class TableNode extends DocumentationParentNodeBase<TableBodyRowNode> implements MultiLineDocumentationNode {
+export class TableNode extends DocumentationParentNodeBase<TableBodyRowNode> {
     constructor(bodyRows: TableBodyRowNode[], headingRow?: TableHeaderRowNode);
     static readonly Empty: TableNode;
     readonly headerRow?: TableHeaderRowNode;
@@ -886,8 +869,8 @@ export function transformApiModel(options: ApiItemTransformationOptions): Docume
 export function transformTsdocNode(node: DocNode, contextApiItem: ApiItem, config: ApiItemTransformationConfiguration): DocumentationNode | undefined;
 
 // @public
-export class UnorderedListNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements MultiLineDocumentationNode {
-    constructor(children: SingleLineDocumentationNode[]);
+export class UnorderedListNode extends DocumentationParentNodeBase {
+    constructor(children: DocumentationNode[]);
     static createFromPlainTextEntries(entries: string[]): UnorderedListNode;
     static readonly Empty: UnorderedListNode;
     get singleLine(): false;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -158,7 +158,7 @@ export { ApiPackage }
 export type ApiSignatureLike = ApiCallSignature | ApiIndexSignature;
 
 // @public
-export class BlockQuoteNode extends DocumentationParentNodeBase implements MultiLineDocumentationNode {
+export class BlockQuoteNode extends DocumentationParentNodeBase {
     constructor(children: DocumentationNode[]);
     static createFromPlainText(text: string): BlockQuoteNode;
     static readonly Empty: BlockQuoteNode;
@@ -167,8 +167,8 @@ export class BlockQuoteNode extends DocumentationParentNodeBase implements Multi
 }
 
 // @public
-export class CodeSpanNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements SingleLineDocumentationNode {
-    constructor(children: SingleLineDocumentationNode[]);
+export class CodeSpanNode extends DocumentationParentNodeBase<PlainTextNode> {
+    constructor(children: PlainTextNode[]);
     static createFromPlainText(text: string): CodeSpanNode;
     static readonly Empty: CodeSpanNode;
     get singleLine(): true;
@@ -374,7 +374,7 @@ export namespace DocumentWriter {
 }
 
 // @public
-export class FencedCodeBlockNode extends DocumentationParentNodeBase implements MultiLineDocumentationNode {
+export class FencedCodeBlockNode extends DocumentationParentNodeBase {
     constructor(children: DocumentationNode[], language?: string);
     static createFromPlainText(text: string, language?: string): FencedCodeBlockNode;
     readonly language?: string;
@@ -462,8 +462,8 @@ export interface Heading {
 }
 
 // @public
-export class HeadingNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements Omit<Heading, "title">, MultiLineDocumentationNode {
-    constructor(content: SingleLineDocumentationNode[], id?: string);
+export class HeadingNode extends DocumentationParentNodeBase implements Omit<Heading, "title"> {
+    constructor(content: DocumentationNode[], id?: string);
     static createFromPlainText(text: string, id?: string): HeadingNode;
     static createFromPlainTextHeading(heading: Heading): HeadingNode;
     readonly id?: string;
@@ -507,7 +507,7 @@ export type HierarchyOptions = {
 };
 
 // @public
-export class HorizontalRuleNode implements MultiLineDocumentationNode {
+export class HorizontalRuleNode implements DocumentationNode {
     constructor();
     readonly isEmpty = false;
     readonly isLiteral = true;
@@ -559,7 +559,7 @@ declare namespace LayoutUtilities {
 export { LayoutUtilities }
 
 // @public
-export class LineBreakNode implements MultiLineDocumentationNode {
+export class LineBreakNode implements DocumentationNode {
     constructor();
     readonly isEmpty = false;
     readonly isLiteral = true;
@@ -576,8 +576,8 @@ export interface Link {
 }
 
 // @public
-export class LinkNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements SingleLineDocumentationNode, Omit<Link, "text"> {
-    constructor(content: SingleLineDocumentationNode[], target: UrlTarget);
+export class LinkNode extends DocumentationParentNodeBase implements Omit<Link, "text"> {
+    constructor(content: DocumentationNode[], target: UrlTarget);
     static createFromPlainText(text: string, target: UrlTarget): LinkNode;
     static createFromPlainTextLink(link: Link): LinkNode;
     get singleLine(): true;
@@ -642,16 +642,11 @@ export interface MarkdownRenderers {
     readonly [documentationNodeKind: string]: (node: DocumentationNode, writer: DocumentWriter, context: MarkdownRenderContext) => void;
 }
 
-// @public
-export interface MultiLineDocumentationNode<TData extends object = Data> extends DocumentationNode<TData> {
-    readonly singleLine: false;
-}
-
 export { NewlineKind }
 
 // @public
-export class OrderedListNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements MultiLineDocumentationNode {
-    constructor(children: SingleLineDocumentationNode[]);
+export class OrderedListNode extends DocumentationParentNodeBase {
+    constructor(children: DocumentationNode[]);
     static createFromPlainTextEntries(entries: string[]): OrderedListNode;
     static readonly Empty: OrderedListNode;
     get singleLine(): false;
@@ -659,7 +654,7 @@ export class OrderedListNode extends DocumentationParentNodeBase<SingleLineDocum
 }
 
 // @public
-export class ParagraphNode extends DocumentationParentNodeBase implements MultiLineDocumentationNode {
+export class ParagraphNode extends DocumentationParentNodeBase {
     constructor(children: DocumentationNode[]);
     static createFromPlainText(text: string): ParagraphNode;
     static readonly Empty: ParagraphNode;
@@ -668,7 +663,7 @@ export class ParagraphNode extends DocumentationParentNodeBase implements MultiL
 }
 
 // @public
-export class PlainTextNode extends DocumentationLiteralNodeBase<string> implements SingleLineDocumentationNode {
+export class PlainTextNode extends DocumentationLiteralNodeBase<string> {
     constructor(text: string, escaped?: boolean);
     static readonly Empty: PlainTextNode;
     readonly escaped: boolean;
@@ -727,7 +722,7 @@ export interface SectionHierarchyConfiguration extends DocumentationHierarchyCon
 }
 
 // @public
-export class SectionNode extends DocumentationParentNodeBase implements MultiLineDocumentationNode {
+export class SectionNode extends DocumentationParentNodeBase {
     constructor(children: DocumentationNode[], heading?: HeadingNode);
     static combine(...sections: SectionNode[]): SectionNode;
     static readonly Empty: SectionNode;
@@ -740,20 +735,8 @@ export class SectionNode extends DocumentationParentNodeBase implements MultiLin
 function shouldItemBeIncluded(apiItem: ApiItem, config: ApiItemTransformationConfiguration): boolean;
 
 // @public
-export interface SingleLineDocumentationNode<TData extends object = Data> extends DocumentationNode<TData> {
-    readonly singleLine: true;
-}
-
-// @public
-export class SingleLineSpanNode extends SpanNode<SingleLineDocumentationNode> implements SingleLineDocumentationNode {
-    constructor(children: SingleLineDocumentationNode[], formatting?: TextFormatting);
-    static createFromPlainText(text: string, formatting?: TextFormatting): SingleLineSpanNode;
-    get singleLine(): true;
-}
-
-// @public
-export class SpanNode<TDocumentationNode extends DocumentationNode = DocumentationNode> extends DocumentationParentNodeBase<TDocumentationNode> {
-    constructor(children: TDocumentationNode[], formatting?: TextFormatting);
+export class SpanNode extends DocumentationParentNodeBase {
+    constructor(children: DocumentationNode[], formatting?: TextFormatting);
     static createFromPlainText(text: string, formatting?: TextFormatting): SpanNode;
     static readonly Empty: SpanNode;
     readonly textFormatting?: TextFormatting;
@@ -800,7 +783,7 @@ export class TableHeaderRowNode extends TableRowNode {
 }
 
 // @public
-export class TableNode extends DocumentationParentNodeBase<TableBodyRowNode> implements MultiLineDocumentationNode {
+export class TableNode extends DocumentationParentNodeBase<TableBodyRowNode> {
     constructor(bodyRows: TableBodyRowNode[], headingRow?: TableHeaderRowNode);
     static readonly Empty: TableNode;
     readonly headerRow?: TableHeaderRowNode;
@@ -864,8 +847,8 @@ export function transformApiModel(options: ApiItemTransformationOptions): Docume
 export function transformTsdocNode(node: DocNode, contextApiItem: ApiItem, config: ApiItemTransformationConfiguration): DocumentationNode | undefined;
 
 // @public
-export class UnorderedListNode extends DocumentationParentNodeBase<SingleLineDocumentationNode> implements MultiLineDocumentationNode {
-    constructor(children: SingleLineDocumentationNode[]);
+export class UnorderedListNode extends DocumentationParentNodeBase {
+    constructor(children: DocumentationNode[]);
     static createFromPlainTextEntries(entries: string[]): UnorderedListNode;
     static readonly Empty: UnorderedListNode;
     get singleLine(): false;

--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -31,8 +31,6 @@ import {
 	LinkNode,
 	ParagraphNode,
 	PlainTextNode,
-	type SingleLineDocumentationNode,
-	SingleLineSpanNode,
 	SpanNode,
 } from "../documentation-domain/index.js";
 
@@ -245,14 +243,14 @@ export function transformTsdocFencedCode(
 export function transformTsdocLinkTag(
 	input: DocLinkTag,
 	options: TsdocNodeTransformOptions,
-): SingleLineDocumentationNode {
+): LinkNode | SpanNode {
 	if (input.codeDestination !== undefined) {
 		const link = options.resolveApiReference(input.codeDestination);
 
 		if (link === undefined) {
 			// If the code link could not be resolved, print the unresolved text in italics.
 			const linkText = input.linkText?.trim() ?? input.codeDestination.emitAsTsdoc().trim();
-			return SingleLineSpanNode.createFromPlainText(linkText, { italic: true });
+			return SpanNode.createFromPlainText(linkText, { italic: true });
 		} else {
 			const linkText = input.linkText?.trim() ?? link.text;
 			const linkTarget = link.target;

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -42,8 +42,6 @@ import {
 	ParagraphNode,
 	PlainTextNode,
 	SectionNode,
-	type SingleLineDocumentationNode,
-	SingleLineSpanNode,
 	SpanNode,
 	UnorderedListNode,
 } from "../../documentation-domain/index.js";
@@ -345,12 +343,12 @@ export function createTypeParametersSection(
 export function createExcerptSpanWithHyperlinks(
 	excerpt: Excerpt,
 	config: ApiItemTransformationConfiguration,
-): SingleLineSpanNode | undefined {
+): SpanNode | undefined {
 	if (excerpt.isEmpty) {
 		return undefined;
 	}
 
-	const children: SingleLineDocumentationNode[] = [];
+	const children: DocumentationNode[] = [];
 	for (const token of excerpt.spannedTokens) {
 		// Markdown doesn't provide a standardized syntax for hyperlinks inside code spans, so we will render
 		// the type expression as DocPlainText.  Instead of creating multiple DocParagraphs, we can simply
@@ -381,7 +379,7 @@ export function createExcerptSpanWithHyperlinks(
 		}
 	}
 
-	return new SingleLineSpanNode(children);
+	return new SpanNode(children);
 }
 
 /**

--- a/tools/api-markdown-documenter/src/documentation-domain/BlockQuoteNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/BlockQuoteNode.ts
@@ -3,11 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	type DocumentationNode,
-	DocumentationParentNodeBase,
-	type MultiLineDocumentationNode,
-} from "./DocumentationNode.js";
+import { type DocumentationNode, DocumentationParentNodeBase } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 import { createNodesFromPlainText } from "./Utilities.js";
 
@@ -34,10 +30,7 @@ import { createNodesFromPlainText } from "./Utilities.js";
  *
  * @public
  */
-export class BlockQuoteNode
-	extends DocumentationParentNodeBase
-	implements MultiLineDocumentationNode
-{
+export class BlockQuoteNode extends DocumentationParentNodeBase {
 	/**
 	 * Static singleton representing an empty Block Quote node.
 	 */

--- a/tools/api-markdown-documenter/src/documentation-domain/CodeSpanNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/CodeSpanNode.ts
@@ -3,10 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	DocumentationParentNodeBase,
-	type SingleLineDocumentationNode,
-} from "./DocumentationNode.js";
+import { DocumentationParentNodeBase } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 import { PlainTextNode } from "./PlainTextNode.js";
 
@@ -27,10 +24,7 @@ import { PlainTextNode } from "./PlainTextNode.js";
  *
  * @public
  */
-export class CodeSpanNode
-	extends DocumentationParentNodeBase<SingleLineDocumentationNode>
-	implements SingleLineDocumentationNode
-{
+export class CodeSpanNode extends DocumentationParentNodeBase<PlainTextNode> {
 	/**
 	 * Static singleton representing an empty Code Span node.
 	 */
@@ -48,7 +42,7 @@ export class CodeSpanNode
 		return true;
 	}
 
-	public constructor(children: SingleLineDocumentationNode[]) {
+	public constructor(children: PlainTextNode[]) {
 		super(children);
 	}
 

--- a/tools/api-markdown-documenter/src/documentation-domain/DocumentationNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/DocumentationNode.ts
@@ -57,32 +57,6 @@ export interface DocumentationNode<TData extends object = UnistData> extends Uni
 }
 
 /**
- * A {@link DocumentationNode} that is contractually rendered to a single line (no line breaks allowed).
- *
- * @public
- */
-export interface SingleLineDocumentationNode<TData extends object = UnistData>
-	extends DocumentationNode<TData> {
-	/**
-	 * {@inheritDoc DocumentationNode.singleLine}
-	 */
-	readonly singleLine: true;
-}
-
-/**
- * A {@link DocumentationNode} that is contractually rendered as more than 1 line.
- *
- * @public
- */
-export interface MultiLineDocumentationNode<TData extends object = UnistData>
-	extends DocumentationNode<TData> {
-	/**
-	 * {@inheritDoc DocumentationNode.singleLine}
-	 */
-	readonly singleLine: false;
-}
-
-/**
  * A documentation node that has child nodes.
  *
  * @see {@link https://github.com/syntax-tree/unist#parent}

--- a/tools/api-markdown-documenter/src/documentation-domain/FencedCodeBlockNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/FencedCodeBlockNode.ts
@@ -3,11 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	type DocumentationNode,
-	DocumentationParentNodeBase,
-	type MultiLineDocumentationNode,
-} from "./DocumentationNode.js";
+import { type DocumentationNode, DocumentationParentNodeBase } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 import { createNodesFromPlainText } from "./Utilities.js";
 
@@ -32,10 +28,7 @@ import { createNodesFromPlainText } from "./Utilities.js";
  *
  * @public
  */
-export class FencedCodeBlockNode
-	extends DocumentationParentNodeBase
-	implements MultiLineDocumentationNode
-{
+export class FencedCodeBlockNode extends DocumentationParentNodeBase {
 	/**
 	 * {@inheritDoc DocumentationNode."type"}
 	 */

--- a/tools/api-markdown-documenter/src/documentation-domain/HeadingNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/HeadingNode.ts
@@ -5,11 +5,7 @@
 
 import type { Heading } from "../Heading.js";
 
-import {
-	DocumentationParentNodeBase,
-	type MultiLineDocumentationNode,
-	type SingleLineDocumentationNode,
-} from "./DocumentationNode.js";
+import { DocumentationParentNodeBase, type DocumentationNode } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 import { PlainTextNode } from "./PlainTextNode.js";
 
@@ -35,8 +31,8 @@ import { PlainTextNode } from "./PlainTextNode.js";
  * @public
  */
 export class HeadingNode
-	extends DocumentationParentNodeBase<SingleLineDocumentationNode>
-	implements Omit<Heading, "title">, MultiLineDocumentationNode
+	extends DocumentationParentNodeBase
+	implements Omit<Heading, "title">
 {
 	/**
 	 * {@inheritDoc DocumentationNode."type"}
@@ -55,7 +51,7 @@ export class HeadingNode
 		return false;
 	}
 
-	public constructor(content: SingleLineDocumentationNode[], id?: string) {
+	public constructor(content: DocumentationNode[], id?: string) {
 		super(content);
 
 		this.id = id;

--- a/tools/api-markdown-documenter/src/documentation-domain/HorizontalRuleNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/HorizontalRuleNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { MultiLineDocumentationNode } from "./DocumentationNode.js";
+import type { DocumentationNode } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 
 /**
@@ -25,7 +25,7 @@ import { DocumentationNodeType } from "./DocumentationNodeType.js";
  *
  * @public
  */
-export class HorizontalRuleNode implements MultiLineDocumentationNode {
+export class HorizontalRuleNode implements DocumentationNode {
 	/**
 	 * {@inheritDoc DocumentationNode."type"}
 	 */

--- a/tools/api-markdown-documenter/src/documentation-domain/LineBreakNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/LineBreakNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { MultiLineDocumentationNode } from "./DocumentationNode.js";
+import type { DocumentationNode } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 
 /**
@@ -18,7 +18,7 @@ import { DocumentationNodeType } from "./DocumentationNodeType.js";
  *
  * @public
  */
-export class LineBreakNode implements MultiLineDocumentationNode {
+export class LineBreakNode implements DocumentationNode {
 	/**
 	 * {@inheritDoc DocumentationNode."type"}
 	 */

--- a/tools/api-markdown-documenter/src/documentation-domain/LinkNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/LinkNode.ts
@@ -5,10 +5,7 @@
 
 import type { Link, UrlTarget } from "../Link.js";
 
-import {
-	DocumentationParentNodeBase,
-	type SingleLineDocumentationNode,
-} from "./DocumentationNode.js";
+import { DocumentationParentNodeBase, type DocumentationNode } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 import { PlainTextNode } from "./PlainTextNode.js";
 
@@ -29,10 +26,7 @@ import { PlainTextNode } from "./PlainTextNode.js";
  *
  * @public
  */
-export class LinkNode
-	extends DocumentationParentNodeBase<SingleLineDocumentationNode>
-	implements SingleLineDocumentationNode, Omit<Link, "text">
-{
+export class LinkNode extends DocumentationParentNodeBase implements Omit<Link, "text"> {
 	/**
 	 * {@inheritDoc DocumentationNode."type"}
 	 */
@@ -50,7 +44,7 @@ export class LinkNode
 		return true;
 	}
 
-	public constructor(content: SingleLineDocumentationNode[], target: UrlTarget) {
+	public constructor(content: DocumentationNode[], target: UrlTarget) {
 		super(content);
 		this.target = target;
 	}

--- a/tools/api-markdown-documenter/src/documentation-domain/OrderedListNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/OrderedListNode.ts
@@ -3,11 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	DocumentationParentNodeBase,
-	type MultiLineDocumentationNode,
-	type SingleLineDocumentationNode,
-} from "./DocumentationNode.js";
+import { DocumentationParentNodeBase, type DocumentationNode } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 import { PlainTextNode } from "./PlainTextNode.js";
 
@@ -37,10 +33,7 @@ import { PlainTextNode } from "./PlainTextNode.js";
  *
  * @public
  */
-export class OrderedListNode
-	extends DocumentationParentNodeBase<SingleLineDocumentationNode>
-	implements MultiLineDocumentationNode
-{
+export class OrderedListNode extends DocumentationParentNodeBase {
 	/**
 	 * Static singleton representing an empty Ordered List node.
 	 */
@@ -58,7 +51,7 @@ export class OrderedListNode
 		return false;
 	}
 
-	public constructor(children: SingleLineDocumentationNode[]) {
+	public constructor(children: DocumentationNode[]) {
 		super(children);
 	}
 

--- a/tools/api-markdown-documenter/src/documentation-domain/ParagraphNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/ParagraphNode.ts
@@ -3,11 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	type DocumentationNode,
-	DocumentationParentNodeBase,
-	type MultiLineDocumentationNode,
-} from "./DocumentationNode.js";
+import { type DocumentationNode, DocumentationParentNodeBase } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 import { createNodesFromPlainText } from "./Utilities.js";
 
@@ -37,10 +33,7 @@ import { createNodesFromPlainText } from "./Utilities.js";
  *
  * @public
  */
-export class ParagraphNode
-	extends DocumentationParentNodeBase
-	implements MultiLineDocumentationNode
-{
+export class ParagraphNode extends DocumentationParentNodeBase {
 	/**
 	 * Static singleton representing an empty Paragraph node.
 	 */

--- a/tools/api-markdown-documenter/src/documentation-domain/PlainTextNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/PlainTextNode.ts
@@ -3,10 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	DocumentationLiteralNodeBase,
-	type SingleLineDocumentationNode,
-} from "./DocumentationNode.js";
+import { DocumentationLiteralNodeBase } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 
 /**
@@ -21,10 +18,7 @@ import { DocumentationNodeType } from "./DocumentationNodeType.js";
  *
  * @public
  */
-export class PlainTextNode
-	extends DocumentationLiteralNodeBase<string>
-	implements SingleLineDocumentationNode
-{
+export class PlainTextNode extends DocumentationLiteralNodeBase<string> {
 	/**
 	 * Static singleton representing an empty Plain Text node.
 	 */

--- a/tools/api-markdown-documenter/src/documentation-domain/SectionNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/SectionNode.ts
@@ -3,11 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	type DocumentationNode,
-	DocumentationParentNodeBase,
-	type MultiLineDocumentationNode,
-} from "./DocumentationNode.js";
+import { type DocumentationNode, DocumentationParentNodeBase } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 import type { HeadingNode } from "./HeadingNode.js";
 
@@ -36,10 +32,7 @@ import type { HeadingNode } from "./HeadingNode.js";
  *
  * @public
  */
-export class SectionNode
-	extends DocumentationParentNodeBase
-	implements MultiLineDocumentationNode
-{
+export class SectionNode extends DocumentationParentNodeBase {
 	/**
 	 * {@inheritDoc DocumentationNode."type"}
 	 */

--- a/tools/api-markdown-documenter/src/documentation-domain/SpanNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/SpanNode.ts
@@ -3,13 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import {
-	type DocumentationNode,
-	DocumentationParentNodeBase,
-	type SingleLineDocumentationNode,
-} from "./DocumentationNode.js";
+import { type DocumentationNode, DocumentationParentNodeBase } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
-import { PlainTextNode } from "./PlainTextNode.js";
 import type { TextFormatting } from "./TextFormatting.js";
 import { createNodesFromPlainText } from "./Utilities.js";
 
@@ -45,9 +40,7 @@ import { createNodesFromPlainText } from "./Utilities.js";
  *
  * @public
  */
-export class SpanNode<
-	TDocumentationNode extends DocumentationNode = DocumentationNode,
-> extends DocumentationParentNodeBase<TDocumentationNode> {
+export class SpanNode extends DocumentationParentNodeBase {
 	/**
 	 * Static singleton representing an empty Span Text node.
 	 */
@@ -65,7 +58,7 @@ export class SpanNode<
 	 */
 	public readonly textFormatting?: TextFormatting;
 
-	public constructor(children: TDocumentationNode[], formatting?: TextFormatting) {
+	public constructor(children: DocumentationNode[], formatting?: TextFormatting) {
 		super(children);
 		this.textFormatting = formatting;
 	}
@@ -76,37 +69,5 @@ export class SpanNode<
 	 */
 	public static createFromPlainText(text: string, formatting?: TextFormatting): SpanNode {
 		return new SpanNode(createNodesFromPlainText(text), formatting);
-	}
-}
-
-/**
- * A {@link SpanNode} that contractually fits on a single line.
- *
- * @public
- */
-export class SingleLineSpanNode
-	extends SpanNode<SingleLineDocumentationNode>
-	implements SingleLineDocumentationNode
-{
-	/**
-	 * {@inheritDoc DocumentationNode.singleLine}
-	 */
-	public override get singleLine(): true {
-		return true;
-	}
-
-	public constructor(children: SingleLineDocumentationNode[], formatting?: TextFormatting) {
-		super(children, formatting);
-	}
-
-	/**
-	 * Generates an `SingleLineSpanNode` from the provided string.
-	 * @param text - The node contents.
-	 */
-	public static createFromPlainText(
-		text: string,
-		formatting?: TextFormatting,
-	): SingleLineSpanNode {
-		return new SingleLineSpanNode([new PlainTextNode(text)], formatting);
 	}
 }

--- a/tools/api-markdown-documenter/src/documentation-domain/TableNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/TableNode.ts
@@ -3,10 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	DocumentationParentNodeBase,
-	type MultiLineDocumentationNode,
-} from "./DocumentationNode.js";
+import { DocumentationParentNodeBase } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 import type { TableBodyRowNode, TableHeaderRowNode } from "./TableRowNode.js";
 
@@ -65,10 +62,7 @@ import type { TableBodyRowNode, TableHeaderRowNode } from "./TableRowNode.js";
  *
  * @public
  */
-export class TableNode
-	extends DocumentationParentNodeBase<TableBodyRowNode>
-	implements MultiLineDocumentationNode
-{
+export class TableNode extends DocumentationParentNodeBase<TableBodyRowNode> {
 	/**
 	 * Static singleton representing an empty Table node.
 	 */

--- a/tools/api-markdown-documenter/src/documentation-domain/UnorderedListNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/UnorderedListNode.ts
@@ -3,11 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	DocumentationParentNodeBase,
-	type MultiLineDocumentationNode,
-	type SingleLineDocumentationNode,
-} from "./DocumentationNode.js";
+import { DocumentationParentNodeBase, type DocumentationNode } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 import { PlainTextNode } from "./PlainTextNode.js";
 
@@ -37,10 +33,7 @@ import { PlainTextNode } from "./PlainTextNode.js";
  *
  * @public
  */
-export class UnorderedListNode
-	extends DocumentationParentNodeBase<SingleLineDocumentationNode>
-	implements MultiLineDocumentationNode
-{
+export class UnorderedListNode extends DocumentationParentNodeBase {
 	/**
 	 * Static singleton representing an empty Unordered List node.
 	 */
@@ -58,7 +51,7 @@ export class UnorderedListNode
 		return false;
 	}
 
-	public constructor(children: SingleLineDocumentationNode[]) {
+	public constructor(children: DocumentationNode[]) {
 		super(children);
 	}
 

--- a/tools/api-markdown-documenter/src/documentation-domain/Utilities.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/Utilities.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { DocumentationNode, SingleLineDocumentationNode } from "./DocumentationNode.js";
 import { LineBreakNode } from "./LineBreakNode.js";
 import { PlainTextNode } from "./PlainTextNode.js";
 
@@ -32,28 +31,4 @@ export function createNodesFromPlainText(text: string): (PlainTextNode | LineBre
 		}
 	}
 	return transformedLines;
-}
-
-/**
- * Asserts that all provided nodes in the list are {@link DocumentationNode.singleLine | single-line}.
- */
-export function assertNodesAreSingleLine(
-	nodes: DocumentationNode[],
-): asserts nodes is SingleLineDocumentationNode[] {
-	for (const node of nodes) {
-		if (!node.singleLine) {
-			throw new Error("List of nodes contains 1 or more multi-line nodes.");
-		}
-	}
-}
-
-/**
- * Asserts that the provided node is {@link DocumentationNode.singleLine | single-line}.
- */
-export function assertNodeIsSingleLine(
-	node: DocumentationNode,
-): asserts node is SingleLineDocumentationNode {
-	if (!node.singleLine) {
-		throw new Error("Node is multi-line.");
-	}
 }

--- a/tools/api-markdown-documenter/src/documentation-domain/index.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/index.ts
@@ -26,8 +26,6 @@ export {
 	DocumentationLiteralNodeBase,
 	type DocumentationParentNode,
 	DocumentationParentNodeBase,
-	type MultiLineDocumentationNode,
-	type SingleLineDocumentationNode,
 } from "./DocumentationNode.js";
 export { DocumentationNodeType } from "./DocumentationNodeType.js";
 export { FencedCodeBlockNode } from "./FencedCodeBlockNode.js";
@@ -39,7 +37,7 @@ export { OrderedListNode } from "./OrderedListNode.js";
 export { ParagraphNode } from "./ParagraphNode.js";
 export { PlainTextNode } from "./PlainTextNode.js";
 export { SectionNode } from "./SectionNode.js";
-export { SpanNode, SingleLineSpanNode } from "./SpanNode.js";
+export { SpanNode } from "./SpanNode.js";
 export {
 	TableCellNode,
 	TableBodyCellNode,

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderOrderedList.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderOrderedList.ts
@@ -40,8 +40,14 @@ function renderOrderedListWithMarkdownSyntax(
 	writer.ensureSkippedLine(); // Lists require leading blank line
 	writer.increaseIndent("1. "); // Use numeric indentation for list
 	for (const child of node.children) {
-		renderNode(child, writer, context);
-		writer.ensureNewLine(); // Ensure newline after previous list item
+		if (child.singleLine) {
+			renderNode(child, writer, context);
+			writer.ensureNewLine(); // Ensure newline after previous list item
+		} else {
+			// If the contents of a child node cannot fit on a single line using Markdown syntax,
+			// we will fall back to HTML syntax.
+			renderNodeWithHtmlSyntax(child, writer, context);
+		}
 	}
 	writer.decreaseIndent();
 	writer.ensureSkippedLine(); // Ensure blank line after list

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderUnorderedList.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderUnorderedList.ts
@@ -40,8 +40,14 @@ function renderUnorderedListWithMarkdownSyntax(
 	writer.ensureSkippedLine(); // Lists require leading blank line
 	writer.increaseIndent("- ");
 	for (const child of node.children) {
-		renderNode(child, writer, context);
-		writer.ensureNewLine(); // Ensure newline after previous list item
+		if (child.singleLine) {
+			renderNode(child, writer, context);
+			writer.ensureNewLine(); // Ensure newline after previous list item
+		} else {
+			// If the contents of a child node cannot fit on a single line using Markdown syntax,
+			// we will fall back to HTML syntax.
+			renderNodeWithHtmlSyntax(child, writer, context);
+		}
 	}
 	writer.decreaseIndent();
 	writer.ensureSkippedLine(); // Ensure blank line after list

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderOrderedList.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderOrderedList.test.ts
@@ -5,7 +5,12 @@
 
 import { expect } from "chai";
 
-import { OrderedListNode } from "../../../documentation-domain/index.js";
+import {
+	LineBreakNode,
+	OrderedListNode,
+	PlainTextNode,
+	SpanNode,
+} from "../../../documentation-domain/index.js";
 
 import { testRender } from "./Utilities.js";
 
@@ -24,6 +29,21 @@ describe("OrderedListNode Markdown rendering tests", () => {
 			const result = testRender(input);
 
 			const expected = ["", `1. ${text1}`, `1. ${text2}`, `1. ${text3}`, "", ""].join("\n");
+
+			expect(result).to.equal(expected);
+		});
+
+		it("Multi-line list item", () => {
+			const item = new SpanNode([
+				new PlainTextNode("Hello"),
+				LineBreakNode.Singleton,
+				new PlainTextNode("world"),
+			]);
+
+			const input = new OrderedListNode([item]);
+			const result = testRender(input);
+
+			const expected = ["", `1. <span>Hello<br>world</span>`, "", ""].join("\n");
 
 			expect(result).to.equal(expected);
 		});

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderUnorderedList.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderUnorderedList.test.ts
@@ -5,7 +5,12 @@
 
 import { expect } from "chai";
 
-import { UnorderedListNode } from "../../../documentation-domain/index.js";
+import {
+	LineBreakNode,
+	PlainTextNode,
+	SpanNode,
+	UnorderedListNode,
+} from "../../../documentation-domain/index.js";
 
 import { testRender } from "./Utilities.js";
 
@@ -24,6 +29,21 @@ describe("UnorderedListNode Markdown rendering tests", () => {
 			const result = testRender(input);
 
 			const expected = ["", `- ${text1}`, `- ${text2}`, `- ${text3}`, "", ""].join("\n");
+
+			expect(result).to.equal(expected);
+		});
+
+		it("Multi-line list item", () => {
+			const item = new SpanNode([
+				new PlainTextNode("Hello"),
+				LineBreakNode.Singleton,
+				new PlainTextNode("world"),
+			]);
+
+			const input = new UnorderedListNode([item]);
+			const result = testRender(input);
+
+			const expected = ["", `- <span>Hello<br>world</span>`, "", ""].join("\n");
 
 			expect(result).to.equal(expected);
 		});


### PR DESCRIPTION
Removes the type concepts of `SingleLine` and `MultiLine` documentation nodes. Instead, rendering of certain kinds of nodes into Markdown syntax will fall back to HTML where necessary. This includes list nodes.

Also updates `CodeSpan` to only accept plain text children, which is the only content allowed in that context in Markdown and is the only way it was used by the system anyways.