### PR TITLE
refactor(bubblebench/shared-tree): Promote eslint configs and fix violations

### DIFF
--- a/examples/benchmarks/bubblebench/shared-tree/.eslintrc.cjs
+++ b/examples/benchmarks/bubblebench/shared-tree/.eslintrc.cjs
@@ -5,7 +5,7 @@
 
 module.exports = {
 	extends: [
-		require.resolve("@fluidframework/eslint-config-fluid/minimal-deprecated"),
+		require.resolve("@fluidframework/eslint-config-fluid"),
 		"prettier",
 		"../../../.eslintrc.cjs",
 	],

--- a/examples/benchmarks/bubblebench/shared-tree/src/appState.ts
+++ b/examples/benchmarks/bubblebench/shared-tree/src/appState.ts
@@ -31,7 +31,7 @@ export class AppState implements IAppState {
 		);
 	}
 
-	public applyEdits() {}
+	public applyEdits(): void {}
 
 	createInitialClientNode(numBubbles: number): IClient {
 		const bubbles: IBubble[] = [];
@@ -50,20 +50,20 @@ export class AppState implements IAppState {
 		return client;
 	}
 
-	public get clients() {
+	public get clients(): Iterable<IClient> {
 		return this.tree.root.clients;
 	}
 
-	public setSize(width?: number, height?: number) {
+	public setSize(width?: number, height?: number): void {
 		this.width = width ?? 640;
 		this.height = height ?? 480;
 	}
 
-	public increaseBubbles() {
+	public increaseBubbles(): void {
 		this.localClient.bubbles.insertAtEnd(makeBubble(this.width, this.height));
 	}
 
-	public decreaseBubbles() {
+	public decreaseBubbles(): void {
 		const bubbles = this.localClient.bubbles;
 		if (bubbles.length > 1) {
 			bubbles.removeAt(bubbles.length - 1);

--- a/examples/benchmarks/bubblebench/shared-tree/src/bubblebench.ts
+++ b/examples/benchmarks/bubblebench/shared-tree/src/bubblebench.ts
@@ -20,7 +20,7 @@ export class Bubblebench extends DataObject {
 	private view: TreeView<typeof App> | undefined;
 	private _appState: AppState | undefined;
 
-	protected async initializingFirstTime() {
+	protected async initializingFirstTime(): Promise<void> {
 		const tree = SharedTree.create(this.runtime);
 
 		this.view = tree.viewWith(appTreeConfiguration);
@@ -28,13 +28,24 @@ export class Bubblebench extends DataObject {
 		this.root.set(treeKey, tree.handle);
 	}
 
-	protected async initializingFromExisting() {
+	protected async initializingFromExisting(): Promise<void> {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const tree = await this.root.get<IFluidHandle<ITree>>(treeKey)!.get();
 		this.view = tree.viewWith(appTreeConfiguration);
 	}
 
-	protected async hasInitialized() {
+	private readonly onConnected = (): void => {
+		// Out of paranoia, we periodically check to see if your client Id has changed and
+		// update the tree if it has.
+		setInterval(() => {
+			const clientId = this.runtime.clientId;
+			if (clientId !== undefined && clientId !== this.appState.localClient.clientId) {
+				this.appState.localClient.clientId = clientId;
+			}
+		}, 1000);
+	};
+
+	protected async hasInitialized(): Promise<void> {
 		this._appState = new AppState(
 			this.tree,
 			/* stageWidth: */ 640,
@@ -42,22 +53,11 @@ export class Bubblebench extends DataObject {
 			/* numBubbles: */ 1,
 		);
 
-		const onConnected = () => {
-			// Out of paranoia, we periodically check to see if your client Id has changed and
-			// update the tree if it has.
-			setInterval(() => {
-				const clientId = this.runtime.clientId;
-				if (clientId !== undefined && clientId !== this.appState.localClient.clientId) {
-					this.appState.localClient.clientId = clientId;
-				}
-			}, 1000);
-		};
-
 		// Wait for connection to begin checking client Id.
 		if (this.runtime.connected) {
-			onConnected();
+			this.onConnected();
 		} else {
-			this.runtime.once("connected", onConnected);
+			this.runtime.once("connected", this.onConnected);
 		}
 	}
 

--- a/examples/benchmarks/bubblebench/shared-tree/src/index.ts
+++ b/examples/benchmarks/bubblebench/shared-tree/src/index.ts
@@ -9,7 +9,7 @@ import React from "react";
 
 import { Bubblebench, BubblebenchInstantiationFactory } from "./bubblebench.js";
 
-const bubblebenchViewCallback = (model: Bubblebench) =>
+const bubblebenchViewCallback = (model: Bubblebench): React.ReactElement =>
 	React.createElement(AppView, { app: model.appState });
 
 /**

--- a/examples/benchmarks/bubblebench/shared-tree/tests/demo.test.ts
+++ b/examples/benchmarks/bubblebench/shared-tree/tests/demo.test.ts
@@ -6,13 +6,7 @@
 import { globals } from "../jest.config.cjs";
 
 describe("Bubblebench", () => {
-	/**
-	 * Bubble bench is currently at a state where it fails to run in a normal state with
-	 * 2 clients due to the inability of the front end application to observe and react
-	 * accordingly to backpressure on the server. Once the backpressure feature has been
-	 * added to sharedtree and implemented in bubble bench, these tests should pass.
-	 */
-	describe.skip("SimpleTree", () => {
+	describe("SimpleTree", () => {
 		beforeAll(async () => {
 			// Wait for the page to load first before running any tests
 			// so this time isn't attributed to the first test


### PR DESCRIPTION
The `minimal-deprecated` config is deprecated and scheduled for deletion.

Also re-enables the package's only test, which was skipped. It passes, so based on the documentation, it should be safe to restore.

[AB#7993](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7993)