### PR TITLE
telemetry(odsp-driver): Add telemetry for join session

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -141,7 +141,6 @@ export class OdspDelayLoadedDeltaStream {
 			this.currentConnection === undefined,
 			0x4ad /* Should not be called when connection is already present! */,
 		);
-
 		// Attempt to connect twice, in case we used expired token.
 		return getWithRetryForTokenRefresh<IDocumentDeltaConnection>(async (options) => {
 			// Presence of getWebsocketToken callback dictates whether callback is used for fetching

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -338,6 +338,17 @@ export class OdspDelayLoadedDeltaStream {
 		clientId: string | undefined,
 		displayName: string | undefined,
 	): Promise<ISocketStorageDiscovery> {
+		const startTime = performanceNow();
+
+		// Log the attempt to join session with key context
+		this.mc.logger.sendTelemetryEvent({
+			eventName: "JoinSessionAttempt",
+			isRefreshingJoinSession,
+			requestSocketToken,
+			clientId: clientId ?? "undefined",
+			driverVersion,
+		});
+
 		// If this call is to refresh the join session for the current connection but we are already disconnected in
 		// the meantime or disconnected and then reconnected then do not make the call. However, we should not have
 		// come here if that is the case because timer should have been disposed, but due to race condition with the
@@ -366,6 +377,20 @@ export class OdspDelayLoadedDeltaStream {
 			isRefreshingJoinSession,
 			displayName,
 		).catch((error) => {
+			// Log failure details before handling facet codes
+			const errorDuration = performanceNow() - startTime;
+			this.mc.logger.sendTelemetryEvent(
+				{
+					eventName: "JoinSessionError",
+					isRefreshingJoinSession,
+					requestSocketToken,
+					clientId: clientId ?? "undefined",
+					duration: errorDuration,
+					driverVersion,
+				},
+				error,
+			);
+
 			if (hasFacetCodes(error) && error.facetCodes !== undefined) {
 				for (const code of error.facetCodes) {
 					switch (code) {
@@ -393,6 +418,21 @@ export class OdspDelayLoadedDeltaStream {
 			}
 			throw error;
 		});
+
+		// Log successful join session
+		const duration = performanceNow() - startTime;
+		this.mc.logger.sendTelemetryEvent({
+			eventName: "JoinSessionSuccess",
+			isRefreshingJoinSession,
+			requestSocketToken,
+			clientId: clientId ?? "undefined",
+			duration,
+			tenantId: response.tenantId,
+			socketId: response.id,
+			refreshSessionDurationSeconds: response.refreshSessionDurationSeconds,
+			driverVersion,
+		});
+
 		this._relayServiceTenantAndSessionId = `${response.tenantId}/${response.id}`;
 		return response;
 	}

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -162,7 +162,6 @@ export class OdspDelayLoadedDeltaStream {
 					eventName: "FirstJoinSessionAttemptDetails",
 					details: {
 						requestWebsocketToken: requestWebsocketTokenFromJoinSession,
-						driverVersion,
 					},
 				});
 			}

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -139,6 +139,7 @@ export const fetchJoinSession = mockify(
 
 				return response.content;
 			},
+			{ start: true, end: true, cancel: "error" },
 		);
 	},
 );

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -139,7 +139,6 @@ export const fetchJoinSession = mockify(
 
 				return response.content;
 			},
-			{ start: true, end: true, cancel: "error" },
 		);
 	},
 );


### PR DESCRIPTION
## Description 
Fixes [AB#42712](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/42712)

LWS has been seeing gaps and timeouts after SocketModuleLoaded event. After the socket module is loaded we should log telemetry for join session attempts, failures, and successes. 