### PR TITLE
Check whether marker is removed in searchForMarker

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1270,7 +1270,7 @@ export class MergeTree {
 			segment,
 			(node) => {
 				if (node.isLeaf()) {
-					if (Marker.is(node) && refHasTileLabel(node, markerLabel)) {
+					if (!isRemoved(node) && Marker.is(node) && refHasTileLabel(node, markerLabel)) {
 						foundMarker = node;
 					}
 				} else {

--- a/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
@@ -596,14 +596,14 @@ describe("TestClient", () => {
 
 		it("Should return undefined when trying to find a removed marker", () => {
 			client.insertTextLocal(0, "abc");
-			client.insertMarkerLocal(0, ReferenceType.Tile, {
+			client.insertMarkerLocal(1, ReferenceType.Tile, {
 				[reservedMarkerIdKey]: "marker",
 				[reservedTileLabelsKey]: ["Eop"],
 			});
 
 			assert.equal(client.getLength(), 4, "length not expected");
 
-			client.removeRangeLocal(0, 1);
+			client.removeRangeLocal(1, 2);
 
 			assert.equal(client.getLength(), 3, "length not expected");
 


### PR DESCRIPTION
Update implementation of searchForMarker to not return removed markers. This matches what getMarkerFromId does. The unit test was passing because the removed marker is at the beginning of the string, so starting the search at index 0 is after it.