### PR TITLE
improvement(container-runtime): Further simplifications for dirty/saved logic

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3437,6 +3437,10 @@ export class ContainerRuntime
 	 * either were not sent out to delta stream or were not yet acknowledged.
 	 */
 	public get isDirty(): boolean {
+		assert(
+			this.lastEmittedDirty === this.computeCurrentDirtyState(),
+			"dirty state should be up to date",
+		);
 		// Rather than recomputing the dirty state in this moment,
 		// just regurgitate the last emitted dirty state.
 		return this.lastEmittedDirty;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3437,10 +3437,6 @@ export class ContainerRuntime
 	 * either were not sent out to delta stream or were not yet acknowledged.
 	 */
 	public get isDirty(): boolean {
-		assert(
-			this.lastEmittedDirty === this.computeCurrentDirtyState(),
-			"dirty state should be up to date",
-		);
 		// Rather than recomputing the dirty state in this moment,
 		// just regurgitate the last emitted dirty state.
 		return this.lastEmittedDirty;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2832,6 +2832,9 @@ export class ContainerRuntime
 				localOpMetadata?: unknown;
 			}[] = this.pendingStateManager.processInboundMessages(inboundResult, local);
 
+			// This message could have been the last pending local (dirtyable) message, in which case we need to update dirty state to "saved"
+			this.updateDocumentDirtyState();
+
 			if (inboundResult.type !== "fullBatch") {
 				assert(
 					messagesWithPendingState.length === 1,
@@ -2924,9 +2927,6 @@ export class ContainerRuntime
 		runtimeBatch: boolean,
 		groupedBatch: boolean,
 	): void {
-		// This message could have been the last pending local (dirtyable) message, in which case we need to update dirty state to "saved"
-		this.updateDocumentDirtyState();
-
 		if (locationInBatch.batchStart) {
 			const firstMessage = messagesWithMetadata[0]?.message;
 			assert(firstMessage !== undefined, 0xa31 /* Batch must have at least one message */);


### PR DESCRIPTION
## Description

Some follow-ups to #24646:

* Don't bother calling `updateDocumentDirtyState` when processing a non-modern-runtime message, since we don't even check for its presence in PendingStateManager
* Get rid of the special treatment of dirty state in `replayPendingStates`.  See commit message on feef9a1fc1014281cf78bd0d663c19e2c4685d57 for details

TODO:

- [ ] write one or two tests
