### PR TITLE
refactor(api-markdown-documenter): Restrict `FencedCodeBlockNode` children

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -32,7 +32,7 @@ Additionally, the structure of `ListNode` has been updated to utilize `ListItemN
 
 ### `FencedCodeBlockNode` updated to only allow plain text and line breaks
 
-This matches the requirements for fenced code in Markdown, and is all that was required by the system.
+This matches the requirements for fenced code in Markdown and is all that was required by the system.
 
 ### `BlockQuoteNode` was removed
 

--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -30,6 +30,10 @@ Their `createFromPlainText` static factory functions have also been removed, as 
 
 Additionally, the structure of `ListNode` has been updated to utilize `ListItemNode`s as children to make it easier to group child contents within a single list entry.
 
+### `FencedCodeBlockNode` updated to only allow plain text and line breaks
+
+This matches the requirements for fenced code in Markdown, and is all that was required by the system.
+
 ### `BlockQuoteNode` was removed
 
 This `DocumentationNode` implementation was not used by the library.

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -357,12 +357,15 @@ export namespace DocumentWriter {
 }
 
 // @public @sealed
-export class FencedCodeBlockNode extends DocumentationParentNodeBase<PhrasingContent> {
-    constructor(children: PhrasingContent[], language?: string);
+export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeBlockNodeContent> {
+    constructor(children: FencedCodeBlockNodeContent[], language?: string);
     static createFromPlainText(text: string, language?: string): FencedCodeBlockNode;
     readonly language?: string;
     readonly type = "fencedCode";
 }
+
+// @public
+export type FencedCodeBlockNodeContent = PlainTextNode | LineBreakNode;
 
 // @public
 export interface FileSystemConfiguration {

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -357,12 +357,15 @@ export namespace DocumentWriter {
 }
 
 // @public @sealed
-export class FencedCodeBlockNode extends DocumentationParentNodeBase<PhrasingContent> {
-    constructor(children: PhrasingContent[], language?: string);
+export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeBlockNodeContent> {
+    constructor(children: FencedCodeBlockNodeContent[], language?: string);
     static createFromPlainText(text: string, language?: string): FencedCodeBlockNode;
     readonly language?: string;
     readonly type = "fencedCode";
 }
+
+// @public
+export type FencedCodeBlockNodeContent = PlainTextNode | LineBreakNode;
 
 // @public
 export interface FileSystemConfiguration {

--- a/tools/api-markdown-documenter/src/documentation-domain/FencedCodeBlockNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/FencedCodeBlockNode.ts
@@ -4,8 +4,16 @@
  */
 
 import { DocumentationParentNodeBase } from "./DocumentationNode.js";
-import type { PhrasingContent } from "./PhrasingContent.js";
+import type { LineBreakNode } from "./LineBreakNode.js";
+import type { PlainTextNode } from "./PlainTextNode.js";
 import { createNodesFromPlainText } from "./Utilities.js";
+
+/**
+ * The types of child nodes that can be contained within a {@link FencedCodeBlockNode}.
+ *
+ * @public
+ */
+export type FencedCodeBlockNodeContent = PlainTextNode | LineBreakNode;
 
 /**
  * A fenced code block, with an optional associated code language.
@@ -29,7 +37,7 @@ import { createNodesFromPlainText } from "./Utilities.js";
  * @sealed
  * @public
  */
-export class FencedCodeBlockNode extends DocumentationParentNodeBase<PhrasingContent> {
+export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeBlockNodeContent> {
 	/**
 	 * {@inheritDoc DocumentationNode."type"}
 	 */
@@ -40,7 +48,7 @@ export class FencedCodeBlockNode extends DocumentationParentNodeBase<PhrasingCon
 	 */
 	public readonly language?: string;
 
-	public constructor(children: PhrasingContent[], language?: string) {
+	public constructor(children: FencedCodeBlockNodeContent[], language?: string) {
 		super(children);
 		this.language = language;
 	}

--- a/tools/api-markdown-documenter/src/documentation-domain/index.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/index.ts
@@ -27,7 +27,10 @@ export {
 	type DocumentationParentNode,
 	DocumentationParentNodeBase,
 } from "./DocumentationNode.js";
-export { FencedCodeBlockNode } from "./FencedCodeBlockNode.js";
+export {
+	FencedCodeBlockNode,
+	type FencedCodeBlockNodeContent,
+} from "./FencedCodeBlockNode.js";
 export { HeadingNode } from "./HeadingNode.js";
 export { HorizontalRuleNode } from "./HorizontalRuleNode.js";
 export { LineBreakNode } from "./LineBreakNode.js";


### PR DESCRIPTION
This matches the requirements for fenced code in Markdown and is all that was required by the system.