### PR TITLE
MergeTree: Fix segment-offset typing

### DIFF
--- a/packages/dds/matrix/src/handlecache.ts
+++ b/packages/dds/matrix/src/handlecache.ts
@@ -82,10 +82,10 @@ export class HandleCache implements IVectorConsumer<Handle> {
 		const { vector } = this;
 
 		for (let pos = start; pos < end; pos++) {
-			const { segment, offset } = vector.getContainingSegment(pos);
-			const asPerm = segment as PermutationSegment;
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			handles.push(asPerm.start + offset!);
+			const { segment, offset } = vector.getContainingSegment(pos)!;
+			const asPerm = segment as PermutationSegment;
+			handles.push(asPerm.start + offset);
 		}
 	}
 

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -465,10 +465,7 @@ export class SharedMatrix<T = any>
 		localSeq: number,
 	): LocalReferencePosition {
 		const segoff = vector.getContainingSegment(pos, undefined, localSeq);
-		assert(
-			segoff.segment !== undefined && segoff.offset !== undefined,
-			0x8b3 /* expected valid position */,
-		);
+		assert(segoff !== undefined, 0x8b3 /* expected valid position */);
 		return vector.createLocalReferencePosition(
 			segoff.segment,
 			segoff.offset,

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -201,15 +201,16 @@ export class PermutationVector extends Client {
 		posToAdjust: number,
 		op: ISequencedDocumentMessage,
 	): { pos: number | undefined; handle: Handle } {
-		const { segment, offset } = this.getContainingSegment<PermutationSegment>(posToAdjust, {
+		const segOff = this.getContainingSegment<PermutationSegment>(posToAdjust, {
 			referenceSequenceNumber: op.referenceSequenceNumber,
 			clientId: op.clientId,
 		});
 
 		assert(
-			segment !== undefined && offset !== undefined,
+			segOff !== undefined,
 			0xbac /* segment must be available for operations in the collab window */,
 		);
+		const { segment, offset } = segOff;
 
 		if (segmentIsRemoved(segment)) {
 			// this case is tricky. the segment which the row or column data is remove
@@ -471,7 +472,7 @@ export function reinsertSegmentIntoVector(
 
 	// (Re)insert the removed number of rows at the original position.
 	const op = vector.insertSegmentLocal(pos, original);
-	const inserted = vector.getContainingSegment(pos).segment as PermutationSegment;
+	const inserted = vector.getContainingSegment(pos)?.segment as PermutationSegment;
 
 	// we reuse the original handle here
 	// so if cells exist, they can be found, and re-inserted

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -878,17 +878,20 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		const useNewSlidingBehavior = true;
 		// Destructuring segment + offset is convenient and segment is reassigned
 		// eslint-disable-next-line prefer-const
-		let { segment: newSegment, offset: newOffset } = getSlideToSegoff(
+		const segOff = getSlideToSegoff(
 			{ segment: oldSegment, offset: oldOffset },
 			slidePreference,
 			reconnectingPerspective,
 			useNewSlidingBehavior,
 		);
 
-		newSegment ??=
-			slidePreference === SlidingPreference.FORWARD
-				? this._mergeTree.endOfTree
-				: this._mergeTree.startOfTree;
+		const { segment: newSegment, offset: newOffset } = segOff ?? {
+			segment:
+				slidePreference === SlidingPreference.FORWARD
+					? this._mergeTree.endOfTree
+					: this._mergeTree.startOfTree,
+			offset: 0,
+		};
 
 		assert(
 			isSegmentLeaf(newSegment) && newOffset !== undefined,
@@ -1612,10 +1615,12 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		pos: number,
 		sequenceArgs?: Pick<ISequencedDocumentMessage, "referenceSequenceNumber" | "clientId">,
 		localSeq?: number,
-	): {
-		segment: T | undefined;
-		offset: number | undefined;
-	} {
+	):
+		| {
+				segment: T;
+				offset: number;
+		  }
+		| undefined {
 		let perspective: Perspective;
 		const clientId =
 			sequenceArgs === undefined
@@ -1630,20 +1635,17 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 			perspective = new PriorPerspective(refSeq, clientId);
 		}
 
-		return this._mergeTree.getContainingSegment(pos, perspective) as {
-			segment: T | undefined;
-			offset: number | undefined;
-		};
+		return this._mergeTree.getContainingSegment(pos, perspective) as
+			| {
+					segment: T;
+					offset: number;
+			  }
+			| undefined;
 	}
 
 	getPropertiesAtPosition(pos: number): PropertySet | undefined {
-		let propertiesAtPosition: PropertySet | undefined;
 		const segoff = this.getContainingSegment(pos);
-		const seg = segoff.segment;
-		if (seg) {
-			propertiesAtPosition = seg.properties;
-		}
-		return propertiesAtPosition;
+		return segoff?.segment?.properties;
 	}
 
 	getRangeExtentsOfPosition(pos: number): {
@@ -1654,7 +1656,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		let posAfterEnd: number | undefined;
 
 		const segoff = this.getContainingSegment(pos);
-		const seg = segoff.segment;
+		const seg = segoff?.segment;
 		if (seg) {
 			posStart = this.getPosition(seg);
 			posAfterEnd = posStart + seg.cachedLength;

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -469,15 +469,17 @@ function getSlideToSegment(
  * @internal
  */
 export function getSlideToSegoff(
-	segoff: { segment: ISegmentInternal | undefined; offset: number | undefined },
+	segoff: { segment: ISegmentInternal; offset: number } | undefined,
 	slidingPreference: SlidingPreference = SlidingPreference.FORWARD,
 	perspective: Perspective = allAckedChangesPerspective,
 	useNewSlidingBehavior: boolean = false,
-): {
-	segment: ISegmentInternal | undefined;
-	offset: number | undefined;
-} {
-	if (!isSegmentLeaf(segoff.segment)) {
+):
+	| {
+			segment: ISegmentInternal;
+			offset: number;
+	  }
+	| undefined {
+	if (!isSegmentLeaf(segoff?.segment)) {
 		return segoff;
 	}
 	const [segment, _] = getSlideToSegment(
@@ -490,8 +492,11 @@ export function getSlideToSegoff(
 	if (segment === segoff.segment) {
 		return segoff;
 	}
-	const offset =
-		segment && segment.ordinal < segoff.segment.ordinal ? segment.cachedLength - 1 : 0;
+	if (segment === undefined) {
+		return undefined;
+	}
+
+	const offset = segment.ordinal < segoff.segment.ordinal ? segment.cachedLength - 1 : 0;
 	return {
 		segment,
 		offset,
@@ -849,10 +854,12 @@ export class MergeTree {
 	public getContainingSegment(
 		pos: number,
 		perspective: Perspective,
-	): {
-		segment: ISegmentLeaf | undefined;
-		offset: number | undefined;
-	} {
+	):
+		| {
+				segment: ISegmentLeaf;
+				offset: number;
+		  }
+		| undefined {
 		assert(
 			perspective.localSeq === undefined ||
 				perspective.clientId === this.collabWindow.clientId,
@@ -868,6 +875,9 @@ export class MergeTree {
 			return false;
 		};
 		this.nodeMap(perspective, leaf, undefined, pos, pos + 1);
+		if (segment === undefined || offset === undefined) {
+			return undefined;
+		}
 		return { segment, offset };
 	}
 
@@ -1260,10 +1270,11 @@ export class MergeTree {
 	): Marker | undefined {
 		let foundMarker: Marker | undefined;
 
-		const { segment } = this.getContainingSegment(startPos, this.localPerspective);
-		if (!isSegmentLeaf(segment)) {
+		const segoff = this.getContainingSegment(startPos, this.localPerspective);
+		if (!isSegmentLeaf(segoff?.segment)) {
 			return undefined;
 		}
+		const { segment } = segoff;
 
 		depthFirstNodeWalk(
 			segment.parent,
@@ -1529,7 +1540,7 @@ export class MergeTree {
 
 		if (isSegmentLeaf(segmentInfo?.segment)) {
 			const segmentPosition = this.getPosition(segmentInfo.segment, this.localPerspective);
-			return segmentPosition + segmentInfo.offset!;
+			return segmentPosition + segmentInfo.offset;
 		} else {
 			if (remoteClientPosition === this.getLength(remotePerspective)) {
 				return this.getLength(this.localPerspective);
@@ -2085,14 +2096,9 @@ export class MergeTree {
 		const createRefFromSequencePlace = (
 			place: InteriorSequencePlace,
 		): LocalReferencePosition => {
-			const { segment: placeSeg, offset: placeOffset } = this.getContainingSegment(
-				place.pos,
-				perspective,
-			);
-			assert(
-				isSegmentLeaf(placeSeg) && placeOffset !== undefined,
-				0xa3f /* segments cannot be undefined */,
-			);
+			const segOff = this.getContainingSegment(place.pos, perspective);
+			assert(isSegmentLeaf(segOff?.segment), 0xa3f /* segments cannot be undefined */);
+			const { segment: placeSeg, offset: placeOffset } = segOff;
 			return this.createLocalReferencePosition(
 				placeSeg,
 				placeOffset,

--- a/packages/dds/merge-tree/src/revertibles.ts
+++ b/packages/dds/merge-tree/src/revertibles.ts
@@ -309,7 +309,7 @@ function revertLocalRemove(
 		const insertSegment = mergeTreeWithRevert.getContainingSegment(
 			realPos,
 			mergeTreeWithRevert.localPerspective,
-		).segment;
+		)?.segment;
 		assertSegmentLeaf(insertSegment);
 
 		const localSlideFilter = (lref: LocalReferencePosition): boolean =>

--- a/packages/dds/merge-tree/src/test/beastTest.spec.ts
+++ b/packages/dds/merge-tree/src/test/beastTest.spec.ts
@@ -374,7 +374,7 @@ export function mergeTreeTest1(): void {
 	checkInsertMergeTree(mergeTree, 4, makeCollabTextSegment("fi"));
 	mergeTree.mapRange(printTextSegment, localPerspective, undefined);
 	const segoff = mergeTree.getContainingSegment(4, mergeTree.localPerspective);
-	log(mergeTree.getPosition(segoff.segment!, mergeTree.localPerspective));
+	log(mergeTree.getPosition(segoff!.segment, mergeTree.localPerspective));
 	log(new MergeTreeTextHelper(mergeTree).getText(mergeTree.localPerspective));
 	log(mergeTree.toString());
 	TestPack().firstTest();
@@ -1502,7 +1502,7 @@ function findReplacePerf(filename: string): void {
 		const curSegOff = client.getContainingSegment<ISegmentPrivate>(pos);
 		cFetches++;
 
-		const curSeg = curSegOff.segment;
+		const curSeg = curSegOff?.segment;
 		const textSeg = <TextSegment>curSeg;
 		if (textSeg !== null) {
 			const text = textSeg.text;

--- a/packages/dds/merge-tree/src/test/client.annotateMarker.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.annotateMarker.spec.ts
@@ -34,7 +34,7 @@ describe("TestClient", () => {
 			});
 			assert(insertOp);
 			const markerInfo = client.getContainingSegment<ISegmentPrivate>(0);
-			const marker = markerInfo.segment as Marker;
+			const marker = markerInfo?.segment as Marker;
 			const annotateOp = client.annotateMarker(marker, { foo: "bar" });
 			assert(annotateOp);
 			assert(marker.properties);

--- a/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.applyMsg.spec.ts
@@ -122,12 +122,12 @@ describe("client.applyMsg", () => {
 			const segmentInfo = client.getContainingSegment<ISegmentPrivate>(i);
 
 			assert.notEqual(
-				toInsertionInfo(segmentInfo.segment)?.insert.seq,
+				toInsertionInfo(segmentInfo?.segment)?.insert.seq,
 				UnassignedSequenceNumber,
 				"all segments should be acked",
 			);
 			assert(
-				segmentInfo.segment?.segmentGroups?.empty !== false,
+				segmentInfo?.segment?.segmentGroups?.empty !== false,
 				"there should be no outstanding segmentGroups",
 			);
 		}
@@ -138,22 +138,25 @@ describe("client.applyMsg", () => {
 
 		const segmentInfo = client.getContainingSegment<ISegmentPrivate>(0);
 
-		assert.equal(toInsertionInfo(segmentInfo.segment)?.insert.seq, UnassignedSequenceNumber);
+		assert.equal(toInsertionInfo(segmentInfo?.segment)?.insert.seq, UnassignedSequenceNumber);
 
 		client.applyMsg(client.makeOpMessage(op, 17));
 
-		assert.equal(toInsertionInfo(segmentInfo.segment)?.insert.seq, 17);
+		assert.equal(toInsertionInfo(segmentInfo?.segment)?.insert.seq, 17);
 	});
 
 	it("removeRangeLocal", () => {
 		const segmentInfo = client.getContainingSegment<ISegmentPrivate>(0);
 
 		const removeOp = client.removeRangeLocal(0, 1);
-		assert.equal(toRemovalInfo(segmentInfo.segment)?.removes[0].seq, UnassignedSequenceNumber);
+		assert.equal(
+			toRemovalInfo(segmentInfo?.segment)?.removes[0].seq,
+			UnassignedSequenceNumber,
+		);
 
 		client.applyMsg(client.makeOpMessage(removeOp, 17));
 
-		assert.equal(toRemovalInfo(segmentInfo.segment)?.removes[0].seq, 17);
+		assert.equal(toRemovalInfo(segmentInfo?.segment)?.removes[0].seq, 17);
 	});
 
 	it("annotateSegmentLocal", () => {
@@ -185,17 +188,23 @@ describe("client.applyMsg", () => {
 
 		const removeOp = client.removeRangeLocal(start, end);
 
-		assert.equal(toRemovalInfo(segmentInfo.segment)?.removes[0].seq, UnassignedSequenceNumber);
+		assert.equal(
+			toRemovalInfo(segmentInfo?.segment)?.removes[0].seq,
+			UnassignedSequenceNumber,
+		);
 		assert.equal(client.mergeTree.pendingSegments?.length, 2);
 
 		client.applyMsg(client.makeOpMessage(annotateOp, 17));
 
-		assert.equal(toRemovalInfo(segmentInfo.segment)?.removes[0].seq, UnassignedSequenceNumber);
+		assert.equal(
+			toRemovalInfo(segmentInfo?.segment)?.removes[0].seq,
+			UnassignedSequenceNumber,
+		);
 		assert.equal(client.mergeTree.pendingSegments?.length, 1);
 
 		client.applyMsg(client.makeOpMessage(removeOp, 18, 0));
 
-		assert.equal(toRemovalInfo(segmentInfo.segment)?.removes[0].seq, 18);
+		assert.equal(toRemovalInfo(segmentInfo?.segment)?.removes[0].seq, 18);
 		assert.equal(client.mergeTree.pendingSegments?.length, 0);
 	});
 
@@ -230,13 +239,16 @@ describe("client.applyMsg", () => {
 		const initialText = client.getText();
 		const initialLength = initialText.length;
 
-		assert.equal(toRemovalInfo(segmentInfo.segment), undefined);
-		assert(segmentInfo.segment?.segmentGroups?.empty !== false);
+		assert.equal(toRemovalInfo(segmentInfo?.segment), undefined);
+		assert(segmentInfo?.segment?.segmentGroups?.empty !== false);
 
 		const removeOp = client.removeRangeLocal(start, end);
 
-		assert.equal(toRemovalInfo(segmentInfo.segment)?.removes[0].seq, UnassignedSequenceNumber);
-		assert.equal(segmentInfo.segment?.segmentGroups?.size, 1);
+		assert.equal(
+			toRemovalInfo(segmentInfo?.segment)?.removes[0].seq,
+			UnassignedSequenceNumber,
+		);
+		assert.equal(segmentInfo?.segment?.segmentGroups?.size, 1);
 
 		const remoteMessage = client.makeOpMessage(removeOp, 17);
 		remoteMessage.clientId = "remoteClient";
@@ -244,18 +256,18 @@ describe("client.applyMsg", () => {
 		client.applyMsg(remoteMessage);
 
 		assert.equal(
-			toRemovalInfo(segmentInfo.segment)?.removes[0].seq,
+			toRemovalInfo(segmentInfo?.segment)?.removes[0].seq,
 			remoteMessage.sequenceNumber,
 		);
-		assert.equal(segmentInfo.segment?.segmentGroups.size, 1);
+		assert.equal(segmentInfo?.segment?.segmentGroups.size, 1);
 
 		client.applyMsg(client.makeOpMessage(removeOp, 18, 0));
 
 		assert.equal(
-			toRemovalInfo(segmentInfo.segment)?.removes[0].seq,
+			toRemovalInfo(segmentInfo?.segment)?.removes[0].seq,
 			remoteMessage.sequenceNumber,
 		);
-		assert(segmentInfo.segment?.segmentGroups.empty);
+		assert(segmentInfo?.segment?.segmentGroups.empty);
 		assert.equal(client.getLength(), initialLength - (end - start));
 		assert.equal(
 			client.getText(),
@@ -553,8 +565,8 @@ describe("client.applyMsg", () => {
 			referenceSequenceNumber: insertMessage2.referenceSequenceNumber,
 			clientId: insertMessage2.clientId,
 		});
-		assert.notStrictEqual(seg.segment, undefined);
-		assert.strictEqual((seg.segment as TextSegment).text, "C");
+		assert.notStrictEqual(seg?.segment, undefined);
+		assert.strictEqual((seg?.segment as TextSegment).text, "C");
 
 		// op with reference sequence >= remove op sequence should not count removed segment
 		const insertMessage3 = clientB.makeOpMessage(insertOp2, seq, removeSequence);
@@ -562,7 +574,7 @@ describe("client.applyMsg", () => {
 			referenceSequenceNumber: insertMessage3.referenceSequenceNumber,
 			clientId: insertMessage3.clientId,
 		});
-		assert.strictEqual(seg.segment, undefined);
+		assert.strictEqual(seg?.segment, undefined);
 	});
 
 	/**
@@ -657,7 +669,7 @@ describe("client.applyMsg", () => {
 		};
 
 		// TODO: tracking group
-		const { segment, offset } = clients.C.getContainingSegment<ISegmentPrivate>(5);
+		const { segment, offset } = clients.C.getContainingSegment<ISegmentPrivate>(5) ?? {};
 		assert(segment !== undefined, "expected segment");
 		const ref = clients.C.createLocalReferencePosition(
 			segment,

--- a/packages/dds/merge-tree/src/test/client.attributionFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.attributionFarm.spec.ts
@@ -74,7 +74,7 @@ describeFuzz("MergeTree.Attribution", ({ testCount }) => {
 							[name: string]: AttributionKey | undefined;
 					  }
 					| undefined => {
-					const { segment, offset } = client.getContainingSegment<ISegmentPrivate>(pos);
+					const { segment, offset } = client.getContainingSegment<ISegmentPrivate>(pos) ?? {};
 					if (segment?.attribution === undefined || offset === undefined) {
 						return undefined;
 					}

--- a/packages/dds/merge-tree/src/test/client.getPosition.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.getPosition.spec.ts
@@ -25,7 +25,8 @@ describe("client.getPosition", () => {
 		client.startOrUpdateCollaboration(localUserLongId);
 
 		const segOff = client.getContainingSegment<ISegmentPrivate>(segPos);
-		assert(TextSegment.is(segOff.segment!));
+		assert(segOff);
+		assert(TextSegment.is(segOff.segment));
 		assert.strictEqual(segOff.offset, 0);
 		assert.strictEqual(segOff.segment.text, "o");
 		segment = segOff.segment;

--- a/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
@@ -87,15 +87,16 @@ describe("MergeTree.Client", () => {
 					refs.push([]);
 					for (let t = 0; t < c.getLength(); t++) {
 						const seg = c.getContainingSegment<ISegmentPrivate>(t);
+						assert(seg);
 						const forwardLref = c.createLocalReferencePosition(
-							seg.segment!,
+							seg.segment,
 							seg.offset,
 							ReferenceType.SlideOnRemove,
 							{ t },
 							SlidingPreference.FORWARD,
 						);
 						const backwardLref = c.createLocalReferencePosition(
-							seg.segment!,
+							seg.segment,
 							seg.offset,
 							ReferenceType.SlideOnRemove,
 							{ t },

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -367,27 +367,31 @@ describe("client.rollback", () => {
 		client.insertTextLocal(0, "d");
 		client.insertTextLocal(0, "abc");
 		const segInfo1 = client.getContainingSegment<ISegmentPrivate>(2);
+		assert(segInfo1);
+
 		const segInfo3 = client.getContainingSegment<ISegmentPrivate>(5);
+		assert(segInfo3);
+
 		const ref1 = client.createLocalReferencePosition(
-			segInfo1.segment!,
+			segInfo1.segment,
 			0,
 			ReferenceType.Simple,
 			undefined,
 		);
 		const refSlide = client.createLocalReferencePosition(
-			segInfo1.segment!,
+			segInfo1.segment,
 			2,
 			ReferenceType.SlideOnRemove,
 			undefined,
 		);
 		const ref2 = client.createLocalReferencePosition(
-			segInfo3.segment!,
+			segInfo3.segment,
 			1,
 			ReferenceType.Simple,
 			undefined,
 		);
 		const refStay = client.createLocalReferencePosition(
-			segInfo3.segment!,
+			segInfo3.segment,
 			1,
 			ReferenceType.StayOnRemove,
 			undefined,
@@ -399,14 +403,14 @@ describe("client.rollback", () => {
 		assert.equal(client.getText(), "abcdefg");
 		const segInfo1After = client.getContainingSegment<ISegmentPrivate>(2);
 		assert.notEqual(segInfo1After, undefined);
-		assert.notEqual(segInfo1After.segment?.localRefs, undefined);
-		assert(segInfo1After.segment?.localRefs!.has(ref1));
-		assert(segInfo1After.segment?.localRefs!.has(refSlide));
+		assert.notEqual(segInfo1After?.segment?.localRefs, undefined);
+		assert(segInfo1After?.segment?.localRefs!.has(ref1));
+		assert(segInfo1After?.segment?.localRefs!.has(refSlide));
 		const segInfo3After = client.getContainingSegment<ISegmentPrivate>(5);
 		assert.notEqual(segInfo3After, undefined);
-		assert.notEqual(segInfo3After.segment?.localRefs, undefined);
-		assert(segInfo3After.segment?.localRefs!.has(ref2));
-		assert(segInfo3After.segment?.localRefs!.has(refStay));
+		assert.notEqual(segInfo3After?.segment?.localRefs, undefined);
+		assert(segInfo3After?.segment?.localRefs!.has(ref2));
+		assert(segInfo3After?.segment?.localRefs!.has(refStay));
 	});
 	it("Should zamboni rolled back remove", () => {
 		client.applyMsg(

--- a/packages/dds/merge-tree/src/test/mergeTree.annotate.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.annotate.spec.ts
@@ -82,7 +82,7 @@ describe("MergeTree", () => {
 					annotateStart,
 					mergeTree.localPerspective,
 				);
-				const segment = segmentInfo.segment as ISegmentPrivate;
+				const segment = segmentInfo?.segment as ISegmentPrivate;
 				assert.equal(segment?.properties?.propertySource, "remote");
 			});
 
@@ -102,7 +102,7 @@ describe("MergeTree", () => {
 					annotateStart,
 					mergeTree.localPerspective,
 				);
-				const segment = segmentInfo.segment as ISegmentPrivate;
+				const segment = segmentInfo?.segment as ISegmentPrivate;
 				assert.equal(segment.properties?.propertySource, "local");
 			});
 		});
@@ -134,7 +134,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 					assert.equal(segment.properties?.propertySource, "local");
 				});
 
@@ -154,7 +154,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 					assert.equal(segment.properties?.secondProperty, "local");
 				});
 
@@ -166,7 +166,7 @@ describe("MergeTree", () => {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					const splitSegment = splitAt(mergeTree, splitPos)!;
 					assertMergeNode(splitSegment);
-					assert.notEqual(segmentInfo.segment?.ordinal, splitSegment.ordinal);
+					assert.notEqual(segmentInfo?.segment?.ordinal, splitSegment.ordinal);
 					assert.equal(splitSegment.properties?.propertySource, "local");
 				});
 
@@ -204,13 +204,13 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 
 					const splitSegmentInfo = mergeTree.getContainingSegment(
 						splitPos,
 						mergeTree.localPerspective,
 					);
-					const splitSegment = splitSegmentInfo.segment as ISegmentPrivate;
+					const splitSegment = splitSegmentInfo?.segment as ISegmentPrivate;
 
 					assert.equal(segment.segmentGroups?.size, 2);
 					assert.equal(segment.properties?.propertySource, "local");
@@ -305,7 +305,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 
 					assert.equal(segment.segmentGroups?.size, 1);
 					assert.equal(segment.properties?.propertySource, "local");
@@ -329,7 +329,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 					assert.equal(segment.segmentGroups?.size, 0);
 					assert.equal(segment.properties?.propertySource, "local");
 				});
@@ -362,7 +362,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 
 					assert.equal(segment.segmentGroups?.size, 0);
 					assert.equal(segment.properties?.propertySource, "remote");
@@ -374,7 +374,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 
 					assert.equal(segment.properties?.propertySource, "local");
 
@@ -499,7 +499,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 
 					assert.equal(segment.properties?.remoteOnly, 1);
 					assert.equal(segment.properties?.propertySource, "remote");
@@ -523,14 +523,14 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					assert(segmentInfo.segment?.segmentGroups?.size !== 0);
+					assert(segmentInfo?.segment?.segmentGroups?.size !== 0);
 				});
 				it("remote only", () => {
 					const segmentInfo = mergeTree.getContainingSegment(
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 					assert.equal(segment.properties?.propertySource, "remote");
 					assert.equal(segment.properties?.remoteProperty, 1);
 				});
@@ -544,7 +544,7 @@ describe("MergeTree", () => {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					const splitSegment = splitAt(mergeTree, annotateStart + 1)!;
 					assertMergeNode(splitSegment);
-					assert.notEqual(segmentInfo.segment?.ordinal, splitSegment.ordinal);
+					assert.notEqual(segmentInfo?.segment?.ordinal, splitSegment.ordinal);
 					assert.equal(splitSegment.properties?.propertySource, "remote");
 					assert.equal(splitSegment.properties?.remoteProperty, 1);
 				});
@@ -565,7 +565,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 					assert.equal(segment.properties?.propertySource, "local");
 					assert.equal(segment.properties?.remoteProperty, 1);
 				});
@@ -579,7 +579,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					assert(segmentInfo.segment?.segmentGroups?.empty !== false);
+					assert(segmentInfo?.segment?.segmentGroups?.empty !== false);
 
 					mergeTree.annotateRange(
 						annotateStart,
@@ -590,7 +590,7 @@ describe("MergeTree", () => {
 						undefined as never,
 					);
 
-					assert.equal(segmentInfo.segment?.segmentGroups?.size, 1);
+					assert.equal(segmentInfo?.segment?.segmentGroups?.size, 1);
 
 					mergeTree.ackOp({
 						op: {
@@ -604,9 +604,9 @@ describe("MergeTree", () => {
 						} as unknown as ISequencedDocumentMessage,
 					});
 
-					assert(segmentInfo.segment?.segmentGroups?.empty);
-					assert.equal(segmentInfo.segment?.properties?.propertySource, "local");
-					assert.equal(segmentInfo.segment?.properties?.remoteProperty, 1);
+					assert(segmentInfo?.segment?.segmentGroups?.empty);
+					assert.equal(segmentInfo?.segment?.properties?.propertySource, "local");
+					assert.equal(segmentInfo?.segment?.properties?.remoteProperty, 1);
 				});
 			});
 			describe("local with rewrite first", () => {
@@ -640,7 +640,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 					assert.equal(segment.properties?.propertySource, "local2");
 					assert.equal(segment.properties?.secondProperty, "local");
 				});
@@ -661,7 +661,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 
 					assert.equal(segment.segmentGroups?.size, 1);
 					assert.equal(segment.properties?.propertySource, "local");
@@ -696,7 +696,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 
 					assert.equal(segment.segmentGroups?.size, 0);
 					assert.equal(segment.properties?.propertySource, "remote");
@@ -742,7 +742,7 @@ describe("MergeTree", () => {
 						annotateStart,
 						mergeTree.localPerspective,
 					);
-					const segment = segmentInfo.segment as ISegmentPrivate;
+					const segment = segmentInfo?.segment as ISegmentPrivate;
 
 					assert.equal(segment.properties?.remoteOnly, 1);
 					assert.equal(segment.properties?.propertySource, "remote");

--- a/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.markRangeRemoved.spec.ts
@@ -89,7 +89,7 @@ describe("MergeTree.markRangeRemoved", () => {
 			"remote",
 		);
 		const segmentExpectedRemovedSeq = seq;
-		const { segment } = client.getContainingSegment<ISegmentPrivate>(0);
+		const { segment } = client.getContainingSegment<ISegmentPrivate>(0) ?? {};
 		assert(segment !== undefined, "expected to find segment");
 		const localDeleteMessage = client.makeOpMessage(
 			client.removeRangeLocal(0, client.getLength()),

--- a/packages/dds/merge-tree/src/test/obliterate.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.spec.ts
@@ -171,11 +171,11 @@ describe("obliterate", () => {
 			);
 			assert.equal(client.getText(), "");
 
-			startSeg.segment?.localRefs?.walkReferences((ref) => {
+			startSeg?.segment.localRefs?.walkReferences((ref) => {
 				const oblProps = ref.properties?.obliterate as ObliterateInfo;
 				assert(oblProps?.start !== undefined, "start ref should NOT be removed");
 			});
-			endSeg.segment?.localRefs?.walkReferences((ref) => {
+			endSeg?.segment.localRefs?.walkReferences((ref) => {
 				const oblProps = ref.properties?.obliterate as ObliterateInfo;
 				assert(oblProps?.end !== undefined, "end ref should NOT be removed");
 			});
@@ -192,11 +192,11 @@ describe("obliterate", () => {
 			}
 
 			// want to check that the start and end segment don't have the obliterate refs on them
-			startSeg.segment?.localRefs?.walkReferences((ref) => {
+			startSeg?.segment.localRefs?.walkReferences((ref) => {
 				const oblProps = ref.properties?.obliterate as ObliterateInfo;
 				assert(oblProps.start === undefined, "start ref should be removed");
 			});
-			endSeg.segment?.localRefs?.walkReferences((ref) => {
+			endSeg?.segment.localRefs?.walkReferences((ref) => {
 				const oblProps = ref.properties?.obliterate as ObliterateInfo;
 				assert(oblProps.end === undefined, "end ref should be removed");
 			});

--- a/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
+++ b/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
@@ -240,7 +240,7 @@ describe("resetPendingSegmentsToOp", () => {
 				prop1: "foo",
 			});
 			assert(insertOp);
-			const { segment } = client.getContainingSegment<ISegmentPrivate>(0);
+			const { segment } = client.getContainingSegment<ISegmentPrivate>(0) ?? {};
 			assert(segment !== undefined && Marker.is(segment));
 			client.annotateMarker(segment, { prop2: "bar" });
 
@@ -253,7 +253,8 @@ describe("resetPendingSegmentsToOp", () => {
 			);
 			otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
-			const { segment: otherSegment } = otherClient.getContainingSegment<ISegmentPrivate>(0);
+			const { segment: otherSegment } =
+				otherClient.getContainingSegment<ISegmentPrivate>(0) ?? {};
 			assert(otherSegment !== undefined && Marker.is(otherSegment));
 			// `clone` here is because properties use a Object.create(null); to compare strict equal the prototype chain
 			// should therefore not include Object.
@@ -277,7 +278,8 @@ describe("resetPendingSegmentsToOp", () => {
 			);
 			otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
-			const { segment: otherSegment } = otherClient.getContainingSegment<ISegmentPrivate>(0);
+			const { segment: otherSegment } =
+				otherClient.getContainingSegment<ISegmentPrivate>(0) ?? {};
 			assert(otherSegment !== undefined && TextSegment.is(otherSegment));
 			assert.deepStrictEqual(otherSegment.properties, clone({ prop1: "foo" }));
 		});
@@ -296,7 +298,8 @@ describe("resetPendingSegmentsToOp", () => {
 			);
 			otherClient.applyMsg(client.makeOpMessage(regeneratedInsert, 1), false);
 
-			const { segment: otherSegment } = otherClient.getContainingSegment<ISegmentPrivate>(0);
+			const { segment: otherSegment } =
+				otherClient.getContainingSegment<ISegmentPrivate>(0) ?? {};
 			assert(otherSegment !== undefined && TextSegment.is(otherSegment));
 			assert.deepStrictEqual(otherSegment.properties, undefined);
 		});

--- a/packages/dds/merge-tree/src/test/snapshot.utils.ts
+++ b/packages/dds/merge-tree/src/test/snapshot.utils.ts
@@ -175,7 +175,7 @@ export class TestString {
 	}
 
 	public getSegment(pos: number): ISegmentPrivate {
-		const { segment } = this.client.getContainingSegment<ISegmentPrivate>(pos);
+		const { segment } = this.client.getContainingSegment<ISegmentPrivate>(pos) ?? {};
 		assert(segment !== undefined);
 		return segment;
 	}

--- a/packages/dds/merge-tree/src/test/sortedSegmentSet.spec.ts
+++ b/packages/dds/merge-tree/src/test/sortedSegmentSet.spec.ts
@@ -68,7 +68,7 @@ describe("SortedSegmentSet", () => {
 		const set = new SortedSegmentSet<{ segment: ISegment }>();
 		for (let i = 0; i < client.getLength(); i++) {
 			for (const pos of [i, client.getLength() - 1 - i]) {
-				const segment = client.getContainingSegment<ISegmentPrivate>(pos).segment;
+				const segment = client.getContainingSegment<ISegmentPrivate>(pos)?.segment;
 				assert(segment);
 				const item = { segment };
 				assert.equal(set.has(item), false);
@@ -84,7 +84,7 @@ describe("SortedSegmentSet", () => {
 		const set = new SortedSegmentSet();
 		for (let i = 0; i < client.getLength(); i++) {
 			for (const pos of [i, client.getLength() - 1 - i]) {
-				const segment = client.getContainingSegment<ISegmentPrivate>(pos).segment;
+				const segment = client.getContainingSegment<ISegmentPrivate>(pos)?.segment;
 				assert(segment);
 				set.addOrUpdate(segment);
 				assert.equal(set.has(segment), true);
@@ -99,7 +99,7 @@ describe("SortedSegmentSet", () => {
 			const random = makeRandom(0);
 			const refsAtAllPositions: LocalReferencePosition[] = [];
 			for (let i = 0; i < client.getLength(); i++) {
-				const { segment, offset } = client.getContainingSegment<ISegmentPrivate>(i);
+				const { segment, offset } = client.getContainingSegment<ISegmentPrivate>(i) ?? {};
 				assert(segment !== undefined);
 				assert(offset !== undefined);
 				refsAtAllPositions.push(

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -419,8 +419,8 @@ export class TestClient extends Client {
 		});
 
 		assert(segment !== undefined, "No segment found");
-		const segoff = getSlideToSegoff({ segment, offset }, undefined, perspective) ?? segment;
-		if (segoff.segment === undefined || segoff.offset === undefined) {
+		const segoff = getSlideToSegoff({ segment, offset }, undefined, perspective);
+		if (segoff === undefined) {
 			return DetachedReferencePosition;
 		}
 
@@ -537,7 +537,7 @@ export class TestClient extends Client {
 	): ReferencePosition | undefined {
 		let foundMarker: Marker | undefined;
 
-		const { segment } = this.getContainingSegment<ISegmentPrivate>(startPos);
+		const { segment } = this.getContainingSegment<ISegmentPrivate>(startPos) ?? {};
 		assertSegmentLeaf(segment);
 		if (Marker.is(segment)) {
 			if (refHasTileLabel(segment, markerLabel)) {

--- a/packages/dds/merge-tree/src/test/tracking.spec.ts
+++ b/packages/dds/merge-tree/src/test/tracking.spec.ts
@@ -45,7 +45,7 @@ describe("MergeTree.tracking", () => {
 
 		assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 1);
 
-		assert(trackingGroup.unlink(segmentInfo.segment), "unlink segment should be true");
+		assert(trackingGroup.unlink(segmentInfo?.segment), "unlink segment should be true");
 
 		assert.equal(segmentInfo?.segment?.trackingCollection.trackingGroups.size, 0);
 	});
@@ -110,9 +110,9 @@ describe("MergeTree.tracking", () => {
 		assert.equal(testClient.getLength(), 3);
 
 		const segmentInfo = testClient.getContainingSegment<ISegmentPrivate>(0);
-		assert(segmentInfo.segment);
+		assert(segmentInfo?.segment);
 		const ref = testClient.createLocalReferencePosition(
-			segmentInfo.segment,
+			segmentInfo?.segment,
 			0,
 			ReferenceType.SlideOnRemove,
 			undefined,
@@ -127,9 +127,9 @@ describe("MergeTree.tracking", () => {
 		assert.equal(testClient.getLength(), 3);
 
 		const segmentInfo = testClient.getContainingSegment<ISegmentPrivate>(0);
-		assert(segmentInfo.segment);
+		assert(segmentInfo?.segment);
 		const ref = testClient.createLocalReferencePosition(
-			segmentInfo.segment,
+			segmentInfo?.segment,
 			0,
 			ReferenceType.SlideOnRemove,
 			undefined,
@@ -157,7 +157,7 @@ describe("MergeTree.tracking", () => {
 
 		testClient.insertTextLocal(0, "abc");
 
-		const { segment } = testClient.getContainingSegment<ISegmentPrivate>(0);
+		const { segment } = testClient.getContainingSegment<ISegmentPrivate>(0) ?? {};
 		segment?.trackingCollection.link(trackingGroup);
 
 		assert.equal(segment?.trackingCollection.trackingGroups.size, 1);
@@ -183,7 +183,7 @@ describe("MergeTree.tracking", () => {
 
 		testClient.insertTextLocal(0, "abc");
 
-		const { segment } = testClient.getContainingSegment<ISegmentPrivate>(0);
+		const { segment } = testClient.getContainingSegment<ISegmentPrivate>(0) ?? {};
 		segment?.trackingCollection.link(trackingGroup);
 
 		assert.equal(segment?.trackingCollection.trackingGroups.size, 1);

--- a/packages/dds/merge-tree/src/test/wordUnitTests.spec.ts
+++ b/packages/dds/merge-tree/src/test/wordUnitTests.spec.ts
@@ -142,8 +142,8 @@ function makeBookmarks(client: TestClient, bookmarkCount: number): ReferencePosi
 			refType = ReferenceType.SlideOnRemove;
 		}
 		const lref = client.mergeTree.createLocalReferencePosition(
-			segoff.segment!,
-			segoff.offset!,
+			segoff!.segment,
+			segoff!.offset,
 			refType,
 			undefined,
 		);
@@ -169,10 +169,10 @@ function measureFetch(startFile: string, withBookmarks = false): void {
 			const curPG = client.searchForMarker(pos, "pg", true)!;
 			const properties = curPG.properties!;
 			const curSegOff = client.getContainingSegment<ISegmentPrivate>(pos)!;
-			const curSeg = curSegOff.segment!;
+			const curSeg = curSegOff.segment;
 			// Combine paragraph and direct properties
 			extend(properties, curSeg.properties);
-			pos += curSeg.cachedLength - curSegOff.offset!;
+			pos += curSeg.cachedLength - curSegOff.offset;
 			count++;
 		}
 	}

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -920,28 +920,28 @@ export class IntervalCollection
 		}
 
 		const { clientId } = this.client.getCollabWindow();
-		const { segment, offset } = this.client.getContainingSegment(
-			pos,
-			{
-				referenceSequenceNumber: seqNumberFrom,
-				clientId: this.client.getLongClientId(clientId),
-			},
-			localSeq,
-		);
+		const { segment, offset } =
+			this.client.getContainingSegment(
+				pos,
+				{
+					referenceSequenceNumber: seqNumberFrom,
+					clientId: this.client.getLongClientId(clientId),
+				},
+				localSeq,
+			) ?? {};
 
 		// if segment is undefined, it slid off the string
-		assert(segment !== undefined, 0x54e /* No segment found */);
+		assert(segment !== undefined && offset !== undefined, 0x54e /* No segment found */);
 
-		const segoff =
-			getSlideToSegoff(
-				{ segment, offset },
-				undefined,
-				createLocalReconnectingPerspective(this.client.getCurrentSeq(), clientId, localSeq),
-				this.options.mergeTreeReferencesCanSlideToEndpoint,
-			) ?? segment;
+		const segoff = getSlideToSegoff(
+			{ segment, offset },
+			undefined,
+			createLocalReconnectingPerspective(this.client.getCurrentSeq(), clientId, localSeq),
+			this.options.mergeTreeReferencesCanSlideToEndpoint,
+		);
 
 		// case happens when rebasing op, but concurrently entire string has been deleted
-		if (segoff.segment === undefined || segoff.offset === undefined) {
+		if (segoff?.segment === undefined || segoff.offset === undefined) {
 			return DetachedReferencePosition;
 		}
 
@@ -1523,28 +1523,27 @@ export class IntervalCollection
 	private getSlideToSegment(
 		lref: LocalReferencePosition,
 		slidingPreference: SlidingPreference,
-	): { segment: ISegment | undefined; offset: number | undefined } | undefined {
+	): { segment: ISegment; offset: number } | undefined {
 		if (!this.client) {
 			throw new LoggingError("client does not exist");
 		}
-		const segoff: { segment: ISegmentInternal | undefined; offset: number | undefined } = {
-			segment: lref.getSegment(),
-			offset: lref.getOffset(),
-		};
-		if (segoff.segment?.localRefs?.has(lref) !== true) {
+		const segment: ISegmentInternal | undefined = lref.getSegment();
+		if (segment === undefined) {
 			return undefined;
 		}
-		const newSegoff = getSlideToSegoff(
+		const segoff = {
+			segment,
+			offset: lref.getOffset(),
+		};
+		if (segoff.segment.localRefs?.has(lref) !== true) {
+			return undefined;
+		}
+		return getSlideToSegoff(
 			segoff,
 			slidingPreference,
 			undefined,
 			this.options.mergeTreeReferencesCanSlideToEndpoint,
 		);
-		const value: { segment: ISegment | undefined; offset: number | undefined } | undefined =
-			segoff.segment === newSegoff.segment && segoff.offset === newSegoff.offset
-				? undefined
-				: newSegoff;
-		return value;
 	}
 
 	private ackInterval(interval: SequenceIntervalClass, op: ISequencedDocumentMessage): void {
@@ -1572,8 +1571,9 @@ export class IntervalCollection
 			setSlideOnRemove(interval.end);
 		}
 
-		const needsStartUpdate = newStart !== undefined && !hasPendingChange;
-		const needsEndUpdate = newEnd !== undefined && !hasPendingChange;
+		const needsStartUpdate =
+			newStart?.segment !== interval.start.getSegment() && !hasPendingChange;
+		const needsEndUpdate = newEnd?.segment !== interval.end.getSegment() && !hasPendingChange;
 
 		if (needsStartUpdate || needsEndUpdate) {
 			if (!this.localCollection) {

--- a/packages/dds/sequence/src/intervals/sequenceInterval.ts
+++ b/packages/dds/sequence/src/intervals/sequenceInterval.ts
@@ -589,7 +589,7 @@ export class SequenceIntervalClass implements SequenceInterval, ISerializableInt
 
 export function createPositionReferenceFromSegoff(
 	client: Client,
-	segoff: { segment: ISegment | undefined; offset: number | undefined } | "start" | "end",
+	segoff: { segment: ISegment; offset: number } | undefined | "start" | "end",
 	refType: ReferenceType,
 	op?: ISequencedDocumentMessage,
 	localSeq?: number,
@@ -609,7 +609,7 @@ export function createPositionReferenceFromSegoff(
 		);
 	}
 
-	if (segoff.segment) {
+	if (segoff?.segment) {
 		const ref = client.createLocalReferencePosition(
 			segoff.segment,
 			segoff.offset,

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -398,12 +398,13 @@ function getSlidePosition(
 	lref: LocalReferencePosition,
 	pos: number,
 ): number {
-	const slide = getSlideToSegoff(
-		{ segment: lref.getSegment(), offset: undefined },
-		lref.slidingPreference,
-	);
-	return slide?.segment !== undefined &&
-		slide.offset !== undefined &&
+	const segment = lref.getSegment();
+	const offset = lref.getOffset();
+	const slide =
+		segment === undefined
+			? undefined
+			: getSlideToSegoff({ segment, offset }, lref.slidingPreference);
+	return slide !== undefined &&
 		string.getPosition(slide.segment) !== -1 &&
 		(pos < 0 || pos >= string.getLength())
 		? string.getPosition(slide.segment) + slide.offset

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -586,7 +586,9 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 		segment: T | undefined;
 		offset: number | undefined;
 	} {
-		return this.client.getContainingSegment<T>(pos);
+		return (
+			this.client.getContainingSegment<T>(pos) ?? { segment: undefined, offset: undefined }
+		);
 	}
 
 	public getLength(): number {


### PR DESCRIPTION
This pull request refactors several methods and classes in the `merge-tree` package to improve type safety and handle undefined values more gracefully. It also updates related test files to align with the new changes. The key changes focus on improving type definitions, ensuring safe navigation, and simplifying code logic.

The primary change is moving from a segment-offset type of the form:
 `{segment: ISegment | undefined, offset: number | undefined}` 
to:
 `{segment: ISegment , offset: number } | undefined`

### Refactoring for Improved Type Safety

* Updated the return type of `getContainingSegment` in `packages/dds/merge-tree/src/mergeTree.ts` to use stricter type definitions (`segment` and `offset` are now required when defined). This ensures better type safety throughout the codebase. [[1]](diffhunk://#diff-8309e2d809e51f70fc12c75a986b3a4c0e490f508bbfb394fd36c57594f3c9f6L852-R862) [[2]](diffhunk://#diff-8309e2d809e51f70fc12c75a986b3a4c0e490f508bbfb394fd36c57594f3c9f6R878-R880)

* Modified `getSlideToSegoff` in `packages/dds/merge-tree/src/mergeTree.ts` to handle undefined values explicitly and use stricter type definitions. Added checks to validate `segment` and `offset` before returning. [[1]](diffhunk://#diff-8309e2d809e51f70fc12c75a986b3a4c0e490f508bbfb394fd36c57594f3c9f6L472-R482) [[2]](diffhunk://#diff-8309e2d809e51f70fc12c75a986b3a4c0e490f508bbfb394fd36c57594f3c9f6L493-R499)

### Graceful Handling of Undefined Values

* Updated methods such as `getPropertiesAtPosition` and `getRangeExtentsOfPosition` in `packages/dds/merge-tree/src/client.ts` to use safe navigation (`?.`) for handling potential undefined values in `segment`. [[1]](diffhunk://#diff-44376f4041a9802657345f8b3f961115e219b0c831da2b8f22894cf95d234badL1633-R1648) [[2]](diffhunk://#diff-44376f4041a9802657345f8b3f961115e219b0c831da2b8f22894cf95d234badL1657-R1659)

* Refactored tests in various files (`client.applyMsg.spec.ts`, `client.localReference.spec.ts`, etc.) to use safe navigation (`?.`) and added assertions to handle undefined values gracefully. [[1]](diffhunk://#diff-baa68ddc1f71b6bd430197fc40f54be7a33ba25df637a80281e25f38859e61fbL125-R130) [[2]](diffhunk://#diff-e6e8de42ce9127f15f55271f3a63cf8fe42b1779f03921a41358cceeea6598dcR78-R80) [[3]](diffhunk://#diff-e6e8de42ce9127f15f55271f3a63cf8fe42b1779f03921a41358cceeea6598dcL215-R220)

### Simplification of Code Logic

* Simplified destructuring logic in `getSlideToSegoff` and `getContainingSegment` methods by using default values and safe navigation operators. This reduces unnecessary checks and improves readability. [[1]](diffhunk://#diff-44376f4041a9802657345f8b3f961115e219b0c831da2b8f22894cf95d234badL881-R894) [[2]](diffhunk://#diff-8309e2d809e51f70fc12c75a986b3a4c0e490f508bbfb394fd36c57594f3c9f6L1532-R1543)

* Updated test cases in `beastTest.spec.ts` and other test files to align with the new type definitions and safe navigation changes, ensuring consistency across the codebase. [[1]](diffhunk://#diff-21868c2af0db60eaae6f2ef1b51a334c8c28b06762b48a47ea40a049ee249e95L377-R377) [[2]](diffhunk://#diff-363de3d3604be524fc68e1abaf1885a3ed6c3ba957f7fe5e30727d5126a3e529L77-R77)

### Test Updates for Consistency

* Refactored assertions and test logic in `client.applyMsg.spec.ts` and `client.localReference.spec.ts` to account for stricter type definitions and safe navigation changes. This ensures tests validate the new behavior correctly. [[1]](diffhunk://#diff-baa68ddc1f71b6bd430197fc40f54be7a33ba25df637a80281e25f38859e61fbL556-R577) [[2]](diffhunk://#diff-e6e8de42ce9127f15f55271f3a63cf8fe42b1779f03921a41358cceeea6598dcR135-R137)

* Updated test cases in `client.getPosition.spec.ts` and `client.annotateMarker.spec.ts` to include assertions for undefined handling and stricter type checks. [[1]](diffhunk://#diff-c7a35013ba27ae6fef79ee0dad2617ed02f67570e475b6c8b2f243d076ee914bL28-R29) [[2]](diffhunk://#diff-af52bd7aec138346deb5a440493f5936fa7fe1bc90f8d77131c364d2155711d2L37-R37)