### PR TITLE
fix(todo): Remove unused event listener

### DIFF
--- a/examples/data-objects/todo/src/Todo/TodoListView.tsx
+++ b/examples/data-objects/todo/src/Todo/TodoListView.tsx
@@ -5,7 +5,6 @@
 
 import { CollaborativeInput } from "@fluid-example/example-utils";
 import { SharedString, type ISharedString } from "@fluidframework/sequence/legacy";
-import { Tree } from "@fluidframework/tree/legacy";
 import React, { useEffect, useRef, useState } from "react";
 
 // eslint-disable-next-line import/no-unassigned-import
@@ -78,7 +77,6 @@ export const TodoListView: React.FC<TodoListProps> = (props: TodoListProps) => {
 					className="action-button"
 					onClick={() => {
 						todoModel.treeView.root.items.delete(id);
-						Tree.on(todoModel.treeView.root.items, "treeChanged", () => {});
 					}}
 				>
 					X


### PR DESCRIPTION
The listener seems to be a leftover from early prototyping, but it is not needed, so it has been removed.