### PR TITLE
Interval Collection: Rename IMapMessageLocalMetadata 

### DIFF
--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -863,7 +863,7 @@ export class IntervalCollection
 
 	public resubmitMessage(
 		op: IIntervalCollectionTypeOperationValue,
-		localOpMetadata: unknown,
+		localOpMetadata: IntervalMessageLocalMetadata,
 	): void {
 		const { opName, value } = op;
 		const rebasedValue =

--- a/packages/dds/sequence/src/intervalCollectionMap.ts
+++ b/packages/dds/sequence/src/intervalCollectionMap.ts
@@ -192,7 +192,10 @@ export class IntervalCollectionMap {
 	 * also sent if we are asked to resubmit the message.
 	 * @returns True if the operation was submitted, false otherwise.
 	 */
-	public tryResubmitMessage(content: unknown, localOpMetadata: unknown): boolean {
+	public tryResubmitMessage(
+		content: unknown,
+		localOpMetadata: IntervalMessageLocalMetadata,
+	): boolean {
 		if (isMapOperation(content)) {
 			const { value, key } = content;
 			const localValue = this.data.get(key);

--- a/packages/dds/sequence/src/intervalCollectionMap.ts
+++ b/packages/dds/sequence/src/intervalCollectionMap.ts
@@ -18,7 +18,7 @@ import {
 } from "./intervalCollection.js";
 import {
 	IIntervalCollectionTypeOperationValue,
-	IMapMessageLocalMetadata,
+	IntervalMessageLocalMetadata,
 	ISerializableIntervalCollection,
 	SequenceOptions,
 } from "./intervalCollectionMapInterfaces.js";
@@ -96,7 +96,7 @@ export class IntervalCollectionMap {
 		private readonly handle: IFluidHandle,
 		private readonly submitMessage: (
 			op: IMapOperation,
-			localOpMetadata: IMapMessageLocalMetadata,
+			localOpMetadata: IntervalMessageLocalMetadata,
 		) => void,
 		private readonly options?: Partial<SequenceOptions>,
 	) {}
@@ -192,10 +192,7 @@ export class IntervalCollectionMap {
 	 * also sent if we are asked to resubmit the message.
 	 * @returns True if the operation was submitted, false otherwise.
 	 */
-	public tryResubmitMessage(
-		content: unknown,
-		localOpMetadata: IMapMessageLocalMetadata,
-	): boolean {
+	public tryResubmitMessage(content: unknown, localOpMetadata: unknown): boolean {
 		if (isMapOperation(content)) {
 			const { value, key } = content;
 			const localValue = this.data.get(key);
@@ -212,7 +209,7 @@ export class IntervalCollectionMap {
 
 			assert(localValue !== undefined, 0xb7e /* Local value expected on rollback */);
 
-			localValue.rollback(content.value, localOpMetadata as IMapMessageLocalMetadata);
+			localValue.rollback(content.value, localOpMetadata as IntervalMessageLocalMetadata);
 
 			return true;
 		}
@@ -254,7 +251,12 @@ export class IntervalCollectionMap {
 		if (isMapOperation(content)) {
 			const { value, key } = content;
 			const localValue = this.data.get(key) ?? this.createCore(key, local);
-			localValue.process(value, local, message, localOpMetadata as IMapMessageLocalMetadata);
+			localValue.process(
+				value,
+				local,
+				message,
+				localOpMetadata as IntervalMessageLocalMetadata,
+			);
 			return true;
 		}
 		return false;

--- a/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
+++ b/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
@@ -17,12 +17,26 @@ import {
 	SerializedIntervalDelta,
 } from "./intervals/index.js";
 
-export interface IMapMessageLocalMetadata {
+export interface IntervalAddLocalMetadata {
+	type: typeof IntervalDeltaOpType.ADD;
 	localSeq: number;
-	previous?: ISerializedInterval;
-	intervalId: string;
+}
+export interface IntervalChangeLocalMetadata {
+	type: typeof IntervalDeltaOpType.CHANGE;
+	localSeq: number;
+	previous: ISerializedInterval;
 }
 
+export interface IntervalDeleteLocalMetadata {
+	type: typeof IntervalDeltaOpType.DELETE;
+	localSeq: number;
+	previous: ISerializedInterval;
+}
+
+export type IntervalMessageLocalMetadata =
+	| IntervalAddLocalMetadata
+	| IntervalChangeLocalMetadata
+	| IntervalDeleteLocalMetadata;
 /**
  * Optional flags that configure options for sequence DDSs
  * @internal
@@ -74,7 +88,7 @@ export interface IIntervalCollectionOperation {
 		params: ISerializedInterval,
 		local: boolean,
 		message: ISequencedDocumentMessage | undefined,
-		localOpMetadata: IMapMessageLocalMetadata | undefined,
+		localOpMetadata: IntervalMessageLocalMetadata | undefined,
 	): void;
 }
 

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -72,7 +72,7 @@ import Deque from "double-ended-queue";
 import { type ISequenceIntervalCollection } from "./intervalCollection.js";
 import { IMapOperation, IntervalCollectionMap } from "./intervalCollectionMap.js";
 import {
-	IMapMessageLocalMetadata,
+	type IntervalMessageLocalMetadata,
 	type SequenceOptions,
 } from "./intervalCollectionMapInterfaces.js";
 import {
@@ -786,7 +786,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 			if (
 				!this.intervalCollections.tryResubmitMessage(
 					content,
-					localOpMetadata as IMapMessageLocalMetadata,
+					localOpMetadata as IntervalMessageLocalMetadata,
 				)
 			) {
 				this.submitSequenceMessage(


### PR DESCRIPTION
Long ago interval collections were based on map, and when they were split, a number of types were copied. This change renames IMapMessageLocalMetadata to IntervalMessageLocalMetadata so it better represents what is used for. Additionally, I've added a type to IntervalMessageLocalMetadata such that they can be discriminated, and each can have its own metadata, which reduces our reliance on optional properties and makes the code clearer.