### PR TITLE
improvement(client-fluid-static): cleanup @internal tags and @inheritDoc

### DIFF
--- a/packages/framework/fluid-static/src/index.ts
+++ b/packages/framework/fluid-static/src/index.ts
@@ -27,7 +27,6 @@ export type {
 	IMember,
 	IServiceAudience,
 	IServiceAudienceEvents,
-	LoadableObjectRecord,
 	MemberChangedListener,
 	Myself,
 } from "./types.js";

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -140,9 +140,6 @@ class RootDataObject
 		await Promise.all(loadInitialObjectsP);
 	}
 
-	/**
-	 * {@inheritDoc IRootDataObject.initialObjects}
-	 */
 	public get initialObjects(): LoadableObjectRecord {
 		if (Object.keys(this._initialObjects).length === 0) {
 			throw new Error("Initial Objects were not correctly initialized");
@@ -150,9 +147,6 @@ class RootDataObject
 		return this._initialObjects;
 	}
 
-	/**
-	 * {@inheritDoc IRootDataObject.create}
-	 */
 	public async create<T>(objectClass: SharedObjectKind<T>): Promise<T> {
 		const internal = objectClass as unknown as LoadableObjectKind<T & IFluidLoadable>;
 		if (isDataObjectKind(internal)) {
@@ -289,9 +283,6 @@ class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
 		this.initialObjects = schema.initialObjects;
 	}
 
-	/**
-	 * {@inheritDoc @fluidframework/aqueduct#BaseContainerRuntimeFactory.containerInitializingFirstTime}
-	 */
 	protected async containerInitializingFirstTime(runtime: IContainerRuntime): Promise<void> {
 		// The first time we create the container we create the RootDataObject
 		await this.rootDataObjectFactory.createRootInstance(rootDataStoreId, runtime, {

--- a/packages/framework/fluid-static/src/serviceAudience.ts
+++ b/packages/framework/fluid-static/src/serviceAudience.ts
@@ -36,8 +36,6 @@ export function createServiceAudience<TMember extends IMember = IMember>(props: 
  * the user and client details returned in {@link IMember}.
  *
  * @typeParam TMember - A service-specific {@link IMember} implementation.
- *
- * @internal
  */
 class ServiceAudience<TMember extends IMember = IMember>
 	extends TypedEventEmitter<IServiceAudienceEvents<TMember>>

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -20,7 +20,6 @@ export type CompatibilityMode = "1" | "2";
 
 /**
  * A mapping of string identifiers to instantiated `DataObject`s or `SharedObject`s.
- * @internal
  */
 export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 
@@ -98,7 +97,6 @@ export interface ContainerSchema {
 /**
  * Holds the collection of objects that the container was initially created with, as well as provides the ability
  * to dynamically create further objects during usage.
- * @internal
  */
 export interface IRootDataObject {
 	/**


### PR DESCRIPTION
Remove `LoadableObjectRecord` as it is fully internal since #24697