### PR TITLE
Move merge-tree's DoublyLinkedList to core-utils

### DIFF
--- a/packages/common/core-utils/src/index.ts
+++ b/packages/common/core-utils/src/index.ts
@@ -16,6 +16,13 @@ export { delay } from "./delay.js";
 export type { IComparer, IHeapNode } from "./heap.js";
 export { Heap, NumberComparer } from "./heap.js";
 export { Lazy, LazyPromise } from "./lazy.js";
+export {
+	DoublyLinkedList,
+	type ListNode,
+	type ListNodeRange,
+	iterateListValuesWhile,
+	walkList,
+} from "./list.js";
 export type { PromiseCacheExpiry, PromiseCacheOptions } from "./promiseCache.js";
 export { PromiseCache } from "./promiseCache.js";
 export { Deferred } from "./promises.js";

--- a/packages/common/core-utils/src/test/list.spec.ts
+++ b/packages/common/core-utils/src/test/list.spec.ts
@@ -5,9 +5,9 @@
 
 import { strict as assert } from "node:assert";
 
-import { DoublyLinkedList, walkList } from "../collections/index.js";
+import { DoublyLinkedList, walkList } from "../index.js";
 
-describe("Collections.DoublyLinkedList", () => {
+describe("DoublyLinkedList", () => {
 	const listCount = 5;
 	let list: DoublyLinkedList<number>;
 

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -7,7 +7,12 @@
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { type IEventThisPlaceHolder, IFluidHandle } from "@fluidframework/core-interfaces";
-import { assert, unreachableCase, isObject } from "@fluidframework/core-utils/internal";
+import {
+	assert,
+	unreachableCase,
+	isObject,
+	type DoublyLinkedList,
+} from "@fluidframework/core-utils/internal";
 import {
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
@@ -26,7 +31,7 @@ import {
 } from "@fluidframework/telemetry-utils/internal";
 
 import { MergeTreeTextHelper, type IMergeTreeTextHelper } from "./MergeTreeTextHelper.js";
-import { DoublyLinkedList, RedBlackTree } from "./collections/index.js";
+import { RedBlackTree } from "./collections/index.js";
 import { NonCollabClient, SquashClient, UniversalSequenceNumber } from "./constants.js";
 import { LocalReferencePosition, SlidingPreference } from "./localReference.js";
 import {

--- a/packages/dds/merge-tree/src/collections/index.ts
+++ b/packages/dds/merge-tree/src/collections/index.ts
@@ -2,14 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-
-export {
-	DoublyLinkedList,
-	ListNode,
-	ListNodeRange,
-	walkList,
-	iterateListValuesWhile,
-} from "./list.js";
 export {
 	ConflictAction,
 	Dictionary,

--- a/packages/dds/merge-tree/src/collections/index.ts
+++ b/packages/dds/merge-tree/src/collections/index.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
 export {
 	ConflictAction,
 	Dictionary,

--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -30,9 +30,6 @@ export {
 	RBNodeActions,
 	RedBlackTree,
 	SortedDictionary,
-	DoublyLinkedList,
-	ListNode,
-	ListNodeRange,
 } from "./collections/index.js";
 export { UnassignedSequenceNumber, UniversalSequenceNumber } from "./constants.js";
 export {

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -4,9 +4,9 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
+import { DoublyLinkedList, ListNode, walkList } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import { DoublyLinkedList, ListNode, walkList } from "./collections/index.js";
 import { type ISegmentInternal } from "./mergeTreeNodes.js";
 import { TrackingGroup, TrackingGroupCollection } from "./mergeTreeTracking.js";
 import { ReferenceType } from "./ops.js";

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -6,12 +6,17 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable no-bitwise */
 
-import { assert, Heap, IComparer } from "@fluidframework/core-utils/internal";
+import {
+	assert,
+	Heap,
+	IComparer,
+	DoublyLinkedList,
+	ListNode,
+} from "@fluidframework/core-utils/internal";
 import { DataProcessingError, UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { IAttributionCollectionSerializer } from "./attributionCollection.js";
 import { Client } from "./client.js";
-import { DoublyLinkedList, ListNode } from "./collections/index.js";
 import {
 	NonCollabClient,
 	TreeMaintenanceSequenceNumber,

--- a/packages/dds/merge-tree/src/revertibles.ts
+++ b/packages/dds/merge-tree/src/revertibles.ts
@@ -3,10 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import {
+	assert,
+	unreachableCase,
+	DoublyLinkedList,
+} from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import { DoublyLinkedList } from "./collections/index.js";
 import { EndOfTreeSegment } from "./endOfTreeSegment.js";
 import { LocalReferenceCollection, LocalReferencePosition } from "./localReference.js";
 import { MergeTree, findRootMergeBlock } from "./mergeTree.js";

--- a/packages/dds/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/dds/merge-tree/src/segmentGroupCollection.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { DoublyLinkedList, walkList } from "./collections/index.js";
+import { DoublyLinkedList, walkList } from "@fluidframework/core-utils/internal";
+
 import { SegmentGroup, type ISegmentLeaf } from "./mergeTreeNodes.js";
 
 export class SegmentGroupCollection {

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -3,9 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import {
+	assert,
+	DoublyLinkedList,
+	iterateListValuesWhile,
+} from "@fluidframework/core-utils/internal";
 
-import { DoublyLinkedList, iterateListValuesWhile } from "./collections/index.js";
 import { UnassignedSequenceNumber, UniversalSequenceNumber } from "./constants.js";
 import type {
 	AdjustParams,

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "node:assert";
 
 import { Trace } from "@fluid-internal/client-utils";
 import { makeRandom } from "@fluid-private/stochastic-test-utils";
+import { DoublyLinkedList } from "@fluidframework/core-utils/internal";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 import { ISummaryTree } from "@fluidframework/driver-definitions";
 import {
@@ -20,7 +21,6 @@ import { MockStorage } from "@fluidframework/test-runtime-utils/internal";
 
 import { MergeTreeTextHelper } from "../MergeTreeTextHelper.js";
 import { Client } from "../client.js";
-import { DoublyLinkedList } from "../collections/index.js";
 import { UnassignedSequenceNumber } from "../constants.js";
 import { IMergeTreeOptions, ReferencePosition } from "../index.js";
 import { MergeTree, getSlideToSegoff } from "../mergeTree.js";

--- a/packages/dds/merge-tree/src/test/testClientLogger.ts
+++ b/packages/dds/merge-tree/src/test/testClientLogger.ts
@@ -5,10 +5,10 @@
 
 import { strict as assert } from "node:assert";
 
+import { DoublyLinkedList } from "@fluidframework/core-utils/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { LoggingError } from "@fluidframework/telemetry-utils/internal";
 
-import { DoublyLinkedList } from "../collections/index.js";
 import { UnassignedSequenceNumber } from "../constants.js";
 import { IMergeTreeOptions } from "../index.js";
 import {

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -7,7 +7,12 @@
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { IEvent } from "@fluidframework/core-interfaces";
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import {
+	assert,
+	DoublyLinkedList,
+	unreachableCase,
+	type ListNode,
+} from "@fluidframework/core-utils/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
 	Client,
@@ -23,8 +28,6 @@ import {
 	endpointPosAndSide,
 	type ISegmentInternal,
 	createLocalReconnectingPerspective,
-	DoublyLinkedList,
-	type ListNode,
 	SlidingPreference,
 } from "@fluidframework/merge-tree/internal";
 import { LoggingError, UsageError } from "@fluidframework/telemetry-utils/internal";

--- a/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
+++ b/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
@@ -3,12 +3,9 @@
  * Licensed under the MIT License.
  */
 
+import type { ListNode } from "@fluidframework/core-utils/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
-import {
-	IMergeTreeOptions,
-	ListNode,
-	type ISegmentInternal,
-} from "@fluidframework/merge-tree/internal";
+import { IMergeTreeOptions, type ISegmentInternal } from "@fluidframework/merge-tree/internal";
 
 import type {
 	IntervalCollection,


### PR DESCRIPTION
This change moves the existing DoublyLInkedList class and related types from merge-tree to core-utils to make reuse easier. 