### PR TITLE
Sort imports needing manual adjustments

### DIFF
--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -3,13 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { assert, fail } from "@fluidframework/core-utils/internal";
 import type {
 	ErasedType,
 	IFluidHandle,
 	IFluidLoadable,
 } from "@fluidframework/core-interfaces/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
+import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type {
 	IChannelView,
 	IFluidSerializer,
@@ -19,7 +20,6 @@ import {
 	UsageError,
 	type ITelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
-import type { IIdCompressor } from "@fluidframework/id-compressor";
 
 import { type ICodecOptions, noopValidator } from "../codec/index.js";
 import {
@@ -43,7 +43,6 @@ import {
 	makeDetachedFieldIndex,
 	moveToDetachedField,
 } from "../core/index.js";
-
 import {
 	DetachedFieldIndexSummarizer,
 	FieldKinds,
@@ -59,6 +58,8 @@ import {
 	makeSchemaCodec,
 	makeTreeChunker,
 } from "../feature-libraries/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import type { Format } from "../feature-libraries/schema-index/index.js";
 import {
 	type ClonableSchemaAndPolicy,
 	DefaultResubmitMachine,
@@ -86,6 +87,12 @@ import {
 	type ITreeAlpha,
 	type SimpleObjectFieldSchema,
 } from "../simple-tree/index.js";
+import {
+	type Breakable,
+	breakingClass,
+	type JsonCompatible,
+	throwIfBroken,
+} from "../util/index.js";
 
 import { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
 import { SharedTreeReadonlyChangeEnricher } from "./sharedTreeChangeEnricher.js";
@@ -93,14 +100,6 @@ import { SharedTreeChangeFamily } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import type { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
 import { type TreeCheckout, type BranchableTree, createTreeCheckout } from "./treeCheckout.js";
-import {
-	type Breakable,
-	breakingClass,
-	type JsonCompatible,
-	throwIfBroken,
-} from "../util/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import type { Format } from "../feature-libraries/schema-index/index.js";
 
 /**
  * Copy of data from an {@link ITreePrivate} at some point in time.

--- a/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
@@ -3,21 +3,30 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
 
 import type { TreeValue } from "../../core/index.js";
 import type { NodeIdentifierManager } from "../../feature-libraries/index.js";
+// This import is required for intellisense in @link doc comments on mouseover in VSCode.
+// eslint-disable-next-line unused-imports/no-unused-imports, @typescript-eslint/no-unused-vars
+import type { TreeAlpha } from "../../shared-tree/index.js";
 import {
 	type RestrictiveStringRecord,
 	getOrCreate,
 	isReadonlyArray,
 } from "../../util/index.js";
-// This import is required for intellisense in @link doc comments on mouseover in VSCode.
-// eslint-disable-next-line unused-imports/no-unused-imports, @typescript-eslint/no-unused-vars
-import type { TreeAlpha } from "../../shared-tree/index.js";
-
+import { type TreeArrayNode, arraySchema } from "../arrayNode.js";
+import type {
+	NodeKind,
+	WithType,
+	TreeNodeSchema,
+	TreeNodeSchemaClass,
+	TreeNodeSchemaNonClass,
+	TreeNodeSchemaBoth,
+} from "../core/index.js";
+import { isLazy } from "../flexList.js";
 import {
 	booleanSchema,
 	handleSchema,
@@ -26,6 +35,12 @@ import {
 	stringSchema,
 	type LeafSchema,
 } from "../leafNodeSchema.js";
+import { type MapNodeInsertableData, type TreeMapNode, mapSchema } from "../mapNode.js";
+import {
+	type InsertableObjectFromSchemaRecord,
+	type TreeObjectNode,
+	objectSchema,
+} from "../objectNode.js";
 import {
 	FieldKind,
 	type FieldSchema,
@@ -43,24 +58,9 @@ import {
 	type UnannotateImplicitAllowedTypes,
 	type UnannotateSchemaRecord,
 } from "../schemaTypes.js";
-import type {
-	NodeKind,
-	WithType,
-	TreeNodeSchema,
-	TreeNodeSchemaClass,
-	TreeNodeSchemaNonClass,
-	TreeNodeSchemaBoth,
-} from "../core/index.js";
-import { type TreeArrayNode, arraySchema } from "../arrayNode.js";
-import {
-	type InsertableObjectFromSchemaRecord,
-	type TreeObjectNode,
-	objectSchema,
-} from "../objectNode.js";
-import { type MapNodeInsertableData, type TreeMapNode, mapSchema } from "../mapNode.js";
-import type { System_Unsafe, FieldSchemaAlphaUnsafe } from "./typesUnsafe.js";
+
 import { createFieldSchemaUnsafe } from "./schemaFactoryRecursive.js";
-import { isLazy } from "../flexList.js";
+import type { System_Unsafe, FieldSchemaAlphaUnsafe } from "./typesUnsafe.js";
 
 /**
  * Gets the leaf domain schema compatible with a given {@link TreeValue}.

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { assert, Lazy, fail, debugAssert } from "@fluidframework/core-utils/internal";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { createEmitter } from "@fluid-internal/client-utils";
 import type { Listenable, Off } from "@fluidframework/core-interfaces";
-import type { InternalTreeNode, Unhydrated } from "./types.js";
+import { assert, Lazy, fail, debugAssert } from "@fluidframework/core-utils/internal";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
+
 import {
 	anchorSlot,
 	type AnchorEvents,
@@ -16,6 +16,9 @@ import {
 	type TreeValue,
 	type UpPath,
 } from "../../core/index.js";
+// TODO: decide how to deal with dependencies on flex-tree implementation.
+// eslint-disable-next-line import/no-internal-modules
+import { makeTree } from "../../feature-libraries/flex-tree/lazyNode.js";
 import {
 	assertFlexTreeEntityNotFreed,
 	ContextSlot,
@@ -25,13 +28,12 @@ import {
 	treeStatusFromAnchorCache,
 	type FlexTreeNode,
 } from "../../feature-libraries/index.js";
-import type { TreeNodeSchema } from "./treeNodeSchema.js";
-// TODO: decide how to deal with dependencies on flex-tree implementation.
-// eslint-disable-next-line import/no-internal-modules
-import { makeTree } from "../../feature-libraries/flex-tree/lazyNode.js";
+
 import { SimpleContextSlot, type Context, type HydratedContext } from "./context.js";
-import { UnhydratedFlexTreeNode } from "./unhydratedFlexTree.js";
 import type { TreeNode } from "./treeNode.js";
+import type { TreeNodeSchema } from "./treeNodeSchema.js";
+import type { InternalTreeNode, Unhydrated } from "./types.js";
+import { UnhydratedFlexTreeNode } from "./unhydratedFlexTree.js";
 
 const treeNodeToKernel = new WeakMap<TreeNode, TreeNodeKernel>();
 

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -14,7 +14,29 @@ import {
 	type FlexTreeOptionalField,
 	type FlexTreeRequiredField,
 } from "../feature-libraries/index.js";
+import type { RestrictiveStringRecord, FlattenKeys } from "../util/index.js";
+
+import {
+	type TreeNodeSchema,
+	NodeKind,
+	type WithType,
+	// eslint-disable-next-line import/no-deprecated
+	typeNameSymbol,
+	typeSchemaSymbol,
+	type InternalTreeNode,
+	type TreeNode,
+	type Context,
+	UnhydratedFlexTreeNode,
+	getOrCreateInnerNode,
+} from "./core/index.js";
+import { getUnhydratedContext } from "./createContext.js";
 import { getTreeNodeForField } from "./getTreeNodeForField.js";
+import {
+	isObjectNodeSchema,
+	type ObjectNodeSchema,
+	type ObjectNodeSchemaInternalData,
+} from "./objectNodeTypes.js";
+import { prepareForInsertion } from "./prepareForInsertion.js";
 import {
 	type ImplicitFieldSchema,
 	getStoredKey,
@@ -32,30 +54,9 @@ import {
 	unannotateSchemaRecord,
 	type UnannotateSchemaRecord,
 } from "./schemaTypes.js";
-import {
-	type TreeNodeSchema,
-	NodeKind,
-	type WithType,
-	// eslint-disable-next-line import/no-deprecated
-	typeNameSymbol,
-	typeSchemaSymbol,
-	type InternalTreeNode,
-	type TreeNode,
-	type Context,
-	UnhydratedFlexTreeNode,
-	getOrCreateInnerNode,
-} from "./core/index.js";
-import { mapTreeFromNodeData, type InsertableContent } from "./toMapTree.js";
-import { prepareForInsertion } from "./prepareForInsertion.js";
-import type { RestrictiveStringRecord, FlattenKeys } from "../util/index.js";
-import {
-	isObjectNodeSchema,
-	type ObjectNodeSchema,
-	type ObjectNodeSchemaInternalData,
-} from "./objectNodeTypes.js";
-import { TreeNodeValid, type MostDerivedData } from "./treeNodeValid.js";
-import { getUnhydratedContext } from "./createContext.js";
 import type { SimpleObjectFieldSchema } from "./simpleSchema.js";
+import { mapTreeFromNodeData, type InsertableContent } from "./toMapTree.js";
+import { TreeNodeValid, type MostDerivedData } from "./treeNodeValid.js";
 
 /**
  * Generates the properties for an ObjectNode from its field schema object.


### PR DESCRIPTION
## Description

Sort a few of tree's imports where the auto-sort causes issues due to comments.

This leaves all the non-test tree files in a state where their imports can be auto sorted when a good time is found to do so to minimize conflicts.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
