### PR TITLE
Directory: Add minimization transform

### DIFF
--- a/packages/dds/map/src/test/mocha/fuzzUtils.ts
+++ b/packages/dds/map/src/test/mocha/fuzzUtils.ts
@@ -12,6 +12,7 @@ import {
 	combineReducers,
 	createWeightedAsyncGenerator,
 	createWeightedGenerator,
+	isOperationType,
 	takeAsync,
 } from "@fluid-private/stochastic-test-utils";
 import type { Client, DDSFuzzModel, DDSFuzzTestState } from "@fluid-private/test-dds-utils";
@@ -509,4 +510,18 @@ export const baseDirModel: DDSFuzzModel<DirectoryFactory, DirOperation> = {
 	reducer: makeDirReducer({ clientIds: ["A", "B", "C"], printConsoleLogs: false }),
 	validateConsistency: async (a, b) => assertEquivalentDirectories(a.channel, b.channel),
 	factory: new DirectoryFactory(),
+	minimizationTransforms: [
+		(op: DirOperation): void => {
+			if (
+				isOperationType<DirSetKey>("set", op) ||
+				isOperationType<DirDeleteKey>("delete", op) ||
+				isOperationType<DirClearKeys>("clear", op)
+			) {
+				const lastPath = op.path.lastIndexOf("/");
+				if (lastPath !== -1) {
+					op.path = op.path.slice(0, lastPath + 1);
+				}
+			}
+		},
+	],
 };


### PR DESCRIPTION
Adds a simple minimization transform for directory fuzz tests. By reducing the path depth it will allow the removal of things like create subdirectory ops, which can lead to a much simpler repo, especially in cases like local server fuzz where we might just be storing a handle in a root dds to attach it, so don't need it in a deep sub dir. 