### PR TITLE
fix(fluid-build): DeclarativeTask executable name matching shouldn't force lower case

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
@@ -412,7 +412,9 @@ export function getTaskDefinitions(
 				if (script === undefined) {
 					throw new Error(`Script not found for task definition '${name}'`);
 				} else if (script.startsWith("fluid-build ")) {
-					throw new Error(`Script task should not invoke 'fluid-build' in '${name}'`);
+					throw new Error(
+						`Script task should not invoke 'fluid-build' in '${name}'. Did you forget to set 'script: false' in the task definition?`,
+					);
 				}
 			} else {
 				if (full.before.length !== 0 || full.after.length !== 0) {


### PR DESCRIPTION
On non-window platforms, executable are case-sensitive. The only impact to the main repo build is for command `flub check buildVersion` in `fluidBuild.config.cjs`.  Need to update after this get published and version in the main repo updated.


Also add clarification to task definition error when the script command is 'fluid-build'