### PR TITLE
fix(eslint-config-fluid): Fix overzealous `require-jsdoc` rule in `strict` config

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @fluidframework/eslint-config-fluid Changelog
 
+## [5.7.4](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.7.4)
+
+Updates the contexts in which `jsdoc/require-jsdoc` is applied to make it less overzealous.
+Specifically, removes the "VariableDeclaration" context, which would incorrectly trigger for variables that were not exported.
+
+### Example
+
+```typescript
+/**
+ * foo
+ */
+export function foo(): void {
+	// Because the outer scope, `foo`, was exported, this would be incorrectly flagged as needing a JSDoc/TSDoc comment.
+	const bar = "baz";
+	...
+}
+```
+
 ## [5.7.3](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.7.3)
 
 Added support for two new patterns in the no-unchecked-record-access ESLint rule:

--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -12,7 +12,8 @@ Specifically, removes the "VariableDeclaration" context, which would incorrectly
  * foo
  */
 export function foo(): void {
-	// Because the outer scope, `foo`, was exported, this would be incorrectly flagged as needing a JSDoc/TSDoc comment.
+	// Before the fix, because the outer scope, `foo`, was exported, this variable `bar` would be incorrectly flagged as needing a JSDoc/TSDoc comment.
+	// After the fix, variables inside exported functions, like `bar`, are no longer flagged.
 	const bar = "baz";
 	...
 }

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "5.7.3",
+	"version": "5.7.4",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/eslint-config-fluid/printed-configs/strict-biome.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict-biome.json
@@ -764,8 +764,7 @@
                 "contexts": [
                     "TSEnumDeclaration",
                     "TSInterfaceDeclaration",
-                    "TSTypeAliasDeclaration",
-                    "VariableDeclaration"
+                    "TSTypeAliasDeclaration"
                 ],
                 "checkConstructors": true,
                 "checkGetters": true,

--- a/common/build/eslint-config-fluid/printed-configs/strict-biome.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict-biome.json
@@ -764,7 +764,8 @@
                 "contexts": [
                     "TSEnumDeclaration",
                     "TSInterfaceDeclaration",
-                    "TSTypeAliasDeclaration"
+                    "TSTypeAliasDeclaration",
+                    "ExportNamedDeclaration > VariableDeclaration"
                 ],
                 "checkConstructors": true,
                 "checkGetters": true,

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -713,7 +713,8 @@
                 "contexts": [
                     "TSEnumDeclaration",
                     "TSInterfaceDeclaration",
-                    "TSTypeAliasDeclaration"
+                    "TSTypeAliasDeclaration",
+                    "ExportNamedDeclaration > VariableDeclaration"
                 ],
                 "checkConstructors": true,
                 "checkGetters": true,

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -713,8 +713,7 @@
                 "contexts": [
                     "TSEnumDeclaration",
                     "TSInterfaceDeclaration",
-                    "TSTypeAliasDeclaration",
-                    "VariableDeclaration"
+                    "TSTypeAliasDeclaration"
                 ],
                 "checkConstructors": true,
                 "checkGetters": true,

--- a/common/build/eslint-config-fluid/strict.js
+++ b/common/build/eslint-config-fluid/strict.js
@@ -42,12 +42,7 @@ module.exports = {
 					// Will report for *any* methods on exported classes, regardless of whether or not they are public
 					MethodDefinition: false,
 				},
-				contexts: [
-					"TSEnumDeclaration",
-					"TSInterfaceDeclaration",
-					"TSTypeAliasDeclaration",
-					"VariableDeclaration",
-				],
+				contexts: ["TSEnumDeclaration", "TSInterfaceDeclaration", "TSTypeAliasDeclaration"],
 			},
 		],
 	},

--- a/common/build/eslint-config-fluid/strict.js
+++ b/common/build/eslint-config-fluid/strict.js
@@ -42,7 +42,15 @@ module.exports = {
 					// Will report for *any* methods on exported classes, regardless of whether or not they are public
 					MethodDefinition: false,
 				},
-				contexts: ["TSEnumDeclaration", "TSInterfaceDeclaration", "TSTypeAliasDeclaration"],
+				contexts: [
+					"TSEnumDeclaration",
+					"TSInterfaceDeclaration",
+					"TSTypeAliasDeclaration",
+
+					// Require JSDoc/TSDoc comments on variable declarations, but only those that are named exports.
+					// Specifying just "VariableDeclaration" results in eslint flagging all variable declarations scoped within something that is exported, including in the body of functions, which is not desired.
+					"ExportNamedDeclaration > VariableDeclaration",
+				],
 			},
 		],
 	},


### PR DESCRIPTION
Updates the contexts in which `jsdoc/require-jsdoc` is applied to make it less overzealous.
Specifically, removes the "VariableDeclaration" context, which would incorrectly trigger for variables that were not exported.

Example:

```typescript
/**
 * foo
 */
export function foo(): void {
	// Because the outer scope, `foo`, was exported, this would be incorrectly flagged as needing a JSDoc/TSDoc comment.
	const bar = "baz";
	...
}
```