### PR TITLE
IntervalCollections: Combine endpoint pending tracking

### DIFF
--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -705,11 +705,7 @@ export class IntervalCollection
 		number,
 		ISerializedInterval | SerializedIntervalDelta
 	>();
-	private readonly pendingChangesStart: Map<string, ISerializedIntervalCollectionV1> = new Map<
-		string,
-		ISerializedIntervalCollectionV1
-	>();
-	private readonly pendingChangesEnd: Map<string, ISerializedIntervalCollectionV1> = new Map<
+	private readonly pendingChanges: Map<string, ISerializedIntervalCollectionV1> = new Map<
 		string,
 		ISerializedIntervalCollectionV1
 	>();
@@ -1302,65 +1298,39 @@ export class IntervalCollection
 		if (!this.isCollaborating) {
 			return;
 		}
-		if (serializedInterval.start !== undefined) {
-			this.addPendingChangeHelper(id, this.pendingChangesStart, serializedInterval);
+		assert(
+			(serializedInterval.start === undefined) === (serializedInterval.end === undefined),
+			"both start and end must be set or unset",
+		);
+		if (serializedInterval.start !== undefined || serializedInterval.end !== undefined) {
+			const entries = this.pendingChanges.get(id) ?? [];
+			this.pendingChanges.set(id, entries);
+			entries.push(serializedInterval as any);
 		}
-		if (serializedInterval.end !== undefined) {
-			this.addPendingChangeHelper(id, this.pendingChangesEnd, serializedInterval);
-		}
-	}
-
-	private addPendingChangeHelper(
-		id: string,
-		pendingChanges: Map<string, SerializedIntervalDelta[]>,
-		serializedInterval: SerializedIntervalDelta,
-	) {
-		let entries: SerializedIntervalDelta[] | undefined = pendingChanges.get(id);
-		if (!entries) {
-			entries = [];
-			pendingChanges.set(id, entries);
-		}
-		entries.push(serializedInterval);
 	}
 
 	private removePendingChange(serializedInterval: SerializedIntervalDelta) {
 		// Change ops always have an ID.
 		const { id } = getSerializedProperties(serializedInterval);
 		if (serializedInterval.start !== undefined) {
-			this.removePendingChangeHelper(id, this.pendingChangesStart, serializedInterval);
-		}
-		if (serializedInterval.end !== undefined) {
-			this.removePendingChangeHelper(id, this.pendingChangesEnd, serializedInterval);
-		}
-	}
-
-	private removePendingChangeHelper(
-		id: string,
-		pendingChanges: Map<string, SerializedIntervalDelta[]>,
-		serializedInterval: SerializedIntervalDelta,
-	) {
-		const entries = pendingChanges.get(id);
-		if (entries) {
-			const pendingChange = entries.shift();
-			if (entries.length === 0) {
-				pendingChanges.delete(id);
-			}
-			if (
-				pendingChange?.start !== serializedInterval.start ||
-				pendingChange?.end !== serializedInterval.end
-			) {
-				throw new LoggingError("Mismatch in pending changes");
+			const entries = this.pendingChanges.get(id);
+			if (entries) {
+				const pendingChange = entries.shift();
+				if (entries.length === 0) {
+					this.pendingChanges.delete(id);
+				}
+				if (
+					pendingChange?.start !== serializedInterval.start ||
+					pendingChange?.end !== serializedInterval.end
+				) {
+					throw new LoggingError("Mismatch in pending changes");
+				}
 			}
 		}
 	}
 
-	private hasPendingChangeStart(id: string) {
-		const entries = this.pendingChangesStart.get(id);
-		return entries && entries.length !== 0;
-	}
-
-	private hasPendingChangeEnd(id: string) {
-		const entries = this.pendingChangesEnd.get(id);
+	private hasPendingChanges(id: string) {
+		const entries = this.pendingChanges.get(id);
 		return entries && entries.length !== 0;
 	}
 
@@ -1405,10 +1375,8 @@ export class IntervalCollection
 			let start: number | "start" | "end" | undefined;
 			let end: number | "start" | "end" | undefined;
 			// Track pending start/end independently of one another.
-			if (!this.hasPendingChangeStart(id)) {
+			if (!this.hasPendingChanges(id)) {
 				start = serializedInterval.start;
-			}
-			if (!this.hasPendingChangeEnd(id)) {
 				end = serializedInterval.end;
 			}
 
@@ -1500,7 +1468,7 @@ export class IntervalCollection
 		if (
 			opName === "change" &&
 			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- ?? is not logically equivalent when .hasPendingChangeStart returns false.
-			(this.hasPendingChangeStart(id) || this.hasPendingChangeEnd(id))
+			this.hasPendingChanges(id)
 		) {
 			this.removePendingChange(serializedInterval);
 			this.addPendingChange(id, rebased);
@@ -1577,19 +1545,15 @@ export class IntervalCollection
 		);
 
 		const id = interval.getIntervalId();
-		const hasPendingStartChange = this.hasPendingChangeStart(id);
-		const hasPendingEndChange = this.hasPendingChangeEnd(id);
+		const hasPendingChange = this.hasPendingChanges(id);
 
-		if (!hasPendingStartChange) {
+		if (!hasPendingChange) {
 			setSlideOnRemove(interval.start);
-		}
-
-		if (!hasPendingEndChange) {
 			setSlideOnRemove(interval.end);
 		}
 
-		const needsStartUpdate = newStart !== undefined && !hasPendingStartChange;
-		const needsEndUpdate = newEnd !== undefined && !hasPendingEndChange;
+		const needsStartUpdate = newStart !== undefined && !hasPendingChange;
+		const needsEndUpdate = newEnd !== undefined && !hasPendingChange;
 
 		if (needsStartUpdate || needsEndUpdate) {
 			if (!this.localCollection) {

--- a/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
+++ b/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
@@ -20,6 +20,7 @@ import {
 export interface IMapMessageLocalMetadata {
 	localSeq: number;
 	previous?: ISerializedInterval;
+	intervalId: string;
 }
 
 /**


### PR DESCRIPTION
The existing code always changes both endpoints, even if only one is technically modified. Due to this, it is also unnecessary to track the pending state of the endpoint separately. This is just a simplification of the existing code, to make further refactoring simpler. 