### PR TITLE
Update CSP header and hash external scripts

### DIFF
--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
 	"globalHeaders": {
 		"cache-control": "must-revalidate, max-age=3600",
-		"Content-Security-Policy-Report-Only": "script-src 'self' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'sha256-fd8PaHQgKg1/SNfCLTu1n0o8pKUigP867TZiWr5NYtU=' 'sha256-dGD3FKK81csDrEhQT4cyi6vTQ7h5P5bq4sJOY1Btb5w=' 'sha256-7AH+m873sdexyPdfDOeaX4fqkWqmdUoBgXQHcRlvvw4=' 'sha256-zqOCmYqzxs0Knhk3lotBdf82YZdgp9viphnaImdEuZ8=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https:; base-uri 'self'; object-src 'none'; require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
+		"Content-Security-Policy-Report-Only": "script-src 'self' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'sha256-fd8PaHQgKg1/SNfCLTu1n0o8pKUigP867TZiWr5NYtU=' 'sha256-dGD3FKK81csDrEhQT4cyi6vTQ7h5P5bq4sJOY1Btb5w=' 'sha256-9B4uzGZj0ISjdPwwyAmR+Lci1Y4WIkbroFP63r0e7kg=' 'sha256-cwVTr+ZyBzKe5diz1+yyhT+CcNJEqwLTneD8H4TIrvA=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https:; base-uri 'self'; object-src 'none'; require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
 	},
 	"navigationFallback": {
 		"rewrite": "/api/fallback"

--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
 	"globalHeaders": {
 		"cache-control": "must-revalidate, max-age=3600",
-		"Content-Security-Policy-Report-Only": "script-src 'self' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'sha256-fd8PaHQgKg1/SNfCLTu1n0o8pKUigP867TZiWr5NYtU=' 'sha256-dGD3FKK81csDrEhQT4cyi6vTQ7h5P5bq4sJOY1Btb5w=' 'sha256-9B4uzGZj0ISjdPwwyAmR+Lci1Y4WIkbroFP63r0e7kg=' 'sha256-cwVTr+ZyBzKe5diz1+yyhT+CcNJEqwLTneD8H4TIrvA=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https:; base-uri 'self'; object-src 'none'; require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
+		"Content-Security-Policy-Report-Only": "script-src 'self' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'sha256-fd8PaHQgKg1/SNfCLTu1n0o8pKUigP867TZiWr5NYtU=' 'sha256-dGD3FKK81csDrEhQT4cyi6vTQ7h5P5bq4sJOY1Btb5w=' 'sha256-9B4uzGZj0ISjdPwwyAmR+Lci1Y4WIkbroFP63r0e7kg=' 'sha256-cwVTr+ZyBzKe5diz1+yyhT+CcNJEqwLTneD8H4TIrvA=' 'unsafe-inline' 'unsafe-eval' https:; base-uri 'self'; object-src 'none'; require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
 	},
 	"navigationFallback": {
 		"rewrite": "/api/fallback"

--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
 	"globalHeaders": {
 		"cache-control": "must-revalidate, max-age=3600",
-		"Content-Security-Policy-Report-Only": "script-src 'self' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'unsafe-inline' 'unsafe-eval'; require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
+		"Content-Security-Policy-Report-Only": "script-src 'self' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https:; base-uri 'self'; object-src 'none'; require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
 	},
 	"navigationFallback": {
 		"rewrite": "/api/fallback"

--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
 	"globalHeaders": {
 		"cache-control": "must-revalidate, max-age=3600",
-		"Content-Security-Policy-Report-Only": "script-src 'self' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https:; base-uri 'self'; object-src 'none'; require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
+		"Content-Security-Policy-Report-Only": "script-src 'self' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'sha256-fd8PaHQgKg1/SNfCLTu1n0o8pKUigP867TZiWr5NYtU=' 'sha256-dGD3FKK81csDrEhQT4cyi6vTQ7h5P5bq4sJOY1Btb5w=' 'sha256-7AH+m873sdexyPdfDOeaX4fqkWqmdUoBgXQHcRlvvw4=' 'sha256-zqOCmYqzxs0Knhk3lotBdf82YZdgp9viphnaImdEuZ8=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https:; base-uri 'self'; object-src 'none'; require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
 	},
 	"navigationFallback": {
 		"rewrite": "/api/fallback"

--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
 	"globalHeaders": {
 		"cache-control": "must-revalidate, max-age=3600",
-		"Content-Security-Policy-Report-Only": "script-src 'self' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA='; require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
+		"Content-Security-Policy-Report-Only": "script-src 'self' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'unsafe-inline' 'unsafe-eval'; require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
 	},
 	"navigationFallback": {
 		"rewrite": "/api/fallback"

--- a/docs/validateHashes.sh
+++ b/docs/validateHashes.sh
@@ -24,8 +24,9 @@ done
 grep -oE '<script[^>]+src="[^"]+"' "$indexFile" | sed -E 's/.*src="([^"]+)".*/\1/' | while read -r srcPath; do
   localFile="build$srcPath"
   if [[ -f "$localFile" ]]; then
-    echo "Hashing external script: $localFile"
-    openssl dgst -sha256 -binary "$localFile" | openssl base64 | sed 's/^/sha256-/' >> "$generatedHashes"
+	hash=$(openssl dgst -sha256 -binary "$localFile" | openssl base64 | sed 's/^/sha256-/')
+	echo "Hashing external script: $localFile to $hash"
+	echo $hash >> "$generatedHashes"
   else
     echo "⚠️  External script not found on disk: $localFile"
   fi

--- a/docs/validateHashes.sh
+++ b/docs/validateHashes.sh
@@ -20,6 +20,17 @@ echo "$scriptContent" | tr -d '\n'| openssl dgst -sha256 -binary | openssl base6
 fi
 done
 
+# Also hash external script files referenced by <script src="...">
+grep -oE '<script[^>]+src="[^"]+"' "$indexFile" | sed -E 's/.*src="([^"]+)".*/\1/' | while read -r srcPath; do
+  localFile="build$srcPath"
+  if [[ -f "$localFile" ]]; then
+    echo "Hashing external script: $localFile"
+    openssl dgst -sha256 -binary "$localFile" | openssl base64 | sed 's/^/sha256-/' >> "$generatedHashes"
+  else
+    echo "⚠️  External script not found on disk: $localFile"
+  fi
+done
+
 echo "Extracted Hashes:"
 cat "$generatedHashes"
 


### PR DESCRIPTION
Seeing some eval violations in the CREM board. Following the same reasoning of cleaning up violations, even though we are not required to meet all of them, I'm adding a couple of options to ignore those violations. According to https://www.owiki.ms/wiki/Strict_Content_Security_Policy, 'unsafe-eval' is allowed while 'unsafe-inline' would be ignored in the presence of hashes, which we have. Adding all options referenced in the wiki anyway to be as close as possible as recommended header example. The only exception would be 'strict-dynamic' which disables host-based allowlisting