### PR TITLE
Track op metadata locally in SharedMap

### DIFF
--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -275,7 +275,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.reSubmitCore}
 	 */
 	protected override reSubmitCore(content: unknown, localOpMetadata: unknown): void {
-		this.kernel.tryResubmitMessage(content as IMapOperation, localOpMetadata as number);
+		this.kernel.tryResubmitMessage(content as IMapOperation, localOpMetadata);
 	}
 
 	/**
@@ -299,7 +299,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 				this.kernel.tryProcessMessage(
 					message.contents as IMapOperation,
 					local,
-					localOpMetadata as number | undefined,
+					localOpMetadata,
 				),
 				0xab2 /* Map received an unrecognized op, possibly from a newer version */,
 			);
@@ -310,6 +310,6 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.rollback}
 	 */
 	protected override rollback(content: unknown, localOpMetadata: unknown): void {
-		this.kernel.rollback(content as IMapOperation, localOpMetadata);
+		this.kernel.rollback(content, localOpMetadata);
 	}
 }

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -275,7 +275,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.reSubmitCore}
 	 */
 	protected override reSubmitCore(content: unknown, localOpMetadata: unknown): void {
-		this.kernel.tryResubmitMessage(content as IMapOperation, localOpMetadata);
+		this.kernel.tryResubmitMessage(content as IMapOperation, localOpMetadata as number);
 	}
 
 	/**
@@ -299,7 +299,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 				this.kernel.tryProcessMessage(
 					message.contents as IMapOperation,
 					local,
-					localOpMetadata,
+					localOpMetadata as number | undefined,
 				),
 				0xab2 /* Map received an unrecognized op, possibly from a newer version */,
 			);

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -275,7 +275,7 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.reSubmitCore}
 	 */
 	protected override reSubmitCore(content: unknown, localOpMetadata: unknown): void {
-		this.kernel.trySubmitMessage(content as IMapOperation, localOpMetadata);
+		this.kernel.tryResubmitMessage(content as IMapOperation, localOpMetadata);
 	}
 
 	/**
@@ -310,6 +310,6 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 	 * {@inheritDoc @fluidframework/shared-object-base#SharedObject.rollback}
 	 */
 	protected override rollback(content: unknown, localOpMetadata: unknown): void {
-		this.kernel.rollback(content, localOpMetadata);
+		this.kernel.rollback(content as IMapOperation, localOpMetadata);
 	}
 }

--- a/packages/dds/map/src/test/mocha/map.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.spec.ts
@@ -18,13 +18,10 @@ import {
 
 import { type ISharedMap, type IValueChanged, MapFactory, SharedMap } from "../../index.js";
 import type {
-	IMapClearLocalOpMetadata,
 	IMapClearOperation,
 	IMapDeleteOperation,
-	IMapKeyEditLocalOpMetadata,
 	IMapSetOperation,
 	ISerializableValue,
-	MapLocalOpMetadata,
 } from "../../internalInterfaces.js";
 import { SharedMap as SharedMapInternal } from "../../map.js";
 import type { IMapOperation } from "../../mapKernel.js";

--- a/packages/dds/map/src/test/mocha/map.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.spec.ts
@@ -58,15 +58,15 @@ function createLocalMap(id: string): SharedMapInternal {
 }
 
 class TestSharedMap extends SharedMapInternal {
-	private lastMetadata?: MapLocalOpMetadata;
-	public testApplyStashedOp(content: IMapOperation): MapLocalOpMetadata | undefined {
+	private lastMetadata?: number;
+	public testApplyStashedOp(content: IMapOperation): number | undefined {
 		this.lastMetadata = undefined;
 		this.applyStashedOp(content);
 		return this.lastMetadata;
 	}
 
 	public submitLocalMessage(op: IMapOperation, localOpMetadata: unknown): void {
-		this.lastMetadata = localOpMetadata as MapLocalOpMetadata;
+		this.lastMetadata = localOpMetadata as number;
 		super.submitLocalMessage(op, localOpMetadata);
 	}
 }
@@ -421,28 +421,19 @@ describe("Map", () => {
 					objectStorage: new MockStorage(undefined),
 				});
 				let metadata = map1.testApplyStashedOp(op);
-				assert.equal(metadata?.type, "add");
-				assert.equal(metadata.pendingMessageId, 0);
-				const editMetadata = map1.testApplyStashedOp(op) as IMapKeyEditLocalOpMetadata;
-				assert.equal(editMetadata.type, "edit");
-				assert.equal(editMetadata.pendingMessageId, 1);
-				assert.equal(editMetadata.previousValue.value, "value");
+				assert.equal(metadata, 0);
+				const editMetadata = map1.testApplyStashedOp(op);
+				assert.equal(editMetadata, 1);
 				const serializable2: ISerializableValue = { type: "Plain", value: "value2" };
 				const op2: IMapSetOperation = { type: "set", key: "key2", value: serializable2 };
 				metadata = map1.testApplyStashedOp(op2);
-				assert.equal(metadata?.type, "add");
-				assert.equal(metadata.pendingMessageId, 2);
+				assert.equal(metadata, 2);
 				const op3: IMapDeleteOperation = { type: "delete", key: "key2" };
-				metadata = map1.testApplyStashedOp(op3) as IMapKeyEditLocalOpMetadata;
-				assert.equal(metadata.type, "edit");
-				assert.equal(metadata.pendingMessageId, 3);
-				assert.equal(metadata.previousValue.value, "value2");
+				metadata = map1.testApplyStashedOp(op3);
+				assert.equal(metadata, 3);
 				const op4: IMapClearOperation = { type: "clear" };
-				metadata = map1.testApplyStashedOp(op4) as IMapClearLocalOpMetadata;
-				assert.equal(metadata.pendingMessageId, 4);
-				assert.equal(metadata.type, "clear");
-				assert.equal(metadata.previousMap?.get("key")?.value, "value");
-				assert.equal(metadata.previousMap?.has("key2"), false);
+				metadata = map1.testApplyStashedOp(op4);
+				assert.equal(metadata, 4);
 			});
 		});
 	});


### PR DESCRIPTION
As part of supporting SharedMap rollback across remote ops (#24822), the tracking of pending ops and the associated metadata needs to move into SharedMap so we can inspect it (whereas today it is stored in the PendingStateManager, where it can't be inspected).  Then the localOpMetadata used can just become a ~~simple number (pendingMessageId)~~ ListNode reference that we can use to do lookup against the local tracking.

This change doesn't alter the current metadata approach but just moves its tracking to be local in preparation for the behavioral change.  Should make that future change at least a little smaller ~~since it also uses simple pendingMessageId for localOpMetadata~~.

Also some typing improvements, or at least making explicit casting choices instead of `any`, accounting for `undefined`, etc.