### PR TITLE
build(client): Bump version to 2.41.1 (patch)

### DIFF
--- a/azure/packages/azure-local-service/package.json
+++ b/azure/packages/azure-local-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-local-service",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Local implementation of the Azure Fluid Relay service for testing/development use",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-service-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Helper service-side utilities for connecting to Azure Fluid Relay service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -95,7 +95,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.55.0",
-		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.40.0",
+		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.41.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",

--- a/examples/apps/ai-collab/package.json
+++ b/examples/apps/ai-collab/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/ai-collab",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Example app that showcases the experimental package for AI collaboration in Fluid-based applications.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/attributable-map/package.json
+++ b/examples/apps/attributable-map/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/attributable-map",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Minimal Fluid Container & Data Object sample to implement a hit counter as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/blobs/package.json
+++ b/examples/apps/blobs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/blobs",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Example of using blobs in Fluid Framework",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/collaborative-textarea",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "A minimal example using the react collaborative-textarea",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/contact-collection",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Example of using a Fluid Object as a collection of items",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/data-object-grid",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Data object grid creates child data objects from a registry and lays them out in a grid.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/presence-tracker/package.json
+++ b/examples/apps/presence-tracker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/presence-tracker",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Example application that tracks page focus and mouse position using the Fluid Framework presence features.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/staging/package.json
+++ b/examples/apps/staging/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/staging",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Using the experimental staging feature.",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/task-selection/package.json
+++ b/examples/apps/task-selection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/task-selection",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Example demonstrating selecting a unique task amongst connected Fluid clients",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/tree-cli-app/package.json
+++ b/examples/apps/tree-cli-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/tree-cli-app",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "SharedTree CLI app demo",
 	"homepage": "https://fluidframework.com",

--- a/examples/apps/tree-comparison/package.json
+++ b/examples/apps/tree-comparison/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/tree-comparison",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Comparing API usage in legacy SharedTree and new SharedTree.",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/baseline/package.json
+++ b/examples/benchmarks/bubblebench/baseline/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-baseline",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/common/package.json
+++ b/examples/benchmarks/bubblebench/common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-common",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/experimental-tree/package.json
+++ b/examples/benchmarks/bubblebench/experimental-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-experimental-tree",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/ot/package.json
+++ b/examples/benchmarks/bubblebench/ot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-ot",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/bubblebench/shared-tree/package.json
+++ b/examples/benchmarks/bubblebench/shared-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bubblebench-shared-tree",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Bubblemark inspired DDS benchmark",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/odspsnapshotfetch-perftestapp",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Benchmark binary vs. json download",
 	"homepage": "https://fluidframework.com",

--- a/examples/benchmarks/tablebench/package.json
+++ b/examples/benchmarks/tablebench/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/tablebench",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Table focused benchmarks",
 	"homepage": "https://fluidframework.com",

--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-insights-logger",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Provides a simple Fluid application with a UI view written in React to test the Fluid App Insights telemetry logger that will route typical Fluid telemetry to configured Azure App Insights",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/canvas",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Fluid ink canvas",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/clicker",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Minimal Fluid component sample to implement a collaborative counter.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/codemirror",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Simple markdown editor",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/diceroller",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Minimal Fluid Container & Object sample to implement a collaborative dice roller.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/inventory-app/package.json
+++ b/examples/data-objects/inventory-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/inventory-app",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Minimal sample of SharedTree/React integration.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/monaco/package.json
+++ b/examples/data-objects/monaco/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/monaco",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Monaco code editor",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-constellation-model",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Constellation model for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-constellation-view",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-container",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Container for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-coordinate-model",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Coordinate model for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-coordinate-interface",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Interface for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-plot-coordinate-view",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-slider-coordinate-view",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/multiview-triangle-view",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "View for multiview sample",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/prosemirror",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "ProseMirror",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/smde/package.json
+++ b/examples/data-objects/smde/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/smde",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Simple markdown editor",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/table-document",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Chaincode component containing a table's data",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/examples/data-objects/table-tree/package.json
+++ b/examples/data-objects/table-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/table-tree",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Simple table example app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/todo",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Simple todo canvas.",
 	"homepage": "https://fluidframework.com",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/webflow",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Collaborative markdown editor.",
 	"homepage": "https://fluidframework.com",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-external-data",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Integrating an external data source with Fluid data.",
 	"homepage": "https://fluidframework.com",

--- a/examples/service-clients/azure-client/external-controller/package.json
+++ b/examples/service-clients/azure-client/external-controller/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-external-controller",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/service-clients/odsp-client/shared-tree-demo/package.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/shared-tree-demo",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "A shared tree demo using react and odsp client",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/bundle-size-tests",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "A package for understanding the bundle size of Fluid Framework",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/example-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Shared utilities used by examples.",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/import-testing/package.json
+++ b/examples/utils/import-testing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/import-testing",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "import-testing",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/migration-tools/package.json
+++ b/examples/utils/migration-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/migration-tools",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Tools for migrating data",
 	"homepage": "https://fluidframework.com",

--- a/examples/utils/webpack-fluid-loader/package.json
+++ b/examples/utils/webpack-fluid-loader/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/webpack-fluid-loader",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Fluid object loader for webpack-dev-server",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/live-schema-upgrade/package.json
+++ b/examples/version-migration/live-schema-upgrade/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-live-schema-upgrade",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Example application that demonstrates how to add a data object to a live container.",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/version-migration-same-container",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Migrate data between two formats by exporting and reimporting in the same container",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/separate-container/package.json
+++ b/examples/version-migration/separate-container/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/version-migration-separate-container",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Migrate data between two formats by exporting and reimporting in a new container",
 	"homepage": "https://fluidframework.com",

--- a/examples/version-migration/tree-shim/package.json
+++ b/examples/version-migration/tree-shim/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/tree-shim",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Migrating from legacy SharedTree to new SharedTree using a tree shim.",
 	"homepage": "https://fluidframework.com",

--- a/examples/view-integration/container-views/package.json
+++ b/examples/view-integration/container-views/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-container-views",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Minimal Fluid Container & data store sample to implement a collaborative dice roller as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/app-integration-external-views",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
 	"homepage": "https://fluidframework.com",

--- a/examples/view-integration/view-framework-sampler/package.json
+++ b/examples/view-integration/view-framework-sampler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-example/view-framework-sampler",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Example of integrating a Fluid data object with a variety of view frameworks.",
 	"homepage": "https://fluidframework.com",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-changeset",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "property changeset definitions and related functionalities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-common",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "common functions used in properties",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/PropertyDDS/packages/property-common/platform-dependent/package.json
+++ b/experimental/PropertyDDS/packages/property-common/platform-dependent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/platform-dependent",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Helper package that separates code for browser and server.",
 	"homepage": "https://fluidframework.com",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-dds",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "definition of the property distributed data store",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/property-properties",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "definitions of properties",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -99,7 +99,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
-		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@2.40.0",
+		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@2.41.0",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/attributable-map",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Distributed map",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/attributable-map/src/packageVersion.ts
+++ b/experimental/dds/attributable-map/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/attributable-map";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/ot",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Distributed data structure for hosting ottypes",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/ot/ot/src/packageVersion.ts
+++ b/experimental/dds/ot/ot/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/ot";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/sharejs-json1",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Distributed data structure for hosting ottypes",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/ot/sharejs/json1/src/packageVersion.ts
+++ b/experimental/dds/ot/sharejs/json1/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/sharejs-json1";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/sequence-deprecated",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Deprecated distributed sequences",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/dds/sequence-deprecated/src/packageVersion.ts
+++ b/experimental/dds/sequence-deprecated/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/sequence-deprecated";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/tree",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Distributed tree",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/data-objects",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A collection of ready to use Fluid Data Objects",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/last-edited",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Tracks the last edited information in the Container.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/experimental/framework/tree-react-api/package.json
+++ b/experimental/framework/tree-react-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/tree-react-api",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Experimental SharedTree API for React integration.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "client-release-group-root",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/client-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Not intended for use outside the Fluid Framework.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -133,7 +133,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
-		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@2.40.0",
+		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@2.41.0",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-definitions",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid container definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -100,7 +100,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.40.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/core-interfaces",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid object interfaces",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -125,7 +125,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.40.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
+++ b/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
@@ -488,6 +488,24 @@ declare type current_as_old_for_Interface_Tagged = requireAssignableTo<TypeOnly<
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Interface_TypedMessage": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_TypedMessage = requireAssignableTo<TypeOnly<old.TypedMessage>, TypeOnly<current.TypedMessage>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_TypedMessage": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_TypedMessage = requireAssignableTo<TypeOnly<current.TypedMessage>, TypeOnly<old.TypedMessage>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "TypeAlias_ConfigTypes": {"forwardCompat": false}
  */
 declare type old_as_current_for_TypeAlias_ConfigTypes = requireAssignableTo<TypeOnly<old.ConfigTypes>, TypeOnly<current.ConfigTypes>>

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -122,7 +122,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@2.40.0",
+		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/core-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Not intended for use outside the Fluid client repo.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -95,7 +95,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.40.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-definitions",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid driver definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/cell",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Distributed data structure for a single value",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -113,7 +113,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.40.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.41.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/cell/src/packageVersion.ts
+++ b/packages/dds/cell/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/cell";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/counter",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Counter DDS",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -131,7 +131,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/container-definitions": "workspace:~",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.40.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/dds/counter/src/packageVersion.ts
+++ b/packages/dds/counter/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/counter";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/ink",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Ink DDS",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/ink/src/packageVersion.ts
+++ b/packages/dds/ink/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/ink";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/legacy-dds/package.json
+++ b/packages/dds/legacy-dds/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/legacy-dds",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Legacy DDSs for the Fluid Framework. These are not intended for use in new code.",
 	"homepage": "https://fluidframework.com",

--- a/packages/dds/legacy-dds/src/packageVersion.ts
+++ b/packages/dds/legacy-dds/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/legacy-dds";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -157,7 +157,7 @@
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.40.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.41.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/map",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Distributed map",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/map/src/packageVersion.ts
+++ b/packages/dds/map/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/map";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -160,7 +160,7 @@
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.40.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.41.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@tiny-calc/micro": "0.0.0-alpha.5",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/matrix",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Distributed matrix",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/matrix/src/packageVersion.ts
+++ b/packages/dds/matrix/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/matrix";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -154,7 +154,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.40.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.41.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/merge-tree",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Merge tree",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/ordered-collection",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Consensus Collection",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.40.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.41.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/ordered-collection/src/packageVersion.ts
+++ b/packages/dds/ordered-collection/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/ordered-collection";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/pact-map/package.json
+++ b/packages/dds/pact-map/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/pact-map",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Distributed data structure for key-value pairs using pact consensus",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/pact-map/src/packageVersion.ts
+++ b/packages/dds/pact-map/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-experimental/pact-map";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/register-collection",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Consensus Register",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.40.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.41.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/register-collection/src/packageVersion.ts
+++ b/packages/dds/register-collection/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/register-collection";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -170,7 +170,7 @@
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.40.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.41.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/sequence",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Distributed sequence",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/sequence/src/packageVersion.ts
+++ b/packages/dds/sequence/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/sequence";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.40.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.41.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/shared-object-base",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid base class for shared distributed data structures",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/shared-object-base/src/packageVersion.ts
+++ b/packages/dds/shared-object-base/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/shared-object-base";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/shared-summary-block",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A DDS that does not generate ops but is part of summary",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.40.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.41.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/src/packageVersion.ts
+++ b/packages/dds/shared-summary-block/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/shared-summary-block";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -136,7 +136,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.40.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.41.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/task-manager",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Distributed data structure for queueing exclusive tasks",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/task-manager/src/packageVersion.ts
+++ b/packages/dds/task-manager/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/task-manager";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-dds-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid DDS test utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tree",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Distributed tree",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -184,7 +184,7 @@
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tree-previous": "npm:@fluidframework/tree@2.40.0",
+		"@fluidframework/tree-previous": "npm:@fluidframework/tree@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
 		"@types/easy-table": "^0.0.32",

--- a/packages/dds/tree/src/packageVersion.ts
+++ b/packages/dds/tree/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/tree";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/debugger",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid Debugger - a tool to play through history of a file",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -94,7 +94,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.40.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -111,7 +111,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.40.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-base",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Shared driver code for Fluid driver implementations",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/driver-base/src/packageVersion.ts
+++ b/packages/drivers/driver-base/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-base";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-web-cache",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Implementation of the driver caching API for a web browser",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -101,7 +101,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.40.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jest": "29.5.3",

--- a/packages/drivers/driver-web-cache/src/packageVersion.ts
+++ b/packages/drivers/driver-web-cache/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-web-cache";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.40.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/node": "^18.19.0",
 		"concurrently": "^8.2.1",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/file-driver",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A driver that reads/write from/to local file storage.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -140,7 +140,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.40.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/local-driver",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid local driver",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-driver-definitions",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Socket storage implementation for SPO and ODC",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -95,7 +95,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.40.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.40.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-driver",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Socket storage implementation for SPO and ODC",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/odsp-driver/src/packageVersion.ts
+++ b/packages/drivers/odsp-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/odsp-driver";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -88,7 +88,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.40.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-urlresolver",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Url Resolver for odsp urls.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/replay-driver",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Document replay version of Socket.IO implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.40.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -136,7 +136,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.40.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/routerlicious-driver",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Socket.IO + Git implementation of Fluid service API",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/routerlicious-driver/src/packageVersion.ts
+++ b/packages/drivers/routerlicious-driver/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/routerlicious-driver";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -86,7 +86,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.40.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/nconf": "^0.10.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/routerlicious-urlresolver",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Url Resolver for routerlicious urls.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tinylicious-driver",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Driver for tinylicious",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -99,7 +99,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.40.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -103,7 +103,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.55.0",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.40.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.41.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/agent-scheduler",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Built in runtime object for distributing agents across instances of a container",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/ai-collab/package.json
+++ b/packages/framework/ai-collab/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/ai-collab",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Experimental package to simplify integrating AI into Fluid-based applications",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/aqueduct",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A set of implementations for Fluid Framework interfaces.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -136,7 +136,7 @@
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.55.0",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.40.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.41.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",

--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/attributor",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Operation attributor",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -93,7 +93,7 @@
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.55.0",
-		"@fluidframework/app-insights-logger-previous": "npm:@fluidframework/app-insights-logger@2.40.0",
+		"@fluidframework/app-insights-logger-previous": "npm:@fluidframework/app-insights-logger@2.41.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/app-insights-logger",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Contains a Fluid logging client that sends telemetry events to Azure App Insights",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/fluid-telemetry",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Customer facing Fluid telemetry types and classes for both producing and consuming said telemetry",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/data-object-base",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Data object base for synchronously and lazily loaded object scenarios",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/dds-interceptions",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Distributed Data Structures that support an interception callback",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fluid-framework",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "The main entry point into Fluid Framework public packages",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/fluid-static",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A tool to enable consumption of Fluid Data Objects without requiring custom container code.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -120,7 +120,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.40.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.41.0",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/oldest-client-observer",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Data object to determine if the local client is the oldest amongst connected clients",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/presence/package.json
+++ b/packages/framework/presence/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/presence",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A component for lightweight data sharing within a single session",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -128,7 +128,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.40.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/request-handler",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A simple request handling library for Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -127,7 +127,7 @@
 		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/runtime-utils": "workspace:~",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.40.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/synthesize",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A library for synthesizing scope objects.",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/undo-redo",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Undo Redo",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -111,7 +111,7 @@
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-runtime-utils": "workspace:~",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.40.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -190,7 +190,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.40.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-loader",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid container loader",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/loader/container-loader/src/packageVersion.ts
+++ b/packages/loader/container-loader/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/container-loader";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/driver-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Collection of utility functions for Fluid drivers",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -131,7 +131,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.40.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/loader/driver-utils/src/packageVersion.ts
+++ b/packages/loader/driver-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/driver-utils";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-loader-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Mocks and other test utilities for the Fluid Framework Loader",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-runtime-definitions",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid Runtime definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -90,7 +90,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.40.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/container-runtime",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid container runtime",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -197,7 +197,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.40.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/runtime/container-runtime/src/packageVersion.ts
+++ b/packages/runtime/container-runtime/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/container-runtime";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/datastore-definitions",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid data store definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -91,7 +91,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.40.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -137,7 +137,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.40.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/datastore",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid data store implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/datastore/src/packageVersion.ts
+++ b/packages/runtime/datastore/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/datastore";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -145,7 +145,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.40.0",
+		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/id-compressor",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "ID compressor",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/id-compressor/src/packageVersion.ts
+++ b/packages/runtime/id-compressor/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/id-compressor";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/runtime-definitions",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid Runtime definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -98,7 +98,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.40.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.40.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/runtime-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Collection of utility functions for Fluid Runtime",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -136,7 +136,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.40.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/test-runtime-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid runtime test utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-client",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A tool to enable creation and loading of Fluid containers using the Azure Fluid Relay service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -105,7 +105,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.55.0",
-		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.40.0",
+		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.41.0",
 		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/azure-end-to-end-tests",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Azure client end to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/end-to-end-tests/odsp-client/package.json
+++ b/packages/service-clients/end-to-end-tests/odsp-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-experimental/odsp-end-to-end-tests",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Odsp client end to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/odsp-client/package.json
+++ b/packages/service-clients/odsp-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-client",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A tool to enable creation and loading of Fluid containers using the ODSP service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tinylicious-client",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A tool to enable creation and loading of Fluid containers using the Tinylicious service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -109,7 +109,7 @@
 		"@fluidframework/container-runtime-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.40.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/functional-tests",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Functional tests",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/local-server-stress-tests/package.json
+++ b/packages/test/local-server-stress-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/local-server-stress-tests",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Stress tests that can only run against the local server",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/local-server-tests",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Tests that can only run against the local server",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/mocha-test-setup",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Utilities for Fluid tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/mocha-test-setup/src/packageVersion.ts
+++ b/packages/test/mocha-test-setup/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/mocha-test-setup";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/test-snapshots",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Comprehensive test of snapshot logic.",
 	"homepage": "https://fluidframework.com",

--- a/packages/test/snapshots/src/packageVersion.ts
+++ b/packages/test/snapshots/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/test-snapshots";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/stochastic-test-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Utilities for stochastic tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/test-driver-definitions",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A driver abstraction and implementations for testing against server",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-drivers",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "A driver abstraction and implementations for testing against server",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-drivers/src/packageVersion.ts
+++ b/packages/test/test-drivers/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/test-drivers";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-end-to-end-tests",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-end-to-end-tests/src/packageVersion.ts
+++ b/packages/test/test-end-to-end-tests/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/test-end-to-end-tests";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-pairwise-generator",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/test-service-load",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Service load tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-service-load/src/packageVersion.ts
+++ b/packages/test/test-service-load/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-internal/test-service-load";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/test-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Utilities for Fluid tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -145,7 +145,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.40.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",

--- a/packages/test/test-utils/src/packageVersion.ts
+++ b/packages/test/test-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/test-utils";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/test-version-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "End to end tests",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/test/test-version-utils/src/packageVersion.ts
+++ b/packages/test/test-version-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluid-private/test-version-utils";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/test/types_jest-environment-puppeteer/package.json
+++ b/packages/test/types_jest-environment-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@types/jest-environment-puppeteer",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "TypeScript `globals` definitions fix-up for jest-environment-puppeteer",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/changelog-generator-wrapper/package.json
+++ b/packages/tools/changelog-generator-wrapper/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/changelog-generator-wrapper",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/devtools-browser-extension",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "A browser extension for visualizing Fluid Framework stats and operations",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -135,7 +135,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@2.40.0",
+		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/id-compressor": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/devtools-core",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid Framework developer tools core functionality",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/devtools/devtools-core/src/packageVersion.ts
+++ b/packages/tools/devtools/devtools-core/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/devtools-core";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/tools/devtools/devtools-test-app/package.json
+++ b/packages/tools/devtools/devtools-test-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/devtools-test-app",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "An example application demonstrating how Fluid's devtools can be integrated into an application",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/devtools-view",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Contains a visualization suite for use alongside the Fluid Devtools",
 	"homepage": "https://fluidframework.com",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -127,7 +127,7 @@
 		"@fluid-tools/build-cli": "^0.55.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
-		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@2.40.0",
+		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@2.41.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/chai": "^4.0.0",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/devtools",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Fluid Framework developer tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -50,7 +50,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.55.0",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.40.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.41.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/fetch-tool",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Console tool to fetch Fluid data from relay service",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/fluid-runner",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Utility for running various functionality inside a Fluid Framework environment",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.40.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-internal/replay-tool",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "A tool that lets the user to replay ops.",
 	"homepage": "https://fluidframework.com",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.40.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/odsp-doclib-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "ODSP utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/utils/odsp-doclib-utils/src/packageVersion.ts
+++ b/packages/utils/odsp-doclib-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/odsp-doclib-utils";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -130,7 +130,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.40.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^10.0.10",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/telemetry-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Collection of telemetry relates utilities for Fluid",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -114,7 +114,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.55.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.40.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.41.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^10.0.10",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/tool-utils",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"description": "Common utilities for Fluid tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/packages/utils/tool-utils/src/packageVersion.ts
+++ b/packages/utils/tool-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/tool-utils";
-export const pkgVersion = "2.41.0";
+export const pkgVersion = "2.41.1";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@22.10.1)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-service-utils-previous':
-        specifier: npm:@fluidframework/azure-service-utils@2.40.0
-        version: '@fluidframework/azure-service-utils@2.40.0'
+        specifier: npm:@fluidframework/azure-service-utils@2.41.0
+        version: '@fluidframework/azure-service-utils@2.41.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -6700,8 +6700,8 @@ importers:
         specifier: ~1.9.3
         version: 1.9.4
       '@fluid-experimental/attributable-map-previous':
-        specifier: npm:@fluid-experimental/attributable-map@2.40.0
-        version: '@fluid-experimental/attributable-map@2.40.0'
+        specifier: npm:@fluid-experimental/attributable-map@2.41.0
+        version: '@fluid-experimental/attributable-map@2.41.0'
       '@fluid-internal/mocha-test-setup':
         specifier: workspace:~
         version: link:../../../packages/test/mocha-test-setup
@@ -7455,8 +7455,8 @@ importers:
         specifier: ~1.9.3
         version: 1.9.4
       '@fluid-internal/client-utils-previous':
-        specifier: npm:@fluid-internal/client-utils@2.40.0
-        version: '@fluid-internal/client-utils@2.40.0'
+        specifier: npm:@fluid-internal/client-utils@2.41.0
+        version: '@fluid-internal/client-utils@2.41.0'
       '@fluid-internal/mocha-test-setup':
         specifier: workspace:~
         version: link:../../test/mocha-test-setup
@@ -7582,8 +7582,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@22.10.1)
       '@fluidframework/container-definitions-previous':
-        specifier: npm:@fluidframework/container-definitions@2.40.0
-        version: '@fluidframework/container-definitions@2.40.0'
+        specifier: npm:@fluidframework/container-definitions@2.41.0
+        version: '@fluidframework/container-definitions@2.41.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -7624,8 +7624,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)
       '@fluidframework/core-interfaces-previous':
-        specifier: npm:@fluidframework/core-interfaces@2.40.0
-        version: '@fluidframework/core-interfaces@2.40.0'
+        specifier: npm:@fluidframework/core-interfaces@2.41.0
+        version: '@fluidframework/core-interfaces@2.41.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -7690,8 +7690,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)
       '@fluidframework/core-utils-previous':
-        specifier: npm:@fluidframework/core-utils@2.40.0
-        version: '@fluidframework/core-utils@2.40.0'
+        specifier: npm:@fluidframework/core-utils@2.41.0
+        version: '@fluidframework/core-utils@2.41.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -7763,8 +7763,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@22.10.1)
       '@fluidframework/driver-definitions-previous':
-        specifier: npm:@fluidframework/driver-definitions@2.40.0
-        version: '@fluidframework/driver-definitions@2.40.0'
+        specifier: npm:@fluidframework/driver-definitions@2.41.0
+        version: '@fluidframework/driver-definitions@2.41.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -7833,8 +7833,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)
       '@fluidframework/cell-previous':
-        specifier: npm:@fluidframework/cell@2.40.0
-        version: '@fluidframework/cell@2.40.0'
+        specifier: npm:@fluidframework/cell@2.41.0
+        version: '@fluidframework/cell@2.41.0'
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -7927,8 +7927,8 @@ importers:
         specifier: workspace:~
         version: link:../../common/container-definitions
       '@fluidframework/counter-previous':
-        specifier: npm:@fluidframework/counter@2.40.0
-        version: '@fluidframework/counter@2.40.0'
+        specifier: npm:@fluidframework/counter@2.41.0
+        version: '@fluidframework/counter@2.41.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -8236,8 +8236,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/map-previous':
-        specifier: npm:@fluidframework/map@2.40.0
-        version: '@fluidframework/map@2.40.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/map@2.41.0
+        version: '@fluidframework/map@2.41.0(debug@4.4.0)'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8360,8 +8360,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/matrix-previous':
-        specifier: npm:@fluidframework/matrix@2.40.0
-        version: '@fluidframework/matrix@2.40.0'
+        specifier: npm:@fluidframework/matrix@2.41.0
+        version: '@fluidframework/matrix@2.41.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8481,8 +8481,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/merge-tree-previous':
-        specifier: npm:@fluidframework/merge-tree@2.40.0
-        version: '@fluidframework/merge-tree@2.40.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/merge-tree@2.41.0
+        version: '@fluidframework/merge-tree@2.41.0(debug@4.4.0)'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8587,8 +8587,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/ordered-collection-previous':
-        specifier: npm:@fluidframework/ordered-collection@2.40.0
-        version: '@fluidframework/ordered-collection@2.40.0'
+        specifier: npm:@fluidframework/ordered-collection@2.41.0
+        version: '@fluidframework/ordered-collection@2.41.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8775,8 +8775,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/register-collection-previous':
-        specifier: npm:@fluidframework/register-collection@2.40.0
-        version: '@fluidframework/register-collection@2.40.0'
+        specifier: npm:@fluidframework/register-collection@2.41.0
+        version: '@fluidframework/register-collection@2.41.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8890,8 +8890,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/sequence-previous':
-        specifier: npm:@fluidframework/sequence@2.40.0
-        version: '@fluidframework/sequence@2.40.0'
+        specifier: npm:@fluidframework/sequence@2.41.0
+        version: '@fluidframework/sequence@2.41.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9011,8 +9011,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/shared-object-base-previous':
-        specifier: npm:@fluidframework/shared-object-base@2.40.0
-        version: '@fluidframework/shared-object-base@2.40.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/shared-object-base@2.41.0
+        version: '@fluidframework/shared-object-base@2.41.0(debug@4.4.0)'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9117,8 +9117,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/shared-summary-block-previous':
-        specifier: npm:@fluidframework/shared-summary-block@2.40.0
-        version: '@fluidframework/shared-summary-block@2.40.0'
+        specifier: npm:@fluidframework/shared-summary-block@2.41.0
+        version: '@fluidframework/shared-summary-block@2.41.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9226,8 +9226,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/task-manager-previous':
-        specifier: npm:@fluidframework/task-manager@2.40.0
-        version: '@fluidframework/task-manager@2.40.0'
+        specifier: npm:@fluidframework/task-manager@2.41.0
+        version: '@fluidframework/task-manager@2.41.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9468,8 +9468,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tree-previous':
-        specifier: npm:@fluidframework/tree@2.40.0
-        version: '@fluidframework/tree@2.40.0'
+        specifier: npm:@fluidframework/tree@2.41.0
+        version: '@fluidframework/tree@2.41.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9568,8 +9568,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)
       '@fluidframework/debugger-previous':
-        specifier: npm:@fluidframework/debugger@2.40.0
-        version: '@fluidframework/debugger@2.40.0'
+        specifier: npm:@fluidframework/debugger@2.41.0
+        version: '@fluidframework/debugger@2.41.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -9635,8 +9635,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)
       '@fluidframework/driver-base-previous':
-        specifier: npm:@fluidframework/driver-base@2.40.0
-        version: '@fluidframework/driver-base@2.40.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/driver-base@2.41.0
+        version: '@fluidframework/driver-base@2.41.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -9714,8 +9714,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)
       '@fluidframework/driver-web-cache-previous':
-        specifier: npm:@fluidframework/driver-web-cache@2.40.0
-        version: '@fluidframework/driver-web-cache@2.40.0'
+        specifier: npm:@fluidframework/driver-web-cache@2.41.0
+        version: '@fluidframework/driver-web-cache@2.41.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -9790,8 +9790,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/file-driver-previous':
-        specifier: npm:@fluidframework/file-driver@2.40.0
-        version: '@fluidframework/file-driver@2.40.0'
+        specifier: npm:@fluidframework/file-driver@2.41.0
+        version: '@fluidframework/file-driver@2.41.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9884,8 +9884,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/local-driver-previous':
-        specifier: npm:@fluidframework/local-driver@2.40.0
-        version: '@fluidframework/local-driver@2.40.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/local-driver@2.41.0
+        version: '@fluidframework/local-driver@2.41.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9990,8 +9990,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-driver-previous':
-        specifier: npm:@fluidframework/odsp-driver@2.40.0
-        version: '@fluidframework/odsp-driver@2.40.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-driver@2.41.0
+        version: '@fluidframework/odsp-driver@2.41.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10063,8 +10063,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-driver-definitions-previous':
-        specifier: npm:@fluidframework/odsp-driver-definitions@2.40.0
-        version: '@fluidframework/odsp-driver-definitions@2.40.0'
+        specifier: npm:@fluidframework/odsp-driver-definitions@2.41.0
+        version: '@fluidframework/odsp-driver-definitions@2.41.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@22.10.1)
@@ -10130,8 +10130,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-urlresolver-previous':
-        specifier: npm:@fluidframework/odsp-urlresolver@2.40.0
-        version: '@fluidframework/odsp-urlresolver@2.40.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-urlresolver@2.41.0
+        version: '@fluidframework/odsp-urlresolver@2.41.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10206,8 +10206,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/replay-driver-previous':
-        specifier: npm:@fluidframework/replay-driver@2.40.0
-        version: '@fluidframework/replay-driver@2.40.0'
+        specifier: npm:@fluidframework/replay-driver@2.41.0
+        version: '@fluidframework/replay-driver@2.41.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10297,8 +10297,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/routerlicious-driver-previous':
-        specifier: npm:@fluidframework/routerlicious-driver@2.40.0
-        version: '@fluidframework/routerlicious-driver@2.40.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/routerlicious-driver@2.41.0
+        version: '@fluidframework/routerlicious-driver@2.41.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10391,8 +10391,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/routerlicious-urlresolver-previous':
-        specifier: npm:@fluidframework/routerlicious-urlresolver@2.40.0
-        version: '@fluidframework/routerlicious-urlresolver@2.40.0'
+        specifier: npm:@fluidframework/routerlicious-urlresolver@2.41.0
+        version: '@fluidframework/routerlicious-urlresolver@2.41.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10476,8 +10476,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/tinylicious-driver-previous':
-        specifier: npm:@fluidframework/tinylicious-driver@2.40.0
-        version: '@fluidframework/tinylicious-driver@2.40.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tinylicious-driver@2.41.0
+        version: '@fluidframework/tinylicious-driver@2.41.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10564,8 +10564,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/agent-scheduler-previous':
-        specifier: npm:@fluidframework/agent-scheduler@2.40.0
-        version: '@fluidframework/agent-scheduler@2.40.0'
+        specifier: npm:@fluidframework/agent-scheduler@2.41.0
+        version: '@fluidframework/agent-scheduler@2.41.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10764,8 +10764,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/aqueduct-previous':
-        specifier: npm:@fluidframework/aqueduct@2.40.0
-        version: '@fluidframework/aqueduct@2.40.0'
+        specifier: npm:@fluidframework/aqueduct@2.41.0
+        version: '@fluidframework/aqueduct@2.41.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10949,8 +10949,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/app-insights-logger-previous':
-        specifier: npm:@fluidframework/app-insights-logger@2.40.0
-        version: '@fluidframework/app-insights-logger@2.40.0(tslib@1.14.1)'
+        specifier: npm:@fluidframework/app-insights-logger@2.41.0
+        version: '@fluidframework/app-insights-logger@2.41.0(tslib@1.14.1)'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -11416,8 +11416,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/fluid-static-previous':
-        specifier: npm:@fluidframework/fluid-static@2.40.0
-        version: '@fluidframework/fluid-static@2.40.0'
+        specifier: npm:@fluidframework/fluid-static@2.41.0
+        version: '@fluidframework/fluid-static@2.41.0'
       '@fluidframework/map':
         specifier: workspace:~
         version: link:../../dds/map
@@ -11677,8 +11677,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/request-handler-previous':
-        specifier: npm:@fluidframework/request-handler@2.40.0
-        version: '@fluidframework/request-handler@2.40.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/request-handler@2.41.0
+        version: '@fluidframework/request-handler@2.41.0(debug@4.4.0)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -11759,8 +11759,8 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/runtime-utils
       '@fluidframework/synthesize-previous':
-        specifier: npm:@fluidframework/synthesize@2.40.0
-        version: '@fluidframework/synthesize@2.40.0'
+        specifier: npm:@fluidframework/synthesize@2.41.0
+        version: '@fluidframework/synthesize@2.41.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -11841,8 +11841,8 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
       '@fluidframework/undo-redo-previous':
-        specifier: npm:@fluidframework/undo-redo@2.40.0
-        version: '@fluidframework/undo-redo@2.40.0'
+        specifier: npm:@fluidframework/undo-redo@2.41.0
+        version: '@fluidframework/undo-redo@2.41.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -11950,8 +11950,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)
       '@fluidframework/container-loader-previous':
-        specifier: npm:@fluidframework/container-loader@2.40.0
-        version: '@fluidframework/container-loader@2.40.0'
+        specifier: npm:@fluidframework/container-loader@2.41.0
+        version: '@fluidframework/container-loader@2.41.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -12056,8 +12056,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)
       '@fluidframework/driver-utils-previous':
-        specifier: npm:@fluidframework/driver-utils@2.40.0
-        version: '@fluidframework/driver-utils@2.40.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/driver-utils@2.41.0
+        version: '@fluidframework/driver-utils@2.41.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -12241,8 +12241,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)
       '@fluidframework/container-runtime-previous':
-        specifier: npm:@fluidframework/container-runtime@2.40.0
-        version: '@fluidframework/container-runtime@2.40.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/container-runtime@2.41.0
+        version: '@fluidframework/container-runtime@2.41.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -12332,8 +12332,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@22.10.1)
       '@fluidframework/container-runtime-definitions-previous':
-        specifier: npm:@fluidframework/container-runtime-definitions@2.40.0
-        version: '@fluidframework/container-runtime-definitions@2.40.0'
+        specifier: npm:@fluidframework/container-runtime-definitions@2.41.0
+        version: '@fluidframework/container-runtime-definitions@2.41.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -12414,8 +12414,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)
       '@fluidframework/datastore-previous':
-        specifier: npm:@fluidframework/datastore@2.40.0
-        version: '@fluidframework/datastore@2.40.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/datastore@2.41.0
+        version: '@fluidframework/datastore@2.41.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -12505,8 +12505,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@22.10.1)
       '@fluidframework/datastore-definitions-previous':
-        specifier: npm:@fluidframework/datastore-definitions@2.40.0
-        version: '@fluidframework/datastore-definitions@2.40.0'
+        specifier: npm:@fluidframework/datastore-definitions@2.41.0
+        version: '@fluidframework/datastore-definitions@2.41.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -12578,8 +12578,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/id-compressor-previous':
-        specifier: npm:@fluidframework/id-compressor@2.40.0
-        version: '@fluidframework/id-compressor@2.40.0'
+        specifier: npm:@fluidframework/id-compressor@2.41.0
+        version: '@fluidframework/id-compressor@2.41.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -12657,8 +12657,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/runtime-definitions-previous':
-        specifier: npm:@fluidframework/runtime-definitions@2.40.0
-        version: '@fluidframework/runtime-definitions@2.40.0'
+        specifier: npm:@fluidframework/runtime-definitions@2.41.0
+        version: '@fluidframework/runtime-definitions@2.41.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@22.10.1)
@@ -12733,8 +12733,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/runtime-utils-previous':
-        specifier: npm:@fluidframework/runtime-utils@2.40.0
-        version: '@fluidframework/runtime-utils@2.40.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/runtime-utils@2.41.0
+        version: '@fluidframework/runtime-utils@2.41.0(debug@4.4.0)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -12848,8 +12848,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils-previous':
-        specifier: npm:@fluidframework/test-runtime-utils@2.40.0
-        version: '@fluidframework/test-runtime-utils@2.40.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/test-runtime-utils@2.41.0
+        version: '@fluidframework/test-runtime-utils@2.41.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -12930,8 +12930,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-client-previous':
-        specifier: npm:@fluidframework/azure-client@2.40.0
-        version: '@fluidframework/azure-client@2.40.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/azure-client@2.41.0
+        version: '@fluidframework/azure-client@2.41.0(encoding@0.1.13)'
       '@fluidframework/azure-local-service':
         specifier: workspace:~
         version: link:../../../azure/packages/azure-local-service
@@ -13417,8 +13417,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tinylicious-client-previous':
-        specifier: npm:@fluidframework/tinylicious-client@2.40.0
-        version: '@fluidframework/tinylicious-client@2.40.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tinylicious-client@2.41.0
+        version: '@fluidframework/tinylicious-client@2.41.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -14735,8 +14735,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/test-utils-previous':
-        specifier: npm:@fluidframework/test-utils@2.40.0
-        version: '@fluidframework/test-utils@2.40.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/test-utils@2.41.0
+        version: '@fluidframework/test-utils@2.41.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -15044,8 +15044,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@22.10.1)
       '@fluidframework/devtools-previous':
-        specifier: npm:@fluidframework/devtools@2.40.0
-        version: '@fluidframework/devtools@2.40.0'
+        specifier: npm:@fluidframework/devtools@2.41.0
+        version: '@fluidframework/devtools@2.41.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -15367,8 +15367,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@22.10.1)
       '@fluidframework/devtools-core-previous':
-        specifier: npm:@fluidframework/devtools-core@2.40.0
-        version: '@fluidframework/devtools-core@2.40.0'
+        specifier: npm:@fluidframework/devtools-core@2.41.0
+        version: '@fluidframework/devtools-core@2.41.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -15865,8 +15865,8 @@ importers:
         specifier: ^0.55.0
         version: 0.55.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluid-tools/fetch-tool-previous':
-        specifier: npm:@fluid-tools/fetch-tool@2.40.0
-        version: '@fluid-tools/fetch-tool@2.40.0(encoding@0.1.13)'
+        specifier: npm:@fluid-tools/fetch-tool@2.41.0
+        version: '@fluid-tools/fetch-tool@2.41.0(encoding@0.1.13)'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -15947,8 +15947,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/fluid-runner-previous':
-        specifier: npm:@fluidframework/fluid-runner@2.40.0
-        version: '@fluidframework/fluid-runner@2.40.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/fluid-runner@2.41.0
+        version: '@fluidframework/fluid-runner@2.41.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -16159,8 +16159,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-doclib-utils-previous':
-        specifier: npm:@fluidframework/odsp-doclib-utils@2.40.0
-        version: '@fluidframework/odsp-doclib-utils@2.40.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-doclib-utils@2.41.0
+        version: '@fluidframework/odsp-doclib-utils@2.41.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -16241,8 +16241,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/telemetry-utils-previous':
-        specifier: npm:@fluidframework/telemetry-utils@2.40.0
-        version: '@fluidframework/telemetry-utils@2.40.0'
+        specifier: npm:@fluidframework/telemetry-utils@2.41.0
+        version: '@fluidframework/telemetry-utils@2.41.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -16341,8 +16341,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/tool-utils-previous':
-        specifier: npm:@fluidframework/tool-utils@2.40.0
-        version: '@fluidframework/tool-utils@2.40.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tool-utils@2.41.0
+        version: '@fluidframework/tool-utils@2.41.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -17461,17 +17461,17 @@ packages:
       '@types/react': '>=16.8.0 <19.0.0'
       react: '>=16.8.0 <19.0.0'
 
-  '@fluid-experimental/attributable-map@2.40.0':
-    resolution: {integrity: sha512-8DA20E+n5G2YBpyfFjUB3bDUUmYa1f3476fzxMsENanVXZrxSbUS6J+bdROCD4pVlw5ISUjLc3dnH99ykoz33Q==}
+  '@fluid-experimental/attributable-map@2.41.0':
+    resolution: {integrity: sha512-i0VY9l7T0bz7bJEewIn4Kp67EbOyJYpbEaHhaqnQwXrxCbBeZPk8zZf1Bgw578iIz7ZqujBVOuxjhYzWaAE+mA==}
 
-  '@fluid-internal/client-utils@2.40.0':
-    resolution: {integrity: sha512-ccV+GXpPncc5Ms62uPODyeGCPT8YZwa/Gp/6kHyNeUXGozuwIajCU7cz4iy/3m/132TOm6o3LR3fHmtOcVjHFA==}
+  '@fluid-internal/client-utils@2.41.0':
+    resolution: {integrity: sha512-t9G6rdiElTKg1J88IIvF3yeTzMFv2DH7RT3QZQcXtREy+NiDsApcasgdJRBuX7VtRvx/T7knMOlxyptIfUL9pw==}
 
   '@fluid-internal/eslint-plugin-fluid@0.1.5':
     resolution: {integrity: sha512-p0nVeMiEfLL2deQJQaRUxid08jgV5wEkh9h9WXNosR1BRq9nFCjD8nZpC1K+YhjwQZEvgGDE+s+28VR2lAg61Q==}
 
-  '@fluid-internal/test-driver-definitions@2.40.0':
-    resolution: {integrity: sha512-B1J/aAgUcptpSd+mszVSlo9CAiwxH4aIXCusOQD7f9mSQ8vWjO3HZUXI27ic04niN8b1996WE9nYZJo2/TdRiA==}
+  '@fluid-internal/test-driver-definitions@2.41.0':
+    resolution: {integrity: sha512-P60xMVK8ySXXEaf+hNdBShYj7CItISKhWdroRhNSK3wSJHrGYlJLiv0I7j0hojgVtNLyJERh5D3yBwePKx5CEw==}
 
   '@fluid-tools/benchmark@0.51.0':
     resolution: {integrity: sha512-Hych9VQu9RrBlYwBHvb2J20GHIs8abpzx1TgypHHIsYDxqK7IVrQ/NRYTE+e8XvXwVHbiuBWQrtpK9oB9bGm2Q==}
@@ -17485,8 +17485,8 @@ packages:
     resolution: {integrity: sha512-uctF9nN8yQqpizqj4ZEjT7Qet2YFMHzpdDFXrS8Dl4turfLPoiMhD+1sFGhE2tsvdx25QcBYe45u7IAsefCFiA==}
     hasBin: true
 
-  '@fluid-tools/fetch-tool@2.40.0':
-    resolution: {integrity: sha512-qAEba+xTqUSbuKKe7ff3UhPbcNPqWl2W+SvA/D9dXh0uMclWdpRpQAgBZZ3RBGSKRfDwffVPmktfGsKGBJ8rLg==}
+  '@fluid-tools/fetch-tool@2.41.0':
+    resolution: {integrity: sha512-dkdXRSuJUuOlrWQvYRHzrbXURagwCzPglsgptn6IMIG/UPa0s81ki18SUysiogWFqJgR08wtxLbMT9g3S/XtnA==}
     hasBin: true
 
   '@fluid-tools/version-tools@0.55.0':
@@ -17494,26 +17494,26 @@ packages:
     engines: {node: '>=20.15.1'}
     hasBin: true
 
-  '@fluidframework/agent-scheduler@2.40.0':
-    resolution: {integrity: sha512-UBWqtL5rfOXV7wER0Lxm3HiV3CnKfLEOaVHKwGM04bnAG8rLbSW4OvF0Amd5EBK8lhYTVenzMjcCejpCMA0OxQ==}
+  '@fluidframework/agent-scheduler@2.41.0':
+    resolution: {integrity: sha512-WXPv2yD32xftibneFzVIo1/mJbscyPJjnKTEOsczZmL2jezHyjt84aeeH2GfnbUVIafnIs8T919LVQnRLUF3qA==}
 
-  '@fluidframework/app-insights-logger@2.40.0':
-    resolution: {integrity: sha512-gh5LYrH4saDdmo3BI4u2amKMwCJFYGdpLxurD0nIpzYibuxyr9zJbOevMCEO/TYK691sybqGk40M71zff5c66Q==}
+  '@fluidframework/app-insights-logger@2.41.0':
+    resolution: {integrity: sha512-LJnTZt5jvKtdlss+zIcMYvOdlg81T0EhI5hL5wVoardQ+cY4/J5rC6KA6jAvhYYkfFnFtmIF+dTFPaVQW4OaWA==}
 
   '@fluidframework/aqueduct@1.4.0':
     resolution: {integrity: sha512-b3I3fWGAWuXQbyuEFeeEi3GVVUOYPWJfFaB4httsu5Jn4C0QSkKxftkielDlor9/7rCJYjHc4IEWViaVO+kBbA==}
 
-  '@fluidframework/aqueduct@2.40.0':
-    resolution: {integrity: sha512-Vuc/5j8NdZeStM7txX8/x5JMH2KGd1ARpqu8y3Bnvqi9BLoM8PosbEx8JPZx5QK9II0PGbc9WGYgyDTO/y+zOQ==}
+  '@fluidframework/aqueduct@2.41.0':
+    resolution: {integrity: sha512-TK1SeTiPiV5HRQjQpeR2fAjI9m0dAyGQoJXDu/bZ4sAd7bYASf2cBttLMpH/rwEKEq63iLiBGx/XvhALdMm8Fg==}
 
   '@fluidframework/azure-client@1.2.0':
     resolution: {integrity: sha512-jpfYF6I1uwwCqOc8X0fOgZz4Lj91QFzKV4S9lM7jSW84GxytlL3nDanj9+EYC+vLn4liRVaOCA3zRwpkDNXRWg==}
 
-  '@fluidframework/azure-client@2.40.0':
-    resolution: {integrity: sha512-aHK7JL4Y788Fa9k+0B6Qphw/Ypy+Dbsgxt77xTFopOPauibXaKgt2v1GcCifnnTKFzTOBE5zjW+8KR/NzvrIgw==}
+  '@fluidframework/azure-client@2.41.0':
+    resolution: {integrity: sha512-GDCzaigLu015piNhrGOHO7AKRmC6aflKrvXcLaz9R0VXjCIj4R3gidwHXFQyjjvfnQFpmmw+qIiFHAGF+nm62g==}
 
-  '@fluidframework/azure-service-utils@2.40.0':
-    resolution: {integrity: sha512-bPjQzDLRqBL2i34wtNZy5gTXWt0NN4F8reWONO9pbaUnMv/mlTwGl0czZje2qDh82/AhoiZgB6HZA044fCcu9A==}
+  '@fluidframework/azure-service-utils@2.41.0':
+    resolution: {integrity: sha512-9++RxkTOgnR3Pq6OsjT2B3GSXvO0fRew/YPjToYeEz+PqhrwdPKHRGZFrlTvya26G7PViOYwD/96ixQpf1Mwug==}
 
   '@fluidframework/build-common@2.0.3':
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
@@ -17527,8 +17527,8 @@ packages:
   '@fluidframework/bundle-size-tools@0.55.0':
     resolution: {integrity: sha512-1j2p1VDFjgRYFNkJRVQI82xTtyA3G3Q6JEp7ohraQknq116TB0FAfIKCADEcvaFawd9oeXcTsnFif9S3gChU1Q==}
 
-  '@fluidframework/cell@2.40.0':
-    resolution: {integrity: sha512-6ZA1LPrrTFkaBMHf0GdLqwrZqy3kTDkdBsFqQsTa4i5XNoPS05qoZ5Ka5inAVesSiUPtqwxMH5BMjOdCxicA3w==}
+  '@fluidframework/cell@2.41.0':
+    resolution: {integrity: sha512-wD8YQKFaHAQTLvh6yPbF7ecSc9D6LDPw2goUh/2sofcUebmZHk/y0/7V82Fuch9dUx2Op6N6Hxoy1bXpElQotQ==}
 
   '@fluidframework/common-definitions@0.20.1':
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
@@ -17548,26 +17548,26 @@ packages:
   '@fluidframework/container-definitions@1.4.0':
     resolution: {integrity: sha512-UwyxdX739ltQhQ9Zr2n7mBKN2eYEVnY7GCsV60ZfLUawb021eeL0rVZZgT0t3BiTCCilBMl4Bw4KQ8XyYu2g/w==}
 
-  '@fluidframework/container-definitions@2.40.0':
-    resolution: {integrity: sha512-iD46JuBKZqeSeUQcmKzXaJ8GuPnsBOmkXmZNKQFnVk2dzuktjhWGQ1rxu72EZMfFMTJj7QOsuMVc+Z578lALuw==}
+  '@fluidframework/container-definitions@2.41.0':
+    resolution: {integrity: sha512-kyfInxrGm6Aor6g/+Nw3t+EeJyxjmYCtNq4Kl+KfNQ0wvbtfcHM8BRSd6tEJYPzElBhwQk7UpzfVQDPD2h+Hkg==}
 
   '@fluidframework/container-loader@1.4.0':
     resolution: {integrity: sha512-D54tW/W5EXLb2nRUGCNd8bID9t9KVkQJmtnHfnQ/JggpaBWODaQRp2tCDtidwo8y6bkiqIheMGjIdjgP9SqJzw==}
 
-  '@fluidframework/container-loader@2.40.0':
-    resolution: {integrity: sha512-jygQ6i7s+M5C4QrGH+HAYNo7rZ7FYvtFAwGvJFHyK1GGcfdn1dk2NztbxFXw4W6hWcGeOcFJZwjHS29KUKOV5w==}
+  '@fluidframework/container-loader@2.41.0':
+    resolution: {integrity: sha512-hjA3SPdWF4TjtJvXejCOSq223syfSptrUlrhXzcZZ+nOPvfVG8/21m6eBzRpqiHiMW2gk/UHi86REY0Ympaijg==}
 
   '@fluidframework/container-runtime-definitions@1.4.0':
     resolution: {integrity: sha512-0rlswYsMVQiD1/btlJ5Ebf3rfTyFd06E2/zRJiKWiaMzgmn9QqF7OoVtiJfAIUsyey+dR8hnI0IFlB1IMfIPOg==}
 
-  '@fluidframework/container-runtime-definitions@2.40.0':
-    resolution: {integrity: sha512-OTyKrUITzBe2ANBBPp0uWvQrrLbfhoIq1Kt22ZIVRgzQAS6D2y5skC9kp7Nvk3d7tGRtFUkc1T3qnuaz19sR7w==}
+  '@fluidframework/container-runtime-definitions@2.41.0':
+    resolution: {integrity: sha512-EohcK3kgwMoWqBPf9PEjbh7U866lWR2Q+hdzYhdKyOCcmrJQFndqkNlZy0dgXLASbX46mwsWiVQSpY2T+qvPZg==}
 
   '@fluidframework/container-runtime@1.4.0':
     resolution: {integrity: sha512-KENgBxuPD7GdNmdjmsyVJpPKZwfXoRlzAxaMNhGdMSbi6oXDrd1LSekY5tchhsLWBpB5ucZpuvmSgbU+h9z3HQ==}
 
-  '@fluidframework/container-runtime@2.40.0':
-    resolution: {integrity: sha512-a13g/6NnHjmeiZASen8toBBXULa/OK25kvCP3qVnP1hAf046w85ghbNcDm4HbqLkLeDyyPazgphRx9BTp/fx7A==}
+  '@fluidframework/container-runtime@2.41.0':
+    resolution: {integrity: sha512-U+vQbkll59M+rU1JCBAo90JF9yHnIymbRq5M50lqasMmBoePJPPvcEVNV1ONJE/g9N6ose8GhkumlQDHHZHnuA==}
 
   '@fluidframework/container-utils@1.4.0':
     resolution: {integrity: sha512-OKYpvuzz5N62gQn8JELMyuKEwJAlToiLNWJP/dn/PS1HCKux5C/Mg7Twdi19DCgXP/hp5qvzAd+EHPqYWxMUGg==}
@@ -17575,72 +17575,72 @@ packages:
   '@fluidframework/core-interfaces@1.4.0':
     resolution: {integrity: sha512-PDIglmsa9BgFh7Xhfs32KA3Q34/arTVHF4m3M0IuAByP4z8Oi2lVuNENZnBEk+IJMcrUhUDk5Q9LH8KGfoAw+Q==}
 
-  '@fluidframework/core-interfaces@2.40.0':
-    resolution: {integrity: sha512-735WxXYQEVe2ZPvQW1BrgAb60Mf4ufVCMMFTnphToE1YTaYA37KI+RjUqpnv6tTSwB5FDkZmPr4kJzi0Gbog2g==}
+  '@fluidframework/core-interfaces@2.41.0':
+    resolution: {integrity: sha512-DHX+aUJ0wraPZ6N4eTbPAQ7OrfaJFb0zBLnDAJpp+o8kZugS8iCVVp/rNlylE5A1g0usFMCjT6FafMhOoL9yzw==}
 
-  '@fluidframework/core-utils@2.40.0':
-    resolution: {integrity: sha512-JbQ89gtOarR80fOlYlebewsUZ0deGdmelfqsuCOQLSmwvcODlpMPuP3AbvJDKMaFapxrIw8svBpPu0YD4Hs9SA==}
+  '@fluidframework/core-utils@2.41.0':
+    resolution: {integrity: sha512-olPPOcmMdYClQAYIyeeTUmoUPreryR138JNCRrl8poQ69RhL3PkKJgOavxlLykS1oofvG4y43jrbttKhjJgbIg==}
 
-  '@fluidframework/counter@2.40.0':
-    resolution: {integrity: sha512-OF2cuc5uf3YbUCk/B+79rzyZylmTHfSgfyukiZEiIIw3SM474+UGUNzHZ1s8DyY7lQbqGIXGrXtDxwSIFVJB0A==}
+  '@fluidframework/counter@2.41.0':
+    resolution: {integrity: sha512-PE8VlK5NEYS5moEIsbQ3Fr4ANps3SuSQfZNbRu18+vsZe4ebpAhbagde/Sp4VbOx15x6gvGbuvEmAXi8PN18rw==}
 
   '@fluidframework/datastore-definitions@1.4.0':
     resolution: {integrity: sha512-Xmebp+XFyK2K8EIauQx10UdwOXYskuSyQt8pSZ6ggTMMFpUsnx44tSR8I8KacSFoYkrWzG/G64osRu23SPCcjQ==}
 
-  '@fluidframework/datastore-definitions@2.40.0':
-    resolution: {integrity: sha512-jV/BY2ur2P4h5uPEzSrAgXBownJmCixPDi7/4L1JH/HIFPUYAsXkgB1Sjf/d0EMg4aILCkjrRvwrrC2TJ1I9HA==}
+  '@fluidframework/datastore-definitions@2.41.0':
+    resolution: {integrity: sha512-hI2ciL71Ff2KD3oAvF0zldJppdfuj3uxTtlKGgVY5w+XeAklnuAhGRbJzgImmwe4dn1QqhL8VBUrm0xhSJHuKA==}
 
   '@fluidframework/datastore@1.4.0':
     resolution: {integrity: sha512-xV8cfmNzGAcpbQMrtEXTe7N6h6IkybrStrguyhZB6zBFzaPw3RNeAsMTiSxEMeVkU4UFcnI/ZU2rMalzVVC3Tg==}
 
-  '@fluidframework/datastore@2.40.0':
-    resolution: {integrity: sha512-9T7bYR8VyXYUPj87B0/65aomqWw/wmJeSGAa3z6bNHzKTm9qoZx9/L0JfevDGjfahtR5+2PYXwoMtTMGJnWADw==}
+  '@fluidframework/datastore@2.41.0':
+    resolution: {integrity: sha512-0P+QeuZGZZWlJxBAPrecB4C4yzeZjXpzUKL1iM0U2GEueOBV6EUowHxQnZEPiL8vIT5LUz7oEWuJqoVl8BIMBA==}
 
-  '@fluidframework/debugger@2.40.0':
-    resolution: {integrity: sha512-m8LyZ69e91JPOnhCSG4b61SLMYLheJIZv+Ap4SVySgzo8prh685jsPSi6Fd1EYGu5eZ3o0c31meLbnjVS3MpHQ==}
+  '@fluidframework/debugger@2.41.0':
+    resolution: {integrity: sha512-zhqaTwgH0dIXJnVGw/BlziqgNHy4D/uHgH0EyW1I46f4YQXgL2pAy+sDqzkR1OLZzmdpefg7fF7ZGpXUhAPaDg==}
 
-  '@fluidframework/devtools-core@2.40.0':
-    resolution: {integrity: sha512-5PGgha5+YV9IL5APVlO4wg0swnOs0jhiVk3NWoeRAqBjDJY2FTBs69v6xKmPMIbafNZv2wFpHg9y7BZt4XiQpw==}
+  '@fluidframework/devtools-core@2.41.0':
+    resolution: {integrity: sha512-E52VKRGhqRquSO+j3SpLf54TwhP1ikwNnCXPN1DgLsADtcmhJelGF7p+kycu+r1ZR8EmjJYFiHOvhs0DszdksQ==}
 
-  '@fluidframework/devtools@2.40.0':
-    resolution: {integrity: sha512-n70v7kCe/X9cLjn10xmlDegyH7+HjnUjjE5uj/21I43JcgVdbBz2OgiGLEuxCr+eQSGPkyK4t/vEJrQH5okjnA==}
+  '@fluidframework/devtools@2.41.0':
+    resolution: {integrity: sha512-0BNeSA8NPQPwk1LCTbnDu8HkNRGYsHMZ2gPKsYYZw/jwvyLuifHBfmxSQ1iXzo2NXiVpObsG5QfH3MtS0HQq4g==}
 
   '@fluidframework/driver-base@1.4.0':
     resolution: {integrity: sha512-w3fYGp1Bkdjp9he3W3dSPQb1vU+zsRIcZZV9wGNfPA1ii7z9rnXzSgscn39IdLbZqvS2704endNwOIYHyBT34g==}
 
-  '@fluidframework/driver-base@2.40.0':
-    resolution: {integrity: sha512-6+YKDg8nsxu70WiHQw3AqbIYp/YkauVEmfEc057OHPHxD6anrUbgRzbIEs8Mzi2Sy+mL7A/fyqqZNwaBZUpTfA==}
+  '@fluidframework/driver-base@2.41.0':
+    resolution: {integrity: sha512-rnkytRzS9xs+zniXjtdDxW0nsMB+FwypyadEbW6rrX1m8zx8SK+l+S7Mzvyen+5WcS4frv25tpar9jUhu2z5cw==}
 
   '@fluidframework/driver-definitions@1.4.0':
     resolution: {integrity: sha512-ay6Wwl8zGS64fjDsdh2iOeKiVVxT57Opeqjp6DqSglnnJi6AkSfYVoOVlMZ5+vJTfYJN3N4ptjrP/i3Mao9zPA==}
 
-  '@fluidframework/driver-definitions@2.40.0':
-    resolution: {integrity: sha512-6OKKPEwiTA7+pS2gl81CEhIRRRPj9swkKRXunA5qolEOKiNJNl5boud4naSMu3BDQfndmifKbzFB5yIILhyPBw==}
+  '@fluidframework/driver-definitions@2.41.0':
+    resolution: {integrity: sha512-+DvwFRLDrtnDivPLWn1V+mAQyLWtnY0dEklI8USan8TtYtdma9cZ/Vp3yBFWxJ3FvRRgzuNmWraueNL3kkQ50g==}
 
   '@fluidframework/driver-utils@1.4.0':
     resolution: {integrity: sha512-NPTFw54a+EnIzop7iwrHTONdt0UAjW59HhMlYVPMH8/aOBodddHl7oi2Ek96nZLc+6qruHImjJ+0OW+NxNS+Gw==}
 
-  '@fluidframework/driver-utils@2.40.0':
-    resolution: {integrity: sha512-dq+dXBwZcnJdtV1iV24/MqtmT1ng10XSRj/NeEARguWCOxeW7bkIgFCQZhhsiPWp0O8YGdgyjDH9CqGhkPvsbg==}
+  '@fluidframework/driver-utils@2.41.0':
+    resolution: {integrity: sha512-cfLY09fNIVWbeAmPyGNZrLIR2EFGuLT64sLFnOEt8GBeZoGAvHqMvOuenrpiuKIjmqdqdbg0BYZrkdgESnYX8w==}
 
-  '@fluidframework/driver-web-cache@2.40.0':
-    resolution: {integrity: sha512-tncnY/iFQgW+bFsf8QeQgyhLYZwWJrW8e+lEqljANtxTBVcFgFhkou6lgFTHjifQ/wq8agYWCxCaBQ4D9Pfwyw==}
+  '@fluidframework/driver-web-cache@2.41.0':
+    resolution: {integrity: sha512-93v7dEaUmisV/z7EpI8ia0Yp/QVyAloxYkj+Hp5svrFwetJ1Z4cYDfTLzjHLPW0eJSAQASykEOpirbNlUMp5Iw==}
 
   '@fluidframework/eslint-config-fluid@5.7.4':
     resolution: {integrity: sha512-2JD0fKhR0wk8kWkUmjNY6FcavLxs0/oQ413z0gFHUSzd8UTkwTYumFQWpDBEoAvXqQw4nUOTAbicNIqHY25EyQ==}
 
-  '@fluidframework/file-driver@2.40.0':
-    resolution: {integrity: sha512-2xnmddHJhfCPHhYjsBbQ11rBlOAS9c5XndF2s6d4Ob+Ps9Mh8FNPIUNqC6+R5pYT0vX9Z6NKb3vgfoFPLpn57A==}
+  '@fluidframework/file-driver@2.41.0':
+    resolution: {integrity: sha512-YpoyED2N/+EDhIO+7L1PSA4DUsMSuUMNJRGQxyp1J3pL9pRbMpyaMBpRTR1HpiYv2rQbgqydbZJNf0XBgj3vzw==}
 
-  '@fluidframework/fluid-runner@2.40.0':
-    resolution: {integrity: sha512-feJc9n00d8ktuzL4KxArNukSUI7OgK2EI3cKnDimS1aXCP690saIEXFwGxJvKDOCFRbDCV461wbio5iae/deRQ==}
+  '@fluidframework/fluid-runner@2.41.0':
+    resolution: {integrity: sha512-s46UuDDWxrJbyG687rXqJVrSagM7KHSYQNvJp/ZdwD2w5GpSyP7eB5fPWS1gOFxzA/0knBPFFGOIe/zAz+6Dsg==}
     hasBin: true
 
   '@fluidframework/fluid-static@1.4.0':
     resolution: {integrity: sha512-YlSX6Ibm3HquB+swxoIJt6QM1Bd6R9rBHp/HYDR9/9JuQwCIqW1xvF2NHmXPN/TGl51DnbhSB0gtm9k6pYd7pg==}
 
-  '@fluidframework/fluid-static@2.40.0':
-    resolution: {integrity: sha512-CmCB/8Xar0/QWe5O9QAKhdkoDX1LHJiTxjoU1ZaRDpJkauRSrwdzLwDtllUFtmPjJ1Y11fcfwo61VB8GfQWTHA==}
+  '@fluidframework/fluid-static@2.41.0':
+    resolution: {integrity: sha512-RbjrHzsnmqUL87n3ogOJXZTEWMn78DIAJWMi8sy8ueWcCFy/bHeKtm43D01R1aMXHElC69pGEWuNyM0GpSHQTg==}
 
   '@fluidframework/garbage-collector@1.4.0':
     resolution: {integrity: sha512-bwt1mv3B2PcvVN/JqBkm8MwdRydVboBM7MguQkANDGkmUPD56dRzjBYEdOl3yNZJEO/xJ2v15RPrkf1coI78Bg==}
@@ -17651,38 +17651,38 @@ packages:
   '@fluidframework/gitresources@5.0.0':
     resolution: {integrity: sha512-nfam1KT+EUqFCENHcxrU9VwUfbhUC83UcLuOsdLpn9I7VuClL+w8KMWosoYauZraO9gDhTo2kCErjgQji5GzGA==}
 
-  '@fluidframework/id-compressor@2.40.0':
-    resolution: {integrity: sha512-itBXlCRKjHdg/S58Tdmc9IDisncPCe4XT9vBb5Kn/vD9enJGO5NgqiY9gmmxpHrhcpIoCvgltuSi6Ey7YEbCrQ==}
+  '@fluidframework/id-compressor@2.41.0':
+    resolution: {integrity: sha512-31MgNoRPe8Flf5+5uM28MKjVIYKqcVIlVnSGVY54sVby3ePAWEDcUZkzAKAg55frMSSvHC52ZYBsLBu/wk1UIw==}
 
-  '@fluidframework/local-driver@2.40.0':
-    resolution: {integrity: sha512-2MGe1DVciqDtSSWLEkH70QKe5V77OInT95PfBvHtqXzBqFmYRbzt3skxtEcTompR9fN2WYLV8POWcRuNDP/QjQ==}
+  '@fluidframework/local-driver@2.41.0':
+    resolution: {integrity: sha512-uUSFkjAeIM8v5naEFAgBR5sl0YJBf+rn9OFdQVAhDIfn9YxSYWhFlr7g0h97rvMjrfZbKhireCLOd030GBT4iQ==}
 
   '@fluidframework/map@1.4.0':
     resolution: {integrity: sha512-KBdHBxCcIvPtsUSqnc5Ztgs2U01FwgnsW8WF3bl+TGt55Xs4esm3+p43WNkET1YU5Q95RVocRVp03dYMN7xelQ==}
 
-  '@fluidframework/map@2.40.0':
-    resolution: {integrity: sha512-hOLpnA6J4LYF2oOjWUP0PCvymJyMQcd4UXjc0y75oN8C0oCxxgjynPZ/LzG4wPhyWzSUARW956d0oDYLglzssQ==}
+  '@fluidframework/map@2.41.0':
+    resolution: {integrity: sha512-Pk3jVt/QcblgFaE7EL3eZFfK5tRIipc3j3wN9ssFfR+r4t5WXrhhgo1Dj1km5Isuugevme/2JF3OgMR/lhlAcg==}
 
-  '@fluidframework/matrix@2.40.0':
-    resolution: {integrity: sha512-F3TPVYK1wNbrQvJtFvM5JuzSz1jYWVNTFM3dNle2O58HQVr1UMhU3goVIlzycfP/nOYGO0nj5UVoKiogQ2lWBA==}
+  '@fluidframework/matrix@2.41.0':
+    resolution: {integrity: sha512-nxW404/I+Re1KEY7kWGJoKfrtQkuteubHlbjjpZe+4JsxCb3aPvbaZmH5XedZj8vdCvixge9idtuWmjUwfgj0Q==}
 
-  '@fluidframework/merge-tree@2.40.0':
-    resolution: {integrity: sha512-qGeTpScS3axkrvGlFYxIHY2jS6M0fPjs0pabykFvsqW59Jyyeg2FDG0VT3chxo3m0ETAVjNXr7zC3cfBjmihkw==}
+  '@fluidframework/merge-tree@2.41.0':
+    resolution: {integrity: sha512-ydsMoN6aYawaetB8xxokaVOedpeBI9QJmnOpDQ7+pMMECAQzyCobwlO1X2Y82zVJhXzqZdbx8Fd0YTg1Dw/WUg==}
 
-  '@fluidframework/odsp-doclib-utils@2.40.0':
-    resolution: {integrity: sha512-K59/l80PaVDlsHsDBQycD+k0txBzHnoO21Kq4jcjR/2H5WmPWVMZAnTSZ3XcAA7q1VlQCmhdzhwn1LVFZ+0Ocw==}
+  '@fluidframework/odsp-doclib-utils@2.41.0':
+    resolution: {integrity: sha512-beFOFTkvR51sozmze0Ui0YJY/JNjnN/uVeUPu4W9U+bnZaCaxG8HSx1xrjTRER2xmnNI7K+FTecV3chqK2Y87w==}
 
-  '@fluidframework/odsp-driver-definitions@2.40.0':
-    resolution: {integrity: sha512-9hOcJ7xjt6r+1tl8v8qvYel/j0nZIyVQcE8mkwkTh99Jky/gbRwCAIXIwjuAf0JrXVUHCSDVcSyUczgPNpwPvA==}
+  '@fluidframework/odsp-driver-definitions@2.41.0':
+    resolution: {integrity: sha512-7ErmRiZ8oXmWVtnru8pN/MIUAoLbhJtxeI7KAuTjFINkCjHNGoKzs46GckLZrEX782bXosGI6pyzSeOL/lZkHA==}
 
-  '@fluidframework/odsp-driver@2.40.0':
-    resolution: {integrity: sha512-2d0wTFodmlB21/vVgy7VGxj3b8h9cJJn471DkDMOKsMvweiosJYRT0DiCdSZNElbIXscfBpxg3dEEM2zBNuTVg==}
+  '@fluidframework/odsp-driver@2.41.0':
+    resolution: {integrity: sha512-/d+DS+6IXMXJik3eX+hFXsqEUH1GumMfDly1rvbVVSls7lbtgEace6j1HwAAuZnpuAeYFkWSG98uVMmuXkMFpQ==}
 
-  '@fluidframework/odsp-urlresolver@2.40.0':
-    resolution: {integrity: sha512-BXFV58K366Aypylwox3AHE7+nYD52KcALfV5QcbzFF3QmbiP0tnbau37xfhHql9ESZ/QFggmF6McoP05pEFj2g==}
+  '@fluidframework/odsp-urlresolver@2.41.0':
+    resolution: {integrity: sha512-kq/li0x8y9SWRGNZp0apoYf8qt96oLw9wU8aQ5sNzsouypBY3VlExeFMthEjUq/2XGDrCR3zc2CESehqdTvYJg==}
 
-  '@fluidframework/ordered-collection@2.40.0':
-    resolution: {integrity: sha512-QMJjTwil8PAqZhrsF4hraU0eOmY5aVJl2duRgGjqBTRY3mukRM39B8BBsif7oVM5zMIVpWtQjreoSm2EMNmQWQ==}
+  '@fluidframework/ordered-collection@2.41.0':
+    resolution: {integrity: sha512-cU1Y/YOrBrL+dY+fujzbChVI2t+eiS91N8ognPKdZ+F1yIV7h4i+LS3C9gv4bsBcB1yy6+Tt8siVXKLVqxQWYQ==}
 
   '@fluidframework/protocol-base@0.1036.5002':
     resolution: {integrity: sha512-mlI9okyLeSusGx7qU32NDJ4GJptSzVo3V6tPDhphPIOPtyOVTBuL4EQRFYdceoSLHlxEdVnQprwhyoRiMNw7Kw==}
@@ -17699,41 +17699,41 @@ packages:
   '@fluidframework/protocol-definitions@3.2.0':
     resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
 
-  '@fluidframework/register-collection@2.40.0':
-    resolution: {integrity: sha512-f7QXM9DwXWR6zLJog1zRzmIJHrMdhLO1mUKYJz0x7gfTQFtNArVGL9d4grZwnE4d8AsY8hAZd4vLhzvodC1sFw==}
+  '@fluidframework/register-collection@2.41.0':
+    resolution: {integrity: sha512-6szlbsjp0Y7f7M3eldoyDag0aUmI9sSF03mVKjcbhmTUfzFRAe0HleLWdW6Mws4IAgZbj85xwOVydo5D0/HOfw==}
 
-  '@fluidframework/replay-driver@2.40.0':
-    resolution: {integrity: sha512-7C1FNa6N5wNRfhMJo9kOxPzAaQYwOJgamj6BXuMaiFZ43do1WEs7QFdXzDeEzwjcu7W3WWSwzYFFGV2lrJF8+A==}
+  '@fluidframework/replay-driver@2.41.0':
+    resolution: {integrity: sha512-9KRvc3cIgAo7Cw5uiRObkz8OnoTzg2KhEh54HaV+OqBqagj3bLsLYr/0CyMB5M7Qcjymt5tzG+SbIIuJGWXAMw==}
 
   '@fluidframework/request-handler@1.4.0':
     resolution: {integrity: sha512-KDYjQcrdvSuHXBtIG+LkDCcIjiDdw1CKX4iWi/aQrbGOTFVyLzfb2SnEXOBz7sw0YuMhxf+S322KTcX/OWd12w==}
 
-  '@fluidframework/request-handler@2.40.0':
-    resolution: {integrity: sha512-krJEo1VltcFxL9zml39VU3hRzJRzhb6np4SXD8vSWw6UfnnxtRBtpag3q6pCB+lKvGTO0dCAECvWqh4dvfpbwg==}
+  '@fluidframework/request-handler@2.41.0':
+    resolution: {integrity: sha512-dx0b5y+1wCpkIJjYOV2ZxUhUspaqtzMMQeMEp4hkrNcxFJgVuP/EjZUVthJC2Eqadm8XG3RTOUmkKwMVDA7ICw==}
 
   '@fluidframework/routerlicious-driver@1.4.0':
     resolution: {integrity: sha512-iyLywWEgo7zWYCiJj0GPzsrn4lmLw65GYJLEod57fBCk9eLRRxhQ2GJuu2k9XGV6nCFadEc1ZEKufDUNIiBPow==}
 
-  '@fluidframework/routerlicious-driver@2.40.0':
-    resolution: {integrity: sha512-y+2dzuQDTZUXg5hn/Fw2DRHByoWu32f/K6f6gbMcQSBP9xKZjBuNoEpBrW3s9flPIAMZErguEmbfdv7ByDE6aw==}
+  '@fluidframework/routerlicious-driver@2.41.0':
+    resolution: {integrity: sha512-6BU+Q9NtvQJARkux7WmSjWXufPmK873Jm+SdwlAOSE5A/mjgd9R4GISSj+/Vosnq5HHqVJjNOM5Bq2K1k1kH6A==}
 
-  '@fluidframework/routerlicious-urlresolver@2.40.0':
-    resolution: {integrity: sha512-pAKV2nkV8wEGV8qFmh5euu23229kym5SAtDew2PQ83TT14IZGw5nsz+uDLXoppfAW7AS1D0+FCEM7JTWLsKegQ==}
+  '@fluidframework/routerlicious-urlresolver@2.41.0':
+    resolution: {integrity: sha512-1oT4GKrEn7pgHxSL0K94EMjzV1zgdsDX6bhtoIoiVS5agn3UooffEWA9RlcfSGrgDjSt/hiApjWbXvJzBogQgA==}
 
   '@fluidframework/runtime-definitions@1.4.0':
     resolution: {integrity: sha512-GewpwBxbeMutnHHXzVWsFYbGQJHKh8dFNqTiW0covMfaOOhXVSM0qzuf7RY7qX9n8Vn/bK3zF4WRo6gx/32fmg==}
 
-  '@fluidframework/runtime-definitions@2.40.0':
-    resolution: {integrity: sha512-LQil7PPNxA/zc0OZQ8Q10HuE6Vczrt5BoYP++38w/k1yYFS5LI+vajr0LDKpaD1R5Yxg52+dyhzMvsdWmDwVig==}
+  '@fluidframework/runtime-definitions@2.41.0':
+    resolution: {integrity: sha512-+XQSF6gRnYNOSiNsuZk0mlj0EYcTSyH5HNFHzMt1LxTlYy6P4mK5pe6fzrVfEoYRRbL/skASrm/aciRqMin1kw==}
 
   '@fluidframework/runtime-utils@1.4.0':
     resolution: {integrity: sha512-0drnuEdUja1m2401FXcsB9l66x5oCGjgW43mLjZgZFKcz5v5jYZml8OKWAtLmwfI/UNLJ9bQkb/nHQSM0Tf3Rw==}
 
-  '@fluidframework/runtime-utils@2.40.0':
-    resolution: {integrity: sha512-njgzS/FUEQx313Drq0VM3NwQLGancHXwv6HPPhDWATRGliuGlToji23k83+ZXnnSrDN1HIO7EhkD7GEVrxWmAg==}
+  '@fluidframework/runtime-utils@2.41.0':
+    resolution: {integrity: sha512-QyNch3BE2Ewg3gRpwYMC4ZTEplIJIEFNZqUMWBve26bE+mxPZDqgHpNE5f7mquXtmi7Noc/gXOTEKAUarzaRiA==}
 
-  '@fluidframework/sequence@2.40.0':
-    resolution: {integrity: sha512-FI+ImIZsJPLKTFV3qjayvQCS4RPULN+QrqEEZichi3pD8N7Fe+qvj5Q1yK0WUZMHLQARlT0txtw5FuL4K5l7eA==}
+  '@fluidframework/sequence@2.41.0':
+    resolution: {integrity: sha512-DFuFDnkAjsSQ4VF9344RbvfcVObg3w5PXFkeQPqcOzdnO8zxTVaIrUu9w43/nT6VOiQVYtU0iM9G65zTTN0ZRg==}
 
   '@fluidframework/server-lambdas-driver@5.0.0':
     resolution: {integrity: sha512-tnMxsxKr2zajQ64Ew7zcTKclK2Rkp7cqK4ghiuYkzhdbt7ZxIMVmkSW3B5/DXDSxVoi4VR6q1BA6cMnGJMcwsw==}
@@ -17771,51 +17771,51 @@ packages:
   '@fluidframework/shared-object-base@1.4.0':
     resolution: {integrity: sha512-NI94dsIyZL7s76UN/UVawd0JqV106cS84MaW1r9Qv91+QGU8aq/KCS3j8R9ZZ8pWFQ46sX9BT4CKa4hy4xZedw==}
 
-  '@fluidframework/shared-object-base@2.40.0':
-    resolution: {integrity: sha512-GnwUyLOQcx3HbkY/ddrzdg0vtMqscCMk/ejZQhCioMW431P/+626gblnLU6a3sKtu8Qp6OJJqp0aZzaqqjuyRQ==}
+  '@fluidframework/shared-object-base@2.41.0':
+    resolution: {integrity: sha512-4fknvISYkBdm8iONfdveOZoX5NrcXAWlReTdmlHiY2ovOmPuYMNZslOYBZ5XdfcdJQEBCjE6loX9OEiNJrm+Xg==}
 
-  '@fluidframework/shared-summary-block@2.40.0':
-    resolution: {integrity: sha512-kNqER1xcWRGUDdyIB2lbOFs0r1eZGUdLRtmbpEq83VisneLEuuZyunp4WIihIcoZGKGZMCXqjgoUmGyY+O2p0w==}
+  '@fluidframework/shared-summary-block@2.41.0':
+    resolution: {integrity: sha512-aqRHSDzvdE+17n7uN9nwBaT4yVOBN24wY/KoUHZYBsxyOSM1w7CUiD8AIi7naVqxr1hHI3Vv/3JpKzAytb7Nsg==}
 
   '@fluidframework/synthesize@1.4.0':
     resolution: {integrity: sha512-0pdq28pZ/cA/OVOp7KiUv8/bDxltwQy2ca7UJQGuyRDF9n1QcXoWC98liu2fB3/imahdfDi5pZ6l2vw/nIiFkA==}
 
-  '@fluidframework/synthesize@2.40.0':
-    resolution: {integrity: sha512-n04sjV9SaLxVgf5GDdoIAKeUanEQLKvwui+TTn6Wk0icvyikA3/2r92IxIjNeAur7umbiN7bCTnf3Ep9Qt6tGg==}
+  '@fluidframework/synthesize@2.41.0':
+    resolution: {integrity: sha512-L+ndTSG3vW2e7IBY5QSkYChr0JO/484iZjq24dC9aer5kIlhMtHSxNORYkzgPH0cLJXj9Y/xUIHvpKE6TR+v0w==}
 
-  '@fluidframework/task-manager@2.40.0':
-    resolution: {integrity: sha512-iXDy05gsuGwq3A7ql2+eE/Z2f2JCp4BQv5Vw85eeI5mEFBFdYY08fvEUg4i6eXTcF3pu8+ligGCxEzU4SO1vRA==}
+  '@fluidframework/task-manager@2.41.0':
+    resolution: {integrity: sha512-WLlj5qYKYEIxXV5ScDgsvePqAVNGhq/KaRemvkB7aIHOFQsI2iuqtJhZSawBPayV1sGM2FQ66KcNTNhUSoLRqQ==}
 
   '@fluidframework/telemetry-utils@1.4.0':
     resolution: {integrity: sha512-WXG1ThL+WJLGdBtUGlCPPlIrHxqnc+zy+YHrYtqFnlIp+75W3W+YApR5dyP1uCfvapISoBPo0htK3WNIiyj8Rw==}
 
-  '@fluidframework/telemetry-utils@2.40.0':
-    resolution: {integrity: sha512-/FIxn47ZCT7SE71h/UdHIFbhs4LtHZULnHIAncQhwtsnZtVxZf04SIvVEelcTlwNgjAA4WYch8HDExPNttxPoQ==}
+  '@fluidframework/telemetry-utils@2.41.0':
+    resolution: {integrity: sha512-k+XYr2EI3zeBt/N3GqrYpqxCG5x48BEpN/K4s11HHeJ5xtEdZjwT82dBOdZzJ15/q1eADeQI1kpe4aPRR2jMNQ==}
 
-  '@fluidframework/test-runtime-utils@2.40.0':
-    resolution: {integrity: sha512-Xf6OxXlEVtzVWYTPcrjPkSCXkN863IVfhyD1awpO4cT5Jukyo+uxr3xCR9JiPt3nhqayzMyHSX1DPXXtBjXq6g==}
+  '@fluidframework/test-runtime-utils@2.41.0':
+    resolution: {integrity: sha512-AjkumOP/FhJyLgmQCiUwVn6tEi6trfeKIIedoWo2DP4VczyRADkaSLQaWBAg1f0kZ3NYm/pkXBqrCYvVHHrBUg==}
 
   '@fluidframework/test-tools@1.0.195075':
     resolution: {integrity: sha512-N7FiXKoz6uQhDJhJxSunya5uP/GWNEp0ohYs0Jkb8Mmnow1SKuxl29x3rC9Kf5zORjUk8krCjam50+d8aPFGaw==}
     hasBin: true
 
-  '@fluidframework/test-utils@2.40.0':
-    resolution: {integrity: sha512-PqCxaJxuuLisw8PWdwUy/5RJpLQdk9slLXRCqkUXr63hYoy7ZIaTPu6klMGXYhz2zM9KpDAWBEGG+1cy7BxEFw==}
+  '@fluidframework/test-utils@2.41.0':
+    resolution: {integrity: sha512-2e5WodCJTZNuxLUzamRqcmIR7PX0SlJf7SwrEprYYJRIWO3kdLGVuCcyo8rN38Bg+uwOURPR578J09Z1lM7wSA==}
 
-  '@fluidframework/tinylicious-client@2.40.0':
-    resolution: {integrity: sha512-RAvGa+YdELlcVwZaVU2LOF8CTWRoqYPjyqgm4ZQaB0X35ijI1/UFemgMJr6g73DixZrXwLv34yvgEIj2pmyopA==}
+  '@fluidframework/tinylicious-client@2.41.0':
+    resolution: {integrity: sha512-olW5XF+8/5XGDYZ683QFLMDM0UDVNaVX+TUZ15lZiJQyPbQXITG247NFiKo7DeTqBBL+vdzjWtF2pitIPXiy5A==}
 
-  '@fluidframework/tinylicious-driver@2.40.0':
-    resolution: {integrity: sha512-4OLwOiNwMW/X39Wqoo0ADR7POJzxTPw69N1aJwmZTDsOOwQmAbuSQa8ar9BbiI9WsMXf6eU1uNBcV2OiMiKIQw==}
+  '@fluidframework/tinylicious-driver@2.41.0':
+    resolution: {integrity: sha512-gM26uU52TTh8Zuv79SD9J+Q/foDbKNCABk+t3/pCv3ZYVHPXXxZcXK/LAM91athEhVa2eVpMDkoBv5Mv0oZ8Ng==}
 
-  '@fluidframework/tool-utils@2.40.0':
-    resolution: {integrity: sha512-J+6Cn9OL5mKDAOFGUqXfzxvlF06oMNZsB/vrug96VBiCPInSryMwJ9y9KRBLSgzt8kfuxzTNFA00Y6o51fUP3w==}
+  '@fluidframework/tool-utils@2.41.0':
+    resolution: {integrity: sha512-hG/gABp8Emm/Kvqe8dpRmcua580sid9DUFIsW5eUBE1q2esSR8Do9Zkf5vDdbkTm4mqrExqpU3XUhCyOGHV4sw==}
 
-  '@fluidframework/tree@2.40.0':
-    resolution: {integrity: sha512-K2CujqH2BzlTRIZdAS7W2LdkBXhH+FRhl/AFlAwPXRhQOghmzOh/yoGoAw8krVz5tnQKfwULDPrgRr/T4wlZAg==}
+  '@fluidframework/tree@2.41.0':
+    resolution: {integrity: sha512-qR3qC8OVahBD2cJg9ftNXyauJz5/jilSQjdeyMCHVZPRKduJhstIx3aektyEr8HChA/wYr+K3J8OBvdrCKKwLw==}
 
-  '@fluidframework/undo-redo@2.40.0':
-    resolution: {integrity: sha512-TJgELybIxEhCITt/itYiS7UA4gJ7muYX2l4mOpKpa0icoS7+8ZQZR8Ie7t9AuSPSTaivCOSvHxdFyX5UqZhjcA==}
+  '@fluidframework/undo-redo@2.41.0':
+    resolution: {integrity: sha512-VYkwA3ZUZ0LwQ6wvxYrFjhRavr32WkVIWpzO/v6AJXeRzzy0dnyTOG9RpuDocWeVk14aoi1/DT+osA7WA9+HxQ==}
 
   '@fluidframework/view-interfaces@1.4.0':
     resolution: {integrity: sha512-YD0HE6rMpG6h/ELR717flLZ4Th0Ik0UUkECgaouW+Qy+Of+uPbi4KVoKRqTEEKzZqBFSbvSR5x3TlbmcXiEZnw==}
@@ -29539,26 +29539,26 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
 
-  '@fluid-experimental/attributable-map@2.40.0':
+  '@fluid-experimental/attributable-map@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluid-internal/client-utils@2.40.0':
+  '@fluid-internal/client-utils@2.41.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
       '@types/events_pkg': '@types/events@3.0.3'
       base64-js: 1.5.1
       buffer: 6.0.3
@@ -29575,10 +29575,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluid-internal/test-driver-definitions@2.40.0':
+  '@fluid-internal/test-driver-definitions@2.41.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
 
   '@fluid-tools/benchmark@0.51.0':
     dependencies:
@@ -29799,24 +29799,24 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/fetch-tool@2.40.0(encoding@0.1.13)':
+  '@fluid-tools/fetch-tool@2.41.0(encoding@0.1.13)':
     dependencies:
       '@azure/identity': 4.5.0
       '@azure/identity-cache-persistence': 1.1.1
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/container-runtime': 2.40.0(debug@4.4.0)
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore': 2.40.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/odsp-doclib-utils': 2.40.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver': 2.40.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.40.0
-      '@fluidframework/odsp-urlresolver': 2.40.0(encoding@0.1.13)
-      '@fluidframework/routerlicious-driver': 2.40.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/routerlicious-urlresolver': 2.40.0
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/tool-utils': 2.40.0(encoding@0.1.13)
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/container-runtime': 2.41.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore': 2.41.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/odsp-doclib-utils': 2.41.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver': 2.41.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.41.0
+      '@fluidframework/odsp-urlresolver': 2.41.0(encoding@0.1.13)
+      '@fluidframework/routerlicious-driver': 2.41.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/routerlicious-urlresolver': 2.41.0
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/tool-utils': 2.41.0(encoding@0.1.13)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -29856,27 +29856,27 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/agent-scheduler@2.40.0':
+  '@fluidframework/agent-scheduler@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore': 2.40.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/map': 2.40.0(debug@4.4.0)
-      '@fluidframework/register-collection': 2.40.0
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore': 2.41.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/map': 2.41.0(debug@4.4.0)
+      '@fluidframework/register-collection': 2.41.0
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/app-insights-logger@2.40.0(tslib@1.14.1)':
+  '@fluidframework/app-insights-logger@2.41.0(tslib@1.14.1)':
     dependencies:
-      '@fluidframework/core-interfaces': 2.40.0
+      '@fluidframework/core-interfaces': 2.41.0
       '@microsoft/applicationinsights-web': 2.8.18(tslib@1.14.1)
       '@ungap/structured-clone': 1.2.1
     transitivePeerDependencies:
@@ -29904,24 +29904,24 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/aqueduct@2.40.0':
+  '@fluidframework/aqueduct@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/container-runtime': 2.40.0(debug@4.4.0)
-      '@fluidframework/container-runtime-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore': 2.40.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/map': 2.40.0(debug@4.4.0)
-      '@fluidframework/request-handler': 2.40.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/synthesize': 2.40.0
-      '@fluidframework/telemetry-utils': 2.40.0
-      '@fluidframework/tree': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/container-runtime': 2.41.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore': 2.41.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/map': 2.41.0(debug@4.4.0)
+      '@fluidframework/request-handler': 2.41.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/synthesize': 2.41.0
+      '@fluidframework/telemetry-utils': 2.41.0
+      '@fluidframework/tree': 2.41.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -29950,17 +29950,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/azure-client@2.40.0(encoding@0.1.13)':
+  '@fluidframework/azure-client@2.41.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/container-loader': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/fluid-static': 2.40.0
-      '@fluidframework/routerlicious-driver': 2.40.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/container-loader': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/fluid-static': 2.41.0
+      '@fluidframework/routerlicious-driver': 2.41.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/telemetry-utils': 2.41.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -29968,9 +29967,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/azure-service-utils@2.40.0':
+  '@fluidframework/azure-service-utils@2.41.0':
     dependencies:
-      '@fluidframework/driver-definitions': 2.40.0
+      '@fluidframework/driver-definitions': 2.41.0
       jsrsasign: 11.1.0
       uuid: 9.0.1
 
@@ -30062,15 +30061,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@fluidframework/cell@2.40.0':
+  '@fluidframework/cell@2.41.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30117,10 +30116,10 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       events: 3.3.0
 
-  '@fluidframework/container-definitions@2.40.0':
+  '@fluidframework/container-definitions@2.41.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
 
   '@fluidframework/container-loader@1.4.0':
     dependencies:
@@ -30144,15 +30143,15 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/container-loader@2.40.0':
+  '@fluidframework/container-loader@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
       '@types/events_pkg': '@types/events@3.0.3'
       '@ungap/structured-clone': 1.2.1
       debug: 4.4.0(supports-color@8.1.1)
@@ -30171,12 +30170,12 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
 
-  '@fluidframework/container-runtime-definitions@2.40.0':
+  '@fluidframework/container-runtime-definitions@2.41.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/runtime-definitions': 2.40.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/runtime-definitions': 2.41.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30204,20 +30203,20 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/container-runtime@2.40.0(debug@4.4.0)':
+  '@fluidframework/container-runtime@2.41.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/container-runtime-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore': 2.40.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/id-compressor': 2.40.0
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/container-runtime-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore': 2.41.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/id-compressor': 2.41.0
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
       '@tylerbu/sorted-btree-es6': 1.8.0
       double-ended-queue: 2.1.0-0
       lz4js: 0.2.0
@@ -30239,19 +30238,19 @@ snapshots:
 
   '@fluidframework/core-interfaces@1.4.0': {}
 
-  '@fluidframework/core-interfaces@2.40.0': {}
+  '@fluidframework/core-interfaces@2.41.0': {}
 
-  '@fluidframework/core-utils@2.40.0': {}
+  '@fluidframework/core-utils@2.41.0': {}
 
-  '@fluidframework/counter@2.40.0':
+  '@fluidframework/counter@2.41.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30265,13 +30264,13 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
 
-  '@fluidframework/datastore-definitions@2.40.0':
+  '@fluidframework/datastore-definitions@2.41.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/id-compressor': 2.40.0
-      '@fluidframework/runtime-definitions': 2.40.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/id-compressor': 2.41.0
+      '@fluidframework/runtime-definitions': 2.41.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30297,62 +30296,62 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/datastore@2.40.0(debug@4.4.0)':
+  '@fluidframework/datastore@2.41.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/id-compressor': 2.40.0
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/id-compressor': 2.41.0
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/debugger@2.40.0':
+  '@fluidframework/debugger@2.41.0':
     dependencies:
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/replay-driver': 2.40.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/replay-driver': 2.41.0
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/devtools-core@2.40.0':
+  '@fluidframework/devtools-core@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/aqueduct': 2.40.0
-      '@fluidframework/cell': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/container-loader': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/counter': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/map': 2.40.0(debug@4.4.0)
-      '@fluidframework/matrix': 2.40.0
-      '@fluidframework/sequence': 2.40.0
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
-      '@fluidframework/tree': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/aqueduct': 2.41.0
+      '@fluidframework/cell': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/container-loader': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/counter': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/map': 2.41.0(debug@4.4.0)
+      '@fluidframework/matrix': 2.41.0
+      '@fluidframework/sequence': 2.41.0
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
+      '@fluidframework/tree': 2.41.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/devtools@2.40.0':
+  '@fluidframework/devtools@2.41.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/devtools-core': 2.40.0
-      '@fluidframework/fluid-static': 2.40.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/devtools-core': 2.41.0
+      '@fluidframework/fluid-static': 2.41.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30369,14 +30368,14 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/driver-base@2.40.0(debug@4.4.0)':
+  '@fluidframework/driver-base@2.41.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30387,9 +30386,9 @@ snapshots:
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
 
-  '@fluidframework/driver-definitions@2.40.0':
+  '@fluidframework/driver-definitions@2.41.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.40.0
+      '@fluidframework/core-interfaces': 2.41.0
 
   '@fluidframework/driver-utils@1.4.0':
     dependencies:
@@ -30407,13 +30406,13 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/driver-utils@2.40.0(debug@4.4.0)':
+  '@fluidframework/driver-utils@2.41.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/telemetry-utils': 2.41.0
       axios: 1.8.4(debug@4.4.0)
       lz4js: 0.2.0
       uuid: 9.0.1
@@ -30421,12 +30420,12 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/driver-web-cache@2.40.0':
+  '@fluidframework/driver-web-cache@2.41.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/odsp-driver-definitions': 2.40.0
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/odsp-driver-definitions': 2.41.0
+      '@fluidframework/telemetry-utils': 2.41.0
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -30442,9 +30441,9 @@ snapshots:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint-config-biome: 1.9.4
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
@@ -30460,28 +30459,28 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluidframework/file-driver@2.40.0':
+  '@fluidframework/file-driver@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/replay-driver': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/replay-driver': 2.41.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/fluid-runner@2.40.0(encoding@0.1.13)':
+  '@fluidframework/fluid-runner@2.41.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/aqueduct': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/container-loader': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/odsp-driver': 2.40.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.40.0
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluidframework/aqueduct': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/container-loader': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/odsp-driver': 2.41.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.41.0
+      '@fluidframework/telemetry-utils': 2.41.0
       '@json2csv/plainjs': 7.0.6
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -30509,22 +30508,23 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/fluid-static@2.40.0':
+  '@fluidframework/fluid-static@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/aqueduct': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/container-loader': 2.40.0
-      '@fluidframework/container-runtime': 2.40.0(debug@4.4.0)
-      '@fluidframework/container-runtime-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/request-handler': 2.40.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/aqueduct': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/container-loader': 2.41.0
+      '@fluidframework/container-runtime': 2.41.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/request-handler': 2.41.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30539,32 +30539,32 @@ snapshots:
 
   '@fluidframework/gitresources@5.0.0': {}
 
-  '@fluidframework/id-compressor@2.40.0':
+  '@fluidframework/id-compressor@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/telemetry-utils': 2.41.0
       '@tylerbu/sorted-btree-es6': 1.8.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/local-driver@2.40.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/local-driver@2.41.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
       '@fluidframework/protocol-base': 5.0.0
-      '@fluidframework/routerlicious-driver': 2.40.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/routerlicious-driver': 2.41.0(debug@4.4.0)(encoding@0.1.13)
       '@fluidframework/server-local-server': 5.0.0
       '@fluidframework/server-services-client': 5.0.0
       '@fluidframework/server-services-core': 5.0.0
       '@fluidframework/server-test-utils': 5.0.0
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluidframework/telemetry-utils': 2.41.0
       jsrsasign: 11.1.0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -30591,37 +30591,37 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/map@2.40.0(debug@4.4.0)':
+  '@fluidframework/map@2.41.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/merge-tree': 2.40.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/merge-tree': 2.41.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/matrix@2.40.0':
+  '@fluidframework/matrix@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/merge-tree': 2.40.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/merge-tree': 2.41.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
       '@tiny-calc/nano': 0.0.0-alpha.5
       double-ended-queue: 2.1.0-0
       tslib: 1.14.1
@@ -30629,52 +30629,52 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/merge-tree@2.40.0(debug@4.4.0)':
+  '@fluidframework/merge-tree@2.41.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/odsp-doclib-utils@2.40.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/odsp-doclib-utils@2.41.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/odsp-driver-definitions': 2.40.0
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/odsp-driver-definitions': 2.41.0
+      '@fluidframework/telemetry-utils': 2.41.0
       isomorphic-fetch: 3.0.0(encoding@0.1.13)
     transitivePeerDependencies:
       - debug
       - encoding
       - supports-color
 
-  '@fluidframework/odsp-driver-definitions@2.40.0':
+  '@fluidframework/odsp-driver-definitions@2.41.0':
     dependencies:
-      '@fluidframework/driver-definitions': 2.40.0
+      '@fluidframework/driver-definitions': 2.41.0
 
-  '@fluidframework/odsp-driver@2.40.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/odsp-driver@2.41.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/odsp-doclib-utils': 2.40.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.40.0
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/odsp-doclib-utils': 2.41.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.41.0
+      '@fluidframework/telemetry-utils': 2.41.0
       socket.io-client: 4.7.5
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -30684,14 +30684,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/odsp-urlresolver@2.40.0(encoding@0.1.13)':
+  '@fluidframework/odsp-urlresolver@2.41.0(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/odsp-driver': 2.40.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/odsp-driver': 2.41.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.41.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -30699,17 +30699,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/ordered-collection@2.40.0':
+  '@fluidframework/ordered-collection@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
@@ -30739,28 +30739,28 @@ snapshots:
 
   '@fluidframework/protocol-definitions@3.2.0': {}
 
-  '@fluidframework/register-collection@2.40.0':
+  '@fluidframework/register-collection@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/replay-driver@2.40.0':
+  '@fluidframework/replay-driver@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30775,13 +30775,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/request-handler@2.40.0(debug@4.4.0)':
+  '@fluidframework/request-handler@2.41.0(debug@4.4.0)':
     dependencies:
-      '@fluidframework/container-runtime-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30811,16 +30811,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/routerlicious-driver@2.40.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/routerlicious-driver@2.41.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
       '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluidframework/telemetry-utils': 2.41.0
       cross-fetch: 3.1.8(encoding@0.1.13)
       json-stringify-safe: 5.0.1
       socket.io-client: 4.7.5
@@ -30832,11 +30832,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/routerlicious-urlresolver@2.40.0':
+  '@fluidframework/routerlicious-urlresolver@2.41.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
       nconf: 0.12.1
 
   '@fluidframework/runtime-definitions@1.4.0':
@@ -30848,13 +30848,13 @@ snapshots:
       '@fluidframework/driver-definitions': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
 
-  '@fluidframework/runtime-definitions@2.40.0':
+  '@fluidframework/runtime-definitions@2.41.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/id-compressor': 2.40.0
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/id-compressor': 2.41.0
+      '@fluidframework/telemetry-utils': 2.41.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30874,34 +30874,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/runtime-utils@2.40.0(debug@4.4.0)':
+  '@fluidframework/runtime-utils@2.41.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/container-runtime-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/container-runtime-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/telemetry-utils': 2.41.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/sequence@2.40.0':
+  '@fluidframework/sequence@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/merge-tree': 2.40.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/merge-tree': 2.41.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
       double-ended-queue: 2.1.0-0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -31147,54 +31147,54 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/shared-object-base@2.40.0(debug@4.4.0)':
+  '@fluidframework/shared-object-base@2.41.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore': 2.40.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/id-compressor': 2.40.0
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore': 2.41.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/id-compressor': 2.41.0
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/shared-summary-block@2.40.0':
+  '@fluidframework/shared-summary-block@2.41.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
 
   '@fluidframework/synthesize@1.4.0': {}
 
-  '@fluidframework/synthesize@2.40.0':
+  '@fluidframework/synthesize@2.41.0':
     dependencies:
-      '@fluidframework/core-utils': 2.40.0
+      '@fluidframework/core-utils': 2.41.0
 
-  '@fluidframework/task-manager@2.40.0':
+  '@fluidframework/task-manager@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/container-runtime-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/container-runtime-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -31209,31 +31209,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/telemetry-utils@2.40.0':
+  '@fluidframework/telemetry-utils@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
       debug: 4.4.0(supports-color@8.1.1)
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/test-runtime-utils@2.40.0(encoding@0.1.13)':
+  '@fluidframework/test-runtime-utils@2.41.0(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/container-runtime-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/id-compressor': 2.40.0
-      '@fluidframework/routerlicious-driver': 2.40.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/container-runtime-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/id-compressor': 2.41.0
+      '@fluidframework/routerlicious-driver': 2.41.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
       jsrsasign: 11.1.0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -31245,28 +31245,28 @@ snapshots:
 
   '@fluidframework/test-tools@1.0.195075': {}
 
-  '@fluidframework/test-utils@2.40.0(encoding@0.1.13)':
+  '@fluidframework/test-utils@2.41.0(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/test-driver-definitions': 2.40.0
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/container-loader': 2.40.0
-      '@fluidframework/container-runtime': 2.40.0(debug@4.4.0)
-      '@fluidframework/container-runtime-definitions': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore': 2.40.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/local-driver': 2.40.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/map': 2.40.0(debug@4.4.0)
-      '@fluidframework/odsp-driver': 2.40.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/request-handler': 2.40.0(debug@4.4.0)
-      '@fluidframework/routerlicious-driver': 2.40.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/test-driver-definitions': 2.41.0
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/container-loader': 2.41.0
+      '@fluidframework/container-runtime': 2.41.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore': 2.41.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/local-driver': 2.41.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/map': 2.41.0(debug@4.4.0)
+      '@fluidframework/odsp-driver': 2.41.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/request-handler': 2.41.0(debug@4.4.0)
+      '@fluidframework/routerlicious-driver': 2.41.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
       best-random: 1.0.3
       debug: 4.4.0(supports-color@8.1.1)
       mocha: 10.8.2
@@ -31277,20 +31277,20 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tinylicious-client@2.40.0(encoding@0.1.13)':
+  '@fluidframework/tinylicious-client@2.41.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/container-definitions': 2.40.0
-      '@fluidframework/container-loader': 2.40.0
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/fluid-static': 2.40.0
-      '@fluidframework/map': 2.40.0(debug@4.4.0)
-      '@fluidframework/routerlicious-driver': 2.40.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
-      '@fluidframework/tinylicious-driver': 2.40.0(encoding@0.1.13)
+      '@fluidframework/container-definitions': 2.41.0
+      '@fluidframework/container-loader': 2.41.0
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/fluid-static': 2.41.0
+      '@fluidframework/map': 2.41.0(debug@4.4.0)
+      '@fluidframework/routerlicious-driver': 2.41.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
+      '@fluidframework/tinylicious-driver': 2.41.0(encoding@0.1.13)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -31298,12 +31298,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tinylicious-driver@2.40.0(encoding@0.1.13)':
+  '@fluidframework/tinylicious-driver@2.41.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/routerlicious-driver': 2.40.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/routerlicious-driver': 2.41.0(debug@4.4.0)(encoding@0.1.13)
       jsrsasign: 11.1.0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -31313,12 +31313,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tool-utils@2.40.0(encoding@0.1.13)':
+  '@fluidframework/tool-utils@2.41.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/driver-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/odsp-doclib-utils': 2.40.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/driver-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/odsp-doclib-utils': 2.41.0(debug@4.4.0)(encoding@0.1.13)
       async-mutex: 0.3.2
       debug: 4.4.0(supports-color@8.1.1)
       jwt-decode: 4.0.0
@@ -31327,19 +31327,19 @@ snapshots:
       - encoding
       - supports-color
 
-  '@fluidframework/tree@2.40.0':
+  '@fluidframework/tree@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/container-runtime': 2.40.0(debug@4.4.0)
-      '@fluidframework/core-interfaces': 2.40.0
-      '@fluidframework/core-utils': 2.40.0
-      '@fluidframework/datastore-definitions': 2.40.0
-      '@fluidframework/driver-definitions': 2.40.0
-      '@fluidframework/id-compressor': 2.40.0
-      '@fluidframework/runtime-definitions': 2.40.0
-      '@fluidframework/runtime-utils': 2.40.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.40.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/container-runtime': 2.41.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.41.0
+      '@fluidframework/core-utils': 2.41.0
+      '@fluidframework/datastore-definitions': 2.41.0
+      '@fluidframework/driver-definitions': 2.41.0
+      '@fluidframework/id-compressor': 2.41.0
+      '@fluidframework/runtime-definitions': 2.41.0
+      '@fluidframework/runtime-utils': 2.41.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.41.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.41.0
       '@sinclair/typebox': 0.34.13
       '@tylerbu/sorted-btree-es6': 1.8.0
       '@types/ungap__structured-clone': 1.2.0
@@ -31349,13 +31349,13 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/undo-redo@2.40.0':
+  '@fluidframework/undo-redo@2.41.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.40.0
-      '@fluidframework/map': 2.40.0(debug@4.4.0)
-      '@fluidframework/matrix': 2.40.0
-      '@fluidframework/merge-tree': 2.40.0(debug@4.4.0)
-      '@fluidframework/sequence': 2.40.0
+      '@fluid-internal/client-utils': 2.41.0
+      '@fluidframework/map': 2.41.0(debug@4.4.0)
+      '@fluidframework/matrix': 2.41.0
+      '@fluidframework/merge-tree': 2.41.0(debug@4.4.0)
+      '@fluidframework/sequence': 2.41.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -36295,33 +36295,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.55.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.0
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36335,13 +36335,13 @@ snapshots:
       eslint: 8.55.0
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       get-tsconfig: 4.10.0
       is-glob: 4.0.3
       minimatch: 3.1.2

--- a/tools/markdown-magic/package.json
+++ b/tools/markdown-magic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/markdown-magic",
-	"version": "2.41.0",
+	"version": "2.41.1",
 	"private": true,
 	"description": "Contains shared utilities for Markdown content generation and embedding using markdown-magic.",
 	"homepage": "https://fluidframework.com",


### PR DESCRIPTION
Bumps the version on the 2.41 release branch to 2.41.1.

Command used:

```shell
pnpm flub bump client -t patch
```

Also bumped the typetest baselines to 2.41.0.