### PR TITLE
fix(shared-matrix): Revert "revert c964635" and fix no found source pipeline error

### DIFF
--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -98,6 +98,7 @@
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"pack:tests": "tar -cf ./matrix.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
+		"test:benchmark:report": "mocha --config src/test/time/.mocharc.cjs",
 		"test:coverage": "c8 npm test",
 		"test:memory": "mocha --config src/test/memory/.mocharc.cjs",
 		"test:memory-profiling:report": "mocha --config src/test/memory/.mocharc.cjs",

--- a/packages/dds/matrix/src/test/time/.mocharc.cjs
+++ b/packages/dds/matrix/src/test/time/.mocharc.cjs
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Mocha configuration file to run execution time tests
+ */
+
+module.exports = {
+	"fgrep": ["@Benchmark", "@ExecutionTime"],
+	"node-option": ["expose-gc", "gc-global", "unhandled-rejections=strict"], // without leading "--"
+	"recursive": true,
+	"reporter": "@fluid-tools/benchmark/dist/MochaReporter.js",
+	"require": ["node_modules/@fluid-internal/mocha-test-setup"],
+	"spec": ["dist/test/time/**/*.spec.*js", "--perfMode"],
+	"timeout": "15000",
+};

--- a/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
@@ -1,0 +1,283 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "node:assert";
+
+import {
+	benchmark,
+	BenchmarkType,
+	isInPerformanceTestingMode,
+	type BenchmarkTimer,
+} from "@fluid-tools/benchmark";
+
+import { SharedMatrix } from "../../index.js";
+import { createLocalMatrix } from "../utils.js";
+
+describe("SharedMatrix execution time", () => {
+	// The value to be set in the cells of the matrix.
+	const matrixValue = "cellValue";
+	// The test matrix's size will be 10*10, 100*100.
+	// Matrix size 1000 benchmarks removed due to high overhead and unreliable results.
+	const matrixSizes = isInPerformanceTestingMode
+		? [10, 100]
+		: // When not measuring perf, use a single smaller data size so the tests run faster.
+			[10];
+
+	// The number of operations to perform on the matrix.
+	const operationCounts = isInPerformanceTestingMode
+		? [10, 100, 1000]
+		: // When not measuring perf, use a single smaller data size so the tests run faster.
+			[5];
+
+	let localMatrix: SharedMatrix;
+	for (const matrixSize of matrixSizes) {
+		describe(`Size of ${matrixSize}*${matrixSize} SharedMatrix`, () => {
+			// Filter counts to ensure remove operation do not exceed matrixSize
+			const validRemoveCounts = operationCounts.filter((count) => count <= matrixSize);
+
+			// Insert-related tests that are not limited by matrixSize
+			for (const count of operationCounts) {
+				// Test the execute time of the SharedMatrix for inserting a column in the middle for a given number of times.
+				benchmark({
+					type: BenchmarkType.Measurement,
+					title: `Insert a column in the middle ${count} times`,
+					benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+						let duration: number;
+
+						do {
+							// Since this setup one collects data from one iteration, assert that this is what is expected.
+							assert.equal(state.iterationsPerBatch, 1);
+
+							// Setup
+							localMatrix = createLocalMatrix({
+								id: "testLocalMatrix",
+								size: matrixSize,
+								initialValue: matrixValue,
+							});
+							// Operation
+							const before = state.timer.now();
+							for (let i = 0; i < count; i++) {
+								localMatrix.insertCols(Math.floor(localMatrix.colCount / 2), 1);
+							}
+							const after = state.timer.now();
+							// Measure
+							duration = state.timer.toSeconds(before, after);
+							// Collect data
+						} while (state.recordBatch(duration));
+					},
+					// Force batch size of 1
+					minBatchDurationSeconds: 0,
+					maxBenchmarkDurationSeconds: matrixSize === 100 ? 10 : 5,
+				});
+
+				// Test the execute time of the SharedMatrix for inserting a row in the middle for a given number of times.
+				benchmark({
+					type: BenchmarkType.Measurement,
+					title: `Insert a row in the middle ${count} times`,
+					benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+						let duration: number;
+
+						do {
+							// Since this setup one collects data from one iteration, assert that this is what is expected.
+							assert.equal(state.iterationsPerBatch, 1);
+
+							// Setup
+							localMatrix = createLocalMatrix({
+								id: "testLocalMatrix",
+								size: matrixSize,
+								initialValue: matrixValue,
+							});
+
+							// Operation
+							const before = state.timer.now();
+							for (let i = 0; i < count; i++) {
+								localMatrix.insertRows(Math.floor(localMatrix.rowCount / 2), 1);
+							}
+							const after = state.timer.now();
+
+							// Measure
+							duration = state.timer.toSeconds(before, after);
+
+							// Collect data
+						} while (state.recordBatch(duration));
+					},
+					// Force batch size of 1
+					minBatchDurationSeconds: 0,
+					maxBenchmarkDurationSeconds: matrixSize === 100 ? 10 : 5,
+				});
+
+				// Test the execute time of the SharedMatrix for inserting a row and a column in the middle for a given number of times.
+				benchmark({
+					type: BenchmarkType.Measurement,
+					title: `Insert a row and a column ${count} times`,
+					benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+						let duration: number;
+
+						do {
+							// Since this setup one collects data from one iteration, assert that this is what is expected.
+							assert.equal(state.iterationsPerBatch, 1);
+
+							// Setup
+							localMatrix = createLocalMatrix({
+								id: "testLocalMatrix",
+								size: matrixSize,
+								initialValue: matrixValue,
+							});
+
+							// Operation
+							const before = state.timer.now();
+							for (let i = 0; i < count; i++) {
+								localMatrix.insertCols(Math.floor(localMatrix.colCount / 2), 1);
+								localMatrix.insertRows(Math.floor(localMatrix.rowCount / 2), 1);
+							}
+							const after = state.timer.now();
+
+							// Measure
+							duration = state.timer.toSeconds(before, after);
+
+							// Collect data
+						} while (state.recordBatch(duration));
+					},
+					// Force batch size of 1
+					minBatchDurationSeconds: 0,
+					// Matrix size 100 benchmarks use increased duration (10s) to improve statistical significance.
+					maxBenchmarkDurationSeconds: matrixSize === 100 ? 10 : 5,
+				});
+			}
+
+			// Set/Remove-related tests that are limited by matrixSize
+			for (const count of validRemoveCounts) {
+				// Test the execute time of the SharedMatrix for removing a column in the middle for a given number of times.
+				benchmark({
+					type: BenchmarkType.Measurement,
+					title: `Remove the middle column ${count} times`,
+					benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+						let duration: number;
+
+						do {
+							// Since this setup one collects data from one iteration, assert that this is what is expected.
+							assert.equal(state.iterationsPerBatch, 1);
+
+							// Setup
+							localMatrix = createLocalMatrix({
+								id: "testLocalMatrix",
+								size: matrixSize,
+								initialValue: matrixValue,
+							});
+
+							// Operation
+							const before = state.timer.now();
+							for (let i = 0; i < count; i++) {
+								localMatrix.removeCols(Math.floor(localMatrix.colCount / 2), 1);
+							}
+							const after = state.timer.now();
+
+							// Measure
+							duration = state.timer.toSeconds(before, after);
+
+							// Collect data
+						} while (state.recordBatch(duration));
+					},
+					// Force batch size of 1
+					minBatchDurationSeconds: 0,
+					// Matrix size 100 benchmarks use increased duration (10s) to improve statistical significance.
+					maxBenchmarkDurationSeconds: matrixSize === 100 ? 10 : 5,
+				});
+
+				// Test the execute time of the SharedMatrix for removing a row in the middle for a given number of times.
+				benchmark({
+					type: BenchmarkType.Measurement,
+					title: `Remove the middle row ${count} times`,
+					benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+						let duration: number;
+
+						do {
+							// Since this setup one collects data from one iteration, assert that this is what is expected.
+							assert.equal(state.iterationsPerBatch, 1);
+
+							// Setup
+							localMatrix = createLocalMatrix({
+								id: "testLocalMatrix",
+								size: matrixSize,
+								initialValue: matrixValue,
+							});
+
+							// Operation
+							const before = state.timer.now();
+							for (let i = 0; i < count; i++) {
+								localMatrix.removeRows(Math.floor(localMatrix.rowCount / 2), 1);
+							}
+							const after = state.timer.now();
+
+							// Measure
+							duration = state.timer.toSeconds(before, after);
+
+							// Collect data
+						} while (state.recordBatch(duration));
+					},
+					// Force batch size of 1
+					minBatchDurationSeconds: 0,
+					// Matrix size 100 benchmarks use increased duration (10s) to improve statistical significance.
+					maxBenchmarkDurationSeconds: matrixSize === 100 ? 10 : 5,
+				});
+
+				// Test the execute time of the SharedMatrix for removing a row and a column in the middle for a given number of times.
+				benchmark({
+					type: BenchmarkType.Measurement,
+					title: `Remove the middle row and column ${count} times`,
+					benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {
+						let duration: number;
+
+						do {
+							// Since this setup one collects data from one iteration, assert that this is what is expected.
+							assert.equal(state.iterationsPerBatch, 1);
+
+							// Setup
+							localMatrix = createLocalMatrix({
+								id: "testLocalMatrix",
+								size: matrixSize,
+								initialValue: matrixValue,
+							});
+
+							// Operation
+							const before = state.timer.now();
+							for (let i = 0; i < count; i++) {
+								localMatrix.removeCols(Math.floor(localMatrix.colCount / 2), 1);
+								localMatrix.removeRows(Math.floor(localMatrix.rowCount / 2), 1);
+							}
+							const after = state.timer.now();
+
+							// Measure
+							duration = state.timer.toSeconds(before, after);
+
+							// Collect data
+						} while (state.recordBatch(duration));
+					},
+					// Force batch size of 1
+					minBatchDurationSeconds: 0,
+					// Matrix size 100 benchmarks use increased duration (10s) to improve statistical significance.
+					maxBenchmarkDurationSeconds: matrixSize === 100 ? 10 : 5,
+				});
+
+				// Test the execute time of the SharedMatrix for setting a string in a cell for a given number of times.
+				benchmark({
+					title: `Set a 3-character string in ${count} cells`,
+					before: async () => {
+						localMatrix = createLocalMatrix({
+							id: "testLocalMatrix",
+							size: matrixSize,
+							initialValue: matrixValue,
+						});
+					},
+					benchmarkFn: () => {
+						for (let i = 0; i < count; i++) {
+							localMatrix.setCell(i, i, "abc");
+						}
+					},
+				});
+			}
+		});
+	}
+});

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -35,6 +35,7 @@ parameters:
   type: object
   default:
     - "@fluidframework/tree"
+    - "@fluidframework/matrix"
     - "@fluid-experimental/tree"
     - "@fluidframework/merge-tree"
     - "@fluidframework/container-runtime"

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -35,7 +35,6 @@ parameters:
   type: object
   default:
     - "@fluidframework/tree"
-    - "@fluidframework/matrix"
     - "@fluid-experimental/tree"
     - "@fluidframework/merge-tree"
     - "@fluidframework/container-runtime"


### PR DESCRIPTION
## Description
This pull request reinstates a previously reverted commit while also addressing issue: Error: Not found SourceFolder. The fix involves removing a specific output directory, allowing the benchmark tool to default to its standard output path. This adjustment successfully resolves the missing output directory error, as verified in [Build 341497](https://dev.azure.com/fluidframework/internal/_build/results?buildId=341497&view=results).

Additionally, while this fix restores the test files with the correction, the benchmark performance pipeline encountered a separate failure on the ODSP stage, persisting since [last Tuesday](https://dev.azure.com/fluidframework/internal/_build?definitionId=96&_a=summary) due to an "Unable to get access token" error.
