### PR TITLE
(tree) Renamed some shape encoding entities in chunked forest

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkEncodingGeneric.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkEncodingGeneric.ts
@@ -43,13 +43,13 @@ export type BufferFormat<TEncodedShape> = (
 )[];
 
 /**
- * Replace shapes and identifiers in buffer and any nested arrays.
+ * Encodes shapes and identifiers in buffer and any nested arrays.
  *
  * This looks inside nested arrays (including transitively) but not inside objects.
  *
  * Note that this modifies `buffer` to avoid having to copy it.
  */
-export function handleShapesAndIdentifiers<TEncodedShape>(
+export function encodeShapesAndIdentifiers<TEncodedShape>(
 	version: number,
 	buffer: BufferFormat<TEncodedShape>[],
 	identifierFilter: CounterFilter<string> = jsonMinimizingFilter,
@@ -68,21 +68,21 @@ export function handleShapesAndIdentifiers<TEncodedShape>(
 		}
 	};
 
-	const arrays: BufferFormat<TEncodedShape>[] = [buffer];
-	for (const array of arrays) {
-		for (const item of array) {
-			if (item instanceof IdentifierToken) {
-				identifiers.add(item.identifier);
-			} else if (item instanceof Shape) {
-				shapeDiscovered(item);
-			} else if (Array.isArray(item)) {
+	const dataBufferArray: BufferFormat<TEncodedShape>[] = [buffer];
+	for (const dataBuffer of dataBufferArray) {
+		for (const data of dataBuffer) {
+			if (data instanceof IdentifierToken) {
+				identifiers.add(data.identifier);
+			} else if (data instanceof Shape) {
+				shapeDiscovered(data);
+			} else if (Array.isArray(data)) {
 				// In JS it is legal to push items to an array which is being iterated,
 				// and they will be visited in order.
-				arrays.push(item);
+				dataBufferArray.push(data);
 			} else if (
-				item !== null &&
-				typeof item === "object" &&
-				(item as Record<string, unknown>).shape instanceof Shape
+				data !== null &&
+				typeof data === "object" &&
+				(data as Record<string, unknown>).shape instanceof Shape
 			) {
 				// because "serializable" is allowed in buffer and it has type `any`, its very easy to mess up including of shapes in the buffer.
 				// This catches the easiest way to get it wrong.
@@ -93,9 +93,9 @@ export function handleShapesAndIdentifiers<TEncodedShape>(
 
 	// Traverse shape graph, discovering and counting all shape to shape and shape to identifier references.
 	{
-		let item: Shape<TEncodedShape> | undefined;
-		while ((item = shapeToCount.pop()) !== undefined) {
-			item.count(identifiers, shapeDiscovered);
+		let shape: Shape<TEncodedShape> | undefined;
+		while ((shape = shapeToCount.pop()) !== undefined) {
+			shape.discoverReferencedShapesAndCount(identifiers, shapeDiscovered);
 		}
 	}
 
@@ -103,13 +103,15 @@ export function handleShapesAndIdentifiers<TEncodedShape>(
 	const identifierTable = identifiers.buildTable(identifierFilter);
 	const shapeTable = shapes.buildTable();
 
-	for (const array of arrays) {
-		for (let index = 0; index < array.length; index++) {
-			const item = array[index];
-			if (item instanceof IdentifierToken) {
-				array[index] = identifierTable.valueToIndex.get(item.identifier) ?? item.identifier;
-			} else if (item instanceof Shape) {
-				array[index] = shapeTable.valueToIndex.get(item) ?? fail(0xb4c /* missing shape */);
+	for (const dataBuffer of dataBufferArray) {
+		for (let index = 0; index < dataBuffer.length; index++) {
+			const data = dataBuffer[index];
+			if (data instanceof IdentifierToken) {
+				dataBuffer[index] =
+					identifierTable.valueToIndex.get(data.identifier) ?? data.identifier;
+			} else if (data instanceof Shape) {
+				dataBuffer[index] =
+					shapeTable.valueToIndex.get(data) ?? fail(0xb4c /* missing shape */);
 			}
 		}
 	}
@@ -143,8 +145,8 @@ export function handleShapesAndIdentifiers<TEncodedShape>(
  * Comparison by content would be difficult due to shape containing references to other shapes.
  *
  * @privateRemarks
- * Unlike with identifiers, conversion from the initial form (this class / IdentifierToken) is done by the `encodeShape` method, not by general purpose logic in `handleShapesAndIdentifiers`.
- * For `handleShapesAndIdentifiers` to do the conversion without help from `encodeShape`,
+ * Unlike with identifiers, conversion from the initial form (this class / IdentifierToken) is done by the `encodeShape` method, not by general purpose logic in `encodeShapesAndIdentifiers`.
+ * For `encodeShapesAndIdentifiers` to do the conversion without help from `encodeShape`,
  * instances of this Shape class would have to either be or output an object that is identical to the `TEncodedShape` format except with all shape references as object references instead of indexes.
  * Those objects would have to be deeply traversed looking for shape objects to replace with reference indexes.
  * This is possible, but making it type safe would involve generating derived types from the `TEncodedShape` deeply replacing any shape references, as well as requiring deep traversal of all objects in the encoded output.
@@ -152,18 +154,18 @@ export function handleShapesAndIdentifiers<TEncodedShape>(
  */
 export abstract class Shape<TEncodedShape> {
 	/**
-	 * Count this shape's contents.
+	 * Discover referenced shapes and call the provided callback for each discovered shape. Also, count this shape's contents.
 	 *
 	 * Used to discover referenced shapes (to ensure they are included in the `shapes` passed to `encodeShape`),
 	 * as well as count usages of shapes and identifiers for more efficient dictionary encoding. See {@link Counter}.
 	 *
-	 * @param shapes - must be invoked with each directly referenced shape (which must provided to `encodeShape`).
+	 * @param shapeDiscovered - must be invoked with each directly referenced shape (which must be provided to `encodeShape`).
 	 * Can be invoked multiple times if a shape is referenced more than once for more efficient dictionary encoding.
 	 * Should not be invoked with `this` unless this shape references itself.
 	 */
-	public abstract count(
+	public abstract discoverReferencedShapesAndCount(
 		identifiers: Counter<string>,
-		shapes: (shape: Shape<TEncodedShape>) => void,
+		shapeDiscovered: (shape: Shape<TEncodedShape>) => void,
 	): void;
 
 	/**

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
@@ -23,7 +23,7 @@ import type { Counter, DeduplicationTable } from "./chunkCodecUtilities.js";
 import {
 	type BufferFormat as BufferFormatGeneric,
 	Shape as ShapeGeneric,
-	encodeShapesAndIdentifiers,
+	updateShapesAndIdentifiersEncoding,
 } from "./chunkEncodingGeneric.js";
 import type { FieldBatch } from "./fieldBatch.js";
 import {
@@ -55,7 +55,7 @@ export function compressedEncode(
 		anyFieldEncoder.encodeField(cursor, cache, buffer);
 		batchBuffer.push(buffer);
 	}
-	return encodeShapesAndIdentifiers(version, batchBuffer);
+	return updateShapesAndIdentifiersEncoding(version, batchBuffer);
 }
 
 export type BufferFormat = BufferFormatGeneric<EncodedChunkShape>;
@@ -175,7 +175,7 @@ export class AnyShape extends ShapeGeneric<EncodedChunkShape> {
 		return { d: encodedAnyShape };
 	}
 
-	public discoverReferencedShapesAndCount(
+	public countReferencedShapesAndIdentifiers(
 		identifiers: Counter<string>,
 		shapeDiscovered: (shape: Shape) => void,
 	): void {}
@@ -332,7 +332,7 @@ export class InlineArrayShape
 		};
 	}
 
-	public discoverReferencedShapesAndCount(
+	public countReferencedShapesAndIdentifiers(
 		identifiers: Counter<string>,
 		shapeDiscovered: (shape: Shape) => void,
 	): void {
@@ -393,7 +393,7 @@ export class NestedArrayShape extends ShapeGeneric<EncodedChunkShape> implements
 		};
 	}
 
-	public discoverReferencedShapesAndCount(
+	public countReferencedShapesAndIdentifiers(
 		identifiers: Counter<string>,
 		shapeDiscovered: (shape: Shape) => void,
 	): void {

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
@@ -23,7 +23,7 @@ import type { Counter, DeduplicationTable } from "./chunkCodecUtilities.js";
 import {
 	type BufferFormat as BufferFormatGeneric,
 	Shape as ShapeGeneric,
-	handleShapesAndIdentifiers,
+	encodeShapesAndIdentifiers,
 } from "./chunkEncodingGeneric.js";
 import type { FieldBatch } from "./fieldBatch.js";
 import {
@@ -55,7 +55,7 @@ export function compressedEncode(
 		anyFieldEncoder.encodeField(cursor, cache, buffer);
 		batchBuffer.push(buffer);
 	}
-	return handleShapesAndIdentifiers(version, batchBuffer);
+	return encodeShapesAndIdentifiers(version, batchBuffer);
 }
 
 export type BufferFormat = BufferFormatGeneric<EncodedChunkShape>;
@@ -175,7 +175,10 @@ export class AnyShape extends ShapeGeneric<EncodedChunkShape> {
 		return { d: encodedAnyShape };
 	}
 
-	public count(identifiers: Counter<string>, shapes: (shape: Shape) => void): void {}
+	public discoverReferencedShapesAndCount(
+		identifiers: Counter<string>,
+		shapeDiscovered: (shape: Shape) => void,
+	): void {}
 
 	public static encodeField(
 		cursor: ITreeCursorSynchronous,
@@ -329,8 +332,11 @@ export class InlineArrayShape
 		};
 	}
 
-	public count(identifiers: Counter<string>, shapes: (shape: Shape) => void): void {
-		shapes(this.inner.shape);
+	public discoverReferencedShapesAndCount(
+		identifiers: Counter<string>,
+		shapeDiscovered: (shape: Shape) => void,
+	): void {
+		shapeDiscovered(this.inner.shape);
 	}
 
 	public get shape(): this {
@@ -387,8 +393,11 @@ export class NestedArrayShape extends ShapeGeneric<EncodedChunkShape> implements
 		};
 	}
 
-	public count(identifiers: Counter<string>, shapes: (shape: Shape) => void): void {
-		shapes(this.inner.shape);
+	public discoverReferencedShapesAndCount(
+		identifiers: Counter<string>,
+		shapeDiscovered: (shape: Shape) => void,
+	): void {
+		shapeDiscovered(this.inner.shape);
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeShape.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeShape.ts
@@ -121,9 +121,9 @@ export class NodeShape extends Shape<EncodedChunkShape> implements NodeEncoder {
 		};
 	}
 
-	public count(
+	public discoverReferencedShapesAndCount(
 		identifiers: Counter<string>,
-		shapes: (shape: Shape<EncodedChunkShape>) => void,
+		shapeDiscovered: (shape: Shape<EncodedChunkShape>) => void,
 	): void {
 		if (this.type !== undefined) {
 			identifiers.add(this.type);
@@ -131,11 +131,11 @@ export class NodeShape extends Shape<EncodedChunkShape> implements NodeEncoder {
 
 		for (const fieldEncoder of this.specializedFieldEncoders) {
 			identifiers.add(fieldEncoder.key);
-			shapes(fieldEncoder.encoder.shape);
+			shapeDiscovered(fieldEncoder.encoder.shape);
 		}
 
 		if (this.otherFieldsEncoder !== undefined) {
-			shapes(this.otherFieldsEncoder.shape);
+			shapeDiscovered(this.otherFieldsEncoder.shape);
 		}
 	}
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeShape.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/nodeShape.ts
@@ -121,7 +121,7 @@ export class NodeShape extends Shape<EncodedChunkShape> implements NodeEncoder {
 		};
 	}
 
-	public discoverReferencedShapesAndCount(
+	public countReferencedShapesAndIdentifiers(
 		identifiers: Counter<string>,
 		shapeDiscovered: (shape: Shape<EncodedChunkShape>) => void,
 	): void {

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
@@ -11,7 +11,7 @@ import type { CounterFilter } from "../../../../feature-libraries/chunked-forest
 // eslint-disable-next-line import/no-internal-modules
 import { decode } from "../../../../feature-libraries/chunked-forest/codec/chunkDecoding.js";
 // eslint-disable-next-line import/no-internal-modules
-import { encodeShapesAndIdentifiers } from "../../../../feature-libraries/chunked-forest/codec/chunkEncodingGeneric.js";
+import { updateShapesAndIdentifiersEncoding } from "../../../../feature-libraries/chunked-forest/codec/chunkEncodingGeneric.js";
 import type {
 	BufferFormat,
 	EncoderCache,
@@ -75,7 +75,7 @@ function checkDecode(
 }
 
 /**
- * Clones anything encodeShapesAndIdentifiers might modify in-place.
+ * Clones anything updateShapesAndIdentifiersEncoding might modify in-place.
  */
 function cloneArrays<T>(data: readonly T[]): T[] {
 	return data.map((item) => (Array.isArray(item) ? cloneArrays(item) : item)) as T[];
@@ -87,7 +87,11 @@ function testDecode(
 	identifierFilter: CounterFilter<string>,
 	idCompressor?: IIdCompressor,
 ): EncodedFieldBatch {
-	const chunk = encodeShapesAndIdentifiers(version, cloneArrays(buffer), identifierFilter);
+	const chunk = updateShapesAndIdentifiersEncoding(
+		version,
+		cloneArrays(buffer),
+		identifierFilter,
+	);
 
 	// TODO: check chunk matches schema
 

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
@@ -11,7 +11,7 @@ import type { CounterFilter } from "../../../../feature-libraries/chunked-forest
 // eslint-disable-next-line import/no-internal-modules
 import { decode } from "../../../../feature-libraries/chunked-forest/codec/chunkDecoding.js";
 // eslint-disable-next-line import/no-internal-modules
-import { handleShapesAndIdentifiers } from "../../../../feature-libraries/chunked-forest/codec/chunkEncodingGeneric.js";
+import { encodeShapesAndIdentifiers } from "../../../../feature-libraries/chunked-forest/codec/chunkEncodingGeneric.js";
 import type {
 	BufferFormat,
 	EncoderCache,
@@ -75,7 +75,7 @@ function checkDecode(
 }
 
 /**
- * Clones anything handleShapesAndIdentifiers might modify in-place.
+ * Clones anything encodeShapesAndIdentifiers might modify in-place.
  */
 function cloneArrays<T>(data: readonly T[]): T[] {
 	return data.map((item) => (Array.isArray(item) ? cloneArrays(item) : item)) as T[];
@@ -87,7 +87,7 @@ function testDecode(
 	identifierFilter: CounterFilter<string>,
 	idCompressor?: IIdCompressor,
 ): EncodedFieldBatch {
-	const chunk = handleShapesAndIdentifiers(version, cloneArrays(buffer), identifierFilter);
+	const chunk = encodeShapesAndIdentifiers(version, cloneArrays(buffer), identifierFilter);
 
 	// TODO: check chunk matches schema
 

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
@@ -27,7 +27,7 @@ import {
 import {
 	type BufferFormat,
 	IdentifierToken,
-	handleShapesAndIdentifiers,
+	encodeShapesAndIdentifiers,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/chunkEncodingGeneric.js";
 import {
@@ -159,7 +159,7 @@ describe("compressedEncode", () => {
 				const buffer: BufferFormat<EncodedChunkShape> = [];
 				encodeValue(value, shape, buffer);
 				assert.deepEqual(buffer, encoded);
-				const processed = handleShapesAndIdentifiers(version, [buffer]);
+				const processed = encodeShapesAndIdentifiers(version, [buffer]);
 				assert(processed.data.length === 1);
 				const stream = { data: processed.data[0], offset: 0 };
 				const decoded = readValue(stream, shape, {

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
@@ -27,7 +27,7 @@ import {
 import {
 	type BufferFormat,
 	IdentifierToken,
-	encodeShapesAndIdentifiers,
+	updateShapesAndIdentifiersEncoding,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/chunkEncodingGeneric.js";
 import {
@@ -159,7 +159,7 @@ describe("compressedEncode", () => {
 				const buffer: BufferFormat<EncodedChunkShape> = [];
 				encodeValue(value, shape, buffer);
 				assert.deepEqual(buffer, encoded);
-				const processed = encodeShapesAndIdentifiers(version, [buffer]);
+				const processed = updateShapesAndIdentifiersEncoding(version, [buffer]);
 				assert(processed.data.length === 1);
 				const stream = { data: processed.data[0], offset: 0 };
 				const decoded = readValue(stream, shape, {

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/nodeShape.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/nodeShape.spec.ts
@@ -34,7 +34,7 @@ describe("nodeShape", () => {
 		it("empty node", () => {
 			const shape = new NodeShape(undefined, false, [], undefined);
 			const identifierCounter = new Counter<string>();
-			shape.discoverReferencedShapesAndCount(identifierCounter, () => fail());
+			shape.countReferencedShapesAndIdentifiers(identifierCounter, () => fail());
 			assert(identifierCounter.buildTable().indexToValue.length === 0);
 
 			const cache = new EncoderCache(
@@ -54,7 +54,7 @@ describe("nodeShape", () => {
 			const shape = new NodeShape(brand("foo"), true, [], undefined);
 
 			const identifierCounter = new Counter<string>();
-			shape.discoverReferencedShapesAndCount(identifierCounter, () => fail());
+			shape.countReferencedShapesAndIdentifiers(identifierCounter, () => fail());
 			const cache = new EncoderCache(
 				() => fail(),
 				() => fail(),

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/nodeShape.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/nodeShape.spec.ts
@@ -34,7 +34,7 @@ describe("nodeShape", () => {
 		it("empty node", () => {
 			const shape = new NodeShape(undefined, false, [], undefined);
 			const identifierCounter = new Counter<string>();
-			shape.count(identifierCounter, () => fail());
+			shape.discoverReferencedShapesAndCount(identifierCounter, () => fail());
 			assert(identifierCounter.buildTable().indexToValue.length === 0);
 
 			const cache = new EncoderCache(
@@ -54,7 +54,7 @@ describe("nodeShape", () => {
 			const shape = new NodeShape(brand("foo"), true, [], undefined);
 
 			const identifierCounter = new Counter<string>();
-			shape.count(identifierCounter, () => fail());
+			shape.discoverReferencedShapesAndCount(identifierCounter, () => fail());
 			const cache = new EncoderCache(
 				() => fail(),
 				() => fail(),


### PR DESCRIPTION
Renamed the following related to shape encoding in chunked forest:
- `handleShapesAndIdentifiers` -> `updateShapesAndIdentifiersEncoding` - This makes it explicit that the function update the encoding of shapes and identifiers in the passed buffer.
- `count` in `Shape` -> `countReferencedShapesAndIdentifiers` - This makes it clear that this function counts any shapes and identifiers in the `Shape` and counts them.
- `shapes` paramater in the above function -> `shapeDiscovered` - This makes it explicit that this is a callback which should be called whenever a shape is discovered.