### PR TITLE
fix(GC): Corrected the determination of whether a request is for a DataStore or one of its children

### DIFF
--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -1543,6 +1543,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 		const requestParser = RequestParser.create(request);
 		const id = requestParser.pathParts[0];
 
+		//* Write test with DataStore route + query that fails this isLeaf(1) check - but is NOT a request for a child!
 		// Differentiate between requesting the dataStore directly, or one of its children
 		const requestForChild = !requestParser.isLeaf(1);
 

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -1543,9 +1543,8 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 		const requestParser = RequestParser.create(request);
 		const id = requestParser.pathParts[0];
 
-		//* Write test with DataStore route + query that fails this isLeaf(1) check - but is NOT a request for a child!
 		// Differentiate between requesting the dataStore directly, or one of its children
-		const requestForChild = !requestParser.isLeaf(1);
+		const requestForChild = requestParser.pathParts.length > 1;
 
 		const headerData: RuntimeHeaderData = {};
 		if (typeof request.headers?.[RuntimeHeaders.wait] === "boolean") {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -33,6 +33,8 @@ import type {
 	IContainerRuntime,
 	IContainerRuntimeEvents,
 	IContainerRuntimeInternal,
+	// eslint-disable-next-line import/no-deprecated
+	IContainerRuntimeWithResolveHandle_Deprecated,
 	OutboundExtensionMessage,
 } from "@fluidframework/container-runtime-definitions/internal";
 import type {
@@ -802,6 +804,8 @@ export class ContainerRuntime
 		IContainerRuntimeInternal,
 		// eslint-disable-next-line import/no-deprecated
 		IContainerRuntimeBaseExperimental,
+		// eslint-disable-next-line import/no-deprecated
+		IContainerRuntimeWithResolveHandle_Deprecated,
 		IRuntime,
 		IGarbageCollectionRuntime,
 		ISummarizerRuntime,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -341,12 +341,34 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 					"Expected the Tombstone header",
 				);
 
+				// This request fails even though there's a query parameter in the URL (simulating a deep link to a tombstoned datastore)
+				const tombstoneErrorResponse2 = await (
+					entryPoint._context.containerRuntime as ContainerRuntime
+				).resolveHandle({
+					url: `${unreferencedId}?query=string`,
+				});
+				assert.equal(
+					tombstoneErrorResponse2.status,
+					404,
+					"Should not be able to retrieve a tombstoned datastore in non-summarizer clients",
+				);
+				assert.equal(
+					tombstoneErrorResponse2.value,
+					`DataStore was tombstoned: ${unreferencedId}`,
+					"Expected the Tombstone error message",
+				);
+				assert.equal(
+					tombstoneErrorResponse2.headers?.[TombstoneResponseHeaderKey],
+					true,
+					"Expected the Tombstone header",
+				);
+
 				// This request succeeds because the "allowTombstone" header is set to true
 				const tombstoneSuccessResponse = await (
 					entryPoint._context.containerRuntime as ContainerRuntime
 				).resolveHandle({
-					url: unreferencedId,
-					headers: { [AllowTombstoneRequestHeaderKey]: true },
+					url: `${unreferencedId}?query=string`,
+					//* headers: { [AllowTombstoneRequestHeaderKey]: true },
 				});
 				assert.equal(
 					tombstoneSuccessResponse.status,


### PR DESCRIPTION
Fixes [AB#39515](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/39515)

## Description

If a request for loading a DataStore has a query parameter (legacy functionality not generally supported), it goes down the wrong codepath when it comes to detecting Tombstoned objects, resulting in a false negative.

This fixes the logic to only check the path length, ignoring the query string.