### PR TITLE
improvement(api-markdown-documenter): Don't needlessly escape `>` characters in Markdown

### DIFF
--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderPlainText.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderPlainText.ts
@@ -117,6 +117,6 @@ function splitLeadingAndTrailingWhitespace(text: string): SplitTextResult {
 export function escapeTextForMarkdown(text: string): string {
 	return text
 		.replace(/\\/g, "\\\\") // first replace the escape character
-		.replace(/[#&*<>[\]_`|~]/g, (x) => `\\${x}`) // then escape any special characters
+		.replace(/[#&*<[\]_`|~]/g, (x) => `\\${x}`) // then escape any special characters
 		.replace(/---/g, "\\-\\-\\-"); // hyphens only if it's 3 or more
 }

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
@@ -1,6 +1,6 @@
 # test-suite-a
 
-[Packages](/) \> [test-suite-a](/test-suite-a/)
+[Packages](/) > [test-suite-a](/test-suite-a/)
 
 Test package
 
@@ -74,7 +74,7 @@ const foo = bar;
 | - | - | - | - |
 | [testFunction(testParameter, testOptionalParameter)](/test-suite-a/testfunction-function) | `Alpha` | TTypeParameter | Test function |
 | [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum/); } | Test function that returns an inline type |
-| [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) \& [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)\<number\> | Test function that returns an inline type |
+| [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) \& [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)\<number> | Test function that returns an inline type |
 | [testFunctionReturningUnionType()](/test-suite-a/testfunctionreturninguniontype-function) |  | string \| [TestInterface](/test-suite-a/testinterface-interface/) | Test function that returns an inline type |
 
 ## Variables

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.md
@@ -1,6 +1,6 @@
 # (constructor)
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestAbstractClass](/test-suite-a/testabstractclass-class/) \> [(constructor)(privateProperty, protectedProperty)](/test-suite-a/testabstractclass-class/_constructor_-constructor)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestAbstractClass](/test-suite-a/testabstractclass-class/) > [(constructor)(privateProperty, protectedProperty)](/test-suite-a/testabstractclass-class/_constructor_-constructor)
 
 This is a _{@customTag constructor}_.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.md
@@ -1,6 +1,6 @@
 # abstractPropertyGetter
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestAbstractClass](/test-suite-a/testabstractclass-class/) \> [abstractPropertyGetter](/test-suite-a/testabstractclass-class/abstractpropertygetter-property)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestAbstractClass](/test-suite-a/testabstractclass-class/) > [abstractPropertyGetter](/test-suite-a/testabstractclass-class/abstractpropertygetter-property)
 
 A test abstract getter property.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.md
@@ -1,6 +1,6 @@
 # TestAbstractClass
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestAbstractClass](/test-suite-a/testabstractclass-class/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestAbstractClass](/test-suite-a/testabstractclass-class/)
 
 A test abstract class.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/protectedproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/protectedproperty-property.md
@@ -1,6 +1,6 @@
 # protectedProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestAbstractClass](/test-suite-a/testabstractclass-class/) \> [protectedProperty](/test-suite-a/testabstractclass-class/protectedproperty-property)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestAbstractClass](/test-suite-a/testabstractclass-class/) > [protectedProperty](/test-suite-a/testabstractclass-class/protectedproperty-property)
 
 A test protected property.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/publicabstractmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/publicabstractmethod-method.md
@@ -1,6 +1,6 @@
 # publicAbstractMethod
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestAbstractClass](/test-suite-a/testabstractclass-class/) \> [publicAbstractMethod()](/test-suite-a/testabstractclass-class/publicabstractmethod-method)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestAbstractClass](/test-suite-a/testabstractclass-class/) > [publicAbstractMethod()](/test-suite-a/testabstractclass-class/publicabstractmethod-method)
 
 A test public abstract method.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/sealedmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/sealedmethod-method.md
@@ -1,6 +1,6 @@
 # sealedMethod
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestAbstractClass](/test-suite-a/testabstractclass-class/) \> [sealedMethod()](/test-suite-a/testabstractclass-class/sealedmethod-method)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestAbstractClass](/test-suite-a/testabstractclass-class/) > [sealedMethod()](/test-suite-a/testabstractclass-class/sealedmethod-method)
 
 A test `@sealed` method.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/virtualmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/virtualmethod-method.md
@@ -1,6 +1,6 @@
 # virtualMethod
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestAbstractClass](/test-suite-a/testabstractclass-class/) \> [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestAbstractClass](/test-suite-a/testabstractclass-class/) > [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method)
 
 A test `@virtual` method.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testbetanamespace-namespace/alphamember-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testbetanamespace-namespace/alphamember-variable.md
@@ -1,6 +1,6 @@
 # alphaMember
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/) \> [alphaMember](/test-suite-a/testbetanamespace-namespace/alphamember-variable)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/) > [alphaMember](/test-suite-a/testbetanamespace-namespace/alphamember-variable)
 
 **WARNING: This API is provided as an alpha preview and may change without notice. Use at your own risk.**
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testbetanamespace-namespace/betamember-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testbetanamespace-namespace/betamember-variable.md
@@ -1,6 +1,6 @@
 # betaMember
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/) \> [betaMember](/test-suite-a/testbetanamespace-namespace/betamember-variable)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/) > [betaMember](/test-suite-a/testbetanamespace-namespace/betamember-variable)
 
 **WARNING: This API is provided as a beta preview and may change without notice. Use at your own risk.**
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testbetanamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testbetanamespace-namespace/index.md
@@ -1,6 +1,6 @@
 # TestBetaNamespace
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/)
 
 A namespace tagged as `@beta`.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testbetanamespace-namespace/publicmember-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testbetanamespace-namespace/publicmember-variable.md
@@ -1,6 +1,6 @@
 # publicMember
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/) \> [publicMember](/test-suite-a/testbetanamespace-namespace/publicmember-variable)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/) > [publicMember](/test-suite-a/testbetanamespace-namespace/publicmember-variable)
 
 **WARNING: This API is provided as a beta preview and may change without notice. Use at your own risk.**
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.md
@@ -1,6 +1,6 @@
 # (constructor)
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestClass](/test-suite-a/testclass-class/) \> [(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)](/test-suite-a/testclass-class/_constructor_-constructor)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestClass](/test-suite-a/testclass-class/) > [(constructor)(privateProperty, protectedProperty, testClassProperty, testClassEventProperty)](/test-suite-a/testclass-class/_constructor_-constructor)
 
 Test class constructor
 
@@ -21,4 +21,4 @@ Here are some remarks about the constructor
 | privateProperty | number | See [TestAbstractClass](/test-suite-a/testabstractclass-class/)'s constructor. |
 | protectedProperty | [TestEnum](/test-suite-a/testenum-enum/) | <p>Some notes about the parameter.</p><p>See <a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a>.</p> |
 | testClassProperty | TTypeParameterB | See [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property). |
-| testClassEventProperty | () =\> void | See [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property). |
+| testClassEventProperty | () => void | See [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property). |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.md
@@ -1,6 +1,6 @@
 # abstractPropertyGetter
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestClass](/test-suite-a/testclass-class/) \> [abstractPropertyGetter](/test-suite-a/testclass-class/abstractpropertygetter-property)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestClass](/test-suite-a/testclass-class/) > [abstractPropertyGetter](/test-suite-a/testclass-class/abstractpropertygetter-property)
 
 A test abstract getter property.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/index.md
@@ -1,6 +1,6 @@
 # TestClass
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestClass](/test-suite-a/testclass-class/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestClass](/test-suite-a/testclass-class/)
 
 Test class
 
@@ -33,7 +33,7 @@ Here are some remarks about the class
 
 | Property | Type | Description |
 | - | - | - |
-| [testClassStaticProperty](/test-suite-a/testclass-class/testclassstaticproperty-property) | (foo: number) =\> string | Test static class property |
+| [testClassStaticProperty](/test-suite-a/testclass-class/testclassstaticproperty-property) | (foo: number) => string | Test static class property |
 
 ## Static Methods
 
@@ -45,7 +45,7 @@ Here are some remarks about the class
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property) | `readonly` | () =\> void | Test class event property |
+| [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property) | `readonly` | () => void | Test class event property |
 
 ## Properties
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/publicabstractmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/publicabstractmethod-method.md
@@ -1,6 +1,6 @@
 # publicAbstractMethod
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestClass](/test-suite-a/testclass-class/) \> [publicAbstractMethod()](/test-suite-a/testclass-class/publicabstractmethod-method)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestClass](/test-suite-a/testclass-class/) > [publicAbstractMethod()](/test-suite-a/testclass-class/publicabstractmethod-method)
 
 A test public abstract method.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclasseventproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclasseventproperty-property.md
@@ -1,6 +1,6 @@
 # testClassEventProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestClass](/test-suite-a/testclass-class/) \> [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestClass](/test-suite-a/testclass-class/) > [testClassEventProperty](/test-suite-a/testclass-class/testclasseventproperty-property)
 
 Test class event property
 
@@ -10,7 +10,7 @@ Test class event property
 readonly testClassEventProperty: () => void;
 ```
 
-**Type**: () =\> void
+**Type**: () => void
 
 ## Remarks {#testclasseventproperty-remarks}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.md
@@ -1,6 +1,6 @@
 # testClassGetterProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestClass](/test-suite-a/testclass-class/) \> [testClassGetterProperty](/test-suite-a/testclass-class/testclassgetterproperty-property)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestClass](/test-suite-a/testclass-class/) > [testClassGetterProperty](/test-suite-a/testclass-class/testclassgetterproperty-property)
 
 Test class property with both a getter and a setter.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.md
@@ -1,6 +1,6 @@
 # testClassMethod
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestClass](/test-suite-a/testclass-class/) \> [testClassMethod(input)](/test-suite-a/testclass-class/testclassmethod-method)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestClass](/test-suite-a/testclass-class/) > [testClassMethod(input)](/test-suite-a/testclass-class/testclassmethod-method)
 
 Test class method
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassproperty-property.md
@@ -1,6 +1,6 @@
 # testClassProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestClass](/test-suite-a/testclass-class/) \> [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestClass](/test-suite-a/testclass-class/) > [testClassProperty](/test-suite-a/testclass-class/testclassproperty-property)
 
 Test class property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.md
@@ -1,6 +1,6 @@
 # testClassStaticMethod
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestClass](/test-suite-a/testclass-class/) \> [testClassStaticMethod(foo)](/test-suite-a/testclass-class/testclassstaticmethod-method)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestClass](/test-suite-a/testclass-class/) > [testClassStaticMethod(foo)](/test-suite-a/testclass-class/testclassstaticmethod-method)
 
 Test class static method
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticproperty-property.md
@@ -1,6 +1,6 @@
 # testClassStaticProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestClass](/test-suite-a/testclass-class/) \> [testClassStaticProperty](/test-suite-a/testclass-class/testclassstaticproperty-property)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestClass](/test-suite-a/testclass-class/) > [testClassStaticProperty](/test-suite-a/testclass-class/testclassstaticproperty-property)
 
 Test static class property
 
@@ -10,4 +10,4 @@ Test static class property
 static testClassStaticProperty: (foo: number) => string;
 ```
 
-**Type**: (foo: number) =\> string
+**Type**: (foo: number) => string

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/virtualmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/virtualmethod-method.md
@@ -1,6 +1,6 @@
 # virtualMethod
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestClass](/test-suite-a/testclass-class/) \> [virtualMethod()](/test-suite-a/testclass-class/virtualmethod-method)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestClass](/test-suite-a/testclass-class/) > [virtualMethod()](/test-suite-a/testclass-class/virtualmethod-method)
 
 Overrides [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method).
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testconst-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testconst-variable.md
@@ -1,6 +1,6 @@
 # testConst
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [testConst](/test-suite-a/testconst-variable)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [testConst](/test-suite-a/testconst-variable)
 
 Test Constant
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.md
@@ -1,6 +1,6 @@
 # testConstWithEmptyDeprecatedBlock
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [testConstWithEmptyDeprecatedBlock](/test-suite-a/testconstwithemptydeprecatedblock-variable)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [testConstWithEmptyDeprecatedBlock](/test-suite-a/testconstwithemptydeprecatedblock-variable)
 
 I have a `@deprecated` tag with an empty comment block.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testemptyinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testemptyinterface-interface/index.md
@@ -1,6 +1,6 @@
 # TestEmptyInterface
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/)
 
 An empty interface
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.md
@@ -1,6 +1,6 @@
 # TestEnum
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestEnum](/test-suite-a/testenum-enum/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestEnum](/test-suite-a/testenum-enum/)
 
 Test Enum
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue1-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue1-enummember.md
@@ -1,6 +1,6 @@
 # TestEnumValue1
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestEnum](/test-suite-a/testenum-enum/) \> [TestEnumValue1](/test-suite-a/testenum-enum/testenumvalue1-enummember)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestEnum](/test-suite-a/testenum-enum/) > [TestEnumValue1](/test-suite-a/testenum-enum/testenumvalue1-enummember)
 
 Test enum value 1 (string)
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue2-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue2-enummember.md
@@ -1,6 +1,6 @@
 # TestEnumValue2
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestEnum](/test-suite-a/testenum-enum/) \> [TestEnumValue2](/test-suite-a/testenum-enum/testenumvalue2-enummember)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestEnum](/test-suite-a/testenum-enum/) > [TestEnumValue2](/test-suite-a/testenum-enum/testenumvalue2-enummember)
 
 Test enum value 2 (number)
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue3-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testenum-enum/testenumvalue3-enummember.md
@@ -1,6 +1,6 @@
 # TestEnumValue3
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestEnum](/test-suite-a/testenum-enum/) \> [TestEnumValue3](/test-suite-a/testenum-enum/testenumvalue3-enummember)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestEnum](/test-suite-a/testenum-enum/) > [TestEnumValue3](/test-suite-a/testenum-enum/testenumvalue3-enummember)
 
 Test enum value 3 (default)
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunction-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunction-function.md
@@ -1,6 +1,6 @@
 # testFunction
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [testFunction(testParameter, testOptionalParameter)](/test-suite-a/testfunction-function)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [testFunction(testParameter, testOptionalParameter)](/test-suite-a/testfunction-function)
 
 Test function
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturninginlinetype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturninginlinetype-function.md
@@ -1,6 +1,6 @@
 # testFunctionReturningInlineType
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function)
 
 Test function that returns an inline type
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.md
@@ -1,6 +1,6 @@
 # testFunctionReturningIntersectionType
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function)
 
 Test function that returns an inline type
 
@@ -18,4 +18,4 @@ export declare function testFunctionReturningIntersectionType(): TestEmptyInterf
 
 an intersection type
 
-**Return type**: [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) \& [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)\<number\>
+**Return type**: [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) \& [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)\<number>

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturninguniontype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunctionreturninguniontype-function.md
@@ -1,6 +1,6 @@
 # testFunctionReturningUnionType
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [testFunctionReturningUnionType()](/test-suite-a/testfunctionreturninguniontype-function)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [testFunctionReturningUnionType()](/test-suite-a/testfunctionreturninguniontype-function)
 
 Test function that returns an inline type
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call_-callsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call_-callsignature.md
@@ -1,6 +1,6 @@
-# (event: 'testCallSignature', listener: (input: unknown) =\> void): any
+# (event: 'testCallSignature', listener: (input: unknown) => void): any
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterface](/test-suite-a/testinterface-interface/) \> [(event: 'testCallSignature', listener: (input: unknown) =\> void): any](/test-suite-a/testinterface-interface/_call_-callsignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterface](/test-suite-a/testinterface-interface/) > [(event: 'testCallSignature', listener: (input: unknown) => void): any](/test-suite-a/testinterface-interface/_call_-callsignature)
 
 Test interface event call signature
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call__1-callsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_call__1-callsignature.md
@@ -1,6 +1,6 @@
-# (event: 'anotherTestCallSignature', listener: (input: number) =\> string): number
+# (event: 'anotherTestCallSignature', listener: (input: number) => string): number
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterface](/test-suite-a/testinterface-interface/) \> [(event: 'anotherTestCallSignature', listener: (input: number) =\> string): number](/test-suite-a/testinterface-interface/_call__1-callsignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterface](/test-suite-a/testinterface-interface/) > [(event: 'anotherTestCallSignature', listener: (input: number) => string): number](/test-suite-a/testinterface-interface/_call__1-callsignature)
 
 Another example call signature
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_new_-constructsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_new_-constructsignature.md
@@ -1,6 +1,6 @@
 # new (): TestInterface
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterface](/test-suite-a/testinterface-interface/) \> [new (): TestInterface](/test-suite-a/testinterface-interface/_new_-constructsignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterface](/test-suite-a/testinterface-interface/) > [new (): TestInterface](/test-suite-a/testinterface-interface/_new_-constructsignature)
 
 Test construct signature.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/getterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/getterproperty-property.md
@@ -1,6 +1,6 @@
 # getterProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterface](/test-suite-a/testinterface-interface/) \> [getterProperty](/test-suite-a/testinterface-interface/getterproperty-property)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterface](/test-suite-a/testinterface-interface/) > [getterProperty](/test-suite-a/testinterface-interface/getterproperty-property)
 
 A test getter-only interface property.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.md
@@ -1,6 +1,6 @@
 # TestInterface
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterface](/test-suite-a/testinterface-interface/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterface](/test-suite-a/testinterface-interface/)
 
 Test interface
 
@@ -24,7 +24,7 @@ Here are some remarks about the interface
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [testClassEventProperty](/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature) | `readonly` | () =\> void | Test interface event property |
+| [testClassEventProperty](/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature) | `readonly` | () => void | Test interface event property |
 
 ## Properties
 
@@ -46,8 +46,8 @@ Here are some remarks about the interface
 
 | CallSignature | Description |
 | - | - |
-| [(event: 'testCallSignature', listener: (input: unknown) =\> void): any](/test-suite-a/testinterface-interface/_call_-callsignature) | Test interface event call signature |
-| [(event: 'anotherTestCallSignature', listener: (input: number) =\> string): number](/test-suite-a/testinterface-interface/_call__1-callsignature) | Another example call signature |
+| [(event: 'testCallSignature', listener: (input: unknown) => void): any](/test-suite-a/testinterface-interface/_call_-callsignature) | Test interface event call signature |
+| [(event: 'anotherTestCallSignature', listener: (input: number) => string): number](/test-suite-a/testinterface-interface/_call__1-callsignature) | Another example call signature |
 
 ## See Also {#testinterface-see-also}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature.md
@@ -1,6 +1,6 @@
 # propertyWithBadInheritDocTarget
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterface](/test-suite-a/testinterface-interface/) \> [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterface](/test-suite-a/testinterface-interface/) > [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature)
 
 ## Signature {#propertywithbadinheritdoctarget-signature}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.md
@@ -1,6 +1,6 @@
 # setterProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterface](/test-suite-a/testinterface-interface/) \> [setterProperty](/test-suite-a/testinterface-interface/setterproperty-property)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterface](/test-suite-a/testinterface-interface/) > [setterProperty](/test-suite-a/testinterface-interface/setterproperty-property)
 
 A test property with a getter and a setter.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature.md
@@ -1,6 +1,6 @@
 # testClassEventProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterface](/test-suite-a/testinterface-interface/) \> [testClassEventProperty](/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterface](/test-suite-a/testinterface-interface/) > [testClassEventProperty](/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature)
 
 Test interface event property
 
@@ -10,7 +10,7 @@ Test interface event property
 readonly testClassEventProperty: () => void;
 ```
 
-**Type**: () =\> void
+**Type**: () => void
 
 ## Remarks {#testclasseventproperty-remarks}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature.md
@@ -1,6 +1,6 @@
 # testInterfaceMethod
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterface](/test-suite-a/testinterface-interface/) \> [testInterfaceMethod()](/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterface](/test-suite-a/testinterface-interface/) > [testInterfaceMethod()](/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature)
 
 Test interface method
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature.md
@@ -1,6 +1,6 @@
 # testInterfaceProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterface](/test-suite-a/testinterface-interface/) \> [testInterfaceProperty](/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterface](/test-suite-a/testinterface-interface/) > [testInterfaceProperty](/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature)
 
 Test interface property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature.md
@@ -1,6 +1,6 @@
 # testOptionalInterfaceProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterface](/test-suite-a/testinterface-interface/) \> [testOptionalInterfaceProperty](/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterface](/test-suite-a/testinterface-interface/) > [testOptionalInterfaceProperty](/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature)
 
 Test optional property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.md
@@ -1,6 +1,6 @@
 # TestInterfaceExtendingOtherInterfaces
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface/)
 
 Test interface that extends other interfaces
 
@@ -10,7 +10,7 @@ Test interface that extends other interfaces
 export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter<number>
 ```
 
-**Extends**: [TestInterface](/test-suite-a/testinterface-interface/), [TestMappedType](/test-suite-a/testmappedtype-typealias/), [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)\<number\>
+**Extends**: [TestInterface](/test-suite-a/testinterface-interface/), [TestMappedType](/test-suite-a/testmappedtype-typealias/), [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)\<number>
 
 ## Remarks {#testinterfaceextendingotherinterfaces-remarks}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.md
@@ -1,6 +1,6 @@
 # testMethod
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface/) \> [testMethod(input)](/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface/) > [testMethod(input)](/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature)
 
 Test interface method accepting a string and returning a number.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature.md
@@ -1,6 +1,6 @@
 # \[foo: number\]: { bar: string; }
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface/) \> [\[foo: number\]: { bar: string; }](/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface/) > [\[foo: number\]: { bar: string; }](/test-suite-a/testinterfacewithindexsignature-interface/_indexer_-indexsignature)
 
 Test index signature.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithindexsignature-interface/index.md
@@ -1,6 +1,6 @@
 # TestInterfaceWithIndexSignature
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface/)
 
 An interface with an index signature.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.md
@@ -1,6 +1,6 @@
 # TestInterfaceWithTypeParameter
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)
 
 Test interface with generic type parameter
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature.md
@@ -1,6 +1,6 @@
 # testProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/) \> [testProperty](/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/) > [testProperty](/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature)
 
 A test interface property using generic type parameter
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmappedtype-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmappedtype-typealias/index.md
@@ -1,6 +1,6 @@
 # TestMappedType
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestMappedType](/test-suite-a/testmappedtype-typealias/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestMappedType](/test-suite-a/testmappedtype-typealias/)
 
 Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum/)
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/foo-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/foo-variable.md
@@ -1,6 +1,6 @@
 # foo
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestModule](/test-suite-a/testmodule-namespace/) \> [foo](/test-suite-a/testmodule-namespace/foo-variable)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestModule](/test-suite-a/testmodule-namespace/) > [foo](/test-suite-a/testmodule-namespace/foo-variable)
 
 Test constant in module.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.md
@@ -1,6 +1,6 @@
 # TestModule
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestModule](/test-suite-a/testmodule-namespace/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestModule](/test-suite-a/testmodule-namespace/)
 
 ## Variables
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.md
@@ -1,6 +1,6 @@
 # TestNamespace
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/)
 
 Test Namespace
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.md
@@ -1,6 +1,6 @@
 # (constructor)
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) \> [(constructor)(testClassProperty)](/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) > [(constructor)(testClassProperty)](/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor)
 
 Test class constructor
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.md
@@ -1,6 +1,6 @@
 # TestClass
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/)
 
 Test class
 
@@ -26,4 +26,4 @@ class TestClass
 
 | Method | Return Type | Description |
 | - | - | - |
-| [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method) | Promise\<string\> | Test class method |
+| [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method) | Promise\<string> | Test class method |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.md
@@ -1,6 +1,6 @@
 # testClassMethod
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) \> [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) > [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method)
 
 Test class method
 
@@ -20,7 +20,7 @@ testClassMethod(testParameter: string): Promise<string>;
 
 A Promise
 
-**Return type**: Promise\<string\>
+**Return type**: Promise\<string>
 
 ## Throws {#testclassmethod-throws}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property.md
@@ -1,6 +1,6 @@
 # testClassProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) \> [testClassProperty](/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestClass](/test-suite-a/testnamespace-namespace/testclass-class/) > [testClassProperty](/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property)
 
 Test interface property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testconst-variable.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testconst-variable.md
@@ -1,6 +1,6 @@
 # TestConst
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestConst](/test-suite-a/testnamespace-namespace/testconst-variable)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestConst](/test-suite-a/testnamespace-namespace/testconst-variable)
 
 Test Constant
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/index.md
@@ -1,6 +1,6 @@
 # TestEnum
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/)
 
 Test Enum
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember.md
@@ -1,6 +1,6 @@
 # TestEnumValue1
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/) \> [TestEnumValue1](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/) > [TestEnumValue1](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue1-enummember)
 
 Test enum value 1
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember.md
@@ -1,6 +1,6 @@
 # TestEnumValue2
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/) \> [TestEnumValue2](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/) > [TestEnumValue2](/test-suite-a/testnamespace-namespace/testenum-enum/testenumvalue2-enummember)
 
 Test enum value 2
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.md
@@ -1,6 +1,6 @@
 # testFunction
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [testFunction(testParameter)](/test-suite-a/testnamespace-namespace/testfunction-function)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [testFunction(testParameter)](/test-suite-a/testnamespace-namespace/testfunction-function)
 
 Test function
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.md
@@ -1,6 +1,6 @@
 # TestInterface
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/)
 
 Test interface
 
@@ -12,7 +12,7 @@ Test interface
 interface TestInterface extends TestInterfaceWithTypeParameter<TestEnum>
 ```
 
-**Extends**: [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)\<[TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/)\>
+**Extends**: [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)\<[TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum/)>
 
 ## Properties
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature.md
@@ -1,6 +1,6 @@
 # testInterfaceMethod
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/) \> [testInterfaceMethod()](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/) > [testInterfaceMethod()](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature)
 
 Test interface method
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature.md
@@ -1,6 +1,6 @@
 # testInterfaceProperty
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/) \> [testInterfaceProperty](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface/) > [testInterfaceProperty](/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature)
 
 Test interface property
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.md
@@ -1,6 +1,6 @@
 # TestSubNamespace
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/)
 
 Test sub-namespace
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testtypealias-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testtypealias-typealias/index.md
@@ -1,6 +1,6 @@
 # TestTypeAlias
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias/)
 
 Test Type-Alias
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/typealias-typealias/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/typealias-typealias/index.md
@@ -1,6 +1,6 @@
 # TypeAlias
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TypeAlias](/test-suite-a/typealias-typealias/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TypeAlias](/test-suite-a/typealias-typealias/)
 
 Test Type-Alias
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/bar-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/bar-propertysignature.md
@@ -1,6 +1,6 @@
 # bar
 
-[Packages](/) \> [test-suite-b](/test-suite-b/) \> [Foo](/test-suite-b/foo-interface/) \> [bar](/test-suite-b/foo-interface/bar-propertysignature)
+[Packages](/) > [test-suite-b](/test-suite-b/) > [Foo](/test-suite-b/foo-interface/) > [bar](/test-suite-b/foo-interface/bar-propertysignature)
 
 Test Enum
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/foo-interface/index.md
@@ -1,6 +1,6 @@
 # Foo
 
-[Packages](/) \> [test-suite-b](/test-suite-b/) \> [Foo](/test-suite-b/foo-interface/)
+[Packages](/) > [test-suite-b](/test-suite-b/) > [Foo](/test-suite-b/foo-interface/)
 
 Bar
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-b/index.md
@@ -1,6 +1,6 @@
 # test-suite-b
 
-[Packages](/) \> [test-suite-b](/test-suite-b/)
+[Packages](/) > [test-suite-b](/test-suite-b/)
 
 ## Interfaces
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
@@ -1,6 +1,6 @@
 # test-suite-a
 
-[Packages](/) \> [test-suite-a](/test-suite-a/)
+[Packages](/) > [test-suite-a](/test-suite-a/)
 
 Test package
 
@@ -74,7 +74,7 @@ const foo = bar;
 | - | - | - | - |
 | [testFunction(testParameter, testOptionalParameter)](/test-suite-a/#testfunction-function) | `Alpha` | TTypeParameter | Test function |
 | [testFunctionReturningInlineType()](/test-suite-a/#testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum); } | Test function that returns an inline type |
-| [testFunctionReturningIntersectionType()](/test-suite-a/#testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)\<number\> | Test function that returns an inline type |
+| [testFunctionReturningIntersectionType()](/test-suite-a/#testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)\<number> | Test function that returns an inline type |
 | [testFunctionReturningUnionType()](/test-suite-a/#testfunctionreturninguniontype-function) |  | string \| [TestInterface](/test-suite-a/testinterface-interface) | Test function that returns an inline type |
 
 ## Variables
@@ -170,7 +170,7 @@ export declare function testFunctionReturningIntersectionType(): TestEmptyInterf
 
 an intersection type
 
-**Return type**: [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)\<number\>
+**Return type**: [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)\<number>
 
 ### testFunctionReturningUnionType {#testfunctionreturninguniontype-function}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testabstractclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testabstractclass-class.md
@@ -1,6 +1,6 @@
 # TestAbstractClass
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestAbstractClass](/test-suite-a/testabstractclass-class)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestAbstractClass](/test-suite-a/testabstractclass-class)
 
 A test abstract class.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testbetanamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testbetanamespace-namespace/index.md
@@ -1,6 +1,6 @@
 # TestBetaNamespace
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/)
 
 A namespace tagged as `@beta`.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
@@ -1,6 +1,6 @@
 # TestClass
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestClass](/test-suite-a/testclass-class)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestClass](/test-suite-a/testclass-class)
 
 Test class
 
@@ -33,7 +33,7 @@ Here are some remarks about the class
 
 | Property | Type | Description |
 | - | - | - |
-| [testClassStaticProperty](/test-suite-a/testclass-class#testclassstaticproperty-property) | (foo: number) =\> string | Test static class property |
+| [testClassStaticProperty](/test-suite-a/testclass-class#testclassstaticproperty-property) | (foo: number) => string | Test static class property |
 
 ## Static Methods
 
@@ -45,7 +45,7 @@ Here are some remarks about the class
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [testClassEventProperty](/test-suite-a/testclass-class#testclasseventproperty-property) | `readonly` | () =\> void | Test class event property |
+| [testClassEventProperty](/test-suite-a/testclass-class#testclasseventproperty-property) | `readonly` | () => void | Test class event property |
 
 ## Properties
 
@@ -86,7 +86,7 @@ Here are some remarks about the constructor
 | privateProperty | number | See [TestAbstractClass](/test-suite-a/testabstractclass-class)'s constructor. |
 | protectedProperty | [TestEnum](/test-suite-a/testenum-enum) | <p>Some notes about the parameter.</p><p>See <a href="/test-suite-a/testabstractclass-class#protectedproperty-property">protectedProperty</a>.</p> |
 | testClassProperty | TTypeParameterB | See [testClassProperty](/test-suite-a/testclass-class#testclassproperty-property). |
-| testClassEventProperty | () =\> void | See [testClassEventProperty](/test-suite-a/testclass-class#testclasseventproperty-property). |
+| testClassEventProperty | () => void | See [testClassEventProperty](/test-suite-a/testclass-class#testclasseventproperty-property). |
 
 ## Event Details
 
@@ -100,7 +100,7 @@ Test class event property
 readonly testClassEventProperty: () => void;
 ```
 
-**Type**: () =\> void
+**Type**: () => void
 
 #### Remarks {#testclasseventproperty-remarks}
 
@@ -164,7 +164,7 @@ Test static class property
 static testClassStaticProperty: (foo: number) => string;
 ```
 
-**Type**: (foo: number) =\> string
+**Type**: (foo: number) => string
 
 ## Method Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testemptyinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testemptyinterface-interface.md
@@ -1,6 +1,6 @@
 # TestEmptyInterface
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestEmptyInterface](/test-suite-a/testemptyinterface-interface)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestEmptyInterface](/test-suite-a/testemptyinterface-interface)
 
 An empty interface
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testenum-enum.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testenum-enum.md
@@ -1,6 +1,6 @@
 # TestEnum
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestEnum](/test-suite-a/testenum-enum)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestEnum](/test-suite-a/testenum-enum)
 
 Test Enum
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
@@ -1,6 +1,6 @@
 # TestInterface
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterface](/test-suite-a/testinterface-interface)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterface](/test-suite-a/testinterface-interface)
 
 Test interface
 
@@ -24,7 +24,7 @@ Here are some remarks about the interface
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [testClassEventProperty](/test-suite-a/testinterface-interface#testclasseventproperty-propertysignature) | `readonly` | () =\> void | Test interface event property |
+| [testClassEventProperty](/test-suite-a/testinterface-interface#testclasseventproperty-propertysignature) | `readonly` | () => void | Test interface event property |
 
 ## Properties
 
@@ -46,8 +46,8 @@ Here are some remarks about the interface
 
 | CallSignature | Description |
 | - | - |
-| [(event: 'testCallSignature', listener: (input: unknown) =\> void): any](/test-suite-a/testinterface-interface#_call_-callsignature) | Test interface event call signature |
-| [(event: 'anotherTestCallSignature', listener: (input: number) =\> string): number](/test-suite-a/testinterface-interface#_call__1-callsignature) | Another example call signature |
+| [(event: 'testCallSignature', listener: (input: unknown) => void): any](/test-suite-a/testinterface-interface#_call_-callsignature) | Test interface event call signature |
+| [(event: 'anotherTestCallSignature', listener: (input: number) => string): number](/test-suite-a/testinterface-interface#_call__1-callsignature) | Another example call signature |
 
 ## Constructor Details
 
@@ -77,7 +77,7 @@ Test interface event property
 readonly testClassEventProperty: () => void;
 ```
 
-**Type**: () =\> void
+**Type**: () => void
 
 #### Remarks {#testclasseventproperty-remarks}
 
@@ -166,7 +166,7 @@ Here are some remarks about the method
 
 ## Call Signature Details
 
-### (event: 'testCallSignature', listener: (input: unknown) =\> void): any {#\_call\_-callsignature}
+### (event: 'testCallSignature', listener: (input: unknown) => void): any {#\_call\_-callsignature}
 
 Test interface event call signature
 
@@ -180,7 +180,7 @@ Test interface event call signature
 
 Here are some remarks about the event call signature
 
-### (event: 'anotherTestCallSignature', listener: (input: number) =\> string): number {#\_call\_\_1-callsignature}
+### (event: 'anotherTestCallSignature', listener: (input: number) => string): number {#\_call\_\_1-callsignature}
 
 Another example call signature
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.md
@@ -1,6 +1,6 @@
 # TestInterfaceExtendingOtherInterfaces
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterfaceExtendingOtherInterfaces](/test-suite-a/testinterfaceextendingotherinterfaces-interface)
 
 Test interface that extends other interfaces
 
@@ -10,7 +10,7 @@ Test interface that extends other interfaces
 export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter<number>
 ```
 
-**Extends**: [TestInterface](/test-suite-a/testinterface-interface), [TestMappedType](/test-suite-a/testmappedtype-typealias), [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)\<number\>
+**Extends**: [TestInterface](/test-suite-a/testinterface-interface), [TestMappedType](/test-suite-a/testmappedtype-typealias), [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)\<number>
 
 ## Remarks {#testinterfaceextendingotherinterfaces-remarks}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithindexsignature-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithindexsignature-interface.md
@@ -1,6 +1,6 @@
 # TestInterfaceWithIndexSignature
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterfaceWithIndexSignature](/test-suite-a/testinterfacewithindexsignature-interface)
 
 An interface with an index signature.
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithtypeparameter-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterfacewithtypeparameter-interface.md
@@ -1,6 +1,6 @@
 # TestInterfaceWithTypeParameter
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)
 
 Test interface with generic type parameter
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testmappedtype-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testmappedtype-typealias.md
@@ -1,6 +1,6 @@
 # TestMappedType
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestMappedType](/test-suite-a/testmappedtype-typealias)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestMappedType](/test-suite-a/testmappedtype-typealias)
 
 Test Mapped Type, using [TestEnum](/test-suite-a/testenum-enum)
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testmodule-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testmodule-namespace/index.md
@@ -1,6 +1,6 @@
 # TestModule
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestModule](/test-suite-a/testmodule-namespace/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestModule](/test-suite-a/testmodule-namespace/)
 
 ## Variables
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.md
@@ -1,6 +1,6 @@
 # TestNamespace
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/)
 
 Test Namespace
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testclass-class.md
@@ -1,6 +1,6 @@
 # TestClass
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestClass](/test-suite-a/testnamespace-namespace/testclass-class)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestClass](/test-suite-a/testnamespace-namespace/testclass-class)
 
 Test class
 
@@ -26,7 +26,7 @@ class TestClass
 
 | Method | Return Type | Description |
 | - | - | - |
-| [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class#testclassmethod-method) | Promise\<string\> | Test class method |
+| [testClassMethod(testParameter)](/test-suite-a/testnamespace-namespace/testclass-class#testclassmethod-method) | Promise\<string> | Test class method |
 
 ## Constructor Details
 
@@ -82,7 +82,7 @@ testClassMethod(testParameter: string): Promise<string>;
 
 A Promise
 
-**Return type**: Promise\<string\>
+**Return type**: Promise\<string>
 
 #### Throws {#testclassmethod-throws}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testenum-enum.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testenum-enum.md
@@ -1,6 +1,6 @@
 # TestEnum
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum)
 
 Test Enum
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testinterface-interface.md
@@ -1,6 +1,6 @@
 # TestInterface
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestInterface](/test-suite-a/testnamespace-namespace/testinterface-interface)
 
 Test interface
 
@@ -12,7 +12,7 @@ Test interface
 interface TestInterface extends TestInterfaceWithTypeParameter<TestEnum>
 ```
 
-**Extends**: [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)\<[TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum)\>
+**Extends**: [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)\<[TestEnum](/test-suite-a/testnamespace-namespace/testenum-enum)>
 
 ## Properties
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/index.md
@@ -1,6 +1,6 @@
 # TestSubNamespace
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestSubNamespace](/test-suite-a/testnamespace-namespace/testsubnamespace-namespace/)
 
 Test sub-namespace
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testtypealias-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testtypealias-typealias.md
@@ -1,6 +1,6 @@
 # TestTypeAlias
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TestNamespace](/test-suite-a/testnamespace-namespace/) \> [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TestNamespace](/test-suite-a/testnamespace-namespace/) > [TestTypeAlias](/test-suite-a/testnamespace-namespace/testtypealias-typealias)
 
 Test Type-Alias
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/typealias-typealias.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/typealias-typealias.md
@@ -1,6 +1,6 @@
 # TypeAlias
 
-[Packages](/) \> [test-suite-a](/test-suite-a/) \> [TypeAlias](/test-suite-a/typealias-typealias)
+[Packages](/) > [test-suite-a](/test-suite-a/) > [TypeAlias](/test-suite-a/typealias-typealias)
 
 Test Type-Alias
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-b/foo-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-b/foo-interface.md
@@ -1,6 +1,6 @@
 # Foo
 
-[Packages](/) \> [test-suite-b](/test-suite-b/) \> [Foo](/test-suite-b/foo-interface)
+[Packages](/) > [test-suite-b](/test-suite-b/) > [Foo](/test-suite-b/foo-interface)
 
 Bar
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-b/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-b/index.md
@@ -1,6 +1,6 @@
 # test-suite-b
 
-[Packages](/) \> [test-suite-b](/test-suite-b/)
+[Packages](/) > [test-suite-b](/test-suite-b/)
 
 ## Interfaces
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
@@ -1,4 +1,4 @@
-[Packages](docs/) \> [test-suite-a](docs/test-suite-a)
+[Packages](docs/) > [test-suite-a](docs/test-suite-a)
 
 Test package
 
@@ -71,7 +71,7 @@ const foo = bar;
 | Function | Alerts | Return Type | Description |
 | - | - | - | - |
 | [testFunctionReturningInlineType()](docs/test-suite-a#testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](docs/test-suite-a#testenum-enum); } | Test function that returns an inline type |
-| [testFunctionReturningIntersectionType()](docs/test-suite-a#testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](docs/test-suite-a#testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](docs/test-suite-a#testinterfacewithtypeparameter-interface)\<number\> | Test function that returns an inline type |
+| [testFunctionReturningIntersectionType()](docs/test-suite-a#testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](docs/test-suite-a#testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](docs/test-suite-a#testinterfacewithtypeparameter-interface)\<number> | Test function that returns an inline type |
 | [testFunctionReturningUnionType()](docs/test-suite-a#testfunctionreturninguniontype-function) |  | string \| [TestInterface](docs/test-suite-a#testinterface-interface) | Test function that returns an inline type |
 
 # Variables
@@ -125,7 +125,7 @@ Here are some remarks about the interface
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [testClassEventProperty](docs/test-suite-a#testinterface-testclasseventproperty-propertysignature) | `readonly` | () =\> void | Test interface event property |
+| [testClassEventProperty](docs/test-suite-a#testinterface-testclasseventproperty-propertysignature) | `readonly` | () => void | Test interface event property |
 
 ### Properties
 
@@ -147,8 +147,8 @@ Here are some remarks about the interface
 
 | CallSignature | Description |
 | - | - |
-| [(event: 'testCallSignature', listener: (input: unknown) =\> void): any](docs/test-suite-a#testinterface-_call_-callsignature) | Test interface event call signature |
-| [(event: 'anotherTestCallSignature', listener: (input: number) =\> string): number](docs/test-suite-a#testinterface-_call__1-callsignature) | Another example call signature |
+| [(event: 'testCallSignature', listener: (input: unknown) => void): any](docs/test-suite-a#testinterface-_call_-callsignature) | Test interface event call signature |
+| [(event: 'anotherTestCallSignature', listener: (input: number) => string): number](docs/test-suite-a#testinterface-_call__1-callsignature) | Another example call signature |
 
 ### Constructor Details
 
@@ -178,7 +178,7 @@ Test interface event property
 readonly testClassEventProperty: () => void;
 ```
 
-**Type**: () =\> void
+**Type**: () => void
 
 ##### Remarks {#testclasseventproperty-remarks}
 
@@ -267,7 +267,7 @@ Here are some remarks about the method
 
 ### Call Signature Details
 
-#### (event: 'testCallSignature', listener: (input: unknown) =\> void): any {#testinterface-\_call\_-callsignature}
+#### (event: 'testCallSignature', listener: (input: unknown) => void): any {#testinterface-\_call\_-callsignature}
 
 Test interface event call signature
 
@@ -281,7 +281,7 @@ Test interface event call signature
 
 Here are some remarks about the event call signature
 
-#### (event: 'anotherTestCallSignature', listener: (input: number) =\> string): number {#testinterface-\_call\_\_1-callsignature}
+#### (event: 'anotherTestCallSignature', listener: (input: number) => string): number {#testinterface-\_call\_\_1-callsignature}
 
 Another example call signature
 
@@ -315,7 +315,7 @@ Test interface that extends other interfaces
 export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter<number>
 ```
 
-**Extends**: [TestInterface](docs/test-suite-a#testinterface-interface), [TestMappedType](docs/test-suite-a#testmappedtype-typealias), [TestInterfaceWithTypeParameter](docs/test-suite-a#testinterfacewithtypeparameter-interface)\<number\>
+**Extends**: [TestInterface](docs/test-suite-a#testinterface-interface), [TestMappedType](docs/test-suite-a#testmappedtype-typealias), [TestInterfaceWithTypeParameter](docs/test-suite-a#testinterfacewithtypeparameter-interface)\<number>
 
 ### Remarks {#testinterfaceextendingotherinterfaces-remarks}
 
@@ -594,7 +594,7 @@ Here are some remarks about the class
 
 | Property | Type | Description |
 | - | - | - |
-| [testClassStaticProperty](docs/test-suite-a#testclass-testclassstaticproperty-property) | (foo: number) =\> string | Test static class property |
+| [testClassStaticProperty](docs/test-suite-a#testclass-testclassstaticproperty-property) | (foo: number) => string | Test static class property |
 
 ### Static Methods
 
@@ -606,7 +606,7 @@ Here are some remarks about the class
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [testClassEventProperty](docs/test-suite-a#testclass-testclasseventproperty-property) | `readonly` | () =\> void | Test class event property |
+| [testClassEventProperty](docs/test-suite-a#testclass-testclasseventproperty-property) | `readonly` | () => void | Test class event property |
 
 ### Properties
 
@@ -647,7 +647,7 @@ Here are some remarks about the constructor
 | privateProperty | number | See [TestAbstractClass](docs/test-suite-a#testabstractclass-class)'s constructor. |
 | protectedProperty | [TestEnum](docs/test-suite-a#testenum-enum) | <p>Some notes about the parameter.</p><p>See <a href="docs/test-suite-a#testabstractclass-protectedproperty-property">protectedProperty</a>.</p> |
 | testClassProperty | TTypeParameterB | See [testClassProperty](docs/test-suite-a#testclass-testclassproperty-property). |
-| testClassEventProperty | () =\> void | See [testClassEventProperty](docs/test-suite-a#testclass-testclasseventproperty-property). |
+| testClassEventProperty | () => void | See [testClassEventProperty](docs/test-suite-a#testclass-testclasseventproperty-property). |
 
 ### Event Details
 
@@ -661,7 +661,7 @@ Test class event property
 readonly testClassEventProperty: () => void;
 ```
 
-**Type**: () =\> void
+**Type**: () => void
 
 ##### Remarks {#testclasseventproperty-remarks}
 
@@ -725,7 +725,7 @@ Test static class property
 static testClassStaticProperty: (foo: number) => string;
 ```
 
-**Type**: (foo: number) =\> string
+**Type**: (foo: number) => string
 
 ### Method Details
 
@@ -966,7 +966,7 @@ export declare function testFunctionReturningIntersectionType(): TestEmptyInterf
 
 an intersection type
 
-**Return type**: [TestEmptyInterface](docs/test-suite-a#testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](docs/test-suite-a#testinterfacewithtypeparameter-interface)\<number\>
+**Return type**: [TestEmptyInterface](docs/test-suite-a#testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](docs/test-suite-a#testinterfacewithtypeparameter-interface)\<number>
 
 ## testFunctionReturningUnionType {#testfunctionreturninguniontype-function}
 
@@ -1181,7 +1181,7 @@ class TestClass
 
 | Method | Return Type | Description |
 | - | - | - |
-| [testClassMethod(testParameter)](docs/test-suite-a#testnamespace-testclass-testclassmethod-method) | Promise\<string\> | Test class method |
+| [testClassMethod(testParameter)](docs/test-suite-a#testnamespace-testclass-testclassmethod-method) | Promise\<string> | Test class method |
 
 ##### Constructor Details
 
@@ -1243,7 +1243,7 @@ testClassMethod(testParameter: string): Promise<string>;
 
 A Promise
 
-**Return type**: Promise\<string\>
+**Return type**: Promise\<string>
 
 <a id="testclassmethod-throws"></a>
 **Throws**

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-b.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-b.md
@@ -1,4 +1,4 @@
-[Packages](docs/) \> [test-suite-b](docs/test-suite-b)
+[Packages](docs/) > [test-suite-b](docs/test-suite-b)
 
 # Interfaces
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/index.md
@@ -71,7 +71,7 @@ const foo = bar;
 | Function | Alerts | Return Type | Description |
 | - | - | - | - |
 | [testFunctionReturningInlineType()](docs/test-suite-a/testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](docs/test-suite-a/testenum-enum); } | Test function that returns an inline type |
-| [testFunctionReturningIntersectionType()](docs/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](docs/test-suite-a/testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](docs/test-suite-a/testinterfacewithtypeparameter-interface)\<number\> | Test function that returns an inline type |
+| [testFunctionReturningIntersectionType()](docs/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](docs/test-suite-a/testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](docs/test-suite-a/testinterfacewithtypeparameter-interface)\<number> | Test function that returns an inline type |
 | [testFunctionReturningUnionType()](docs/test-suite-a/testfunctionreturninguniontype-function) |  | string \| [TestInterface](docs/test-suite-a/testinterface-interface) | Test function that returns an inline type |
 
 ### Variables

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-_constructor_-constructor.md
@@ -19,4 +19,4 @@ Here are some remarks about the constructor
 | privateProperty | number | See [TestAbstractClass](docs/test-suite-a/testabstractclass-class)'s constructor. |
 | protectedProperty | [TestEnum](docs/test-suite-a/testenum-enum) | <p>Some notes about the parameter.</p><p>See <a href="docs/test-suite-a/testabstractclass-protectedproperty-property">protectedProperty</a>.</p> |
 | testClassProperty | TTypeParameterB | See [testClassProperty](docs/test-suite-a/testclass-testclassproperty-property). |
-| testClassEventProperty | () =\> void | See [testClassEventProperty](docs/test-suite-a/testclass-testclasseventproperty-property). |
+| testClassEventProperty | () => void | See [testClassEventProperty](docs/test-suite-a/testclass-testclasseventproperty-property). |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-class.md
@@ -31,7 +31,7 @@ Here are some remarks about the class
 
 | Property | Type | Description |
 | - | - | - |
-| [testClassStaticProperty](docs/test-suite-a/testclass-testclassstaticproperty-property) | (foo: number) =\> string | Test static class property |
+| [testClassStaticProperty](docs/test-suite-a/testclass-testclassstaticproperty-property) | (foo: number) => string | Test static class property |
 
 ### Static Methods
 
@@ -43,7 +43,7 @@ Here are some remarks about the class
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [testClassEventProperty](docs/test-suite-a/testclass-testclasseventproperty-property) | `readonly` | () =\> void | Test class event property |
+| [testClassEventProperty](docs/test-suite-a/testclass-testclasseventproperty-property) | `readonly` | () => void | Test class event property |
 
 ### Properties
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-testclasseventproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-testclasseventproperty-property.md
@@ -8,7 +8,7 @@ Test class event property
 readonly testClassEventProperty: () => void;
 ```
 
-**Type**: () =\> void
+**Type**: () => void
 
 ### Remarks {#testclasseventproperty-remarks}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-testclassstaticproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-testclassstaticproperty-property.md
@@ -8,4 +8,4 @@ Test static class property
 static testClassStaticProperty: (foo: number) => string;
 ```
 
-**Type**: (foo: number) =\> string
+**Type**: (foo: number) => string

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testfunctionreturningintersectiontype-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testfunctionreturningintersectiontype-function.md
@@ -16,4 +16,4 @@ export declare function testFunctionReturningIntersectionType(): TestEmptyInterf
 
 an intersection type
 
-**Return type**: [TestEmptyInterface](docs/test-suite-a/testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](docs/test-suite-a/testinterfacewithtypeparameter-interface)\<number\>
+**Return type**: [TestEmptyInterface](docs/test-suite-a/testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](docs/test-suite-a/testinterfacewithtypeparameter-interface)\<number>

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-_call_-callsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-_call_-callsignature.md
@@ -1,4 +1,4 @@
-## (event: 'testCallSignature', listener: (input: unknown) =\> void): any
+## (event: 'testCallSignature', listener: (input: unknown) => void): any
 
 Test interface event call signature
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-_call__1-callsignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-_call__1-callsignature.md
@@ -1,4 +1,4 @@
-## (event: 'anotherTestCallSignature', listener: (input: number) =\> string): number
+## (event: 'anotherTestCallSignature', listener: (input: number) => string): number
 
 Another example call signature
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-interface.md
@@ -22,7 +22,7 @@ Here are some remarks about the interface
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [testClassEventProperty](docs/test-suite-a/testinterface-testclasseventproperty-propertysignature) | `readonly` | () =\> void | Test interface event property |
+| [testClassEventProperty](docs/test-suite-a/testinterface-testclasseventproperty-propertysignature) | `readonly` | () => void | Test interface event property |
 
 ### Properties
 
@@ -44,8 +44,8 @@ Here are some remarks about the interface
 
 | CallSignature | Description |
 | - | - |
-| [(event: 'testCallSignature', listener: (input: unknown) =\> void): any](docs/test-suite-a/testinterface-_call_-callsignature) | Test interface event call signature |
-| [(event: 'anotherTestCallSignature', listener: (input: number) =\> string): number](docs/test-suite-a/testinterface-_call__1-callsignature) | Another example call signature |
+| [(event: 'testCallSignature', listener: (input: unknown) => void): any](docs/test-suite-a/testinterface-_call_-callsignature) | Test interface event call signature |
+| [(event: 'anotherTestCallSignature', listener: (input: number) => string): number](docs/test-suite-a/testinterface-_call__1-callsignature) | Another example call signature |
 
 ### See Also {#testinterface-see-also}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-testclasseventproperty-propertysignature.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-testclasseventproperty-propertysignature.md
@@ -8,7 +8,7 @@ Test interface event property
 readonly testClassEventProperty: () => void;
 ```
 
-**Type**: () =\> void
+**Type**: () => void
 
 ### Remarks {#testclasseventproperty-remarks}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.md
@@ -8,7 +8,7 @@ Test interface that extends other interfaces
 export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter<number>
 ```
 
-**Extends**: [TestInterface](docs/test-suite-a/testinterface-interface), [TestMappedType](docs/test-suite-a/testmappedtype-typealias), [TestInterfaceWithTypeParameter](docs/test-suite-a/testinterfacewithtypeparameter-interface)\<number\>
+**Extends**: [TestInterface](docs/test-suite-a/testinterface-interface), [TestMappedType](docs/test-suite-a/testmappedtype-typealias), [TestInterfaceWithTypeParameter](docs/test-suite-a/testinterfacewithtypeparameter-interface)\<number>
 
 ### Remarks {#testinterfaceextendingotherinterfaces-remarks}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-class.md
@@ -24,4 +24,4 @@ class TestClass
 
 | Method | Return Type | Description |
 | - | - | - |
-| [testClassMethod(testParameter)](docs/test-suite-a/testnamespace-testclass-testclassmethod-method) | Promise\<string\> | Test class method |
+| [testClassMethod(testParameter)](docs/test-suite-a/testnamespace-testclass-testclassmethod-method) | Promise\<string> | Test class method |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-testclassmethod-method.md
@@ -18,7 +18,7 @@ testClassMethod(testParameter: string): Promise<string>;
 
 A Promise
 
-**Return type**: Promise\<string\>
+**Return type**: Promise\<string>
 
 ### Throws {#testclassmethod-throws}
 


### PR DESCRIPTION
Escaping of `>` is not strictly required in Markdown. `>` only has special meaning if it is closing an unescaped `<`. So, as long as we continue to escape the latter, we don't need to escape the former.

The primary goal of this PR is to align our Markdown rendering with the behavior of `mdast-util-to-markdown`, which we plan to use to replace our custom Markdown rendering.