### PR TITLE
Limit permissions made available to tokens in GitHub actions

### DIFF
--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -11,12 +11,12 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   load_report:
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:

--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
   load_report:
+    permissions:
+      pull-requests: write # for marocchino/sticky-pull-request-comment to create or update PR comment
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3

--- a/.github/workflows/linkcheck-reporter.yml
+++ b/.github/workflows/linkcheck-reporter.yml
@@ -6,11 +6,13 @@ on:
       - completed
 
 permissions:
-  actions: read
-  pull-requests: write
+  contents: read
+  actions: read  # for dawidd6/action-download-artifact to query and download artifacts
 
 jobs:
   load_report:
+    permissions:
+      pull-requests: write  # for marocchino/sticky-pull-request-comment to create or update PR comment
     runs-on: ubuntu-latest
     steps:
       - name: Download results

--- a/.github/workflows/pr-changeset-review.yml
+++ b/.github/workflows/pr-changeset-review.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   vale:
     permissions:
-      pull-requests: write
+      pull-requests: write # for errata-ai/vale-action to add comments to PRs
     name: vale
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-changeset-review.yml
+++ b/.github/workflows/pr-changeset-review.yml
@@ -16,11 +16,10 @@ on:
     paths:
       - ".changeset/**" # Trigger only when changes are found under .changeset
 
-permissions:
-  pull-requests: write
-
 jobs:
   vale:
+    permissions:
+      pull-requests: write
     name: vale
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -12,7 +12,7 @@ on:
     types: [labeled, unlabeled, opened, synchronize, reopened]
 
 permissions:
-  pull-requests: read
+  contents: read
 
 jobs:
   # When a PR has the changeset-required label, check if it has a changeset.

--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   # When a PR has the changeset-required label, check if it has a changeset.

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -5,10 +5,12 @@ on:
     branches: [main, next, release/**/*]
 
 permissions:
-  pull-requests: write
+  contents: read  # for actions/labeler to determine modified files
 
 jobs:
   areas_label:
+    permissions:
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     name: Label areas
     # Skip labeling main-next merge PRs. The area labels are noisy and distracting for main-next PRs because they can
@@ -27,6 +29,8 @@ jobs:
   # Changes to some paths should automatically add the changeset-required label. This label is often added manually, so
   # this CI job calls the labeler action wuth sync-labels=false, so the label won't be removed automatically.
   changesets_label:
+    permissions:
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     name: Label changeset-required
     steps:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -40,6 +40,8 @@ jobs:
           repo-token: "${{ github.token }}"
           sync-labels: false # The changeset-required label is often added manually, so don't remove it.
   branches_label:
+    permissions:
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     name: Label base branches and external contributors
     steps:

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -13,11 +13,12 @@ on:
       - test/release/**
 
 permissions:
-  # Needed to write the comments to the PRs themselves
-  pull-requests: write
+  contents: read # for actions/checkout to fetch code
 
 jobs:
   warning:
+    permissions:
+      pull-requests: write  # for marocchino/sticky-pull-request-comment to create or update PR comment
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # ratchet:actions/checkout@v4

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,7 +12,7 @@ on:
       - release/**/*
 
 permissions:
-  pull-requests: write
+  contents: read # for actions/checkout to fetch code
 
 jobs:
   validate-codeowners:
@@ -29,6 +29,8 @@ jobs:
 
   # This job checks that PR template placeholder content has been removed from the PR body.
   placeholder-content:
+    permissions:
+      pull-requests: write # for sitezen/pr-comment-checker to add comments to PRs
     name: PR template placeholder content
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -21,10 +21,12 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   create-release:
+    permissions:
+      contents: write  # for ncipollo/release-action to create a release
     name: Create GitHub release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-approval.yml
+++ b/.github/workflows/release-approval.yml
@@ -21,11 +21,8 @@ on:
         required: true
 
 permissions:
-  # Needed to read artifacts from upstream workflows
-  actions: read
-
-  # Needed to check pull request metadata for review status
-  pull-requests: read
+  actions: read  # Needed to download artifacts from the release-branches workflow
+  pull-requests: read  # Needed to read the PR details, such as the head commit SHA and the PR number.
 
 jobs:
   metadata:
@@ -100,8 +97,7 @@ jobs:
 
   check_approval:
     permissions:
-      # Needed to update the PR check status to permit/prevent merge
-      statuses: write
+      statuses: write # Needed to set the commit status on the PR's head commit to permit/prevent merge
     name: Check PR approval
     if: needs.metadata.outputs.is_release_branch == 'true'
     needs: metadata

--- a/.github/workflows/release-approval.yml
+++ b/.github/workflows/release-approval.yml
@@ -27,9 +27,6 @@ permissions:
   # Needed to check pull request metadata for review status
   pull-requests: read
 
-  # Needed to update the PR check status to permit/prevent merge
-  statuses: write
-
 jobs:
   metadata:
     name: Get PR metadata
@@ -102,6 +99,9 @@ jobs:
             return pr.head.sha;
 
   check_approval:
+    permissions:
+      # Needed to update the PR check status to permit/prevent merge
+      statuses: write
     name: Check PR approval
     if: needs.metadata.outputs.is_release_branch == 'true'
     needs: metadata

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -31,7 +31,7 @@ on:
       - dismissed
 
 permissions:
-  pull-requests: read
+  contents: read
 
 jobs:
   check_branch:

--- a/.github/workflows/release-notes-issue.yml
+++ b/.github/workflows/release-notes-issue.yml
@@ -18,11 +18,10 @@ on:
 env:
   ISSUE: ${{ vars.RELEASE_NOTES_ISSUE }}
 
-permissions:
-  issues: write
-
 jobs:
   update-issue:
+    permissions:
+      issues: write
     name: Update release notes
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -5,10 +5,12 @@ name: Delete Stale Branches
 on: workflow_dispatch
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   stale_branches:
+    permissions:
+      contents: write
     name: Cleanup old branches
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/website-validation.yml
+++ b/.github/workflows/website-validation.yml
@@ -16,7 +16,7 @@ defaults:
     working-directory: ./docs
 
 permissions:
-  pull-requests: read
+  contents: read
 
 jobs:
 


### PR DESCRIPTION
## Description

These changes were made to limit the permissions available to tokens in GitHub actions, so that we can improve our score for Token-Permissions on scorecard.

The changes made were done by following guidelines from the Token-Permissions section of the scorecard docs: 
https://github.com/ossf/scorecard/blob/ea7e27ed41b76ab879c862fa0ca4cc9c61764ee4/docs/checks.md#token-permissions
Mainly, write permissions were moved to the job level, with read permissions at the top-level.

This tool (recommended by the scorecard docs) was used to help determine the minimum permissions needed on the workflow:
https://app.stepsecurity.io/secureworkflow