### PR TITLE
refactor(tree): Leverage schema type-narrowing helper functions

### DIFF
--- a/packages/dds/tree/src/simple-tree/api/configuration.ts
+++ b/packages/dds/tree/src/simple-tree/api/configuration.ts
@@ -18,7 +18,14 @@ import {
 import type { TreeNodeSchema } from "../core/index.js";
 import { toStoredSchema } from "../toStoredSchema.js";
 import { LeafNodeSchema } from "../leafNodeSchema.js";
-import { isArrayNodeSchema, isMapNodeSchema, isObjectNodeSchema, type ArrayNodeSchema, type MapNodeSchema, type ObjectNodeSchema } from "../node-kinds/index.js";
+import {
+	isArrayNodeSchema,
+	isMapNodeSchema,
+	isObjectNodeSchema,
+	type ArrayNodeSchema,
+	type MapNodeSchema,
+	type ObjectNodeSchema,
+} from "../node-kinds/index.js";
 import { getOrCreate } from "../../util/index.js";
 import type { MakeNominal } from "../../util/index.js";
 import { walkFieldSchema } from "../walkFieldSchema.js";

--- a/packages/dds/tree/src/simple-tree/api/configuration.ts
+++ b/packages/dds/tree/src/simple-tree/api/configuration.ts
@@ -15,10 +15,10 @@ import {
 	markSchemaMostDerived,
 	normalizeFieldSchema,
 } from "../schemaTypes.js";
-import { NodeKind, type TreeNodeSchema } from "../core/index.js";
+import type { TreeNodeSchema } from "../core/index.js";
 import { toStoredSchema } from "../toStoredSchema.js";
 import { LeafNodeSchema } from "../leafNodeSchema.js";
-import { isObjectNodeSchema, type ObjectNodeSchema } from "../node-kinds/index.js";
+import { isArrayNodeSchema, isMapNodeSchema, isObjectNodeSchema, type ArrayNodeSchema, type MapNodeSchema, type ObjectNodeSchema } from "../node-kinds/index.js";
 import { getOrCreate } from "../../util/index.js";
 import type { MakeNominal } from "../../util/index.js";
 import { walkFieldSchema } from "../walkFieldSchema.js";
@@ -293,10 +293,10 @@ export function checkUnion(
 	ambiguityErrors: string[],
 ): void {
 	const checked: Set<TreeNodeSchema> = new Set();
-	const maps: TreeNodeSchema[] = [];
-	const arrays: TreeNodeSchema[] = [];
-
+	const maps: MapNodeSchema[] = [];
+	const arrays: ArrayNodeSchema[] = [];
 	const objects: ObjectNodeSchema[] = [];
+
 	// Map from key to schema using that key
 	const allObjectKeys: Map<string, Set<TreeNodeSchema>> = new Map();
 
@@ -313,10 +313,10 @@ export function checkUnion(
 			for (const key of schema.fields.keys()) {
 				getOrCreate(allObjectKeys, key, () => new Set()).add(schema);
 			}
-		} else if (schema.kind === NodeKind.Array) {
+		} else if (isArrayNodeSchema(schema)) {
 			arrays.push(schema);
 		} else {
-			assert(schema.kind === NodeKind.Map, 0x9e7 /* invalid schema */);
+			assert(isMapNodeSchema(schema), 0x9e7 /* invalid schema */);
 			maps.push(schema);
 		}
 	}

--- a/packages/dds/tree/src/simple-tree/api/customTree.ts
+++ b/packages/dds/tree/src/simple-tree/api/customTree.ts
@@ -22,7 +22,7 @@ import {
 } from "../../core/index.js";
 import { FieldKinds, valueSchemaAllows } from "../../feature-libraries/index.js";
 import { cloneWithReplacements } from "../../util/index.js";
-import { NodeKind, type TreeNodeSchema } from "../core/index.js";
+import type { TreeNodeSchema } from "../core/index.js";
 import {
 	booleanSchema,
 	handleSchema,
@@ -30,7 +30,7 @@ import {
 	numberSchema,
 	stringSchema,
 } from "../leafNodeSchema.js";
-import { isObjectNodeSchema } from "../node-kinds/index.js";
+import { isArrayNodeSchema, isObjectNodeSchema } from "../node-kinds/index.js";
 import type { TreeLeafValue } from "../schemaTypes.js";
 
 /**
@@ -106,7 +106,7 @@ export function customFromCursor<TChild>(
 			return reader.value;
 		default: {
 			assert(reader.value === undefined, 0xa54 /* out of schema: unexpected value */);
-			if (nodeSchema.kind === NodeKind.Array) {
+			if (isArrayNodeSchema(nodeSchema)) {
 				const fields = inCursorField(reader, EmptyKey, () =>
 					mapCursorField(reader, () => childHandler(reader, options, schema)),
 				);

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -38,7 +38,7 @@ import {
 	getOrCreateInnerNode,
 } from "../core/index.js";
 import type { TreeChangeEvents } from "./treeChangeEvents.js";
-import { isObjectNodeSchema } from "../node-kinds/index.js";
+import { isArrayNodeSchema, isObjectNodeSchema } from "../node-kinds/index.js";
 import { tryGetTreeNodeForField } from "../getTreeNodeForField.js";
 
 /**
@@ -193,7 +193,7 @@ export const treeNodeApi: TreeNodeApi = {
 						);
 						listener({ changedProperties });
 					});
-				} else if (nodeSchema.kind === NodeKind.Array) {
+				} else if (isArrayNodeSchema(nodeSchema)) {
 					return kernel.events.on("childrenChangedAfterBatch", () => {
 						listener({ changedProperties: undefined });
 					});

--- a/packages/dds/tree/src/simple-tree/core/index.ts
+++ b/packages/dds/tree/src/simple-tree/core/index.ts
@@ -42,6 +42,7 @@ export {
 	getOrCreateNodeFromInnerUnboxedNode,
 } from "./getOrCreateNode.js";
 export {
+	UnhydratedFlexTreeField,
 	UnhydratedFlexTreeNode,
 	UnhydratedSequenceField,
 	UnhydratedContext,

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -207,6 +207,7 @@ export {
 	type InsertableObjectFromSchemaRecord,
 	type ObjectFromSchemaRecord,
 	ObjectNodeSchema,
+	type ObjectNodeSchemaPrivate,
 	isObjectNodeSchema,
 	type InsertableObjectFromAnnotatedSchemaRecord,
 	type TreeObjectNode,

--- a/packages/dds/tree/src/simple-tree/node-kinds/index.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/index.ts
@@ -33,6 +33,7 @@ export {
 	isObjectNodeSchema,
 	type ObjectFromSchemaRecord,
 	ObjectNodeSchema,
+	type ObjectNodeSchemaPrivate,
 	objectSchema,
 	setField,
 	type TreeObjectNode,

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/index.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/index.ts
@@ -13,4 +13,8 @@ export {
 	setField,
 	type TreeObjectNode,
 } from "./objectNode.js";
-export { isObjectNodeSchema, ObjectNodeSchema, type ObjectNodeSchemaPrivate } from "./objectNodeTypes.js";
+export {
+	isObjectNodeSchema,
+	ObjectNodeSchema,
+	type ObjectNodeSchemaPrivate,
+} from "./objectNodeTypes.js";

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/index.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/index.ts
@@ -13,4 +13,4 @@ export {
 	setField,
 	type TreeObjectNode,
 } from "./objectNode.js";
-export { isObjectNodeSchema, ObjectNodeSchema } from "./objectNodeTypes.js";
+export { isObjectNodeSchema, ObjectNodeSchema, type ObjectNodeSchemaPrivate } from "./objectNodeTypes.js";

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -40,6 +40,7 @@ import {
 	isObjectNodeSchema,
 	type ObjectNodeSchema,
 	type ObjectNodeSchemaInternalData,
+	type ObjectNodeSchemaPrivate,
 } from "./objectNodeTypes.js";
 import { prepareForInsertion } from "../../prepareForInsertion.js";
 import {
@@ -216,7 +217,7 @@ function createFlexKeyMapping(
  * If not provided `{}` is used for the target.
  */
 function createProxyHandler(
-	schema: ObjectNodeSchema & ObjectNodeSchemaInternalData,
+	schema: ObjectNodeSchemaPrivate,
 	allowAdditionalProperties: boolean,
 ): ProxyHandler<TreeNode> {
 	// To satisfy 'deepEquals' level scrutiny, the target of the proxy must be an object with the same
@@ -476,7 +477,7 @@ export function objectSchema<
 		protected static override oneTimeSetup<T2>(this: typeof TreeNodeValid<T2>): Context {
 			// One time initialization that required knowing the most derived type (from this.constructor) and thus has to be lazy.
 			customizable = (this as unknown) !== CustomObjectNode;
-			const schema = this as unknown as ObjectNodeSchema & ObjectNodeSchemaInternalData;
+			const schema = this as unknown as ObjectNodeSchemaPrivate;
 			handler = createProxyHandler(schema, customizable);
 			unhydratedContext = getUnhydratedContext(schema);
 

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNodeTypes.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNodeTypes.ts
@@ -83,8 +83,13 @@ export const ObjectNodeSchema = {
 	},
 } as const;
 
+/**
+ * {@link ObjectNodeSchema} with data that is not part of the package-exported API surface.
+ */
+export type ObjectNodeSchemaPrivate = ObjectNodeSchema & ObjectNodeSchemaInternalData;
+
 export function isObjectNodeSchema(
 	schema: TreeNodeSchema,
-): schema is ObjectNodeSchema & ObjectNodeSchemaInternalData {
+): schema is ObjectNodeSchemaPrivate {
 	return schema.kind === NodeKind.Object;
 }

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNodeTypes.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNodeTypes.ts
@@ -88,8 +88,6 @@ export const ObjectNodeSchema = {
  */
 export type ObjectNodeSchemaPrivate = ObjectNodeSchema & ObjectNodeSchemaInternalData;
 
-export function isObjectNodeSchema(
-	schema: TreeNodeSchema,
-): schema is ObjectNodeSchemaPrivate {
+export function isObjectNodeSchema(schema: TreeNodeSchema): schema is ObjectNodeSchemaPrivate {
 	return schema.kind === NodeKind.Object;
 }

--- a/packages/dds/tree/src/simple-tree/unhydratedFlexTreeFromInsertable.ts
+++ b/packages/dds/tree/src/simple-tree/unhydratedFlexTreeFromInsertable.ts
@@ -54,8 +54,7 @@ import { isArrayNodeSchema, type ArrayNodeSchema } from "./node-kinds/array/arra
 import { isMapNodeSchema, type MapNodeSchema } from "./node-kinds/map/mapNodeTypes.js";
 import {
 	isObjectNodeSchema,
-	type ObjectNodeSchema,
-	type ObjectNodeSchemaInternalData,
+	type ObjectNodeSchemaPrivate,
 } from "./node-kinds/object/objectNodeTypes.js";
 /* eslint-enable import/no-internal-modules */
 
@@ -366,7 +365,7 @@ function mapToFlexContent(data: FactoryContent, schema: MapNodeSchema): FlexCont
  */
 function objectToFlexContent(
 	data: FactoryContent,
-	schema: ObjectNodeSchema & ObjectNodeSchemaInternalData,
+	schema: ObjectNodeSchemaPrivate,
 ): FlexContent {
 	if (
 		typeof data !== "object" ||

--- a/packages/dds/tree/src/simple-tree/unhydratedFlexTreeFromInsertable.ts
+++ b/packages/dds/tree/src/simple-tree/unhydratedFlexTreeFromInsertable.ts
@@ -40,6 +40,7 @@ import {
 	UnhydratedSequenceField,
 } from "./core/index.js";
 import { getUnhydratedContext } from "./createContext.js";
+import { convertFieldKind } from "./toStoredSchema.js";
 
 // Required to prevent the introduction of new circular dependencies
 // TODO: Having the schema provide their own policy functions for compatibility which
@@ -56,7 +57,6 @@ import {
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import { createField, type UnhydratedFlexTreeField } from "./core/unhydratedFlexTree.js";
 /* eslint-enable import/no-internal-modules */
-import { convertFieldKind } from "./toStoredSchema.js";
 
 /**
  * Module notes:

--- a/packages/dds/tree/src/simple-tree/unhydratedFlexTreeFromInsertable.ts
+++ b/packages/dds/tree/src/simple-tree/unhydratedFlexTreeFromInsertable.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import { assert, fail, unreachableCase } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
@@ -30,12 +31,14 @@ import {
 	type ContextualFieldProvider,
 } from "./schemaTypes.js";
 import {
+	createField,
 	getKernel,
 	isTreeNode,
 	NodeKind,
 	type TreeNode,
 	type TreeNodeSchema,
 	type Unhydrated,
+	type UnhydratedFlexTreeField,
 	UnhydratedFlexTreeNode,
 	UnhydratedSequenceField,
 } from "./core/index.js";
@@ -54,8 +57,6 @@ import {
 	type ObjectNodeSchema,
 	type ObjectNodeSchemaInternalData,
 } from "./node-kinds/object/objectNodeTypes.js";
-import type { IFluidHandle } from "@fluidframework/core-interfaces";
-import { createField, type UnhydratedFlexTreeField } from "./core/unhydratedFlexTree.js";
 /* eslint-enable import/no-internal-modules */
 
 /**

--- a/packages/dds/tree/src/simple-tree/unhydratedFlexTreeFromInsertable.ts
+++ b/packages/dds/tree/src/simple-tree/unhydratedFlexTreeFromInsertable.ts
@@ -46,8 +46,8 @@ import { getUnhydratedContext } from "./createContext.js";
 // `unhydratedFlexTreeFromInsertable` invokes instead of manually handling each kind would remove this bad
 // dependency, and reduce coupling.
 /* eslint-disable import/no-internal-modules */
-import { isArrayNodeSchema, type ArrayNodeSchema } from "./node-kinds/array/index.js";
-import { isMapNodeSchema, type MapNodeSchema } from "./node-kinds/map/index.js";
+import { isArrayNodeSchema, type ArrayNodeSchema } from "./node-kinds/array/arrayNodeTypes.js";
+import { isMapNodeSchema, type MapNodeSchema } from "./node-kinds/map/mapNodeTypes.js";
 import {
 	isObjectNodeSchema,
 	type ObjectNodeSchema,


### PR DESCRIPTION
Replaces some explicit `node.kind` equality checks with existing type-narrowing helpers.