### PR TITLE
Upload release manifests only after publishing packages

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -47,14 +47,6 @@ stages:
       buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
       pnpmStorePath: ${{ parameters.pnpmStorePath }}
 
-  # Only generate manifest files for runs in the internal project (i.e. CI runs, not PR run), for the main, test and release branch, and
-  # for the build of the client release group (we don't need manifests for anything else).
-  # Enabling this template for every PR run risks overwriting existing manifest files uploaded to Azure blobs. Therefore, it's crucial to restrict this template to commits merged into the main and release branch.
-  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.tagName, 'client'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/'))) }}:
-    - template: /tools/pipelines/templates/upload-dev-manifest.yml@self
-      parameters:
-        buildDirectory: '${{ parameters.buildDirectory }}'
-
 # This stage and the following stage both run for non-test builds. The build feed is equivalent to the public npmjs.org
 # feed except it contains builds for every main- or next-branch build.
 - stage: publish_npm_internal_build
@@ -75,14 +67,6 @@ stages:
       buildDirectory: ${{ parameters.buildDirectory }}
       buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
       pnpmStorePath: ${{ parameters.pnpmStorePath }}
-
-  # Only generate manifest files for runs in the internal project (i.e. CI runs, not PR run), for the main, test and release branch, and
-  # for the build of the client release group (we don't need manifests for anything else).
-  # Enabling this template for every PR run risks overwriting existing manifest files uploaded to Azure blobs. Therefore, it's crucial to restrict this template to commits merged into the main and release branch.
-  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.tagName, 'client'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/'))) }}:
-    - template: /tools/pipelines/templates/upload-dev-manifest.yml@self
-      parameters:
-        buildDirectory: '${{ parameters.buildDirectory }}'
 
 # Only add a stage to publish packages to the dev feed for release groups, which have separate lists of packages to
 # publish to each feed. Non-release-group builds (for an independent package) only need to publish to the build feed.
@@ -125,3 +109,20 @@ stages:
       buildDirectory: ${{ parameters.buildDirectory }}
       buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
       pnpmStorePath: ${{ parameters.pnpmStorePath }}
+
+# Only generate manifest files for runs in the internal project (i.e. CI runs, not PR run), for the main, test and release branch, and
+# for the build of the client release group (we don't need manifests for anything else).
+# Enabling this template for every PR run risks overwriting existing manifest files uploaded to Azure blobs. Therefore, it's crucial to restrict this template to commits merged into the main and release branch.
+- ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.tagName, 'client'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/'))) }}:
+  - stage: upload_manifests
+    dependsOn:
+    - publish_npm_public
+    - publish_npm_internal_dev
+    - publish_npm_internal_build
+    - publish_npm_internal_test
+    variables:
+    - group: ado-feeds
+    jobs:
+    - template: /tools/pipelines/templates/upload-dev-manifest.yml@self
+      parameters:
+        buildDirectory: '${{ parameters.buildDirectory }}'

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -110,9 +110,9 @@ stages:
       buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
       pnpmStorePath: ${{ parameters.pnpmStorePath }}
 
-# Only generate manifest files for runs in the internal project (i.e. CI runs, not PR run), for the main, test and release branch, and
+# Only upload release manifest files for runs in the internal project (i.e. CI runs, not PR runs), for the main, test, and release branches, and
 # for the build of the client release group (we don't need manifests for anything else).
-# Enabling this template for every PR run risks overwriting existing manifest files uploaded to Azure blobs. Therefore, it's crucial to restrict this template to commits merged into the main and release branch.
+# Enabling this template for every PR run risks overwriting existing manifest files uploaded to Azure blobs. Therefore, it's crucial to restrict this template to commits merged into the main and release branches.
 - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.tagName, 'client'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/'))) }}:
   - stage: upload_manifests
     displayName: Upload release manifests

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -117,15 +117,16 @@ stages:
   - stage: upload_manifests
     displayName: Upload release manifests
     dependsOn:
-    - ${{ if in(variables.release, 'release', 'prerelease') }}:
-      - publish_npm_public
-    - ${{ if eq(variables.testBuild, true) }}:
-      - publish_npm_internal_test
-    - ${{ elseif eq(variables.testBuild, false) }}:
-      - publish_npm_internal_build
-    - ${{ else }}:
-      'Unable to determine testBuild variable at queue time. This indicates an error in include-publish-npm-package.yml.': error
-    # Note dev feed packages do not get manifests as we don't intend them to be consumed publicly
+    - publish_npm_public
+    - publish_npm_internal_test
+    - publish_npm_internal_build
+    condition: |
+      and(
+        in(dependencies.publish_npm_public.result, 'Succeeded', 'Skipped'),
+        in(dependencies.publish_npm_internal_test.result, 'Succeeded', 'Skipped'),
+        in(dependencies.publish_npm_internal_build.result, 'Succeeded', 'Skipped')
+      )
+    # Note dev feed packages do not get manifests as we don't intend them to be consumed publicly, so no need for that to be a dependency here.
     variables:
     - group: ado-feeds
     jobs:

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -117,10 +117,13 @@ stages:
   - stage: upload_manifests
     displayName: Upload release manifests
     dependsOn:
-    - publish_npm_public
-    - publish_npm_internal_dev
-    - publish_npm_internal_build
-    - publish_npm_internal_test
+    - ${{ if or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')) }}:
+      - publish_npm_public
+    - ${{ if variables.testBuild }}:
+      - publish_npm_internal_test
+    - ${{ else }}:
+      - publish_npm_internal_build
+    # Note dev feed packages do not get manifests as we don't intend them to be consumed publicly
     variables:
     - group: ado-feeds
     jobs:

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -115,6 +115,7 @@ stages:
 # Enabling this template for every PR run risks overwriting existing manifest files uploaded to Azure blobs. Therefore, it's crucial to restrict this template to commits merged into the main and release branch.
 - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.tagName, 'client'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/test/'))) }}:
   - stage: upload_manifests
+    displayName: Upload release manifests
     dependsOn:
     - publish_npm_public
     - publish_npm_internal_dev

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -117,12 +117,14 @@ stages:
   - stage: upload_manifests
     displayName: Upload release manifests
     dependsOn:
-    - ${{ if or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')) }}:
+    - ${{ if in(variables.release, 'release', 'prerelease') }}:
       - publish_npm_public
-    - ${{ if variables.testBuild }}:
+    - ${{ if eq(variables.testBuild, true) }}:
       - publish_npm_internal_test
-    - ${{ else }}:
+    - ${{ elseif eq(variables.testBuild, false) }}:
       - publish_npm_internal_build
+    - ${{ else }}:
+      'Unable to determine testBuild variable at queue time. This indicates an error in include-publish-npm-package.yml.': error
     # Note dev feed packages do not get manifests as we don't intend them to be consumed publicly
     variables:
     - group: ado-feeds

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -120,6 +120,8 @@ stages:
     - publish_npm_public
     - publish_npm_internal_test
     - publish_npm_internal_build
+    # This must be declared as an explicit dependency because upload-dev-manifest uses the version variable it outputs to generate the manifest.
+    - build
     condition: |
       and(
         in(dependencies.publish_npm_public.result, 'Succeeded', 'Skipped'),


### PR DESCRIPTION
## Description

Updates release manifest upload to happen in its own stage. The manifests we publish to `storage.fluidframework.com` aim to reflect recent released versions of the Fluid Framework packages. However, the previous structure of our publishing pipeline uploaded these files in parallel with the process of actually publishing these packages. This meant that we would "advertise" releases of FF packages before they were actually available by a span of 5-10 minutes.

That race condition was enough to cause relatively frequent disruptions in some of our CI infrastructure that integrates FF releases.

This PR takes the approach of moving release manifest upload to its own stage that only happens after we publish to any internal feeds as well as npm (if releasing to npm is deemed necessary).

An alternative approach might be to declare an explicit job dependency, but:

1. It feels weird to upload release manifests only upon completion of internal publishing when they are publicly available and in theory usable by anyone
2. Due to the way our template is factored, this introduces some awkward dependencies between different job names that I didn't really like.

Sample run of the pipeline can be found [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=338831&view=results).