### PR TITLE
(compat) Fixed layer compat test failing due to UsageError validation

### DIFF
--- a/packages/loader/container-loader/src/test/loaderLayerCompatValidation.spec.ts
+++ b/packages/loader/container-loader/src/test/loaderLayerCompatValidation.spec.ts
@@ -18,7 +18,7 @@ import {
 	type IResolvedUrl,
 	type IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { isFluidError } from "@fluidframework/telemetry-utils/internal";
 import Sinon from "sinon";
 
 import { Loader } from "../loader.js";
@@ -51,7 +51,10 @@ function validateFailureProperties(
 	layerType: "Runtime" | "Driver",
 	unsupportedFeatures?: string[],
 ): boolean {
-	assert(error instanceof UsageError, "The error should be a UsageError");
+	assert(
+		isFluidError(error) && error.errorType === FluidErrorTypes.usageError,
+		"Error should be a usageError",
+	);
 	assert.strictEqual(
 		error.errorType,
 		FluidErrorTypes.usageError,
@@ -131,7 +134,7 @@ describe("Loader Layer compatibility", () => {
 			const layerSupportRequirements = testCase.layerSupportRequirements;
 			let originalRequiredFeatures: readonly string[];
 			beforeEach(() => {
-				originalRequiredFeatures = layerSupportRequirements.requiredFeatures;
+				originalRequiredFeatures = [...layerSupportRequirements.requiredFeatures];
 			});
 
 			afterEach(() => {

--- a/packages/runtime/container-runtime/src/test/runtimeLayerCompatValidation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/runtimeLayerCompatValidation.spec.ts
@@ -18,7 +18,7 @@ import {
 	FluidErrorTypes,
 	type ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces/internal";
-import { createChildLogger, UsageError } from "@fluidframework/telemetry-utils/internal";
+import { createChildLogger, isFluidError } from "@fluidframework/telemetry-utils/internal";
 import {
 	MockDeltaManager,
 	MockAudience,
@@ -52,7 +52,10 @@ function validateFailureProperties(
 	layerType: "Loader" | "DataStore",
 	unsupportedFeatures?: string[],
 ): boolean {
-	assert(error instanceof UsageError, "The error should be a UsageError");
+	assert(
+		isFluidError(error) && error.errorType === FluidErrorTypes.usageError,
+		"Error should be a usageError",
+	);
 	assert.strictEqual(
 		error.errorType,
 		FluidErrorTypes.usageError,
@@ -104,7 +107,7 @@ describe("Runtime Layer compatibility", () => {
 	describe("Runtime <-> Loader compatibility", () => {
 		let originalRequiredFeatures: readonly string[];
 		beforeEach(() => {
-			originalRequiredFeatures = loaderSupportRequirements.requiredFeatures;
+			originalRequiredFeatures = [...loaderSupportRequirements.requiredFeatures];
 		});
 
 		afterEach(() => {

--- a/packages/runtime/datastore/src/test/dataStoreLayerCompatValidation.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreLayerCompatValidation.spec.ts
@@ -14,7 +14,7 @@ import {
 	type ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces/internal";
 import type { IChannel } from "@fluidframework/datastore-definitions/internal";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { isFluidError } from "@fluidframework/telemetry-utils/internal";
 import { MockFluidDataStoreContext } from "@fluidframework/test-runtime-utils/internal";
 import Sinon from "sinon";
 
@@ -36,7 +36,7 @@ type ILayerCompatSupportRequirementsOverride = Omit<
 describe("DataStore Layer compatibility", () => {
 	let originalRequiredFeatures: readonly string[];
 	beforeEach(() => {
-		originalRequiredFeatures = runtimeSupportRequirements.requiredFeatures;
+		originalRequiredFeatures = [...runtimeSupportRequirements.requiredFeatures];
 	});
 
 	afterEach(() => {
@@ -50,7 +50,10 @@ describe("DataStore Layer compatibility", () => {
 		runtimeGeneration: number,
 		unsupportedFeatures?: string[],
 	): boolean {
-		assert(error instanceof UsageError, "The error should be a UsageError");
+		assert(
+			isFluidError(error) && error.errorType === FluidErrorTypes.usageError,
+			"Error should be a usageError",
+		);
 		assert.strictEqual(
 			error.errorType,
 			FluidErrorTypes.usageError,

--- a/packages/test/test-end-to-end-tests/src/test/layerCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/layerCompat.spec.ts
@@ -11,13 +11,9 @@ import {
 	driverSupportRequirements,
 	loaderCoreCompatDetails,
 } from "@fluidframework/container-loader/internal";
-import {
-	FluidErrorTypes,
-	type ITelemetryBaseProperties,
-} from "@fluidframework/core-interfaces/internal";
+import { type ITelemetryBaseProperties } from "@fluidframework/core-interfaces/internal";
 import { localDriverCompatDetailsForLoader } from "@fluidframework/local-driver/internal";
-import { isFluidError } from "@fluidframework/telemetry-utils/internal";
-import { ITestObjectProvider } from "@fluidframework/test-utils/internal";
+import { isUsageError, ITestObjectProvider } from "@fluidframework/test-utils/internal";
 
 type ILayerCompatSupportRequirementsOverride = Omit<
 	ILayerCompatSupportRequirements,
@@ -36,10 +32,7 @@ function validateFailureProperties(
 	minSupportedGeneration: number,
 	unsupportedFeatures?: string[],
 ): boolean {
-	assert(
-		isFluidError(error) && error.errorType === FluidErrorTypes.usageError,
-		"Error should be a usageError",
-	);
+	assert(isUsageError(error), "Error should be a usageError");
 	const telemetryProps = error.getTelemetryProperties();
 	assert(typeof telemetryProps.errorDetails === "string", "Error details should be present");
 	const properties = JSON.parse(telemetryProps.errorDetails) as ITelemetryBaseProperties;

--- a/packages/test/test-end-to-end-tests/src/test/layerCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/layerCompat.spec.ts
@@ -16,7 +16,7 @@ import {
 	type ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces/internal";
 import { localDriverCompatDetailsForLoader } from "@fluidframework/local-driver/internal";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { isFluidError } from "@fluidframework/telemetry-utils/internal";
 import { ITestObjectProvider } from "@fluidframework/test-utils/internal";
 
 type ILayerCompatSupportRequirementsOverride = Omit<
@@ -36,11 +36,9 @@ function validateFailureProperties(
 	minSupportedGeneration: number,
 	unsupportedFeatures?: string[],
 ): boolean {
-	assert(error instanceof UsageError, "The error should be a UsageError");
-	assert.strictEqual(
-		error.errorType,
-		FluidErrorTypes.usageError,
-		"Error type should be usageError",
+	assert(
+		isFluidError(error) && error.errorType === FluidErrorTypes.usageError,
+		"Error should be a usageError",
 	);
 	const telemetryProps = error.getTelemetryProperties();
 	assert(typeof telemetryProps.errorDetails === "string", "Error details should be present");
@@ -111,7 +109,7 @@ describeCompat("Layer compatibility", "NoCompat", (getTestObjectProvider) => {
 		let originalMinSupportedGeneration: number;
 
 		beforeEach(() => {
-			originalRequiredFeatures = driverSupportRequirementsOverride.requiredFeatures;
+			originalRequiredFeatures = [...driverSupportRequirementsOverride.requiredFeatures];
 			originalMinSupportedGeneration =
 				driverSupportRequirementsOverride.minSupportedGeneration;
 		});
@@ -135,7 +133,7 @@ describeCompat("Layer compatibility", "NoCompat", (getTestObjectProvider) => {
 			);
 		});
 
-		itExpects.skip(
+		itExpects(
 			`Driver generation is not compatible with Loader`,
 			[{ eventName: "fluid:telemetry:Container:ContainerDispose", errorType: "usageError" }],
 			async () => {
@@ -158,7 +156,7 @@ describeCompat("Layer compatibility", "NoCompat", (getTestObjectProvider) => {
 			},
 		);
 
-		itExpects.skip(
+		itExpects(
 			`Driver supported features are not compatible with Loader`,
 			[{ eventName: "fluid:telemetry:Container:ContainerDispose", errorType: "usageError" }],
 			async () => {

--- a/packages/test/test-utils/src/errors.ts
+++ b/packages/test/test-utils/src/errors.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { FluidErrorTypes } from "@fluidframework/core-interfaces/internal";
+import { isFluidError, type IFluidErrorBase } from "@fluidframework/telemetry-utils/internal";
+
+/**
+ * Helper that returns whether the provided error is a usage error. There are more than one implementations of
+ * UsageError, so checking for "instanceOf UsageError" in end to end tests can yield in incorrect behavior. This
+ * function is agnostic of the implementation of UsageError and checks for the errorType instead.
+ *
+ *
+ * @internal
+ */
+export function isUsageError(error: unknown): error is IFluidErrorBase {
+	return isFluidError(error) && error.errorType === FluidErrorTypes.usageError;
+}

--- a/packages/test/test-utils/src/index.ts
+++ b/packages/test/test-utils/src/index.ts
@@ -70,3 +70,5 @@ export {
 } from "./testContainerRuntimeFactoryWithDefaultDataStore.js";
 
 export { TestFluidObjectInternal } from "./testFluidObjectInternal.js";
+
+export { isUsageError } from "./errors.js";


### PR DESCRIPTION
## Bug
Some of the layer compat end-to-end tests were disabled recently via https://github.com/microsoft/FluidFramework/pull/24843.

These tests were failing in the end-to-end test CI pipeline. The reason for the failures was that they were validating that the error thrown due to layer compat incompatibility were an instance of UsageError. However, there are 2 classes of UsageError loaded (it has 2 implementations) and so, for some reason due to either compat config or some other dynamic import, there was a mismatch during validation.

## Fix
This PR fixes the issue by validating the error is `isFluidError` and the errorType is `usageError` asn these checks are agnostic to instanceOf.