### PR TITLE
refactor(aqueduct): Hide `sharedTree` property on `TreeDataObject`

### DIFF
--- a/packages/framework/aqueduct/src/data-objects/treeDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/treeDataObject.ts
@@ -36,11 +36,6 @@ const uninitializedErrorString =
  * }
  * ```
  *
- * @privateRemarks
- * TODO: Before promoting this beyond internal, we should consider alternative API patterns that don't depend on
- * sub-classing and don't leak Fluid concepts that should ideally be internal.
- * See `tree-react-api` for an example of a pattern that avoids unnecessary leakage of implementation details.
- *
  * @internal
  */
 export abstract class TreeDataObject<TTreeView> extends PureDataObject {
@@ -58,8 +53,11 @@ export abstract class TreeDataObject<TTreeView> extends PureDataObject {
 
 	/**
 	 * Gets the underlying {@link @fluidframework/tree#ITree | tree}.
+	 * @remarks
+	 * Note: in most cases, you will want to use {@link TreeDataObject.treeView} instead.
+	 * Created once during initialization.
 	 */
-	public get sharedTree(): ITree {
+	protected get sharedTree(): ITree {
 		if (this.#sharedTree === undefined) {
 			throw new UsageError(uninitializedErrorString);
 		}

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DataVisualization.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DataVisualization.ts
@@ -255,7 +255,9 @@ export class DataVisualizerGraph
 			objectId = getKeyForFluidObject(rootSharedObject);
 			visualizationFunction = visualizeDataObject;
 		} else if (isTreeDataObj) {
-			rootSharedObject = visualizableObject.sharedTree as unknown as ISharedObject;
+			rootSharedObject = (
+				visualizableObject as unknown as { readonly sharedTree: ISharedObject }
+			).sharedTree;
 			objectId = getKeyForFluidObject(rootSharedObject);
 			visualizationFunction = visualizeTreeDataObject;
 		} else {
@@ -576,7 +578,7 @@ function isTreeDataObject(value: unknown): value is TreeDataObject<unknown> {
 			Object.getOwnPropertyDescriptor(Object.getPrototypeOf(value), "sharedTree")?.get !==
 				undefined)
 	) {
-		const tree = (value as TreeDataObject<unknown>).sharedTree;
+		const tree = (value as { readonly sharedTree?: ISharedObject }).sharedTree;
 		if (tree === undefined) {
 			throw new Error(
 				"TreeDataObject must have a `sharedTree` property, but it was undefined.",


### PR DESCRIPTION
This property was exposed ultimately for access by Devtools. If a user wants direct access to the `SharedTree` object, they can make that their (optionally) derived view, so exposing this publicly isn't really needed outside of devtools. Instead, devtools now takes the same approach for accessing this property as it does for `DataObject`.