### PR TITLE
mint local ids when replacing revisions

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -18,6 +18,7 @@ import type {
 import type { IdAllocator, Invariant } from "../../util/index.js";
 
 import type { CrossFieldManager } from "./crossFieldQueries.js";
+import type { ReplaceRevisionIdInfo } from "./modularChangeFamily.js";
 import type { EncodedNodeChangeset } from "./modularChangeFormat.js";
 import type { CrossFieldKeyRange, NodeId } from "./modularChangeTypes.js";
 
@@ -168,6 +169,7 @@ export interface FieldChangeRebaser<TChangeset> {
 		change: TChangeset,
 		oldRevisions: Set<RevisionTag | undefined>,
 		newRevisions: RevisionTag | undefined,
+		replaceRevisionIdInfo?: ReplaceRevisionIdInfo,
 	): TChangeset;
 }
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -28,6 +28,7 @@ import { FieldKindWithEditor } from "./fieldKindWithEditor.js";
 import { makeGenericChangeCodec } from "./genericFieldKindCodecs.js";
 import { newGenericChangeset, type GenericChangeset } from "./genericFieldKindTypes.js";
 import type { NodeId } from "./modularChangeTypes.js";
+import type { ReplaceRevisionIdInfo } from "./modularChangeFamily.js";
 
 /**
  * {@link FieldChangeHandler} implementation for {@link GenericChangeset}.
@@ -156,8 +157,11 @@ function replaceRevisions(
 	changeset: GenericChangeset,
 	oldRevisions: Set<RevisionTag | undefined>,
 	newRevision: RevisionTag | undefined,
+	replaceRevisionIdInfo: ReplaceRevisionIdInfo,
 ): GenericChangeset {
-	return changeset.mapValues((node) => replaceAtomRevisions(node, oldRevisions, newRevision));
+	return changeset.mapValues((node) =>
+		replaceAtomRevisions(node, oldRevisions, newRevision, replaceRevisionIdInfo),
+	);
 }
 
 /**

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -449,7 +449,8 @@ const nodesChunk = chunkFieldSingle(fieldJsonCursor([{}, {}]), {
 	idCompressor: testIdCompressor,
 });
 
-describe("ModularChangeFamily", () => {
+// TODO: remove after debugging
+describe.only("ModularChangeFamily", () => {
 	describe("compose", () => {
 		const composedValues: ValueChangeset = { old: 0, new: 2 };
 


### PR DESCRIPTION
## Description

This PR mints new local ids when replacing revisions to prevent duplicate local ids (with different revisions) from becoming duplicate local ids (with the same revision) for a changeset.

## Reviewer Guidance

Currently this is incomplete, and needs some debugging. The code fails in `modularChangeFamily.spec.ts` (before getting to the tests) on this code block with assert "0x9ca /* Unknown node ID */"

const rootChange4: ModularChangeset = removeAliases(
	family.compose([
		tagChangeInline(rootChange3, tag4),
		makeAnonChange(buildExistsConstraint(pathA0)),
	]),
);

When checking the changesets (before and after update) for this example, it looks like it updated the changeset correctly, but was unable to debug what the issue was.
