### PR TITLE
Remove external script hashes. Add validation to GitHub

### DIFF
--- a/.github/workflows/website-validation.yml
+++ b/.github/workflows/website-validation.yml
@@ -39,6 +39,9 @@ jobs:
         run: |
           pnpm i --frozen-lockfile
           npm run build
+      - name: Validate CSP hashes
+        run: |
+          ./validateHashes.sh
       - name: Upload site artifact
         # release notes: https://github.com/actions/upload-artifact/releases/tag/v4.4.3
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # ratchet:actions/upload-artifact@v4

--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
 	"globalHeaders": {
 		"cache-control": "must-revalidate, max-age=3600",
-		"Content-Security-Policy": "script-src 'self' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'sha256-fd8PaHQgKg1/SNfCLTu1n0o8pKUigP867TZiWr5NYtU=' 'sha256-dGD3FKK81csDrEhQT4cyi6vTQ7h5P5bq4sJOY1Btb5w=' 'sha256-9B4uzGZj0ISjdPwwyAmR+Lci1Y4WIkbroFP63r0e7kg=' 'sha256-cwVTr+ZyBzKe5diz1+yyhT+CcNJEqwLTneD8H4TIrvA=' 'unsafe-inline' 'unsafe-eval' https:; base-uri 'self'; object-src 'none'; require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
+		"Content-Security-Policy": "script-src 'self' 'sha256-faMHt+UAWeoFU7ZBnPhfAu9zOnnNUwL4RYp09gSUEjU=' 'sha256-O8zYuOjyuzUZDv3fub7DKfAs5TEd1dG+fz+hCSCFmQA=' 'unsafe-inline' 'unsafe-eval' https:; base-uri 'self'; object-src 'none'; require-trusted-types-for 'script'; trusted-types default dompurify ff#webpack; report-uri https://csp.microsoft.com/report/FluidFramework-WW"
 	},
 	"navigationFallback": {
 		"rewrite": "/api/fallback"

--- a/docs/validateHashes.sh
+++ b/docs/validateHashes.sh
@@ -20,18 +20,6 @@ echo "$scriptContent" | tr -d '\n'| openssl dgst -sha256 -binary | openssl base6
 fi
 done
 
-# Also hash external script files referenced by <script src="...">
-grep -oE '<script[^>]+src="[^"]+"' "$indexFile" | sed -E 's/.*src="([^"]+)".*/\1/' | while read -r srcPath; do
-  localFile="build$srcPath"
-  if [[ -f "$localFile" ]]; then
-	hash=$(openssl dgst -sha256 -binary "$localFile" | openssl base64 | sed 's/^/sha256-/')
-	echo "Hashing external script: $localFile to $hash"
-	echo $hash >> "$generatedHashes"
-  else
-    echo "⚠️  External script not found on disk: $localFile"
-  fi
-done
-
 echo "Extracted Hashes:"
 cat "$generatedHashes"
 


### PR DESCRIPTION
As a strict security measure, we had added external script hashing validation to our content security policy. These scripts will change every time any documentation file is updated making it really hard to maintain.
There was no requirement solving strict CSP guidelines to validate this kind of scripts so removing them from our CSP policy.

GitHub website validation didn't have the validation step so also adding it there.