### PR TITLE
Revert changes to MockFluidDataStoreContext from PR24704

### DIFF
--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -453,7 +453,7 @@ export class FluidDataStoreRuntime
 		return (
 			// eslint-disable-next-line import/no-deprecated
 			(this.dataStoreContext.containerRuntime as IContainerRuntimeBaseExperimental)
-				.inStagingMode
+				?.inStagingMode
 		);
 	}
 

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -113,7 +113,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 	}
 
 	public submitMessage(type: string, content: any, localOpMetadata: unknown): void {
-		throw new Error("Method not implemented.");
+		// No-op for mock context
 	}
 
 	public submitSignal(type: string, content: any): void {

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -51,6 +51,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 	public baseSnapshot: ISnapshotTree | undefined;
 	public deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> =
 		new MockDeltaManager(() => this.clientId);
+
 	public containerRuntime: IContainerRuntimeBase = undefined as any;
 	public storage: IDocumentStorageService = undefined as any;
 	public IFluidDataStoreRegistry: IFluidDataStoreRegistry = undefined as any;

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -51,11 +51,11 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 	public baseSnapshot: ISnapshotTree | undefined;
 	public deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage> =
 		new MockDeltaManager(() => this.clientId);
-	public containerRuntime: IContainerRuntimeBase = {} as any;
-	public storage: IDocumentStorageService = {} as any;
-	public IFluidDataStoreRegistry: IFluidDataStoreRegistry = {} as any;
-	public IFluidHandleContext: IFluidHandleContext = {} as any;
-	public idCompressor: IIdCompressorCore & IIdCompressor = {} as any;
+	public containerRuntime: IContainerRuntimeBase = undefined as any;
+	public storage: IDocumentStorageService = undefined as any;
+	public IFluidDataStoreRegistry: IFluidDataStoreRegistry = undefined as any;
+	public IFluidHandleContext: IFluidHandleContext = undefined as any;
+	public idCompressor: IIdCompressorCore & IIdCompressor = undefined as any;
 	public readonly gcThrowOnTombstoneUsage = false;
 	public readonly gcTombstoneEnforcementAllowed = false;
 
@@ -113,7 +113,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 	}
 
 	public submitMessage(type: string, content: any, localOpMetadata: unknown): void {
-		// No-op for mock context
+		throw new Error("Method not implemented.");
 	}
 
 	public submitSignal(type: string, content: any): void {


### PR DESCRIPTION
Reverts parts of microsoft/FluidFramework#24704

While not yet confirmed, it seems plausible that microsoft/FluidFramework#24704 has caused the bohemia FF integration pipeline to [fail](https://dev.azure.com/office/OC/_build/results?buildId=37401808).

The failing tests in the integration pipeline seem encounter an issue with `MockFluidDataStoreContext.containerRuntime.on` not being a function. The reverted PR made some changes to `MockFluidDataStoreContext.containerRuntime` that could be the cause.

[A separate PR](https://github.com/microsoft/FluidFramework/pull/24744) was first made to revert the whole of microsoft/FluidFramework#24704 but that requires fluid-cr-api approval (none of the people seem present) and as Mark pointed out, it should not be necessary to revert the whole thing.

See [Teams thread](https://teams.microsoft.com/l/message/19:2309a5f41d894db984a8efc811dbb4b6@thread.skype/1748637508660?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=422665a0-7ad3-4d0d-9171-e8881d0397d9&parentMessageId=1748637508660&teamName=Loop&channelName=Dev%20%F0%9F%91%A9%E2%80%8D%F0%9F%92%BB&createdTime=1748637508660) for context and discussion.
