### PR TITLE
Register subdirectory events on directory load

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -2014,6 +2014,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 	 */
 	public populateSubDirectory(subdirName: string, newSubDir: SubDirectory): void {
 		this.throwIfDisposed();
+		this.registerEventsOnSubDirectory(newSubDir, subdirName);
 		this._subdirectories.set(subdirName, newSubDir);
 	}
 
@@ -2459,7 +2460,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 				this.logger,
 			);
 			/**
-			 * Store the sequnce numbers of newly created subdirectory to the proper creation tracker, based
+			 * Store the sequence numbers of newly created subdirectory to the proper creation tracker, based
 			 * on whether the creation behavior has been ack'd or not
 			 */
 			if (isAcknowledgedOrDetached(seqData)) {

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -675,6 +675,51 @@ describe("Directory", () => {
 				assert.equal(nestedSubDir.get("deepKey1"), "deepValue1");
 				assert.equal(nestedSubDir.get("long2"), logWord2);
 			});
+
+			it("Should register subdirectory events on load", async () => {
+				directory.createSubDirectory("child");
+
+				const summarizeResult = directory.getAttachSummary();
+				const summaryTree = summarizeResult.summary;
+				assert.strictEqual(summaryTree.type, SummaryType.Tree, "summary should be a tree");
+
+				const storage = MockSharedObjectServices.createFromSummary(summarizeResult.summary);
+				const factory = SharedDirectory.getFactory();
+
+				const loadedDirectory = await factory.load(
+					dataStoreRuntime,
+					"test",
+					storage,
+					factory.attributes,
+				);
+				const subdir = loadedDirectory.getSubDirectory("child");
+				assert(subdir, "child subdirectory should exist");
+
+				let subDirectoryCreatedEventCounts = 0;
+				loadedDirectory.on("subDirectoryCreated", (path, _local, _target) => {
+					subDirectoryCreatedEventCounts++;
+					assert.equal(path, "child/grandchild", "created path should match");
+				});
+				let subDirectoryDeletedEventCounts = 0;
+				loadedDirectory.on("subDirectoryDeleted", (path, _local, _target) => {
+					subDirectoryDeletedEventCounts++;
+					assert.equal(path, "child/grandchild", "deleted path should match");
+				});
+
+				subdir.createSubDirectory("grandchild");
+				subdir.deleteSubDirectory("grandchild");
+
+				assert.equal(
+					subDirectoryCreatedEventCounts,
+					1,
+					"Sub directory created event should fire once for grandchild",
+				);
+				assert.equal(
+					subDirectoryDeletedEventCounts,
+					1,
+					"Sub directory deleted event should fire once for grandchild",
+				);
+			});
 		});
 
 		describe("Op processing", () => {


### PR DESCRIPTION
When loading from snapshot, nested subdirectory create and delete events do not propagate. This change registers the events on load. [AB#39281](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/39281)