### PR TITLE
fix(test-version-utils): Add driverEndpointName to telemetry event

### DIFF
--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -4,7 +4,11 @@
  */
 
 import { mixinAttributor } from "@fluid-experimental/attributor";
-import { TestDriverTypes } from "@fluid-internal/test-driver-definitions";
+import {
+	TestDriverTypes,
+	type OdspEndpoint,
+	type RouterliciousEndpoint,
+} from "@fluid-internal/test-driver-definitions";
 import { FluidTestDriverConfig, createFluidTestDriver } from "@fluid-private/test-drivers";
 import {
 	DefaultSummaryConfiguration,
@@ -411,4 +415,31 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 			},
 		},
 	);
+}
+
+/**
+ * Returns an object with `driverType` and `driverEndpointName` properties for use in telemetry.
+ * @remarks Mostly exists to have a single place for this logic.
+ *
+ * @param driver - The driver type according to the config (environment or however it was provided)
+ * @param odspEndpointName - The ODSP endpoint name according to the config (environment or however it was provided)
+ * @param r11sEndpointName - The R11S endpoint name according to the config (environment or however it was provided)
+ */
+export function getDriverInformationWhenNoProviderIsAvailable(
+	driver: TestDriverTypes,
+	odspEndpointName: OdspEndpoint | undefined,
+	r11sEndpointName: RouterliciousEndpoint | undefined,
+): {
+	driverType: TestDriverTypes;
+	driverEndpointName: OdspEndpoint | RouterliciousEndpoint | undefined;
+} {
+	return {
+		driverType: driver,
+		driverEndpointName:
+			driver === "odsp"
+				? odspEndpointName
+				: driver === "routerlicious" || driver === "r11s"
+					? r11sEndpointName
+					: undefined,
+	};
 }

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -100,7 +100,7 @@ function createCompatSuite(
 						});
 						logger.sendErrorEvent(
 							{
-								// Note: places where the ITestObjectProvider is available can use provider.driver.[type|endpointName].
+								// Note: TestObjectProvider already adds driverType and driverEndpointName to logs that go through it.
 								// In this code path we could not create the provider so we have to do things by hand.
 								...getDriverInformationWhenNoProviderIsAvailable(
 									driver,

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -30,6 +30,7 @@ import {
 import {
 	getVersionedTestObjectProviderFromApis,
 	getCompatVersionedTestObjectProviderFromApis,
+	getDriverInformationWhenNoProviderIsAvailable,
 } from "./compatUtils.js";
 import {
 	getContainerRuntimeApi,
@@ -99,8 +100,14 @@ function createCompatSuite(
 						});
 						logger.sendErrorEvent(
 							{
+								// Note: places where the ITestObjectProvider is available can use provider.driver.[type|endpointName].
+								// In this code path we could not create the provider so we have to do things by hand.
+								...getDriverInformationWhenNoProviderIsAvailable(
+									driver,
+									odspEndpointName,
+									r11sEndpointName,
+								),
 								eventName: "TestObjectProviderLoadFailed",
-								driverType: driver,
 							},
 							error,
 						);

--- a/packages/test/test-version-utils/src/describeE2eDocs.ts
+++ b/packages/test/test-version-utils/src/describeE2eDocs.ts
@@ -22,7 +22,10 @@ import {
 	r11sEndpointName,
 	tenantIndex,
 } from "./compatOptions.js";
-import { getVersionedTestObjectProviderFromApis } from "./compatUtils.js";
+import {
+	getDriverInformationWhenNoProviderIsAvailable,
+	getVersionedTestObjectProviderFromApis,
+} from "./compatUtils.js";
 import { ITestObjectProviderOptions } from "./describeCompat.js";
 import {
 	getDataRuntimeApi,
@@ -373,7 +376,7 @@ function createE2EDocCompatSuite(
 						),
 					};
 
-					before(async function () {
+					before("Create TestObjectProvider", async function () {
 						try {
 							provider = await getVersionedTestObjectProviderFromApis(apis, {
 								type: driver,
@@ -389,8 +392,14 @@ function createE2EDocCompatSuite(
 							});
 							logger.sendErrorEvent(
 								{
+									// Note: places where the ITestObjectProvider is available can use provider.driver.[type|endpointName].
+									// In this code path we could not create the provider so we have to do things by hand.
+									...getDriverInformationWhenNoProviderIsAvailable(
+										driver,
+										odspEndpointName,
+										r11sEndpointName,
+									),
 									eventName: "TestObjectProviderLoadFailed",
-									driverType: driver,
 								},
 								error,
 							);

--- a/packages/test/test-version-utils/src/describeE2eDocs.ts
+++ b/packages/test/test-version-utils/src/describeE2eDocs.ts
@@ -392,7 +392,7 @@ function createE2EDocCompatSuite(
 							});
 							logger.sendErrorEvent(
 								{
-									// Note: places where the ITestObjectProvider is available can use provider.driver.[type|endpointName].
+									// Note: TestObjectProvider already adds driverType and driverEndpointName to logs that go through it.
 									// In this code path we could not create the provider so we have to do things by hand.
 									...getDriverInformationWhenNoProviderIsAvailable(
 										driver,


### PR DESCRIPTION
## Description

Updates the telemetry event generated in a few places in test-version-utils when we cannot create an `ITestObjectProvider` to include the driver endpoint name. This should fix the subject and embedded queries in the incident emails our OCEs get when this failure happens enough times to trigger an incident.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
