### PR TITLE
refactor(client-presence): Remove all usage of audience

### DIFF
--- a/packages/framework/presence/src/datastorePresenceManagerFactory.ts
+++ b/packages/framework/presence/src/datastorePresenceManagerFactory.ts
@@ -55,7 +55,6 @@ class PresenceManagerDataObject extends LoadableFluidObject {
 				getClientId: () => runtime.clientId,
 				events,
 				getQuorum: runtime.getQuorum.bind(runtime),
-				getAudience: runtime.getAudience.bind(runtime),
 				submitSignal: (message: OutboundPresenceMessage) =>
 					runtime.submitSignal(message.type, message.content, message.targetClientId),
 				supportedFeatures:

--- a/packages/framework/presence/src/presenceManager.ts
+++ b/packages/framework/presence/src/presenceManager.ts
@@ -99,7 +99,7 @@ class PresenceManager implements Presence, PresenceExtensionInterface {
 			}
 		});
 
-		runtime.getAudience().on("removeMember", this.removeClientConnectionId.bind(this));
+		runtime.events.on("remoteDisconnected", this.removeClientConnectionId.bind(this));
 
 		// Check if already connected at the time of construction.
 		// If constructed during data store load, the runtime may already be connected
@@ -166,7 +166,6 @@ function setupSubComponents(
 		attendeeId,
 		systemWorkspaceDatastore,
 		events,
-		runtime.getAudience(),
 	);
 	const datastoreManager = new PresenceDatastoreManagerImpl(
 		attendeeId,

--- a/packages/framework/presence/src/presenceManager.ts
+++ b/packages/framework/presence/src/presenceManager.ts
@@ -99,6 +99,8 @@ class PresenceManager implements Presence, PresenceExtensionInterface {
 			}
 		});
 
+		runtime.getQuorum().on("removeMember", this.removeClientConnectionId.bind(this));
+
 		runtime.events.on("remoteDisconnected", this.removeClientConnectionId.bind(this));
 
 		// Check if already connected at the time of construction.

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -224,6 +224,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	public readonly closeAbortController = new AbortController();
 
 	private readonly deltaStorageDelayId = uuid();
+	"";
 	private readonly deltaStreamDelayId = uuid();
 
 	private messageBuffer: IDocumentMessage[] = [];

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -224,7 +224,6 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	public readonly closeAbortController = new AbortController();
 
 	private readonly deltaStorageDelayId = uuid();
-	"";
 	private readonly deltaStreamDelayId = uuid();
 
 	private messageBuffer: IDocumentMessage[] = [];

--- a/packages/runtime/container-runtime-definitions/src/containerExtension.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerExtension.ts
@@ -4,7 +4,6 @@
  */
 
 import type { ILayerCompatDetails } from "@fluid-internal/client-utils";
-import type { IAudience } from "@fluidframework/container-definitions/internal";
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- BrandedType is a class declaration only
 import type {
 	BrandedType,
@@ -206,6 +205,7 @@ export interface ContainerExtension<
 export interface ExtensionHostEvents {
 	"disconnected": () => void;
 	"connected": (clientId: ClientConnectionId) => void;
+	"remoteDisconnected": (clientId: ClientConnectionId) => void;
 }
 
 /**
@@ -245,8 +245,6 @@ export interface ExtensionHost<TRuntimeProperties extends ExtensionRuntimeProper
 	 * Also contains a map of key-value pairs that must be agreed upon by all clients before being accepted.
 	 */
 	getQuorum: () => IQuorumClients;
-
-	getAudience: () => IAudience;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -5109,6 +5109,12 @@ export class ContainerRuntime
 		const eventEmitter = createEmitter<ExtensionHostEvents>();
 		this.on("connected", (clientId) => eventEmitter.emit("connected", clientId));
 		this.on("disconnected", () => eventEmitter.emit("disconnected"));
+		this.deltaManager.inboundSignal.on("op", (message) => {
+			const messageContent = message.content as { content: unknown; type: string };
+			if (messageContent.type === MessageType.ClientLeave && message.clientId !== null) {
+				eventEmitter.emit("remoteDisconnected", message.clientId);
+			}
+		});
 		return eventEmitter;
 	});
 
@@ -5141,7 +5147,6 @@ export class ContainerRuntime
 					this.submitExtensionSignal(id, addressChain, message);
 				},
 				getQuorum: this.getQuorum.bind(this),
-				getAudience: this.getAudience.bind(this),
 				supportedFeatures: this.ILayerCompatDetails.supportedFeatures,
 			} satisfies ExtensionHost<TRuntimeProperties>;
 			entry = new factory(runtime, ...useContext);


### PR DESCRIPTION
## Description

Fixes [AB#41349](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/41349)

We currently use audience.removeMember in presence to track when remote clients disconnect. To move off this dependency, we use a combination of ClientLeave signals sent from service and Quroum removeMember events to track the disconnections of read and write clients respectively. 

We also remove the checks we make against audience to verify connection status of remote clients in system workspace. We instead mark remote disconnections within the datastore to know which connectionIds are inactive.  