### PR TITLE
LocalServerStress: Minimize number of clients

### DIFF
--- a/packages/dds/map/src/test/mocha/fuzzUtils.ts
+++ b/packages/dds/map/src/test/mocha/fuzzUtils.ts
@@ -12,6 +12,7 @@ import {
 	combineReducers,
 	createWeightedAsyncGenerator,
 	createWeightedGenerator,
+	isOperationType,
 	takeAsync,
 } from "@fluid-private/stochastic-test-utils";
 import type { Client, DDSFuzzModel, DDSFuzzTestState } from "@fluid-private/test-dds-utils";
@@ -509,4 +510,18 @@ export const baseDirModel: DDSFuzzModel<DirectoryFactory, DirOperation> = {
 	reducer: makeDirReducer({ clientIds: ["A", "B", "C"], printConsoleLogs: false }),
 	validateConsistency: async (a, b) => assertEquivalentDirectories(a.channel, b.channel),
 	factory: new DirectoryFactory(),
+	minimizationTransforms: [
+		(op: DirOperation): void => {
+			if (
+				isOperationType<DirSetKey>("set", op) ||
+				isOperationType<DirDeleteKey>("delete", op) ||
+				isOperationType<DirClearKeys>("clear", op)
+			) {
+				const lastPath = op.path.lastIndexOf("/");
+				if (lastPath !== -1) {
+					op.path = op.path.slice(0, lastPath + 1);
+				}
+			}
+		},
+	],
 };

--- a/packages/test/local-server-stress-tests/src/localServerStressHarness.ts
+++ b/packages/test/local-server-stress-tests/src/localServerStressHarness.ts
@@ -684,6 +684,21 @@ function mixinClientSelection<TOperation extends BaseOperation>(
 	};
 	return {
 		...model,
+		minimizationTransforms: [
+			...(model.minimizationTransforms ?? []),
+			(op) => {
+				// the clients are somewhat interchangeable, and the fewer clients
+				// involved in a repro the easier it is to debug, so try to
+				// reduce the client id
+				if (hasSelectedClientSpec(op)) {
+					const dashIndex = op.clientTag.lastIndexOf("-");
+					const id = Number.parseInt(op.clientTag.slice(dashIndex + 1), 10);
+					if (id > 1) {
+						op.clientTag = `client-${id - 1}`;
+					}
+				}
+			},
+		],
 		generatorFactory,
 		reducer,
 	};

--- a/packages/test/local-server-stress-tests/src/localServerStressHarness.ts
+++ b/packages/test/local-server-stress-tests/src/localServerStressHarness.ts
@@ -692,9 +692,11 @@ function mixinClientSelection<TOperation extends BaseOperation>(
 				// reduce the client id
 				if (hasSelectedClientSpec(op)) {
 					const dashIndex = op.clientTag.lastIndexOf("-");
-					const id = Number.parseInt(op.clientTag.slice(dashIndex + 1), 10);
-					if (id > 1) {
-						op.clientTag = `client-${id - 1}`;
+					if (dashIndex !== -1) {
+						const id = Number.parseInt(op.clientTag.slice(dashIndex + 1), 10);
+						if (id > 1) {
+							op.clientTag = `client-${id - 1}`;
+						}
 					}
 				}
 			},


### PR DESCRIPTION
This change adds a minimizer for client selection which tries to reduce the number of clients, as synchronized clients are frequently interchangeable, and non-dependent changes may not need a specific client to run on. so far this does a good job of reducing the number of clients in the repos i'm playing with.