### PR TITLE
fix(client-core-interfaces): support Opaque unknown thru JsonSerializable

### DIFF
--- a/packages/common/core-interfaces/src/exposedInternalUtilityTypes.ts
+++ b/packages/common/core-interfaces/src/exposedInternalUtilityTypes.ts
@@ -859,8 +859,11 @@ export namespace InternalUtilityTypes {
 	 *
 	 * @remarks
 	 * {@link OpaqueJsonSerializable} and {@link OpaqueJsonDeserialized} instances
-	 * are limited to `Controls` given context supports. Further, the data type
-	 * is filtered through {@link JsonSerializable} with those `Controls`.
+	 * are limited to `Controls` given context supports.
+	 * `T` from the original Opaque type is preserved. In the case that this now
+	 * produces an improper type such as a `bigint` being let through that is no
+	 * longer supported, then the variance of `Controls` is expected to raise
+	 * the incompatibility error.
 	 *
 	 * @privateRemarks
 	 * Additional intersections beyond {@link OpaqueJsonSerializable},
@@ -878,25 +881,13 @@ export namespace InternalUtilityTypes {
 		| OpaqueJsonDeserialized<infer TData, any, unknown>
 		? T extends OpaqueJsonSerializable<TData, any, unknown> &
 				OpaqueJsonDeserialized<TData, any, unknown>
-			? OpaqueJsonSerializable<
-					JsonSerializableImpl<TData, Controls>,
-					Controls["AllowExactly"],
-					Controls["AllowExtensionOf"]
-				> &
-					OpaqueJsonDeserialized<
-						JsonSerializableImpl<TData, Controls>,
-						Controls["AllowExactly"],
-						Controls["AllowExtensionOf"]
-					>
+			? OpaqueJsonSerializable<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]> &
+					OpaqueJsonDeserialized<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]>
 			: T extends OpaqueJsonSerializable<TData, any, unknown>
-				? OpaqueJsonSerializable<
-						JsonSerializableImpl<TData, Controls>,
-						Controls["AllowExactly"],
-						Controls["AllowExtensionOf"]
-					>
+				? OpaqueJsonSerializable<TData, Controls["AllowExactly"], Controls["AllowExtensionOf"]>
 				: T extends OpaqueJsonDeserialized<TData, any, unknown>
 					? OpaqueJsonDeserialized<
-							JsonSerializableImpl<TData, Controls>,
+							TData,
 							Controls["AllowExactly"],
 							Controls["AllowExtensionOf"]
 						>

--- a/packages/common/core-interfaces/src/test/jsonSerializable.spec.ts
+++ b/packages/common/core-interfaces/src/test/jsonSerializable.spec.ts
@@ -174,6 +174,9 @@ import {
 	opaqueSerializableObject,
 	opaqueDeserializedObject,
 	opaqueSerializableAndDeserializedObject,
+	opaqueSerializableUnknown,
+	opaqueDeserializedUnknown,
+	opaqueSerializableAndDeserializedUnknown,
 	opaqueSerializableObjectRequiringBigintSupport,
 	opaqueDeserializedObjectRequiringBigintSupport,
 	opaqueSerializableAndDeserializedObjectRequiringBigintSupport,
@@ -764,6 +767,23 @@ describe("JsonSerializable", () => {
 				it("opaque serializable and deserialized object", () => {
 					const { filteredIn, out } = passThru(opaqueSerializableAndDeserializedObject);
 					assertIdenticalTypes(filteredIn, opaqueSerializableAndDeserializedObject);
+					// @ts-expect-error In this case, `out` has a unique `OpaqueJsonDeserialized` result.
+					assertIdenticalTypes(filteredIn, out);
+				});
+				it("opaque serializable unknown", () => {
+					const { filteredIn, out } = passThru(opaqueSerializableUnknown);
+					assertIdenticalTypes(filteredIn, opaqueSerializableUnknown);
+					// @ts-expect-error In this case, `out` has a unique `OpaqueJsonDeserialized` result.
+					assertIdenticalTypes(filteredIn, out);
+				});
+				it("opaque deserialized unknown", () => {
+					const { filteredIn, out } = passThru(opaqueDeserializedUnknown);
+					assertIdenticalTypes(filteredIn, opaqueDeserializedUnknown);
+					assertIdenticalTypes(filteredIn, out);
+				});
+				it("opaque serializable and deserialized unknown", () => {
+					const { filteredIn, out } = passThru(opaqueSerializableAndDeserializedUnknown);
+					assertIdenticalTypes(filteredIn, opaqueSerializableAndDeserializedUnknown);
 					// @ts-expect-error In this case, `out` has a unique `OpaqueJsonDeserialized` result.
 					assertIdenticalTypes(filteredIn, out);
 				});
@@ -1813,37 +1833,37 @@ describe("JsonSerializable", () => {
 			describe("opaque Json types requiring extra allowed types", () => {
 				it("opaque serializable object with `bigint`", () => {
 					const { filteredIn } = passThruThrows(
-						// @ts-expect-error `bigint` is not supported (becomes `never`)
+						// @ts-expect-error `bigint` is not supported and `AllowExactly` parameters are incompatible
 						opaqueSerializableObjectRequiringBigintSupport,
 						new TypeError("Do not know how to serialize a BigInt"),
 					);
 					assertIdenticalTypes(
 						filteredIn,
-						createInstanceOf<OpaqueJsonSerializable<{ bigint: never }>>(),
+						createInstanceOf<OpaqueJsonSerializable<{ bigint: bigint }>>(),
 					);
 				});
 				it("opaque deserialized object with `bigint`", () => {
 					const { filteredIn } = passThruThrows(
-						// @ts-expect-error `bigint` is not supported (becomes `never`)
+						// @ts-expect-error `bigint` is not supported and `AllowExactly` parameters are incompatible
 						opaqueDeserializedObjectRequiringBigintSupport,
 						new TypeError("Do not know how to serialize a BigInt"),
 					);
 					assertIdenticalTypes(
 						filteredIn,
-						createInstanceOf<OpaqueJsonDeserialized<{ bigint: never }>>(),
+						createInstanceOf<OpaqueJsonDeserialized<{ bigint: bigint }>>(),
 					);
 				});
 				it("opaque serializable and deserialized object with `bigint`", () => {
 					const { filteredIn } = passThruThrows(
-						// @ts-expect-error `bigint` is not supported (becomes `never`)
+						// @ts-expect-error `bigint` is not supported and `AllowExactly` parameters are incompatible
 						opaqueSerializableAndDeserializedObjectRequiringBigintSupport,
 						new TypeError("Do not know how to serialize a BigInt"),
 					);
 					assertIdenticalTypes(
 						filteredIn,
 						createInstanceOf<
-							OpaqueJsonSerializable<{ bigint: never }> &
-								OpaqueJsonDeserialized<{ bigint: never }>
+							OpaqueJsonSerializable<{ bigint: bigint }> &
+								OpaqueJsonDeserialized<{ bigint: bigint }>
 						>(),
 					);
 				});

--- a/packages/common/core-interfaces/src/test/testValues.ts
+++ b/packages/common/core-interfaces/src/test/testValues.ts
@@ -672,6 +672,14 @@ export const opaqueSerializableAndDeserializedObject =
 	objectWithNumber as unknown as OpaqueJsonSerializable<typeof objectWithNumber> &
 		OpaqueJsonDeserialized<typeof objectWithNumber>;
 
+export const opaqueSerializableUnknown =
+	opaqueSerializableObject as OpaqueJsonSerializable<unknown>;
+export const opaqueDeserializedUnknown =
+	opaqueDeserializedObject as OpaqueJsonDeserialized<unknown>;
+export const opaqueSerializableAndDeserializedUnknown =
+	opaqueSerializableAndDeserializedObject as OpaqueJsonSerializable<unknown> &
+		OpaqueJsonDeserialized<unknown>;
+
 export const opaqueSerializableObjectRequiringBigintSupport =
 	objectWithBigint as unknown as OpaqueJsonSerializable<typeof objectWithBigint, [bigint]>;
 export const opaqueDeserializedObjectRequiringBigintSupport =


### PR DESCRIPTION
Filtering the inner type when applying additional `JsonSerializable` filters broken the result down into `JsonTypeWith | Opaque` degenerate substitutes when `unknown` was sufficient already and would break the filter type checking.

Now preserve the Opaque type's `T` as-is and rely on changes in `Controls` to dictate incompatibility.