### PR TITLE
build(docs): Update dependency on `@fluid-tools/api-markdown-documenter` to version `0.20`

### DIFF
--- a/docs/infra/api-markdown-documenter/admonition-node.mjs
+++ b/docs/infra/api-markdown-documenter/admonition-node.mjs
@@ -4,7 +4,7 @@
  */
 
 //@ts-check
-/** @typedef {import("@fluid-tools/api-markdown-documenter").DocumentationNode} DocumentationNode */
+/** @typedef {import("@fluid-tools/api-markdown-documenter").BlockContent} BlockContent */
 
 import { DocumentationParentNodeBase } from "@fluid-tools/api-markdown-documenter";
 
@@ -47,7 +47,7 @@ export const admonitionNodeType = "Admonition";
  */
 export class AdmonitionNode extends DocumentationParentNodeBase {
 	/**
-	 * @param {DocumentationNode[]} children - Child node content.
+	 * @param {BlockContent[]} children - Child node content.
 	 * @param {string} admonitionKind - The kind of admonition. See {@link https://docusaurus.io/docs/markdown-features/admonitions}.
 	 * @param {string | undefined} title - (Optional) Title text for the admonition.
 	 */

--- a/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
+++ b/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
@@ -20,7 +20,7 @@ import {
 	ReleaseTag,
 	SectionNode,
 	SpanNode,
-	transformTsdocNode,
+	transformTsdoc,
 } from "@fluid-tools/api-markdown-documenter";
 
 import { AdmonitionNode } from "./admonition-node.mjs";
@@ -229,7 +229,7 @@ export function layoutContent(apiItem, itemSpecificContent, config) {
 	}
 
 	// Add summary comment (if any)
-	addSection(LayoutUtilities.createSummaryParagraph(apiItem, config));
+	addSection(LayoutUtilities.createSummarySection(apiItem, config));
 
 	// Add system notice (if any) that supersedes deprecation and import notices
 	if (!addSection(createTagNotice(apiItem, "@system", systemNotice))) {
@@ -298,13 +298,13 @@ function createDeprecationNoticeSection(apiItem, config) {
 		return undefined;
 	}
 
-	const transformedDeprecatedBlock = transformTsdocNode(deprecatedBlock, apiItem, config);
-	if (transformedDeprecatedBlock === undefined) {
+	const transformedDeprecatedBlockContents = transformTsdoc(deprecatedBlock, apiItem, config);
+	if (transformedDeprecatedBlockContents === undefined) {
 		throw new Error("Failed to transform deprecated block.");
 	}
 
 	return new AdmonitionNode(
-		[transformedDeprecatedBlock],
+		transformedDeprecatedBlockContents,
 		"Warning",
 		"This API is deprecated and will be removed in a future release.",
 	);

--- a/docs/package.json
+++ b/docs/package.json
@@ -69,7 +69,7 @@
 		"@docusaurus/theme-mermaid": "^3.6.2",
 		"@docusaurus/tsconfig": "^3.6.2",
 		"@docusaurus/types": "^3.6.2",
-		"@fluid-tools/api-markdown-documenter": "^0.19.0",
+		"@fluid-tools/api-markdown-documenter": "^0.20.0",
 		"@fluid-tools/markdown-magic": "file:../tools/markdown-magic",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/eslint-config-fluid": "^5.5.1",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@fluid-tools/api-markdown-documenter':
-        specifier: ^0.19.0
-        version: 0.19.0(@types/node@22.9.1)
+        specifier: ^0.20.0
+        version: 0.20.0(@types/node@22.9.1)
       '@fluid-tools/markdown-magic':
         specifier: file:../tools/markdown-magic
         version: file:../tools/markdown-magic(@types/node@22.9.1)(markdown-magic@2.6.1)
@@ -1433,8 +1433,8 @@ packages:
   '@fluid-internal/eslint-plugin-fluid@0.1.3':
     resolution: {integrity: sha512-l3MPEQ34lYP9QOIQ9vx9ncyvkYqR7ci7ZixxD4RdOmGBnAFOqipBjn5Je9AJfztQ3jWgcT3jiV+AVT3rBjc2Yw==}
 
-  '@fluid-tools/api-markdown-documenter@0.19.0':
-    resolution: {integrity: sha512-SxAJ5rhfCVlHh8wJsl8annHVHCNR+J3CPU7R5Rlr6VRzAqLhFySM8Nwufx2YrppWkFnfQtdMn61u5ZltwvWMoA==}
+  '@fluid-tools/api-markdown-documenter@0.20.0':
+    resolution: {integrity: sha512-zSeyfHLV7DLJ8B7OjTJCG6CTc+CffijT6oIlhXO3w1QDblcvE62DcT+Cb4vUPsN4AA2m9mznb8q+ArG9FBIXTQ==}
 
   '@fluid-tools/markdown-magic@file:../tools/markdown-magic':
     resolution: {directory: ../tools/markdown-magic, type: directory}
@@ -5482,6 +5482,7 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -5491,6 +5492,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -10655,7 +10657,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluid-tools/api-markdown-documenter@0.19.0(@types/node@22.9.1)':
+  '@fluid-tools/api-markdown-documenter@0.20.0(@types/node@22.9.1)':
     dependencies:
       '@microsoft/api-extractor-model': 7.28.21(@types/node@22.9.1)
       '@microsoft/tsdoc': 0.14.2


### PR DESCRIPTION
Includes a number of changes that help simplify the structure of generated HTML contents.
See changelog details [here](https://github.com/microsoft/FluidFramework/blob/main/tools/api-markdown-documenter/CHANGELOG.md#0200).