### PR TITLE
Add note to orderSequentially that it may enter staging mode

### DIFF
--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -215,6 +215,9 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
 	 * sequentially.
 	 *
 	 * If the callback throws an error, the container will close and the error will be logged.
+	 *
+	 * @remarks
+	 * `orderSequentially` may enter staging mode for the duration of the function. This is necessary for rolling back certain op types.
 	 */
 	orderSequentially(callback: () => void): void;
 


### PR DESCRIPTION
The `orderSequentially` function may enter staging mode for the duration of the call. Because of this, an error will be thrown if a user tries to enter staging mode in the callback provided to `orderSequentially`. The error's message is `"Already in staging mode"`, and could be confusing from the end user's perspective as they never entered staging mode themselves.

See https://github.com/microsoft/FluidFramework/pull/24728#discussion_r2157781376

Example:
```
// This will throw a UsageError "Already in staging mode"
containerRuntime.orderSequentially(() => {
    containerRuntime.enterStagingMode();
});
```