### PR TITLE
fix(id-allocation): Schedule a flush when submitting ID Allocation op before replaying pending states

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -4511,6 +4511,7 @@ export class ContainerRuntime
 				if (!this.batchRunner.running) {
 					this.doPendingFlush();
 				}
+				break;
 			}
 			case FlushMode.TurnBased: {
 				// When in TurnBased flush mode the runtime will buffer operations in the current turn and send them as a single

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2551,6 +2551,7 @@ export class ContainerRuntime
 			// Since we don't submit ID Allocation ops when staged, any outstanding ranges would be from
 			// before staging mode so we can simply say staged: false.
 			this.submitIdAllocationOpIfNeeded({ resubmitOutstandingRanges: true, staged: false });
+			this.scheduleFlush();
 
 			// replay the ops
 			this.pendingStateManager.replayPendingStates();


### PR DESCRIPTION
## Description

Fixes [AB#39398](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/39398)

In `ContainerRuntime`, we submit to the `Outbox` directly from `replayPendingStates`, and so we should also call `scheduleFlush` to ensure that op doesn't get stuck in the Outbox.  Being "stuck in the Outbox" is a problem because it's assumed that all ops in a batch come during the same JS turn and have the same reference sequence number, and this will violate that invariant.

That one-line change is accompanied by some refactoring so we don't have to consider Immediate mode at that callsite (`scheduleFlush` handles it now).

## In-Depth

In the typical case, calling `PendingStateManager.replayPendingStates` will trigger another op(s) to submit which will schedule the flush.  But here's a counterexample:

> Create a new DataStore and use a compressed ID in it. Reconnect before attaching it or making any other changes.

This will result in the replay flow, and we will submit an ID Allocation op, but there's nothing else to resubmit. This op will be "stuck" in the Outbox.

In the current code, this is _kind of_ ok, because ID Allocation ops don't make the container dirty, and it's ok to drop that op.  BUT, as mentioned above, it can easily violate the invariant that all ops in a batch have the same reference sequence number, because that "old" op will be included in the next batch, which could be some time later after new ops have been processed (which advances the refSeq).  See the unit test added here.