### PR TITLE
Local Server Stress: Make minimization more thorough

### DIFF
--- a/packages/test/local-server-stress-tests/src/ddsOperations.ts
+++ b/packages/test/local-server-stress-tests/src/ddsOperations.ts
@@ -22,6 +22,7 @@ import { makeUnreachableCodePathProxy } from "./utils.js";
 export interface DDSModelOp {
 	type: "DDSModelOp";
 	op: unknown;
+	channelType: string;
 }
 
 export interface OrderSequentially {
@@ -87,19 +88,21 @@ export const DDSModelOpGenerator: AsyncGenerator<DDSModelOp, LocalServerStressSt
 	state,
 ) => {
 	const channel = state.channel;
-	const model = ddsModelMap.get(channel.attributes.type);
+	const channelType = channel.attributes.type;
+	const model = ddsModelMap.get(channelType);
 	assert(model !== undefined, "must have model");
 
 	const op = await timeoutAwait(
 		model.generator(await covertLocalServerStateToDdsState(state)),
 		{
-			errorMsg: `Timed out waiting for dds generator: ${state.channel.attributes.type}`,
+			errorMsg: `Timed out waiting for dds generator: ${channelType}`,
 		},
 	);
 
 	return {
 		type: "DDSModelOp",
 		op,
+		channelType,
 	} satisfies DDSModelOp;
 };
 

--- a/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
@@ -5,7 +5,13 @@
 
 import { takeAsync } from "@fluid-private/stochastic-test-utils";
 
-import { makeGenerator, reducer, saveFailures, type StressOperations } from "../baseModel.js";
+import {
+	ddsModelMinimizers,
+	makeGenerator,
+	reducer,
+	saveFailures,
+	type StressOperations,
+} from "../baseModel.js";
 import { validateConsistencyOfAllDDS } from "../ddsOperations";
 import {
 	createLocalServerStressSuite,
@@ -18,6 +24,7 @@ describe("Local Server Stress", () => {
 		generatorFactory: () => takeAsync(100, makeGenerator()),
 		reducer,
 		validateConsistency: validateConsistencyOfAllDDS,
+		minimizationTransforms: ddsModelMinimizers,
 	};
 
 	createLocalServerStressSuite(model, {

--- a/packages/test/local-server-stress-tests/src/test/localServerStressOrderSequentially.spec.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStressOrderSequentially.spec.ts
@@ -5,7 +5,13 @@
 
 import { done, isOperationType, takeAsync } from "@fluid-private/stochastic-test-utils";
 
-import { makeGenerator, reducer, saveFailures, type StressOperations } from "../baseModel.js";
+import {
+	ddsModelMinimizers,
+	makeGenerator,
+	reducer,
+	saveFailures,
+	type StressOperations,
+} from "../baseModel.js";
 import {
 	convertToRealHandles,
 	covertLocalServerStateToDdsState,
@@ -81,6 +87,7 @@ describe("Local Server Stress with rollback", () => {
 				? orderSequentiallyReducer(state, op)
 				: reducer(state, op),
 		validateConsistency: validateConsistencyOfAllDDS,
+		minimizationTransforms: ddsModelMinimizers,
 	};
 
 	createLocalServerStressSuite(model, {

--- a/packages/test/stochastic-test-utils/src/minification.ts
+++ b/packages/test/stochastic-test-utils/src/minification.ts
@@ -86,18 +86,22 @@ export class FuzzTestMinimizer<TOperation extends BaseOperation> {
 	}
 
 	private async tryDeleteEachOp(): Promise<void> {
-		let idx = this.operations.length - 1;
+		let previousLength = 0;
+		do {
+			previousLength = this.operations.length;
+			let idx = previousLength - 1;
 
-		while (idx > 0) {
-			const deletedOp = this.operations.splice(idx, 1)[0];
+			while (idx > 0) {
+				const deletedOp = this.operations.splice(idx, 1)[0];
 
-			// don't remove attach ops, as it creates invalid scenarios
-			if (deletedOp.type === "attach" || !(await this.assertFails())) {
-				this.operations.splice(idx, 0, deletedOp);
+				// don't remove attach ops, as it creates invalid scenarios
+				if (deletedOp.type === "attach" || !(await this.assertFails())) {
+					this.operations.splice(idx, 0, deletedOp);
+				}
+
+				idx -= 1;
 			}
-
-			idx -= 1;
-		}
+		} while (this.operations.length !== previousLength);
 	}
 
 	/**


### PR DESCRIPTION
This makes the dds minimizers available to the local server stress tests, and modifies the minimization algorithm to be more aggressive by continuing to minimize util no more minimization is possible.