### PR TITLE
Remove mapTreeFromNodeData overloads, cleanup comments

### DIFF
--- a/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
+++ b/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
@@ -118,7 +118,7 @@ export function prepareForInsertionContextless<TIn extends InsertableContent | u
 	const fieldSchema = convertField(normalizeFieldSchema(schema));
 	validateAndPrepare(schemaAndPolicy, hydratedData, fieldSchema, contentArray);
 
-	return mapTree as TIn extends undefined ? undefined : ExclusiveMapTree;
+	return mapTree;
 }
 
 /**


### PR DESCRIPTION
## Description

Remove mapTreeFromNodeData overloads, cleanup comments

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

