### PR TITLE
test: improvement: use satisfies instead of explicit typing for errorScenarios

### DIFF
--- a/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
@@ -113,7 +113,7 @@ describe("Routerlicious Socket Error Handling", () => {
 			expectedErrorType: RouterliciousErrorTypes.clusterDrainingError,
 			expectedInternalErrorCode: R11sServiceClusterDrainingErrorCode,
 		},
-	] satisfies IErrorScenario[];
+	] as const satisfies IErrorScenario[];
 
 	beforeEach(async () => {
 		routerliciousDocumentServiceFactory = new RouterliciousDocumentServiceFactory(

--- a/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
@@ -87,7 +87,7 @@ describe("Routerlicious Socket Error Handling", () => {
 	}
 
 	// Defines error scenarios in a structured way to avoid test code repetition.
-	const errorScenarios: IErrorScenario[] = [
+	const errorScenarios = [
 		{
 			name: "Token Revoked",
 			errorToThrow: {
@@ -113,7 +113,7 @@ describe("Routerlicious Socket Error Handling", () => {
 			expectedErrorType: RouterliciousErrorTypes.clusterDrainingError,
 			expectedInternalErrorCode: R11sServiceClusterDrainingErrorCode,
 		},
-	];
+	] satisfies IErrorScenario[];
 
 	beforeEach(async () => {
 		routerliciousDocumentServiceFactory = new RouterliciousDocumentServiceFactory(


### PR DESCRIPTION
Address PR feedback from @jason-ha on #24844 to use `satisfies IErrorScenario[]` instead of explicit typing `const errorScenarios: IErrorScenario[] = [...]`.

**Changes:**
- Changed `const errorScenarios: IErrorScenario[] = [` to `const errorScenarios = [ ... ] satisfies IErrorScenario[];`
