### PR TITLE
improvement(api-markdown-documenter): Simplify Markdown table rendering

### DIFF
--- a/tools/api-markdown-documenter/src/documentation-domain/TableNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/TableNode.ts
@@ -17,7 +17,7 @@ import type { TableBodyRowNode, TableHeaderRowNode } from "./TableRowNode.js";
  *
  * ```md
  * | Header A | Header CB | Header C |
- * | --- | --- | --- |
+ * | - | - | - |
  * | Foo | Bar | Baz |
  * | A | B | C |
  * | 1 | 2| 3 |

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderTable.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderTable.ts
@@ -59,9 +59,7 @@ function renderTableWithMarkdownSyntax(
 		renderNode(
 			new TableBodyRowNode(
 				// eslint-disable-next-line unicorn/new-for-builtins
-				Array<TableCellNode>(headerCellCount).fill(
-					TableBodyCellNode.createFromPlainText("---"),
-				),
+				Array<TableCellNode>(headerCellCount).fill(TableBodyCellNode.createFromPlainText("-")),
 			),
 			writer,
 			{

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderTable.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderTable.test.ts
@@ -72,7 +72,7 @@ describe("Table Markdown rendering tests", () => {
 			const expected = [
 				"",
 				"| Header A | Header B | Header C |",
-				"| --- | --- | --- |",
+				"| - | - | - |",
 				"| Cell 1A | Cell 1B |",
 				"| Cell 2A | Cell 2B | Cell 2C |",
 				"",

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/index.md
@@ -3,6 +3,6 @@
 ## Packages
 
 | Package | Description |
-| --- | --- |
+| - | - |
 | [test-suite-a](/test-suite-a/) | Test package |
 | [test-suite-b](/test-suite-b/) |  |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
@@ -41,7 +41,7 @@ const foo = bar;
 ## Interfaces
 
 | Interface | Description |
-| --- | --- |
+| - | - |
 | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) | An empty interface |
 | [TestInterface](/test-suite-a/testinterface-interface/) | Test interface |
 | [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface/) | Test interface that extends other interfaces |
@@ -51,27 +51,27 @@ const foo = bar;
 ## Classes
 
 | Class | Description |
-| --- | --- |
+| - | - |
 | [TestAbstractClass](/test-suite-a/testabstractclass-class/) | A test abstract class. |
 | [TestClass](/test-suite-a/testclass-class/) | Test class |
 
 ## Enumerations
 
 | Enum | Description |
-| --- | --- |
+| - | - |
 | [TestEnum](/test-suite-a/testenum-enum/) | Test Enum |
 
 ## Types
 
 | TypeAlias | Description |
-| --- | --- |
+| - | - |
 | [TestMappedType](/test-suite-a/testmappedtype-typealias/) | Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum/) |
 | [TypeAlias](/test-suite-a/typealias-typealias/) | Test Type-Alias |
 
 ## Functions
 
 | Function | Alerts | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testFunction(testParameter, testOptionalParameter)](/test-suite-a/testfunction-function) | `Alpha` | TTypeParameter | Test function |
 | [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum/); } | Test function that returns an inline type |
 | [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) &amp; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)&lt;number&gt; | Test function that returns an inline type |
@@ -80,14 +80,14 @@ const foo = bar;
 ## Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [testConst](/test-suite-a/testconst-variable) | `Beta` | `readonly` |  | Test Constant |
 | [testConstWithEmptyDeprecatedBlock](/test-suite-a/testconstwithemptydeprecatedblock-variable) | `Deprecated` | `readonly` | string | I have a `@deprecated` tag with an empty comment block. |
 
 ## Namespaces
 
 | Namespace | Alerts | Description |
-| --- | --- | --- |
+| - | - | - |
 | [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/) | `Beta` | A namespace tagged as `@beta`. |
 | [TestModule](/test-suite-a/testmodule-namespace/) |  |  |
 | [TestNamespace](/test-suite-a/testnamespace-namespace/) |  | Test Namespace |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.md
@@ -13,6 +13,6 @@ protected constructor(privateProperty: number, protectedProperty: TestEnum);
 ## Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | privateProperty | number |  |
 | protectedProperty | [TestEnum](/test-suite-a/testenum-enum/) |  |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.md
@@ -13,20 +13,20 @@ export declare abstract class TestAbstractClass
 ## Constructors
 
 | Constructor | Description |
-| --- | --- |
+| - | - |
 | [(constructor)(privateProperty, protectedProperty)](/test-suite-a/testabstractclass-class/_constructor_-constructor) | This is a _{@customTag constructor}_. |
 
 ## Properties
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [abstractPropertyGetter](/test-suite-a/testabstractclass-class/abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias/) | A test abstract getter property. |
 | [protectedProperty](/test-suite-a/testabstractclass-class/protectedproperty-property) | `readonly` | [TestEnum](/test-suite-a/testenum-enum/) | A test protected property. |
 
 ## Methods
 
 | Method | Modifiers | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [publicAbstractMethod()](/test-suite-a/testabstractclass-class/publicabstractmethod-method) |  | void | A test public abstract method. |
 | [sealedMethod()](/test-suite-a/testabstractclass-class/sealedmethod-method) | `sealed` | string | A test `@sealed` method. |
 | [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method) | `virtual` | number | A test `@virtual` method. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testbetanamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testbetanamespace-namespace/index.md
@@ -19,7 +19,7 @@ Tests release level inheritance.
 ## Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [alphaMember](/test-suite-a/testbetanamespace-namespace/alphamember-variable) | `Alpha` | `readonly` |  |  |
 | [betaMember](/test-suite-a/testbetanamespace-namespace/betamember-variable) | `Beta` | `readonly` |  |  |
 | [publicMember](/test-suite-a/testbetanamespace-namespace/publicmember-variable) | `Beta` | `readonly` |  |  |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.md
@@ -17,7 +17,7 @@ Here are some remarks about the constructor
 ## Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | privateProperty | number | See [TestAbstractClass](/test-suite-a/testabstractclass-class/)'s constructor. |
 | protectedProperty | [TestEnum](/test-suite-a/testenum-enum/) | <p>Some notes about the parameter.</p><p>See <a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a>.</p> |
 | testClassProperty | TTypeParameterB | See [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property). |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/index.md
@@ -15,7 +15,7 @@ export declare class TestClass<TTypeParameterA, TTypeParameterB> extends TestAbs
 ### Type Parameters
 
 | Parameter | Description |
-| --- | --- |
+| - | - |
 | TTypeParameterA | A type parameter |
 | TTypeParameterB | Another type parameter |
 
@@ -26,31 +26,31 @@ Here are some remarks about the class
 ## Constructors
 
 | Constructor | Description |
-| --- | --- |
+| - | - |
 | [(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)](/test-suite-a/testclass-class/_constructor_-constructor) | Test class constructor |
 
 ## Static Properties
 
 | Property | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testClassStaticProperty](/test-suite-a/testclass-class/testclassstaticproperty-property) | (foo: number) =&gt; string | Test static class property |
 
 ## Static Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testClassStaticMethod(foo)](/test-suite-a/testclass-class/testclassstaticmethod-method) | string | Test class static method |
 
 ## Events
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property) | `readonly` | () =&gt; void | Test class event property |
 
 ## Properties
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [abstractPropertyGetter](/test-suite-a/testclass-class/abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias/) | A test abstract getter property. |
 | [testClassGetterProperty](/test-suite-a/testclass-class/testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
 | [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
@@ -58,7 +58,7 @@ Here are some remarks about the class
 ## Methods
 
 | Method | Modifiers | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [publicAbstractMethod()](/test-suite-a/testclass-class/publicabstractmethod-method) |  | void | A test public abstract method. |
 | [testClassMethod(input)](/test-suite-a/testclass-class/testclassmethod-method) | `sealed` | TTypeParameterA | Test class method |
 | [virtualMethod()](/test-suite-a/testclass-class/virtualmethod-method) |  | number | Overrides [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method). |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.md
@@ -18,7 +18,7 @@ Here are some remarks about the method
 ## Parameters {#testclassmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | input | TTypeParameterA |  |
 
 ## Returns {#testclassmethod-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.md
@@ -13,7 +13,7 @@ static testClassStaticMethod(foo: number): string;
 ## Parameters {#testclassstaticmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | foo | number | Some number |
 
 ## Returns {#testclassstaticmethod-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.md
@@ -35,7 +35,7 @@ const bar = TestEnum.TestEnumValue2
 ## Flags
 
 | Flag | Description |
-| --- | --- |
+| - | - |
 | [TestEnumValue1](/test-suite-a/testenum-enum/testenumvalue1-enummember) | Test enum value 1 (string) |
 | [TestEnumValue2](/test-suite-a/testenum-enum/testenumvalue2-enummember) | Test enum value 2 (number) |
 | [TestEnumValue3](/test-suite-a/testenum-enum/testenumvalue3-enummember) | Test enum value 3 (default) |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunction-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunction-function.md
@@ -15,7 +15,7 @@ export declare function testFunction<TTypeParameter extends TestInterface = Test
 ### Type Parameters
 
 | Parameter | Constraint | Default | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | TTypeParameter | [TestInterface](/test-suite-a/testinterface-interface/) | [TestInterface](/test-suite-a/testinterface-interface/) | A test type parameter |
 
 ## Remarks {#testfunction-remarks}
@@ -25,7 +25,7 @@ This is a test [link](/test-suite-a/testinterface-interface/) to another API mem
 ## Parameters {#testfunction-parameters}
 
 | Parameter | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | testParameter |  | TTypeParameter | A test parameter |
 | testOptionalParameter | optional | TTypeParameter |  |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.md
@@ -17,19 +17,19 @@ Here are some remarks about the interface
 ## Constructors
 
 | Constructor | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [new (): TestInterface](/test-suite-a/testinterface-interface/_new_-constructsignature) | [TestInterface](/test-suite-a/testinterface-interface/) | Test construct signature. |
 
 ## Events
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testClassEventProperty](/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature) | `readonly` | () =&gt; void | Test interface event property |
 
 ## Properties
 
 | Property | Modifiers | Default Value | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [getterProperty](/test-suite-a/testinterface-interface/getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
 | [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature) |  |  | boolean |  |
 | [setterProperty](/test-suite-a/testinterface-interface/setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
@@ -39,13 +39,13 @@ Here are some remarks about the interface
 ## Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testInterfaceMethod()](/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature) | void | Test interface method |
 
 ## Call Signatures
 
 | CallSignature | Description |
-| --- | --- |
+| - | - |
 | [(event: 'testCallSignature', listener: (input: unknown) =&gt; void): any](/test-suite-a/testinterface-interface/_call_-callsignature) | Test interface event call signature |
 | [(event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number](/test-suite-a/testinterface-interface/_call__1-callsignature) | Another example call signature |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.md
@@ -19,7 +19,7 @@ Here are some remarks about the interface
 ## Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testMethod(input)](/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature) | number | Test interface method accepting a string and returning a number. |
 
 ## See Also {#testinterfaceextendingotherinterfaces-see-also}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.md
@@ -17,7 +17,7 @@ Here are some remarks about the method
 ## Parameters {#testmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | input | string | A string |
 
 ## Returns {#testmethod-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.md
@@ -13,5 +13,5 @@ export interface TestInterfaceWithIndexSignature
 ## Index Signatures
 
 | IndexSignature | Description |
-| --- | --- |
+| - | - |
 | [\[foo: number\]: { bar: string; }](/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature) | Test index signature. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.md
@@ -13,7 +13,7 @@ export interface TestInterfaceWithTypeParameter<T>
 ### Type Parameters
 
 | Parameter | Description |
-| --- | --- |
+| - | - |
 | T | A type parameter |
 
 ## Remarks {#testinterfacewithtypeparameter-remarks}
@@ -23,5 +23,5 @@ Here are some remarks about the interface
 ## Properties
 
 | Property | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testProperty](/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature) | T | A test interface property using generic type parameter |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.md
@@ -5,5 +5,5 @@
 ## Variables
 
 | Variable | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [foo](/test-suite-a/testmodule-namespace/foo-variable) | `readonly` |  | Test constant in module. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.md
@@ -37,41 +37,41 @@ const foo = {
 ## Interfaces
 
 | Interface | Alerts | Description |
-| --- | --- | --- |
+| - | - | - |
 | [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/) | `Alpha` | Test interface |
 
 ## Classes
 
 | Class | Description |
-| --- | --- |
+| - | - |
 | [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) | Test class |
 
 ## Enumerations
 
 | Enum | Description |
-| --- | --- |
+| - | - |
 | [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/) | Test Enum |
 
 ## Types
 
 | TypeAlias | Description |
-| --- | --- |
+| - | - |
 | [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias/) | Test Type-Alias |
 
 ## Functions
 
 | Function | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testFunction(testParameter)](/test-suite-a/testnamespace-namespace/testfunction-function) | number | Test function |
 
 ## Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [TestConst](/test-suite-a/testnamespace-namespace/testconst-variable) | `Beta` | `readonly` |  | Test Constant |
 
 ## Namespaces
 
 | Namespace | Description |
-| --- | --- |
+| - | - |
 | [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/) | Test sub-namespace |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.md
@@ -13,5 +13,5 @@ constructor(testClassProperty: string);
 ## Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | testClassProperty | string | See [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property) |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.md
@@ -13,17 +13,17 @@ class TestClass
 ## Constructors
 
 | Constructor | Description |
-| --- | --- |
+| - | - |
 | [(constructor)(testClassProperty)](/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor) | Test class constructor |
 
 ## Properties
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testClassProperty](/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property) | `readonly` | string | Test interface property |
 
 ## Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method) | Promise&lt;string&gt; | Test class method |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.md
@@ -13,7 +13,7 @@ testClassMethod(testParameter: string): Promise<string>;
 ## Parameters {#testclassmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | testParameter | string | A string |
 
 ## Returns {#testclassmethod-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/index.md
@@ -13,7 +13,7 @@ enum TestEnum
 ## Flags
 
 | Flag | Description |
-| --- | --- |
+| - | - |
 | [TestEnumValue1](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember) | Test enum value 1 |
 | [TestEnumValue2](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember) | Test enum value 2 |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.md
@@ -13,7 +13,7 @@ function testFunction(testParameter: number): number;
 ## Parameters {#testfunction-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | testParameter | number |  |
 
 ## Returns {#testfunction-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.md
@@ -17,11 +17,11 @@ interface TestInterface extends TestInterfaceWithTypeParameter<TestEnum>
 ## Properties
 
 | Property | Alerts | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testInterfaceProperty](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature) | `Alpha` | boolean | Test interface property |
 
 ## Methods
 
 | Method | Alerts | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testInterfaceMethod()](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature) | `Alpha` | void | Test interface method |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/index.md
@@ -13,5 +13,5 @@ export interface Foo
 ## Properties
 
 | Property | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [bar](/test-suite-b/foo-interface/bar-propertysignature) | [TestEnum](/test-suite-a/testenum-enum/) | Test Enum |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/index.md
@@ -5,5 +5,5 @@
 ## Interfaces
 
 | Interface | Description |
-| --- | --- |
+| - | - |
 | [Foo](/test-suite-b/foo-interface/) | Bar |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/index.md
@@ -3,6 +3,6 @@
 ## Packages
 
 | Package | Description |
-| --- | --- |
+| - | - |
 | [test-suite-a](/test-suite-a/) | Test package |
 | [test-suite-b](/test-suite-b/) |  |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
@@ -41,7 +41,7 @@ const foo = bar;
 ## Interfaces
 
 | Interface | Description |
-| --- | --- |
+| - | - |
 | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) | An empty interface |
 | [TestInterface](/test-suite-a/testinterface-interface) | Test interface |
 | [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface) | Test interface that extends other interfaces |
@@ -51,27 +51,27 @@ const foo = bar;
 ## Classes
 
 | Class | Description |
-| --- | --- |
+| - | - |
 | [TestAbstractClass](/test-suite-a/testabstractclass-class) | A test abstract class. |
 | [TestClass](/test-suite-a/testclass-class) | Test class |
 
 ## Enumerations
 
 | Enum | Description |
-| --- | --- |
+| - | - |
 | [TestEnum](/test-suite-a/testenum-enum) | Test Enum |
 
 ## Types
 
 | TypeAlias | Description |
-| --- | --- |
+| - | - |
 | [TestMappedType](/test-suite-a/testmappedtype-typealias) | Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum) |
 | [TypeAlias](/test-suite-a/typealias-typealias) | Test Type-Alias |
 
 ## Functions
 
 | Function | Alerts | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testFunction(testParameter, testOptionalParameter)](/test-suite-a/#testfunction-function) | `Alpha` | TTypeParameter | Test function |
 | [testFunctionReturningInlineType()](/test-suite-a/#testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum); } | Test function that returns an inline type |
 | [testFunctionReturningIntersectionType()](/test-suite-a/#testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) &amp; [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)&lt;number&gt; | Test function that returns an inline type |
@@ -80,14 +80,14 @@ const foo = bar;
 ## Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [testConst](/test-suite-a/#testconst-variable) | `Beta` | `readonly` |  | Test Constant |
 | [testConstWithEmptyDeprecatedBlock](/test-suite-a/#testconstwithemptydeprecatedblock-variable) | `Deprecated` | `readonly` | string | I have a `@deprecated` tag with an empty comment block. |
 
 ## Namespaces
 
 | Namespace | Alerts | Description |
-| --- | --- | --- |
+| - | - | - |
 | [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/) | `Beta` | A namespace tagged as `@beta`. |
 | [TestModule](/test-suite-a/testmodule-namespace/) |  |  |
 | [TestNamespace](/test-suite-a/testnamespace-namespace/) |  | Test Namespace |
@@ -109,7 +109,7 @@ export declare function testFunction<TTypeParameter extends TestInterface = Test
 ##### Type Parameters
 
 | Parameter | Constraint | Default | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | TTypeParameter | [TestInterface](/test-suite-a/testinterface-interface) | [TestInterface](/test-suite-a/testinterface-interface) | A test type parameter |
 
 #### Remarks {#testfunction-remarks}
@@ -119,7 +119,7 @@ This is a test [link](/test-suite-a/testinterface-interface) to another API memb
 #### Parameters {#testfunction-parameters}
 
 | Parameter | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | testParameter |  | TTypeParameter | A test parameter |
 | testOptionalParameter | optional | TTypeParameter |  |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testabstractclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testabstractclass-class.md
@@ -13,20 +13,20 @@ export declare abstract class TestAbstractClass
 ## Constructors
 
 | Constructor | Description |
-| --- | --- |
+| - | - |
 | [(constructor)(privateProperty, protectedProperty)](/test-suite-a/testabstractclass-class#_constructor_-constructor) | This is a _{@customTag constructor}_. |
 
 ## Properties
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [abstractPropertyGetter](/test-suite-a/testabstractclass-class#abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
 | [protectedProperty](/test-suite-a/testabstractclass-class#protectedproperty-property) | `readonly` | [TestEnum](/test-suite-a/testenum-enum) | A test protected property. |
 
 ## Methods
 
 | Method | Modifiers | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [publicAbstractMethod()](/test-suite-a/testabstractclass-class#publicabstractmethod-method) |  | void | A test public abstract method. |
 | [sealedMethod()](/test-suite-a/testabstractclass-class#sealedmethod-method) | `sealed` | string | A test `@sealed` method. |
 | [virtualMethod()](/test-suite-a/testabstractclass-class#virtualmethod-method) | `virtual` | number | A test `@virtual` method. |
@@ -46,7 +46,7 @@ protected constructor(privateProperty: number, protectedProperty: TestEnum);
 #### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | privateProperty | number |  |
 | protectedProperty | [TestEnum](/test-suite-a/testenum-enum) |  |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testbetanamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testbetanamespace-namespace/index.md
@@ -19,7 +19,7 @@ Tests release level inheritance.
 ## Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [alphaMember](/test-suite-a/testbetanamespace-namespace/#alphamember-variable) | `Alpha` | `readonly` |  |  |
 | [betaMember](/test-suite-a/testbetanamespace-namespace/#betamember-variable) | `Beta` | `readonly` |  |  |
 | [publicMember](/test-suite-a/testbetanamespace-namespace/#publicmember-variable) | `Beta` | `readonly` |  |  |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
@@ -15,7 +15,7 @@ export declare class TestClass<TTypeParameterA, TTypeParameterB> extends TestAbs
 ### Type Parameters
 
 | Parameter | Description |
-| --- | --- |
+| - | - |
 | TTypeParameterA | A type parameter |
 | TTypeParameterB | Another type parameter |
 
@@ -26,31 +26,31 @@ Here are some remarks about the class
 ## Constructors
 
 | Constructor | Description |
-| --- | --- |
+| - | - |
 | [(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)](/test-suite-a/testclass-class#_constructor_-constructor) | Test class constructor |
 
 ## Static Properties
 
 | Property | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testClassStaticProperty](/test-suite-a/testclass-class#testclassstaticproperty-property) | (foo: number) =&gt; string | Test static class property |
 
 ## Static Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testClassStaticMethod(foo)](/test-suite-a/testclass-class#testclassstaticmethod-method) | string | Test class static method |
 
 ## Events
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testClassEventProperty](/test-suite-a/testclass-class#testclasseventproperty-property) | `readonly` | () =&gt; void | Test class event property |
 
 ## Properties
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [abstractPropertyGetter](/test-suite-a/testclass-class#abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
 | [testClassGetterProperty](/test-suite-a/testclass-class#testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
 | [testClassProperty](/test-suite-a/testclass-class#testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
@@ -58,7 +58,7 @@ Here are some remarks about the class
 ## Methods
 
 | Method | Modifiers | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [publicAbstractMethod()](/test-suite-a/testclass-class#publicabstractmethod-method) |  | void | A test public abstract method. |
 | [testClassMethod(input)](/test-suite-a/testclass-class#testclassmethod-method) | `sealed` | TTypeParameterA | Test class method |
 | [virtualMethod()](/test-suite-a/testclass-class#virtualmethod-method) |  | number | Overrides [virtualMethod()](/test-suite-a/testabstractclass-class#virtualmethod-method). |
@@ -82,7 +82,7 @@ Here are some remarks about the constructor
 #### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | privateProperty | number | See [TestAbstractClass](/test-suite-a/testabstractclass-class)'s constructor. |
 | protectedProperty | [TestEnum](/test-suite-a/testenum-enum) | <p>Some notes about the parameter.</p><p>See <a href="/test-suite-a/testabstractclass-class#protectedproperty-property">protectedProperty</a>.</p> |
 | testClassProperty | TTypeParameterB | See [testClassProperty](/test-suite-a/testclass-class#testclassproperty-property). |
@@ -196,7 +196,7 @@ Here are some remarks about the method
 #### Parameters {#testclassmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | input | TTypeParameterA |  |
 
 #### Returns {#testclassmethod-returns}
@@ -222,7 +222,7 @@ static testClassStaticMethod(foo: number): string;
 #### Parameters {#testclassstaticmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | foo | number | Some number |
 
 #### Returns {#testclassstaticmethod-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testenum-enum.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testenum-enum.md
@@ -35,7 +35,7 @@ const bar = TestEnum.TestEnumValue2
 ## Flags
 
 | Flag | Description |
-| --- | --- |
+| - | - |
 | [TestEnumValue1](/test-suite-a/testenum-enum#testenumvalue1-enummember) | Test enum value 1 (string) |
 | [TestEnumValue2](/test-suite-a/testenum-enum#testenumvalue2-enummember) | Test enum value 2 (number) |
 | [TestEnumValue3](/test-suite-a/testenum-enum#testenumvalue3-enummember) | Test enum value 3 (default) |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
@@ -17,19 +17,19 @@ Here are some remarks about the interface
 ## Constructors
 
 | Constructor | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [new (): TestInterface](/test-suite-a/testinterface-interface#_new_-constructsignature) | [TestInterface](/test-suite-a/testinterface-interface) | Test construct signature. |
 
 ## Events
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testClassEventProperty](/test-suite-a/testinterface-interface#testclasseventproperty-propertysignature) | `readonly` | () =&gt; void | Test interface event property |
 
 ## Properties
 
 | Property | Modifiers | Default Value | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [getterProperty](/test-suite-a/testinterface-interface#getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
 | [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface#propertywithbadinheritdoctarget-propertysignature) |  |  | boolean |  |
 | [setterProperty](/test-suite-a/testinterface-interface#setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
@@ -39,13 +39,13 @@ Here are some remarks about the interface
 ## Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testInterfaceMethod()](/test-suite-a/testinterface-interface#testinterfacemethod-methodsignature) | void | Test interface method |
 
 ## Call Signatures
 
 | CallSignature | Description |
-| --- | --- |
+| - | - |
 | [(event: 'testCallSignature', listener: (input: unknown) =&gt; void): any](/test-suite-a/testinterface-interface#_call_-callsignature) | Test interface event call signature |
 | [(event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number](/test-suite-a/testinterface-interface#_call__1-callsignature) | Another example call signature |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.md
@@ -19,7 +19,7 @@ Here are some remarks about the interface
 ## Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testMethod(input)](/test-suite-a/testinterfaceextendingotherinterfaces-interface#testmethod-methodsignature) | number | Test interface method accepting a string and returning a number. |
 
 ## Method Details
@@ -41,7 +41,7 @@ Here are some remarks about the method
 #### Parameters {#testmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | input | string | A string |
 
 #### Returns {#testmethod-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithindexsignature-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithindexsignature-interface.md
@@ -13,7 +13,7 @@ export interface TestInterfaceWithIndexSignature
 ## Index Signatures
 
 | IndexSignature | Description |
-| --- | --- |
+| - | - |
 | [\[foo: number\]: { bar: string; }](/test-suite-a/testinterfacewithindexsignature-interface#_indexer_-indexsignature) | Test index signature. |
 
 ## Index Signature Details

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithtypeparameter-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithtypeparameter-interface.md
@@ -13,7 +13,7 @@ export interface TestInterfaceWithTypeParameter<T>
 ### Type Parameters
 
 | Parameter | Description |
-| --- | --- |
+| - | - |
 | T | A type parameter |
 
 ## Remarks {#testinterfacewithtypeparameter-remarks}
@@ -23,7 +23,7 @@ Here are some remarks about the interface
 ## Properties
 
 | Property | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testProperty](/test-suite-a/testinterfacewithtypeparameter-interface#testproperty-propertysignature) | T | A test interface property using generic type parameter |
 
 ## Property Details

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testmodule-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testmodule-namespace/index.md
@@ -5,7 +5,7 @@
 ## Variables
 
 | Variable | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [foo](/test-suite-a/testmodule-namespace/#foo-variable) | `readonly` |  | Test constant in module. |
 
 ## Variable Details

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.md
@@ -37,43 +37,43 @@ const foo = {
 ## Interfaces
 
 | Interface | Alerts | Description |
-| --- | --- | --- |
+| - | - | - |
 | [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface) | `Alpha` | Test interface |
 
 ## Classes
 
 | Class | Description |
-| --- | --- |
+| - | - |
 | [TestClass](/test-suite-a/testnamespace-namespace/testclass-class) | Test class |
 
 ## Enumerations
 
 | Enum | Description |
-| --- | --- |
+| - | - |
 | [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum) | Test Enum |
 
 ## Types
 
 | TypeAlias | Description |
-| --- | --- |
+| - | - |
 | [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias) | Test Type-Alias |
 
 ## Functions
 
 | Function | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testFunction(testParameter)](/test-suite-a/testnamespace-namespace/#testfunction-function) | number | Test function |
 
 ## Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [TestConst](/test-suite-a/testnamespace-namespace/#testconst-variable) | `Beta` | `readonly` |  | Test Constant |
 
 ## Namespaces
 
 | Namespace | Description |
-| --- | --- |
+| - | - |
 | [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/) | Test sub-namespace |
 
 ## Function Details
@@ -91,7 +91,7 @@ function testFunction(testParameter: number): number;
 #### Parameters {#testfunction-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | testParameter | number |  |
 
 #### Returns {#testfunction-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testclass-class.md
@@ -13,19 +13,19 @@ class TestClass
 ## Constructors
 
 | Constructor | Description |
-| --- | --- |
+| - | - |
 | [(constructor)(testClassProperty)](/test-suite-a/testnamespace-namespace/testclass-class#_constructor_-constructor) | Test class constructor |
 
 ## Properties
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testClassProperty](/test-suite-a/testnamespace-namespace/testclass-class#testclassproperty-property) | `readonly` | string | Test interface property |
 
 ## Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class#testclassmethod-method) | Promise&lt;string&gt; | Test class method |
 
 ## Constructor Details
@@ -43,7 +43,7 @@ constructor(testClassProperty: string);
 #### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | testClassProperty | string | See [testClassProperty](/test-suite-a/testclass-class#testclassproperty-property) |
 
 ## Property Details
@@ -75,7 +75,7 @@ testClassMethod(testParameter: string): Promise<string>;
 #### Parameters {#testclassmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | testParameter | string | A string |
 
 #### Returns {#testclassmethod-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testenum-enum.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testenum-enum.md
@@ -13,7 +13,7 @@ enum TestEnum
 ## Flags
 
 | Flag | Description |
-| --- | --- |
+| - | - |
 | [TestEnumValue1](/test-suite-a/testnamespace-namespace/testenum-enum#testenumvalue1-enummember) | Test enum value 1 |
 | [TestEnumValue2](/test-suite-a/testnamespace-namespace/testenum-enum#testenumvalue2-enummember) | Test enum value 2 |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testinterface-interface.md
@@ -17,13 +17,13 @@ interface TestInterface extends TestInterfaceWithTypeParameter<TestEnum>
 ## Properties
 
 | Property | Alerts | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testInterfaceProperty](/test-suite-a/testnamespace-namespace/testinterface-interface#testinterfaceproperty-propertysignature) | `Alpha` | boolean | Test interface property |
 
 ## Methods
 
 | Method | Alerts | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testInterfaceMethod()](/test-suite-a/testnamespace-namespace/testinterface-interface#testinterfacemethod-methodsignature) | `Alpha` | void | Test interface method |
 
 ## Property Details

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-b/foo-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-b/foo-interface.md
@@ -13,7 +13,7 @@ export interface Foo
 ## Properties
 
 | Property | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [bar](/test-suite-b/foo-interface#bar-propertysignature) | [TestEnum](/test-suite-a/testenum-enum) | Test Enum |
 
 ## Property Details

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-b/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-b/index.md
@@ -5,5 +5,5 @@
 ## Interfaces
 
 | Interface | Description |
-| --- | --- |
+| - | - |
 | [Foo](/test-suite-b/foo-interface) | Bar |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/index.md
@@ -1,6 +1,6 @@
 # Packages
 
 | Package | Description |
-| --- | --- |
+| - | - |
 | [test-suite-a](docs/test-suite-a) | Test package |
 | [test-suite-b](docs/test-suite-b) |  |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
@@ -39,7 +39,7 @@ const foo = bar;
 # Interfaces
 
 | Interface | Description |
-| --- | --- |
+| - | - |
 | [TestEmptyInterface](docs/test-suite-a#testemptyinterface-interface) | An empty interface |
 | [TestInterface](docs/test-suite-a#testinterface-interface) | Test interface |
 | [TestInterfaceExtendingOtherInterfaces](docs/test-suite-a#testinterfaceextendingotherinterfaces-interface) | Test interface that extends other interfaces |
@@ -49,27 +49,27 @@ const foo = bar;
 # Classes
 
 | Class | Description |
-| --- | --- |
+| - | - |
 | [TestAbstractClass](docs/test-suite-a#testabstractclass-class) | A test abstract class. |
 | [TestClass](docs/test-suite-a#testclass-class) | Test class |
 
 # Enumerations
 
 | Enum | Description |
-| --- | --- |
+| - | - |
 | [TestEnum](docs/test-suite-a#testenum-enum) | Test Enum |
 
 # Types
 
 | TypeAlias | Description |
-| --- | --- |
+| - | - |
 | [TestMappedType](docs/test-suite-a#testmappedtype-typealias) | Test Mapped Type, using [TestEnum](docs/test-suite-a#testenum-enum) |
 | [TypeAlias](docs/test-suite-a#typealias-typealias) | Test Type-Alias |
 
 # Functions
 
 | Function | Alerts | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testFunctionReturningInlineType()](docs/test-suite-a#testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](docs/test-suite-a#testenum-enum); } | Test function that returns an inline type |
 | [testFunctionReturningIntersectionType()](docs/test-suite-a#testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](docs/test-suite-a#testemptyinterface-interface) &amp; [TestInterfaceWithTypeParameter](docs/test-suite-a#testinterfacewithtypeparameter-interface)&lt;number&gt; | Test function that returns an inline type |
 | [testFunctionReturningUnionType()](docs/test-suite-a#testfunctionreturninguniontype-function) |  | string \| [TestInterface](docs/test-suite-a#testinterface-interface) | Test function that returns an inline type |
@@ -77,14 +77,14 @@ const foo = bar;
 # Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [testConst](docs/test-suite-a#testconst-variable) | `Beta` | `readonly` |  | Test Constant |
 | [testConstWithEmptyDeprecatedBlock](docs/test-suite-a#testconstwithemptydeprecatedblock-variable) | `Deprecated` | `readonly` | string | I have a `@deprecated` tag with an empty comment block. |
 
 # Namespaces
 
 | Namespace | Alerts | Description |
-| --- | --- | --- |
+| - | - | - |
 | [TestBetaNamespace](docs/test-suite-a#testbetanamespace-namespace) | `Beta` | A namespace tagged as `@beta`. |
 | [TestModule](docs/test-suite-a#testmodule-namespace) |  |  |
 | [TestNamespace](docs/test-suite-a#testnamespace-namespace) |  | Test Namespace |
@@ -118,19 +118,19 @@ Here are some remarks about the interface
 ### Constructors
 
 | Constructor | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [new (): TestInterface](docs/test-suite-a#testinterface-_new_-constructsignature) | [TestInterface](docs/test-suite-a#testinterface-interface) | Test construct signature. |
 
 ### Events
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testClassEventProperty](docs/test-suite-a#testinterface-testclasseventproperty-propertysignature) | `readonly` | () =&gt; void | Test interface event property |
 
 ### Properties
 
 | Property | Modifiers | Default Value | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [getterProperty](docs/test-suite-a#testinterface-getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
 | [propertyWithBadInheritDocTarget](docs/test-suite-a#testinterface-propertywithbadinheritdoctarget-propertysignature) |  |  | boolean |  |
 | [setterProperty](docs/test-suite-a#testinterface-setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
@@ -140,13 +140,13 @@ Here are some remarks about the interface
 ### Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testInterfaceMethod()](docs/test-suite-a#testinterface-testinterfacemethod-methodsignature) | void | Test interface method |
 
 ### Call Signatures
 
 | CallSignature | Description |
-| --- | --- |
+| - | - |
 | [(event: 'testCallSignature', listener: (input: unknown) =&gt; void): any](docs/test-suite-a#testinterface-_call_-callsignature) | Test interface event call signature |
 | [(event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number](docs/test-suite-a#testinterface-_call__1-callsignature) | Another example call signature |
 
@@ -324,7 +324,7 @@ Here are some remarks about the interface
 ### Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testMethod(input)](docs/test-suite-a#testinterfaceextendingotherinterfaces-testmethod-methodsignature) | number | Test interface method accepting a string and returning a number. |
 
 ### Method Details
@@ -346,7 +346,7 @@ Here are some remarks about the method
 ##### Parameters {#testmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | input | string | A string |
 
 ##### Returns {#testmethod-returns}
@@ -376,7 +376,7 @@ export interface TestInterfaceWithIndexSignature
 ### Index Signatures
 
 | IndexSignature | Description |
-| --- | --- |
+| - | - |
 | [\[foo: number\]: { bar: string; }](docs/test-suite-a#testinterfacewithindexsignature-_indexer_-indexsignature) | Test index signature. |
 
 ### Index Signature Details
@@ -406,7 +406,7 @@ export interface TestInterfaceWithTypeParameter<T>
 #### Type Parameters
 
 | Parameter | Description |
-| --- | --- |
+| - | - |
 | T | A type parameter |
 
 ### Remarks {#testinterfacewithtypeparameter-remarks}
@@ -416,7 +416,7 @@ Here are some remarks about the interface
 ### Properties
 
 | Property | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testProperty](docs/test-suite-a#testinterfacewithtypeparameter-testproperty-propertysignature) | T | A test interface property using generic type parameter |
 
 ### Property Details
@@ -452,20 +452,20 @@ export declare abstract class TestAbstractClass
 ### Constructors
 
 | Constructor | Description |
-| --- | --- |
+| - | - |
 | [(constructor)(privateProperty, protectedProperty)](docs/test-suite-a#testabstractclass-_constructor_-constructor) | This is a _{@customTag constructor}_. |
 
 ### Properties
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [abstractPropertyGetter](docs/test-suite-a#testabstractclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/test-suite-a#testmappedtype-typealias) | A test abstract getter property. |
 | [protectedProperty](docs/test-suite-a#testabstractclass-protectedproperty-property) | `readonly` | [TestEnum](docs/test-suite-a#testenum-enum) | A test protected property. |
 
 ### Methods
 
 | Method | Modifiers | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [publicAbstractMethod()](docs/test-suite-a#testabstractclass-publicabstractmethod-method) |  | void | A test public abstract method. |
 | [sealedMethod()](docs/test-suite-a#testabstractclass-sealedmethod-method) | `sealed` | string | A test `@sealed` method. |
 | [virtualMethod()](docs/test-suite-a#testabstractclass-virtualmethod-method) | `virtual` | number | A test `@virtual` method. |
@@ -485,7 +485,7 @@ protected constructor(privateProperty: number, protectedProperty: TestEnum);
 ##### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | privateProperty | number |  |
 | protectedProperty | [TestEnum](docs/test-suite-a#testenum-enum) |  |
 
@@ -576,7 +576,7 @@ export declare class TestClass<TTypeParameterA, TTypeParameterB> extends TestAbs
 #### Type Parameters
 
 | Parameter | Description |
-| --- | --- |
+| - | - |
 | TTypeParameterA | A type parameter |
 | TTypeParameterB | Another type parameter |
 
@@ -587,31 +587,31 @@ Here are some remarks about the class
 ### Constructors
 
 | Constructor | Description |
-| --- | --- |
+| - | - |
 | [(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)](docs/test-suite-a#testclass-_constructor_-constructor) | Test class constructor |
 
 ### Static Properties
 
 | Property | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testClassStaticProperty](docs/test-suite-a#testclass-testclassstaticproperty-property) | (foo: number) =&gt; string | Test static class property |
 
 ### Static Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testClassStaticMethod(foo)](docs/test-suite-a#testclass-testclassstaticmethod-method) | string | Test class static method |
 
 ### Events
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testClassEventProperty](docs/test-suite-a#testclass-testclasseventproperty-property) | `readonly` | () =&gt; void | Test class event property |
 
 ### Properties
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [abstractPropertyGetter](docs/test-suite-a#testclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/test-suite-a#testmappedtype-typealias) | A test abstract getter property. |
 | [testClassGetterProperty](docs/test-suite-a#testclass-testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
 | [testClassProperty](docs/test-suite-a#testclass-testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
@@ -619,7 +619,7 @@ Here are some remarks about the class
 ### Methods
 
 | Method | Modifiers | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [publicAbstractMethod()](docs/test-suite-a#testclass-publicabstractmethod-method) |  | void | A test public abstract method. |
 | [testClassMethod(input)](docs/test-suite-a#testclass-testclassmethod-method) | `sealed` | TTypeParameterA | Test class method |
 | [virtualMethod()](docs/test-suite-a#testclass-virtualmethod-method) |  | number | Overrides [virtualMethod()](docs/test-suite-a#testabstractclass-virtualmethod-method). |
@@ -643,7 +643,7 @@ Here are some remarks about the constructor
 ##### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | privateProperty | number | See [TestAbstractClass](docs/test-suite-a#testabstractclass-class)'s constructor. |
 | protectedProperty | [TestEnum](docs/test-suite-a#testenum-enum) | <p>Some notes about the parameter.</p><p>See <a href="docs/test-suite-a#testabstractclass-protectedproperty-property">protectedProperty</a>.</p> |
 | testClassProperty | TTypeParameterB | See [testClassProperty](docs/test-suite-a#testclass-testclassproperty-property). |
@@ -757,7 +757,7 @@ Here are some remarks about the method
 ##### Parameters {#testclassmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | input | TTypeParameterA |  |
 
 ##### Returns {#testclassmethod-returns}
@@ -783,7 +783,7 @@ static testClassStaticMethod(foo: number): string;
 ##### Parameters {#testclassstaticmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | foo | number | Some number |
 
 ##### Returns {#testclassstaticmethod-returns}
@@ -848,7 +848,7 @@ const bar = TestEnum.TestEnumValue2
 ### Flags
 
 | Flag | Description |
-| --- | --- |
+| - | - |
 | [TestEnumValue1](docs/test-suite-a#testenum-testenumvalue1-enummember) | Test enum value 1 (string) |
 | [TestEnumValue2](docs/test-suite-a#testenum-testenumvalue2-enummember) | Test enum value 2 (number) |
 | [TestEnumValue3](docs/test-suite-a#testenum-testenumvalue3-enummember) | Test enum value 3 (default) |
@@ -1037,7 +1037,7 @@ Tests release level inheritance.
 ### Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [betaMember](docs/test-suite-a#testbetanamespace-betamember-variable) | `Beta` | `readonly` |  |  |
 | [publicMember](docs/test-suite-a#testbetanamespace-publicmember-variable) | `Beta` | `readonly` |  |  |
 
@@ -1068,7 +1068,7 @@ publicMember = "public"
 ### Variables
 
 | Variable | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [foo](docs/test-suite-a#testmodule-foo-variable) | `readonly` |  | Test constant in module. |
 
 ### Variable Details
@@ -1120,37 +1120,37 @@ const foo = {
 ### Classes
 
 | Class | Description |
-| --- | --- |
+| - | - |
 | [TestClass](docs/test-suite-a#testnamespace-testclass-class) | Test class |
 
 ### Enumerations
 
 | Enum | Description |
-| --- | --- |
+| - | - |
 | [TestEnum](docs/test-suite-a#testnamespace-testenum-enum) | Test Enum |
 
 ### Types
 
 | TypeAlias | Description |
-| --- | --- |
+| - | - |
 | [TestTypeAlias](docs/test-suite-a#testnamespace-testtypealias-typealias) | Test Type-Alias |
 
 ### Functions
 
 | Function | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testFunction(testParameter)](docs/test-suite-a#testnamespace-testfunction-function) | number | Test function |
 
 ### Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [TestConst](docs/test-suite-a#testnamespace-testconst-variable) | `Beta` | `readonly` |  | Test Constant |
 
 ### Namespaces
 
 | Namespace | Description |
-| --- | --- |
+| - | - |
 | [TestSubNamespace](docs/test-suite-a#testnamespace-testsubnamespace-namespace) | Test sub-namespace |
 
 ### Class Details
@@ -1168,19 +1168,19 @@ class TestClass
 ##### Constructors
 
 | Constructor | Description |
-| --- | --- |
+| - | - |
 | [(constructor)(testClassProperty)](docs/test-suite-a#testnamespace-testclass-_constructor_-constructor) | Test class constructor |
 
 ##### Properties
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testClassProperty](docs/test-suite-a#testnamespace-testclass-testclassproperty-property) | `readonly` | string | Test interface property |
 
 ##### Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testClassMethod(testParameter)](docs/test-suite-a#testnamespace-testclass-testclassmethod-method) | Promise&lt;string&gt; | Test class method |
 
 ##### Constructor Details
@@ -1200,7 +1200,7 @@ constructor(testClassProperty: string);
 **Parameters**
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | testClassProperty | string | See [testClassProperty](docs/test-suite-a#testclass-testclassproperty-property) |
 
 ##### Property Details
@@ -1235,7 +1235,7 @@ testClassMethod(testParameter: string): Promise<string>;
 **Parameters**
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | testParameter | string | A string |
 
 <a id="testclassmethod-returns"></a>
@@ -1269,7 +1269,7 @@ enum TestEnum
 ##### Flags
 
 | Flag | Description |
-| --- | --- |
+| - | - |
 | [TestEnumValue1](docs/test-suite-a#testnamespace-testenum-testenumvalue1-enummember) | Test enum value 1 |
 | [TestEnumValue2](docs/test-suite-a#testnamespace-testenum-testenumvalue2-enummember) | Test enum value 2 |
 
@@ -1322,7 +1322,7 @@ function testFunction(testParameter: number): number;
 ##### Parameters {#testfunction-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | testParameter | number |  |
 
 ##### Returns {#testfunction-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-b.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-b.md
@@ -3,7 +3,7 @@
 # Interfaces
 
 | Interface | Description |
-| --- | --- |
+| - | - |
 | [Foo](docs/test-suite-b#foo-interface) | Bar |
 
 # Interface Details
@@ -21,7 +21,7 @@ export interface Foo
 ### Properties
 
 | Property | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [bar](docs/test-suite-b#foo-bar-propertysignature) | [TestEnum](docs/test-suite-a#testenum-enum) | Test Enum |
 
 ### Property Details

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/index.md
@@ -3,5 +3,5 @@
 ### Packages
 
 | Package | Description |
-| --- | --- |
+| - | - |
 | [test-suite-a](docs/test-suite-a/) | Test package |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/index.md
@@ -39,7 +39,7 @@ const foo = bar;
 ### Interfaces
 
 | Interface | Description |
-| --- | --- |
+| - | - |
 | [TestEmptyInterface](docs/test-suite-a/testemptyinterface-interface) | An empty interface |
 | [TestInterface](docs/test-suite-a/testinterface-interface) | Test interface |
 | [TestInterfaceExtendingOtherInterfaces](docs/test-suite-a/testinterfaceextendingotherinterfaces-interface) | Test interface that extends other interfaces |
@@ -49,27 +49,27 @@ const foo = bar;
 ### Classes
 
 | Class | Description |
-| --- | --- |
+| - | - |
 | [TestAbstractClass](docs/test-suite-a/testabstractclass-class) | A test abstract class. |
 | [TestClass](docs/test-suite-a/testclass-class) | Test class |
 
 ### Enumerations
 
 | Enum | Description |
-| --- | --- |
+| - | - |
 | [TestEnum](docs/test-suite-a/testenum-enum) | Test Enum |
 
 ### Types
 
 | TypeAlias | Description |
-| --- | --- |
+| - | - |
 | [TestMappedType](docs/test-suite-a/testmappedtype-typealias) | Test Mapped Type, using [TestEnum](docs/test-suite-a/testenum-enum) |
 | [TypeAlias](docs/test-suite-a/typealias-typealias) | Test Type-Alias |
 
 ### Functions
 
 | Function | Alerts | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testFunctionReturningInlineType()](docs/test-suite-a/testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](docs/test-suite-a/testenum-enum); } | Test function that returns an inline type |
 | [testFunctionReturningIntersectionType()](docs/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](docs/test-suite-a/testemptyinterface-interface) &amp; [TestInterfaceWithTypeParameter](docs/test-suite-a/testinterfacewithtypeparameter-interface)&lt;number&gt; | Test function that returns an inline type |
 | [testFunctionReturningUnionType()](docs/test-suite-a/testfunctionreturninguniontype-function) |  | string \| [TestInterface](docs/test-suite-a/testinterface-interface) | Test function that returns an inline type |
@@ -77,12 +77,12 @@ const foo = bar;
 ### Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [testConstWithEmptyDeprecatedBlock](docs/test-suite-a/testconstwithemptydeprecatedblock-variable) | `Deprecated` | `readonly` | string | I have a `@deprecated` tag with an empty comment block. |
 
 ### Namespaces
 
 | Namespace | Description |
-| --- | --- |
+| - | - |
 | [TestModule](docs/test-suite-a/testmodule-namespace) |  |
 | [TestNamespace](docs/test-suite-a/testnamespace-namespace) | Test Namespace |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-_constructor_-constructor.md
@@ -11,6 +11,6 @@ protected constructor(privateProperty: number, protectedProperty: TestEnum);
 ### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | privateProperty | number |  |
 | protectedProperty | [TestEnum](docs/test-suite-a/testenum-enum) |  |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-class.md
@@ -11,20 +11,20 @@ export declare abstract class TestAbstractClass
 ### Constructors
 
 | Constructor | Description |
-| --- | --- |
+| - | - |
 | [(constructor)(privateProperty, protectedProperty)](docs/test-suite-a/testabstractclass-_constructor_-constructor) | This is a _{@customTag constructor}_. |
 
 ### Properties
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [abstractPropertyGetter](docs/test-suite-a/testabstractclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
 | [protectedProperty](docs/test-suite-a/testabstractclass-protectedproperty-property) | `readonly` | [TestEnum](docs/test-suite-a/testenum-enum) | A test protected property. |
 
 ### Methods
 
 | Method | Modifiers | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [publicAbstractMethod()](docs/test-suite-a/testabstractclass-publicabstractmethod-method) |  | void | A test public abstract method. |
 | [sealedMethod()](docs/test-suite-a/testabstractclass-sealedmethod-method) | `sealed` | string | A test `@sealed` method. |
 | [virtualMethod()](docs/test-suite-a/testabstractclass-virtualmethod-method) | `virtual` | number | A test `@virtual` method. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-_constructor_-constructor.md
@@ -15,7 +15,7 @@ Here are some remarks about the constructor
 ### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | privateProperty | number | See [TestAbstractClass](docs/test-suite-a/testabstractclass-class)'s constructor. |
 | protectedProperty | [TestEnum](docs/test-suite-a/testenum-enum) | <p>Some notes about the parameter.</p><p>See <a href="docs/test-suite-a/testabstractclass-protectedproperty-property">protectedProperty</a>.</p> |
 | testClassProperty | TTypeParameterB | See [testClassProperty](docs/test-suite-a/testclass-testclassproperty-property). |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-class.md
@@ -13,7 +13,7 @@ export declare class TestClass<TTypeParameterA, TTypeParameterB> extends TestAbs
 #### Type Parameters
 
 | Parameter | Description |
-| --- | --- |
+| - | - |
 | TTypeParameterA | A type parameter |
 | TTypeParameterB | Another type parameter |
 
@@ -24,31 +24,31 @@ Here are some remarks about the class
 ### Constructors
 
 | Constructor | Description |
-| --- | --- |
+| - | - |
 | [(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)](docs/test-suite-a/testclass-_constructor_-constructor) | Test class constructor |
 
 ### Static Properties
 
 | Property | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testClassStaticProperty](docs/test-suite-a/testclass-testclassstaticproperty-property) | (foo: number) =&gt; string | Test static class property |
 
 ### Static Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testClassStaticMethod(foo)](docs/test-suite-a/testclass-testclassstaticmethod-method) | string | Test class static method |
 
 ### Events
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testClassEventProperty](docs/test-suite-a/testclass-testclasseventproperty-property) | `readonly` | () =&gt; void | Test class event property |
 
 ### Properties
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [abstractPropertyGetter](docs/test-suite-a/testclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
 | [testClassGetterProperty](docs/test-suite-a/testclass-testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
 | [testClassProperty](docs/test-suite-a/testclass-testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
@@ -56,7 +56,7 @@ Here are some remarks about the class
 ### Methods
 
 | Method | Modifiers | Return Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [publicAbstractMethod()](docs/test-suite-a/testclass-publicabstractmethod-method) |  | void | A test public abstract method. |
 | [testClassMethod(input)](docs/test-suite-a/testclass-testclassmethod-method) | `sealed` | TTypeParameterA | Test class method |
 | [virtualMethod()](docs/test-suite-a/testclass-virtualmethod-method) |  | number | Overrides [virtualMethod()](docs/test-suite-a/testabstractclass-virtualmethod-method). |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-testclassmethod-method.md
@@ -16,7 +16,7 @@ Here are some remarks about the method
 ### Parameters {#testclassmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | input | TTypeParameterA |  |
 
 ### Returns {#testclassmethod-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-testclassstaticmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-testclassstaticmethod-method.md
@@ -11,7 +11,7 @@ static testClassStaticMethod(foo: number): string;
 ### Parameters {#testclassstaticmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | foo | number | Some number |
 
 ### Returns {#testclassstaticmethod-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testenum-enum.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testenum-enum.md
@@ -33,7 +33,7 @@ const bar = TestEnum.TestEnumValue2
 ### Flags
 
 | Flag | Description |
-| --- | --- |
+| - | - |
 | [TestEnumValue1](docs/test-suite-a/testenum-testenumvalue1-enummember) | Test enum value 1 (string) |
 | [TestEnumValue2](docs/test-suite-a/testenum-testenumvalue2-enummember) | Test enum value 2 (number) |
 | [TestEnumValue3](docs/test-suite-a/testenum-testenumvalue3-enummember) | Test enum value 3 (default) |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-interface.md
@@ -15,19 +15,19 @@ Here are some remarks about the interface
 ### Constructors
 
 | Constructor | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [new (): TestInterface](docs/test-suite-a/testinterface-_new_-constructsignature) | [TestInterface](docs/test-suite-a/testinterface-interface) | Test construct signature. |
 
 ### Events
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testClassEventProperty](docs/test-suite-a/testinterface-testclasseventproperty-propertysignature) | `readonly` | () =&gt; void | Test interface event property |
 
 ### Properties
 
 | Property | Modifiers | Default Value | Type | Description |
-| --- | --- | --- | --- | --- |
+| - | - | - | - | - |
 | [getterProperty](docs/test-suite-a/testinterface-getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
 | [propertyWithBadInheritDocTarget](docs/test-suite-a/testinterface-propertywithbadinheritdoctarget-propertysignature) |  |  | boolean |  |
 | [setterProperty](docs/test-suite-a/testinterface-setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
@@ -37,13 +37,13 @@ Here are some remarks about the interface
 ### Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testInterfaceMethod()](docs/test-suite-a/testinterface-testinterfacemethod-methodsignature) | void | Test interface method |
 
 ### Call Signatures
 
 | CallSignature | Description |
-| --- | --- |
+| - | - |
 | [(event: 'testCallSignature', listener: (input: unknown) =&gt; void): any](docs/test-suite-a/testinterface-_call_-callsignature) | Test interface event call signature |
 | [(event: 'anotherTestCallSignature', listener: (input: number) =&gt; string): number](docs/test-suite-a/testinterface-_call__1-callsignature) | Another example call signature |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.md
@@ -17,7 +17,7 @@ Here are some remarks about the interface
 ### Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testMethod(input)](docs/test-suite-a/testinterfaceextendingotherinterfaces-testmethod-methodsignature) | number | Test interface method accepting a string and returning a number. |
 
 ### See Also {#testinterfaceextendingotherinterfaces-see-also}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfaceextendingotherinterfaces-testmethod-methodsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfaceextendingotherinterfaces-testmethod-methodsignature.md
@@ -15,7 +15,7 @@ Here are some remarks about the method
 ### Parameters {#testmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | input | string | A string |
 
 ### Returns {#testmethod-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfacewithindexsignature-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfacewithindexsignature-interface.md
@@ -11,5 +11,5 @@ export interface TestInterfaceWithIndexSignature
 ### Index Signatures
 
 | IndexSignature | Description |
-| --- | --- |
+| - | - |
 | [\[foo: number\]: { bar: string; }](docs/test-suite-a/testinterfacewithindexsignature-_indexer_-indexsignature) | Test index signature. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfacewithtypeparameter-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfacewithtypeparameter-interface.md
@@ -11,7 +11,7 @@ export interface TestInterfaceWithTypeParameter<T>
 #### Type Parameters
 
 | Parameter | Description |
-| --- | --- |
+| - | - |
 | T | A type parameter |
 
 ### Remarks {#testinterfacewithtypeparameter-remarks}
@@ -21,5 +21,5 @@ Here are some remarks about the interface
 ### Properties
 
 | Property | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testProperty](docs/test-suite-a/testinterfacewithtypeparameter-testproperty-propertysignature) | T | A test interface property using generic type parameter |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testmodule-namespace.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testmodule-namespace.md
@@ -3,5 +3,5 @@
 ### Variables
 
 | Variable | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [foo](docs/test-suite-a/testmodule-foo-variable) | `readonly` |  | Test constant in module. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-namespace.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-namespace.md
@@ -35,29 +35,29 @@ const foo = {
 ### Classes
 
 | Class | Description |
-| --- | --- |
+| - | - |
 | [TestClass](docs/test-suite-a/testnamespace-testclass-class) | Test class |
 
 ### Enumerations
 
 | Enum | Description |
-| --- | --- |
+| - | - |
 | [TestEnum](docs/test-suite-a/testnamespace-testenum-enum) | Test Enum |
 
 ### Types
 
 | TypeAlias | Description |
-| --- | --- |
+| - | - |
 | [TestTypeAlias](docs/test-suite-a/testnamespace-testtypealias-typealias) | Test Type-Alias |
 
 ### Functions
 
 | Function | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testFunction(testParameter)](docs/test-suite-a/testnamespace-testfunction-function) | number | Test function |
 
 ### Namespaces
 
 | Namespace | Description |
-| --- | --- |
+| - | - |
 | [TestSubNamespace](docs/test-suite-a/testnamespace-testsubnamespace-namespace) | Test sub-namespace |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-_constructor_-constructor.md
@@ -11,5 +11,5 @@ constructor(testClassProperty: string);
 ### Parameters {#\_constructor\_-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | testClassProperty | string | See [testClassProperty](docs/test-suite-a/testclass-testclassproperty-property) |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-class.md
@@ -11,17 +11,17 @@ class TestClass
 ### Constructors
 
 | Constructor | Description |
-| --- | --- |
+| - | - |
 | [(constructor)(testClassProperty)](docs/test-suite-a/testnamespace-testclass-_constructor_-constructor) | Test class constructor |
 
 ### Properties
 
 | Property | Modifiers | Type | Description |
-| --- | --- | --- | --- |
+| - | - | - | - |
 | [testClassProperty](docs/test-suite-a/testnamespace-testclass-testclassproperty-property) | `readonly` | string | Test interface property |
 
 ### Methods
 
 | Method | Return Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | [testClassMethod(testParameter)](docs/test-suite-a/testnamespace-testclass-testclassmethod-method) | Promise&lt;string&gt; | Test class method |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-testclassmethod-method.md
@@ -11,7 +11,7 @@ testClassMethod(testParameter: string): Promise<string>;
 ### Parameters {#testclassmethod-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | testParameter | string | A string |
 
 ### Returns {#testclassmethod-returns}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testenum-enum.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testenum-enum.md
@@ -11,7 +11,7 @@ enum TestEnum
 ### Flags
 
 | Flag | Description |
-| --- | --- |
+| - | - |
 | [TestEnumValue1](docs/test-suite-a/testnamespace-testenum-testenumvalue1-enummember) | Test enum value 1 |
 | [TestEnumValue2](docs/test-suite-a/testnamespace-testenum-testenumvalue2-enummember) | Test enum value 2 |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testfunction-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testfunction-function.md
@@ -11,7 +11,7 @@ function testFunction(testParameter: number): number;
 ### Parameters {#testfunction-parameters}
 
 | Parameter | Type | Description |
-| --- | --- | --- |
+| - | - | - |
 | testParameter | number |  |
 
 ### Returns {#testfunction-returns}


### PR DESCRIPTION
Updates Markdown rendering to use only a single `-` for heading delimiter cells, rather than 3. This reduces the size of generated documents, but more importantly, it aligns with `mdast-util-to-markdown`'s behavior. The plan is to replace our custom Markdown rendering logic with this library, so making this change now will make future PR diffs easier to reason about and review.