### PR TITLE
Support input tag

### DIFF
--- a/build-tools/packages/build-cli/.eslintignore
+++ b/build-tools/packages/build-cli/.eslintignore
@@ -1,2 +1,3 @@
 /dist
 /lib
+/src/test/data

--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -474,6 +474,8 @@ export function generateCompatibilityTestCases(
 /**
  * Internals of {@link generateCompatibilityTestCases} for a single type.
  *
+ * @param typeData - The type to test.
+ * @param brokenData - Expected broken compatibilities, if any.
  * @returns - string array representing generated compatibility test cases
  */
 export function generateCompatibilityTestCase(

--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -528,7 +528,7 @@ export function generateCompatibilityTestCase(
 			);
 		}
 		if (typeData.tags.has("input")) {
-			// If the type was `@sealed` then only the code declaring it is allowed to read from it.
+			// If the type was `@input` then only the code declaring it is allowed to read from it.
 			// This means that as long as the old value of the type is assignable to the new (current) version, it is allowed.
 			// That case is covered above: skip this case where new type is assigned to the old.
 		} else {

--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -476,7 +476,7 @@ export function generateCompatibilityTestCases(
  *
  * @param typeData - The type to test.
  * @param brokenData - Expected broken compatibilities, if any.
- * @returns - string array representing generated compatibility test cases
+ * @returns Lines of TypeScript code that make up the compatibility test.
  */
 export function generateCompatibilityTestCase(
 	typeData: TypeData,

--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -44,6 +44,7 @@ import { type TestCaseTypeData, buildTestCase } from "../../typeValidator/testGe
 // eslint-disable-next-line import/no-internal-modules
 import type { TypeData } from "../../typeValidator/typeData.js";
 import {
+	type BrokenCompatSettings,
 	type BrokenCompatTypes,
 	type PackageWithTypeTestSettings,
 	defaultTypeValidationConfig,
@@ -182,11 +183,12 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
 `,
 		];
 
-		const testCases = generateCompatibilityTestCases(typeMap, currentPackageJson, fileHeader);
+		const testCases = generateCompatibilityTestCases(typeMap, currentPackageJson);
+		const output = [...fileHeader, ...testCases].join("\n");
 
 		await mkdir(outDir, { recursive: true });
 
-		await writeFile(typeTestOutputFile, testCases.join("\n"));
+		await writeFile(typeTestOutputFile, output);
 		this.info(
 			`${pkg.nameColored}: Generated type test file: ${path.resolve(typeTestOutputFile)}`,
 		);
@@ -449,14 +451,13 @@ export function loadTypesSourceFile(typesPath: string): SourceFile {
  *
  * @param typeMap - map containing type data to use to generate type tests
  * @param packageObject - package.json object containing type validation settings
- * @param testString - array to store generated test strings
  * @returns - string array representing generated compatibility test cases
  */
 export function generateCompatibilityTestCases(
 	typeMap: Map<string, TypeData>,
 	packageObject: PackageWithTypeTestSettings,
-	testString: string[],
 ): string[] {
+	const testString: string[] = [];
 	const broken: BrokenCompatTypes = packageObject.typeValidation?.broken ?? {};
 
 	// Convert Map entries to an array and sort by key. This is not strictly needed since Maps are iterated in insertion
@@ -465,52 +466,72 @@ export function generateCompatibilityTestCases(
 	const sortedEntries = [...typeMap.entries()].sort((a, b) => a[0].localeCompare(b[0]));
 
 	for (const [testCaseName, typeData] of sortedEntries) {
-		const [oldType, currentType]: TestCaseTypeData[] = [
-			{
-				prefix: "old",
-				...typeData,
-				removed: false,
-			},
-			{
-				prefix: "current",
-				...typeData,
-				removed: false,
-			},
-		];
-		const brokenData = broken?.[testCaseName];
+		testString.push(...generateCompatibilityTestCase(typeData, broken[testCaseName]));
+	}
+	return testString;
+}
 
-		const typePreprocessor = selectTypePreprocessor(currentType);
-		if (typePreprocessor !== undefined) {
-			if (typeData.tags.has("sealed")) {
-				// If the type was `@sealed` then only the code declaring it is allowed to create implementations.
-				// This means that the case of having the new (current) version of the type,
-				// but trying to implement it based on the old version should not occur and is not a supported usage.
-				// This means that adding members to sealed types, as well as making their members have more specific types is allowed as a non-breaking change.
-				// This check implements skipping generation of type tests which would flag such changes to sealed types as errors.
-			} else if (typeData.useTypeof) {
-				// If the type was using typeof treat it like `@sealed`.
-				// This assumes adding members to existing variables (and class statics) is non-breaking.
-				// This is true in most cases, though there are some edge cases where this assumption is wrong
-				// (for example name collisions with inherited statics in subclasses, and explicit use of typeof in user code to define a type which it implements),
-				// but overall skipping this case seems preferable to the large amount of false positives keeping it produces.
-			} else {
-				testString.push(
-					`/*`,
-					` * Validate forward compatibility by using the old type in place of the current type.`,
-					` * If this test starts failing, it indicates a change that is not forward compatible.`,
-					` * To acknowledge the breaking change, add the following to package.json under`,
-					` * typeValidation.broken:`,
-					` * "${currentType.testCaseName}": {"forwardCompat": false}`,
-					" */",
-					...buildTestCase(
-						oldType,
-						currentType,
-						brokenData?.forwardCompat ?? true,
-						typePreprocessor,
-					),
-					"",
-				);
-			}
+/**
+ * Internals of {@link generateCompatibilityTestCases} for a single type.
+ *
+ * @returns - string array representing generated compatibility test cases
+ */
+export function generateCompatibilityTestCase(
+	typeData: TypeData,
+	brokenData: BrokenCompatSettings | undefined,
+): string[] {
+	const testString: string[] = [];
+
+	const [oldType, currentType]: TestCaseTypeData[] = [
+		{
+			prefix: "old",
+			...typeData,
+			removed: false,
+		},
+		{
+			prefix: "current",
+			...typeData,
+			removed: false,
+		},
+	];
+
+	const typePreprocessor = selectTypePreprocessor(currentType);
+	if (typePreprocessor !== undefined) {
+		if (typeData.tags.has("sealed")) {
+			// If the type was `@sealed` then only the code declaring it is allowed to create implementations.
+			// This means that the case of having the new (current) version of the type,
+			// but trying to implement it based on the old version should not occur and is not a supported usage.
+			// This means that adding members to sealed types, as well as making their members have more specific types is allowed as a non-breaking change.
+			// This check implements skipping generation of type tests which would flag such changes to sealed types as errors.
+		} else if (typeData.useTypeof) {
+			// If the type was using typeof treat it like `@sealed`.
+			// This assumes adding members to existing variables (and class statics) is non-breaking.
+			// This is true in most cases, though there are some edge cases where this assumption is wrong
+			// (for example name collisions with inherited statics in subclasses, and explicit use of typeof in user code to define a type which it implements),
+			// but overall skipping this case seems preferable to the large amount of false positives keeping it produces.
+		} else {
+			testString.push(
+				`/*`,
+				` * Validate forward compatibility by using the old type in place of the current type.`,
+				` * If this test starts failing, it indicates a change that is not forward compatible.`,
+				` * To acknowledge the breaking change, add the following to package.json under`,
+				` * typeValidation.broken:`,
+				` * "${currentType.testCaseName}": {"forwardCompat": false}`,
+				" */",
+				...buildTestCase(
+					oldType,
+					currentType,
+					brokenData?.forwardCompat ?? true,
+					typePreprocessor,
+				),
+				"",
+			);
+		}
+		if (typeData.tags.has("input")) {
+			// If the type was `@sealed` then only the code declaring it is allowed to read from it.
+			// This means that as long as the old value of the type is assignable to the new (current) version, it is allowed.
+			// That case is covered above: skip this case where new type is assigned to the old.
+		} else {
 			testString.push(
 				`/*`,
 				` * Validate backward compatibility by using the current type in place of the old type.`,
@@ -535,7 +556,7 @@ export function generateCompatibilityTestCases(
 /**
  * Returns the name of the type preprocessing type meta-function to use, or undefined if no type test should be generated.
  */
-function selectTypePreprocessor(typeData: TypeData): string | undefined {
+function selectTypePreprocessor(typeData: Omit<TypeData, "node">): string | undefined {
 	if (typeData.tags.has("system")) {
 		return undefined;
 	}

--- a/build-tools/packages/build-cli/src/test/data/exports/exports.d.ts
+++ b/build-tools/packages/build-cli/src/test/data/exports/exports.d.ts
@@ -20,3 +20,13 @@ export declare const c: number;
 import * as InternalTypes from "./innerFile.js";
 // eslint-disable-next-line unicorn/prefer-export-from -- intentional; we are testing this case
 export { InternalTypes };
+
+/**
+ * @sealed
+ */
+export declare type Sealed = number;
+
+/**
+ * @input
+ */
+export declare type Input = number;

--- a/build-tools/packages/build-cli/src/test/tsconfig.json
+++ b/build-tools/packages/build-cli/src/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
 	"include": ["./**/*"],
+	"exclude": ["./data/**/*"],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/build-tools/packages/build-cli/src/typeValidator/typeData.ts
+++ b/build-tools/packages/build-cli/src/typeValidator/typeData.ts
@@ -17,6 +17,11 @@ export interface TypeData {
 	 */
 	readonly testCaseName: string;
 	readonly node: Node;
+	/**
+	 * Tags on the type.
+	 * @remarks
+	 * Does not include the "\@" prefix.
+	 */
 	readonly tags: ReadonlySet<string>;
 	/**
 	 * Indicates if this TypeData refer to the named item (false), or the typeof the named item (true).

--- a/common/build/build-common/api-extractor-base.json
+++ b/common/build/build-common/api-extractor-base.json
@@ -27,7 +27,8 @@
 		// These tags have breaking change implications, so they provide useful context during code reviews.
 		"tagsToReport": {
 			"@legacy": true,
-			"@system": true
+			"@system": true,
+			"@input": true
 		}
 	},
 

--- a/common/build/build-common/tsdoc-base.json
+++ b/common/build/build-common/tsdoc-base.json
@@ -16,11 +16,17 @@
 			// change version to version.
 			"tagName": "@system",
 			"syntaxKind": "modifier"
+		},
+		{
+			// This tag indicates API is an input type, and thus can be made more general as a non breaking change.
+			"tagName": "@input",
+			"syntaxKind": "modifier"
 		}
 	],
 
 	"supportForTags": {
 		"@legacy": true,
-		"@system": true
+		"@system": true,
+		"@input": true
 	}
 }

--- a/common/build/build-common/tsdoc-base.json
+++ b/common/build/build-common/tsdoc-base.json
@@ -18,7 +18,7 @@
 			"syntaxKind": "modifier"
 		},
 		{
-			// This tag indicates API is an input type, and thus can be made more general as a non breaking change.
+			// This tag indicates API is an input type, and thus can be made more general as a non-breaking change.
 			"tagName": "@input",
 			"syntaxKind": "modifier"
 		}

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -827,7 +827,7 @@ export const SharedTreeFormatVersion: {
 // @alpha
 export type SharedTreeFormatVersion = typeof SharedTreeFormatVersion;
 
-// @alpha
+// @alpha @input
 export type SharedTreeOptions = Partial<ICodecOptions> & Partial<SharedTreeFormatOptions> & ForestOptions;
 
 // @alpha @sealed

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -585,7 +585,7 @@ export type SharedTreeFormatVersion = typeof SharedTreeFormatVersion;
 
 /**
  * Configuration options for SharedTree.
- * @alpha
+ * @alpha @input
  */
 export type SharedTreeOptions = Partial<ICodecOptions> &
 	Partial<SharedTreeFormatOptions> &

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1195,7 +1195,7 @@ export const SharedTreeFormatVersion: {
 // @alpha
 export type SharedTreeFormatVersion = typeof SharedTreeFormatVersion;
 
-// @alpha
+// @alpha @input
 export type SharedTreeOptions = Partial<ICodecOptions> & Partial<SharedTreeFormatOptions> & ForestOptions;
 
 // @alpha @sealed


### PR DESCRIPTION
## Description

https://github.com/microsoft/FluidFramework/pull/24690 added support for the "input" tag in our documentation generation.

This change adds support for it in the other places.

Included is a small refactor of type test generator to make them more testable, as well as a test for the input and sealed cases.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


