### PR TITLE
Fix unhydrated node parent tracking

### DIFF
--- a/.changeset/eight-ears-feel.md
+++ b/.changeset/eight-ears-feel.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Fix Tree.key and Tree.parent for Unhydrated nodes after edits
+
+In some cases editing [Unhydrated](https://fluidframework.com/docs/api/fluid-framework/unhydrated-typealias) nodes could result in incorrect results being returned from [Tree.key](https://fluidframework.com/docs/data-structures/tree/nodes#treekey) and [Tree.parent](https://fluidframework.com/docs/data-structures/tree/nodes#treeparent).
+This has been fixed.

--- a/.changeset/eight-ears-feel.md
+++ b/.changeset/eight-ears-feel.md
@@ -5,5 +5,5 @@
 ---
 Fix Tree.key and Tree.parent for Unhydrated nodes after edits
 
-In some cases editing [Unhydrated](https://fluidframework.com/docs/api/fluid-framework/unhydrated-typealias) nodes could result in incorrect results being returned from [Tree.key](https://fluidframework.com/docs/data-structures/tree/nodes#treekey) and [Tree.parent](https://fluidframework.com/docs/data-structures/tree/nodes#treeparent).
+In some cases, editing [Unhydrated](https://fluidframework.com/docs/api/fluid-framework/unhydrated-typealias) nodes could result in incorrect results being returned from [Tree.key](https://fluidframework.com/docs/data-structures/tree/nodes#treekey) and [Tree.parent](https://fluidframework.com/docs/data-structures/tree/nodes#treeparent).
 This has been fixed.

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -402,11 +402,22 @@ class UnhydratedFlexTreeField implements FlexTreeField {
 	 */
 	protected edit(edit: (mapTrees: ExclusiveMapTree[]) => void | ExclusiveMapTree[]): void {
 		const oldMapTrees = this.parent.mapTree.fields.get(this.key) ?? [];
+
+		// Clear parents for all old map trees.
+		for (const tree of oldMapTrees) {
+			tryUnhydratedFlexTreeNode(tree)?.adoptBy(undefined);
+		}
+
 		const newMapTrees = edit(oldMapTrees) ?? oldMapTrees;
 		if (newMapTrees.length > 0) {
 			this.parent.mapTree.fields.set(this.key, newMapTrees);
 		} else {
 			this.parent.mapTree.fields.delete(this.key);
+		}
+
+		// Set parents for all new map trees.
+		for (const [index, tree] of newMapTrees.entries()) {
+			tryUnhydratedFlexTreeNode(tree)?.adoptBy(this, index);
 		}
 
 		this.onEdit?.();
@@ -434,16 +445,6 @@ class EagerMapTreeOptionalField
 {
 	public readonly editor = {
 		set: (newContent: ExclusiveMapTree | undefined): void => {
-			// If the new content is a UnhydratedFlexTreeNode, it needs to have its parent pointer updated
-			if (newContent !== undefined) {
-				nodeCache.get(newContent)?.adoptBy(this, 0);
-			}
-			// If the old content is a UnhydratedFlexTreeNode, it needs to have its parent pointer unset
-			const oldContent = this.mapTrees[0];
-			if (oldContent !== undefined) {
-				nodeCache.get(oldContent)?.adoptBy(undefined);
-			}
-
 			this.edit((mapTrees) => {
 				if (newContent !== undefined) {
 					mapTrees[0] = newContent;
@@ -484,10 +485,8 @@ export class UnhydratedTreeSequenceField
 {
 	public readonly editor: UnhydratedTreeSequenceFieldEditBuilder = {
 		insert: (index, newContent): void => {
-			for (let i = 0; i < newContent.length; i++) {
-				const c = newContent[i];
+			for (const c of newContent) {
 				assert(c !== undefined, 0xa0a /* Unexpected sparse array content */);
-				nodeCache.get(c)?.adoptBy(this, index + i);
 			}
 			this.edit((mapTrees) => {
 				if (newContent.length < 1000) {
@@ -503,7 +502,6 @@ export class UnhydratedTreeSequenceField
 			for (let i = index; i < index + count; i++) {
 				const c = this.mapTrees[i];
 				assert(c !== undefined, 0xa0b /* Unexpected sparse array */);
-				nodeCache.get(c)?.adoptBy(undefined);
 			}
 			let removed: ExclusiveMapTree[] | undefined;
 			this.edit((mapTrees) => {

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -186,7 +186,10 @@ describe("treeNodeApi", () => {
 
 			const added = new Child({ x: {}, y: {} });
 
-			// TODO: is this how we want to handle root keys?
+			// This is this how we handle root keys.
+			// Seems odd for detached fields other than root to have this key though.
+			// As exactly which key is given in this case is undocumented, it could change in the future.
+			// See also TreeAlpha.key2 which handles them differently.
 			assert.equal(Tree.key(added), rootFieldKey);
 
 			// Check index is updated after insert.


### PR DESCRIPTION
## Description

Fix unhydrated node parent tracking by centralizing the logic to update parents, and applying it consistently after every edit.

This does make small edits in large sequences do O(N) parent updates, but they were already O(N) from modifying the large array, and need to do O(N) parent updates in the insertion is near the front anyway.


## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
