### PR TITLE
test(shared-matrix): enable shared-matrix execution time tests in benchmark perf pipeline

### DIFF
--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -35,6 +35,7 @@ parameters:
   type: object
   default:
     - "@fluidframework/tree"
+    - "@fluidframework/matrix"
     - "@fluid-experimental/tree"
     - "@fluidframework/merge-tree"
     - "@fluidframework/container-runtime"


### PR DESCRIPTION
## Description

This PR enables shared-matrix execution time tests in the benchmark perf pipeline.