### PR TITLE
fix(staging-mode): Add some more preconditions to enterStagingMode

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3419,7 +3419,13 @@ export class ContainerRuntime
 	// eslint-disable-next-line import/no-deprecated
 	public enterStagingMode = (): StageControlsExperimental => {
 		if (this.stageControls !== undefined) {
-			throw new Error("already in staging mode");
+			throw new UsageError("already in staging mode");
+		}
+		if (this.attachState === AttachState.Detached) {
+			throw new UsageError("cannot enter staging mode while detached");
+		}
+		if (this.flushMode !== FlushMode.TurnBased) {
+			throw new UsageError("Staging Mode is only supported in TurnBased flush mode");
 		}
 
 		// Make sure all BatchManagers are empty before entering staging mode,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3424,9 +3424,6 @@ export class ContainerRuntime
 		if (this.attachState === AttachState.Detached) {
 			throw new UsageError("cannot enter staging mode while detached");
 		}
-		if (this.flushMode !== FlushMode.TurnBased) {
-			throw new UsageError("Staging Mode is only supported in TurnBased flush mode");
-		}
 
 		// Make sure all BatchManagers are empty before entering staging mode,
 		// since we mark whole batches as "staged" or not to indicate whether to submit them.

--- a/packages/test/local-server-stress-tests/src/test/localServerStressOrderSequentially.spec.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStressOrderSequentially.spec.ts
@@ -79,6 +79,7 @@ describe("Local Server Stress with rollback", () => {
 							} satisfies OrderSequentially;
 						},
 						50,
+						(state) => state.client.container.attachState !== "Detached",
 					],
 				]),
 			),
@@ -99,13 +100,14 @@ describe("Local Server Stress with rollback", () => {
 		// saveSuccesses,
 		configurations: { "Fluid.ContainerRuntime.EnableRollback": true },
 		skip: [
-			...[12, 28, 30], // Key not found or value not matching key
-			...[15, 38, 51, 63], // Number of keys not same (directory)
+			...[12], // Values differ at key
+			...[28, 30], // Key not found or value not matching key
+			...[15, 31, 38], // Number of keys not same (directory)
 			...[24], // have different number of keys (map)
-			...[25], // Number of subDirectories not same
-			...[53], // SubDirectory with name ... not present in second directory
-			...[65], // closed or disposed: 0x2f5
-			...[72], // closed or disposed: 0x2fa
+			...[25, 53], // Number of subDirectories not same
+			...[], // SubDirectory with name ... not present in second directory
+			...[65, 67], // 0x2f5 (op create references must be SlideOnRemove)
+			...[], // 0x2fa (Unexpected pending message received)
 		],
 	});
 });


### PR DESCRIPTION
## Description

Adding these preconditions to `enterStagingMode`:

1. Must not be detached.
   - Changes made while detached are local-only already, and typically don't result in ops anyway (included in attach summary instead), so this is not a useful mode.  So codify this assumption to simplify our own reasoning about Staging Mode
2. ~Must be using TurnBased flush mode~
   - ~TurnBased is the only option we provide, with one caveat which is 2.x Declarative Mode clients that want to support collab with 1.x clients.  We don't anticipate offering Staging Mode in that configuration.~

_Never mind about TurnBased - It's not actually a problem, I was just trying to simplify.  But since OrderSequentially is now built on Staging Mode, I'm choosing not to touch this.  OrderSequentially + Immediate mode is not actually supported via any API surface, but we have tests that do cover this, and it's a sensible feature to maintain support for, as long as Immediate Mode exists._