### PR TITLE
fix(tree): Correct error messaging when accessing disposed nodes

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -99,7 +99,7 @@ export enum TreeStatus {
 	 * - The node was removed and nothing (e.g. undo/redo history) kept it from being cleaned up.
 	 * - The {@link TreeView} was disposed or had a schema change which made the tree incompatible.
 	 *
-	 * Deleted nodes' contents should not be observed or edited. This includes functionality exposed via {@link Tree},
+	 * Deleted nodes' contents should not be observed or edited. This includes functionality exposed via {@link (Tree:variable)},
 	 * with the exception of {@link TreeNodeApi.status}.
 	 *
 	 * @privateRemarks

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -98,6 +98,10 @@ export enum TreeStatus {
 	 * Nodes can enter this state for multiple reasons:
 	 * - The node was removed and nothing (e.g. undo/redo history) kept it from being cleaned up.
 	 * - The {@link TreeView} was disposed or had a schema change which made the tree incompatible.
+	 *
+	 * Deleted nodes' contents should not be observed or edited. This includes functionality exposed via {@link Tree},
+	 * with the exception of {@link TreeNodeApi.status}.
+	 *
 	 * @privateRemarks
 	 * There was planned work (AB#17948) to make the first reason a node could become "Deleted" impossible,
 	 * at least as an opt in feature,

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -49,7 +49,7 @@ import { lazilyAllocateIdentifier, isObjectNodeSchema } from "../node-kinds/inde
  * been {@link TreeStatus.Deleted | deleted}.
  * To verify whether or not a node already has been deleted, use the {@link TreeNodeApi.status} function.
  *
- * This type should only be used via the public `Tree` export.
+ * This type should only be used via the public {@link (Tree:variable)} export.
  *
  * @privateRemarks
  * Due to limitations of API-Extractor link resolution, this type can't be moved into internalTypes but should be considered just an implementation detail of the `Tree` export.

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -43,9 +43,14 @@ import { lazilyAllocateIdentifier, isObjectNodeSchema } from "../node-kinds/inde
 
 /**
  * Provides various functions for analyzing {@link TreeNode}s.
- * * @remarks
- * This type should only be used via the public `Tree` export.
+ *
+ * @remarks
+ * With the exception of {@link TreeNodeApi.status}, these functions should not be called with nodes that have been disposed.
+ * To verify whether or not a node already has been disposed, use the {@link TreeNodeApi.status} function.
+ *
  * @privateRemarks
+ * This type should only be used via the public `Tree` export.
+ *
  * Due to limitations of API-Extractor link resolution, this type can't be moved into internalTypes but should be considered just an implementation detail of the `Tree` export.
  *
  * Inlining the typing of this interface onto the `Tree` object provides slightly different .d.ts generation,
@@ -127,6 +132,10 @@ export interface TreeNodeApi {
 
 /**
  * The `Tree` object holds various functions for analyzing {@link TreeNode}s.
+ *
+ * @remarks
+ * With the exception of {@link TreeNodeApi.status}, these functions should not be called with nodes that have been disposed.
+ * To verify whether or not a node already has been disposed, use the {@link TreeNodeApi.status} function.
  */
 export const treeNodeApi: TreeNodeApi = {
 	parent(node: TreeNode): TreeNode | undefined {

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -49,9 +49,9 @@ import { lazilyAllocateIdentifier, isObjectNodeSchema } from "../node-kinds/inde
  * been {@link TreeStatus.Deleted | deleted}.
  * To verify whether or not a node already has been deleted, use the {@link TreeNodeApi.status} function.
  *
- * @privateRemarks
  * This type should only be used via the public `Tree` export.
  *
+ * @privateRemarks
  * Due to limitations of API-Extractor link resolution, this type can't be moved into internalTypes but should be considered just an implementation detail of the `Tree` export.
  *
  * Inlining the typing of this interface onto the `Tree` object provides slightly different .d.ts generation,

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -82,7 +82,7 @@ export interface TreeNodeApi {
 	/**
 	 * Return the node under which this node resides in the tree (or undefined if this is a root node of the tree).
 	 *
-	 * @throws If the node has been {@link TreeStatus.Deleted | deleted}.
+	 * @throws A {@link @fluidframework/telemetry-utils#UsageError} if the node has been {@link TreeStatus.Deleted | deleted}.
 	 */
 	parent(node: TreeNode): TreeNode | undefined;
 
@@ -93,7 +93,7 @@ export interface TreeNodeApi {
 	 * If `node` is an element in a {@link (TreeArrayNode:interface)}, this returns the index of `node` in the array node (a `number`).
 	 * Otherwise, this returns the key of the field that it is under (a `string`).
 	 *
-	 * @throws If the node has been {@link TreeStatus.Deleted | deleted}.
+	 * @throws A {@link @fluidframework/telemetry-utils#UsageError} if the node has been {@link TreeStatus.Deleted | deleted}.
 	 */
 	key(node: TreeNode): string | number;
 

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -45,8 +45,9 @@ import { lazilyAllocateIdentifier, isObjectNodeSchema } from "../node-kinds/inde
  * Provides various functions for analyzing {@link TreeNode}s.
  *
  * @remarks
- * With the exception of {@link TreeNodeApi.status}, these functions should not be called with nodes that have been disposed.
- * To verify whether or not a node already has been disposed, use the {@link TreeNodeApi.status} function.
+ * With the exception of {@link TreeNodeApi.status}, these functions should not be called with nodes that have
+ * been {@link TreeStatus.Deleted | deleted}.
+ * To verify whether or not a node already has been deleted, use the {@link TreeNodeApi.status} function.
  *
  * @privateRemarks
  * This type should only be used via the public `Tree` export.
@@ -80,14 +81,19 @@ export interface TreeNodeApi {
 
 	/**
 	 * Return the node under which this node resides in the tree (or undefined if this is a root node of the tree).
+	 *
+	 * @throws If the node has been {@link TreeStatus.Deleted | deleted}.
 	 */
 	parent(node: TreeNode): TreeNode | undefined;
 
 	/**
 	 * The key of the given node under its parent.
+	 *
 	 * @remarks
 	 * If `node` is an element in a {@link (TreeArrayNode:interface)}, this returns the index of `node` in the array node (a `number`).
 	 * Otherwise, this returns the key of the field that it is under (a `string`).
+	 *
+	 * @throws If the node has been {@link TreeStatus.Deleted | deleted}.
 	 */
 	key(node: TreeNode): string | number;
 
@@ -134,8 +140,9 @@ export interface TreeNodeApi {
  * The `Tree` object holds various functions for analyzing {@link TreeNode}s.
  *
  * @remarks
- * With the exception of {@link TreeNodeApi.status}, these functions should not be called with nodes that have been disposed.
- * To verify whether or not a node already has been disposed, use the {@link TreeNodeApi.status} function.
+ * With the exception of {@link TreeNodeApi.status}, these functions should not be called with nodes that have
+ * been {@link TreeStatus.Deleted | deleted}.
+ * To verify whether or not a node already has been deleted, use the {@link TreeNodeApi.status} function.
  */
 export const treeNodeApi: TreeNodeApi = {
 	parent(node: TreeNode): TreeNode | undefined {

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -137,12 +137,7 @@ export interface TreeNodeApi {
 }
 
 /**
- * The `Tree` object holds various functions for analyzing {@link TreeNode}s.
- *
- * @remarks
- * With the exception of {@link TreeNodeApi.status}, these functions should not be called with nodes that have
- * been {@link TreeStatus.Deleted | deleted}.
- * To verify whether or not a node already has been deleted, use the {@link TreeNodeApi.status} function.
+ * {@inheritDoc TreeNodeApi}
  */
 export const treeNodeApi: TreeNodeApi = {
 	parent(node: TreeNode): TreeNode | undefined {

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -311,7 +311,7 @@ export class TreeNodeKernel {
 		}
 
 		if (this.disposed) {
-			throw new UsageError("Cannot access a Deleted node.");
+			throw new UsageError("Cannot access a deleted node.");
 		}
 
 		if (this.#hydrationState.innerNode === undefined) {

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -311,7 +311,7 @@ export class TreeNodeKernel {
 		}
 
 		if (this.disposed) {
-			throw new UsageError("Cannot access a deleted node.");
+			throw new UsageError("Cannot access a Deleted node.");
 		}
 
 		if (this.#hydrationState.innerNode === undefined) {

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -298,10 +298,9 @@ export class TreeNodeKernel {
 	 *
 	 * For hydrated nodes it returns a FlexTreeNode backed by the forest.
 	 * Note that for "marinated" nodes, this FlexTreeNode exists and returns it: it does not return the MapTreeNode which is the current InnerNode.
-	 *
-	 * If `allowDeleted` is false, this will throw a UsageError if the node is deleted.
+	 * @throws A {@link @fluidframework/telemetry-utils#UsageError} if the node has been deleted.
 	 */
-	public getOrCreateInnerNode(allowDeleted = false): InnerNode {
+	public getOrCreateInnerNode(): InnerNode {
 		if (!isHydrated(this.#hydrationState)) {
 			debugAssert(
 				() =>
@@ -327,16 +326,12 @@ export class TreeNodeKernel {
 				context.checkout.forest.moveCursorToPath(anchorNode, cursor);
 				this.#hydrationState.innerNode = makeTree(context, cursor);
 				cursor.free();
-				if (!allowDeleted) {
-					assertFlexTreeEntityNotFreed(this.#hydrationState.innerNode);
-				}
+				assertFlexTreeEntityNotFreed(this.#hydrationState.innerNode);
 			}
 		}
 
-		if (!allowDeleted) {
-			if (this.#hydrationState.innerNode.context.isDisposed()) {
-				throw new UsageError("Cannot access a Deleted node.");
-			}
+		if (this.#hydrationState.innerNode.context.isDisposed()) {
+			throw new UsageError("Cannot access a Deleted node.");
 		}
 
 		return this.#hydrationState.innerNode;
@@ -445,11 +440,11 @@ export function getSimpleContextFromInnerNode(innerNode: InnerNode): Context {
  * For hydrated nodes it returns a FlexTreeNode backed by the forest.
  * Note that for "marinated" nodes, this FlexTreeNode exists and returns it: it does not return the MapTreeNode which is the current InnerNode.
  *
- * If `allowDeleted` is false, this will throw a UsageError if the node is deleted.
+ * @throws A {@link @fluidframework/telemetry-utils#UsageError} if the node has been deleted.
  */
-export function getOrCreateInnerNode(treeNode: TreeNode, allowDeleted = false): InnerNode {
+export function getOrCreateInnerNode(treeNode: TreeNode): InnerNode {
 	const kernel = getKernel(treeNode);
-	return kernel.getOrCreateInnerNode(allowDeleted);
+	return kernel.getOrCreateInnerNode();
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -298,7 +298,8 @@ export class TreeNodeKernel {
 	 *
 	 * For hydrated nodes it returns a FlexTreeNode backed by the forest.
 	 * Note that for "marinated" nodes, this FlexTreeNode exists and returns it: it does not return the MapTreeNode which is the current InnerNode.
-	 * @throws A {@link @fluidframework/telemetry-utils#UsageError} if the node has been deleted.
+	 *
+	 * @throws If the node has been deleted.
 	 */
 	public getOrCreateInnerNode(): InnerNode {
 		if (!isHydrated(this.#hydrationState)) {
@@ -440,7 +441,8 @@ export function getSimpleContextFromInnerNode(innerNode: InnerNode): Context {
  * For hydrated nodes it returns a FlexTreeNode backed by the forest.
  * Note that for "marinated" nodes, this FlexTreeNode exists and returns it: it does not return the MapTreeNode which is the current InnerNode.
  *
- * @throws A {@link @fluidframework/telemetry-utils#UsageError} if the node has been deleted.
+ *
+ * @throws If the node has been deleted.
  */
 export function getOrCreateInnerNode(treeNode: TreeNode): InnerNode {
 	const kernel = getKernel(treeNode);

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -310,6 +310,10 @@ export class TreeNodeKernel {
 			return this.#hydrationState.innerNode; // Unhydrated case
 		}
 
+		if (this.disposed) {
+			throw new UsageError("Cannot access a deleted node.");
+		}
+
 		if (this.#hydrationState.innerNode === undefined) {
 			// Marinated case -> cooked
 			const anchorNode = this.#hydrationState.anchorNode;
@@ -328,10 +332,6 @@ export class TreeNodeKernel {
 				cursor.free();
 				assertFlexTreeEntityNotFreed(this.#hydrationState.innerNode);
 			}
-		}
-
-		if (this.#hydrationState.innerNode.context.isDisposed()) {
-			throw new UsageError("Cannot access a Deleted node.");
 		}
 
 		return this.#hydrationState.innerNode;

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -299,7 +299,7 @@ export class TreeNodeKernel {
 	 * For hydrated nodes it returns a FlexTreeNode backed by the forest.
 	 * Note that for "marinated" nodes, this FlexTreeNode exists and returns it: it does not return the MapTreeNode which is the current InnerNode.
 	 *
-	 * @throws If the node has been deleted.
+	 * @throws A {@link @fluidframework/telemetry-utils#UsageError} if the node has been deleted.
 	 */
 	public getOrCreateInnerNode(): InnerNode {
 		if (!isHydrated(this.#hydrationState)) {
@@ -441,8 +441,7 @@ export function getSimpleContextFromInnerNode(innerNode: InnerNode): Context {
  * For hydrated nodes it returns a FlexTreeNode backed by the forest.
  * Note that for "marinated" nodes, this FlexTreeNode exists and returns it: it does not return the MapTreeNode which is the current InnerNode.
  *
- *
- * @throws If the node has been deleted.
+ * @throws A {@link @fluidframework/telemetry-utils#UsageError} if the node has been deleted.
  */
 export function getOrCreateInnerNode(treeNode: TreeNode): InnerNode {
 	const kernel = getKernel(treeNode);

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -178,6 +178,7 @@ export class TreeNodeKernel {
 		} else {
 			// Hydrated case
 			this.#hydrationState = this.createHydratedState(innerNode.anchorNode);
+			this.#hydrationState.innerNode = innerNode;
 		}
 	}
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -241,7 +241,7 @@ describe("SharedTree", () => {
 			view1.dispose();
 
 			assert(Tree.status(root1) === TreeStatus.Deleted);
-			assert.throws(() => root1.number, validateUsageError(/Deleted/));
+			assert.throws(() => root1.number, validateUsageError(/deleted/));
 
 			checkAnchors(false);
 

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -47,7 +47,7 @@ import {
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../simple-tree/leafNodeSchema.js";
 // eslint-disable-next-line import/no-internal-modules
-import { tryGetSchema } from "../../../simple-tree/api/treeNodeApi.js";
+import { treeNodeApi, tryGetSchema } from "../../../simple-tree/api/treeNodeApi.js";
 import { testSimpleTrees } from "../../testTrees.js";
 import { FluidClientVersion } from "../../../codec/index.js";
 import { ajvValidator } from "../../codec/index.js";
@@ -57,7 +57,7 @@ const schema = new SchemaFactory("com.example");
 
 class Point extends schema.object("Point", {}) {}
 
-describe("treeNodeApi", () => {
+describe.only("treeNodeApi", () => {
 	describe("is", () => {
 		it("is", () => {
 			const config = new TreeViewConfiguration({ schema: [Point, schema.number] });
@@ -228,6 +228,31 @@ describe("treeNodeApi", () => {
 			assert.equal(Tree.parent(added), root);
 			root.removeRange(0, 1);
 			assert.equal(Tree.parent(added), undefined);
+		});
+
+		it("parent - throws for disposed node", () => {
+			const config = new TreeViewConfiguration({ schema: Point });
+			const view = getView(config);
+			const node = new Point({});
+			view.initialize(node);
+
+			view.dispose();
+
+			assert.throws(
+				() => Tree.parent(node),
+				validateUsageError(/Cannot access a deleted node/),
+			);
+		});
+
+		it("key - throws for disposed node", () => {
+			const config = new TreeViewConfiguration({ schema: Point });
+			const view = getView(config);
+			const node = new Point({});
+			view.initialize(node);
+
+			view.dispose();
+
+			assert.throws(() => Tree.key(node), validateUsageError(/Cannot access a deleted node/));
 		});
 	});
 


### PR DESCRIPTION
Error messaging was inconsistent when attempting to access disposed node contents. Some cases threw a user-friendly error message, but other cases yielded an internal-facing assertion error. This PR makes the errors consistent.

Also:
- Introduces a small optimization by caching `innerNode` in kernal construction
- Removes `allowDeleted` parameter from `getOrCreateInnerNode`, which was unused (all code paths used the default value of `false`)