### PR TITLE
(learning): About Document Schema and enabling ID Compressor

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -419,7 +419,6 @@ export interface ContainerRuntimeOptions {
 
 	/**
 	 * Enable the IdCompressor in the runtime.
-	 * @experimental Not ready for use.
 	 */
 	readonly enableRuntimeIdCompressor: IdCompressorMode;
 
@@ -4506,11 +4505,6 @@ export class ContainerRuntime
 				"Unexpected message type submitted in Staging Mode",
 			);
 
-			// Before submitting any non-staged change, submit the ID Allocation op to cover any compressed IDs included in the op.
-			if (!staged) {
-				this.submitIdAllocationOpIfNeeded({ staged: false });
-			}
-
 			// Allow document schema controller to send a message if it needs to propose change in document schema.
 			// If it needs to send a message, it will call provided callback with payload of such message and rely
 			// on this callback to do actual sending.
@@ -4533,6 +4527,11 @@ export class ContainerRuntime
 					referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
 					staged,
 				});
+			}
+
+			// Before submitting any non-staged change, submit the ID Allocation op to cover any compressed IDs included in the op.
+			if (!staged) {
+				this.submitIdAllocationOpIfNeeded({ staged: false });
 			}
 
 			const message: LocalBatchMessage = {

--- a/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
@@ -14,7 +14,10 @@ import {
 	getContainerEntryPointBackCompat,
 } from "@fluidframework/test-utils/internal";
 
-describeCompat(
+//* SKIP
+//* SKIP
+//* SKIP
+describeCompat.skip(
 	"ContainerRuntime Document Schema",
 	"FullCompat",
 	(getTestObjectProvider, apis) => {
@@ -205,9 +208,9 @@ describeCompat("Id Compressor Schema change", "NoCompat", (getTestObjectProvider
 		provider = getTestObjectProvider();
 	});
 
-	it("upgrade with explicitSchemaControl = false", async () => {
-		await testUpgrade(false);
-	});
+	// it("upgrade with explicitSchemaControl = false", async () => {
+	// 	await testUpgrade(false);
+	// });
 
 	it("upgrade with explicitSchemaControl = true", async () => {
 		await testUpgrade(true);
@@ -222,7 +225,7 @@ describeCompat("Id Compressor Schema change", "NoCompat", (getTestObjectProvider
 
 		const container = await provider.makeTestContainer({
 			runtimeOptions: {
-				explicitSchemaControl: false,
+				explicitSchemaControl: true,
 				enableRuntimeIdCompressor: undefined,
 			},
 		});


### PR DESCRIPTION
I thought there was an issue with op ordering between submitted Doc Schema messages to enable ID Compressor and then submitting ID Allocation ops right away.  Turns out ID Allocation ops won't be sent until that Doc Schema message is _ack'd_ so all good.

This branch is where I was poking around.