### PR TITLE
(tree) Unify summarize and getAttachSummary methods on summarizables

### DIFF
--- a/.changeset/loud-dolls-appear.md
+++ b/.changeset/loud-dolls-appear.md
@@ -5,4 +5,4 @@
 Added an optional boolean parameter `fullTree` to `SharedObject`'s `summarizeCore` method
 
 This parameter tells the shared object that it should generate a full tree summary, i.e., it must not summarize incrementally.
-Currently, none of the shared object's do incremental summaries. However, if one decides to do it, it needs to take "fullTree" parameter into consideration.
+Currently no known SharedObjects's do incremental summaries; however any that do exist or are made in the future must take this "fullTree" parameter into consideration to function correctly.

--- a/.changeset/loud-dolls-appear.md
+++ b/.changeset/loud-dolls-appear.md
@@ -2,7 +2,7 @@
 "@fluidframework/shared-object-base": minor
 "__section": legacy
 ---
-Added an optional boolean parameter `fullTree` to `SharedObject`'s `summarizeCore` method
+Added an optional boolean parameter "fullTree" to SharedObject's summarizeCore method
 
 This parameter tells the shared object that it should generate a full tree summary, i.e., it must not summarize incrementally.
-Currently no known SharedObjects's do incremental summaries; however any that do exist or are made in the future must take this "fullTree" parameter into consideration to function correctly.
+Currently no known `SharedObject`'s do incremental summaries; however, any that do exist or are made in the future must take this "fullTree" parameter into consideration to function correctly.

--- a/.changeset/loud-dolls-appear.md
+++ b/.changeset/loud-dolls-appear.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/shared-object-base": minor
+"__section": legacy
+---
+Added an optional boolean parameter `fullTree` to `SharedObject`'s `summarizeCore` method
+
+This parameter tells the shared object that it should generate a full tree summary, i.e., it must not summarize incrementally.
+Currently, none of the shared object's do incremental summaries. However, if one decides to do it, it needs to take "fullTree" parameter into consideration.

--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
@@ -47,7 +47,7 @@ export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedO
     // (undocumented)
     protected get serializer(): IFluidSerializer;
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
-    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): ISummaryTreeWithStats;
+    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext, fullTree?: boolean): ISummaryTreeWithStats;
 }
 
 // @alpha @legacy

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -842,7 +842,12 @@ export abstract class SharedObject<
 		trackState: boolean = false,
 		telemetryContext?: ITelemetryContext,
 	): ISummaryTreeWithStats {
-		const result = this.summarizeCore(this.serializer, telemetryContext);
+		const result = this.summarizeCore(
+			this.serializer,
+			telemetryContext,
+			undefined /* incrementalSummaryContext */,
+			fullTree,
+		);
 		this.incrementTelemetryMetric(
 			blobCountPropertyName,
 			result.stats.blobNodeCount,
@@ -869,6 +874,7 @@ export abstract class SharedObject<
 			this.serializer,
 			telemetryContext,
 			incrementalSummaryContext,
+			fullTree,
 		);
 		this.incrementTelemetryMetric(
 			blobCountPropertyName,
@@ -937,6 +943,7 @@ export abstract class SharedObject<
 		serializer: IFluidSerializer,
 		telemetryContext?: ITelemetryContext,
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
+		fullTree?: boolean,
 	): ISummaryTreeWithStats;
 
 	private incrementTelemetryMetric(

--- a/packages/dds/shared-object-base/src/sharedObjectKernel.ts
+++ b/packages/dds/shared-object-base/src/sharedObjectKernel.ts
@@ -62,6 +62,7 @@ export interface SharedKernel {
 		serializer: IFluidSerializer,
 		telemetryContext: ITelemetryContext | undefined,
 		incrementalSummaryContext: IExperimentalIncrementalSummaryContext | undefined,
+		fullTree?: boolean,
 	): ISummaryTreeWithStats;
 
 	/**
@@ -146,8 +147,14 @@ class SharedObjectFromKernel<
 		serializer: IFluidSerializer,
 		telemetryContext?: ITelemetryContext,
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
+		fullTree?: boolean,
 	): ISummaryTreeWithStats {
-		return this.#kernel.summarizeCore(serializer, telemetryContext, incrementalSummaryContext);
+		return this.#kernel.summarizeCore(
+			serializer,
+			telemetryContext,
+			incrementalSummaryContext,
+			fullTree,
+		);
 	}
 
 	protected override initializeLocalCore(): void {

--- a/packages/dds/tree/src/feature-libraries/detachedFieldIndexSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/detachedFieldIndexSummarizer.ts
@@ -33,15 +33,15 @@ export class DetachedFieldIndexSummarizer implements Summarizable {
 
 	public constructor(private readonly detachedFieldIndex: DetachedFieldIndex) {}
 
-	public summarize(
-		stringify: SummaryElementStringifier,
-		fullTree?: boolean,
-		trackState?: boolean,
-		telemetryContext?: ITelemetryContext,
-		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
-	): ISummaryTreeWithStats {
+	public summarize(props: {
+		stringify: SummaryElementStringifier;
+		fullTree?: boolean;
+		trackState?: boolean;
+		telemetryContext?: ITelemetryContext;
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext;
+	}): ISummaryTreeWithStats {
 		const data = this.detachedFieldIndex.encode();
-		return createSingleBlobSummary(detachedFieldIndexBlobKey, stringify(data));
+		return createSingleBlobSummary(detachedFieldIndexBlobKey, props.stringify(data));
 	}
 
 	public async load(

--- a/packages/dds/tree/src/feature-libraries/detachedFieldIndexSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/detachedFieldIndexSummarizer.ts
@@ -6,6 +6,7 @@
 import { bufferToString } from "@fluid-internal/client-utils";
 import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import type {
+	IExperimentalIncrementalSummaryContext,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions/internal";
@@ -32,23 +33,15 @@ export class DetachedFieldIndexSummarizer implements Summarizable {
 
 	public constructor(private readonly detachedFieldIndex: DetachedFieldIndex) {}
 
-	public getAttachSummary(
+	public summarize(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): ISummaryTreeWithStats {
 		const data = this.detachedFieldIndex.encode();
 		return createSingleBlobSummary(detachedFieldIndexBlobKey, stringify(data));
-	}
-
-	public async summarize(
-		stringify: SummaryElementStringifier,
-		fullTree?: boolean,
-		trackState?: boolean,
-		telemetryContext?: ITelemetryContext,
-	): Promise<ISummaryTreeWithStats> {
-		return this.getAttachSummary(stringify, fullTree, trackState, telemetryContext);
 	}
 
 	public async load(

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -8,6 +8,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type {
+	IExperimentalIncrementalSummaryContext,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions/internal";
@@ -95,21 +96,13 @@ export class ForestSummarizer implements Summarizable {
 		return stringify(encoded);
 	}
 
-	public getAttachSummary(
+	public summarize(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): ISummaryTreeWithStats {
-		return createSingleBlobSummary(treeBlobKey, this.getTreeString(stringify));
-	}
-
-	public async summarize(
-		stringify: SummaryElementStringifier,
-		fullTree?: boolean,
-		trackState?: boolean,
-		telemetryContext?: ITelemetryContext,
-	): Promise<ISummaryTreeWithStats> {
 		return createSingleBlobSummary(treeBlobKey, this.getTreeString(stringify));
 	}
 

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -96,14 +96,14 @@ export class ForestSummarizer implements Summarizable {
 		return stringify(encoded);
 	}
 
-	public summarize(
-		stringify: SummaryElementStringifier,
-		fullTree?: boolean,
-		trackState?: boolean,
-		telemetryContext?: ITelemetryContext,
-		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
-	): ISummaryTreeWithStats {
-		return createSingleBlobSummary(treeBlobKey, this.getTreeString(stringify));
+	public summarize(props: {
+		stringify: SummaryElementStringifier;
+		fullTree?: boolean;
+		trackState?: boolean;
+		telemetryContext?: ITelemetryContext;
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext;
+	}): ISummaryTreeWithStats {
+		return createSingleBlobSummary(treeBlobKey, this.getTreeString(props.stringify));
 	}
 
 	public async load(

--- a/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
@@ -53,7 +53,7 @@ export class SchemaSummarizer implements Summarizable {
 
 	public summarize(props: {
 		stringify: SummaryElementStringifier;
-		fullTree: boolean;
+		fullTree?: boolean;
 		trackState?: boolean;
 		telemetryContext?: ITelemetryContext;
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext;

--- a/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
@@ -51,15 +51,16 @@ export class SchemaSummarizer implements Summarizable {
 		});
 	}
 
-	public getAttachSummary(
+	public summarize(
 		stringify: SummaryElementStringifier,
-		fullTree?: boolean,
+		fullTree: boolean = false,
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
-		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined,
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): ISummaryTreeWithStats {
 		const builder = new SummaryTreeBuilder();
 		if (
+			!fullTree &&
 			incrementalSummaryContext !== undefined &&
 			this.schemaIndexLastChangedSeq !== undefined &&
 			incrementalSummaryContext.latestSummarySequenceNumber >= this.schemaIndexLastChangedSeq
@@ -67,23 +68,13 @@ export class SchemaSummarizer implements Summarizable {
 			builder.addHandle(
 				schemaStringKey,
 				SummaryType.Blob,
-				`${incrementalSummaryContext.summaryPath}/indexes/${this.key}/${schemaStringKey}`,
+				`${incrementalSummaryContext.summaryPath}/${schemaStringKey}`,
 			);
 		} else {
 			const dataString = JSON.stringify(this.codec.encode(this.schema));
 			builder.addBlob(schemaStringKey, dataString);
 		}
 		return builder.getSummaryTree();
-	}
-
-	public async summarize(
-		stringify: SummaryElementStringifier,
-		fullTree?: boolean,
-		trackState?: boolean,
-		telemetryContext?: ITelemetryContext,
-		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined,
-	): Promise<ISummaryTreeWithStats> {
-		throw new Error("Method not implemented.");
 	}
 
 	public async load(

--- a/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
@@ -51,14 +51,16 @@ export class SchemaSummarizer implements Summarizable {
 		});
 	}
 
-	public summarize(
-		stringify: SummaryElementStringifier,
-		fullTree: boolean = false,
-		trackState?: boolean,
-		telemetryContext?: ITelemetryContext,
-		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
-	): ISummaryTreeWithStats {
+	public summarize(props: {
+		stringify: SummaryElementStringifier;
+		fullTree: boolean;
+		trackState?: boolean;
+		telemetryContext?: ITelemetryContext;
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext;
+	}): ISummaryTreeWithStats {
+		const incrementalSummaryContext = props.incrementalSummaryContext;
 		const builder = new SummaryTreeBuilder();
+		const fullTree = props.fullTree ?? false;
 		if (
 			!fullTree &&
 			incrementalSummaryContext !== undefined &&

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -8,6 +8,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type {
+	IExperimentalIncrementalSummaryContext,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
 } from "@fluidframework/runtime-definitions/internal";
@@ -49,21 +50,13 @@ export class EditManagerSummarizer<TChangeset> implements Summarizable {
 		private readonly schemaAndPolicy?: SchemaAndPolicy,
 	) {}
 
-	public getAttachSummary(
+	public summarize(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): ISummaryTreeWithStats {
-		return this.summarizeCore(stringify);
-	}
-
-	public async summarize(
-		stringify: SummaryElementStringifier,
-		fullTree?: boolean,
-		trackState?: boolean,
-		telemetryContext?: ITelemetryContext,
-	): Promise<ISummaryTreeWithStats> {
 		return this.summarizeCore(stringify);
 	}
 

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -50,14 +50,14 @@ export class EditManagerSummarizer<TChangeset> implements Summarizable {
 		private readonly schemaAndPolicy?: SchemaAndPolicy,
 	) {}
 
-	public summarize(
-		stringify: SummaryElementStringifier,
-		fullTree?: boolean,
-		trackState?: boolean,
-		telemetryContext?: ITelemetryContext,
-		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
-	): ISummaryTreeWithStats {
-		return this.summarizeCore(stringify);
+	public summarize(props: {
+		stringify: SummaryElementStringifier;
+		fullTree?: boolean;
+		trackState?: boolean;
+		telemetryContext?: ITelemetryContext;
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext;
+	}): ISummaryTreeWithStats {
+		return this.summarizeCore(props.stringify);
 	}
 
 	private summarizeCore(stringify: SummaryElementStringifier): ISummaryTreeWithStats {

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -229,13 +229,13 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 						};
 			summarizableBuilder.addWithStats(
 				s.key,
-				s.summarize(
-					(contents) => serializer.stringify(contents, this.sharedObject.handle),
+				s.summarize({
+					stringify: (contents: unknown) =>
+						serializer.stringify(contents, this.sharedObject.handle),
 					fullTree,
-					undefined /* trackState */,
 					telemetryContext,
-					childIncrementalSummaryContext,
-				),
+					incrementalSummaryContext: childIncrementalSummaryContext,
+				}),
 			);
 		}
 
@@ -447,14 +447,24 @@ export interface Summarizable {
 	/**
 	 * {@inheritDoc @fluidframework/datastore-definitions#(IChannel:interface).summarize}
 	 * @param stringify - Serializes the contents of the component (including {@link (IFluidHandle:interface)}s) for storage.
+	 * @param fullTree - flag indicating whether the attempt should generate a full
+	 * summary tree without any handles for unchanged subtrees. It should only be set to true when generating
+	 * a summary from the entire container.
+	 * @param trackState - An optimization for tracking state of objects across summaries. If the state
+	 * of an object did not change since last successful summary, an
+	 * {@link @fluidframework/protocol-definitions#ISummaryHandle} can be used
+	 * instead of re-summarizing it. If this is `false`, the expectation is that you should never
+	 * send an `ISummaryHandle`, since you are not expected to track state.
+	 * @param telemetryContext - See {@link @fluidframework/runtime-definitions#ITelemetryContext}.
+	 * @param incrementalSummaryContext - See {@link @fluidframework/runtime-definitions#IExperimentalIncrementalSummaryContext}.
 	 */
-	summarize(
-		stringify: SummaryElementStringifier,
-		fullTree?: boolean,
-		trackState?: boolean,
-		telemetryContext?: ITelemetryContext,
-		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
-	): ISummaryTreeWithStats;
+	summarize(props: {
+		stringify: SummaryElementStringifier;
+		fullTree?: boolean;
+		trackState?: boolean;
+		telemetryContext?: ITelemetryContext;
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext;
+	}): ISummaryTreeWithStats;
 
 	/**
 	 * Allows the component to perform custom loading. The storage service is scoped to this component and therefore

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -447,14 +447,14 @@ export interface Summarizable {
 	/**
 	 * {@inheritDoc @fluidframework/datastore-definitions#(IChannel:interface).summarize}
 	 * @param stringify - Serializes the contents of the component (including {@link (IFluidHandle:interface)}s) for storage.
-	 * @param fullTree - flag indicating whether the attempt should generate a full
+	 * @param fullTree - A flag indicating whether the attempt should generate a full
 	 * summary tree without any handles for unchanged subtrees. It should only be set to true when generating
-	 * a summary from the entire container.
+	 * a summary from the entire container. The default value is false.
 	 * @param trackState - An optimization for tracking state of objects across summaries. If the state
 	 * of an object did not change since last successful summary, an
 	 * {@link @fluidframework/protocol-definitions#ISummaryHandle} can be used
 	 * instead of re-summarizing it. If this is `false`, the expectation is that you should never
-	 * send an `ISummaryHandle`, since you are not expected to track state.
+	 * send an `ISummaryHandle`, since you are not expected to track state. The default value is true.
 	 * @param telemetryContext - See {@link @fluidframework/runtime-definitions#ITelemetryContext}.
 	 * @param incrementalSummaryContext - See {@link @fluidframework/runtime-definitions#IExperimentalIncrementalSummaryContext}.
 	 */

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -203,7 +203,7 @@ describe("End to end chunked encoding", () => {
 			assert(chunk.isShared());
 			return JSON.stringify(content);
 		}
-		forestSummarizer.getAttachSummary(stringifier);
+		forestSummarizer.summarize(stringifier);
 	});
 
 	// See note on above test.
@@ -236,7 +236,7 @@ describe("End to end chunked encoding", () => {
 			assert(chunk.isShared());
 			return JSON.stringify(content);
 		}
-		forestSummarizer.getAttachSummary(stringifier);
+		forestSummarizer.summarize(stringifier);
 	});
 
 	describe("identifier field encoding", () => {
@@ -257,7 +257,7 @@ describe("End to end chunked encoding", () => {
 			function stringifier(content: unknown) {
 				return JSON.stringify(content);
 			}
-			const { summary } = forestSummarizer.getAttachSummary(stringifier);
+			const { summary } = forestSummarizer.summarize(stringifier);
 			const tree = summary.tree.ForestTree;
 			assert(tree.type === SummaryType.Blob);
 			const treeContent = JSON.parse(tree.content as string);
@@ -287,7 +287,7 @@ describe("End to end chunked encoding", () => {
 			function stringifier(content: unknown) {
 				return JSON.stringify(content);
 			}
-			const { summary } = forestSummarizer.getAttachSummary(stringifier);
+			const { summary } = forestSummarizer.summarize(stringifier);
 			const tree = summary.tree.ForestTree;
 			assert(tree.type === SummaryType.Blob);
 			const treeContent = JSON.parse(tree.content as string);
@@ -312,7 +312,7 @@ describe("End to end chunked encoding", () => {
 			function stringifier(content: unknown) {
 				return JSON.stringify(content);
 			}
-			const { summary } = forestSummarizer.getAttachSummary(stringifier);
+			const { summary } = forestSummarizer.summarize(stringifier);
 			const tree = summary.tree.ForestTree;
 			assert(tree.type === SummaryType.Blob);
 			const treeContent = JSON.parse(tree.content as string);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -194,7 +194,7 @@ describe("End to end chunked encoding", () => {
 		);
 
 		// This function is declared in the test to have access to the original uniform chunk for comparison.
-		function stringifier(content: unknown) {
+		function stringify(content: unknown) {
 			const insertedChunk = decode((content as Format).fields as EncodedFieldBatch, {
 				idCompressor,
 				originatorId: idCompressor.localSessionId,
@@ -203,7 +203,7 @@ describe("End to end chunked encoding", () => {
 			assert(chunk.isShared());
 			return JSON.stringify(content);
 		}
-		forestSummarizer.summarize(stringifier);
+		forestSummarizer.summarize({ stringify });
 	});
 
 	// See note on above test.
@@ -227,7 +227,7 @@ describe("End to end chunked encoding", () => {
 		);
 
 		// This function is declared in the test to have access to the original uniform chunk for comparison.
-		function stringifier(content: unknown) {
+		function stringify(content: unknown) {
 			const insertedChunk = decode((content as Format).fields as EncodedFieldBatch, {
 				idCompressor,
 				originatorId: idCompressor.localSessionId,
@@ -236,7 +236,7 @@ describe("End to end chunked encoding", () => {
 			assert(chunk.isShared());
 			return JSON.stringify(content);
 		}
-		forestSummarizer.summarize(stringifier);
+		forestSummarizer.summarize({ stringify });
 	});
 
 	describe("identifier field encoding", () => {
@@ -254,10 +254,7 @@ describe("End to end chunked encoding", () => {
 				testIdCompressor,
 			);
 
-			function stringifier(content: unknown) {
-				return JSON.stringify(content);
-			}
-			const { summary } = forestSummarizer.summarize(stringifier);
+			const { summary } = forestSummarizer.summarize({ stringify: JSON.stringify });
 			const tree = summary.tree.ForestTree;
 			assert(tree.type === SummaryType.Blob);
 			const treeContent = JSON.parse(tree.content as string);
@@ -284,10 +281,7 @@ describe("End to end chunked encoding", () => {
 				testIdCompressor,
 			);
 
-			function stringifier(content: unknown) {
-				return JSON.stringify(content);
-			}
-			const { summary } = forestSummarizer.summarize(stringifier);
+			const { summary } = forestSummarizer.summarize({ stringify: JSON.stringify });
 			const tree = summary.tree.ForestTree;
 			assert(tree.type === SummaryType.Blob);
 			const treeContent = JSON.parse(tree.content as string);
@@ -309,10 +303,7 @@ describe("End to end chunked encoding", () => {
 				testIdCompressor,
 			);
 
-			function stringifier(content: unknown) {
-				return JSON.stringify(content);
-			}
-			const { summary } = forestSummarizer.summarize(stringifier);
+			const { summary } = forestSummarizer.summarize({ stringify: JSON.stringify });
 			const tree = summary.tree.ForestTree;
 			assert(tree.type === SummaryType.Blob);
 			const treeContent = JSON.parse(tree.content as string);

--- a/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -586,7 +586,7 @@ describe("SharedTreeCore", () => {
 
 	interface MockSummarizableEvents extends IEvent {
 		(event: "loaded", listener: (blobContents?: string) => void): void;
-		(event: "summarize" | "summarizeAttached" | "summarizeAsync" | "gcRequested"): void;
+		(event: "summarize" | "summarizeAttached" | "gcRequested"): void;
 	}
 
 	class MockSummarizable
@@ -613,23 +613,13 @@ describe("SharedTreeCore", () => {
 			}
 		}
 
-		public getAttachSummary(
+		public summarize(
 			stringify: SummaryElementStringifier,
 			fullTree?: boolean | undefined,
 			trackState?: boolean | undefined,
 			telemetryContext?: ITelemetryContext | undefined,
 		): ISummaryTreeWithStats {
 			this.emit("summarizeAttached");
-			return this.summarizeCore(stringify);
-		}
-
-		public async summarize(
-			stringify: SummaryElementStringifier,
-			fullTree?: boolean | undefined,
-			trackState?: boolean | undefined,
-			telemetryContext?: ITelemetryContext | undefined,
-		): Promise<ISummaryTreeWithStats> {
-			this.emit("summarizeAsync");
 			return this.summarizeCore(stringify);
 		}
 

--- a/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -613,14 +613,14 @@ describe("SharedTreeCore", () => {
 			}
 		}
 
-		public summarize(
-			stringify: SummaryElementStringifier,
-			fullTree?: boolean | undefined,
-			trackState?: boolean | undefined,
-			telemetryContext?: ITelemetryContext | undefined,
-		): ISummaryTreeWithStats {
+		public summarize(props: {
+			stringify: SummaryElementStringifier;
+			fullTree?: boolean | undefined;
+			trackState?: boolean | undefined;
+			telemetryContext?: ITelemetryContext | undefined;
+		}): ISummaryTreeWithStats {
 			this.emit("summarizeAttached");
-			return this.summarizeCore(stringify);
+			return this.summarizeCore(props.stringify);
 		}
 
 		private summarizeCore(stringify: SummaryElementStringifier): ISummaryTreeWithStats {


### PR DESCRIPTION
## Description
This PR makes the following changes:
1. Removed the `getAttachSummary` method from `Summarizable` in shared tree and replaces it with the existing `summarize` method.
These methods are supposed to be used in two different scenarios - `getAttachSummary` for the summary that is synchronously generated during container attach and `summarize` for the summary that is asynchronously generated during regular summarization in case tree wants to support async summarization for scenarios like virtualization.
However, currently only `getAttachSummary` is used in both these scenarios since DDSes do not do async summarization. Some of the summarizables implement both of these methods and some only implement one of them. This leads to some confusion and also using the method "getAttachSummary" for regular summarization is also misleading.
So, this PR keeps the `summarize` method and makes in syncronous. The async version of this method can be added later when it is needed.
2. Added a `fullTree` param to the `summarizeCore` method in `SharedObject`. This is needed for tree (or any DDS) to support incremental summarization. If this param is true, a full tree must be generated without any incrementality.
3. In `SharedTreeCore`'s `summarizeCore` method, append the sub-tree path's to the incremental summary context before passing it to the individual summarizables. This will keep the logic in one place without having each summarizable do it and also, the summarizables shouldn't know about its parent's incremental summary details.

[AB#40395](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/40395)