### PR TITLE
refactor(client-presence): Remove `lookupClient` 

### DIFF
--- a/packages/framework/presence/src/latestMapValueManager.ts
+++ b/packages/framework/presence/src/latestMapValueManager.ts
@@ -387,7 +387,7 @@ class LatestMapRawValueManagerImpl<
 		const allKnownStates = this.datastore.knownValues(this.key);
 		for (const attendeeId of objectKeys(allKnownStates.states)) {
 			if (attendeeId !== allKnownStates.self) {
-				const attendee = this.datastore.lookupClient(attendeeId);
+				const attendee = this.presence.attendees.getAttendee(attendeeId);
 				const items = this.getRemote(attendee);
 				yield { attendee, items };
 			}
@@ -398,7 +398,7 @@ class LatestMapRawValueManagerImpl<
 		const allKnownStates = this.datastore.knownValues(this.key);
 		return objectKeys(allKnownStates.states)
 			.filter((attendeeId) => attendeeId !== allKnownStates.self)
-			.map((attendeeId) => this.datastore.lookupClient(attendeeId));
+			.map((attendeeId) => this.presence.attendees.getAttendee(attendeeId));
 	}
 
 	public getRemote(attendee: Attendee): ReadonlyMap<Keys, LatestData<T>> {

--- a/packages/framework/presence/src/latestMapValueManager.ts
+++ b/packages/framework/presence/src/latestMapValueManager.ts
@@ -387,7 +387,7 @@ class LatestMapRawValueManagerImpl<
 		const allKnownStates = this.datastore.knownValues(this.key);
 		for (const attendeeId of objectKeys(allKnownStates.states)) {
 			if (attendeeId !== allKnownStates.self) {
-				const attendee = this.presence.attendees.getAttendee(attendeeId);
+				const attendee = this.datastore.presence.attendees.getAttendee(attendeeId);
 				const items = this.getRemote(attendee);
 				yield { attendee, items };
 			}
@@ -398,7 +398,7 @@ class LatestMapRawValueManagerImpl<
 		const allKnownStates = this.datastore.knownValues(this.key);
 		return objectKeys(allKnownStates.states)
 			.filter((attendeeId) => attendeeId !== allKnownStates.self)
-			.map((attendeeId) => this.presence.attendees.getAttendee(attendeeId));
+			.map((attendeeId) => this.datastore.presence.attendees.getAttendee(attendeeId));
 	}
 
 	public getRemote(attendee: Attendee): ReadonlyMap<Keys, LatestData<T>> {

--- a/packages/framework/presence/src/latestValueManager.ts
+++ b/packages/framework/presence/src/latestValueManager.ts
@@ -131,7 +131,7 @@ class LatestValueManagerImpl<T, Key extends string>
 		for (const [attendeeId, value] of objectEntries(allKnownStates.states)) {
 			if (attendeeId !== allKnownStates.self) {
 				yield {
-					attendee: this.datastore.lookupClient(attendeeId),
+					attendee: this.presence.attendees.getAttendee(attendeeId),
 					value: asDeeplyReadonly(value.value),
 					metadata: { revision: value.rev, timestamp: value.timestamp },
 				};
@@ -143,7 +143,7 @@ class LatestValueManagerImpl<T, Key extends string>
 		const allKnownStates = this.datastore.knownValues(this.key);
 		return Object.keys(allKnownStates.states)
 			.filter((attendeeId) => attendeeId !== allKnownStates.self)
-			.map((attendeeId) => this.datastore.lookupClient(attendeeId));
+			.map((attendeeId) => this.presence.attendees.getAttendee(attendeeId));
 	}
 
 	public getRemote(attendee: Attendee): LatestData<T> {

--- a/packages/framework/presence/src/latestValueManager.ts
+++ b/packages/framework/presence/src/latestValueManager.ts
@@ -131,7 +131,7 @@ class LatestValueManagerImpl<T, Key extends string>
 		for (const [attendeeId, value] of objectEntries(allKnownStates.states)) {
 			if (attendeeId !== allKnownStates.self) {
 				yield {
-					attendee: this.presence.attendees.getAttendee(attendeeId),
+					attendee: this.datastore.presence.attendees.getAttendee(attendeeId),
 					value: asDeeplyReadonly(value.value),
 					metadata: { revision: value.rev, timestamp: value.timestamp },
 				};
@@ -143,7 +143,7 @@ class LatestValueManagerImpl<T, Key extends string>
 		const allKnownStates = this.datastore.knownValues(this.key);
 		return Object.keys(allKnownStates.states)
 			.filter((attendeeId) => attendeeId !== allKnownStates.self)
-			.map((attendeeId) => this.presence.attendees.getAttendee(attendeeId));
+			.map((attendeeId) => this.datastore.presence.attendees.getAttendee(attendeeId));
 	}
 
 	public getRemote(attendee: Attendee): LatestData<T> {

--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -14,7 +14,6 @@ import type { IEphemeralRuntime, PostUpdateAction } from "./internalTypes.js";
 import { objectEntries } from "./internalUtils.js";
 import type {
 	AttendeeId,
-	Attendee,
 	PresenceWithNotifications as Presence,
 	PresenceEvents,
 } from "./presence.js";
@@ -142,7 +141,6 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 	public constructor(
 		private readonly attendeeId: AttendeeId,
 		private readonly runtime: IEphemeralRuntime,
-		private readonly lookupClient: (clientId: AttendeeId) => Attendee,
 		private readonly logger: ITelemetryLoggerExt | undefined,
 		private readonly events: IEmitter<PresenceEvents>,
 		private readonly presence: Presence,
@@ -217,7 +215,6 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 			{
 				presence: this.presence,
 				attendeeId: this.attendeeId,
-				lookupClient: this.lookupClient,
 				localUpdate,
 			},
 			workspaceDatastore,

--- a/packages/framework/presence/src/presenceManager.ts
+++ b/packages/framework/presence/src/presenceManager.ts
@@ -173,7 +173,6 @@ function setupSubComponents(
 	const datastoreManager = new PresenceDatastoreManagerImpl(
 		attendeeId,
 		runtime,
-		systemWorkspaceConfig.workspace.getAttendee.bind(systemWorkspaceConfig.workspace),
 		logger,
 		events,
 		presence,

--- a/packages/framework/presence/src/presenceStates.ts
+++ b/packages/framework/presence/src/presenceStates.ts
@@ -423,7 +423,7 @@ class PresenceStatesImpl<TSchema extends StatesWorkspaceSchema>
 			} else {
 				const node = unbrandIVM(brandedIVM);
 				for (const [attendeeId, value] of objectEntries(remoteAllKnownState)) {
-					const client = this.presence.attendees.getAttendee(attendeeId);
+					const client = this.runtime.presence.attendees.getAttendee(attendeeId);
 					postUpdateActions.push(...node.update(client, received, value));
 				}
 			}

--- a/packages/framework/presence/src/presenceStates.ts
+++ b/packages/framework/presence/src/presenceStates.ts
@@ -12,11 +12,7 @@ import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { ClientRecord, PostUpdateAction } from "./internalTypes.js";
 import type { RecordEntryTypes } from "./internalUtils.js";
 import { getOrCreateRecord, objectEntries } from "./internalUtils.js";
-import type {
-	AttendeeId,
-	Attendee,
-	PresenceWithNotifications as Presence,
-} from "./presence.js";
+import type { AttendeeId, PresenceWithNotifications as Presence } from "./presence.js";
 import type { LocalStateUpdateOptions, StateDatastore } from "./stateDatastore.js";
 import { handleFromDatastore } from "./stateDatastore.js";
 import type { AnyWorkspace, StatesWorkspace, StatesWorkspaceSchema } from "./types.js";
@@ -57,7 +53,6 @@ export interface RuntimeLocalUpdateOptions {
 export interface PresenceRuntime {
 	readonly presence: Presence;
 	readonly attendeeId: AttendeeId;
-	lookupClient(clientId: ClientConnectionId): Attendee;
 	localUpdate(
 		states: { [key: string]: ClientUpdateEntry },
 		options: RuntimeLocalUpdateOptions,
@@ -360,10 +355,6 @@ class PresenceStatesImpl<TSchema extends StatesWorkspaceSchema>
 		allKnownState[clientId] = mergeValueDirectory(allKnownState[clientId], value, 0);
 	}
 
-	public lookupClient(clientId: ClientConnectionId): Attendee {
-		return this.runtime.lookupClient(clientId);
-	}
-
 	public add<
 		TKey extends string,
 		TValue extends InternalTypes.ValueDirectoryOrState<unknown>,
@@ -432,7 +423,7 @@ class PresenceStatesImpl<TSchema extends StatesWorkspaceSchema>
 			} else {
 				const node = unbrandIVM(brandedIVM);
 				for (const [attendeeId, value] of objectEntries(remoteAllKnownState)) {
-					const client = this.runtime.lookupClient(attendeeId);
+					const client = this.presence.attendees.getAttendee(attendeeId);
 					postUpdateActions.push(...node.update(client, received, value));
 				}
 			}

--- a/packages/framework/presence/src/stateDatastore.ts
+++ b/packages/framework/presence/src/stateDatastore.ts
@@ -6,11 +6,7 @@
 import type { ClientConnectionId } from "./baseTypes.js";
 import type { InternalTypes } from "./exposedInternalTypes.js";
 import type { ClientRecord } from "./internalTypes.js";
-import type {
-	Attendee,
-	AttendeeId,
-	PresenceWithNotifications as Presence,
-} from "./presence.js";
+import type { AttendeeId, PresenceWithNotifications as Presence } from "./presence.js";
 
 // type StateDatastoreSchemaNode<
 // 	TValue extends InternalTypes.ValueDirectoryOrState<any> = InternalTypes.ValueDirectoryOrState<unknown>,
@@ -59,7 +55,6 @@ export interface StateDatastore<
 		self: AttendeeId | undefined;
 		states: ClientRecord<TValue>;
 	};
-	lookupClient(clientId: ClientConnectionId): Attendee;
 }
 
 /**


### PR DESCRIPTION
## Description
Fixes [AB#39549](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/39549)

lookupClient was needed in places before `Presence` had reliable `attendees` property with `getAttendee` and `Presence` was passed down through all layers. It is also incorrectly typed to expect "clientId: ClientConnectionId" when most uses actually have `AttendeeId` (which is a string but more specific). Repace `lookupClient` uses with `presence.attendees.getAttendee` and then remove implementations and declarations.