### PR TITLE
fix(container-runtime): Reentrant op rebasing wrongly skipped for single-op batch

### DIFF
--- a/packages/dds/pact-map/src/pactMap.ts
+++ b/packages/dds/pact-map/src/pactMap.ts
@@ -371,7 +371,6 @@ export class PactMapClass<T = unknown>
 	protected reSubmitCore(content: unknown, localOpMetadata: unknown): void {
 		const pactMapOp = content as IPactMapOperation<T>;
 
-
 		// Filter out set messages that have no chance of being accepted because there's another value pending
 		// or another value was accepted while we were disconnected.
 		const currentValue = this.values.get(pactMapOp.key);

--- a/packages/dds/pact-map/src/test/pactMap.spec.ts
+++ b/packages/dds/pact-map/src/test/pactMap.spec.ts
@@ -454,6 +454,11 @@ describe("PactMap", () => {
 			containerRuntimeFactory.processAllMessages(); // Process the accept from client 2
 			containerRuntime1.connected = true;
 			assert.strictEqual(
+				containerRuntimeFactory.outstandingMessageCount,
+				1,
+				"Should have client 1 accept",
+			);
+			assert.strictEqual(
 				pactMap1.get(targetKey),
 				"expected",
 				"PactMap1 should see the expected value",
@@ -471,6 +476,11 @@ describe("PactMap", () => {
 			containerRuntimeFactory.processOneMessage(); // pactMap1 "set"
 			containerRuntime1.connected = false;
 			containerRuntime1.connected = true;
+			assert.strictEqual(
+				containerRuntimeFactory.outstandingMessageCount,
+				2,
+				"Should only have client 1 and client 2 accept",
+			);
 			assert.strictEqual(
 				pactMap1.get(targetKey),
 				undefined,

--- a/packages/dds/pact-map/src/test/pactMap.spec.ts
+++ b/packages/dds/pact-map/src/test/pactMap.spec.ts
@@ -454,11 +454,6 @@ describe("PactMap", () => {
 			containerRuntimeFactory.processAllMessages(); // Process the accept from client 2
 			containerRuntime1.connected = true;
 			assert.strictEqual(
-				containerRuntimeFactory.outstandingMessageCount,
-				0,
-				"Should not have generated an op",
-			);
-			assert.strictEqual(
 				pactMap1.get(targetKey),
 				"expected",
 				"PactMap1 should see the expected value",
@@ -476,11 +471,6 @@ describe("PactMap", () => {
 			containerRuntimeFactory.processOneMessage(); // pactMap1 "set"
 			containerRuntime1.connected = false;
 			containerRuntime1.connected = true;
-			assert.strictEqual(
-				containerRuntimeFactory.outstandingMessageCount,
-				1,
-				"Should only have client 2 accept",
-			);
 			assert.strictEqual(
 				pactMap1.get(targetKey),
 				undefined,

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -455,10 +455,7 @@ export class Outbox {
 		if (
 			batchManager.options.canRebase &&
 			rawBatch.hasReentrantOps === true &&
-			// NOTE: This is too restrictive. We should rebase for any reentrant op, not just if it's going to be a grouped batch
-			// However there is some test that is depending on this behavior so we haven't removed these conditions yet. See AB#33427
-			groupingEnabled &&
-			rawBatch.messages.length > 1
+			groupingEnabled
 		) {
 			assert(!this.rebasing, 0x6fa /* A rebased batch should never have reentrant ops */);
 			// If a batch contains reentrant ops (ops created as a result from processing another op)

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -1136,7 +1136,7 @@ describe("Outbox", () => {
 			validateCounts(0, 0, 2);
 		});
 
-		it("batch has a single reentrant op - don't rebase", () => {
+		it("batch has a single reentrant op", () => {
 			const outbox = getOutbox({
 				context: getMockContext(),
 				opGroupingConfig: {
@@ -1152,7 +1152,7 @@ describe("Outbox", () => {
 
 			outbox.flush();
 
-			validateCounts(1, 1, 0);
+			validateCounts(0, 0, 1);
 		});
 
 		it("should group the batch", () => {


### PR DESCRIPTION
## Description 

Fixes [AB#33427](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/33427)

In Outbox.flushInternal, we skip rebase for single-message batches. This is an eventual consistency bug (Repro here:  https://github.com/microsoft/FluidFramework/compare/main...anthony-murphy:mt-rententrancy). This change attempts to fix this by removing the message size check when rebasing in outbox. 

The cause of the migration tests that were failing was that In PactMap (which is used for MigrationTool), the "accept" op is always a single message reentrant op in response to a "set" op (which proposes a new version). This "accept" op is now rebased/resubmitted. We had a check in PactMap that would drop all "accept" ops that were resubmitted because we assumed that resubmit would only be called in the case of disconnect (we would drop these because on disconnect our client is removed from quorum and implicitly accepts). Now accepting the rebasing of single message batches, we need to adjust this to allow the resubmission of these "accept" ops. 

The solution/change made in PactMap in this PR here is to allow resubmission of accept ops and passively return early if we receive an accept op that has already been accepted. 