### PR TITLE
improvement(client-presence): separate system:presence index from others

### DIFF
--- a/packages/framework/presence/src/presenceDatastoreManager.ts
+++ b/packages/framework/presence/src/presenceDatastoreManager.ts
@@ -32,6 +32,7 @@ import type {
 	GeneralDatastoreMessageContent,
 	InboundClientJoinMessage,
 	InboundDatastoreUpdateMessage,
+	InternalWorkspaceAddress,
 	OutboundDatastoreUpdateMessage,
 	SignalMessages,
 	SystemDatastore,
@@ -58,10 +59,8 @@ interface AnyWorkspaceEntry<TSchema extends StatesWorkspaceSchema> {
 }
 
 type PresenceDatastore = SystemDatastore & {
-	[WorkspaceAddress: string]: ValueElementMap<StatesWorkspaceSchema>;
+	[WorkspaceAddress: InternalWorkspaceAddress]: ValueElementMap<StatesWorkspaceSchema>;
 };
-
-type InternalWorkspaceAddress = `${"s" | "n"}:${WorkspaceAddress}`;
 
 const internalWorkspaceTypes: Readonly<Record<string, "States" | "Notifications">> = {
 	s: "States",
@@ -109,7 +108,7 @@ function mergeGeneralDatastoreMessageContent(
 
 	// Merge the current data with the existing data, if any exists.
 	// Iterate over the current message data; individual items are workspaces.
-	for (const [workspaceName, workspaceData] of Object.entries(newData)) {
+	for (const [workspaceName, workspaceData] of objectEntries(newData)) {
 		// Initialize the merged data as the queued datastore entry for the workspace.
 		// Since the key might not exist, create an empty object in that case. It will
 		// be set explicitly after the loop.
@@ -400,7 +399,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 		}
 
 		// Handle activation of unregistered workspaces before processing updates.
-		for (const [workspaceAddress] of Object.entries(message.content.data)) {
+		for (const [workspaceAddress] of objectEntries(message.content.data)) {
 			// The first part of OR condition checks if workspace is already registered.
 			// The second part checks if the workspace has already been seen before.
 			// In either case we can skip emitting 'workspaceActivated' event.
@@ -429,7 +428,7 @@ export class PresenceDatastoreManagerImpl implements PresenceDatastoreManager {
 		// While the system workspace is processed here too, it is declared as
 		// conforming to the general schema. So drop its override.
 		const data = message.content.data as Omit<typeof message.content.data, "system:presence">;
-		for (const [workspaceAddress, remoteDatastore] of Object.entries(data)) {
+		for (const [workspaceAddress, remoteDatastore] of objectEntries(data)) {
 			// Direct to the appropriate Presence Workspace, if present.
 			const workspace = this.workspaces.get(workspaceAddress);
 			if (workspace) {

--- a/packages/framework/presence/src/protocol.ts
+++ b/packages/framework/presence/src/protocol.ts
@@ -12,6 +12,7 @@ import type { ClientConnectionId } from "./baseTypes.js";
 import type { AttendeeId } from "./presence.js";
 import type { ClientUpdateEntry } from "./presenceStates.js";
 import type { SystemWorkspaceDatastore } from "./systemWorkspace.js";
+import type { WorkspaceAddress } from "./types.js";
 
 /**
  * Datastore that contains system workspace data
@@ -21,17 +22,22 @@ export interface SystemDatastore {
 }
 
 /**
+ * Expected address format for general workspaces in the presence protocol.
+ */
+export type InternalWorkspaceAddress = `${"s" | "n"}:${WorkspaceAddress}`;
+
+/**
  * General datastore (and message) structure.
  */
 export interface GeneralDatastoreMessageContent {
-	[WorkspaceAddress: string]: {
+	[WorkspaceAddress: InternalWorkspaceAddress]: {
 		[StateValueManagerKey: string]: {
 			[AttendeeId: AttendeeId]: ClientUpdateEntry;
 		};
 	};
 }
 
-type DatastoreMessageContent = GeneralDatastoreMessageContent & SystemDatastore;
+type DatastoreMessageContent = SystemDatastore & GeneralDatastoreMessageContent;
 type AcknowledgmentId = string;
 
 /**

--- a/packages/framework/presence/src/test/notificationsManager.spec.ts
+++ b/packages/framework/presence/src/test/notificationsManager.spec.ts
@@ -8,7 +8,12 @@ import { strict as assert, fail } from "node:assert";
 import { EventAndErrorTrackingLogger } from "@fluidframework/test-utils/internal";
 import { useFakeTimers, type SinonFakeTimers } from "sinon";
 
-import type { Attendee, NotificationsManager, NotificationsWorkspace } from "../index.js";
+import type {
+	Attendee,
+	ClientConnectionId,
+	NotificationsManager,
+	NotificationsWorkspace,
+} from "../index.js";
 import { Notifications } from "../index.js";
 import type { createPresenceManager } from "../presenceManager.js";
 
@@ -24,8 +29,7 @@ import {
 } from "./testUtils.js";
 
 const attendeeId3 = createSpecificAttendeeId("attendeeId-3");
-// Really a ClientConnectionId, but typed as AttendeeId for TypeScript workaround.
-const connectionId3 = createSpecificAttendeeId("client3");
+const connectionId3 = "client3" as const satisfies ClientConnectionId;
 
 describe("Presence", () => {
 	describe("NotificationsManager", () => {

--- a/packages/framework/presence/src/test/presenceDatastoreManager.spec.ts
+++ b/packages/framework/presence/src/test/presenceDatastoreManager.spec.ts
@@ -11,6 +11,7 @@ import { useFakeTimers, spy } from "sinon";
 
 import type { AttendeeId } from "../presence.js";
 import { createPresenceManager } from "../presenceManager.js";
+import type { InternalWorkspaceAddress } from "../protocol.js";
 import type { SystemWorkspaceDatastore } from "../systemWorkspace.js";
 
 import { MockEphemeralRuntime } from "./mockEphemeralRuntime.js";
@@ -323,7 +324,7 @@ describe("Presence", () => {
 							avgLatency: 20,
 							data: {
 								"system:presence": systemWorkspaceUpdate,
-								"u:name:testUnknownWorkspace": {
+								["u:name:testUnknownWorkspace" as InternalWorkspaceAddress]: {
 									"latest": {
 										[attendeeId1]: {
 											"rev": 1,
@@ -390,7 +391,8 @@ describe("Presence", () => {
 							data: {
 								"system:presence": systemWorkspaceUpdate,
 								// Unrecognized internal address
-								"sn:name:testStateWorkspace": statesWorkspaceUpdate,
+								["sn:name:testStateWorkspace" as InternalWorkspaceAddress]:
+									statesWorkspaceUpdate,
 							},
 						},
 						clientId: "client1",
@@ -418,7 +420,7 @@ describe("Presence", () => {
 							data: {
 								"system:presence": systemWorkspaceUpdate,
 								// Invalid public address (must be `${string}:${string}`)
-								"s:testStateWorkspace": statesWorkspaceUpdate,
+								["s:testStateWorkspace" as InternalWorkspaceAddress]: statesWorkspaceUpdate,
 							},
 						},
 						clientId: "client1",
@@ -472,7 +474,7 @@ describe("Presence", () => {
 				assert.strictEqual(listener.callCount, 1);
 			});
 
-			it("with acknowledgementId sends targeted acknowledgment messsage back to requestor", () => {
+			it("with acknowledgementId sends targeted acknowledgment message back to requestor", () => {
 				// We expect to send a targeted acknowledgment back to the requestor
 				runtime.signalsExpected.push([
 					{

--- a/packages/framework/presence/src/test/testUtils.ts
+++ b/packages/framework/presence/src/test/testUtils.ts
@@ -56,19 +56,8 @@ export const attendeeId1 = createSpecificAttendeeId("attendeeId-1");
 export const attendeeId2 = createSpecificAttendeeId("attendeeId-2");
 /**
  * Mock {@link ClientConnectionId}.
- *
- * @remarks
- * This is an {@link AttendeeId} as a workaround to TypeScript expectation
- * that specific properties overriding an indexed property still conform
- * to the index signature. This makes cases where it is used as
- * `clientConnectionId` key in {@link SystemWorkspaceDatastore} also
- * satisfy {@link GeneralDatastoreMessageContent}'s `AttendeeId` key.
- *
- * The only known alternative is to use
- * `satisfies SystemWorkspaceDatastore as SystemWorkspaceDatastore`
- * wherever "system:presence" is defined.
  */
-export const connectionId2 = createSpecificAttendeeId("client2");
+export const connectionId2 = "client2" as const satisfies ClientConnectionId;
 
 /**
  * Generates expected inbound join signal for a client that was initialized while connected.


### PR DESCRIPTION
This is required to allow `system:presence` workspace's datastore to deviate from the common general workspace datastore typing.

This also removes test workarounds when specifying `clientToSessionId` records.