### PR TITLE
Add HydratedFlexTreeNode type

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -22,13 +22,13 @@ import type {
 import type { MinimalMapTreeNodeView } from "../mapTreeCursor.js";
 import type { FlexFieldKind } from "../modular-schema/index.js";
 
-import type { FlexTreeContext } from "./context.js";
+import type { FlexTreeContext, FlexTreeHydratedContext } from "./context.js";
 
 /**
  * An anchor slot which records the {@link FlexTreeNode} associated with that anchor, if there is one.
  * @remarks This always points to a "real" {@link FlexTreeNode} (i.e. a `LazyTreeNode`), never to a "raw" node.
  */
-export const flexTreeSlot = anchorSlot<FlexTreeNode>();
+export const flexTreeSlot = anchorSlot<HydratedFlexTreeNode>();
 
 /**
  * Indicates that an object is a flex tree.
@@ -174,16 +174,6 @@ export interface FlexTreeNode extends FlexTreeEntity {
 	boxedIterator(): IterableIterator<FlexTreeField>;
 
 	/**
-	 * The anchor node associated with this node
-	 *
-	 * @remarks
-	 * The ref count keeping this alive is owned by the FlexTreeNode:
-	 * if holding onto this anchor for longer than the FlexTreeNode might be alive,
-	 * a separate Anchor (and thus ref count) must be allocated to keep it alive.
-	 */
-	readonly anchorNode: AnchorNode;
-
-	/**
 	 * Returns an iterable of keys for non-empty fields.
 	 *
 	 * @remarks
@@ -206,6 +196,33 @@ export interface FlexTreeNode extends FlexTreeEntity {
 	 * Must not be held onto across edits or any other tree API use.
 	 */
 	borrowCursor(): ITreeCursorSynchronous;
+
+	/**
+	 * If true, this node is a {@link HydratedFlexTreeNode}.
+	 *
+	 * If false, this node is unhydrated.
+	 */
+	isHydrated(): this is HydratedFlexTreeNode;
+}
+
+/**
+ * A FlexTreeNode that is hydrated, meaning it is associated with a {@link FlexTreeHydratedContext}.
+ */
+export interface HydratedFlexTreeNode extends FlexTreeNode {
+	/**
+	 * {@inheritDoc FlexTreeNode.context}
+	 */
+	readonly context: FlexTreeHydratedContext;
+
+	/**
+	 * The anchor node associated with this node
+	 *
+	 * @remarks
+	 * The ref count keeping this alive is owned by the FlexTreeNode:
+	 * if holding onto this anchor for longer than the FlexTreeNode might be alive,
+	 * a separate Anchor (and thus ref count) must be allocated to keep it alive.
+	 */
+	readonly anchorNode: AnchorNode;
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
@@ -19,6 +19,7 @@ export {
 	flexTreeSlot,
 	type FlexibleNodeContent,
 	type FlexibleFieldContent,
+	type HydratedFlexTreeNode,
 } from "./flexTreeTypes.js";
 
 export {

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -37,7 +37,6 @@ import type { Context } from "./context.js";
 import {
 	FlexTreeEntityKind,
 	type FlexTreeField,
-	type FlexTreeNode,
 	type FlexTreeOptionalField,
 	type FlexTreeRequiredField,
 	type FlexTreeSequenceField,
@@ -45,6 +44,7 @@ import {
 	type FlexTreeUnknownUnboxed,
 	type FlexibleFieldContent,
 	type FlexibleNodeContent,
+	type HydratedFlexTreeNode,
 	TreeStatus,
 	flexTreeMarker,
 	flexTreeSlot,
@@ -161,7 +161,7 @@ export abstract class LazyField extends LazyEntity<FieldAnchor> implements FlexT
 		return this.schema === kind.identifier;
 	}
 
-	public get parent(): FlexTreeNode | undefined {
+	public get parent(): HydratedFlexTreeNode | undefined {
 		if (this.anchor.parent === undefined) {
 			return undefined;
 		}
@@ -195,7 +195,7 @@ export abstract class LazyField extends LazyEntity<FieldAnchor> implements FlexT
 		);
 	}
 
-	public boxedAt(index: number): FlexTreeNode | undefined {
+	public boxedAt(index: number): HydratedFlexTreeNode | undefined {
 		const finalIndex = indexForAt(index, this.length);
 
 		if (finalIndex === undefined) {
@@ -209,7 +209,7 @@ export abstract class LazyField extends LazyEntity<FieldAnchor> implements FlexT
 		return Array.from(this, callbackfn);
 	}
 
-	public boxedIterator(): IterableIterator<FlexTreeNode> {
+	public boxedIterator(): IterableIterator<HydratedFlexTreeNode> {
 		return iterateCursorField(this.cursor, (cursor) => makeTree(this.context, cursor));
 	}
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -28,7 +28,7 @@ import type { Context } from "./context.js";
 import {
 	FlexTreeEntityKind,
 	type FlexTreeField,
-	type FlexTreeNode,
+	type HydratedFlexTreeNode,
 	flexTreeMarker,
 	flexTreeSlot,
 } from "./flexTreeTypes.js";
@@ -63,7 +63,7 @@ function cleanupTree(anchor: AnchorNode): void {
 /**
  * Lazy implementation of {@link FlexTreeNode}.
  */
-export class LazyTreeNode extends LazyEntity<Anchor> implements FlexTreeNode {
+export class LazyTreeNode extends LazyEntity<Anchor> implements HydratedFlexTreeNode {
 	public get [flexTreeMarker](): FlexTreeEntityKind.Node {
 		return FlexTreeEntityKind.Node;
 	}
@@ -86,6 +86,10 @@ export class LazyTreeNode extends LazyEntity<Anchor> implements FlexTreeNode {
 		assert(cursor.mode === CursorLocationType.Nodes, 0x783 /* must be in nodes mode */);
 		anchorNode.slots.set(flexTreeSlot, this);
 		this.#removeDeleteCallback = anchorNode.events.on("afterDestroy", cleanupTree);
+	}
+
+	public isHydrated(): this is HydratedFlexTreeNode {
+		return true;
 	}
 
 	public borrowCursor(): ITreeCursorSynchronous {

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -182,6 +182,7 @@ export {
 	type FlexibleNodeContent,
 	type FlexibleFieldContent,
 	type FlexTreeHydratedContextMinimal,
+	type HydratedFlexTreeNode,
 } from "./flex-tree/index.js";
 
 export { TreeCompressionStrategy } from "./treeCompressionUtils.js";

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -500,6 +500,15 @@ export function requireSchema(
 	return view;
 }
 
+/**
+ * Adds constraints to a `checkout`'s pending transaction.
+ *
+ * @param checkout - The checkout's who's transaction will have the constraints added to it.
+ * @param constraintsOnRevert - If true, use {@link ISharedTreeEditor.addNodeExistsConstraintOnRevert}.
+ * @param constraints - The constraints to add to the transaction.
+ *
+ * @see {@link RunTransactionParams.preconditions}.
+ */
 export function addConstraintsToTransaction(
 	checkout: ITreeCheckout,
 	constraintsOnRevert: boolean,

--- a/packages/dds/tree/src/simple-tree/core/getOrCreateNode.ts
+++ b/packages/dds/tree/src/simple-tree/core/getOrCreateNode.ts
@@ -10,6 +10,7 @@ import {
 	type InnerNode,
 	simpleTreeNodeSlot,
 	createTreeNodeFromInner,
+	splitInnerNodeType,
 } from "./treeNodeKernel.js";
 import { UnhydratedFlexTreeNode } from "./unhydratedFlexTree.js";
 
@@ -20,6 +21,8 @@ import { UnhydratedFlexTreeNode } from "./unhydratedFlexTree.js";
  * This supports both hydrated and unhydrated nodes.
  */
 export function getOrCreateNodeFromInnerNode(flexNode: InnerNode): TreeNode | TreeValue {
+	splitInnerNodeType(flexNode);
+
 	const cached =
 		flexNode instanceof UnhydratedFlexTreeNode
 			? flexNode.treeNode

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -27,6 +27,7 @@ import {
 	TreeStatus,
 	treeStatusFromAnchorCache,
 	type FlexTreeNode,
+	type HydratedFlexTreeNode,
 } from "../../feature-libraries/index.js";
 
 import { SimpleContextSlot, type Context, type HydratedContext } from "./context.js";
@@ -143,6 +144,8 @@ export class TreeNodeKernel {
 		innerNode: InnerNode,
 		private readonly initialContext: Context,
 	) {
+		splitInnerNodeType(innerNode);
+
 		assert(!treeNodeToKernel.has(node), 0xa1a /* only one kernel per node can be made */);
 		treeNodeToKernel.set(node, this);
 
@@ -354,18 +357,24 @@ const kernelEvents = ["childrenChangedAfterBatch", "subtreeChangedAfterBatch"] a
 type KernelEvents = Pick<AnchorEvents, (typeof kernelEvents)[number]>;
 
 /**
- * For "cooked" nodes this is a FlexTreeNode thats a projection of forest content.
- * For {@link Unhydrated} nodes this is a MapTreeNode.
+ * For "cooked" nodes this is a HydratedFlexTreeNode thats a projection of forest content.
+ * For {@link Unhydrated} nodes this is a UnhydratedFlexTreeNode.
+ *
  * For "marinated" nodes, some code (ex: getOrCreateInnerNode) returns the FlexTreeNode thats a projection of forest content, and some code (ex: tryGetInnerNode) returns undefined.
- *
- * @remarks
- * Currently MapTreeNode extends FlexTreeNode, and most code which can work with either just uses FlexTreeNode.
- * TODO: Code should be migrating toward using this type to distinguish to two use-cases.
- *
- * TODO: The inconsistent handling of "marinated" cases should be cleaned up.
- * Maybe getOrCreateInnerNode should cook marinated nodes so they have a proper InnerNode?
  */
-export type InnerNode = FlexTreeNode | UnhydratedFlexTreeNode;
+export type InnerNode = FlexTreeNode;
+
+/**
+ * Narrows innerNode to either {@link UnhydratedFlexTreeNode} or {@link HydratedFlexTreeNode}.
+ */
+export function splitInnerNodeType(
+	innerNode: InnerNode,
+): asserts innerNode is UnhydratedFlexTreeNode | HydratedFlexTreeNode {
+	assert(
+		innerNode instanceof UnhydratedFlexTreeNode || innerNode.isHydrated(),
+		"Invalid inner node type",
+	);
+}
 
 /**
  * An anchor slot which associates an anchor with its corresponding {@link TreeNode}, if there is one.
@@ -399,6 +408,7 @@ export function getSimpleNodeSchemaFromInnerNode(innerNode: InnerNode): TreeNode
  * Gets the {@link Context} for the {@link InnerNode}.
  */
 export function getSimpleContextFromInnerNode(innerNode: InnerNode): Context {
+	splitInnerNodeType(innerNode);
 	if (innerNode instanceof UnhydratedFlexTreeNode) {
 		return innerNode.simpleContext;
 	}
@@ -427,7 +437,7 @@ export function getOrCreateInnerNode(treeNode: TreeNode): InnerNode {
 /**
  * Gets a flex node from an anchor node
  */
-function flexNodeFromAnchor(anchorNode: AnchorNode): FlexTreeNode {
+function flexNodeFromAnchor(anchorNode: AnchorNode): HydratedFlexTreeNode {
 	const flexNode = anchorNode.slots.get(flexTreeSlot);
 	if (flexNode !== undefined) {
 		return flexNode; // If it does have a flex node, return it...

--- a/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
+++ b/packages/dds/tree/src/simple-tree/core/unhydratedFlexTree.ts
@@ -10,7 +10,6 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
 	type AnchorEvents,
-	type AnchorNode,
 	EmptyKey,
 	type FieldKey,
 	type FieldKindIdentifier,
@@ -49,6 +48,7 @@ import {
 	type FlexibleFieldContent,
 	type MapTreeFieldViewGeneric,
 	type MapTreeNodeViewGeneric,
+	type HydratedFlexTreeNode,
 } from "../../feature-libraries/index.js";
 import { brand, filterIterable, getOrCreate } from "../../util/index.js";
 
@@ -73,6 +73,10 @@ interface LocationInField {
 export class UnhydratedFlexTreeNode
 	implements FlexTreeNode, MapTreeNodeViewGeneric<UnhydratedFlexTreeNode>
 {
+	public isHydrated(): this is HydratedFlexTreeNode {
+		return false;
+	}
+
 	private location = unparentedLocation;
 
 	public get storedSchema(): TreeNodeStoredSchema {
@@ -245,12 +249,6 @@ export class UnhydratedFlexTreeNode
 
 	public get value(): Value {
 		return this.data.value;
-	}
-
-	public get anchorNode(): AnchorNode {
-		// This API is relevant to `LazyTreeNode`s, but not `UnhydratedFlexTreeNode`s.
-		// TODO: Refactor the FlexTreeNode interface so that stubbing this out isn't necessary.
-		return fail(0xb47 /* UnhydratedFlexTreeNode does not implement anchorNode */);
 	}
 
 	public emitChangedEvent(key: FieldKey): void {

--- a/packages/dds/tree/src/test/feature-libraries/indexing/treeIndex.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/indexing/treeIndex.spec.ts
@@ -133,6 +133,7 @@ describe("tree indexes", () => {
 							key,
 							nodes.map((f) => {
 								const flexNode: FlexTreeNode = getOrCreateInnerNode(f);
+								assert(flexNode.isHydrated());
 								return getOrCreate(
 									anchorIds,
 									flexNode.anchorNode,
@@ -300,6 +301,7 @@ describe("tree indexes", () => {
 								key,
 								nodes.map((f) => {
 									const flexNode: FlexTreeNode = getOrCreateInnerNode(f);
+									assert(flexNode.isHydrated());
 									return getOrCreate(
 										anchorIds,
 										flexNode.anchorNode,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -777,6 +777,7 @@ export interface FieldPathWithCount {
 
 function upPathFromNode(node: TreeNode): UpPath {
 	const flexNode = getOrCreateInnerNode(node);
+	assert(flexNode.isHydrated());
 	const anchorNode = flexNode.anchorNode;
 	return anchorNode;
 }

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -437,9 +437,9 @@ export function applyConstraint(state: FuzzTestState, constraint: Constraint) {
 				: undefined;
 
 			if (constraintNode !== undefined) {
-				tree.checkout.editor.addNodeExistsConstraint(
-					getOrCreateInnerNode(constraintNode).anchorNode,
-				);
+				const flex = getOrCreateInnerNode(constraintNode);
+				assert(flex.isHydrated());
+				tree.checkout.editor.addNodeExistsConstraint(flex.anchorNode);
 			}
 			break;
 		}

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -81,7 +81,9 @@ describe("sharedTreeView", () => {
 			);
 			view.initialize({ x: 24 });
 			const root = view.root;
-			const anchorNode = getOrCreateInnerNode(root).anchorNode;
+			const flex = getOrCreateInnerNode(root);
+			assert(flex.isHydrated());
+			const anchorNode = flex.anchorNode;
 			const log: string[] = [];
 			const unsubscribe = anchorNode.events.on("childrenChanging", () => log.push("change"));
 			const unsubscribeSubtree = anchorNode.events.on("subtreeChanging", () => {
@@ -123,7 +125,9 @@ describe("sharedTreeView", () => {
 			);
 			view.initialize({ x: 24 });
 			const root = view.root;
-			const anchorNode = getOrCreateInnerNode(root).anchorNode;
+			const flex = getOrCreateInnerNode(root);
+			assert(flex.isHydrated());
+			const anchorNode = flex.anchorNode;
 			const log: string[] = [];
 			const unsubscribe = anchorNode.events.on("childrenChanging", (upPath) =>
 				log.push(`change-${String(upPath.parentField)}-${upPath.parentIndex}`),
@@ -369,10 +373,9 @@ describe("sharedTreeView", () => {
 		itView("update anchors after applying a change", ({ view }) => {
 			view.root.insertAtStart("A");
 			let cursor = view.checkout.forest.allocateCursor();
-			view.checkout.forest.moveCursorToPath(
-				getOrCreateInnerNode(view.root).anchorNode,
-				cursor,
-			);
+			const flex = getOrCreateInnerNode(view.root);
+			assert(flex.isHydrated());
+			view.checkout.forest.moveCursorToPath(flex.anchorNode, cursor);
 			cursor.enterField(EmptyKey);
 			cursor.firstNode();
 			const anchor = cursor.buildAnchor();
@@ -390,10 +393,9 @@ describe("sharedTreeView", () => {
 				const parentCheckout = parentView.checkout;
 				parentView.root.insertAtStart("A");
 				let cursor = parentCheckout.forest.allocateCursor();
-				parentCheckout.forest.moveCursorToPath(
-					getOrCreateInnerNode(parentView.root).anchorNode,
-					cursor,
-				);
+				const flex = getOrCreateInnerNode(parentView.root);
+				assert(flex.isHydrated());
+				parentCheckout.forest.moveCursorToPath(flex.anchorNode, cursor);
 				cursor.enterField(EmptyKey);
 				cursor.firstNode();
 				const anchor = cursor.buildAnchor();
@@ -415,10 +417,9 @@ describe("sharedTreeView", () => {
 				const parentCheckout = parentView.checkout;
 				parentView.root.insertAtStart("A");
 				let cursor = parentCheckout.forest.allocateCursor();
-				parentCheckout.forest.moveCursorToPath(
-					getOrCreateInnerNode(parentView.root).anchorNode,
-					cursor,
-				);
+				const flex = getOrCreateInnerNode(parentView.root);
+				assert(flex.isHydrated());
+				parentCheckout.forest.moveCursorToPath(flex.anchorNode, cursor);
 				cursor.enterField(EmptyKey);
 				cursor.firstNode();
 				const anchor = cursor.buildAnchor();
@@ -439,10 +440,9 @@ describe("sharedTreeView", () => {
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
 			view.root.insertAtStart("A");
 			let cursor = view.checkout.forest.allocateCursor();
-			view.checkout.forest.moveCursorToPath(
-				getOrCreateInnerNode(view.root).anchorNode,
-				cursor,
-			);
+			const flex = getOrCreateInnerNode(view.root);
+			assert(flex.isHydrated());
+			view.checkout.forest.moveCursorToPath(flex.anchorNode, cursor);
 			cursor.enterField(EmptyKey);
 			cursor.firstNode();
 			const anchor = cursor.buildAnchor();
@@ -753,10 +753,9 @@ describe("sharedTreeView", () => {
 		itView("update anchors correctly", ({ view }) => {
 			view.root.insertAtStart("A");
 			let cursor = view.checkout.forest.allocateCursor();
-			view.checkout.forest.moveCursorToPath(
-				getOrCreateInnerNode(view.root).anchorNode,
-				cursor,
-			);
+			const flex = getOrCreateInnerNode(view.root);
+			assert(flex.isHydrated());
+			view.checkout.forest.moveCursorToPath(flex.anchorNode, cursor);
 			cursor.enterField(EmptyKey);
 			cursor.firstNode();
 			const anchor = cursor.buildAnchor();

--- a/packages/dds/tree/src/test/simple-tree/core/unhydratedFlexTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/unhydratedFlexTree.spec.ts
@@ -208,10 +208,10 @@ describe("unhydratedFlexTree", () => {
 			assert.equal(object.context.isHydrated(), false);
 		});
 
-		it("get their anchor node", () => {
-			assert.throws(() => map.anchorNode);
-			assert.throws(() => arrayNode.anchorNode);
-			assert.throws(() => object.anchorNode);
+		it("is unhydrated", () => {
+			assert(map.isHydrated() === false);
+			assert(arrayNode.isHydrated() === false);
+			assert(object.isHydrated() === false);
 		});
 	});
 

--- a/packages/dds/tree/src/test/simple-tree/core/unhydratedFlexTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/unhydratedFlexTree.spec.ts
@@ -201,18 +201,16 @@ describe("unhydratedFlexTree", () => {
 		assert.equal(object.parentField.parent.parent, undefined);
 	});
 
-	describe("cannot", () => {
-		it("get their context", () => {
-			assert.equal(map.context.isHydrated(), false);
-			assert.equal(arrayNode.context.isHydrated(), false);
-			assert.equal(object.context.isHydrated(), false);
-		});
+	it("get their context", () => {
+		assert.equal(map.context.isHydrated(), false);
+		assert.equal(arrayNode.context.isHydrated(), false);
+		assert.equal(object.context.isHydrated(), false);
+	});
 
-		it("is unhydrated", () => {
-			assert(map.isHydrated() === false);
-			assert(arrayNode.isHydrated() === false);
-			assert(object.isHydrated() === false);
-		});
+	it("is unhydrated", () => {
+		assert(map.isHydrated() === false);
+		assert(arrayNode.isHydrated() === false);
+		assert(object.isHydrated() === false);
 	});
 
 	describe("can mutate", () => {


### PR DESCRIPTION
## Description

Add HydratedFlexTreeNode to better seperate Unhydrated and Hydrated FlexTreeNodes.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

