### PR TITLE
Docs(tree): clarify TreeChangeEvents contract

### DIFF
--- a/packages/dds/tree/src/simple-tree/api/treeChangeEvents.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeChangeEvents.ts
@@ -26,7 +26,10 @@
  */
 export interface TreeChangeEvents {
 	/**
-	 * Emitted by a node after a batch of changes has been applied to the tree, if any of the changes affected the node.
+	 * Emitted by a node if any changes affected the node.
+	 *
+	 * This event is emitted after all the changes in a batch have been applied to the whole tree.
+	 * This means that a handler for this event will be able to read the updated state of the tree.
 	 *
 	 * - Object nodes define a change as being when the value of one of its properties changes (i.e., the property's value is set, including when set to `undefined`).
 	 *
@@ -65,8 +68,10 @@ export interface TreeChangeEvents {
 	nodeChanged(unstable?: unknown): void;
 
 	/**
-	 * Emitted by a node after a batch of changes has been applied to the tree, when something changed anywhere in the
-	 * subtree rooted at it.
+	 * Emitted by a node if something changed anywhere in the subtree rooted at it.
+	 *
+	 * This event is emitted after all the changes in a batch have been applied to the whole tree.
+	 * This means that a handler for this event will be able to read the updated state of the tree.
 	 *
 	 * @remarks
 	 * This event is not emitted when the node itself is moved to a different location in the tree or removed from the tree.


### PR DESCRIPTION
## Description

Clarifies the contract for TreeChangeEvents, specifically with respect to the state of the tree when the events are fired.

This was prompted by a conversation with a developer on the Designer team. They mistakenly thought they had a dependency on the relative ordering of `nodeChanged` vs. `treeChanged` events.

## Breaking Changes

None

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

> List any specific things you want to get reviewer opinions on, and anything a reviewer would need to know to review this PR effectively.
> Things you might want to include:
>
> -   Questions about how to properly make automated tests for your changes.
> -   Questions about design choices you made.
> -   Descriptions of how to manually test the changes (and how much of that you have done).
> -   etc.
>
> If you have any questions in this section, consider making the PR a draft until all questions have been resolved.
