### PR TITLE
Remove IFluidHandleInternal.bind

### DIFF
--- a/experimental/dds/tree/src/migration-shim/shimHandle.ts
+++ b/experimental/dds/tree/src/migration-shim/shimHandle.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { type IFluidHandleInternal } from '@fluidframework/core-interfaces/internal';
 import { FluidHandleBase, toFluidHandleInternal } from '@fluidframework/runtime-utils/internal';
 
 import { type IShim } from './types.js';
@@ -32,11 +31,5 @@ export class ShimHandle<TShim extends IShim> extends FluidHandleBase<TShim> {
 	}
 	public async get(): Promise<TShim> {
 		return this.shim;
-	}
-	/**
-	 * @deprecated No replacement provided. Arbitrary handles may not serve as a bind source.
-	 */
-	public bind(handle: IFluidHandleInternal): void {
-		return toFluidHandleInternal(this.shim.currentTree.handle).bind(handle);
 	}
 }

--- a/experimental/dds/tree/src/test/utilities/TestSerializer.ts
+++ b/experimental/dds/tree/src/test/utilities/TestSerializer.ts
@@ -39,13 +39,6 @@ export class TestFluidHandle extends FluidHandleBase<unknown> {
 		throw new Error('Method not implemented.');
 	}
 
-	/**
-	 * @deprecated No replacement provided. Arbitrary handles may not serve as a bind source.
-	 */
-	public bind(handle: IFluidHandle): void {
-		throw new Error('Method not implemented.');
-	}
-
 	public attachGraph(): void {
 		throw new Error('Method not implemented.');
 	}

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -94,14 +94,6 @@ export interface IFluidHandleInternal<
 	 * Runs through the graph and attach the bounded handles.
 	 */
 	attachGraph(): void;
-
-	/**
-	 * Binds the given handle to this one or attach the given handle if this handle is attached.
-	 * A bound handle will also be attached once this handle is attached.
-	 *
-	 * @deprecated No replacement provided. Arbitrary handles may not serve as a bind source.
-	 */
-	bind(handle: IFluidHandleInternal): void;
 }
 
 /**

--- a/packages/dds/test-dds-utils/src/ddsFuzzHandle.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHandle.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { type IFluidHandle } from "@fluidframework/core-interfaces";
 import { type IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import {
 	FluidHandleBase,
@@ -42,12 +41,6 @@ export class DDSFuzzHandle extends FluidHandleBase<string> {
 			this.attached = true;
 		}
 	}
-
-	// eslint-disable-next-line jsdoc/require-description
-	/**
-	 * @deprecated No replacement provided. Arbitrary handles may not serve as a bind source.
-	 */
-	public bind(handle: IFluidHandle): void {}
 }
 
 export class PoisonedDDSFuzzHandle extends FluidHandleBase<string> implements IPoisonedHandle {
@@ -80,10 +73,4 @@ export class PoisonedDDSFuzzHandle extends FluidHandleBase<string> implements IP
 			this.attached = true;
 		}
 	}
-
-	// eslint-disable-next-line jsdoc/require-description
-	/**
-	 * @deprecated No replacement provided. Arbitrary handles may not serve as a bind source.
-	 */
-	public bind(handle: IFluidHandle): void {}
 }

--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -13,7 +13,6 @@ import type {
 	IEmitter,
 	IEventProvider,
 	IFluidHandleContext,
-	IFluidHandleInternal,
 	IFluidHandleInternalPayloadPending,
 	ILocalFluidHandle,
 	ILocalFluidHandleEvents,
@@ -124,14 +123,6 @@ export class BlobHandle
 			this.attached = true;
 			this.onAttachGraph?.();
 		}
-	}
-
-	// eslint-disable-next-line jsdoc/require-description
-	/**
-	 * @deprecated No replacement provided. Arbitrary handles may not serve as a bind source.
-	 */
-	public bind(handle: IFluidHandleInternal): void {
-		throw new Error("Cannot bind to blob handle");
 	}
 }
 

--- a/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.alpha.api.md
@@ -120,6 +120,7 @@ export class FluidObjectHandle<T extends FluidObject = FluidObject> extends Flui
     readonly routeContext: IFluidHandleContext;
     // (undocumented)
     protected readonly value: T | Promise<T>;
+    protected get visible(): boolean;
 }
 
 // @alpha @legacy (undocumented)

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -158,7 +158,20 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_FluidDataStoreRuntime": {
+				"backCompat": false
+			},
+			"Class_FluidObjectHandle": {
+				"backCompat": false
+			},
+			"ClassStatics_FluidDataStoreRuntime": {
+				"backCompat": false
+			},
+			"ClassStatics_FluidObjectHandle": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/datastore/src/fluidHandle.ts
+++ b/packages/runtime/datastore/src/fluidHandle.ts
@@ -104,9 +104,9 @@ export class FluidObjectHandle<
 	// eslint-disable-next-line jsdoc/require-description
 	/**
 	 * @deprecated No replacement provided. Arbitrary handles may not serve as a bind source.
-	 * @privateRemarks This implementation will be moved to SharedObjectHandle once this is removed.
+	 * @privateRemarks This implementation will be moved to SharedObjectHandle, along with some logic from attachGraph above.
 	 */
-	public bind(handle: IFluidHandleInternal): void {
+	protected bind(handle: IFluidHandleInternal): void {
 		// If this handle is visible, attach the graph of the incoming handle as well.
 		if (this.visible) {
 			handle.attachGraph();

--- a/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
+++ b/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
@@ -31,6 +31,7 @@ declare type old_as_current_for_Class_FluidDataStoreRuntime = requireAssignableT
  * typeValidation.broken:
  * "Class_FluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_FluidDataStoreRuntime = requireAssignableTo<TypeOnly<current.FluidDataStoreRuntime>, TypeOnly<old.FluidDataStoreRuntime>>
 
 /*
@@ -49,6 +50,7 @@ declare type old_as_current_for_Class_FluidObjectHandle = requireAssignableTo<Ty
  * typeValidation.broken:
  * "Class_FluidObjectHandle": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_FluidObjectHandle = requireAssignableTo<TypeOnly<current.FluidObjectHandle>, TypeOnly<old.FluidObjectHandle>>
 
 /*
@@ -58,6 +60,7 @@ declare type current_as_old_for_Class_FluidObjectHandle = requireAssignableTo<Ty
  * typeValidation.broken:
  * "ClassStatics_FluidDataStoreRuntime": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_FluidDataStoreRuntime = requireAssignableTo<TypeOnly<typeof current.FluidDataStoreRuntime>, TypeOnly<typeof old.FluidDataStoreRuntime>>
 
 /*
@@ -67,6 +70,7 @@ declare type current_as_old_for_ClassStatics_FluidDataStoreRuntime = requireAssi
  * typeValidation.broken:
  * "ClassStatics_FluidObjectHandle": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_FluidObjectHandle = requireAssignableTo<TypeOnly<typeof current.FluidObjectHandle>, TypeOnly<typeof old.FluidObjectHandle>>
 
 /*

--- a/packages/runtime/runtime-utils/src/handles.ts
+++ b/packages/runtime/runtime-utils/src/handles.ts
@@ -180,10 +180,6 @@ export function toFluidHandleErased<T>(
 export abstract class FluidHandleBase<T> implements IFluidHandleInternal<T> {
 	public abstract absolutePath: string;
 	public abstract attachGraph(): void;
-	/**
-	 * @deprecated No replacement provided. Arbitrary handles may not serve as a bind source.
-	 */
-	public abstract bind(handle: IFluidHandleInternal): void;
 	public abstract readonly isAttached: boolean;
 	public abstract get(): Promise<T>;
 

--- a/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
+++ b/packages/runtime/runtime-utils/src/remoteFluidObjectHandle.ts
@@ -4,11 +4,8 @@
  */
 
 import { FluidObject, IRequest } from "@fluidframework/core-interfaces";
-import {
-	IFluidHandleContext,
-	type IFluidHandleInternal,
-} from "@fluidframework/core-interfaces/internal";
-import { assert, fail } from "@fluidframework/core-utils/internal";
+import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
+import { assert } from "@fluidframework/core-utils/internal";
 
 import { responseToException } from "./dataStoreHelpers.js";
 import { FluidHandleBase } from "./handles.js";
@@ -68,12 +65,5 @@ export class RemoteFluidObjectHandle extends FluidHandleBase<FluidObject> {
 
 	public attachGraph(): void {
 		return;
-	}
-
-	/**
-	 * @deprecated No replacement provided. Arbitrary handles may not serve as a bind source.
-	 */
-	public bind(handle: IFluidHandleInternal): void {
-		fail("RemoteFluidObjectHandle not supported as a bind source");
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/mockHandle.ts
+++ b/packages/runtime/test-runtime-utils/src/mockHandle.ts
@@ -32,10 +32,4 @@ export class MockHandle<T> extends FluidHandleBase<T> {
 	public attachGraph(): void {
 		this.graphAttachState = AttachState.Attached;
 	}
-	/**
-	 * @deprecated No replacement provided. Arbitrary handles may not serve as a bind source.
-	 */
-	public bind() {
-		throw Error("MockHandle.bind() unimplemented.");
-	}
 }

--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -569,14 +569,6 @@ describeCompat(
 				channel3.set("channel2handle", channel2.handle);
 				channel2.set("dataStore3", dataStore3.handle);
 				channel3.set("dataStore2", dataStore2.handle);
-				toFluidHandleInternal(dataStore2.handle).bind(
-					toFluidHandleInternal(dataStore3.handle),
-				);
-				toFluidHandleInternal(dataStore2.handle).bind(toFluidHandleInternal(channel3.handle));
-				toFluidHandleInternal(dataStore3.handle).bind(
-					toFluidHandleInternal(dataStore2.handle),
-				);
-				toFluidHandleInternal(dataStore3.handle).bind(toFluidHandleInternal(channel2.handle));
 
 				toFluidHandleInternal(dataStore2.handle).attachGraph();
 				assert.strictEqual(
@@ -675,11 +667,9 @@ describeCompat(
 					"Channel should be detached",
 				);
 
-				channel2OfDataStore2.set("componet3Handle", dataStore3.handle);
+				channel2OfDataStore2.set("dataStore3Handle", dataStore3.handle);
 				channel1OfDataStore3.set("channel23handle", channel2OfDataStore3.handle);
-				toFluidHandleInternal(dataStore3.handle).bind(
-					toFluidHandleInternal(dataStore4.handle),
-				);
+				channel1OfDataStore3.set("dataStore4Handle", dataStore4.handle);
 
 				// Channel 1 of dataStore 2 points to its parent dataStore 2.
 				// Channel 2 of dataStore 2 points to its parent dataStore 2 and also to dataStore 3.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { ITestDataObject, describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
-import { IFluidHandle, IRequest, IResponse } from "@fluidframework/core-interfaces";
+import { IRequest, IResponse } from "@fluidframework/core-interfaces";
 import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
 // This test doesn't care to test compat of the Fluid handle implementation, it's just used for convenience
@@ -34,13 +34,6 @@ export class TestFluidHandle extends FluidHandleBase<unknown> {
 	public isAttached: boolean = false;
 
 	public async get(): Promise<any> {
-		throw new Error("Method not implemented.");
-	}
-
-	/**
-	 * @deprecated No replacement provided. Arbitrary handles may not serve as a bind source.
-	 */
-	public bind(handle: IFluidHandle): void {
 		throw new Error("Method not implemented.");
 	}
 


### PR DESCRIPTION
Fixes #24557

## Description

This was deprecated in #24553 

## Breaking Changes

_Yes, more info coming._

## Reviewer Guidance

There is one instance left, which is on base class `FluidObjectHandle`.  Its logic around tracking bound handles needs to be moved to `SharedObjectHandle`.

There were also some weird tests that were explicitly testing using a DataStore's handle as a bind source.  Removed those parts.