### PR TITLE
docs(tree): TSDoc syntax improvements

### DIFF
--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -70,7 +70,7 @@ export type EncodedChangeAtomId = [ChangesetLocalId, EncodedRevisionTag] | Chang
 export type ChangeAtomIdMap<T> = NestedMap<RevisionTag | undefined, ChangesetLocalId, T>;
 
 /**
- * @returns true iff `a` and `b` are the same.
+ * Returns true iff `a` and `b` are the same.
  */
 export function areEqualChangeAtomIds(a: ChangeAtomId, b: ChangeAtomId): boolean {
 	return a.localId === b.localId && a.revision === b.revision;
@@ -88,7 +88,7 @@ export function areEqualChangeAtomIdOpts(
 }
 
 /**
- * @returns a ChangeAtomId with the given revision and local ID.
+ * Returns a ChangeAtomId with the given revision and local ID.
  */
 export function makeChangeAtomId(
 	localId: ChangesetLocalId,

--- a/packages/dds/tree/src/core/rebase/utils.ts
+++ b/packages/dds/tree/src/core/rebase/utils.ts
@@ -372,8 +372,6 @@ export function rebaseChange<TChange>(
 	};
 }
 
-/**
- */
 export function revisionMetadataSourceFromInfo(
 	revInfos: readonly RevisionInfo[],
 ): RevisionMetadataSource {

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -1075,7 +1075,7 @@ class PathNode extends ReferenceCountedBase implements AnchorNode {
 	}
 
 	/**
-	 * Whether or not this PathNode is the special root node that sits above all the detached fields.
+	 * Whether or not this `PathNode` is the special root node that sits above all the detached fields.
 	 * @remarks
 	 * In this case, the fields are detached sequences.
 	 * Note that the special root node should never appear in an UpPath

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -1075,7 +1075,8 @@ class PathNode extends ReferenceCountedBase implements AnchorNode {
 	}
 
 	/**
-	 * @returns true iff this PathNode is the special root node that sits above all the detached fields.
+	 * Whether or not this PathNode is the special root node that sits above all the detached fields.
+	 * @remarks
 	 * In this case, the fields are detached sequences.
 	 * Note that the special root node should never appear in an UpPath
 	 * since UpPaths represent this root as `undefined`.

--- a/packages/dds/tree/src/core/tree/pathTree.ts
+++ b/packages/dds/tree/src/core/tree/pathTree.ts
@@ -177,7 +177,8 @@ export type NodeIndex = number;
 export type PlaceIndex = number;
 
 /**
- * @returns the number of nodes above this one.
+ * Gets the number of nodes above this one.
+ * @remarks
  * Zero when the path's parent is undefined, meaning the path represents a node in a detached field.
  * Runs in O(depth) time.
  */
@@ -192,14 +193,14 @@ export function getDepth(path: UpPath): number {
 }
 
 /**
- * @returns a deep copy of the provided path as simple javascript objects.
- * This is safe to hold onto and use deep object comparisons on.
+ * Creates deep copy of the provided path as simple javascript objects.
+ * @remarks This is safe to hold onto and use deep object comparisons on.
  */
 export function clonePath(path: UpPath): UpPath;
 
 /**
- * @returns a deep copy of the provided path as simple javascript objects.
- * This is safe to hold onto and use deep object comparisons on.
+ * Creates a deep copy of the provided path as simple javascript objects.
+ * @remarks This is safe to hold onto and use deep object comparisons on.
  */
 export function clonePath(path: UpPath | undefined): UpPath | undefined;
 
@@ -215,8 +216,8 @@ export function clonePath(path: UpPath | undefined): UpPath | undefined {
 }
 
 /**
- * @returns The elements of the given `path`, ordered from root-most to child-most.
- * These elements are unchanged and therefore still point "up".
+ * Gets the elements of the given `path`, ordered from root-most to child-most.
+ * @remarks These elements are unchanged and therefore still point "up".
  */
 export function topDownPath(path: UpPath | undefined): UpPath[] {
 	const out: UpPath[] = [];
@@ -230,8 +231,8 @@ export function topDownPath(path: UpPath | undefined): UpPath[] {
 }
 
 /**
- * @returns true iff `a` and `b` describe the same path.
- *
+ * Returns true if and only if `a` and `b` describe the same path.
+ * @remarks
  * Note that for mutable paths (as used in `AnchorSet`), this equality may change over time: this only checks if the two paths are currently the same.
  */
 export function compareUpPaths(a: UpPath | undefined, b: UpPath | undefined): boolean {
@@ -249,8 +250,8 @@ export function compareUpPaths(a: UpPath | undefined, b: UpPath | undefined): bo
 }
 
 /**
- * @returns true iff `a` and `b` describe the same field path.
- *
+ * Returns true if and only if `a` and `b` describe the same field path.
+ * @remarks
  * Note that for mutable paths (as used in `AnchorSet`), this equality may change over time: this only checks if the two paths are currently the same.
  */
 export function compareFieldUpPaths(a: FieldUpPath, b: FieldUpPath): boolean {

--- a/packages/dds/tree/src/core/tree/pathTree.ts
+++ b/packages/dds/tree/src/core/tree/pathTree.ts
@@ -193,13 +193,13 @@ export function getDepth(path: UpPath): number {
 }
 
 /**
- * Creates deep copy of the provided path as simple javascript objects.
+ * Creates deep copy of the provided path as simple JavaScript object.
  * @remarks This is safe to hold onto and use deep object comparisons on.
  */
 export function clonePath(path: UpPath): UpPath;
 
 /**
- * Creates a deep copy of the provided path as simple javascript objects.
+ * Creates a deep copy of the provided path as simple JavaScript object.
  * @remarks This is safe to hold onto and use deep object comparisons on.
  */
 export function clonePath(path: UpPath | undefined): UpPath | undefined;

--- a/packages/dds/tree/src/core/tree/treeTextFormat.ts
+++ b/packages/dds/tree/src/core/tree/treeTextFormat.ts
@@ -140,7 +140,7 @@ export function setGenericTreeField<T>(
 }
 
 /**
- * @returns keys for fields of `tree`.
+ * Returns keys for fields of `tree`.
  */
 export function genericTreeKeys<T>(tree: GenericFieldsNode<T>): readonly FieldKey[] {
 	const fields = tree.fields;

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -468,7 +468,7 @@ class Cursor extends BasicChunkCursor implements ITreeSubscriptionCursor {
 }
 
 /**
- * @returns an implementation of {@link IEditableForest} with no data or schema.
+ * Creates an implementation of {@link IEditableForest} with no data or schema.
  */
 export function buildChunkedForest(
 	chunker: IChunker,

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -452,7 +452,7 @@ export interface SequenceFieldEditBuilder<TContent> {
 }
 
 /**
- * @returns The number of path elements that both paths share, starting at index 0.
+ * Gets the number of path elements that both paths share, starting at index 0.
  */
 function getSharedPrefixLength(pathA: readonly UpPath[], pathB: readonly UpPath[]): number {
 	const minDepth = Math.min(pathA.length, pathB.length);

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldKindWithEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldKindWithEditor.ts
@@ -66,7 +66,7 @@ export class FieldKindWithEditor<
 	}
 
 	/**
-	 * @returns true iff `superset` permits a (non-strict) superset of the subtrees
+	 * Returns true if and only if `superset` permits a (non-strict) superset of the subtrees
 	 * allowed by field made from `this` and `originalTypes`.
 	 */
 	public allowsFieldSuperset(

--- a/packages/dds/tree/src/feature-libraries/modular-schema/isNeverTree.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/isNeverTree.ts
@@ -17,8 +17,6 @@ import {
 
 import type { FullSchemaPolicy } from "./fieldKind.js";
 
-/**
- */
 export function isNeverField(
 	policy: FullSchemaPolicy,
 	originalData: TreeStoredSchema,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
@@ -344,7 +344,7 @@ function rebaseMarkIgnoreChild(
 }
 
 /**
- * @returns A pair of marks that represent the effects which should remain in place in the face of concurrent move,
+ * Returns a pair of marks that represent the effects which should remain in place in the face of concurrent move,
  * and the effects that should be sent to the move destination.
  */
 function separateEffectsForMove(mark: MarkEffect): {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -423,7 +423,7 @@ export function getOutputLength(mark: Mark, ignorePairing: boolean = false): num
 }
 
 /**
- * Gets he number of nodes within the input context of the mark.
+ * Gets the number of nodes within the input context of the mark.
  * @param mark - The mark to get the length of.
  */
 export function getInputLength(mark: Mark): number {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -289,7 +289,7 @@ export function compareCellPositionsUsingTombstones(
 }
 
 /**
- * @returns the ID of the cell in the output context of the given detach `mark`.
+ * Gets the ID of the cell in the output context of the given detach `mark`.
  */
 export function getDetachOutputCellId(mark: Detach | Rename): ChangeAtomId {
 	if (isRename(mark)) {
@@ -304,7 +304,7 @@ export function getDetachOutputCellId(mark: Detach | Rename): ChangeAtomId {
 }
 
 /**
- * @returns the ID of the detached node in the output context of the given detach `mark`.
+ * Gets the ID of the detached node in the output context of the given detach `mark`.
  */
 export function getDetachedNodeId(mark: Detach | Rename): ChangeAtomId {
 	switch (mark.type) {
@@ -413,18 +413,18 @@ export function cloneCellId(id: CellId): CellId {
 }
 
 /**
+ * Gets the number of nodes within the output context of the mark.
  * @param mark - The mark to get the length of.
  * @param ignorePairing - When true, the length of a paired mark (e.g. MoveIn/MoveOut) whose matching mark is not active
  * will be treated the same as if the matching mark were active.
- * @returns The number of nodes within the output context of the mark.
  */
 export function getOutputLength(mark: Mark, ignorePairing: boolean = false): number {
 	return areOutputCellsEmpty(mark) ? 0 : mark.count;
 }
 
 /**
+ * Gets he number of nodes within the input context of the mark.
  * @param mark - The mark to get the length of.
- * @returns The number of nodes within the input context of the mark.
  */
 export function getInputLength(mark: Mark): number {
 	return areInputCellsEmpty(mark) ? 0 : mark.count;
@@ -491,7 +491,9 @@ export function settleMark(mark: Mark): Mark {
 }
 
 /**
- * @returns true, iff the given `mark` would have impact on the field when applied.
+ * Returns true if and only iff the given `mark` would have impact on the field when applied.
+ *
+ * @remarks
  * Ignores the impact of nested changes.
  * CellRename effects are considered impactful if they actually change the ID of the cells.
  */

--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -372,14 +372,14 @@ class StackCursor<TNode> extends SynchronousCursor implements CursorWithNode<TNo
 	}
 
 	/**
-	 * @returns the value of the current node
+	 * The value of the current node
 	 */
 	public get value(): Value {
 		return this.adapter.value(this.getNode());
 	}
 
 	/**
-	 * @returns the type of the current node
+	 * The type of the current node
 	 */
 	public get type(): TreeType {
 		return this.adapter.type(this.getNode());

--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -66,7 +66,7 @@ export function cursorForJsonableTreeNode(root: JsonableTree): ITreeCursorSynchr
 }
 
 /**
- * @returns an {@link ITreeCursorSynchronous} in fields mode for a JsonableTree field.
+ * Creates an {@link ITreeCursorSynchronous} in fields mode for a JsonableTree field.
  */
 export function cursorForJsonableTreeField(
 	trees: JsonableTree[],

--- a/packages/dds/tree/src/shared-tree-core/branch.ts
+++ b/packages/dds/tree/src/shared-tree-core/branch.ts
@@ -170,7 +170,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> {
 	}
 
 	/**
-	 * @returns the commit at the head of this branch.
+	 * Gets the commit at the head of this branch.
 	 */
 	public getHead(): GraphCommit<TChange> {
 		return this.head;

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -627,8 +627,10 @@ export class EditManager<
 	}
 
 	/**
-	 * @returns The length of the longest branch maintained by this EditManager.
+	 * Gets the length of the longest branch maintained by this `EditManager`.
 	 * This may be the length of a peer branch or the local branch.
+	 *
+	 * @remarks
 	 * The length is counted from the lowest common ancestor with the trunk such that a fully sequenced branch would
 	 * have length zero.
 	 */
@@ -825,7 +827,7 @@ export interface SummaryData<TChangeset> {
 }
 
 /**
- * @returns the path from the base of a branch to its head
+ * Gets the path from the base of a branch to its head.
  */
 function getPathFromBase<TCommit extends { parent?: TCommit }>(
 	branchHead: TCommit,

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -52,7 +52,7 @@ export function makeMessageCodec<TChangeset>(
 }
 
 /**
- * @privateRemarks - Exported for testing.
+ * @privateRemarks Exported for testing.
  */
 export function makeMessageCodecs<TChangeset>(
 	changeCodecs: ICodecFamily<TChangeset, ChangeEncodingContext>,

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldUtils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldUtils.ts
@@ -96,7 +96,7 @@ export const Change = {
 					childChanges: [],
 				},
 	/**
-	 * Creates a changeset that reserves an register.
+	 * Creates a changeset that reserves a register.
 	 * @param target - The register to reserve. The register must NOT be full in the input context of the changeset.
 	 * @param dst - The register that the contents of the target register should be moved to should it become populated.
 	 * The register must be empty in the input context of the changeset, or emptied as part of the changeset.

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldUtils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldUtils.ts
@@ -48,14 +48,14 @@ export interface ProtoChange {
 
 export const Change = {
 	/**
-	 * @returns An empty changeset
+	 * Creates an empty changeset
 	 */
 	empty: (): OptionalChangeset => ({ moves: [], childChanges: [] }),
 	/**
+	 * Creates a changeset that moves a node from `src` to `dst`.
 	 * @param src - The register to move a node from. The register must be full in the input context of the changeset.
 	 * @param dst - The register to move that node to.
 	 * The register must be empty in the input context of the changeset, or emptied as part of the changeset.
-	 * @returns A changeset that moves a node from src to dst.
 	 */
 	move: (
 		src: RegisterId | ChangesetLocalId | ChangeAtomId,
@@ -76,10 +76,10 @@ export const Change = {
 		};
 	},
 	/**
+	 * Creates a changeset that clears a register and moves the contents to another register.
 	 * @param target - The register remove a node from. The register must be full in the input context of the changeset.
 	 * @param dst - The register to move the contents of the target register to.
 	 * The register must be empty in the input context of the changeset, or emptied as part of the changeset.
-	 * @returns A changeset that clears a register and moves the contents to another register.
 	 */
 	clear: (
 		target: RegisterId | ChangesetLocalId,
@@ -96,10 +96,10 @@ export const Change = {
 					childChanges: [],
 				},
 	/**
+	 * Creates a changeset that reserves an register.
 	 * @param target - The register to reserve. The register must NOT be full in the input context of the changeset.
 	 * @param dst - The register that the contents of the target register should be moved to should it become populated.
 	 * The register must be empty in the input context of the changeset, or emptied as part of the changeset.
-	 * @returns A changeset that reserves an register.
 	 */
 	reserve: (
 		target: RegisterId | ChangesetLocalId,
@@ -113,9 +113,9 @@ export const Change = {
 		};
 	},
 	/**
+	 * Creates a changeset that pins the current node to the field.
 	 * @param dst - The register that the contents of the field should be moved to should it become populated
 	 * with a different node that the current one (which will take its place).
-	 * @returns A changeset that pins the current node to the field.
 	 */
 	pin: (dst: ChangeAtomId | ChangesetLocalId): OptionalChangeset => {
 		return {
@@ -125,19 +125,19 @@ export const Change = {
 		};
 	},
 	/**
+	 * Creates a changeset that applies a change to a child node in the given register.
 	 * @param location - The register that contains the child node to be changed.
 	 * That register must be full in the input context of the changeset.
 	 * @param change - A change to apply to a child node.
-	 * @returns A changeset that applies the given change to the child node in the given register.
 	 */
 	childAt: (location: RegisterId | ChangesetLocalId, change: NodeId): OptionalChangeset => ({
 		moves: [],
 		childChanges: [[asRegister(location), change]],
 	}),
 	/**
+	 * Creates a changeset that applies the given change to the child node in the "self" register.
+	 * @remarks The "self" register must be full in the input context of the changeset.
 	 * @param change - A change to apply to a child node in the "self" register.
-	 * @returns A changeset that applies the given change to the child node in the "self" register.
-	 * The "self" register must be full in the input context of the changeset.
 	 */
 	child: (change: NodeId): OptionalChangeset => Change.childAt("self", change),
 	/**

--- a/packages/dds/tree/src/test/rebase/rebaseBranch.spec.ts
+++ b/packages/dds/tree/src/test/rebase/rebaseBranch.spec.ts
@@ -333,7 +333,7 @@ describe("rebaseBranch", () => {
 });
 
 /**
- * @returns the path from the base of a branch to its head
+ * Returns the path from the base of a branch to its head.
  */
 function getPath<TChange>(
 	fromAncestor: GraphCommit<TChange> | undefined,

--- a/packages/dds/tree/src/test/scalableTestTrees.ts
+++ b/packages/dds/tree/src/test/scalableTestTrees.ts
@@ -127,7 +127,7 @@ export function makeWideStoredContentWithEndValue(
 }
 
 /**
- * Returns a tree with specified number of nodes, with the end leaf node set to the endLeafValue
+ * Returns a tree with specified number of nodes, with the end leaf node set to the endLeafValue.
  * @param numberOfNodes - number of nodes of the tree
  * @param endLeafValue - the value of the end leaf of the tree. If not provided its index is used.
  */

--- a/packages/dds/tree/src/test/scalableTestTrees.ts
+++ b/packages/dds/tree/src/test/scalableTestTrees.ts
@@ -94,10 +94,9 @@ export function makeDeepStoredContent(
 }
 
 /**
- *
+ * Returns a tree with specified number of nodes, with the end leaf node set to the endLeafValue
  * @param numberOfNodes - number of nodes of the tree
  * @param endLeafValue - the value of the end leaf of the tree. If not provided its index is used.
- * @returns a tree with specified number of nodes, with the end leaf node set to the endLeafValue
  */
 export function makeWideContentWithEndValueSimple(
 	numberOfNodes: number,
@@ -112,9 +111,9 @@ export function makeWideContentWithEndValueSimple(
 }
 
 /**
+ * Returns a tree with specified number of nodes, with the end leaf node set to the endLeafValue.
  * @param numberOfNodes - number of nodes of the tree
  * @param endLeafValue - the value of the end leaf of the tree. If not provided its index is used.
- * @returns a tree with specified number of nodes, with the end leaf node set to the endLeafValue
  */
 export function makeWideStoredContentWithEndValue(
 	numberOfNodes: number,
@@ -128,10 +127,9 @@ export function makeWideStoredContentWithEndValue(
 }
 
 /**
- *
+ * Returns a tree with specified number of nodes, with the end leaf node set to the endLeafValue
  * @param numberOfNodes - number of nodes of the tree
  * @param endLeafValue - the value of the end leaf of the tree. If not provided its index is used.
- * @returns a tree with specified number of nodes, with the end leaf node set to the endLeafValue
  */
 export function makeJsWideTreeWithEndValue(
 	numberOfNodes: number,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzUtils.ts
@@ -99,10 +99,9 @@ export const initialFuzzSchema = createTreeViewSchema([]);
 export const fuzzFieldSchema = FuzzNode.info.optionalChild;
 
 /**
- *
+ * Returns the {@link FuzzNodeSchema} with the {@link initialAllowedTypes}, as well as the additional nodeTypes passed in.
  * @param nodeTypes - The additional node types outside of the {@link initialAllowedTypes} that the fuzzNode is allowed to contain
  * @param schemaFactory - The schemaFactory used to build the {@link FuzzNodeSchema}. The scope prefix must be "treeFuzz".
- * @returns the {@link FuzzNodeSchema} with the {@link initialAllowedTypes}, as well as the additional nodeTypes passed in.
  */
 function createFuzzNodeSchema(
 	nodeTypes: TreeNodeSchema[],

--- a/packages/dds/tree/src/test/shared-tree/summary.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/summary.bench.ts
@@ -172,8 +172,8 @@ describe("Summary benchmarks", () => {
 });
 
 /**
- * @param content - content to full the tree with
- * @returns the tree's summary
+ * Returns the tree's summary.
+ * @param content - The content to fill the tree with.
  */
 function getSummaryTree<T extends ImplicitFieldSchema>(
 	content: TreeSimpleContentTyped<T>,

--- a/packages/dds/tree/src/test/testAnchor.ts
+++ b/packages/dds/tree/src/test/testAnchor.ts
@@ -30,7 +30,7 @@ export class TestAnchor {
 	) {}
 
 	/**
-	 * @returns a `TestAnchor` for the node at the given path.
+	 * Returns a `TestAnchor` for the node at the given path.
 	 */
 	public static fromPath(forest: IForestSubscription, path: UpPath): TestAnchor {
 		const cursor = forest.allocateCursor();
@@ -41,7 +41,7 @@ export class TestAnchor {
 	}
 
 	/**
-	 * @returns a `TestAnchor` for the node with the given value.
+	 * Returns a `TestAnchor` for the node with the given value.
 	 * Fails if the value is not found or found multiple times in the tree.
 	 */
 	public static fromValue(forest: IForestSubscription, value: TreeValue): TestAnchor {
@@ -73,7 +73,7 @@ export class TestAnchor {
 	}
 
 	/**
-	 * @returns A cursor that is positioned at the anchor.
+	 * Returns a cursor that is positioned at the anchor.
 	 * The cursor is owned (and therefore must be freed) by the caller.
 	 */
 	public acquireCursor(): ITreeSubscriptionCursor {


### PR DESCRIPTION
Makes some misc. improvements to TSDoc comments in `tree`. Namely, adds missing summary docs (mostly by replacing comments that only included `@returns` blocks. Also replaces some instances of "iff" with "if and only if" for accessibility.