### PR TITLE
MergeTree: Support squashing in normalize and reconnect perspective

### DIFF
--- a/packages/dds/merge-tree/src/perspective.ts
+++ b/packages/dds/merge-tree/src/perspective.ts
@@ -154,8 +154,13 @@ export function createLocalReconnectingPerspective(
 	refSeq: number,
 	clientId: number,
 	localSeq: number,
+	squash: boolean = false,
 ): Perspective {
-	return new LocalReconnectingPerspective(refSeq, clientId, localSeq);
+	return new (squash ? LocalSquashPerspective : LocalReconnectingPerspective)(
+		refSeq,
+		clientId,
+		localSeq,
+	);
 }
 
 /**

--- a/packages/dds/sequence/src/intervalCollectionMap.ts
+++ b/packages/dds/sequence/src/intervalCollectionMap.ts
@@ -188,12 +188,16 @@ export class IntervalCollectionMap {
 	 * also sent if we are asked to resubmit the message.
 	 * @returns True if the operation was submitted, false otherwise.
 	 */
-	public tryResubmitMessage(content: unknown, localOpMetadata: unknown): boolean {
+	public tryResubmitMessage(
+		content: unknown,
+		localOpMetadata: unknown,
+		squash: boolean,
+	): boolean {
 		if (isMapOperation(content)) {
 			const { value, key } = content;
 			const localValue = this.data.get(key);
 			assert(localValue !== undefined, 0x3f8 /* Local value expected on resubmission */);
-			localValue.resubmitMessage(value, localOpMetadata);
+			localValue.resubmitMessage(value, localOpMetadata, squash);
 			return true;
 		}
 		return false;

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -782,7 +782,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 			0x8bb /* Expected a recorded refSeq when resubmitting an op */,
 		);
 		this.useResubmitRefSeq(originalRefSeq, () => {
-			if (!this.intervalCollections.tryResubmitMessage(content, localOpMetadata)) {
+			if (!this.intervalCollections.tryResubmitMessage(content, localOpMetadata, squash)) {
 				this.submitSequenceMessage(
 					this.client.regeneratePendingOp(content as IMergeTreeOp, localOpMetadata, squash),
 				);


### PR DESCRIPTION
This pull request introduces changes to improve the handling of "squash" operations in the `merge-tree` and `sequence` packages. The updates primarily focus on adding support for a `squash` parameter across various methods and event listeners, enabling more granular control over rebasing and resubmitting operations. 

### Changes to `merge-tree` package:

* **Refactor Perspective Creation:**
  - Added `squash` as an optional parameter to the `createLocalReconnectingPerspective` function in `perspective.ts`, allowing dynamic selection between `LocalSquashPerspective` and `LocalReconnectingPerspective`.
  - Updated the `Client` class to use the refactored `createLocalReconnectingPerspective` function instead of directly instantiating perspectives. 

* **Event Listener Updates:**
  - Modified the `normalize` event listener in the `Client` class to include the `squash` parameter, enabling listeners to respond differently based on whether the operation involves squashing. 

### Changes to `sequence` package:

* **Interval Rebasing Enhancements:**
  - Added `squash` as a parameter to several methods in the `IntervalCollection` class, including `rebaseReferenceWithSegmentSlide`, `computeRebasedPositions`, and `rebaseLocalInterval`, to support squash-specific rebasing logic.

* **Message Resubmission Updates:**
  - Updated `tryResubmitMessage` in `IntervalCollectionMap` and its usage in `SharedSegmentSequence` to include the `squash` parameter, ensuring squash-specific resubmission behavior. 