### PR TITLE
improvement(api-markdown-documenter): Simplify empty table cell rendering in Markdown

### DIFF
--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderTableRow.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderTableRow.ts
@@ -24,11 +24,19 @@ export function renderTableRow(
 	writer.write("| ");
 	for (let i = 0; i < node.children.length; i++) {
 		const child = node.children[i];
-		renderNode(child, writer, {
-			...context,
-			insideTable: true,
-		});
-		writer.write(i === node.children.length - 1 ? " |" : " | ");
+
+		if (child.isEmpty) {
+			writer.write("|");
+		} else {
+			renderNode(child, writer, {
+				...context,
+				insideTable: true,
+			});
+			writer.write(" |");
+		}
+		if (i < node.children.length - 1) {
+			writer.write(" ");
+		}
 	}
 	writer.ensureNewLine(); // Ensure line break after row
 }

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/index.md
@@ -5,4 +5,4 @@
 | Package | Description |
 | - | - |
 | [test-suite-a](/test-suite-a/) | Test package |
-| [test-suite-b](/test-suite-b/) |  |
+| [test-suite-b](/test-suite-b/) | |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/index.md
@@ -73,15 +73,15 @@ const foo = bar;
 | Function | Alerts | Return Type | Description |
 | - | - | - | - |
 | [testFunction(testParameter, testOptionalParameter)](/test-suite-a/testfunction-function) | `Alpha` | TTypeParameter | Test function |
-| [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum/); } | Test function that returns an inline type |
+| [testFunctionReturningInlineType()](/test-suite-a/testfunctionreturninginlinetype-function) | | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum/); } | Test function that returns an inline type |
 | [testFunctionReturningIntersectionType()](/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface/) \& [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface/)\<number\> | Test function that returns an inline type |
-| [testFunctionReturningUnionType()](/test-suite-a/testfunctionreturninguniontype-function) |  | string \| [TestInterface](/test-suite-a/testinterface-interface/) | Test function that returns an inline type |
+| [testFunctionReturningUnionType()](/test-suite-a/testfunctionreturninguniontype-function) | | string \| [TestInterface](/test-suite-a/testinterface-interface/) | Test function that returns an inline type |
 
 ## Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
 | - | - | - | - | - |
-| [testConst](/test-suite-a/testconst-variable) | `Beta` | `readonly` |  | Test Constant |
+| [testConst](/test-suite-a/testconst-variable) | `Beta` | `readonly` | | Test Constant |
 | [testConstWithEmptyDeprecatedBlock](/test-suite-a/testconstwithemptydeprecatedblock-variable) | `Deprecated` | `readonly` | string | I have a `@deprecated` tag with an empty comment block. |
 
 ## Namespaces
@@ -89,5 +89,5 @@ const foo = bar;
 | Namespace | Alerts | Description |
 | - | - | - |
 | [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/) | `Beta` | A namespace tagged as `@beta`. |
-| [TestModule](/test-suite-a/testmodule-namespace/) |  |  |
-| [TestNamespace](/test-suite-a/testnamespace-namespace/) |  | Test Namespace |
+| [TestModule](/test-suite-a/testmodule-namespace/) | | |
+| [TestNamespace](/test-suite-a/testnamespace-namespace/) | | Test Namespace |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.md
@@ -14,5 +14,5 @@ protected constructor(privateProperty: number, protectedProperty: TestEnum);
 
 | Parameter | Type | Description |
 | - | - | - |
-| privateProperty | number |  |
-| protectedProperty | [TestEnum](/test-suite-a/testenum-enum/) |  |
+| privateProperty | number | |
+| protectedProperty | [TestEnum](/test-suite-a/testenum-enum/) | |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.md
@@ -27,6 +27,6 @@ export declare abstract class TestAbstractClass
 
 | Method | Modifiers | Return Type | Description |
 | - | - | - | - |
-| [publicAbstractMethod()](/test-suite-a/testabstractclass-class/publicabstractmethod-method) |  | void | A test public abstract method. |
+| [publicAbstractMethod()](/test-suite-a/testabstractclass-class/publicabstractmethod-method) | | void | A test public abstract method. |
 | [sealedMethod()](/test-suite-a/testabstractclass-class/sealedmethod-method) | `sealed` | string | A test `@sealed` method. |
 | [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method) | `virtual` | number | A test `@virtual` method. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testbetanamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testbetanamespace-namespace/index.md
@@ -20,6 +20,6 @@ Tests release level inheritance.
 
 | Variable | Alerts | Modifiers | Type | Description |
 | - | - | - | - | - |
-| [alphaMember](/test-suite-a/testbetanamespace-namespace/alphamember-variable) | `Alpha` | `readonly` |  |  |
-| [betaMember](/test-suite-a/testbetanamespace-namespace/betamember-variable) | `Beta` | `readonly` |  |  |
-| [publicMember](/test-suite-a/testbetanamespace-namespace/publicmember-variable) | `Beta` | `readonly` |  |  |
+| [alphaMember](/test-suite-a/testbetanamespace-namespace/alphamember-variable) | `Alpha` | `readonly` | | |
+| [betaMember](/test-suite-a/testbetanamespace-namespace/betamember-variable) | `Beta` | `readonly` | | |
+| [publicMember](/test-suite-a/testbetanamespace-namespace/publicmember-variable) | `Beta` | `readonly` | | |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/index.md
@@ -59,9 +59,9 @@ Here are some remarks about the class
 
 | Method | Modifiers | Return Type | Description |
 | - | - | - | - |
-| [publicAbstractMethod()](/test-suite-a/testclass-class/publicabstractmethod-method) |  | void | A test public abstract method. |
+| [publicAbstractMethod()](/test-suite-a/testclass-class/publicabstractmethod-method) | | void | A test public abstract method. |
 | [testClassMethod(input)](/test-suite-a/testclass-class/testclassmethod-method) | `sealed` | TTypeParameterA | Test class method |
-| [virtualMethod()](/test-suite-a/testclass-class/virtualmethod-method) |  | number | Overrides [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method). |
+| [virtualMethod()](/test-suite-a/testclass-class/virtualmethod-method) | | number | Overrides [virtualMethod()](/test-suite-a/testabstractclass-class/virtualmethod-method). |
 
 ## See Also {#testclass-see-also}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.md
@@ -19,7 +19,7 @@ Here are some remarks about the method
 
 | Parameter | Type | Description |
 | - | - | - |
-| input | TTypeParameterA |  |
+| input | TTypeParameterA | |
 
 ## Returns {#testclassmethod-returns}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunction-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testfunction-function.md
@@ -26,8 +26,8 @@ This is a test [link](/test-suite-a/testinterface-interface/) to another API mem
 
 | Parameter | Modifiers | Type | Description |
 | - | - | - | - |
-| testParameter |  | TTypeParameter | A test parameter |
-| testOptionalParameter | optional | TTypeParameter |  |
+| testParameter | | TTypeParameter | A test parameter |
+| testOptionalParameter | optional | TTypeParameter | |
 
 ## Returns {#testfunction-returns}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.md
@@ -30,10 +30,10 @@ Here are some remarks about the interface
 
 | Property | Modifiers | Default Value | Type | Description |
 | - | - | - | - | - |
-| [getterProperty](/test-suite-a/testinterface-interface/getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
-| [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature) |  |  | boolean |  |
-| [setterProperty](/test-suite-a/testinterface-interface/setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
-| [testInterfaceProperty](/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature) |  |  | number | Test interface property |
+| [getterProperty](/test-suite-a/testinterface-interface/getterproperty-property) | `readonly` | | boolean | A test getter-only interface property. |
+| [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature) | | | boolean | |
+| [setterProperty](/test-suite-a/testinterface-interface/setterproperty-property) | | | boolean | A test property with a getter and a setter. |
+| [testInterfaceProperty](/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature) | | | number | Test interface property |
 | [testOptionalInterfaceProperty](/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature) | `optional` | 0 | number | Test optional property |
 
 ## Methods

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testmodule-namespace/index.md
@@ -6,4 +6,4 @@
 
 | Variable | Modifiers | Type | Description |
 | - | - | - | - |
-| [foo](/test-suite-a/testmodule-namespace/foo-variable) | `readonly` |  | Test constant in module. |
+| [foo](/test-suite-a/testmodule-namespace/foo-variable) | `readonly` | | Test constant in module. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.md
@@ -68,7 +68,7 @@ const foo = {
 
 | Variable | Alerts | Modifiers | Type | Description |
 | - | - | - | - | - |
-| [TestConst](/test-suite-a/testnamespace-namespace/testconst-variable) | `Beta` | `readonly` |  | Test Constant |
+| [TestConst](/test-suite-a/testnamespace-namespace/testconst-variable) | `Beta` | `readonly` | | Test Constant |
 
 ## Namespaces
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.md
@@ -14,7 +14,7 @@ function testFunction(testParameter: number): number;
 
 | Parameter | Type | Description |
 | - | - | - |
-| testParameter | number |  |
+| testParameter | number | |
 
 ## Returns {#testfunction-returns}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/index.md
@@ -5,4 +5,4 @@
 | Package | Description |
 | - | - |
 | [test-suite-a](/test-suite-a/) | Test package |
-| [test-suite-b](/test-suite-b/) |  |
+| [test-suite-b](/test-suite-b/) | |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/index.md
@@ -73,15 +73,15 @@ const foo = bar;
 | Function | Alerts | Return Type | Description |
 | - | - | - | - |
 | [testFunction(testParameter, testOptionalParameter)](/test-suite-a/#testfunction-function) | `Alpha` | TTypeParameter | Test function |
-| [testFunctionReturningInlineType()](/test-suite-a/#testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum); } | Test function that returns an inline type |
+| [testFunctionReturningInlineType()](/test-suite-a/#testfunctionreturninginlinetype-function) | | {     foo: number;     bar: [TestEnum](/test-suite-a/testenum-enum); } | Test function that returns an inline type |
 | [testFunctionReturningIntersectionType()](/test-suite-a/#testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](/test-suite-a/testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](/test-suite-a/testinterfacewithtypeparameter-interface)\<number\> | Test function that returns an inline type |
-| [testFunctionReturningUnionType()](/test-suite-a/#testfunctionreturninguniontype-function) |  | string \| [TestInterface](/test-suite-a/testinterface-interface) | Test function that returns an inline type |
+| [testFunctionReturningUnionType()](/test-suite-a/#testfunctionreturninguniontype-function) | | string \| [TestInterface](/test-suite-a/testinterface-interface) | Test function that returns an inline type |
 
 ## Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
 | - | - | - | - | - |
-| [testConst](/test-suite-a/#testconst-variable) | `Beta` | `readonly` |  | Test Constant |
+| [testConst](/test-suite-a/#testconst-variable) | `Beta` | `readonly` | | Test Constant |
 | [testConstWithEmptyDeprecatedBlock](/test-suite-a/#testconstwithemptydeprecatedblock-variable) | `Deprecated` | `readonly` | string | I have a `@deprecated` tag with an empty comment block. |
 
 ## Namespaces
@@ -89,8 +89,8 @@ const foo = bar;
 | Namespace | Alerts | Description |
 | - | - | - |
 | [TestBetaNamespace](/test-suite-a/testbetanamespace-namespace/) | `Beta` | A namespace tagged as `@beta`. |
-| [TestModule](/test-suite-a/testmodule-namespace/) |  |  |
-| [TestNamespace](/test-suite-a/testnamespace-namespace/) |  | Test Namespace |
+| [TestModule](/test-suite-a/testmodule-namespace/) | | |
+| [TestNamespace](/test-suite-a/testnamespace-namespace/) | | Test Namespace |
 
 ## Function Details
 
@@ -120,8 +120,8 @@ This is a test [link](/test-suite-a/testinterface-interface) to another API memb
 
 | Parameter | Modifiers | Type | Description |
 | - | - | - | - |
-| testParameter |  | TTypeParameter | A test parameter |
-| testOptionalParameter | optional | TTypeParameter |  |
+| testParameter | | TTypeParameter | A test parameter |
+| testOptionalParameter | optional | TTypeParameter | |
 
 #### Returns {#testfunction-returns}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testabstractclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testabstractclass-class.md
@@ -27,7 +27,7 @@ export declare abstract class TestAbstractClass
 
 | Method | Modifiers | Return Type | Description |
 | - | - | - | - |
-| [publicAbstractMethod()](/test-suite-a/testabstractclass-class#publicabstractmethod-method) |  | void | A test public abstract method. |
+| [publicAbstractMethod()](/test-suite-a/testabstractclass-class#publicabstractmethod-method) | | void | A test public abstract method. |
 | [sealedMethod()](/test-suite-a/testabstractclass-class#sealedmethod-method) | `sealed` | string | A test `@sealed` method. |
 | [virtualMethod()](/test-suite-a/testabstractclass-class#virtualmethod-method) | `virtual` | number | A test `@virtual` method. |
 
@@ -47,8 +47,8 @@ protected constructor(privateProperty: number, protectedProperty: TestEnum);
 
 | Parameter | Type | Description |
 | - | - | - |
-| privateProperty | number |  |
-| protectedProperty | [TestEnum](/test-suite-a/testenum-enum) |  |
+| privateProperty | number | |
+| protectedProperty | [TestEnum](/test-suite-a/testenum-enum) | |
 
 ## Property Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testbetanamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testbetanamespace-namespace/index.md
@@ -20,9 +20,9 @@ Tests release level inheritance.
 
 | Variable | Alerts | Modifiers | Type | Description |
 | - | - | - | - | - |
-| [alphaMember](/test-suite-a/testbetanamespace-namespace/#alphamember-variable) | `Alpha` | `readonly` |  |  |
-| [betaMember](/test-suite-a/testbetanamespace-namespace/#betamember-variable) | `Beta` | `readonly` |  |  |
-| [publicMember](/test-suite-a/testbetanamespace-namespace/#publicmember-variable) | `Beta` | `readonly` |  |  |
+| [alphaMember](/test-suite-a/testbetanamespace-namespace/#alphamember-variable) | `Alpha` | `readonly` | | |
+| [betaMember](/test-suite-a/testbetanamespace-namespace/#betamember-variable) | `Beta` | `readonly` | | |
+| [publicMember](/test-suite-a/testbetanamespace-namespace/#publicmember-variable) | `Beta` | `readonly` | | |
 
 ## Variable Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
@@ -59,9 +59,9 @@ Here are some remarks about the class
 
 | Method | Modifiers | Return Type | Description |
 | - | - | - | - |
-| [publicAbstractMethod()](/test-suite-a/testclass-class#publicabstractmethod-method) |  | void | A test public abstract method. |
+| [publicAbstractMethod()](/test-suite-a/testclass-class#publicabstractmethod-method) | | void | A test public abstract method. |
 | [testClassMethod(input)](/test-suite-a/testclass-class#testclassmethod-method) | `sealed` | TTypeParameterA | Test class method |
-| [virtualMethod()](/test-suite-a/testclass-class#virtualmethod-method) |  | number | Overrides [virtualMethod()](/test-suite-a/testabstractclass-class#virtualmethod-method). |
+| [virtualMethod()](/test-suite-a/testclass-class#virtualmethod-method) | | number | Overrides [virtualMethod()](/test-suite-a/testabstractclass-class#virtualmethod-method). |
 
 ## Constructor Details
 
@@ -197,7 +197,7 @@ Here are some remarks about the method
 
 | Parameter | Type | Description |
 | - | - | - |
-| input | TTypeParameterA |  |
+| input | TTypeParameterA | |
 
 #### Returns {#testclassmethod-returns}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
@@ -30,10 +30,10 @@ Here are some remarks about the interface
 
 | Property | Modifiers | Default Value | Type | Description |
 | - | - | - | - | - |
-| [getterProperty](/test-suite-a/testinterface-interface#getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
-| [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface#propertywithbadinheritdoctarget-propertysignature) |  |  | boolean |  |
-| [setterProperty](/test-suite-a/testinterface-interface#setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
-| [testInterfaceProperty](/test-suite-a/testinterface-interface#testinterfaceproperty-propertysignature) |  |  | number | Test interface property |
+| [getterProperty](/test-suite-a/testinterface-interface#getterproperty-property) | `readonly` | | boolean | A test getter-only interface property. |
+| [propertyWithBadInheritDocTarget](/test-suite-a/testinterface-interface#propertywithbadinheritdoctarget-propertysignature) | | | boolean | |
+| [setterProperty](/test-suite-a/testinterface-interface#setterproperty-property) | | | boolean | A test property with a getter and a setter. |
+| [testInterfaceProperty](/test-suite-a/testinterface-interface#testinterfaceproperty-propertysignature) | | | number | Test interface property |
 | [testOptionalInterfaceProperty](/test-suite-a/testinterface-interface#testoptionalinterfaceproperty-propertysignature) | `optional` | 0 | number | Test optional property |
 
 ## Methods

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testmodule-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testmodule-namespace/index.md
@@ -6,7 +6,7 @@
 
 | Variable | Modifiers | Type | Description |
 | - | - | - | - |
-| [foo](/test-suite-a/testmodule-namespace/#foo-variable) | `readonly` |  | Test constant in module. |
+| [foo](/test-suite-a/testmodule-namespace/#foo-variable) | `readonly` | | Test constant in module. |
 
 ## Variable Details
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.md
@@ -68,7 +68,7 @@ const foo = {
 
 | Variable | Alerts | Modifiers | Type | Description |
 | - | - | - | - | - |
-| [TestConst](/test-suite-a/testnamespace-namespace/#testconst-variable) | `Beta` | `readonly` |  | Test Constant |
+| [TestConst](/test-suite-a/testnamespace-namespace/#testconst-variable) | `Beta` | `readonly` | | Test Constant |
 
 ## Namespaces
 
@@ -92,7 +92,7 @@ function testFunction(testParameter: number): number;
 
 | Parameter | Type | Description |
 | - | - | - |
-| testParameter | number |  |
+| testParameter | number | |
 
 #### Returns {#testfunction-returns}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/index.md
@@ -3,4 +3,4 @@
 | Package | Description |
 | - | - |
 | [test-suite-a](docs/test-suite-a) | Test package |
-| [test-suite-b](docs/test-suite-b) |  |
+| [test-suite-b](docs/test-suite-b) | |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
@@ -70,15 +70,15 @@ const foo = bar;
 
 | Function | Alerts | Return Type | Description |
 | - | - | - | - |
-| [testFunctionReturningInlineType()](docs/test-suite-a#testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](docs/test-suite-a#testenum-enum); } | Test function that returns an inline type |
+| [testFunctionReturningInlineType()](docs/test-suite-a#testfunctionreturninginlinetype-function) | | {     foo: number;     bar: [TestEnum](docs/test-suite-a#testenum-enum); } | Test function that returns an inline type |
 | [testFunctionReturningIntersectionType()](docs/test-suite-a#testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](docs/test-suite-a#testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](docs/test-suite-a#testinterfacewithtypeparameter-interface)\<number\> | Test function that returns an inline type |
-| [testFunctionReturningUnionType()](docs/test-suite-a#testfunctionreturninguniontype-function) |  | string \| [TestInterface](docs/test-suite-a#testinterface-interface) | Test function that returns an inline type |
+| [testFunctionReturningUnionType()](docs/test-suite-a#testfunctionreturninguniontype-function) | | string \| [TestInterface](docs/test-suite-a#testinterface-interface) | Test function that returns an inline type |
 
 # Variables
 
 | Variable | Alerts | Modifiers | Type | Description |
 | - | - | - | - | - |
-| [testConst](docs/test-suite-a#testconst-variable) | `Beta` | `readonly` |  | Test Constant |
+| [testConst](docs/test-suite-a#testconst-variable) | `Beta` | `readonly` | | Test Constant |
 | [testConstWithEmptyDeprecatedBlock](docs/test-suite-a#testconstwithemptydeprecatedblock-variable) | `Deprecated` | `readonly` | string | I have a `@deprecated` tag with an empty comment block. |
 
 # Namespaces
@@ -86,8 +86,8 @@ const foo = bar;
 | Namespace | Alerts | Description |
 | - | - | - |
 | [TestBetaNamespace](docs/test-suite-a#testbetanamespace-namespace) | `Beta` | A namespace tagged as `@beta`. |
-| [TestModule](docs/test-suite-a#testmodule-namespace) |  |  |
-| [TestNamespace](docs/test-suite-a#testnamespace-namespace) |  | Test Namespace |
+| [TestModule](docs/test-suite-a#testmodule-namespace) | | |
+| [TestNamespace](docs/test-suite-a#testnamespace-namespace) | | Test Namespace |
 
 # Interface Details
 
@@ -131,10 +131,10 @@ Here are some remarks about the interface
 
 | Property | Modifiers | Default Value | Type | Description |
 | - | - | - | - | - |
-| [getterProperty](docs/test-suite-a#testinterface-getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
-| [propertyWithBadInheritDocTarget](docs/test-suite-a#testinterface-propertywithbadinheritdoctarget-propertysignature) |  |  | boolean |  |
-| [setterProperty](docs/test-suite-a#testinterface-setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
-| [testInterfaceProperty](docs/test-suite-a#testinterface-testinterfaceproperty-propertysignature) |  |  | number | Test interface property |
+| [getterProperty](docs/test-suite-a#testinterface-getterproperty-property) | `readonly` | | boolean | A test getter-only interface property. |
+| [propertyWithBadInheritDocTarget](docs/test-suite-a#testinterface-propertywithbadinheritdoctarget-propertysignature) | | | boolean | |
+| [setterProperty](docs/test-suite-a#testinterface-setterproperty-property) | | | boolean | A test property with a getter and a setter. |
+| [testInterfaceProperty](docs/test-suite-a#testinterface-testinterfaceproperty-propertysignature) | | | number | Test interface property |
 | [testOptionalInterfaceProperty](docs/test-suite-a#testinterface-testoptionalinterfaceproperty-propertysignature) | `optional` | 0 | number | Test optional property |
 
 ### Methods
@@ -466,7 +466,7 @@ export declare abstract class TestAbstractClass
 
 | Method | Modifiers | Return Type | Description |
 | - | - | - | - |
-| [publicAbstractMethod()](docs/test-suite-a#testabstractclass-publicabstractmethod-method) |  | void | A test public abstract method. |
+| [publicAbstractMethod()](docs/test-suite-a#testabstractclass-publicabstractmethod-method) | | void | A test public abstract method. |
 | [sealedMethod()](docs/test-suite-a#testabstractclass-sealedmethod-method) | `sealed` | string | A test `@sealed` method. |
 | [virtualMethod()](docs/test-suite-a#testabstractclass-virtualmethod-method) | `virtual` | number | A test `@virtual` method. |
 
@@ -486,8 +486,8 @@ protected constructor(privateProperty: number, protectedProperty: TestEnum);
 
 | Parameter | Type | Description |
 | - | - | - |
-| privateProperty | number |  |
-| protectedProperty | [TestEnum](docs/test-suite-a#testenum-enum) |  |
+| privateProperty | number | |
+| protectedProperty | [TestEnum](docs/test-suite-a#testenum-enum) | |
 
 ### Property Details
 
@@ -620,9 +620,9 @@ Here are some remarks about the class
 
 | Method | Modifiers | Return Type | Description |
 | - | - | - | - |
-| [publicAbstractMethod()](docs/test-suite-a#testclass-publicabstractmethod-method) |  | void | A test public abstract method. |
+| [publicAbstractMethod()](docs/test-suite-a#testclass-publicabstractmethod-method) | | void | A test public abstract method. |
 | [testClassMethod(input)](docs/test-suite-a#testclass-testclassmethod-method) | `sealed` | TTypeParameterA | Test class method |
-| [virtualMethod()](docs/test-suite-a#testclass-virtualmethod-method) |  | number | Overrides [virtualMethod()](docs/test-suite-a#testabstractclass-virtualmethod-method). |
+| [virtualMethod()](docs/test-suite-a#testclass-virtualmethod-method) | | number | Overrides [virtualMethod()](docs/test-suite-a#testabstractclass-virtualmethod-method). |
 
 ### Constructor Details
 
@@ -758,7 +758,7 @@ Here are some remarks about the method
 
 | Parameter | Type | Description |
 | - | - | - |
-| input | TTypeParameterA |  |
+| input | TTypeParameterA | |
 
 ##### Returns {#testclassmethod-returns}
 
@@ -1038,8 +1038,8 @@ Tests release level inheritance.
 
 | Variable | Alerts | Modifiers | Type | Description |
 | - | - | - | - | - |
-| [betaMember](docs/test-suite-a#testbetanamespace-betamember-variable) | `Beta` | `readonly` |  |  |
-| [publicMember](docs/test-suite-a#testbetanamespace-publicmember-variable) | `Beta` | `readonly` |  |  |
+| [betaMember](docs/test-suite-a#testbetanamespace-betamember-variable) | `Beta` | `readonly` | | |
+| [publicMember](docs/test-suite-a#testbetanamespace-publicmember-variable) | `Beta` | `readonly` | | |
 
 ### Variable Details
 
@@ -1069,7 +1069,7 @@ publicMember = "public"
 
 | Variable | Modifiers | Type | Description |
 | - | - | - | - |
-| [foo](docs/test-suite-a#testmodule-foo-variable) | `readonly` |  | Test constant in module. |
+| [foo](docs/test-suite-a#testmodule-foo-variable) | `readonly` | | Test constant in module. |
 
 ### Variable Details
 
@@ -1145,7 +1145,7 @@ const foo = {
 
 | Variable | Alerts | Modifiers | Type | Description |
 | - | - | - | - | - |
-| [TestConst](docs/test-suite-a#testnamespace-testconst-variable) | `Beta` | `readonly` |  | Test Constant |
+| [TestConst](docs/test-suite-a#testnamespace-testconst-variable) | `Beta` | `readonly` | | Test Constant |
 
 ### Namespaces
 
@@ -1323,7 +1323,7 @@ function testFunction(testParameter: number): number;
 
 | Parameter | Type | Description |
 | - | - | - |
-| testParameter | number |  |
+| testParameter | number | |
 
 ##### Returns {#testfunction-returns}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/index.md
@@ -70,9 +70,9 @@ const foo = bar;
 
 | Function | Alerts | Return Type | Description |
 | - | - | - | - |
-| [testFunctionReturningInlineType()](docs/test-suite-a/testfunctionreturninginlinetype-function) |  | {     foo: number;     bar: [TestEnum](docs/test-suite-a/testenum-enum); } | Test function that returns an inline type |
+| [testFunctionReturningInlineType()](docs/test-suite-a/testfunctionreturninginlinetype-function) | | {     foo: number;     bar: [TestEnum](docs/test-suite-a/testenum-enum); } | Test function that returns an inline type |
 | [testFunctionReturningIntersectionType()](docs/test-suite-a/testfunctionreturningintersectiontype-function) | `Deprecated` | [TestEmptyInterface](docs/test-suite-a/testemptyinterface-interface) \& [TestInterfaceWithTypeParameter](docs/test-suite-a/testinterfacewithtypeparameter-interface)\<number\> | Test function that returns an inline type |
-| [testFunctionReturningUnionType()](docs/test-suite-a/testfunctionreturninguniontype-function) |  | string \| [TestInterface](docs/test-suite-a/testinterface-interface) | Test function that returns an inline type |
+| [testFunctionReturningUnionType()](docs/test-suite-a/testfunctionreturninguniontype-function) | | string \| [TestInterface](docs/test-suite-a/testinterface-interface) | Test function that returns an inline type |
 
 ### Variables
 
@@ -84,5 +84,5 @@ const foo = bar;
 
 | Namespace | Description |
 | - | - |
-| [TestModule](docs/test-suite-a/testmodule-namespace) |  |
+| [TestModule](docs/test-suite-a/testmodule-namespace) | |
 | [TestNamespace](docs/test-suite-a/testnamespace-namespace) | Test Namespace |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-_constructor_-constructor.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-_constructor_-constructor.md
@@ -12,5 +12,5 @@ protected constructor(privateProperty: number, protectedProperty: TestEnum);
 
 | Parameter | Type | Description |
 | - | - | - |
-| privateProperty | number |  |
-| protectedProperty | [TestEnum](docs/test-suite-a/testenum-enum) |  |
+| privateProperty | number | |
+| protectedProperty | [TestEnum](docs/test-suite-a/testenum-enum) | |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-class.md
@@ -25,6 +25,6 @@ export declare abstract class TestAbstractClass
 
 | Method | Modifiers | Return Type | Description |
 | - | - | - | - |
-| [publicAbstractMethod()](docs/test-suite-a/testabstractclass-publicabstractmethod-method) |  | void | A test public abstract method. |
+| [publicAbstractMethod()](docs/test-suite-a/testabstractclass-publicabstractmethod-method) | | void | A test public abstract method. |
 | [sealedMethod()](docs/test-suite-a/testabstractclass-sealedmethod-method) | `sealed` | string | A test `@sealed` method. |
 | [virtualMethod()](docs/test-suite-a/testabstractclass-virtualmethod-method) | `virtual` | number | A test `@virtual` method. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-class.md
@@ -57,9 +57,9 @@ Here are some remarks about the class
 
 | Method | Modifiers | Return Type | Description |
 | - | - | - | - |
-| [publicAbstractMethod()](docs/test-suite-a/testclass-publicabstractmethod-method) |  | void | A test public abstract method. |
+| [publicAbstractMethod()](docs/test-suite-a/testclass-publicabstractmethod-method) | | void | A test public abstract method. |
 | [testClassMethod(input)](docs/test-suite-a/testclass-testclassmethod-method) | `sealed` | TTypeParameterA | Test class method |
-| [virtualMethod()](docs/test-suite-a/testclass-virtualmethod-method) |  | number | Overrides [virtualMethod()](docs/test-suite-a/testabstractclass-virtualmethod-method). |
+| [virtualMethod()](docs/test-suite-a/testclass-virtualmethod-method) | | number | Overrides [virtualMethod()](docs/test-suite-a/testabstractclass-virtualmethod-method). |
 
 ### See Also {#testclass-see-also}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-testclassmethod-method.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-testclassmethod-method.md
@@ -17,7 +17,7 @@ Here are some remarks about the method
 
 | Parameter | Type | Description |
 | - | - | - |
-| input | TTypeParameterA |  |
+| input | TTypeParameterA | |
 
 ### Returns {#testclassmethod-returns}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-interface.md
@@ -28,10 +28,10 @@ Here are some remarks about the interface
 
 | Property | Modifiers | Default Value | Type | Description |
 | - | - | - | - | - |
-| [getterProperty](docs/test-suite-a/testinterface-getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
-| [propertyWithBadInheritDocTarget](docs/test-suite-a/testinterface-propertywithbadinheritdoctarget-propertysignature) |  |  | boolean |  |
-| [setterProperty](docs/test-suite-a/testinterface-setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
-| [testInterfaceProperty](docs/test-suite-a/testinterface-testinterfaceproperty-propertysignature) |  |  | number | Test interface property |
+| [getterProperty](docs/test-suite-a/testinterface-getterproperty-property) | `readonly` | | boolean | A test getter-only interface property. |
+| [propertyWithBadInheritDocTarget](docs/test-suite-a/testinterface-propertywithbadinheritdoctarget-propertysignature) | | | boolean | |
+| [setterProperty](docs/test-suite-a/testinterface-setterproperty-property) | | | boolean | A test property with a getter and a setter. |
+| [testInterfaceProperty](docs/test-suite-a/testinterface-testinterfaceproperty-propertysignature) | | | number | Test interface property |
 | [testOptionalInterfaceProperty](docs/test-suite-a/testinterface-testoptionalinterfaceproperty-propertysignature) | `optional` | 0 | number | Test optional property |
 
 ### Methods

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testmodule-namespace.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testmodule-namespace.md
@@ -4,4 +4,4 @@
 
 | Variable | Modifiers | Type | Description |
 | - | - | - | - |
-| [foo](docs/test-suite-a/testmodule-foo-variable) | `readonly` |  | Test constant in module. |
+| [foo](docs/test-suite-a/testmodule-foo-variable) | `readonly` | | Test constant in module. |

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testfunction-function.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testnamespace-testfunction-function.md
@@ -12,7 +12,7 @@ function testFunction(testParameter: number): number;
 
 | Parameter | Type | Description |
 | - | - | - |
-| testParameter | number |  |
+| testParameter | number | |
 
 ### Returns {#testfunction-returns}
 


### PR DESCRIPTION
Optimizes rendering of empty table cells in Markdown to omit only a single space instead of two.

The primary goal of this PR is to align our Markdown rendering with the behavior of `mdast-util-to-markdown`, which we plan to use to replace our custom Markdown rendering.
