### PR TITLE
Fuzz Minimization: Fix off by one error

### DIFF
--- a/packages/test/stochastic-test-utils/src/minification.ts
+++ b/packages/test/stochastic-test-utils/src/minification.ts
@@ -91,7 +91,7 @@ export class FuzzTestMinimizer<TOperation extends BaseOperation> {
 			previousLength = this.operations.length;
 			let idx = previousLength - 1;
 
-			while (idx > 0) {
+			while (idx >= 0) {
 				const deletedOp = this.operations.splice(idx, 1)[0];
 
 				// don't remove attach ops, as it creates invalid scenarios


### PR DESCRIPTION
This pull request includes a small but significant change to the `FuzzTestMinimizer` class in the `stochastic-test-utils` package. The change adjusts the loop condition in the `minification.ts` file to ensure the loop iterates over all operations, including the first one.

* [`packages/test/stochastic-test-utils/src/minification.ts`](diffhunk://#diff-9c112b4f8da82c2073195da15003b53b84b8cebc2edbe8a217a0d6a38fc40518L94-R94): Changed the loop condition in the `FuzzTestMinimizer` class from `idx > 0` to `idx >= 0`, ensuring that the first operation in the list is also considered during the loop.