### PR TITLE
refactor(client-fluid-static): hide fluid-static entryPoint

### DIFF
--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -103,6 +103,7 @@
 		"@fluidframework/container-runtime": "workspace:~",
 		"@fluidframework/container-runtime-definitions": "workspace:~",
 		"@fluidframework/core-interfaces": "workspace:~",
+		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/datastore-definitions": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/request-handler": "workspace:~",

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -10,7 +10,13 @@ import {
 	type ICriticalContainerError,
 } from "@fluidframework/container-definitions";
 import type { IContainer } from "@fluidframework/container-definitions/internal";
-import type { IEvent, IEventProvider, IFluidLoadable } from "@fluidframework/core-interfaces";
+import type {
+	FluidObject,
+	IEvent,
+	IEventProvider,
+	IFluidLoadable,
+} from "@fluidframework/core-interfaces";
+import { assert } from "@fluidframework/core-utils/internal";
 import type { SharedObjectKind } from "@fluidframework/shared-object-base";
 
 import type { ContainerAttachProps, ContainerSchema, IRootDataObject } from "./types.js";
@@ -249,13 +255,17 @@ export interface IFluidContainerInternal {
  *
  * @internal
  */
-export function createFluidContainer<
+export async function createFluidContainer<
 	TContainerSchema extends ContainerSchema = ContainerSchema,
 >(props: {
 	container: IContainer;
-	rootDataObject: IRootDataObject;
-}): IFluidContainer<TContainerSchema> {
-	return new FluidContainer<TContainerSchema>(props.container, props.rootDataObject);
+}): Promise<IFluidContainer<TContainerSchema>> {
+	const entryPoint: FluidObject<IRootDataObject> = await props.container.getEntryPoint();
+	assert(
+		entryPoint.IRootDataObject !== undefined,
+		0x875 /* entryPoint must be of type IRootDataObject */,
+	);
+	return new FluidContainer<TContainerSchema>(props.container, entryPoint.IRootDataObject);
 }
 
 /**

--- a/packages/framework/fluid-static/src/index.ts
+++ b/packages/framework/fluid-static/src/index.ts
@@ -25,8 +25,6 @@ export type {
 	ContainerAttachProps,
 	IConnection,
 	IMember,
-	IProvideRootDataObject,
-	IRootDataObject,
 	IServiceAudience,
 	IServiceAudienceEvents,
 	LoadableObjectRecord,

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -173,7 +173,7 @@ const rootDataStoreId = "rootDOId";
 
 /**
  * Creates an {@link @fluidframework/aqueduct#BaseContainerRuntimeFactory} which constructs containers
- * with a single {@link IRootDataObject} as their entry point, where the root data object's registry
+ * with a single IRootDataObject as their entry point, where the root data object's registry
  * and initial objects are configured based on the provided schema (and optionally, data store registry).
  *
  * @internal

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -94,10 +94,7 @@ export interface ContainerSchema {
 	readonly dynamicObjectTypes?: readonly SharedObjectKind[];
 }
 
-/**
- * @internal
- */
-export interface IProvideRootDataObject {
+interface IProvideRootDataObject {
 	readonly IRootDataObject: IRootDataObject;
 }
 

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -95,7 +95,6 @@
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/core-interfaces": "workspace:~",
-		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/driver-utils": "workspace:~",
 		"@fluidframework/fluid-static": "workspace:~",

--- a/packages/service-clients/azure-client/src/AzureClient.ts
+++ b/packages/service-clients/azure-client/src/AzureClient.ts
@@ -16,11 +16,9 @@ import {
 	type ILoaderProps,
 } from "@fluidframework/container-loader/internal";
 import type {
-	FluidObject,
 	IConfigProviderBase,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import { assert } from "@fluidframework/core-utils/internal";
 import type { IClient } from "@fluidframework/driver-definitions";
 import type {
 	IDocumentServiceFactory,
@@ -33,7 +31,6 @@ import type {
 	CompatibilityMode,
 } from "@fluidframework/fluid-static";
 import {
-	type IRootDataObject,
 	createDOProviderContainerRuntimeFactory,
 	createFluidContainer,
 	createServiceAudience,
@@ -185,10 +182,8 @@ export class AzureClient {
 			...loaderProps,
 			request: { url: url.href },
 		});
-		const rootDataObject = await this.getContainerEntryPoint(container);
-		const fluidContainer = createFluidContainer<TContainerSchema>({
+		const fluidContainer = await createFluidContainer<TContainerSchema>({
 			container,
-			rootDataObject,
 		});
 		const services = this.getContainerServices(container);
 		return { container: fluidContainer, services };
@@ -224,10 +219,8 @@ export class AzureClient {
 			url: url.href,
 			headers: { [LoaderHeader.version]: version.id },
 		});
-		const rootDataObject = await this.getContainerEntryPoint(container);
-		const fluidContainer = createFluidContainer<TContainerSchema>({
+		const fluidContainer = await createFluidContainer<TContainerSchema>({
 			container,
-			rootDataObject,
 		});
 		return { container: fluidContainer };
 	}
@@ -322,8 +315,6 @@ export class AzureClient {
 			getTenantId(connection),
 		);
 
-		const rootDataObject = await this.getContainerEntryPoint(container);
-
 		/**
 		 * See {@link FluidContainer.attach}
 		 */
@@ -337,21 +328,11 @@ export class AzureClient {
 			}
 			return container.resolvedUrl.id;
 		};
-		const fluidContainer = createFluidContainer<TContainerSchema>({
+		const fluidContainer = await createFluidContainer<TContainerSchema>({
 			container,
-			rootDataObject,
 		});
 		fluidContainer.attach = attach;
 		return fluidContainer;
-	}
-
-	private async getContainerEntryPoint(container: IContainer): Promise<IRootDataObject> {
-		const rootDataObject: FluidObject<IRootDataObject> = await container.getEntryPoint();
-		assert(
-			rootDataObject.IRootDataObject !== undefined,
-			0x90a /* entryPoint must be of type IRootDataObject */,
-		);
-		return rootDataObject.IRootDataObject;
 	}
 	// #endregion
 }

--- a/packages/service-clients/odsp-client/src/odspClient.ts
+++ b/packages/service-clients/odsp-client/src/odspClient.ts
@@ -14,12 +14,10 @@ import {
 	type ILoaderProps,
 } from "@fluidframework/container-loader/internal";
 import type {
-	FluidObject,
 	IConfigProviderBase,
 	IRequest,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import { assert } from "@fluidframework/core-utils/internal";
 import type { IClient } from "@fluidframework/driver-definitions";
 import type { IDocumentServiceFactory } from "@fluidframework/driver-definitions/internal";
 import type {
@@ -27,7 +25,6 @@ import type {
 	ContainerSchema,
 	IFluidContainer,
 } from "@fluidframework/fluid-static";
-import type { IRootDataObject } from "@fluidframework/fluid-static/internal";
 import {
 	createDOProviderContainerRuntimeFactory,
 	createFluidContainer,
@@ -158,9 +155,8 @@ export class OdspClient {
 		});
 		const container = await loadExistingContainer({ ...loaderProps, request: { url } });
 
-		const fluidContainer = createFluidContainer({
+		const fluidContainer = await createFluidContainer({
 			container,
-			rootDataObject: await this.getContainerEntryPoint(container),
 		});
 		const services = await this.getContainerServices(container);
 		return { container: fluidContainer as IFluidContainer<T>, services };
@@ -203,8 +199,6 @@ export class OdspClient {
 		container: IContainer,
 		connection: OdspConnectionConfig,
 	): Promise<IFluidContainer> {
-		const rootDataObject = await this.getContainerEntryPoint(container);
-
 		/**
 		 * See {@link FluidContainer.attach}
 		 */
@@ -237,7 +231,7 @@ export class OdspClient {
 			 */
 			return resolvedUrl.itemId;
 		};
-		const fluidContainer = createFluidContainer({ container, rootDataObject });
+		const fluidContainer = await createFluidContainer({ container });
 		fluidContainer.attach = attach;
 		return fluidContainer;
 	}
@@ -249,14 +243,5 @@ export class OdspClient {
 				createServiceMember: createOdspAudienceMember,
 			}),
 		};
-	}
-
-	private async getContainerEntryPoint(container: IContainer): Promise<IRootDataObject> {
-		const rootDataObject: FluidObject<IRootDataObject> = await container.getEntryPoint();
-		assert(
-			rootDataObject.IRootDataObject !== undefined,
-			0x878 /* entryPoint must be of type IRootDataObject */,
-		);
-		return rootDataObject.IRootDataObject;
 	}
 }

--- a/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
@@ -13,12 +13,7 @@ import {
 	loadExistingContainer,
 	type ILoaderProps,
 } from "@fluidframework/container-loader/internal";
-import type {
-	ConfigTypes,
-	FluidObject,
-	ITelemetryBaseLogger,
-} from "@fluidframework/core-interfaces";
-import { assert } from "@fluidframework/core-utils/internal";
+import type { ConfigTypes, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import type { IClient } from "@fluidframework/driver-definitions";
 import type {
 	IDocumentServiceFactory,
@@ -30,7 +25,6 @@ import type {
 	CompatibilityMode,
 } from "@fluidframework/fluid-static";
 import {
-	type IRootDataObject,
 	createDOProviderContainerRuntimeFactory,
 	createFluidContainer,
 	createServiceAudience,
@@ -101,8 +95,6 @@ export class TinyliciousClient {
 			},
 		});
 
-		const rootDataObject = await this.getContainerEntryPoint(container);
-
 		/**
 		 * See {@link FluidContainer.attach}
 		 */
@@ -118,9 +110,8 @@ export class TinyliciousClient {
 			return container.resolvedUrl.id;
 		};
 
-		const fluidContainer = createFluidContainer<TContainerSchema>({
+		const fluidContainer = await createFluidContainer<TContainerSchema>({
 			container,
-			rootDataObject,
 		});
 		fluidContainer.attach = attach;
 
@@ -145,10 +136,8 @@ export class TinyliciousClient {
 	}> {
 		const loaderProps = this.getLoaderProps(containerSchema, compatibilityMode);
 		const container = await loadExistingContainer({ ...loaderProps, request: { url: id } });
-		const rootDataObject = await this.getContainerEntryPoint(container);
-		const fluidContainer = createFluidContainer<TContainerSchema>({
+		const fluidContainer = await createFluidContainer<TContainerSchema>({
 			container,
-			rootDataObject,
 		});
 		const services = this.getContainerServices(container);
 		return { container: fluidContainer, services };
@@ -204,15 +193,6 @@ export class TinyliciousClient {
 		};
 
 		return loaderProps;
-	}
-
-	private async getContainerEntryPoint(container: IContainer): Promise<IRootDataObject> {
-		const rootDataObject: FluidObject<IRootDataObject> = await container.getEntryPoint();
-		assert(
-			rootDataObject.IRootDataObject !== undefined,
-			0x875 /* entryPoint must be of type IRootDataObject */,
-		);
-		return rootDataObject.IRootDataObject;
 	}
 	// #endregion
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11363,6 +11363,9 @@ importers:
       '@fluidframework/core-interfaces':
         specifier: workspace:~
         version: link:../../common/core-interfaces
+      '@fluidframework/core-utils':
+        specifier: workspace:~
+        version: link:../../common/core-utils
       '@fluidframework/datastore-definitions':
         specifier: workspace:~
         version: link:../../runtime/datastore-definitions
@@ -12898,9 +12901,6 @@ importers:
       '@fluidframework/core-interfaces':
         specifier: workspace:~
         version: link:../../common/core-interfaces
-      '@fluidframework/core-utils':
-        specifier: workspace:~
-        version: link:../../common/core-utils
       '@fluidframework/driver-definitions':
         specifier: workspace:~
         version: link:../../common/driver-definitions


### PR DESCRIPTION
from service clients that don't need to know about the type or its internals.

Move the acquisition of entrypoint into `createFluidContainer`.