### PR TITLE
fix(staging-mode): Make rollback semantics explicit for all ContainerMessageTypes in light of Staging Mode

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -784,12 +784,9 @@ function canStageMessageOfType(
 	| ContainerMessageType.GC
 	| ContainerMessageType.DocumentSchemaChange {
 	return (
-		type in
-		[
-			ContainerMessageType.FluidDataStoreOp,
-			ContainerMessageType.GC,
-			ContainerMessageType.DocumentSchemaChange,
-		]
+		type === ContainerMessageType.FluidDataStoreOp ||
+		type === ContainerMessageType.GC ||
+		type === ContainerMessageType.DocumentSchemaChange
 	);
 }
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -4720,7 +4720,7 @@ export class ContainerRuntime
 				throw new Error(`Handling ${type} ops in rolled back batch not yet implemented`);
 			}
 			case ContainerMessageType.Attach: // Attach ops won't be generated in Staging Mode
-			case ContainerMessageType.Alias: // BUG: Alias ops shouldn't be supported in Staging Mode
+			case ContainerMessageType.Alias: // Alias ops won't be generated in Staging Mode
 			case ContainerMessageType.BlobAttach: // Attach ops won't be generated in Staging Mode
 			case ContainerMessageType.IdAllocation: // ID Allocation ops won't be generated in Staging Mode
 			// Rejoin ops are unused

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -4715,7 +4715,6 @@ export class ContainerRuntime
 			}
 			case ContainerMessageType.GC:
 			case ContainerMessageType.DocumentSchemaChange: {
-				//* Instead of submitting these right away, put them in a "system queue" on CR class and include them on flush of the main batch
 				throw new Error(`Handling ${type} ops in rolled back batch not yet implemented`);
 			}
 			case ContainerMessageType.Attach: // Attach ops won't be generated in Staging Mode

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3419,7 +3419,6 @@ export class ContainerRuntime
 			// Now that we've exited, we need to submit an ID Allocation op for any IDs that were generated while in Staging Mode.
 			this.submitIdAllocationOpIfNeeded({ staged: false });
 			discardOrCommit();
-			//* Why isn't an error thrown from in discardOrCommit being propagated to caller of discard?
 
 			this.channelCollection.notifyStagingMode(false);
 		};
@@ -4716,7 +4715,7 @@ export class ContainerRuntime
 			}
 			case ContainerMessageType.GC:
 			case ContainerMessageType.DocumentSchemaChange: {
-				// FUTURE: These ops should probably just be requeued post-rollback
+				//* Instead of submitting these right away, put them in a "system queue" on CR class and include them on flush of the main batch
 				throw new Error(`Handling ${type} ops in rolled back batch not yet implemented`);
 			}
 			case ContainerMessageType.Attach: // Attach ops won't be generated in Staging Mode

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -4500,7 +4500,7 @@ export class ContainerRuntime
 
 			assert(
 				!staged || canStageMessageOfType(type),
-				`Unexpected message submitted in staging mode, type=${type}`,
+				"Unexpected message type submitted in Staging Mode",
 			);
 
 			// Before submitting any non-staged change, submit the ID Allocation op to cover any compressed IDs included in the op.
@@ -4727,7 +4727,7 @@ export class ContainerRuntime
 		{ type, contents }: LocalContainerRuntimeMessage,
 		localOpMetadata: unknown,
 	): void {
-		assert(canStageMessageOfType(type), `Can't rollback message of type: ${type}`);
+		assert(canStageMessageOfType(type), "Unexpected message type to be rolled back");
 
 		switch (type) {
 			case ContainerMessageType.FluidDataStoreOp: {

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -11,6 +11,8 @@ import {
 	AliasResult,
 	IDataStore,
 	IFluidDataStoreChannel,
+	// eslint-disable-next-line import/no-deprecated
+	type IContainerRuntimeBaseExperimental,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	ITelemetryLoggerExt,
@@ -77,6 +79,11 @@ class DataStore implements IDataStore {
 	async trySetAlias(alias: string): Promise<AliasResult> {
 		if (alias.includes("/")) {
 			throw new UsageError(`The alias cannot contain slashes: '${alias}'`);
+		}
+		// eslint-disable-next-line import/no-deprecated
+		const runtime = this.parentContext.containerRuntime as IContainerRuntimeBaseExperimental;
+		if (runtime.inStagingMode === true) {
+			throw new UsageError("Cannot set aliases while in staging mode");
 		}
 
 		switch (this.aliasState) {

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -678,7 +678,7 @@ export class PendingStateManager implements IDisposable {
 		);
 		assert(
 			!pendingMessage.batchInfo.staged,
-			0xb85 /* Pending state mismatch, ack came in but next message is staged */,
+			0xb85 /* Pending state mismatch, ack came in but next pending message is staged */,
 		);
 
 		// If this batch became empty on resubmit, batch.messages will be empty (but keyMessage is always set)

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -676,7 +676,10 @@ export class PendingStateManager implements IDisposable {
 			pendingMessage !== undefined,
 			0xa21 /* No pending message found as we start processing this remote batch */,
 		);
-		assert(!pendingMessage.batchInfo.staged, 0xb85 /* Can't get an ack from a staged batch */);
+		assert(
+			!pendingMessage.batchInfo.staged,
+			0xb85 /* Pending state mismatch, ack came in but next message is staged */,
+		);
 
 		// If this batch became empty on resubmit, batch.messages will be empty (but keyMessage is always set)
 		// and the next pending message should be an empty batch marker.

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1808,7 +1808,7 @@ export const shortCodeMap = {
 	"0xb82": "Staged batches expected to have runtimeOp defined",
 	"0xb83": "Invalid delta manager",
 	"0xb84": "Staged batches should not have been submitted",
-	"0xb85": "Pending state mismatch, ack came in but next message is staged",
+	"0xb85": "Pending state mismatch, ack came in but next pending message is staged",
 	"0xb86": "Staged batch was followed by non-staged batch",
 	"0xb87": "viableOp is only undefined for empty batches",
 	"0xb88": "viableOp is only undefined for empty batches",

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1808,7 +1808,7 @@ export const shortCodeMap = {
 	"0xb82": "Staged batches expected to have runtimeOp defined",
 	"0xb83": "Invalid delta manager",
 	"0xb84": "Staged batches should not have been submitted",
-	"0xb85": "Can't get an ack from a staged batch",
+	"0xb85": "Pending state mismatch, ack came in but next message is staged",
 	"0xb86": "Staged batch was followed by non-staged batch",
 	"0xb87": "viableOp is only undefined for empty batches",
 	"0xb88": "viableOp is only undefined for empty batches",

--- a/packages/test/local-server-tests/src/test/stagingMode.spec.ts
+++ b/packages/test/local-server-tests/src/test/stagingMode.spec.ts
@@ -661,23 +661,21 @@ describe("Staging Mode", () => {
 		});
 	}
 
-	describe("other operations", () => {
-		it("Aliasing a datastore not supported in staging mode", async () => {
-			const deltaConnectionServer = LocalDeltaConnectionServer.create();
-			const clients = await createClients(deltaConnectionServer);
+	it("Aliasing a datastore not supported in staging mode", async () => {
+		const deltaConnectionServer = LocalDeltaConnectionServer.create();
+		const clients = await createClients(deltaConnectionServer);
 
-			clients.original.dataObject.enterStagingMode();
+		clients.original.dataObject.enterStagingMode();
 
-			// Create and alias a new datastore in staging mode
-			const newDataStore = await clients.original.dataObject.containerRuntime.createDataStore(
-				dataObjectFactory.type,
-			);
+		// Create and alias a new datastore in staging mode
+		const newDataStore = await clients.original.dataObject.containerRuntime.createDataStore(
+			dataObjectFactory.type,
+		);
 
-			await assert.rejects(
-				async () => newDataStore.trySetAlias("staged-alias"),
-				/Cannot set aliases while in staging mode/,
-				"Should not be able to set an alias in staging mode",
-			);
-		});
+		await assert.rejects(
+			async () => newDataStore.trySetAlias("staged-alias"),
+			/Cannot set aliases while in staging mode/,
+			"Should not be able to set an alias in staging mode",
+		);
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -169,10 +169,7 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 		);
 	});
 
-	//* ONLY
-	//* ONLY
-	//* ONLY
-	itExpects.only(
+	itExpects(
 		"Rollback should throw if unsupported op (e.g. rejoin) is rolled back",
 		[
 			{

--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -18,6 +18,7 @@ import type {
 	SequenceDeltaEvent,
 	SharedString,
 } from "@fluidframework/sequence/internal";
+import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 import {
 	ChannelFactoryRegistry,
 	DataObjectFactoryType,
@@ -189,12 +190,8 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 				error = err as Error;
 			}
 
-			assert.notEqual(error, undefined, "No error");
-			assert.equal(
-				error?.message,
-				"Unexpected message submitted in staging mode, type=rejoin",
-				"Unexpected error message",
-			);
+			assert(error !== undefined, "No error");
+			validateAssertionError(error, "Unexpected message type submitted in Staging Mode");
 			assert.equal(
 				changedEventData.length,
 				3,


### PR DESCRIPTION
## Description

Only one behavior change here:  Block setting aliases while in Staging Mode.  This is a consensus operation and not well-suited for Staging Mode.  We don't expect any partner will have a need for this, but we can revisit if/when they do.

Besides that, just making things a little more explicit and adding some tests.

### Additional notes

Rollback was originally added for `orderSequentially` which has limited use (experimental only so far), and only support synchronous callbacks.  So the only `ContainerMessageType` that's supported for rollback is `ContainerMessageType.FluidDataStoreOp`.

But now Staging Mode invokes rollback as well, and it seems like anything can happen while in Staging Mode (from a user perspective), so we need to be more thoughtful about handling all ContainerMessageTypes.

That said - we implemented Staging Mode carefully and now (well, after #24729) we can likewise guarantee that only `ContainerMessageType.FluidDataStoreOp`* will be submitted while in staging mode.

## Reviewer Guidance

~Note: For GC ops and Document Schema ops, they really shouldn't be allowed in Staging Mode either.  Subsequent PR #24729 takes care of this.~

\* Update: GC and Document Schema ops _are_ allowed in Staging Mode.  See #24774 and #24776