### PR TITLE
docs(client-presence): missing API comments

### DIFF
--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -16,7 +16,7 @@ export type AttendeeId = SessionId & {
     readonly AttendeeId: "AttendeeId";
 };
 
-// @beta @sealed (undocumented)
+// @beta @sealed
 export interface AttendeesEvents {
     // @eventProperty
     attendeeConnected: (attendee: Attendee) => void;
@@ -153,15 +153,12 @@ export interface LatestArguments<T extends object | null> {
 
 // @beta @sealed
 export interface LatestClientData<T> extends LatestData<T> {
-    // (undocumented)
     attendee: Attendee;
 }
 
 // @beta @sealed
 export interface LatestData<T> {
-    // (undocumented)
     metadata: LatestMetadata;
-    // (undocumented)
     value: DeepReadonly<JsonDeserialized<T>>;
 }
 
@@ -179,23 +176,18 @@ export interface LatestMapArguments<T, Keys extends string | number = string | n
 // @beta @sealed
 export interface LatestMapClientData<T, Keys extends string | number, SpecificAttendeeId extends AttendeeId = AttendeeId> {
     attendee: Attendee<SpecificAttendeeId>;
-    // (undocumented)
     items: ReadonlyMap<Keys, LatestData<T>>;
 }
 
 // @beta @sealed
 export interface LatestMapItemRemovedClientData<K extends string | number> {
-    // (undocumented)
     attendee: Attendee;
-    // (undocumented)
     key: K;
-    // (undocumented)
     metadata: LatestMetadata;
 }
 
 // @beta @sealed
 export interface LatestMapItemUpdatedClientData<T, K extends string | number> extends LatestClientData<T> {
-    // (undocumented)
     key: K;
 }
 
@@ -210,7 +202,7 @@ export interface LatestMapRaw<T, Keys extends string | number = string | number>
     readonly presence: Presence;
 }
 
-// @beta @sealed (undocumented)
+// @beta @sealed
 export interface LatestMapRawEvents<T, K extends string | number> {
     // @eventProperty
     localItemRemoved: (removedItem: {
@@ -247,7 +239,7 @@ export interface LatestRaw<T> {
     readonly presence: Presence;
 }
 
-// @beta @sealed (undocumented)
+// @beta @sealed
 export interface LatestRawEvents<T> {
     // @eventProperty
     localUpdated: (update: {
@@ -320,7 +312,7 @@ export interface Presence {
     };
 }
 
-// @beta @sealed (undocumented)
+// @beta @sealed
 export interface PresenceEvents {
     workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
 }
@@ -342,15 +334,12 @@ export const StateFactory: {
 // @beta @sealed
 export interface StateMap<K extends string | number, V> {
     clear(): void;
-    // (undocumented)
     delete(key: K): boolean;
     forEach(callbackfn: (value: DeepReadonly<JsonDeserialized<V>>, key: K, map: StateMap<K, V>) => void, thisArg?: unknown): void;
     get(key: K): DeepReadonly<JsonDeserialized<V>> | undefined;
-    // (undocumented)
     has(key: K): boolean;
     keys(): IterableIterator<K>;
     set(key: K, value: JsonSerializable<V> & JsonDeserialized<V>): this;
-    // (undocumented)
     readonly size: number;
 }
 
@@ -375,7 +364,6 @@ export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalTyp
 
 // @beta
 export interface StatesWorkspaceSchema {
-    // (undocumented)
     [key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<any>>;
 }
 

--- a/packages/framework/presence/api-report/presence.beta.api.md
+++ b/packages/framework/presence/api-report/presence.beta.api.md
@@ -16,7 +16,7 @@ export type AttendeeId = SessionId & {
     readonly AttendeeId: "AttendeeId";
 };
 
-// @beta @sealed (undocumented)
+// @beta @sealed
 export interface AttendeesEvents {
     // @eventProperty
     attendeeConnected: (attendee: Attendee) => void;
@@ -126,15 +126,12 @@ export interface LatestArguments<T extends object | null> {
 
 // @beta @sealed
 export interface LatestClientData<T> extends LatestData<T> {
-    // (undocumented)
     attendee: Attendee;
 }
 
 // @beta @sealed
 export interface LatestData<T> {
-    // (undocumented)
     metadata: LatestMetadata;
-    // (undocumented)
     value: DeepReadonly<JsonDeserialized<T>>;
 }
 
@@ -152,23 +149,18 @@ export interface LatestMapArguments<T, Keys extends string | number = string | n
 // @beta @sealed
 export interface LatestMapClientData<T, Keys extends string | number, SpecificAttendeeId extends AttendeeId = AttendeeId> {
     attendee: Attendee<SpecificAttendeeId>;
-    // (undocumented)
     items: ReadonlyMap<Keys, LatestData<T>>;
 }
 
 // @beta @sealed
 export interface LatestMapItemRemovedClientData<K extends string | number> {
-    // (undocumented)
     attendee: Attendee;
-    // (undocumented)
     key: K;
-    // (undocumented)
     metadata: LatestMetadata;
 }
 
 // @beta @sealed
 export interface LatestMapItemUpdatedClientData<T, K extends string | number> extends LatestClientData<T> {
-    // (undocumented)
     key: K;
 }
 
@@ -183,7 +175,7 @@ export interface LatestMapRaw<T, Keys extends string | number = string | number>
     readonly presence: Presence;
 }
 
-// @beta @sealed (undocumented)
+// @beta @sealed
 export interface LatestMapRawEvents<T, K extends string | number> {
     // @eventProperty
     localItemRemoved: (removedItem: {
@@ -220,7 +212,7 @@ export interface LatestRaw<T> {
     readonly presence: Presence;
 }
 
-// @beta @sealed (undocumented)
+// @beta @sealed
 export interface LatestRawEvents<T> {
     // @eventProperty
     localUpdated: (update: {
@@ -246,7 +238,7 @@ export interface Presence {
     };
 }
 
-// @beta @sealed (undocumented)
+// @beta @sealed
 export interface PresenceEvents {
     workspaceActivated: (workspaceAddress: WorkspaceAddress, type: "States" | "Notifications" | "Unknown") => void;
 }
@@ -260,15 +252,12 @@ export const StateFactory: {
 // @beta @sealed
 export interface StateMap<K extends string | number, V> {
     clear(): void;
-    // (undocumented)
     delete(key: K): boolean;
     forEach(callbackfn: (value: DeepReadonly<JsonDeserialized<V>>, key: K, map: StateMap<K, V>) => void, thisArg?: unknown): void;
     get(key: K): DeepReadonly<JsonDeserialized<V>> | undefined;
-    // (undocumented)
     has(key: K): boolean;
     keys(): IterableIterator<K>;
     set(key: K, value: JsonSerializable<V> & JsonDeserialized<V>): this;
-    // (undocumented)
     readonly size: number;
 }
 
@@ -293,7 +282,6 @@ export type StatesWorkspaceEntry<TKey extends string, TValue extends InternalTyp
 
 // @beta
 export interface StatesWorkspaceSchema {
-    // (undocumented)
     [key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<any>>;
 }
 

--- a/packages/framework/presence/src/latestMapValueManager.ts
+++ b/packages/framework/presence/src/latestMapValueManager.ts
@@ -23,7 +23,7 @@ import { datastoreFromHandle, type StateDatastore } from "./stateDatastore.js";
 import { brandIVM } from "./valueManager.js";
 
 /**
- * Collection of latest known values for a specific client.
+ * Collection of latest known values for a specific {@link Attendee}.
  *
  * @sealed
  * @beta
@@ -34,11 +34,13 @@ export interface LatestMapClientData<
 	SpecificAttendeeId extends AttendeeId = AttendeeId,
 > {
 	/**
-	 * Associated attendee.
+	 * Associated {@link Attendee}.
 	 */
 	attendee: Attendee<SpecificAttendeeId>;
 
 	/**
+	 * Map of items for the state.
+	 *
 	 * @privateRemarks This could be regular map currently as no Map is
 	 * stored internally and a new instance is created for every request.
 	 */
@@ -53,6 +55,9 @@ export interface LatestMapClientData<
  */
 export interface LatestMapItemUpdatedClientData<T, K extends string | number>
 	extends LatestClientData<T> {
+	/**
+	 * Key of the updated item.
+	 */
 	key: K;
 }
 
@@ -63,12 +68,23 @@ export interface LatestMapItemUpdatedClientData<T, K extends string | number>
  * @beta
  */
 export interface LatestMapItemRemovedClientData<K extends string | number> {
+	/**
+	 * Associated {@link Attendee}.
+	 */
 	attendee: Attendee;
+	/**
+	 * Key of the removed item.
+	 */
 	key: K;
+	/**
+	 * Metadata associated with the removal of the item.
+	 */
 	metadata: LatestMetadata;
 }
 
 /**
+ * Events from {@link LatestMapRaw}.
+ *
  * @sealed
  * @beta
  */
@@ -135,6 +151,8 @@ export interface StateMap<K extends string | number, V> {
 	clear(): void;
 
 	/**
+	 * Removes the element with the specified key from the StateMap, if it exists.
+	 *
 	 * @returns true if an element in the StateMap existed and has been removed, or false if
 	 * the element does not exist.
 	 * @remarks No entry is fully removed. Instead an undefined placeholder is locally and
@@ -158,12 +176,14 @@ export interface StateMap<K extends string | number, V> {
 	): void;
 
 	/**
-	 * Returns a specified element from the StateMap object.
+	 * Returns the element with the specified key from the StateMap.
+	 *
 	 * @returns Returns the element associated with the specified key. If no element is associated with the specified key, undefined is returned.
 	 */
 	get(key: K): DeepReadonly<JsonDeserialized<V>> | undefined;
 
 	/**
+	 * Checks if an element with the specified key exists in the StateMap.
 	 * @returns boolean indicating whether an element with the specified key exists or not.
 	 */
 	has(key: K): boolean;
@@ -179,6 +199,8 @@ export interface StateMap<K extends string | number, V> {
 	set(key: K, value: JsonSerializable<V> & JsonDeserialized<V>): this;
 
 	/**
+	 * The number of elements in the StateMap.
+	 *
 	 * @returns the number of elements in the StateMap.
 	 */
 	readonly size: number;

--- a/packages/framework/presence/src/latestMapValueManager.ts
+++ b/packages/framework/presence/src/latestMapValueManager.ts
@@ -176,7 +176,7 @@ export interface StateMap<K extends string | number, V> {
 	): void;
 
 	/**
-	 * Returns the element with the specified key from the StateMap.
+	 * Returns the element with the specified key from the StateMap, if it exists.
 	 *
 	 * @returns Returns the element associated with the specified key. If no element is associated with the specified key, undefined is returned.
 	 */
@@ -200,8 +200,6 @@ export interface StateMap<K extends string | number, V> {
 
 	/**
 	 * The number of elements in the StateMap.
-	 *
-	 * @returns the number of elements in the StateMap.
 	 */
 	readonly size: number;
 

--- a/packages/framework/presence/src/latestValueManager.ts
+++ b/packages/framework/presence/src/latestValueManager.ts
@@ -23,6 +23,8 @@ import { datastoreFromHandle, type StateDatastore } from "./stateDatastore.js";
 import { brandIVM } from "./valueManager.js";
 
 /**
+ * Events from {@link LatestRaw}.
+ *
  * @sealed
  * @beta
  */

--- a/packages/framework/presence/src/latestValueTypes.ts
+++ b/packages/framework/presence/src/latestValueTypes.ts
@@ -35,16 +35,27 @@ export interface LatestMetadata {
  * @beta
  */
 export interface LatestData<T> {
+	/**
+	 * The value of the state.
+	 * @remarks This is a deeply readonly value, meaning it cannot be modified.
+	 */
 	value: DeepReadonly<JsonDeserialized<T>>;
+
+	/**
+	 * Metadata associated with the value.
+	 */
 	metadata: LatestMetadata;
 }
 
 /**
- * State of a specific attendee's value and its metadata.
+ * State of a specific {@link Attendee}'s value and its metadata.
  *
  * @sealed
  * @beta
  */
 export interface LatestClientData<T> extends LatestData<T> {
+	/**
+	 * Associated {@link Attendee}.
+	 */
 	attendee: Attendee;
 }

--- a/packages/framework/presence/src/presence.ts
+++ b/packages/framework/presence/src/presence.ts
@@ -116,6 +116,8 @@ export type SpecificAttendee<SpecificAttendeeId extends AttendeeId> =
 	string extends SpecificAttendeeId ? never : Attendee<SpecificAttendeeId>;
 
 /**
+ * Events from {@link Presence.attendees}.
+ *
  * @sealed
  * @beta
  */
@@ -136,6 +138,8 @@ export interface AttendeesEvents {
 }
 
 /**
+ * Events from {@link Presence}.
+ *
  * @sealed
  * @beta
  */
@@ -202,12 +206,12 @@ export interface Presence {
 
 	readonly states: {
 		/**
-		 * Acquires a StatesWorkspace from store or adds new one.
+		 * Acquires a {@link StatesWorkspace} from store or adds new one.
 		 *
-		 * @param workspaceAddress - Address of the requested StatesWorkspace
+		 * @param workspaceAddress - Address of the requested {@link StatesWorkspace}
 		 * @param requestedStates - Requested states for the workspace
 		 * @param controls - Optional settings for default broadcast controls
-		 * @returns A StatesWorkspace
+		 * @returns A {@link StatesWorkspace}
 		 */
 		getWorkspace<StatesSchema extends StatesWorkspaceSchema>(
 			workspaceAddress: WorkspaceAddress,

--- a/packages/framework/presence/src/types.ts
+++ b/packages/framework/presence/src/types.ts
@@ -47,6 +47,9 @@ export type StatesWorkspaceEntry<
  * @beta
  */
 export interface StatesWorkspaceSchema {
+	/**
+	 * Key-value pairs of State objects registered with the {@link StatesWorkspace}.
+	 */
 	[key: string]: StatesWorkspaceEntry<typeof key, InternalTypes.ValueDirectoryOrState<any>>;
 }
 


### PR DESCRIPTION
adds documentation to beta APIs that are not `@system` nor `attendees` or `states` properties of `Presence`

Follow-up for #24710