### PR TITLE
fix(Offline): Applying stashed ops with empty batches

### DIFF
--- a/packages/runtime/container-runtime/src/metadata.ts
+++ b/packages/runtime/container-runtime/src/metadata.ts
@@ -26,7 +26,7 @@ export function asEmptyBatchLocalOpMetadata(
  */
 export interface IEmptyBatchMetadata {
 	// Set to true on localOpMetadata for empty batches
-	emptyBatch?: boolean;
+	emptyBatch?: true;
 }
 /**
  * Properties put on the op metadata object for batch tracking

--- a/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
@@ -8,6 +8,7 @@ import type { IBatchMessage } from "@fluidframework/container-definitions/intern
 import { CompressionAlgorithms } from "../compressionDefinitions.js";
 import type { LocalContainerRuntimeMessage } from "../messageTypes.js";
 import type { IEmptyBatchMetadata } from "../metadata.js";
+
 import type { EmptyGroupedBatch } from "./opGroupingManager.js";
 
 /**

--- a/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
@@ -7,6 +7,8 @@ import type { IBatchMessage } from "@fluidframework/container-definitions/intern
 
 import { CompressionAlgorithms } from "../compressionDefinitions.js";
 import type { LocalContainerRuntimeMessage } from "../messageTypes.js";
+import type { IEmptyBatchMetadata } from "../metadata.js";
+import type { EmptyGroupedBatch } from "./opGroupingManager.js";
 
 /**
  * Local Batch message, before it is virtualized and sent to the ordering service
@@ -34,7 +36,7 @@ export interface LocalBatchMessage {
 	staged?: boolean;
 
 	/**
-	 * @deprecated Use serializedOp
+	 * @deprecated Use runtimeOp
 	 */
 	contents?: never; // To ensure we don't leave this one when converting from OutboundBatchMessage
 }
@@ -44,8 +46,9 @@ export interface LocalBatchMessage {
  */
 export interface LocalEmptyBatchPlaceholder {
 	metadata?: Record<string, unknown>;
-	localOpMetadata: { emptyBatch: true };
+	localOpMetadata: Required<IEmptyBatchMetadata>;
 	referenceSequenceNumber: number;
+	runtimeOp: EmptyGroupedBatch;
 }
 
 /**
@@ -59,7 +62,7 @@ export type OutboundBatchMessage = IBatchMessage & {
 	/**
 	 * @deprecated Use contents
 	 */
-	serializedOp?: never; // To ensure we don't leave this one when converting from LocalBatchMessage
+	runtimeOp?: never; // To ensure we don't leave this one when converting from LocalBatchMessage
 };
 
 /**

--- a/packages/runtime/container-runtime/src/opLifecycle/index.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/index.ts
@@ -43,6 +43,7 @@ export {
 	unpackRuntimeMessage,
 } from "./remoteMessageProcessor.js";
 export {
+	EmptyGroupedBatch,
 	OpGroupingManager,
 	OpGroupingManagerConfig,
 	isGroupedBatch,

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -51,10 +51,10 @@ export interface OpGroupingManagerConfig {
  * We also put this in the placeholder for an empty batch in the PendingStateManager.
  * But most places throughout the ContainerRuntime, this will not be used (just as Grouped Batches in general don't appear outside opLifecycle dir)
  */
-export type EmptyGroupedBatch = {
+export interface EmptyGroupedBatch {
 	type: typeof OpGroupingManager.groupedBatchOp;
 	contents: readonly unknown[];
-};
+}
 
 /**
  * This is an empty grouped batch which is sent when resubmitting an empty batch.

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -56,14 +56,6 @@ export interface EmptyGroupedBatch {
 	contents: readonly unknown[];
 }
 
-/**
- * This is an empty grouped batch which is sent when resubmitting an empty batch.
- */
-const makeEmptyGroupedBatch = (): EmptyGroupedBatch => ({
-	type: "groupedBatch",
-	contents: [],
-});
-
 export class OpGroupingManager {
 	static readonly groupedBatchOp = "groupedBatch";
 	private readonly logger: ITelemetryLoggerExt;
@@ -94,7 +86,10 @@ export class OpGroupingManager {
 			0xa00 /* cannot create empty grouped batch when grouped batching is disabled */,
 		);
 
-		const emptyGroupedBatch = makeEmptyGroupedBatch();
+		const emptyGroupedBatch: EmptyGroupedBatch = {
+			type: "groupedBatch",
+			contents: [],
+		};
 		const serializedOp = JSON.stringify(emptyGroupedBatch);
 
 		const placeholderMessage: LocalEmptyBatchPlaceholder = {

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -59,10 +59,10 @@ export interface EmptyGroupedBatch {
 /**
  * This is an empty grouped batch which is sent when resubmitting an empty batch.
  */
-const emptyGroupedBatch: EmptyGroupedBatch = {
+const makeEmptyGroupedBatch = (): EmptyGroupedBatch => ({
 	type: "groupedBatch",
 	contents: [],
-};
+});
 
 export class OpGroupingManager {
 	static readonly groupedBatchOp = "groupedBatch";
@@ -94,6 +94,7 @@ export class OpGroupingManager {
 			0xa00 /* cannot create empty grouped batch when grouped batching is disabled */,
 		);
 
+		const emptyGroupedBatch = makeEmptyGroupedBatch();
 		const serializedOp = JSON.stringify(emptyGroupedBatch);
 
 		const placeholderMessage: LocalEmptyBatchPlaceholder = {

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -46,6 +46,24 @@ export interface OpGroupingManagerConfig {
 	readonly groupedBatchingEnabled: boolean;
 }
 
+/**
+ * This is the type of an empty grouped batch we send over the wire
+ * We also put this in the placeholder for an empty batch in the PendingStateManager.
+ * But most places throughout the ContainerRuntime, this will not be used (just as Grouped Batches in general don't appear outside opLifecycle dir)
+ */
+export type EmptyGroupedBatch = {
+	type: typeof OpGroupingManager.groupedBatchOp;
+	contents: readonly unknown[];
+};
+
+/**
+ * This is an empty grouped batch which is sent when resubmitting an empty batch.
+ */
+const emptyGroupedBatch: EmptyGroupedBatch = {
+	type: "groupedBatch",
+	contents: [],
+};
+
 export class OpGroupingManager {
 	static readonly groupedBatchOp = "groupedBatch";
 	private readonly logger: ITelemetryLoggerExt;
@@ -75,19 +93,18 @@ export class OpGroupingManager {
 			this.config.groupedBatchingEnabled,
 			0xa00 /* cannot create empty grouped batch when grouped batching is disabled */,
 		);
-		const serializedOp = JSON.stringify({
-			type: OpGroupingManager.groupedBatchOp,
-			contents: [],
-		});
+
+		const serializedOp = JSON.stringify(emptyGroupedBatch);
 
 		const placeholderMessage: LocalEmptyBatchPlaceholder = {
 			metadata: { batchId: resubmittingBatchId },
 			localOpMetadata: { emptyBatch: true },
 			referenceSequenceNumber,
+			runtimeOp: emptyGroupedBatch,
 		};
 		const outboundBatch: OutboundSingletonBatch = {
 			contentSizeInBytes: 0,
-			messages: [{ ...placeholderMessage, contents: serializedOp }],
+			messages: [{ ...placeholderMessage, runtimeOp: undefined, contents: serializedOp }],
 			referenceSequenceNumber,
 		};
 		return { outboundBatch, placeholderMessage };

--- a/packages/runtime/container-runtime/src/opLifecycle/opSerialization.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opSerialization.ts
@@ -12,6 +12,8 @@ import {
 
 import type { LocalContainerRuntimeMessage } from "../messageTypes.js";
 
+import type { EmptyGroupedBatch } from "./opGroupingManager.js";
+
 /**
  * Takes an incoming runtime message (outer type "op"), JSON.parses the message's contents in place,
  * if needed (old Loader does this for us).
@@ -34,7 +36,10 @@ export function ensureContentsDeserialized(mutableMessage: ISequencedDocumentMes
  * @param toSerialize - op message to serialize. Also supports an array of ops.
  */
 export function serializeOp(
-	toSerialize: LocalContainerRuntimeMessage | LocalContainerRuntimeMessage[],
+	toSerialize:
+		| EmptyGroupedBatch
+		| LocalContainerRuntimeMessage
+		| LocalContainerRuntimeMessage[],
 ): string {
 	return JSON.stringify(
 		toSerialize,

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -31,6 +31,7 @@ import {
 	type LocalEmptyBatchPlaceholder,
 	type BatchResubmitInfo,
 } from "./opLifecycle/index.js";
+import type { EmptyGroupedBatch } from "./opLifecycle/opGroupingManager.js";
 
 /**
  * This represents a message that has been submitted and is added to the pending queue when `submit` is called on the
@@ -49,7 +50,7 @@ export interface IPendingMessage {
 	 * The original runtime op that was submitted to the ContainerRuntime
 	 * Unless this pending message came from stashed content, in which case this was roundtripped through string
 	 */
-	runtimeOp?: LocalContainerRuntimeMessage | undefined; // Undefined for empty batches and initial messages before parsing
+	runtimeOp?: LocalContainerRuntimeMessage | EmptyGroupedBatch | undefined; // Undefined for initial messages before parsing
 	/**
 	 * Local Op Metadata that was passed to the ContainerRuntime when the op was submitted.
 	 * This contains state needed when processing the ack, or to resubmit or rollback the op.
@@ -146,9 +147,7 @@ export interface IRuntimeStateHandler {
 }
 
 function isEmptyBatchPendingMessage(message: IPendingMessageFromStash): boolean {
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-	const content = JSON.parse(message.content);
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	const content = JSON.parse(message.content) as Partial<EmptyGroupedBatch>;
 	return content.type === "groupedBatch" && content.contents?.length === 0;
 }
 
@@ -300,8 +299,11 @@ export class PendingStateManager implements IDisposable {
 	public hasPendingUserChanges(): boolean {
 		for (let i = 0; i < this.pendingMessages.length; i++) {
 			const element = this.pendingMessages.get(i);
-			// Missing runtimeOp implies not dirtyable: This only happens for empty batches
-			if (element?.runtimeOp !== undefined && isContainerMessageDirtyable(element.runtimeOp)) {
+			if (
+				element?.runtimeOp !== undefined &&
+				isNotEmptyGroupedBatch(element) &&
+				isContainerMessageDirtyable(element.runtimeOp)
+			) {
 				return true;
 			}
 		}
@@ -385,12 +387,7 @@ export class PendingStateManager implements IDisposable {
 		clientSequenceNumber: number | undefined,
 		staged: boolean,
 	): void {
-		// We have to cast because runtimeOp doesn't apply for empty batches and is missing on LocalEmptyBatchPlaceholder
-		this.onFlushBatch(
-			[placeholder satisfies Omit<LocalBatchMessage, "runtimeOp"> as LocalBatchMessage],
-			clientSequenceNumber,
-			staged,
-		);
+		this.onFlushBatch([placeholder], clientSequenceNumber, staged);
 	}
 
 	/**
@@ -403,7 +400,7 @@ export class PendingStateManager implements IDisposable {
 	 * @param ignoreBatchId - Whether to ignore the batchId in the batchStartInfo
 	 */
 	public onFlushBatch(
-		batch: LocalBatchMessage[],
+		batch: LocalBatchMessage[] | [LocalEmptyBatchPlaceholder],
 		clientSequenceNumber: number | undefined,
 		staged: boolean,
 		ignoreBatchId?: boolean,
@@ -469,7 +466,9 @@ export class PendingStateManager implements IDisposable {
 			// We still need to track it for resubmission.
 			try {
 				if (isEmptyBatchPendingMessage(nextMessage)) {
-					nextMessage.localOpMetadata = { emptyBatch: true }; // equivalent to applyStashedOp for empty batch
+					nextMessage.localOpMetadata = {
+						emptyBatch: true,
+					} satisfies LocalEmptyBatchPlaceholder["localOpMetadata"]; // equivalent to applyStashedOp for empty batch
 					patchbatchInfo(nextMessage); // Back compat
 					this.pendingMessages.push(nextMessage);
 					continue;
@@ -808,7 +807,7 @@ export class PendingStateManager implements IDisposable {
 			}
 
 			assert(
-				pendingMessage.runtimeOp !== undefined,
+				pendingMessage.runtimeOp !== undefined && isNotEmptyGroupedBatch(pendingMessage),
 				0xb87 /* viableOp is only undefined for empty batches */,
 			);
 
@@ -844,7 +843,7 @@ export class PendingStateManager implements IDisposable {
 			// check is >= because batch end may be last pending message
 			while (remainingPendingMessagesCount >= 0) {
 				assert(
-					pendingMessage.runtimeOp !== undefined,
+					pendingMessage.runtimeOp !== undefined && isNotEmptyGroupedBatch(pendingMessage),
 					0xb88 /* viableOp is only undefined for empty batches */,
 				);
 				batch.push({
@@ -887,14 +886,20 @@ export class PendingStateManager implements IDisposable {
 	}
 
 	/**
-	 * Pops all staged batches, invoking the callback on each one in order (LIFO)
+	 * Pops all staged batches, invoking the callback on each constituent op in order (LIFO)
 	 */
-	public popStagedBatches(callback: (stagedMessage: IPendingMessage) => void): void {
+	public popStagedBatches(
+		callback: (
+			stagedMessage: IPendingMessage & { runtimeOp?: LocalContainerRuntimeMessage }, // exclude empty grouped batches
+		) => void,
+	): void {
 		while (!this.pendingMessages.isEmpty()) {
 			const stagedMessage = this.pendingMessages.peekBack();
 			if (stagedMessage?.batchInfo.staged === true) {
-				callback(stagedMessage);
-				this.pendingMessages.pop();
+				if (isNotEmptyGroupedBatch(stagedMessage)) {
+					callback(stagedMessage);
+					this.pendingMessages.pop();
+				}
 			} else {
 				break; // no more staged messages
 			}
@@ -917,4 +922,10 @@ function patchbatchInfo(
 		// Using uuid guarantees uniqueness, retaining existing behavior
 		message.batchInfo = { clientId: uuid(), batchStartCsn: -1, length: -1, staged: false };
 	}
+}
+
+function isNotEmptyGroupedBatch(
+	message: IPendingMessage,
+): message is IPendingMessage & { runtimeOp: LocalContainerRuntimeMessage } {
+	return message.runtimeOp !== undefined && message.runtimeOp.type !== "groupedBatch";
 }

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -795,7 +795,9 @@ export class PendingStateManager implements IDisposable {
 			assert(batchMetadataFlag !== false, 0x41b /* We cannot process batches in chunks */);
 
 			// The next message starts a batch (possibly single-message), and we'll need its batchId.
-			const batchId = getEffectiveBatchId(pendingMessage);
+			const batchId = pendingMessage.batchInfo.ignoreBatchId
+				? undefined
+				: getEffectiveBatchId(pendingMessage);
 
 			const staged = pendingMessage.batchInfo.staged;
 

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -23,6 +23,7 @@ import {
 } from "./messageTypes.js";
 import { asBatchMetadata, asEmptyBatchLocalOpMetadata } from "./metadata.js";
 import {
+	EmptyGroupedBatch,
 	LocalBatchMessage,
 	getEffectiveBatchId,
 	BatchStartInfo,
@@ -31,7 +32,6 @@ import {
 	type LocalEmptyBatchPlaceholder,
 	type BatchResubmitInfo,
 } from "./opLifecycle/index.js";
-import type { EmptyGroupedBatch } from "./opLifecycle/opGroupingManager.js";
 
 /**
  * This represents a message that has been submitted and is added to the pending queue when `submit` is called on the

--- a/packages/runtime/container-runtime/src/test/definitions.spec.ts
+++ b/packages/runtime/container-runtime/src/test/definitions.spec.ts
@@ -6,28 +6,38 @@
 import { ContainerMessageType } from "../messageTypes.js";
 import type { LocalBatchMessage, OutboundBatchMessage } from "../opLifecycle/index.js";
 
-// TEST CASE: Try converting from LocalBatchMessage to OutboundBatchMessage.  Make sure runtimeOp is erased.
-declare const localBatchMessage: LocalBatchMessage;
-export const goodOutboundBatchMessage: OutboundBatchMessage = {
-	...localBatchMessage,
-	runtimeOp: undefined,
-	contents: "test",
-};
-// @ts-expect-error "runtimeOp must be explicitly erased by setting to undefined"
-export const badOutboundBatchMessage: OutboundBatchMessage = {
-	...localBatchMessage,
-	contents: "test",
-};
+// //////////////////////////////////////////////////
+// NOTE: THESE TESTS ARE NOT TO BE RUN, ONLY COMPILED
+// //////////////////////////////////////////////////
 
-// TEST CASE: Try converting from OutboundBatchMessage to LocalBatchMessage.  Make sure contents is erased.
-declare const outboundBatchMessage: OutboundBatchMessage;
-export const goodLocalBatchMessage: LocalBatchMessage = {
-	...outboundBatchMessage,
-	contents: undefined,
-	runtimeOp: { type: ContainerMessageType.Rejoin, contents: undefined },
-};
-// @ts-expect-error "contents must be explicitly erased by setting to undefined"
-export const badLocalBatchMessage: LocalBatchMessage = {
-	...outboundBatchMessage,
-	runtimeOp: { type: ContainerMessageType.Rejoin, contents: undefined },
-};
+// TYPE TEST CASE: Try converting from LocalBatchMessage to OutboundBatchMessage.  Make sure runtimeOp must be erased.
+export function testLocalToOutbound(localBatchMessage: LocalBatchMessage): unknown {
+	const goodOutboundBatchMessage: OutboundBatchMessage = {
+		...localBatchMessage,
+		runtimeOp: undefined,
+		contents: "test",
+	};
+
+	// @ts-expect-error "runtimeOp must be explicitly erased by setting to undefined"
+	const badOutboundBatchMessage: OutboundBatchMessage = {
+		...localBatchMessage,
+		contents: "test",
+	};
+
+	return { goodOutboundBatchMessage, badOutboundBatchMessage };
+}
+
+// TYPE TEST CASE: Try converting from OutboundBatchMessage to LocalBatchMessage.  Make sure contents must be erased.
+export function testOutboundToLocal(outboundBatchMessage: OutboundBatchMessage): unknown {
+	const goodLocalBatchMessage: LocalBatchMessage = {
+		...outboundBatchMessage,
+		contents: undefined,
+		runtimeOp: { type: ContainerMessageType.Rejoin, contents: undefined },
+	};
+	// @ts-expect-error "contents must be explicitly erased by setting to undefined"
+	const badLocalBatchMessage: LocalBatchMessage = {
+		...outboundBatchMessage,
+		runtimeOp: { type: ContainerMessageType.Rejoin, contents: undefined },
+	};
+	return { goodLocalBatchMessage, badLocalBatchMessage };
+}

--- a/packages/runtime/container-runtime/src/test/definitions.spec.ts
+++ b/packages/runtime/container-runtime/src/test/definitions.spec.ts
@@ -1,0 +1,33 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ContainerMessageType } from "../messageTypes.js";
+import type { LocalBatchMessage, OutboundBatchMessage } from "../opLifecycle/index.js";
+
+// TEST CASE: Try converting from LocalBatchMessage to OutboundBatchMessage.  Make sure runtimeOp is erased.
+declare const localBatchMessage: LocalBatchMessage;
+export const goodOutboundBatchMessage: OutboundBatchMessage = {
+	...localBatchMessage,
+	runtimeOp: undefined,
+	contents: "test",
+};
+// @ts-expect-error "runtimeOp must be explicitly erased by setting to undefined"
+export const badOutboundBatchMessage: OutboundBatchMessage = {
+	...localBatchMessage,
+	contents: "test",
+};
+
+// TEST CASE: Try converting from OutboundBatchMessage to LocalBatchMessage.  Make sure contents is erased.
+declare const outboundBatchMessage: OutboundBatchMessage;
+export const goodLocalBatchMessage: LocalBatchMessage = {
+	...outboundBatchMessage,
+	contents: undefined,
+	runtimeOp: { type: ContainerMessageType.Rejoin, contents: undefined },
+};
+// @ts-expect-error "contents must be explicitly erased by setting to undefined"
+export const badLocalBatchMessage: LocalBatchMessage = {
+	...outboundBatchMessage,
+	runtimeOp: { type: ContainerMessageType.Rejoin, contents: undefined },
+};

--- a/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
@@ -15,6 +15,8 @@ import {
 	OpGroupingManager,
 	isGroupedBatch,
 	type OutboundBatch,
+	type EmptyGroupedBatch,
+	type LocalEmptyBatchPlaceholder,
 } from "../../opLifecycle/index.js";
 
 describe("OpGroupingManager", () => {
@@ -102,12 +104,17 @@ describe("OpGroupingManager", () => {
 		});
 
 		it("create empty batch", () => {
+			const emptyGroupedBatch: EmptyGroupedBatch = {
+				type: "groupedBatch",
+				contents: [],
+			};
 			const batchId = "batchId";
-			const expectedPlaceholderMessage: OutboundBatchMessage = {
+			const expectedOutboundMessage: OutboundBatchMessage = {
 				contents: '{"type":"groupedBatch","contents":[]}',
 				metadata: { batchId },
 				localOpMetadata: { emptyBatch: true },
 				referenceSequenceNumber: 0,
+				runtimeOp: undefined,
 			};
 
 			const result = new OpGroupingManager(
@@ -117,10 +124,14 @@ describe("OpGroupingManager", () => {
 				mockLogger,
 			).createEmptyGroupedBatch(batchId, 0);
 
-			assert.deepStrictEqual(result.outboundBatch.messages, [expectedPlaceholderMessage]);
+			assert.deepStrictEqual(result.outboundBatch.messages, [expectedOutboundMessage]);
 
-			// contents not included on the returned placeholder message
-			delete expectedPlaceholderMessage.contents;
+			const expectedPlaceholderMessage: LocalEmptyBatchPlaceholder = {
+				runtimeOp: emptyGroupedBatch,
+				metadata: { batchId },
+				localOpMetadata: { emptyBatch: true },
+				referenceSequenceNumber: 0,
+			};
 			assert.deepStrictEqual(result.placeholderMessage, expectedPlaceholderMessage);
 		});
 

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -192,7 +192,8 @@ describe("Outbox", () => {
 		message: LocalBatchMessage | OutboundBatchMessage,
 		batchMarker: boolean | undefined = undefined,
 	): IBatchMessage => ({
-		contents: "runtimeOp" in message ? serializeOp(message.runtimeOp) : message.contents,
+		contents:
+			message.runtimeOp === undefined ? message.contents : serializeOp(message.runtimeOp),
 		metadata:
 			batchMarker === undefined
 				? message.metadata

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -300,10 +300,7 @@ describe("Pending State Manager", () => {
 			);
 		});
 
-		//* ONLY
-		//* ONLY
-		//* ONLY
-		it.only("empty batch is processed correctly", () => {
+		it("empty batch is processed correctly", () => {
 			const { placeholderMessage } = opGroupingManager.createEmptyGroupedBatch("batchId", 0);
 			pendingStateManager.onFlushEmptyBatch(
 				placeholderMessage,
@@ -751,10 +748,7 @@ describe("Pending State Manager", () => {
 			assert.strictEqual(resubmittedBatchIds[1], `${clientId}_[0]`);
 		});
 
-		//* ONLY
-		//* ONLY
-		//* ONLY
-		it.only("replays pending states with empty batch", () => {
+		it("replays pending states with empty batch", () => {
 			const { placeholderMessage } = opGroupingManager.createEmptyGroupedBatch("batchId", 0);
 			pendingStateManager.onFlushEmptyBatch(placeholderMessage, 0, false /* staged */);
 			pendingStateManager.replayPendingStates();
@@ -801,10 +795,7 @@ describe("Pending State Manager", () => {
 			assert.strictEqual(pendingStateManager.pendingMessagesCount, 2);
 		});
 
-		//* ONLY
-		//* ONLY
-		//* ONLY
-		it.only("applyStashedOpsAt for empty batch", async () => {
+		it("applyStashedOpsAt for empty batch", async () => {
 			const oldPsm = new PendingStateManager(
 				{
 					applyStashedOp: async () => undefined,
@@ -1140,10 +1131,7 @@ describe("Pending State Manager", () => {
 			);
 		});
 
-		//* ONLY
-		//* ONLY
-		//* ONLY
-		it.only("returns false if all pending messages are empty batches (runtimeOp undefined)", () => {
+		it("returns false if all pending messages are empty batches (runtimeOp undefined)", () => {
 			const psm = createPendingStateManager();
 			const { placeholderMessage } = opGroupingManager.createEmptyGroupedBatch("batchId", 0);
 			psm.onFlushEmptyBatch(placeholderMessage, 0, false);


### PR DESCRIPTION
Fixes [AB#39270](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/39270)

## Description

Recent work for Staging Mode broke this.  Fixing it here.

I accidentally got rid of the empty grouped batch object in the PSM placeholder. So when we roundtripped though stashed local state, there was no way to recognize the empty batch (it actually would crash trying to JSON.parse undefined)

There's also another small fix in PendingStateManager.  Since ID Allocation ops aren't resubmitted, we don't care to track their batch IDs.  This means we shouldn't include batchId when replaying them (they're going to get dropped anyway) - without this fix we were triggering the empty batch logic (since they're not actually submitted on replay) when we shouldn't be resubmitting an empty batch.

