### PR TITLE
refactor(api-markdown-documenter): Make `SpanNode`s more restrictive

### DIFF
--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.alpha.api.md
@@ -824,12 +824,9 @@ export class SectionNode extends DocumentationParentNodeBase<SectionContent> {
 // @public
 function shouldItemBeIncluded(apiItem: ApiItem, config: ApiItemTransformationConfiguration): boolean;
 
-// @public @sealed
-export type SpanContent = PhrasingContent | BlockContent;
-
 // @public
-export class SpanNode extends DocumentationParentNodeBase<SpanContent> {
-    constructor(children: SpanContent[], formatting?: TextFormatting);
+export class SpanNode extends DocumentationParentNodeBase<PhrasingContent> {
+    constructor(children: PhrasingContent[], formatting?: TextFormatting);
     static createFromPlainText(text: string, formatting?: TextFormatting): SpanNode;
     static readonly Empty: SpanNode;
     readonly textFormatting?: TextFormatting;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -810,12 +810,9 @@ export class SectionNode extends DocumentationParentNodeBase<SectionContent> {
 // @public
 function shouldItemBeIncluded(apiItem: ApiItem, config: ApiItemTransformationConfiguration): boolean;
 
-// @public @sealed
-export type SpanContent = PhrasingContent | BlockContent;
-
 // @public
-export class SpanNode extends DocumentationParentNodeBase<SpanContent> {
-    constructor(children: SpanContent[], formatting?: TextFormatting);
+export class SpanNode extends DocumentationParentNodeBase<PhrasingContent> {
+    constructor(children: PhrasingContent[], formatting?: TextFormatting);
     static createFromPlainText(text: string, formatting?: TextFormatting): SpanNode;
     static readonly Empty: SpanNode;
     readonly textFormatting?: TextFormatting;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -788,12 +788,9 @@ export class SectionNode extends DocumentationParentNodeBase<SectionContent> {
 // @public
 function shouldItemBeIncluded(apiItem: ApiItem, config: ApiItemTransformationConfiguration): boolean;
 
-// @public @sealed
-export type SpanContent = PhrasingContent | BlockContent;
-
 // @public
-export class SpanNode extends DocumentationParentNodeBase<SpanContent> {
-    constructor(children: SpanContent[], formatting?: TextFormatting);
+export class SpanNode extends DocumentationParentNodeBase<PhrasingContent> {
+    constructor(children: PhrasingContent[], formatting?: TextFormatting);
     static createFromPlainText(text: string, formatting?: TextFormatting): SpanNode;
     static readonly Empty: SpanNode;
     readonly textFormatting?: TextFormatting;

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -45,7 +45,6 @@ import {
 	PlainTextNode,
 	type SectionContent,
 	SectionNode,
-	type SpanContent,
 	SpanNode,
 	UnorderedListNode,
 } from "../../documentation-domain/index.js";
@@ -253,7 +252,7 @@ function createHeritageTypeListSpan(
 			}
 		}
 
-		const renderedList = injectSeparator<SpanContent>(
+		const renderedList = injectSeparator<PhrasingContent>(
 			renderedHeritageTypes,
 			new PlainTextNode(", "),
 		);
@@ -347,7 +346,7 @@ export function createExcerptSpanWithHyperlinks(
 		return undefined;
 	}
 
-	const children: SpanContent[] = [];
+	const children: PhrasingContent[] = [];
 	for (const token of excerpt.spannedTokens) {
 		// Markdown doesn't provide a standardized syntax for hyperlinks inside code spans, so we will render
 		// the type expression as DocPlainText.  Instead of creating multiple DocParagraphs, we can simply
@@ -568,10 +567,8 @@ export function createDeprecationNoticeSection(
 				{ bold: true },
 			),
 			LineBreakNode.Singleton,
-			new SpanNode(transformTsdoc(deprecatedBlock, apiItem, config), {
-				italic: true,
-			}),
 		]),
+		...transformTsdoc(deprecatedBlock, apiItem, config),
 	]);
 }
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -38,7 +38,6 @@ import {
 	type DocumentationParentNode,
 	FencedCodeBlockNode,
 	HeadingNode,
-	LineBreakNode,
 	LinkNode,
 	ParagraphNode,
 	type PhrasingContent,
@@ -566,7 +565,6 @@ export function createDeprecationNoticeSection(
 				"WARNING: This API is deprecated and will be removed in a future release.",
 				{ bold: true },
 			),
-			LineBreakNode.Singleton,
 		]),
 		...transformTsdoc(deprecatedBlock, apiItem, config),
 	]);

--- a/tools/api-markdown-documenter/src/documentation-domain/SpanNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/SpanNode.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { BlockContent } from "./BlockContent.js";
 import { DocumentationParentNodeBase } from "./DocumentationNode.js";
 import { DocumentationNodeType } from "./DocumentationNodeType.js";
 import type { PhrasingContent } from "./PhrasingContent.js";
@@ -14,14 +13,6 @@ import { createNodesFromPlainText } from "./Utilities.js";
 // It just groups child nodes with formatting we want applied to them.
 // It also probably makes sense to not wrap the output in a `<span> tag in HTML, since the formatting tags already
 // group the child content.
-
-/**
- * The types of child nodes that can be contained within a {@link SpanNode}.
- *
- * @sealed
- * @public
- */
-export type SpanContent = PhrasingContent | BlockContent;
 
 /**
  * A grouping of text, potentially spanning multiple lines, which may have some {@link TextFormatting}.
@@ -50,7 +41,7 @@ export type SpanContent = PhrasingContent | BlockContent;
  *
  * @public
  */
-export class SpanNode extends DocumentationParentNodeBase<SpanContent> {
+export class SpanNode extends DocumentationParentNodeBase<PhrasingContent> {
 	/**
 	 * Static singleton representing an empty Span Text node.
 	 */
@@ -68,7 +59,7 @@ export class SpanNode extends DocumentationParentNodeBase<SpanContent> {
 	 */
 	public readonly textFormatting?: TextFormatting;
 
-	public constructor(children: SpanContent[], formatting?: TextFormatting) {
+	public constructor(children: PhrasingContent[], formatting?: TextFormatting) {
 		super(children);
 		this.textFormatting = formatting;
 	}

--- a/tools/api-markdown-documenter/src/documentation-domain/index.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/index.ts
@@ -39,7 +39,7 @@ export { ParagraphNode } from "./ParagraphNode.js";
 export type { PhrasingContent, PhrasingContentMap } from "./PhrasingContent.js";
 export { PlainTextNode } from "./PlainTextNode.js";
 export { type SectionContent, SectionNode } from "./SectionNode.js";
-export { type SpanContent, SpanNode } from "./SpanNode.js";
+export { SpanNode } from "./SpanNode.js";
 export {
 	type TableCellContent,
 	TableCellNode,

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
@@ -13,7 +13,7 @@
         <p>I have a <code>@deprecated</code> tag with an empty comment block.</p>
       </section>
       <section>
-        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
+        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span></p>
       </section>
       <section>
         <h2 id="testconstwithemptydeprecatedblock-signature">Signature</h2><code>testConstWithEmptyDeprecatedBlock: string</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
@@ -13,7 +13,7 @@
         <p>I have a <code>@deprecated</code> tag with an empty comment block.</p>
       </section>
       <section>
-        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br><span></span></p>
+        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
       </section>
       <section>
         <h2 id="testconstwithemptydeprecatedblock-signature">Signature</h2><code>testConstWithEmptyDeprecatedBlock: string</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.html
@@ -13,7 +13,8 @@
         <p>Test function that returns an inline type</p>
       </section>
       <section>
-        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br><span><p><i>This is a test deprecation notice. Here is a </i><a href="/test-suite-a/testfunctionreturninguniontype-function"><i>link</i></a><i> to something else!</i></p></span></p>
+        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
+        <p>This is a test deprecation notice. Here is a <a href="/test-suite-a/testfunctionreturninguniontype-function">link</a> to something else!</p>
       </section>
       <section>
         <h2 id="testfunctionreturningintersectiontype-signature">Signature</h2><code>export declare function testFunctionReturningIntersectionType(): TestEmptyInterface &#x26; TestInterfaceWithTypeParameter&#x3C;number>;</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.html
@@ -13,7 +13,7 @@
         <p>Test function that returns an inline type</p>
       </section>
       <section>
-        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
+        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span></p>
         <p>This is a test deprecation notice. Here is a <a href="/test-suite-a/testfunctionreturninguniontype-function">link</a> to something else!</p>
       </section>
       <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/index.html
@@ -316,7 +316,7 @@
             <p>Test function that returns an inline type</p>
           </section>
           <section>
-            <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
+            <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span></p>
             <p>This is a test deprecation notice. Here is a <a href="/test-suite-a/#testfunctionreturninguniontype-function">link</a> to something else!</p>
           </section>
           <section>
@@ -367,7 +367,7 @@
             <p>I have a <code>@deprecated</code> tag with an empty comment block.</p>
           </section>
           <section>
-            <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
+            <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span></p>
           </section>
           <section>
             <h4 id="testconstwithemptydeprecatedblock-signature">Signature</h4><code>testConstWithEmptyDeprecatedBlock: string</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/index.html
@@ -316,7 +316,8 @@
             <p>Test function that returns an inline type</p>
           </section>
           <section>
-            <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br><span><p><i>This is a test deprecation notice. Here is a </i><a href="/test-suite-a/#testfunctionreturninguniontype-function"><i>link</i></a><i> to something else!</i></p></span></p>
+            <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
+            <p>This is a test deprecation notice. Here is a <a href="/test-suite-a/#testfunctionreturninguniontype-function">link</a> to something else!</p>
           </section>
           <section>
             <h4 id="testfunctionreturningintersectiontype-signature">Signature</h4><code>export declare function testFunctionReturningIntersectionType(): TestEmptyInterface &#x26; TestInterfaceWithTypeParameter&#x3C;number>;</code>
@@ -366,7 +367,7 @@
             <p>I have a <code>@deprecated</code> tag with an empty comment block.</p>
           </section>
           <section>
-            <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br><span></span></p>
+            <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
           </section>
           <section>
             <h4 id="testconstwithemptydeprecatedblock-signature">Signature</h4><code>testConstWithEmptyDeprecatedBlock: string</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
@@ -1424,7 +1424,7 @@
           <p>Test function that returns an inline type</p>
         </section>
         <section>
-          <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
+          <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span></p>
           <p>This is a test deprecation notice. Here is a <a href="docs/test-suite-a#testfunctionreturninguniontype-function">link</a> to something else!</p>
         </section>
         <section>
@@ -1475,7 +1475,7 @@
           <p>I have a <code>@deprecated</code> tag with an empty comment block.</p>
         </section>
         <section>
-          <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
+          <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span></p>
         </section>
         <section>
           <h3 id="testconstwithemptydeprecatedblock-signature">Signature</h3><code>testConstWithEmptyDeprecatedBlock: string</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
@@ -1424,7 +1424,8 @@
           <p>Test function that returns an inline type</p>
         </section>
         <section>
-          <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br><span><p><i>This is a test deprecation notice. Here is a </i><a href="docs/test-suite-a#testfunctionreturninguniontype-function"><i>link</i></a><i> to something else!</i></p></span></p>
+          <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
+          <p>This is a test deprecation notice. Here is a <a href="docs/test-suite-a#testfunctionreturninguniontype-function">link</a> to something else!</p>
         </section>
         <section>
           <h3 id="testfunctionreturningintersectiontype-signature">Signature</h3><code>export declare function testFunctionReturningIntersectionType(): TestEmptyInterface &#x26; TestInterfaceWithTypeParameter&#x3C;number>;</code>
@@ -1474,7 +1475,7 @@
           <p>I have a <code>@deprecated</code> tag with an empty comment block.</p>
         </section>
         <section>
-          <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br><span></span></p>
+          <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
         </section>
         <section>
           <h3 id="testconstwithemptydeprecatedblock-signature">Signature</h3><code>testConstWithEmptyDeprecatedBlock: string</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
@@ -10,7 +10,7 @@
         <p>I have a <code>@deprecated</code> tag with an empty comment block.</p>
       </section>
       <section>
-        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
+        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span></p>
       </section>
       <section>
         <h3 id="testconstwithemptydeprecatedblock-signature">Signature</h3><code>testConstWithEmptyDeprecatedBlock: string</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
@@ -10,7 +10,7 @@
         <p>I have a <code>@deprecated</code> tag with an empty comment block.</p>
       </section>
       <section>
-        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br><span></span></p>
+        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
       </section>
       <section>
         <h3 id="testconstwithemptydeprecatedblock-signature">Signature</h3><code>testConstWithEmptyDeprecatedBlock: string</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testfunctionreturningintersectiontype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testfunctionreturningintersectiontype-function.html
@@ -10,7 +10,8 @@
         <p>Test function that returns an inline type</p>
       </section>
       <section>
-        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br><span><p><i>This is a test deprecation notice. Here is a </i><a href="docs/test-suite-a/testfunctionreturninguniontype-function"><i>link</i></a><i> to something else!</i></p></span></p>
+        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
+        <p>This is a test deprecation notice. Here is a <a href="docs/test-suite-a/testfunctionreturninguniontype-function">link</a> to something else!</p>
       </section>
       <section>
         <h3 id="testfunctionreturningintersectiontype-signature">Signature</h3><code>export declare function testFunctionReturningIntersectionType(): TestEmptyInterface &#x26; TestInterfaceWithTypeParameter&#x3C;number>;</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testfunctionreturningintersectiontype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testfunctionreturningintersectiontype-function.html
@@ -10,7 +10,7 @@
         <p>Test function that returns an inline type</p>
       </section>
       <section>
-        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span><br></p>
+        <p><span><b>WARNING: This API is deprecated and will be removed in a future release.</b></span></p>
         <p>This is a test deprecation notice. Here is a <a href="docs/test-suite-a/testfunctionreturninguniontype-function">link</a> to something else!</p>
       </section>
       <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.md
@@ -6,7 +6,7 @@ Test function that returns an inline type
 
 **WARNING: This API is deprecated and will be removed in a future release.**
 
-_This is a test deprecation notice. Here is a_ [_link_](/test-suite-a/testfunctionreturninguniontype-function)<!-- --> _to something else!_
+This is a test deprecation notice. Here is a [link](/test-suite-a/testfunctionreturninguniontype-function) to something else!
 
 ## Signature {#testfunctionreturningintersectiontype-signature}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
@@ -158,7 +158,7 @@ Test function that returns an inline type
 
 **WARNING: This API is deprecated and will be removed in a future release.**
 
-_This is a test deprecation notice. Here is a_ [_link_](/test-suite-a/#testfunctionreturninguniontype-function)<!-- --> _to something else!_
+This is a test deprecation notice. Here is a [link](/test-suite-a/#testfunctionreturninguniontype-function) to something else!
 
 #### Signature {#testfunctionreturningintersectiontype-signature}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
@@ -954,7 +954,7 @@ Test function that returns an inline type
 
 **WARNING: This API is deprecated and will be removed in a future release.**
 
-_This is a test deprecation notice. Here is a_ [_link_](docs/test-suite-a#testfunctionreturninguniontype-function)<!-- --> _to something else!_
+This is a test deprecation notice. Here is a [link](docs/test-suite-a#testfunctionreturninguniontype-function) to something else!
 
 ### Signature {#testfunctionreturningintersectiontype-signature}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testfunctionreturningintersectiontype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testfunctionreturningintersectiontype-function.md
@@ -4,7 +4,7 @@ Test function that returns an inline type
 
 **WARNING: This API is deprecated and will be removed in a future release.**
 
-_This is a test deprecation notice. Here is a_ [_link_](docs/test-suite-a/testfunctionreturninguniontype-function)<!-- --> _to something else!_
+This is a test deprecation notice. Here is a [link](docs/test-suite-a/testfunctionreturninguniontype-function) to something else!
 
 ### Signature {#testfunctionreturningintersectiontype-signature}
 


### PR DESCRIPTION
We use `SpanNode` to represent a block of content with common formatting applies. It can be thought of as sort of an amalgamation of italics, bold, and underline formatting components (which in other contexts like HTML would be separate node kinds).

Previously, this type supported wrapping block content (paragraphs, etc.) in common formatting. This is a departure from Markdown / MDAST. It turns out we only used this support in a single place, and that was for strictly subjective formatting reasons (which are ultimately unused anyways).

This PR brings the span concept in line with Markdown requirements by restricting SpanNode children to phrasing content only.