### PR TITLE
Remove LazyField Iterator

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -19,6 +19,7 @@ import {
 	type TreeNavigationResult,
 	inCursorNode,
 	iterateCursorField,
+	mapCursorField,
 	rootFieldKey,
 } from "../../core/index.js";
 import { disposeSymbol, getOrCreate } from "../../util/index.js";
@@ -206,17 +207,13 @@ export abstract class LazyField extends LazyEntity<FieldAnchor> implements FlexT
 	}
 
 	public map<U>(callbackfn: (value: FlexTreeUnknownUnboxed, index: number) => U): U[] {
-		return Array.from(this, callbackfn);
+		return mapCursorField(this.cursor, (cursor) =>
+			callbackfn(unboxedFlexNode(this.context, cursor, this.anchor), cursor.fieldIndex),
+		);
 	}
 
 	public boxedIterator(): IterableIterator<HydratedFlexTreeNode> {
 		return iterateCursorField(this.cursor, (cursor) => makeTree(this.context, cursor));
-	}
-
-	public [Symbol.iterator](): IterableIterator<FlexTreeUnknownUnboxed> {
-		return iterateCursorField(this.cursor, (cursor) =>
-			unboxedFlexNode(this.context, cursor, this.anchor),
-		);
 	}
 
 	public getFieldPath(): NormalizedFieldUpPath {

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -518,11 +518,5 @@ describe("LazyField", () => {
 			const mapResult = sequence.map((value) => (value as number) * 2);
 			assert.deepEqual(mapResult, [2, 4]);
 		});
-
-		it("asArray", () => {
-			const sequence = testSequence([37, 42]);
-			const array = [...sequence];
-			assert.deepEqual(array, [37, 42]);
-		});
 	});
 });


### PR DESCRIPTION
## Description

This iterator was not exposed on the interface, and only had one use which could be better optimized by inlining the implementation.

This change was motivated by wanting to clear up room for adding a different iterator to the FlexTreeField interface to help it align with MapTree like how UnhydratedFlexTreeField does.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
