### PR TITLE
improvement(client-core-interfaces): list OpaqueJsonSerializable as degenerate option

### DIFF
--- a/packages/common/core-interfaces/src/exposedInternalUtilityTypes.ts
+++ b/packages/common/core-interfaces/src/exposedInternalUtilityTypes.ts
@@ -790,15 +790,23 @@ export namespace InternalUtilityTypes {
 		AllowExtensionOf: Options extends { AllowExtensionOf: unknown }
 			? Options["AllowExtensionOf"]
 			: never;
-		// There Substitute type could be extracted to helper type, but are kept explicit here
-		// to make JsonTypeWith show explicitly in results for users, rather
-		// than either the helper type name or a partially unrolled version.
-		DegenerateSubstitute: JsonTypeWith<
-			| (Options extends { AllowExactly: unknown[] }
-					? TupleToUnion<Options["AllowExactly"]>
-					: never)
-			| (Options extends { AllowExtensionOf: unknown } ? Options["AllowExtensionOf"] : never)
-		>;
+		// The Substitute type could be extracted to helper type, but is kept explicit here
+		// to make JsonTypeWith and OpaqueJsonSerializable show explicitly in results for
+		// users, rather than either the helper type name or a partially unrolled version.
+		DegenerateSubstitute:
+			| JsonTypeWith<
+					| (Options extends { AllowExactly: unknown[] }
+							? TupleToUnion<Options["AllowExactly"]>
+							: never)
+					| (Options extends { AllowExtensionOf: unknown }
+							? Options["AllowExtensionOf"]
+							: never)
+			  >
+			| OpaqueJsonSerializable<
+					unknown,
+					Options extends { AllowExactly: unknown[] } ? Options["AllowExactly"] : [],
+					Options extends { AllowExtensionOf: unknown } ? Options["AllowExtensionOf"] : never
+			  >;
 	} extends infer Controls
 		? /* Controls should always satisfy FilterControlsWithSubstitution, but Typescript wants a check */
 			Controls extends FilterControlsWithSubstitution
@@ -1091,7 +1099,7 @@ export namespace InternalUtilityTypes {
 		AllowExtensionOf: Options extends { AllowExtensionOf: unknown }
 			? Options["AllowExtensionOf"]
 			: never;
-		// There Substitute types could be extracted to helper type, but are kept explicit here
+		// The Substitute types could be extracted to helper type, but are kept explicit here
 		// to make JsonTypeWith/NonNullJsonObjectWith show explicitly in results for users, rather
 		// than either the helper type name or a partially unrolled version.
 		DegenerateSubstitute: JsonTypeWith<

--- a/packages/common/core-interfaces/src/jsonSerializable.ts
+++ b/packages/common/core-interfaces/src/jsonSerializable.ts
@@ -89,8 +89,8 @@ export interface JsonSerializableOptions {
  * Also, `JsonSerializable<T>` does not prevent the construction of circular references.
  *
  * Specifying `JsonSerializable<unknown>` or `JsonSerializable<any>` yields a type
- * alias for {@link JsonTypeWith}`<never>` and should not be used if precise type
- * safety is desired.
+ * alias for {@link JsonTypeWith}`<never>` | {@link OpaqueJsonSerializable}`<unknown>`
+ * and should not be used if precise type safety is desired.
  *
  * Class instances are indistinguishable from general objects by type checking
  * unless they have non-public members.

--- a/packages/common/core-interfaces/src/test/jsonSerializable.spec.ts
+++ b/packages/common/core-interfaces/src/test/jsonSerializable.spec.ts
@@ -833,10 +833,13 @@ describe("JsonSerializable", () => {
 			});
 			it("`unknown`", () => {
 				const { filteredIn } = passThru(
-					// @ts-expect-error `unknown` is not supported (expects `JsonTypeWith<never>`)
+					// @ts-expect-error `unknown` is not supported (expects `JsonTypeWith<never> | OpaqueJsonSerializable<unknown>`)
 					{} as unknown,
 				); // {} value is actually supported; so, no runtime error.
-				assertIdenticalTypes(filteredIn, createInstanceOf<JsonTypeWith<never>>());
+				assertIdenticalTypes(
+					filteredIn,
+					createInstanceOf<JsonTypeWith<never> | OpaqueJsonSerializable<unknown>>(),
+				);
 			});
 			it("`symbol`", () => {
 				const { filteredIn } = passThruThrows(
@@ -1055,10 +1058,13 @@ describe("JsonSerializable", () => {
 				});
 				it("array of `unknown`", () => {
 					const { filteredIn } = passThru(
-						// @ts-expect-error 'unknown[]' is not assignable to parameter of type 'JsonTypeWith<never>[]'
+						// @ts-expect-error 'unknown[]' is not assignable to parameter of type '(JsonTypeWith<never> | OpaqueJsonSerializable<unknown>)[]'
 						arrayOfUnknown,
 					);
-					assertIdenticalTypes(filteredIn, createInstanceOf<JsonTypeWith<never>[]>());
+					assertIdenticalTypes(
+						filteredIn,
+						createInstanceOf<(JsonTypeWith<never> | OpaqueJsonSerializable<unknown>)[]>(),
+					);
 				});
 				it("array of functions", () => {
 					const { filteredIn } = passThru(
@@ -1232,12 +1238,14 @@ describe("JsonSerializable", () => {
 				});
 				it("object with array of `unknown`", () => {
 					const { filteredIn } = passThru(
-						// @ts-expect-error 'unknown[]' is not assignable to parameter of type 'JsonTypeWith<never>[]'
+						// @ts-expect-error 'unknown[]' is not assignable to parameter of type '(JsonTypeWith<never> | OpaqueJsonSerializable<unknown>)[]'
 						objectWithArrayOfUnknown,
 					);
 					assertIdenticalTypes(
 						filteredIn,
-						createInstanceOf<{ arrayOfUnknown: JsonTypeWith<never>[] }>(),
+						createInstanceOf<{
+							arrayOfUnknown: (JsonTypeWith<never> | OpaqueJsonSerializable<unknown>)[];
+						}>(),
 					);
 				});
 				it("object with array of functions", () => {
@@ -1343,19 +1351,23 @@ describe("JsonSerializable", () => {
 				});
 
 				it("`string` indexed record of `unknown`", () => {
-					// @ts-expect-error not assignable to parameter of type '{ [x: string]: JsonTypeWith<never>; }'.
+					// @ts-expect-error not assignable to parameter of type '{ [x: string]: JsonTypeWith<never> | OpaqueJsonSerializable<unknown>; }'.
 					const { filteredIn } = passThru(stringRecordOfUnknown);
 					assertIdenticalTypes(
 						filteredIn,
-						createInstanceOf<{ [x: string]: JsonTypeWith<never> }>(),
+						createInstanceOf<{
+							[x: string]: JsonTypeWith<never> | OpaqueJsonSerializable<unknown>;
+						}>(),
 					);
 				});
 				it("`Partial<>` `string` indexed record of `unknown`", () => {
-					// @ts-expect-error not assignable to parameter of type '{ [x: string]: JsonTypeWith<never>; }'.
+					// @ts-expect-error not assignable to parameter of type '{ [x: string]: JsonTypeWith<never> | OpaqueJsonSerializable<unknown>; }'.
 					const { filteredIn } = passThru(partialStringRecordOfUnknown);
 					assertIdenticalTypes(
 						filteredIn,
-						createInstanceOf<{ [x: string]: JsonTypeWith<never> }>(),
+						createInstanceOf<{
+							[x: string]: JsonTypeWith<never> | OpaqueJsonSerializable<unknown>;
+						}>(),
 					);
 				});
 
@@ -1881,11 +1893,14 @@ describe("JsonSerializable", () => {
 		it("explicit `any` generic still limits allowed types", () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const { filteredIn } = passThruThrows<any>(
-				// @ts-expect-error `any` is not an open door (expects `JsonTypeWith<never>`)
+				// @ts-expect-error `any` is not an open door (expects `JsonTypeWith<never> | OpaqueJsonSerializable<unknown>`)
 				undefined,
 				new Error("JSON.stringify returned undefined"),
 			);
-			assertIdenticalTypes(filteredIn, createInstanceOf<JsonTypeWith<never>>());
+			assertIdenticalTypes(
+				filteredIn,
+				createInstanceOf<JsonTypeWith<never> | OpaqueJsonSerializable<unknown>>(),
+			);
 		});
 
 		describe("`number` edge cases", () => {
@@ -2042,19 +2057,29 @@ describe("JsonSerializable", () => {
 			describe("continue rejecting unsupported that are not alternately allowed", () => {
 				it("`unknown` (simple object) expects `JsonTypeWith<bigint>`", () => {
 					const { filteredIn } = passThruHandlingBigint(
-						// @ts-expect-error `unknown` is not supported (expects `JsonTypeWith<bigint>`)
+						// @ts-expect-error `unknown` is not supported (expects `JsonTypeWith<bigint> | OpaqueJsonSerializable<unknown, [bigint]>`)
 						unknownValueOfSimpleRecord,
 						// value is actually supported; so, no runtime error.
 					);
-					assertIdenticalTypes(filteredIn, createInstanceOf<JsonTypeWith<bigint>>());
+					assertIdenticalTypes(
+						filteredIn,
+						createInstanceOf<
+							JsonTypeWith<bigint> | OpaqueJsonSerializable<unknown, [bigint]>
+						>(),
+					);
 				});
 				it("`unknown` (with bigint) expects `JsonTypeWith<bigint>`", () => {
 					const { filteredIn } = passThruHandlingBigint(
-						// @ts-expect-error `unknown` is not supported (expects `JsonTypeWith<bigint>`)
+						// @ts-expect-error `unknown` is not supported (expects `JsonTypeWith<bigint> | OpaqueJsonSerializable<unknown, [bigint]>`)
 						unknownValueWithBigint,
 						// value is actually supported; so, no runtime error.
 					);
-					assertIdenticalTypes(filteredIn, createInstanceOf<JsonTypeWith<bigint>>());
+					assertIdenticalTypes(
+						filteredIn,
+						createInstanceOf<
+							JsonTypeWith<bigint> | OpaqueJsonSerializable<unknown, [bigint]>
+						>(),
+					);
 				});
 				it("`symbol` still becomes `never`", () => {
 					passThruHandlingBigintThrows(

--- a/packages/framework/presence/src/test/latestMapValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestMapValueManager.spec.ts
@@ -201,7 +201,7 @@ export function checkCompiles(): void {
 				null: null,
 				string: "string",
 				number: 0,
-				boolean: true,
+				true: true,
 			},
 		}),
 	);
@@ -210,13 +210,19 @@ export function checkCompiles(): void {
 
 	// map value types are not matched to specific key
 	localPrimitiveMap.set("string", 1);
-	localPrimitiveMap.set("number", false);
+	localPrimitiveMap.set("number", true);
 	// eslint-disable-next-line unicorn/no-null
-	localPrimitiveMap.set("boolean", null);
+	localPrimitiveMap.set("true", null);
 	localPrimitiveMap.set("null", "null");
 
 	// @ts-expect-error with inferred keys only those named in init are accessible
 	localPrimitiveMap.set("key3", "value");
 	// @ts-expect-error value of type value is not assignable
 	localPrimitiveMap.set("null", { value: "value" });
+	// latestMap infers that only `true` is a valid value without use of `false` or explicit specification.
+	// This happened under PR #24752 unexpectedly. Presumably from some additional inference complication.
+	// This is a better inferred result; so it can stand, but would not be terrible if the behavior changes.
+	// Caller can always use explicit generic specification to be completely clear about the types.
+	// @ts-expect-error Argument of type 'false' is not assignable to parameter of type 'string | number | true | null'.
+	localPrimitiveMap.set("true", false);
 }


### PR DESCRIPTION
Listing `OpaqueJsonSerializable<unknown>` for degenerate option allows a filtered and captured type to accept other declared `OpaqueJsonSerializable` types.

Fix required in `presence` test as now more specific value type is inferred from initial values. (`true` becomes `true` instead of `boolean`.)