### PR TITLE
fix(client-presence): move validated State objects to internal

### DIFF
--- a/.changeset/green-poets-run.md
+++ b/.changeset/green-poets-run.md
@@ -1,8 +1,0 @@
----
-"@fluidframework/presence": minor
-"__section": other
----
-StateFactory.latest and StateFactory.latestMap now accept a validator parameter
-
-The StateFactory.latest and StateFactory.latestMap APIs now accept a `validator` argument. This argument is
-reserved for future use. **Passing the `validator` argument in version 2.43.0 will result in a runtime exception.**

--- a/packages/framework/presence/api-report/presence.alpha.api.md
+++ b/packages/framework/presence/api-report/presence.alpha.api.md
@@ -157,17 +157,6 @@ export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedVal
     readonly presence: Presence;
 }
 
-// @beta
-export function latest<T extends object | null, Key extends string = string>(args: LatestArguments<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, Latest<T>>;
-
-// @beta
-export function latest<T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>;
-
-// @beta @input
-export interface LatestArguments<T extends object | null> extends LatestArgumentsRaw<T> {
-    validator: StateSchemaValidator<T>;
-}
-
 // @beta @input
 export interface LatestArgumentsRaw<T extends object | null> {
     local: JsonSerializable<T>;
@@ -196,6 +185,11 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
 }
 
 // @beta @sealed
+export interface LatestFactory {
+    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>;
+}
+
+// @beta @sealed
 export interface LatestMap<T, Keys extends string | number = string | number, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     readonly controls: BroadcastControls;
     readonly events: Listenable<LatestMapEvents<T, Keys, TRemoteAccessor>>;
@@ -204,20 +198,6 @@ export interface LatestMap<T, Keys extends string | number = string | number, TR
     getStateAttendees(): Attendee[];
     readonly local: StateMap<Keys, T>;
     readonly presence: Presence;
-}
-
-// @beta
-export function latestMap<T, Keys extends string | number = string | number, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
-
-// @beta
-export function latestMap<T, Keys extends string | number = string | number, RegistrationKey extends string = string>(args: LatestMapArgumentsRaw<T, Keys>): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
-
-// @beta
-export function latestMap<T, Keys extends string | number = string | number, RegistrationKey extends string = string>(): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
-
-// @beta @input
-export interface LatestMapArguments<T, Keys extends string | number = string | number> extends LatestMapArgumentsRaw<T, Keys> {
-    validator: StateSchemaValidator<T>;
 }
 
 // @beta @input
@@ -251,6 +231,11 @@ export interface LatestMapEvents<T, K extends string | number, TRemoteValueAcces
     remoteItemUpdated: (updatedItem: LatestMapItemUpdatedClientData<T, K, TRemoteValueAccessor>) => void;
     // @eventProperty
     remoteUpdated: (updates: LatestMapClientData<T, K, TRemoteValueAccessor>) => void;
+}
+
+// @beta @sealed
+export interface LatestMapFactory {
+    <T, Keys extends string | number = string | number, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 }
 
 // @beta @sealed
@@ -375,8 +360,8 @@ export interface RawValueAccessor<T> {
 
 // @beta
 export const StateFactory: {
-    latest: typeof latest;
-    latestMap: typeof latestMap;
+    latest: LatestFactory;
+    latestMap: LatestMapFactory;
 };
 
 // @beta @sealed

--- a/packages/framework/presence/api-report/presence.beta.api.md
+++ b/packages/framework/presence/api-report/presence.beta.api.md
@@ -130,17 +130,6 @@ export interface Latest<T, TRemoteAccessor extends ValueAccessor<T> = ProxiedVal
     readonly presence: Presence;
 }
 
-// @beta
-export function latest<T extends object | null, Key extends string = string>(args: LatestArguments<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, Latest<T>>;
-
-// @beta
-export function latest<T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>;
-
-// @beta @input
-export interface LatestArguments<T extends object | null> extends LatestArgumentsRaw<T> {
-    validator: StateSchemaValidator<T>;
-}
-
 // @beta @input
 export interface LatestArgumentsRaw<T extends object | null> {
     local: JsonSerializable<T>;
@@ -169,6 +158,11 @@ export interface LatestEvents<T, TRemoteValueAccessor extends ValueAccessor<T> =
 }
 
 // @beta @sealed
+export interface LatestFactory {
+    <T extends object | null, Key extends string = string>(args: LatestArgumentsRaw<T>): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>;
+}
+
+// @beta @sealed
 export interface LatestMap<T, Keys extends string | number = string | number, TRemoteAccessor extends ValueAccessor<T> = ProxiedValueAccessor<T>> {
     readonly controls: BroadcastControls;
     readonly events: Listenable<LatestMapEvents<T, Keys, TRemoteAccessor>>;
@@ -177,20 +171,6 @@ export interface LatestMap<T, Keys extends string | number = string | number, TR
     getStateAttendees(): Attendee[];
     readonly local: StateMap<Keys, T>;
     readonly presence: Presence;
-}
-
-// @beta
-export function latestMap<T, Keys extends string | number = string | number, RegistrationKey extends string = string>(args: LatestMapArguments<T, Keys>): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMap<T, Keys>>;
-
-// @beta
-export function latestMap<T, Keys extends string | number = string | number, RegistrationKey extends string = string>(args: LatestMapArgumentsRaw<T, Keys>): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
-
-// @beta
-export function latestMap<T, Keys extends string | number = string | number, RegistrationKey extends string = string>(): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
-
-// @beta @input
-export interface LatestMapArguments<T, Keys extends string | number = string | number> extends LatestMapArgumentsRaw<T, Keys> {
-    validator: StateSchemaValidator<T>;
 }
 
 // @beta @input
@@ -224,6 +204,11 @@ export interface LatestMapEvents<T, K extends string | number, TRemoteValueAcces
     remoteItemUpdated: (updatedItem: LatestMapItemUpdatedClientData<T, K, TRemoteValueAccessor>) => void;
     // @eventProperty
     remoteUpdated: (updates: LatestMapClientData<T, K, TRemoteValueAccessor>) => void;
+}
+
+// @beta @sealed
+export interface LatestMapFactory {
+    <T, Keys extends string | number = string | number, RegistrationKey extends string = string>(args?: LatestMapArgumentsRaw<T, Keys>): InternalTypes.ManagerFactory<RegistrationKey, InternalTypes.MapValueState<T, Keys>, LatestMapRaw<T, Keys>>;
 }
 
 // @beta @sealed
@@ -293,8 +278,8 @@ export interface RawValueAccessor<T> {
 
 // @beta
 export const StateFactory: {
-    latest: typeof latest;
-    latestMap: typeof latestMap;
+    latest: LatestFactory;
+    latestMap: LatestMapFactory;
 };
 
 // @beta @sealed

--- a/packages/framework/presence/src/index.ts
+++ b/packages/framework/presence/src/index.ts
@@ -47,12 +47,12 @@ export {
 } from "./datastorePresenceManagerFactory.js";
 
 export type {
-	latestMap,
 	LatestMap,
-	LatestMapArguments,
+	// LatestMapArguments,
 	LatestMapArgumentsRaw,
 	LatestMapClientData,
 	LatestMapEvents,
+	LatestMapFactory,
 	LatestMapItemRemovedClientData,
 	LatestMapItemUpdatedClientData,
 	LatestMapRaw,
@@ -60,11 +60,11 @@ export type {
 	StateMap,
 } from "./latestMapValueManager.js";
 export type {
-	latest,
 	Latest,
-	LatestArguments,
+	// LatestArguments,
 	LatestArgumentsRaw,
 	LatestEvents,
+	LatestFactory,
 	LatestRaw,
 	LatestRawEvents,
 } from "./latestValueManager.js";

--- a/packages/framework/presence/src/latestMapValueManager.ts
+++ b/packages/framework/presence/src/latestMapValueManager.ts
@@ -606,88 +606,68 @@ export interface LatestMapArguments<T, Keys extends string | number = string | n
 	validator: StateSchemaValidator<T>;
 }
 
-// #region function overloads
-// Overloads should be ordered from most specific to least specific.
-
-/**
- * Factory for creating a {@link LatestMap} State object.
- *
- * @remarks
- * This overload is used when called with {@link LatestMapArguments}. That is, if a validator function is provided.
- *
- * @beta
- */
-export function latestMap<
-	T,
-	Keys extends string | number = string | number,
-	RegistrationKey extends string = string,
->(
-	args: LatestMapArguments<T, Keys>,
-): InternalTypes.ManagerFactory<
-	RegistrationKey,
-	InternalTypes.MapValueState<T, Keys>,
-	LatestMap<T, Keys>
->;
+// #region factory function overloads
+// Overloads should be ordered from most specific to least specific when combined.
 
 /**
  * Factory for creating a {@link LatestMapRaw} State object.
  *
- * @remarks
- * This overload is used when called with {@link LatestMapArgumentsRaw}. That is, if a validator function is
- * _not_ provided.
- *
  * @beta
+ * @sealed
  */
-export function latestMap<
-	T,
-	Keys extends string | number = string | number,
-	RegistrationKey extends string = string,
->(
-	args: LatestMapArgumentsRaw<T, Keys>,
-): InternalTypes.ManagerFactory<
-	RegistrationKey,
-	InternalTypes.MapValueState<T, Keys>,
-	LatestMapRaw<T, Keys>
->;
+export interface LatestMapFactory {
+	/**
+	 * Factory for creating a {@link LatestMapRaw} State object.
+	 *
+	 * @privateRemarks (change to `remarks` when adding signature overload)
+	 * This overload is used when called with {@link LatestMapArgumentsRaw}.
+	 * That is, if a validator function is _not_ provided.
+	 */
+	// eslint-disable-next-line @typescript-eslint/prefer-function-type -- interface to allow for clean overload evolution
+	<T, Keys extends string | number = string | number, RegistrationKey extends string = string>(
+		args?: LatestMapArgumentsRaw<T, Keys>,
+	): InternalTypes.ManagerFactory<
+		RegistrationKey,
+		InternalTypes.MapValueState<T, Keys>,
+		LatestMapRaw<T, Keys>
+	>;
+}
 
 /**
- * Factory for creating a {@link LatestMapRaw} State object.
- *
- * @remarks
- * This overload is used when called with no arguments.
- *
- * @beta
+ * Factory for creating a {@link LatestMap} or {@link LatestMapRaw} State object.
  */
-export function latestMap<
-	T,
-	Keys extends string | number = string | number,
-	RegistrationKey extends string = string,
->(): InternalTypes.ManagerFactory<
-	RegistrationKey,
-	InternalTypes.MapValueState<T, Keys>,
-	LatestMapRaw<T, Keys>
->;
+export interface LatestMapFactoryInternal extends LatestMapFactory {
+	/**
+	 * Factory for creating a {@link LatestMap} State object.
+	 *
+	 * @remarks
+	 * This overload is used when called with {@link LatestMapArguments}. That is, if a validator function is provided.
+	 */
+	<T, Keys extends string | number = string | number, RegistrationKey extends string = string>(
+		args: LatestMapArguments<T, Keys>,
+	): InternalTypes.ManagerFactory<
+		RegistrationKey,
+		InternalTypes.MapValueState<T, Keys>,
+		LatestMap<T, Keys>
+	>;
+}
 
 // #endregion
 
-// eslint-disable-next-line jsdoc/require-jsdoc -- no tsdoc since the overloads are documented
-export function latestMap<
+/**
+ * Factory for creating a {@link LatestMap} or {@link LatestMapRaw} State object.
+ */
+export const latestMap: LatestMapFactoryInternal = <
 	T,
 	Keys extends string | number = string | number,
 	RegistrationKey extends string = string,
 >(
 	args?: Partial<LatestMapArguments<T, Keys>>,
-):
-	| InternalTypes.ManagerFactory<
-			RegistrationKey,
-			InternalTypes.MapValueState<T, Keys>,
-			LatestMapRaw<T, Keys>
-	  >
-	| InternalTypes.ManagerFactory<
-			RegistrationKey,
-			InternalTypes.MapValueState<T, Keys>,
-			LatestMap<T, Keys>
-	  > {
+): InternalTypes.ManagerFactory<
+	RegistrationKey,
+	InternalTypes.MapValueState<T, Keys>,
+	LatestMapRaw<T, Keys> & LatestMap<T, Keys>
+> => {
 	const settings = args?.settings;
 	const initialValues = args?.local;
 	const validator = args?.validator;
@@ -720,7 +700,7 @@ export function latestMap<
 		>,
 	): {
 		initialData: { value: typeof value; allowableUpdateLatencyMs: number | undefined };
-		manager: InternalTypes.StateValue<LatestMapRaw<T, Keys>>;
+		manager: InternalTypes.StateValue<LatestMapRaw<T, Keys> & LatestMap<T, Keys>>;
 	} => ({
 		initialData: { value, allowableUpdateLatencyMs: settings?.allowableUpdateLatencyMs },
 		manager: brandIVM<
@@ -737,4 +717,4 @@ export function latestMap<
 		),
 	});
 	return Object.assign(factory, { instanceBase: LatestMapValueManagerImpl });
-}
+};

--- a/packages/framework/presence/src/latestValueManager.ts
+++ b/packages/framework/presence/src/latestValueManager.ts
@@ -270,42 +270,59 @@ export interface LatestArguments<T extends object | null> extends LatestArgument
 	validator: StateSchemaValidator<T>;
 }
 
-// #region function overloads
-// Overloads should be ordered from most specific to least specific.
-
-/**
- * Factory for creating a {@link Latest} State object.
- *
- * @remarks
- * This overload is used when called with {@link LatestArguments}. That is, if a validator function is provided.
- *
- * @beta
- */
-export function latest<T extends object | null, Key extends string = string>(
-	args: LatestArguments<T>,
-): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, Latest<T>>;
+// #region factory function overloads
+// Overloads should be ordered from most specific to least specific when combined.
 
 /**
  * Factory for creating a {@link LatestRaw} State object.
  *
- * @remarks
- * This overload is used when called with {@link LatestArgumentsRaw}. That is, if a validator function is _not_
- * provided.
- *
  * @beta
+ * @sealed
  */
-export function latest<T extends object | null, Key extends string = string>(
-	args: LatestArgumentsRaw<T>,
-): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>;
+export interface LatestFactory {
+	/**
+	 * Factory for creating a {@link LatestRaw} State object.
+	 *
+	 * @privateRemarks (change to `remarks` when adding signature overload)
+	 * This overload is used when called with {@link LatestArgumentsRaw}.
+	 * That is, if a validator function is _not_ provided.
+	 */
+	// eslint-disable-next-line @typescript-eslint/prefer-function-type -- interface to allow for clean overload evolution
+	<T extends object | null, Key extends string = string>(
+		args: LatestArgumentsRaw<T>,
+	): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>;
+}
+
+/**
+ * Factory for creating a {@link Latest} or {@link LatestRaw} State object.
+ */
+export interface LatestFactoryInternal extends LatestFactory {
+	/**
+	 * Factory for creating a {@link Latest} State object.
+	 *
+	 * @remarks
+	 * This overload is used when called with {@link LatestArguments}. That is, if a validator function is provided.
+	 */
+	<T extends object | null, Key extends string = string>(
+		args: LatestArguments<T>,
+	): InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, Latest<T>>;
+}
 
 // #endregion
 
-// eslint-disable-next-line jsdoc/require-jsdoc -- no tsdoc since the overloads are documented
-export function latest<T extends object | null, Key extends string = string>(
+/**
+ * Factory for creating a {@link Latest} or {@link LatestRaw} State object.
+ */
+export const latest: LatestFactoryInternal = <
+	T extends object | null,
+	Key extends string = string,
+>(
 	args: LatestArguments<T> | LatestArgumentsRaw<T>,
-):
-	| InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, LatestRaw<T>>
-	| InternalTypes.ManagerFactory<Key, InternalTypes.ValueRequiredState<T>, Latest<T>> {
+): InternalTypes.ManagerFactory<
+	Key,
+	InternalTypes.ValueRequiredState<T>,
+	LatestRaw<T> & Latest<T>
+> => {
 	const { local, settings } = args;
 	if ("validator" in args) {
 		throw new Error(`Validators are not yet implemented.`);
@@ -327,7 +344,7 @@ export function latest<T extends object | null, Key extends string = string>(
 		>,
 	): {
 		initialData: { value: typeof value; allowableUpdateLatencyMs: number | undefined };
-		manager: InternalTypes.StateValue<LatestRaw<T>>;
+		manager: InternalTypes.StateValue<LatestRaw<T> & Latest<T>>;
 	} => ({
 		initialData: { value, allowableUpdateLatencyMs: settings?.allowableUpdateLatencyMs },
 		manager: brandIVM<LatestValueManagerImpl<T, Key>, T, InternalTypes.ValueRequiredState<T>>(
@@ -335,4 +352,4 @@ export function latest<T extends object | null, Key extends string = string>(
 		),
 	});
 	return Object.assign(factory, { instanceBase: LatestValueManagerImpl });
-}
+};

--- a/packages/framework/presence/src/stateFactory.ts
+++ b/packages/framework/presence/src/stateFactory.ts
@@ -3,22 +3,29 @@
  * Licensed under the MIT License.
  */
 
+import type { LatestMapFactory } from "./latestMapValueManager.js";
 import { latestMap } from "./latestMapValueManager.js";
+import type { LatestFactory } from "./latestValueManager.js";
 import { latest } from "./latestValueManager.js";
 
 /**
  * Factory for creating presence State objects.
+ */
+export const StateFactoryInternal = {
+	latest,
+	latestMap,
+};
+
+/**
+ * Factory for creating presence State objects.
+ *
+ * @remarks
+ * Use `latest` to create a {@link LatestRaw} State object.
+ * Use `latestMap` to create a {@link LatestMapRaw} State object.
  *
  * @beta
  */
-export const StateFactory = {
-	/**
-	 * Factory for creating a {@link Latest} or {@link LatestRaw} State object.
-	 */
-	latest,
-
-	/**
-	 * Factory for creating a {@link LatestMap} or {@link LatestMapRaw} State object.
-	 */
-	latestMap,
-};
+export const StateFactory: {
+	latest: LatestFactory;
+	latestMap: LatestMapFactory;
+} = StateFactoryInternal;

--- a/packages/framework/presence/src/test/latestMapValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestMapValueManager.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import { createPresenceManager } from "../presenceManager.js";
+import { StateFactoryInternal } from "../stateFactory.js";
 
 import { addControlsTests } from "./broadcastControlsTests.js";
 import { MockEphemeralRuntime } from "./mockEphemeralRuntime.js";
@@ -123,7 +124,7 @@ export function checkCompiles(): void {
 					key2: { ref: "default", someId: 0 },
 				},
 			}),
-			validatedMap: StateFactory.latestMap({
+			validatedMap: StateFactoryInternal.latestMap({
 				local: {
 					key1: { x: 0, y: 0 },
 					key2: { ref: "default", someId: 0 },

--- a/packages/framework/presence/src/test/latestValueManager.spec.ts
+++ b/packages/framework/presence/src/test/latestValueManager.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import { createPresenceManager } from "../presenceManager.js";
+import { StateFactoryInternal } from "../stateFactory.js";
 
 import { addControlsTests } from "./broadcastControlsTests.js";
 import { MockEphemeralRuntime } from "./mockEphemeralRuntime.js";
@@ -161,7 +162,7 @@ export function checkCompiles(): void {
 		cursor: StateFactory.latest({ local: { x: 0, y: 0 } }),
 		camera: StateFactory.latest({ local: { x: 0, y: 0, z: 0 } }),
 		nullablePoint: StateFactory.latest<null | { x: number; y: number }>({ local: null }),
-		validated: StateFactory.latest({
+		validated: StateFactoryInternal.latest({
 			local: { num: 22 },
 			validator: (data: unknown) => data as { num: number },
 		}),

--- a/packages/framework/presence/src/test/schemaValidation.spec.ts
+++ b/packages/framework/presence/src/test/schemaValidation.spec.ts
@@ -11,6 +11,7 @@ import { useFakeTimers, type SinonFakeTimers } from "sinon";
 
 import { toOpaqueJson } from "../internalUtils.js";
 import type { createPresenceManager } from "../presenceManager.js";
+import { StateFactoryInternal } from "../stateFactory.js";
 
 import { MockEphemeralRuntime } from "./mockEphemeralRuntime.js";
 import {
@@ -23,7 +24,6 @@ import {
 	prepareConnectedPresence,
 } from "./testUtils.js";
 
-import { StateFactory } from "@fluidframework/presence/beta";
 import type {
 	InternalTypes,
 	Latest,
@@ -178,7 +178,7 @@ describe("Presence", () => {
 					]);
 
 					stateWorkspace = presence.states.getWorkspace("name:testStateWorkspace", {
-						count: StateFactory.latest({
+						count: StateFactoryInternal.latest({
 							local: { num: 0 } satisfies TestData,
 							validator: validatorFunction,
 							settings: { allowableUpdateLatencyMs: 0 },
@@ -345,7 +345,7 @@ describe("Presence", () => {
 				assert.equal(validatorFunction.callCount, 0);
 
 				stateWorkspace = presence.states.getWorkspace("name:testStateWorkspace", {
-					count: StateFactory.latestMap({
+					count: StateFactoryInternal.latestMap({
 						local: { "key1": { num: 0 } },
 						validator: validatorFunction,
 						settings: { allowableUpdateLatencyMs: 0 },


### PR DESCRIPTION
Some validation related type remain exposed as the *Raw types reference them.