### PR TITLE
feat(client-core-interfaces): opaque JSON placeholder types

### DIFF
--- a/packages/common/core-interfaces/src/exposedInternalUtilityTypes.ts
+++ b/packages/common/core-interfaces/src/exposedInternalUtilityTypes.ts
@@ -12,6 +12,7 @@ import type {
 	SerializationErrorPerUndefinedArrayElement,
 } from "./jsonSerializationErrors.js";
 import type { JsonTypeWith, NonNullJsonObjectWith, ReadonlyJsonTypeWith } from "./jsonType.js";
+import type { OpaqueJsonDeserialized, OpaqueJsonSerializable } from "./opaqueJson.js";
 
 /**
  * Unique symbol for recursion meta-typing.
@@ -558,6 +559,20 @@ export namespace InternalUtilityTypes {
 		: T;
 
 	/**
+	 * Convenience constraint for any Opaque Json type.
+	 *
+	 * @remarks
+	 * Use in extends check: `T extends AnyOpaqueJsonType`
+	 *
+	 * @system
+	 */
+	export type AnyOpaqueJsonType =
+		/* eslint-disable @typescript-eslint/no-explicit-any -- must use `any` for invariant constraint override */
+		| OpaqueJsonSerializable<unknown, any, unknown>
+		| OpaqueJsonDeserialized<unknown, any, unknown>;
+	/* eslint-enable @typescript-eslint/no-explicit-any */
+
+	/**
 	 * Extracts Function portion from an intersection (&) type returning
 	 * the extracted portion in the `function` property or `unknown` if
 	 * no function is found.
@@ -796,8 +811,14 @@ export namespace InternalUtilityTypes {
 								T,
 								{
 									AllowExactly: Controls["AllowExactly"];
-									// Add in primitives that may be branded to ignore intersection classes
-									AllowExtensionOf: Controls["AllowExtensionOf"] | boolean | number | string;
+									AllowExtensionOf:
+										| Controls["AllowExtensionOf"]
+										// Add in primitives that may be branded to ignore intersection classes
+										| boolean
+										| number
+										| string
+										// Add in Opaque Json types
+										| AnyOpaqueJsonType;
 									DegenerateSubstitute: Controls["DegenerateSubstitute"];
 								},
 								"found non-publics",
@@ -824,6 +845,56 @@ export namespace InternalUtilityTypes {
 							>
 			: never /* FilterControlsWithSubstitution assert else; should never be reached */
 		: never /* unreachable else for infer */;
+
+	/**
+	 * Handle Opaque Json types for {@link JsonSerializable}.
+	 *
+	 * @remarks
+	 * {@link OpaqueJsonSerializable} and {@link OpaqueJsonDeserialized} instances
+	 * are limited to `Controls` given context supports. Further, the data type
+	 * is filtered through {@link JsonSerializable} with those `Controls`.
+	 *
+	 * @privateRemarks
+	 * Additional intersections beyond {@link OpaqueJsonSerializable},
+	 * {@link OpaqueJsonDeserialized}, or intersected matching opaque pair are
+	 * not correctly filtered as need is not expected.
+	 *
+	 * @system
+	 */
+	export type JsonSerializableOpaqueAllowances<
+		T extends AnyOpaqueJsonType,
+		Controls extends FilterControlsWithSubstitution,
+	> = /* eslint-disable @typescript-eslint/no-explicit-any -- must use `any` for invariant constraint override */
+	/* infer underlying data type */ T extends
+		| OpaqueJsonSerializable<infer TData, any, unknown>
+		| OpaqueJsonDeserialized<infer TData, any, unknown>
+		? T extends OpaqueJsonSerializable<TData, any, unknown> &
+				OpaqueJsonDeserialized<TData, any, unknown>
+			? OpaqueJsonSerializable<
+					JsonSerializableImpl<TData, Controls>,
+					Controls["AllowExactly"],
+					Controls["AllowExtensionOf"]
+				> &
+					OpaqueJsonDeserialized<
+						JsonSerializableImpl<TData, Controls>,
+						Controls["AllowExactly"],
+						Controls["AllowExtensionOf"]
+					>
+			: T extends OpaqueJsonSerializable<TData, any, unknown>
+				? OpaqueJsonSerializable<
+						JsonSerializableImpl<TData, Controls>,
+						Controls["AllowExactly"],
+						Controls["AllowExtensionOf"]
+					>
+				: T extends OpaqueJsonDeserialized<TData, any, unknown>
+					? OpaqueJsonDeserialized<
+							JsonSerializableImpl<TData, Controls>,
+							Controls["AllowExactly"],
+							Controls["AllowExtensionOf"]
+						>
+					: "internal error: failed to determine Opaque Json type"
+		: never;
+	/* eslint-enable @typescript-eslint/no-explicit-any */
 
 	/**
 	 * Essentially a check for a template literal that has $\{string\} or
@@ -933,45 +1004,50 @@ export namespace InternalUtilityTypes {
 											>
 										: /* test for enum like types */ IfEnumLike<T> extends never
 											? /* enum or similar simple type (return as-is) => */ T
-											: /* property bag => */ FlattenIntersection<
-													{
-														/* required properties are recursed and may not have undefined values. */
-														[K in keyof T as RequiredNonSymbolKeysOf<
-															T,
-															K
-														>]-?: IfPossiblyUndefinedProperty<
-															K,
-															T[K],
-															{
-																IfPossiblyUndefined: {
-																	["error required property may not allow `undefined` value"]: never;
-																};
-																IfUnknownNonIndexed: {
-																	["error required property may not allow `unknown` value"]: never;
-																};
-																Otherwise: JsonSerializableFilter<
-																	T[K],
-																	Controls,
-																	[TNextAncestor, ...TAncestorTypes]
-																>;
-															}
-														>;
-													} & {
-														/* optional properties are recursed and, when exactOptionalPropertyTypes is
+											: /* test for Opaque Json types */ T extends AnyOpaqueJsonType
+												? /* Opaque Json type => */ JsonSerializableOpaqueAllowances<
+														T,
+														Controls
+													>
+												: /* property bag => */ FlattenIntersection<
+														{
+															/* required properties are recursed and may not have undefined values. */
+															[K in keyof T as RequiredNonSymbolKeysOf<
+																T,
+																K
+															>]-?: IfPossiblyUndefinedProperty<
+																K,
+																T[K],
+																{
+																	IfPossiblyUndefined: {
+																		["error required property may not allow `undefined` value"]: never;
+																	};
+																	IfUnknownNonIndexed: {
+																		["error required property may not allow `unknown` value"]: never;
+																	};
+																	Otherwise: JsonSerializableFilter<
+																		T[K],
+																		Controls,
+																		[TNextAncestor, ...TAncestorTypes]
+																	>;
+																}
+															>;
+														} & {
+															/* optional properties are recursed and, when exactOptionalPropertyTypes is
 														   false, are allowed to preserve undefined value type. */
-														[K in keyof T as OptionalNonSymbolKeysOf<
-															T,
-															K
-														>]?: JsonSerializableFilter<
-															T[K],
-															Controls,
-															[TNextAncestor, ...TAncestorTypes]
-														>;
-													} & {
-														/* symbol properties are rejected */
-														[K in keyof T & symbol]: never;
-													}
-												>
+															[K in keyof T as OptionalNonSymbolKeysOf<
+																T,
+																K
+															>]?: JsonSerializableFilter<
+																T[K],
+																Controls,
+																[TNextAncestor, ...TAncestorTypes]
+															>;
+														} & {
+															/* symbol properties are rejected */
+															[K in keyof T & symbol]: never;
+														}
+													>
 								: /* not an object => */ never
 							: /* function => */ never;
 
@@ -1110,6 +1186,35 @@ export namespace InternalUtilityTypes {
 		: JsonDeserializedFilter<T, Controls, RecurseLimit, TAncestorTypes | T>;
 
 	/**
+	 * Handle Opaque Json types for {@link JsonDeserialized}.
+	 *
+	 * @remarks
+	 * {@link OpaqueJsonSerializable} instances are converted to {@link OpaqueJsonDeserialized}.
+	 * The `AllowExactly` and `AllowExtensionOf` properties are set to match the given `Controls`.
+	 * The data type is kept exactly as-is to avoid processing in generic contexts that can't
+	 * produce a meaningful result. The data type should always be filtered through
+	 * {@link JsonDeserialized} when {@link OpaqueJsonDeserialized} is cracked open. So, really
+	 * the filtering is just deferred.
+	 *
+	 * @privateRemarks
+	 * Additional intersections beyond {@link OpaqueJsonSerializable},
+	 * {@link OpaqueJsonDeserialized}, or intersected matching opaque pair are
+	 * not correctly filtered as need is not expected.
+	 *
+	 * @system
+	 */
+	export type JsonDeserializedOpaqueConversion<
+		T extends AnyOpaqueJsonType,
+		Controls extends FilterControls,
+	> = /* eslint-disable @typescript-eslint/no-explicit-any -- must use `any` for invariant constraint override */
+	T extends
+		| OpaqueJsonSerializable<infer TData, any, unknown>
+		| OpaqueJsonDeserialized<infer TData, any, unknown>
+		? OpaqueJsonDeserialized<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]>
+		: "internal error: failed to determine Opaque Json type";
+	/* eslint-enable @typescript-eslint/no-explicit-any */
+
+	/**
 	 * Core implementation of {@link JsonDeserialized}.
 	 *
 	 * @system
@@ -1157,36 +1262,38 @@ export namespace InternalUtilityTypes {
 									? /* `object` => */ Controls["DegenerateNonNullObjectSubstitute"]
 									: /* test for enum like types */ IfEnumLike<T> extends never
 										? /* enum or similar simple type (return as-is) => */ T
-										: /* property bag => */ FlattenIntersection<
-												/* properties with symbol keys or wholly unsupported values are removed */
-												{
-													/* properties with defined values are recursed */
-													[K in keyof T as NonSymbolWithDeserializablePropertyOf<
-														T,
-														Controls["AllowExactly"],
-														Controls["AllowExtensionOf"],
-														K
-													>]: JsonDeserializedRecursion<
-														T[K],
-														Controls,
-														RecurseLimit,
-														TAncestorTypes
-													>;
-												} & {
-													/* properties that may have undefined values are optional */
-													[K in keyof T as NonSymbolWithPossiblyDeserializablePropertyOf<
-														T,
-														Controls["AllowExactly"],
-														Controls["AllowExtensionOf"],
-														K
-													>]?: JsonDeserializedRecursion<
-														T[K],
-														Controls,
-														RecurseLimit,
-														TAncestorTypes
-													>;
-												}
-											>
+										: /* test for matching Opaque Json types */ T extends AnyOpaqueJsonType
+											? /* Opaque Json type => */ JsonDeserializedOpaqueConversion<T, Controls>
+											: /* property bag => */ FlattenIntersection<
+													/* properties with symbol keys or wholly unsupported values are removed */
+													{
+														/* properties with defined values are recursed */
+														[K in keyof T as NonSymbolWithDeserializablePropertyOf<
+															T,
+															Controls["AllowExactly"],
+															Controls["AllowExtensionOf"],
+															K
+														>]: JsonDeserializedRecursion<
+															T[K],
+															Controls,
+															RecurseLimit,
+															TAncestorTypes
+														>;
+													} & {
+														/* properties that may have undefined values are optional */
+														[K in keyof T as NonSymbolWithPossiblyDeserializablePropertyOf<
+															T,
+															Controls["AllowExactly"],
+															Controls["AllowExtensionOf"],
+															K
+														>]?: JsonDeserializedRecursion<
+															T[K],
+															Controls,
+															RecurseLimit,
+															TAncestorTypes
+														>;
+													}
+												>
 						: /* not an object => */ never;
 
 	// #endregion

--- a/packages/common/core-interfaces/src/exposedUtilityTypes.ts
+++ b/packages/common/core-interfaces/src/exposedUtilityTypes.ts
@@ -21,6 +21,7 @@ export type {
 	NonNullJsonObjectWith,
 	ReadonlyJsonTypeWith,
 } from "./jsonType.js";
+export type { OpaqueJsonDeserialized, OpaqueJsonSerializable } from "./opaqueJson.js";
 export type { ShallowReadonly } from "./shallowReadonly.js";
 
 export type {

--- a/packages/common/core-interfaces/src/internal.ts
+++ b/packages/common/core-interfaces/src/internal.ts
@@ -10,6 +10,8 @@ export * from "./index.js";
 //  index.js is listed as the runtime file. This is done so that all imports are
 //  using the same outer runtime file. (Could be changed if needed.)
 
+export type { JsonTypeToOpaqueJson, OpaqueJsonToJsonType } from "./jsonUtils.js";
+
 // Export set of utility types re-tagged as internal for FF client convenience.
 // These types are not intended for direct use by customers and api-extractor will
 // flag misuse. If an externally visible version of these types is needed, import
@@ -28,6 +30,10 @@ import type {
 	JsonTypeWith as ExposedJsonTypeWith,
 	ReadonlyNonNullJsonObjectWith as ExposedReadonlyNonNullJsonObjectWith,
 } from "./jsonType.js";
+import type {
+	OpaqueJsonDeserialized as ExposedOpaqueJsonDeserialized,
+	OpaqueJsonSerializable as ExposedOpaqueJsonSerializable,
+} from "./opaqueJson.js";
 
 // Note: There are no docs for these re-exports. `@inheritdoc` cannot be used as:
 //   1. api-extractor does not support renames.
@@ -70,6 +76,24 @@ export type JsonTypeWith<T> = ExposedJsonTypeWith<T>;
  * @internal
  */
 export type ReadonlyNonNullJsonObjectWith<T> = ExposedReadonlyNonNullJsonObjectWith<T>;
+
+/**
+ * @internal
+ */
+export type OpaqueJsonDeserialized<
+	T,
+	Option_AllowExactly extends unknown[] = [],
+	Option_AllowExtensionOf = never,
+> = ExposedOpaqueJsonDeserialized<T, Option_AllowExactly, Option_AllowExtensionOf>;
+
+/**
+ * @internal
+ */
+export type OpaqueJsonSerializable<
+	T,
+	Option_AllowExactly extends unknown[] = [],
+	Option_AllowExtensionOf = never,
+> = ExposedOpaqueJsonSerializable<T, Option_AllowExactly, Option_AllowExtensionOf>;
 
 /**
  * @internal

--- a/packages/common/core-interfaces/src/jsonUtils.ts
+++ b/packages/common/core-interfaces/src/jsonUtils.ts
@@ -11,7 +11,7 @@ import type { OpaqueJsonDeserialized, OpaqueJsonSerializable } from "./opaqueJso
  * Helper to return an Opaque Json type version of Json type
  *
  * @remarks
- * To use this helper create a helper function that filters type `T` through at
+ * To use this helper, create a helper function that filters type `T` through at
  * least {@link JsonSerializable} and optionally {@link JsonDeserialized}. Then
  * cast value through `unknown as JsonTypeToOpaqueJson<T, Options>`, where
  * `Options` reflects the serialization capabilities of that area.

--- a/packages/common/core-interfaces/src/jsonUtils.ts
+++ b/packages/common/core-interfaces/src/jsonUtils.ts
@@ -1,0 +1,90 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { JsonDeserialized } from "./jsonDeserialized.js";
+import type { JsonSerializable, JsonSerializableOptions } from "./jsonSerializable.js";
+import type { OpaqueJsonDeserialized, OpaqueJsonSerializable } from "./opaqueJson.js";
+
+/**
+ * Helper to return an Opaque Json type version of Json type
+ *
+ * @remarks
+ * To use this helper create a helper function that filters type `T` through at
+ * least {@link JsonSerializable} and optionally {@link JsonDeserialized}. Then
+ * cast value through `unknown as JsonTypeToOpaqueJson<T, Options>`, where
+ * `Options` reflects the serialization capabilities of that area.
+ *
+ * @example
+ * ```ts
+ * function castToOpaqueJson<T>(value: JsonSerializable<T>): JsonTypeToOpaqueJson<T> {
+ *     return value as unknown as JsonTypeToOpaqueJson<T>;
+ * }
+ * ```
+ *
+ * @internal
+ */
+export type JsonTypeToOpaqueJson<
+	T,
+	Options extends JsonSerializableOptions = {
+		AllowExactly: [];
+		AllowExtensionOf: never;
+	},
+> = T extends JsonSerializable<T, Options> & JsonDeserialized<T, Options>
+	? OpaqueJsonSerializable<
+			T,
+			Options extends { AllowExactly: unknown[] } ? Options["AllowExactly"] : [],
+			Options extends { AllowExtensionOf: unknown } ? Options["AllowExtensionOf"] : never
+		> &
+			OpaqueJsonDeserialized<
+				T,
+				Options extends { AllowExactly: unknown[] } ? Options["AllowExactly"] : [],
+				Options extends { AllowExtensionOf: unknown } ? Options["AllowExtensionOf"] : never
+			>
+	: T extends JsonDeserialized<T, Options>
+		? OpaqueJsonDeserialized<
+				T,
+				Options extends { AllowExactly: unknown[] } ? Options["AllowExactly"] : [],
+				Options extends { AllowExtensionOf: unknown } ? Options["AllowExtensionOf"] : never
+			>
+		: T extends JsonSerializable<T, Options>
+			? OpaqueJsonSerializable<
+					T,
+					Options extends { AllowExactly: unknown[] } ? Options["AllowExactly"] : [],
+					Options extends { AllowExtensionOf: unknown } ? Options["AllowExtensionOf"] : never
+				>
+			: never;
+
+/**
+ * Helper to extract Json type from an Opaque Json type
+ *
+ * @remarks
+ * This type only works with basic serialization capabilities (options).
+ * Attempts to make `Options` generic resulted in infinite recursion
+ * in TypeScript compiler that was not understood, so this type only
+ * supports TJson (value type) variance.
+ *
+ * To use this helper, create a helper function that accepts
+ * `OpaqueJsonSerializable<unknown> | OpaqueJsonDeserialized<unknown>`.
+ *
+ * @example
+ * ```ts
+ * function exposeFromOpaqueJson<TOpaque extends OpaqueJsonSerializable<unknown> | OpaqueJsonDeserialized<unknown>>(
+ *	 opaque: TOpaque,
+ * ): OpaqueJsonToJsonType<TOpaque> {
+ *     return opaque as unknown as OpaqueJsonToJsonType<TOpaque>;
+ * }
+ * ```
+ *
+ * @internal
+ */
+export type OpaqueJsonToJsonType<
+	TOpaque extends OpaqueJsonSerializable<unknown> | OpaqueJsonDeserialized<unknown>,
+> = TOpaque extends OpaqueJsonSerializable<infer TJson> & OpaqueJsonDeserialized<infer TJson>
+	? JsonSerializable<TJson> & JsonDeserialized<TJson>
+	: TOpaque extends OpaqueJsonDeserialized<infer TJson>
+		? JsonDeserialized<TJson>
+		: TOpaque extends OpaqueJsonSerializable<infer TJson>
+			? JsonSerializable<TJson>
+			: never;

--- a/packages/common/core-interfaces/src/opaqueJson.ts
+++ b/packages/common/core-interfaces/src/opaqueJson.ts
@@ -6,7 +6,7 @@
 import { BrandedType } from "./brandedType.js";
 
 /**
- * Placeholder for value that has is known to be Json because it has been
+ * Placeholder for value that is known to be JSON because it has been
  * deserialized (`T` filtered through {@link JsonDeserialized} as out value).
  *
  * @remarks
@@ -46,8 +46,8 @@ export declare class OpaqueJsonDeserialized<
 }
 
 /**
- * Placeholder for value that has is known to be Json because it will be
- * serialized (`T` filtered through {@link JsonSerializable} before "created").
+ * Placeholder for value that is known to be JSON because it will have been
+ * serialized checked (`T` filtered through {@link JsonSerializable} before "created").
  *
  * @remarks
  * Usage:

--- a/packages/common/core-interfaces/src/opaqueJson.ts
+++ b/packages/common/core-interfaces/src/opaqueJson.ts
@@ -1,0 +1,87 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { BrandedType } from "./brandedType.js";
+
+/**
+ * Placeholder for value that has is known to be Json because it has been
+ * deserialized (`T` filtered through {@link JsonDeserialized} as out value).
+ *
+ * @remarks
+ * Usage:
+ *
+ * - Cast to with `as unknown as OpaqueJsonDeserialized<T>` when value `T`
+ * has been filtered through {@link JsonDeserialized}.
+ *
+ * - Cast from with `as unknown as JsonDeserialized<T>` when "instance" will
+ * be read.
+ *
+ * @sealed
+ * @beta
+ */
+export declare class OpaqueJsonDeserialized<
+	T,
+	// These options are split from typical `JsonDeserializedOptions` as this type
+	// requires correct variance per the two options and AllowExactly has special
+	// variance and must be treated as invariant. In actuality, each member of the
+	// AllowExactly tuple is invariant, but tuple as a set is covariant. This is not
+	// expressible in TypeScript.
+	in out Option_AllowExactly extends unknown[] = [],
+	out Option_AllowExtensionOf = never,
+> extends BrandedType<"JsonDeserialized"> {
+	protected readonly JsonDeserialized: {
+		Type: T;
+		Options: {
+			AllowExactly: Option_AllowExactly;
+			AllowExtensionOf: Option_AllowExtensionOf;
+		};
+	};
+	// Option_AllowExactly is covariant from above. This removes covariance, leaving only invariance.
+	protected readonly Option_AllowExactly_Invariance: (
+		Option_AllowExactly: Option_AllowExactly,
+	) => void;
+	private constructor();
+}
+
+/**
+ * Placeholder for value that has is known to be Json because it will be
+ * serialized (`T` filtered through {@link JsonSerializable} before "created").
+ *
+ * @remarks
+ * Usage:
+ *
+ * - Cast to with `as unknown as OpaqueJsonSerializable<T>` when value `T`
+ * has been filtered through {@link JsonSerializable}.
+ *
+ * - Cast from with `as unknown as JsonSerializable<T>` or `as unknown as T`
+ * when "instance" will be forwarded along.
+ *
+ * @sealed
+ * @beta
+ */
+export declare class OpaqueJsonSerializable<
+	T,
+	// These options are split from typical `JsonSerializableOptions` as this type
+	// requires correct variance per the two options and AllowExactly has special
+	// variance and must be treated as invariant. In actuality, each member of the
+	// AllowExactly tuple is invariant, but tuple as a set is covariant. This is not
+	// expressible in TypeScript.
+	in out Option_AllowExactly extends unknown[] = [],
+	out Option_AllowExtensionOf = never,
+	// JsonSerializableOptions.IgnoreInaccessibleMembers is ignored
+> extends BrandedType<"JsonSerializable"> {
+	protected readonly JsonSerializable: {
+		Type: T;
+		Options: {
+			AllowExactly: Option_AllowExactly;
+			AllowExtensionOf: Option_AllowExtensionOf;
+		};
+	};
+	// Option_AllowExactly is covariant from above. This removes covariance, leaving only invariance.
+	protected readonly Option_AllowExactly_Invariance: (
+		Option_AllowExactly: Option_AllowExactly,
+	) => void;
+	private constructor();
+}

--- a/packages/common/core-interfaces/src/test/jsonDeserialized.spec.ts
+++ b/packages/common/core-interfaces/src/test/jsonDeserialized.spec.ts
@@ -1575,7 +1575,7 @@ describe("JsonDeserialized", () => {
 		});
 	});
 
-	// These test cases are note really negative compilation test like they are to JsonSerializable.
+	// These test cases are not really negative compilation test like they are to JsonSerializable.
 	// These cases are for instances of notable loss of original information.
 	describe("negative compilation tests", () => {
 		describe("assumptions", () => {

--- a/packages/common/core-interfaces/src/test/jsonDeserialized.spec.ts
+++ b/packages/common/core-interfaces/src/test/jsonDeserialized.spec.ts
@@ -10,6 +10,7 @@ import { strict as assert } from "node:assert";
 import {
 	assertIdenticalTypes,
 	createInstanceOf,
+	exposeFromOpaqueJson,
 	replaceBigInt,
 	reviveBigInt,
 } from "./testUtils.js";
@@ -172,6 +173,15 @@ import {
 	objectWithBrandedString,
 	fluidHandleToNumber,
 	objectWithFluidHandle,
+	opaqueSerializableObject,
+	opaqueDeserializedObject,
+	opaqueSerializableAndDeserializedObject,
+	opaqueSerializableObjectRequiringBigintSupport,
+	opaqueDeserializedObjectRequiringBigintSupport,
+	opaqueSerializableAndDeserializedObjectRequiringBigintSupport,
+	opaqueSerializableObjectExpectingBigintSupport,
+	opaqueDeserializedObjectExpectingBigintSupport,
+	opaqueSerializableAndDeserializedObjectExpectingBigintSupport,
 } from "./testValues.js";
 
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
@@ -180,6 +190,7 @@ import type {
 	JsonDeserialized,
 	JsonTypeWith,
 	NonNullJsonObjectWith,
+	OpaqueJsonDeserialized,
 } from "@fluidframework/core-interfaces/internal/exposedUtilityTypes";
 
 /**
@@ -665,6 +676,13 @@ describe("JsonDeserialized", () => {
 					const resultRead = passThru(objectWithOptionalNumberDefined);
 					assertIdenticalTypes(resultRead, objectWithOptionalNumberDefined);
 				});
+			});
+
+			it("OpaqueJsonDeserialized<{number:number}>", () => {
+				const resultRead = passThru(opaqueDeserializedObject);
+				assertIdenticalTypes(resultRead, opaqueDeserializedObject);
+				const transparentResult = exposeFromOpaqueJson(resultRead);
+				assertIdenticalTypes(transparentResult, objectWithNumber);
 			});
 		});
 
@@ -1376,6 +1394,103 @@ describe("JsonDeserialized", () => {
 				);
 				assertIdenticalTypes(resultRead, createInstanceOf<NonNullJsonObjectWith<never>>());
 			});
+
+			describe("OpaqueJsonSerialized becomes OpaqueJsonDeserialized counterpart", () => {
+				it("OpaqueJsonSerializable<{number:number}> becomes OpaqueJsonDeserialized<{number:number}>", () => {
+					const resultRead = passThru(opaqueSerializableObject);
+					assertIdenticalTypes(
+						resultRead,
+						createInstanceOf<OpaqueJsonDeserialized<{ number: number }>>(),
+					);
+					const transparentResult = exposeFromOpaqueJson(resultRead);
+					assertIdenticalTypes(transparentResult, objectWithNumber);
+				});
+				it("OpaqueJsonSerializable<{number:number}>&OpaqueJsonDeserialized<{number:number}> becomes OpaqueJsonDeserialized<{number:number}>", () => {
+					const resultRead = passThru(opaqueSerializableAndDeserializedObject);
+
+					assertIdenticalTypes(
+						resultRead,
+						createInstanceOf<OpaqueJsonDeserialized<{ number: number }>>(),
+					);
+					const transparentResult = exposeFromOpaqueJson(resultRead);
+					assertIdenticalTypes(transparentResult, objectWithNumber);
+				});
+			});
+
+			describe("opaque Json types requiring extra allowed types have extras removed", () => {
+				it("opaque serializable object with `bigint`", () => {
+					const resultRead = passThruThrows(
+						opaqueSerializableObjectRequiringBigintSupport,
+						new TypeError("Do not know how to serialize a BigInt"),
+					);
+					assertIdenticalTypes(
+						resultRead,
+						createInstanceOf<OpaqueJsonDeserialized<{ bigint: bigint }>>(),
+					);
+					const transparentResult = exposeFromOpaqueJson(resultRead);
+					assertIdenticalTypes(transparentResult, {});
+				});
+				it("opaque deserialized object with `bigint`", () => {
+					const resultRead = passThruThrows(
+						opaqueDeserializedObjectRequiringBigintSupport,
+						new TypeError("Do not know how to serialize a BigInt"),
+					);
+					assertIdenticalTypes(
+						resultRead,
+						createInstanceOf<OpaqueJsonDeserialized<{ bigint: bigint }>>(),
+					);
+					const transparentResult = exposeFromOpaqueJson(resultRead);
+					assertIdenticalTypes(transparentResult, {});
+				});
+				it("opaque serializable and deserialized object with `bigint`", () => {
+					const resultRead = passThruThrows(
+						opaqueSerializableAndDeserializedObjectRequiringBigintSupport,
+						new TypeError("Do not know how to serialize a BigInt"),
+					);
+					assertIdenticalTypes(
+						resultRead,
+						createInstanceOf<OpaqueJsonDeserialized<{ bigint: bigint }>>(),
+					);
+					const transparentResult = exposeFromOpaqueJson(resultRead);
+					assertIdenticalTypes(transparentResult, {});
+				});
+
+				it("opaque serializable object with number array expecting `bigint` support", () => {
+					const resultRead = passThru(opaqueSerializableObjectExpectingBigintSupport);
+					assertIdenticalTypes(
+						resultRead,
+						createInstanceOf<
+							OpaqueJsonDeserialized<{ readonlyArrayOfNumbers: readonly number[] }>
+						>(),
+					);
+					const transparentResult = exposeFromOpaqueJson(resultRead);
+					assertIdenticalTypes(transparentResult, objectWithReadonlyArrayOfNumbers);
+				});
+				it("opaque deserialized object with number array expecting `bigint` support", () => {
+					const resultRead = passThru(opaqueDeserializedObjectExpectingBigintSupport);
+					assertIdenticalTypes(
+						resultRead,
+						createInstanceOf<
+							OpaqueJsonDeserialized<{ readonlyArrayOfNumbers: readonly number[] }>
+						>(),
+					);
+					const transparentResult = exposeFromOpaqueJson(resultRead);
+					assertIdenticalTypes(transparentResult, objectWithReadonlyArrayOfNumbers);
+				});
+				it("opaque serializable and deserialized object with number array expecting `bigint` support", () => {
+					const resultRead = passThru(
+						opaqueSerializableAndDeserializedObjectExpectingBigintSupport,
+					);
+					assertIdenticalTypes(
+						resultRead,
+						createInstanceOf<
+							OpaqueJsonDeserialized<{ readonlyArrayOfNumbers: readonly number[] }>
+						>(),
+					);
+					const transparentResult = exposeFromOpaqueJson(resultRead);
+					assertIdenticalTypes(transparentResult, objectWithReadonlyArrayOfNumbers);
+				});
+			});
 		});
 
 		describe("fully supported union types are preserved", () => {
@@ -1460,6 +1575,8 @@ describe("JsonDeserialized", () => {
 		});
 	});
 
+	// These test cases are note really negative compilation test like they are to JsonSerializable.
+	// These cases are for instances of notable loss of original information.
 	describe("negative compilation tests", () => {
 		describe("assumptions", () => {
 			it("const enums are never readable", () => {
@@ -1707,6 +1824,30 @@ describe("JsonDeserialized", () => {
 					const resultRead = passThruHandlingBigint(arrayOfBigintOrObjects);
 					assertIdenticalTypes(resultRead, arrayOfBigintOrObjects);
 				});
+				it("opaque serializable object with `bigint`", () => {
+					const resultRead = passThruHandlingBigint(
+						opaqueSerializableObjectRequiringBigintSupport,
+					);
+					assertIdenticalTypes(
+						resultRead,
+						createInstanceOf<OpaqueJsonDeserialized<{ bigint: bigint }, [bigint]>>(),
+					);
+				});
+				it("opaque deserialized object with `bigint`", () => {
+					const resultRead = passThruHandlingBigint(
+						opaqueDeserializedObjectRequiringBigintSupport,
+					);
+					assertIdenticalTypes(resultRead, opaqueDeserializedObjectRequiringBigintSupport);
+				});
+				it("opaque serializable and deserialized object with `bigint`", () => {
+					const resultRead = passThruHandlingBigint(
+						opaqueSerializableAndDeserializedObjectRequiringBigintSupport,
+					);
+					assertIdenticalTypes(
+						resultRead,
+						createInstanceOf<OpaqueJsonDeserialized<{ bigint: bigint }, [bigint]>>(),
+					);
+				});
 				it("object with specific function", () => {
 					const objectWithSpecificFunction = {
 						genericFn: () => undefined as unknown,
@@ -1839,7 +1980,7 @@ describe("JsonDeserialized", () => {
 				});
 			});
 
-			describe("continue rejecting unsupported that are not alternately allowed", () => {
+			describe("continues rejecting unsupported that are not alternately allowed", () => {
 				it("`unknown` (simple object) becomes `JsonTypeWith<bigint>`", () => {
 					const resultRead = passThruHandlingBigint(
 						unknownValueOfSimpleRecord,

--- a/packages/common/core-interfaces/src/test/jsonSerializable.spec.ts
+++ b/packages/common/core-interfaces/src/test/jsonSerializable.spec.ts
@@ -171,6 +171,15 @@ import {
 	fluidHandleToNumber,
 	objectWithFluidHandle,
 	objectWithFluidHandleOrRecursion,
+	opaqueSerializableObject,
+	opaqueDeserializedObject,
+	opaqueSerializableAndDeserializedObject,
+	opaqueSerializableObjectRequiringBigintSupport,
+	opaqueDeserializedObjectRequiringBigintSupport,
+	opaqueSerializableAndDeserializedObjectRequiringBigintSupport,
+	opaqueSerializableObjectExpectingBigintSupport,
+	opaqueDeserializedObjectExpectingBigintSupport,
+	opaqueSerializableAndDeserializedObjectExpectingBigintSupport,
 } from "./testValues.js";
 
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
@@ -181,6 +190,8 @@ import type {
 	JsonSerializableOptions,
 	JsonTypeWith,
 	NonNullJsonObjectWith,
+	OpaqueJsonDeserialized,
+	OpaqueJsonSerializable,
 	SerializationErrorPerNonPublicProperties,
 	SerializationErrorPerUndefinedArrayElement,
 } from "@fluidframework/core-interfaces/internal/exposedUtilityTypes";
@@ -664,6 +675,21 @@ describe("JsonSerializable", () => {
 				it("with defined value", () => {
 					const { filteredIn } = passThru(objectWithOptionalNumberDefined);
 					assertIdenticalTypes(filteredIn, objectWithOptionalNumberDefined);
+				});
+			});
+
+			describe("opaque Json types", () => {
+				it("opaque serializable object", () => {
+					const { filteredIn } = passThru(opaqueSerializableObject);
+					assertIdenticalTypes(filteredIn, opaqueSerializableObject);
+				});
+				it("opaque deserialized object", () => {
+					const { filteredIn } = passThru(opaqueDeserializedObject);
+					assertIdenticalTypes(filteredIn, opaqueDeserializedObject);
+				});
+				it("opaque serializable and deserialized object", () => {
+					const { filteredIn } = passThru(opaqueSerializableAndDeserializedObject);
+					assertIdenticalTypes(filteredIn, opaqueSerializableAndDeserializedObject);
 				});
 			});
 		});
@@ -1680,6 +1706,83 @@ describe("JsonSerializable", () => {
 							}>(),
 						);
 					});
+				});
+			});
+
+			describe("opaque Json types requiring extra allowed types", () => {
+				it("opaque serializable object with `bigint`", () => {
+					const { filteredIn } = passThruThrows(
+						// @ts-expect-error `bigint` is not supported (becomes `never`)
+						opaqueSerializableObjectRequiringBigintSupport,
+						new TypeError("Do not know how to serialize a BigInt"),
+					);
+					assertIdenticalTypes(
+						filteredIn,
+						createInstanceOf<OpaqueJsonSerializable<{ bigint: never }>>(),
+					);
+				});
+				it("opaque deserialized object with `bigint`", () => {
+					const { filteredIn } = passThruThrows(
+						// @ts-expect-error `bigint` is not supported (becomes `never`)
+						opaqueDeserializedObjectRequiringBigintSupport,
+						new TypeError("Do not know how to serialize a BigInt"),
+					);
+					assertIdenticalTypes(
+						filteredIn,
+						createInstanceOf<OpaqueJsonDeserialized<{ bigint: never }>>(),
+					);
+				});
+				it("opaque serializable and deserialized object with `bigint`", () => {
+					const { filteredIn } = passThruThrows(
+						// @ts-expect-error `bigint` is not supported (becomes `never`)
+						opaqueSerializableAndDeserializedObjectRequiringBigintSupport,
+						new TypeError("Do not know how to serialize a BigInt"),
+					);
+					assertIdenticalTypes(
+						filteredIn,
+						createInstanceOf<
+							OpaqueJsonSerializable<{ bigint: never }> &
+								OpaqueJsonDeserialized<{ bigint: never }>
+						>(),
+					);
+				});
+
+				it("opaque serializable object with number array expecting `bigint` support", () => {
+					const { filteredIn } = passThru(
+						// @ts-expect-error The types of 'JsonSerializable.Options.AllowExtensionOf' are incompatible between these types. Type 'bigint' is not assignable to type 'never'.
+						opaqueSerializableObjectExpectingBigintSupport,
+					);
+					assertIdenticalTypes(
+						filteredIn,
+						createInstanceOf<
+							OpaqueJsonSerializable<{ readonlyArrayOfNumbers: readonly number[] }>
+						>(),
+					);
+				});
+				it("opaque deserialized object with number array expecting `bigint` support", () => {
+					const { filteredIn } = passThru(
+						// @ts-expect-error The types of 'JsonSerializable.Options.AllowExtensionOf' are incompatible between these types. Type 'bigint' is not assignable to type 'never'.
+						opaqueDeserializedObjectExpectingBigintSupport,
+					);
+					assertIdenticalTypes(
+						filteredIn,
+						createInstanceOf<
+							OpaqueJsonDeserialized<{ readonlyArrayOfNumbers: readonly number[] }>
+						>(),
+					);
+				});
+				it("opaque serializable and deserialized object with number array expecting `bigint` support", () => {
+					const { filteredIn } = passThru(
+						// @ts-expect-error The types of 'JsonSerializable.Options.AllowExtensionOf' are incompatible between these types. Type 'bigint' is not assignable to type 'never'.
+						opaqueSerializableAndDeserializedObjectExpectingBigintSupport,
+					);
+					assertIdenticalTypes(
+						filteredIn,
+						createInstanceOf<
+							OpaqueJsonSerializable<{ readonlyArrayOfNumbers: readonly number[] }> &
+								OpaqueJsonDeserialized<{ readonlyArrayOfNumbers: readonly number[] }>
+						>(),
+					);
 				});
 			});
 

--- a/packages/common/core-interfaces/src/test/opaqueJson.spec.ts
+++ b/packages/common/core-interfaces/src/test/opaqueJson.spec.ts
@@ -1,0 +1,335 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	assertIdenticalTypes,
+	castToOpaqueJson,
+	createInstanceOf,
+	exposeFromOpaqueJson,
+} from "./testUtils.js";
+
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import type {
+	JsonDeserialized,
+	JsonSerializable,
+	OpaqueJsonDeserialized,
+	OpaqueJsonSerializable,
+} from "@fluidframework/core-interfaces/internal/exposedUtilityTypes";
+
+function saveJsonSerializable<const T>(value: JsonSerializable<T>): OpaqueJsonSerializable<T> {
+	return value as unknown as OpaqueJsonSerializable<T>;
+}
+
+function forwardJsonSerializable<const T>(
+	value: OpaqueJsonSerializable<T>,
+): JsonSerializable<T> {
+	return value as unknown as JsonSerializable<T>;
+}
+
+function saveJsonDeserialized<const T>(value: JsonDeserialized<T>): OpaqueJsonDeserialized<T> {
+	return value as unknown as OpaqueJsonDeserialized<T>;
+}
+
+function saveJsonRoundTrippable<const T>(
+	value: JsonSerializable<T> & JsonDeserialized<T>,
+): OpaqueJsonSerializable<T> & OpaqueJsonDeserialized<T> {
+	return value as unknown as OpaqueJsonSerializable<T> & OpaqueJsonDeserialized<T>;
+}
+
+function returnJsonDeserialized<const T>(
+	value: OpaqueJsonDeserialized<T>,
+): JsonDeserialized<T> {
+	return value as unknown as JsonDeserialized<T>;
+}
+
+function returnJsonSerializableAndDeserialized<const T>(
+	value: OpaqueJsonSerializable<T> & OpaqueJsonDeserialized<T>,
+): JsonSerializable<T> & JsonDeserialized<T> {
+	return value as unknown as JsonSerializable<T> & JsonDeserialized<T>;
+}
+
+// Use to have a value appear as used (read)
+function use(_: unknown): void {}
+
+describe("OpaqueJsonSerializable and OpaqueJsonDeserialized", () => {
+	const generalValue = { a: 0 };
+
+	describe("positive compilation tests", () => {
+		const autoOpaqueValue = castToOpaqueJson(generalValue);
+		assertIdenticalTypes(
+			autoOpaqueValue,
+			createInstanceOf<
+				OpaqueJsonSerializable<typeof generalValue> &
+					OpaqueJsonDeserialized<typeof generalValue>
+			>(),
+		);
+
+		it("OpaqueJsonSerializable is covariant (more specific is assignable to general)", () => {
+			// Setup
+			let serializableGeneralValue = saveJsonSerializable({ ...generalValue });
+			use(serializableGeneralValue);
+			const serializableSpecificValue = saveJsonSerializable({ a: 1 });
+			const serializableValueWithMore = saveJsonSerializable({ a: 2 as number, b: "test" });
+
+			// Act & Verify
+			serializableGeneralValue = serializableSpecificValue; // should be assignable
+			serializableGeneralValue = serializableValueWithMore; // should be assignable
+			serializableGeneralValue = autoOpaqueValue; // should be assignable
+		});
+
+		it("OpaqueJsonDeserialized is covariant (more specific is assignable to general)", () => {
+			// Setup
+			let deserializedGeneralValue = saveJsonDeserialized({ ...generalValue });
+			use(deserializedGeneralValue);
+			const deserializedSpecificValue = saveJsonDeserialized({ a: 1 });
+			const deserializedValueWithMore = saveJsonDeserialized({
+				a: 2 as number,
+				b: "test",
+			});
+
+			// Act & Verify
+			deserializedGeneralValue = deserializedSpecificValue; // should be assignable
+			deserializedGeneralValue = deserializedValueWithMore; // should be assignable
+			deserializedGeneralValue = autoOpaqueValue; // should be assignable
+		});
+
+		it("OpaqueJsonSerializable & OpaqueJsonDeserialized is covariant (more specific is assignable to general)", () => {
+			// Setup
+			let roundTrippableGeneralValue = saveJsonRoundTrippable({ ...generalValue });
+			use(roundTrippableGeneralValue);
+			const roundTrippableSpecificValue = saveJsonRoundTrippable({ a: 1 });
+			const roundTrippableValueWithMore = saveJsonRoundTrippable({
+				a: 2 as number,
+				b: "test",
+			});
+
+			// Act & Verify
+			roundTrippableGeneralValue = roundTrippableSpecificValue; // should be assignable
+			roundTrippableGeneralValue = roundTrippableValueWithMore; // should be assignable
+		});
+
+		describe("in a generic context", <T>() => {
+			it("OpaqueJsonDeserialized assignability varies with JsonDeserialized Options", () => {
+				// Setup
+				function acceptsOpaqueJsonDeserialized(
+					_: OpaqueJsonDeserialized<T, [IFluidHandle<bigint | string>], bigint>,
+				): void {}
+
+				// Act & Verify Options variance
+
+				// Same options are allowed
+				// biome-ignore format: keep single lines for comparability
+				acceptsOpaqueJsonDeserialized(createInstanceOf<OpaqueJsonDeserialized<T, [IFluidHandle<bigint|string>], bigint>>());
+				// More limited AllowExtensionOf is allowed
+				// biome-ignore format: keep single lines for comparability
+				// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments -- explicit `never` *default) for clarity
+				acceptsOpaqueJsonDeserialized(createInstanceOf<OpaqueJsonDeserialized<T, [IFluidHandle<bigint|string>], never>>());
+
+				// Broader Option_AllowExtensionOf is not allowed
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Type 'bigint | object' is not assignable to type 'bigint'.
+				acceptsOpaqueJsonDeserialized(createInstanceOf<OpaqueJsonDeserialized<T, [IFluidHandle<bigint|string>], bigint | object>>());
+
+				// More narrow options are not allowed (for Option_AllowExactly)
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Types of parameters 'Option_AllowExactly' and 'Option_AllowExactly' are incompatible. Type '[IFluidHandle<string | bigint>]' is not assignable to type '[IFluidHandle<string>]'.
+				acceptsOpaqueJsonDeserialized(createInstanceOf<OpaqueJsonDeserialized<T, [IFluidHandle<string>], bigint>>());
+				// More narrow options are not allowed (for Option_AllowExactly)
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Types of parameters 'Option_AllowExactly' and 'Option_AllowExactly' are incompatible. Type '[IFluidHandle<string | bigint>]' is not assignable to type '[never]'.
+				acceptsOpaqueJsonDeserialized(createInstanceOf<OpaqueJsonDeserialized<T, [never], bigint>>());
+				// More narrow options are not allowed (for Option_AllowExactly)
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Type '[]' is not assignable to type '[IFluidHandle<bigint|string>]'.
+				acceptsOpaqueJsonDeserialized(createInstanceOf<OpaqueJsonDeserialized<T, [], bigint>>());
+				// Broader options are not allowed (for Option_AllowExactly)
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Type '[IFluidHandle<bigint|string>, never]' is not assignable to type '[IFluidHandle<bigint|string>]'.
+				acceptsOpaqueJsonDeserialized(createInstanceOf<OpaqueJsonDeserialized<T, [IFluidHandle<bigint|string>, never], bigint>>());
+
+				// Default options (more narrow) are not allowed (per Option_AllowExactly)
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Type '[]' is not assignable to type '[IFluidHandle<bigint|string>]'.
+				acceptsOpaqueJsonDeserialized(createInstanceOf<OpaqueJsonDeserialized<T>>());
+				// However, similar case with unfortunate AllowExactly using `never` is allowed
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Type '(Option_AllowExactly: [never]) => void' is not assignable to type '(Option_AllowExactly: [IFluidHandle<string | bigint>]) => void'
+				acceptsOpaqueJsonDeserialized(createInstanceOf<OpaqueJsonDeserialized<T, [never]>>());
+			});
+
+			it("OpaqueJsonSerializable assignability varies with JsonSerializable Options", () => {
+				// Setup
+				function acceptsOpaqueJsonSerializable(
+					_: OpaqueJsonSerializable<T, [IFluidHandle<bigint | string>], bigint>,
+				): void {}
+
+				// Act & Verify Options variance
+
+				// Same options are allowed
+				// biome-ignore format: keep single lines for comparability
+				acceptsOpaqueJsonSerializable(createInstanceOf<OpaqueJsonSerializable<T, [IFluidHandle<bigint|string>], bigint>>());
+				// More limited AllowExtensionOf is allowed
+				// biome-ignore format: keep single lines for comparability
+				// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments -- explicit `never` *default) for clarity
+				acceptsOpaqueJsonSerializable(createInstanceOf<OpaqueJsonSerializable<T, [IFluidHandle<bigint|string>], never>>());
+
+				// Broader Option_AllowExtensionOf is not allowed
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Type 'bigint | object' is not assignable to type 'bigint'.
+				acceptsOpaqueJsonSerializable(createInstanceOf<OpaqueJsonSerializable<T, [IFluidHandle<bigint|string>], bigint | object>>());
+
+				// More narrow options are not allowed (for Option_AllowExactly)
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Types of parameters 'Option_AllowExactly' and 'Option_AllowExactly' are incompatible. Type '[IFluidHandle<string | bigint>]' is not assignable to type '[IFluidHandle<string>]'.
+				acceptsOpaqueJsonSerializable(createInstanceOf<OpaqueJsonSerializable<T, [IFluidHandle<string>], bigint>>());
+				// More narrow options are not allowed (for Option_AllowExactly)
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Types of parameters 'Option_AllowExactly' and 'Option_AllowExactly' are incompatible. Type '[IFluidHandle<string | bigint>]' is not assignable to type '[never]'.
+				acceptsOpaqueJsonSerializable(createInstanceOf<OpaqueJsonSerializable<T, [never], bigint>>());
+				// More narrow options are not allowed (for Option_AllowExactly)
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Type '[]' is not assignable to type '[IFluidHandle<bigint|string>]'.
+				acceptsOpaqueJsonSerializable(createInstanceOf<OpaqueJsonSerializable<T, [], bigint>>());
+				// Broader options are not allowed (for Option_AllowExactly)
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Type '[IFluidHandle<bigint|string>, never]' is not assignable to type '[IFluidHandle<bigint|string>]'.
+				acceptsOpaqueJsonSerializable(createInstanceOf<OpaqueJsonSerializable<T, [IFluidHandle<bigint|string>, never], bigint>>());
+
+				// Default options (more narrow) are not allowed (per Option_AllowExactly)
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Type '[]' is not assignable to type '[IFluidHandle<bigint|string>]'.
+				acceptsOpaqueJsonSerializable(createInstanceOf<OpaqueJsonSerializable<T>>());
+				// However, similar case with unfortunate AllowExactly using `never` is allowed
+				// biome-ignore format: keep single lines for comparability
+				// @ts-expect-error Type '(Option_AllowExactly: [never]) => void' is not assignable to type '(Option_AllowExactly: [IFluidHandle<string | bigint>]) => void'
+				acceptsOpaqueJsonSerializable(createInstanceOf<OpaqueJsonSerializable<T, [never]>>());
+			});
+
+			it("OpaqueJsonSerializable may be forwarded as JsonSerializable", () => {
+				// Setup
+				let serializableGenericValue = { ...generalValue } as unknown as JsonSerializable<T>;
+				const opaqueSerializableGenericValue = saveJsonSerializable(serializableGenericValue);
+
+				// Act & Verify
+				serializableGenericValue = forwardJsonSerializable(opaqueSerializableGenericValue);
+				serializableGenericValue = exposeFromOpaqueJson(opaqueSerializableGenericValue);
+			});
+
+			it("OpaqueJsonDeserialized may be returned to JsonDeserialized", () => {
+				// Setup
+				let deserializedGenericValue = { ...generalValue } as unknown as JsonDeserialized<T>;
+				const opaqueDeserializedGenericValue = saveJsonDeserialized(deserializedGenericValue);
+
+				// Act & Verify
+				deserializedGenericValue = returnJsonDeserialized(opaqueDeserializedGenericValue);
+				deserializedGenericValue = exposeFromOpaqueJson(opaqueDeserializedGenericValue);
+			});
+
+			it("OpaqueJsonSerializable & OpaqueJsonDeserialized may be returned to JsonSerializable & JsonDeserialized", () => {
+				// Setup
+				let roundTrippableGenericValue = {
+					...generalValue,
+				} as unknown as JsonSerializable<T> & JsonDeserialized<T>;
+				const opaqueRoundTrippableGenericValue = saveJsonRoundTrippable(
+					roundTrippableGenericValue,
+				);
+
+				// Act & Verify
+				roundTrippableGenericValue = returnJsonSerializableAndDeserialized(
+					opaqueRoundTrippableGenericValue,
+				);
+				roundTrippableGenericValue = exposeFromOpaqueJson(opaqueRoundTrippableGenericValue);
+			});
+
+			it("OpaqueJsonSerializable & OpaqueJsonDeserialized may be forwarded as JsonSerializable", () => {
+				// Setup
+				const roundTrippableGenericValue = {
+					...generalValue,
+				} as unknown as JsonSerializable<T> & JsonDeserialized<T>;
+				const opaqueRoundTrippableGenericValue = saveJsonRoundTrippable(
+					roundTrippableGenericValue,
+				);
+
+				// Act & Verify
+				const serializableGenericValue = forwardJsonSerializable(
+					opaqueRoundTrippableGenericValue,
+				);
+				assertIdenticalTypes(
+					serializableGenericValue,
+					createInstanceOf<JsonSerializable<T>>(),
+				);
+			});
+
+			it("OpaqueJsonSerializable & OpaqueJsonDeserialized may be returned as JsonDeserialized", () => {
+				// Setup
+				const roundTrippableGenericValue = {
+					...generalValue,
+				} as unknown as JsonSerializable<T> & JsonDeserialized<T>;
+				const opaqueRoundTrippableGenericValue = saveJsonRoundTrippable(
+					roundTrippableGenericValue,
+				);
+
+				// Act & Verify
+				const deserializedGenericValue = returnJsonDeserialized(
+					opaqueRoundTrippableGenericValue,
+				);
+				assertIdenticalTypes(
+					deserializedGenericValue,
+					createInstanceOf<JsonDeserialized<T>>(),
+				);
+			});
+		});
+	});
+
+	describe("negative compilation tests", () => {
+		it("OpaqueJsonSerializable is covariant (more general is NOT assignable to specific)", () => {
+			// Setup
+			const serializableGeneralValue = saveJsonSerializable(generalValue);
+			let serializableSpecificValue = saveJsonSerializable({ a: 1 });
+			use(serializableSpecificValue);
+			let serializableValueWithMore = saveJsonSerializable({ a: 2 as number, b: "test" });
+			use(serializableValueWithMore);
+
+			// Act & Verify
+			// @ts-expect-error 'OpaqueJsonSerializable<{ readonly a: number; }>' is not assignable to type 'OpaqueJsonSerializable<{ readonly a: 1; }>'
+			serializableSpecificValue = serializableGeneralValue; // should not be assignable
+			// @ts-expect-error 'OpaqueJsonSerializable<{ readonly a: number; }>' is not assignable to type 'OpaqueJsonSerializable<{ readonly a: number; b: "test"; }>'
+			serializableValueWithMore = serializableGeneralValue; // should not be assignable
+		});
+
+		it("OpaqueJsonDeserialized is covariant (more general is NOT assignable to specific)", () => {
+			// Setup
+			const deserializedGeneralValue = saveJsonDeserialized(generalValue);
+			let deserializedSpecificValue = saveJsonDeserialized({ a: 1 });
+			use(deserializedSpecificValue);
+			let deserializedValueWithMore = saveJsonDeserialized({
+				a: 2 as number,
+				b: "test",
+			});
+			use(deserializedValueWithMore);
+
+			// Act & Verify
+			// @ts-expect-error 'OpaqueJsonDeserialized<{ readonly a: number; }>' is not assignable to type 'OpaqueJsonDeserialized<{ readonly a: 1; }>'
+			deserializedSpecificValue = deserializedGeneralValue; // should not be assignable
+			// @ts-expect-error 'OpaqueJsonDeserialized<{ readonly a: number; }>' is not assignable to type 'OpaqueJsonDeserialized<{ readonly a: number; b: "test"; }>'
+			deserializedValueWithMore = deserializedGeneralValue; // should not be assignable
+		});
+
+		it("OpaqueJsonSerializable & OpaqueJsonDeserialized is covariant (more specific is assignable to general)", () => {
+			// Setup
+			const roundTrippableGeneralValue = saveJsonRoundTrippable(generalValue);
+			let roundTrippableSpecificValue = saveJsonRoundTrippable({ a: 1 });
+			use(roundTrippableSpecificValue);
+			let roundTrippableValueWithMore = saveJsonRoundTrippable({ a: 2 as number, b: "test" });
+			use(roundTrippableValueWithMore);
+
+			// Act & Verify
+			// @ts-expect-error 'OpaqueJsonSerializable<{ readonly a: number; }> & OpaqueJsonDeserialized<{ readonly a: number; }>' is not assignable to type 'OpaqueJsonSerializable<{ readonly a: 1; }> & OpaqueJsonDeserialized<{ readonly a: 1; }>'
+			roundTrippableSpecificValue = roundTrippableGeneralValue; // should not be assignable
+			// @ts-expect-error 'OpaqueJsonSerializable<{ readonly a: number; }> & OpaqueJsonDeserialized<{ readonly a: number; }>' is not assignable to type 'OpaqueJsonSerializable<{ readonly a: number; b: "test"; }> & OpaqueJsonDeserialized<{ readonly a: number; b: "test"; }>'
+			roundTrippableValueWithMore = roundTrippableGeneralValue; // should not be assignable
+		});
+	});
+});

--- a/packages/common/core-interfaces/src/test/testUtils.ts
+++ b/packages/common/core-interfaces/src/test/testUtils.ts
@@ -64,7 +64,7 @@ export function reviveBigInt(_key: string, value: unknown): unknown {
  * Helper to return an Opaque Json type version of Json type
  */
 export function castToOpaqueJson<const T>(v: JsonSerializable<T>): JsonTypeToOpaqueJson<T> {
-	return v as unknown as JsonTypeToOpaqueJson<T>;
+	return v as JsonTypeToOpaqueJson<T>;
 }
 
 /**

--- a/packages/common/core-interfaces/src/test/testUtils.ts
+++ b/packages/common/core-interfaces/src/test/testUtils.ts
@@ -5,6 +5,16 @@
 
 import type { InternalUtilityTypes } from "../exposedInternalUtilityTypes.js";
 
+import type {
+	JsonTypeToOpaqueJson,
+	OpaqueJsonToJsonType,
+} from "@fluidframework/core-interfaces/internal";
+import type {
+	JsonSerializable,
+	OpaqueJsonDeserialized,
+	OpaqueJsonSerializable,
+} from "@fluidframework/core-interfaces/internal/exposedUtilityTypes";
+
 /**
  * Use to compile-time assert types of two variables are identical.
  *
@@ -48,4 +58,23 @@ export function reviveBigInt(_key: string, value: unknown): unknown {
 		return BigInt(value.slice(8, -9));
 	}
 	return value;
+}
+
+/**
+ * Helper to return an Opaque Json type version of Json type
+ */
+export function castToOpaqueJson<const T>(v: JsonSerializable<T>): JsonTypeToOpaqueJson<T> {
+	return v as unknown as JsonTypeToOpaqueJson<T>;
+}
+
+/**
+ * Helper to cast an Opaque Json type to its inner Json type, applying appropriate filtering.
+ * @remarks
+ * Only works with basic built-in stringify-parse logic (i.e. default
+ * {@link JsonSerializableOptions} and {@link JsonDeserializedOptions}).
+ */
+export function exposeFromOpaqueJson<
+	TOpaque extends OpaqueJsonSerializable<unknown> | OpaqueJsonDeserialized<unknown>,
+>(v: TOpaque): OpaqueJsonToJsonType<TOpaque> {
+	return v as unknown as OpaqueJsonToJsonType<TOpaque>;
 }

--- a/packages/common/core-interfaces/src/test/testValues.ts
+++ b/packages/common/core-interfaces/src/test/testValues.ts
@@ -11,12 +11,17 @@ import type {
 	IFluidHandleErased,
 } from "@fluidframework/core-interfaces";
 import { fluidHandleSymbol } from "@fluidframework/core-interfaces";
-import type { ReadonlyNonNullJsonObjectWith } from "@fluidframework/core-interfaces/internal";
+import type {
+	BrandedType,
+	ReadonlyNonNullJsonObjectWith,
+} from "@fluidframework/core-interfaces/internal";
 import type {
 	JsonTypeWith,
 	InternalUtilityTypes,
 	ReadonlyJsonTypeWith,
 	NonNullJsonObjectWith,
+	OpaqueJsonSerializable,
+	OpaqueJsonDeserialized,
 } from "@fluidframework/core-interfaces/internal/exposedUtilityTypes";
 
 /* eslint-disable jsdoc/require-jsdoc */
@@ -619,12 +624,6 @@ export const readonlySetOfRecords: ReadonlySet<StringRecordOfPoints> = setOfReco
 
 // #region Branded types
 
-declare class BrandedType<Brand> {
-	protected readonly brand: (dummy: never) => Brand;
-	private constructor();
-	public static [Symbol.hasInstance](value: never): value is never;
-}
-
 export const brandedNumber = 0 as number & BrandedType<"zero">;
 export const brandedString = "encoding" as string & BrandedType<"encoded">;
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -661,7 +660,43 @@ export const objectWithFluidHandle = {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface TestErasedType<T> extends ErasedType<readonly ["TestCustomType", T]> {}
 
-export const erasedType: TestErasedType<number> = 0 as unknown as TestErasedType<number>;
+export const erasedType = 0 as unknown as TestErasedType<number>;
+
+export const opaqueSerializableObject = objectWithNumber as unknown as OpaqueJsonSerializable<
+	typeof objectWithNumber
+>;
+export const opaqueDeserializedObject = objectWithNumber as unknown as OpaqueJsonDeserialized<
+	typeof objectWithNumber
+>;
+export const opaqueSerializableAndDeserializedObject =
+	objectWithNumber as unknown as OpaqueJsonSerializable<typeof objectWithNumber> &
+		OpaqueJsonDeserialized<typeof objectWithNumber>;
+
+export const opaqueSerializableObjectRequiringBigintSupport =
+	objectWithBigint as unknown as OpaqueJsonSerializable<typeof objectWithBigint, [bigint]>;
+export const opaqueDeserializedObjectRequiringBigintSupport =
+	objectWithBigint as unknown as OpaqueJsonDeserialized<typeof objectWithBigint, [bigint]>;
+export const opaqueSerializableAndDeserializedObjectRequiringBigintSupport =
+	objectWithBigint as unknown as OpaqueJsonSerializable<typeof objectWithBigint, [bigint]> &
+		OpaqueJsonDeserialized<typeof objectWithBigint, [bigint]>;
+
+// These values are branded as expecting `bigint` support, but they don't actually require it.
+export const opaqueSerializableObjectExpectingBigintSupport =
+	objectWithReadonlyArrayOfNumbers as unknown as OpaqueJsonSerializable<
+		typeof objectWithReadonlyArrayOfNumbers,
+		[bigint]
+	>;
+export const opaqueDeserializedObjectExpectingBigintSupport =
+	objectWithReadonlyArrayOfNumbers as unknown as OpaqueJsonDeserialized<
+		typeof objectWithReadonlyArrayOfNumbers,
+		[bigint]
+	>;
+export const opaqueSerializableAndDeserializedObjectExpectingBigintSupport =
+	objectWithReadonlyArrayOfNumbers as unknown as OpaqueJsonSerializable<
+		typeof objectWithReadonlyArrayOfNumbers,
+		[bigint]
+	> &
+		OpaqueJsonDeserialized<typeof objectWithReadonlyArrayOfNumbers, [bigint]>;
 
 // #endregion
 


### PR DESCRIPTION
Introduce `OpaqueJsonDeserialized`, and `OpaqueJsonSerializable` as "handles" for generic values.

Opaque Json types can be used when there is no direct need to work with a complex or unknown type, but still need to respect serializability. Common use is when a value that has passed through `JsonSerializable` or `JsonDeserialized` filter utilities needs to be stored, especially in a generic context. The Opaque types are recognized by `JsonSerializable` and `JsonDeserialized` allowing those stored captures to themselves be part of flow that checks for serializability or deserialization.

Test cases:
  JsonDeserialized
    positive compilation tests
      fully supported object types are preserved
        ✔ OpaqueJsonDeserialized<{number:number}>
      partially supported object types are modified
        OpaqueJsonSerialized becomes OpaqueJsonDeserialized counterpart
          ✔ OpaqueJsonSerializable<{number:number}> becomes OpaqueJsonDeserialized<{number:number}>
          ✔ OpaqueJsonSerializable<{number:number}>&OpaqueJsonDeserialized<{number:number}> becomes OpaqueJsonDeserialized<{number:number}>
        opaque Json types requiring extra allowed types have extras removed
          ✔ opaque serializable object with `bigint`
          ✔ opaque deserialized object with `bigint`
          ✔ opaque serializable and deserialized object with `bigint`
          ✔ opaque serializable object with number array expecting `bigint` support
          ✔ opaque deserialized object with number array expecting `bigint` support
          ✔ opaque serializable and deserialized object with number array expecting `bigint` support
    special cases
      using alternately allowed types
        are preserved
          ✔ opaque serializable object with `bigint`
          ✔ opaque deserialized object with `bigint`
          ✔ opaque serializable and deserialized object with `bigint`

  JsonSerializable
    positive compilation tests
      supported object types
        opaque Json types
          ✔ opaque serializable object
          ✔ opaque deserialized object
          ✔ opaque serializable and deserialized object
    negative compilation tests
      unsupported types cause compiler error
        opaque Json types requiring extra allowed types
          ✔ opaque serializable object with `bigint`
          ✔ opaque deserialized object with `bigint`
          ✔ opaque serializable and deserialized object with `bigint`
          ✔ opaque serializable object with number array expecting `bigint` support
          ✔ opaque deserialized object with number array expecting `bigint` support
          ✔ opaque serializable and deserialized object with number array expecting `bigint` support

  OpaqueJsonSerializable and OpaqueJsonDeserialized
    positive compilation tests
      ✔ OpaqueJsonSerializable is covariant (more specific is assignable to general)
      ✔ OpaqueJsonDeserialized is covariant (more specific is assignable to general)
      ✔ OpaqueJsonSerializable & OpaqueJsonDeserialized is covariant (more specific is assignable to general)
      in a generic context
        ✔ OpaqueJsonDeserialized assignability varies with JsonDeserialized Options
        ✔ OpaqueJsonSerializable assignability varies with JsonSerializable Options
        ✔ OpaqueJsonSerializable may be forwarded as JsonSerializable
        ✔ OpaqueJsonDeserialized may be returned to JsonDeserialized
        ✔ OpaqueJsonSerializable & OpaqueJsonDeserialized may be returned to JsonSerializable & JsonDeserialized
        ✔ OpaqueJsonSerializable & OpaqueJsonDeserialized may be forwarded as JsonSerializable
        ✔ OpaqueJsonSerializable & OpaqueJsonDeserialized may be returned as JsonDeserialized
    negative compilation tests
      ✔ OpaqueJsonSerializable is covariant (more general is NOT assignable to specific)
      ✔ OpaqueJsonDeserialized is covariant (more general is NOT assignable to specific)
      ✔ OpaqueJsonSerializable & OpaqueJsonDeserialized is covariant (more specific is assignable to general)