### PR TITLE
test(client-presence): consistency and typo fixes

### DIFF
--- a/packages/framework/presence/src/test/eventing.spec.ts
+++ b/packages/framework/presence/src/test/eventing.spec.ts
@@ -10,6 +10,8 @@ import type { SinonFakeTimers, SinonSpy } from "sinon";
 import { useFakeTimers, spy } from "sinon";
 
 import type { Attendee, WorkspaceAddress } from "../index.js";
+import { toOpaqueJson } from "../internalUtils.js";
+import type { GeneralDatastoreMessageContent, InternalWorkspaceAddress } from "../protocol.js";
 
 import { MockEphemeralRuntime } from "./mockEphemeralRuntime.js";
 import {
@@ -27,6 +29,7 @@ import { Notifications, StateFactory } from "@fluidframework/presence/alpha";
 
 const datastoreUpdateType = "Pres:DatastoreUpdate";
 
+type StatesObjectUpdateContent = GeneralDatastoreMessageContent[InternalWorkspaceAddress];
 /**
  * Workspace updates
  */
@@ -44,10 +47,10 @@ const latestUpdate = {
 		[attendeeId1]: {
 			"rev": 1,
 			"timestamp": 0,
-			"value": { x: 1, y: 1, z: 1 },
+			"value": toOpaqueJson({ x: 1, y: 1, z: 1 }),
 		},
 	},
-} as const;
+} as const satisfies StatesObjectUpdateContent;
 const latestMapUpdate = {
 	"latestMap": {
 		[attendeeId1]: {
@@ -56,26 +59,26 @@ const latestMapUpdate = {
 				"key1": {
 					"rev": 1,
 					"timestamp": 0,
-					"value": { a: 1, b: 1 },
+					"value": toOpaqueJson({ a: 1, b: 1 }),
 				},
 				"key2": {
 					"rev": 1,
 					"timestamp": 0,
-					"value": { c: 1, d: 1 },
+					"value": toOpaqueJson({ c: 1, d: 1 }),
 				},
 			},
 		},
 	},
-} as const;
+} as const satisfies StatesObjectUpdateContent;
 const latestUpdateRev2 = {
 	"latest": {
 		[attendeeId1]: {
 			"rev": 2,
 			"timestamp": 50,
-			"value": { x: 2, y: 2, z: 2 },
+			"value": toOpaqueJson({ x: 2, y: 2, z: 2 }),
 		},
 	},
-} as const;
+} as const satisfies StatesObjectUpdateContent;
 const itemRemovedMapUpdate = {
 	"latestMap": {
 		[attendeeId1]: {
@@ -88,7 +91,7 @@ const itemRemovedMapUpdate = {
 			},
 		},
 	},
-} as const;
+} as const satisfies StatesObjectUpdateContent;
 const itemRemovedAndItemUpdatedMapUpdate = {
 	"latestMap": {
 		[attendeeId1]: {
@@ -101,13 +104,13 @@ const itemRemovedAndItemUpdatedMapUpdate = {
 				"key1": {
 					"rev": 2,
 					"timestamp": 50,
-					"value": { a: 2, b: 2 },
+					"value": toOpaqueJson({ a: 2, b: 2 }),
 				},
 			},
 		},
 	},
-};
-const itemUpdatedAndItemRemoveddMapUpdate = {
+} as const satisfies StatesObjectUpdateContent;
+const itemUpdatedAndItemRemovedMapUpdate = {
 	"latestMap": {
 		[attendeeId1]: {
 			"rev": 2,
@@ -115,7 +118,7 @@ const itemUpdatedAndItemRemoveddMapUpdate = {
 				"key1": {
 					"rev": 2,
 					"timestamp": 50,
-					"value": { a: 2, b: 2 },
+					"value": toOpaqueJson({ a: 2, b: 2 }),
 				},
 				"key2": {
 					"rev": 2,
@@ -124,21 +127,17 @@ const itemUpdatedAndItemRemoveddMapUpdate = {
 			},
 		},
 	},
-};
-const latestMapItemRemovedAndLatestUpdate = {
-	latestUpdateRev2,
-	itemRemovedMapUpdate,
-} as const;
+} as const satisfies StatesObjectUpdateContent;
 const notificationsUpdate = {
 	"testEvents": {
 		[attendeeId1]: {
 			"rev": 0,
 			"timestamp": 0,
-			"value": { "name": "newId", "args": [42] },
+			"value": toOpaqueJson({ "name": "newId", "args": [42] }),
 			"ignoreUnmonitored": true,
 		},
 	},
-};
+} as const satisfies StatesObjectUpdateContent;
 
 describe("Presence", () => {
 	describe("events are fired with consistent and final state when", () => {
@@ -234,18 +233,6 @@ describe("Presence", () => {
 			clock.restore();
 		});
 
-		type UpdateContent =
-			| typeof attendeeUpdate
-			| typeof latestUpdate
-			| typeof latestMapUpdate
-			| typeof latestMapItemRemovedAndLatestUpdate
-			| (typeof latestUpdate & typeof latestMapUpdate)
-			| typeof latestUpdateRev2
-			| typeof itemRemovedMapUpdate
-			| typeof itemRemovedAndItemUpdatedMapUpdate
-			| typeof itemUpdatedAndItemRemoveddMapUpdate
-			| typeof notificationsUpdate;
-
 		function setupSharedStatesWorkspace({
 			notifications,
 		}: { notifications?: true } = {}): void {
@@ -294,7 +281,7 @@ describe("Presence", () => {
 			notificationManager = notificationsWorkspace.notifications.testEvents;
 		}
 
-		function processUpdates(valueManagerUpdates: Record<string, UpdateContent>): void {
+		function processUpdates(valueManagerUpdates: GeneralDatastoreMessageContent): void {
 			const updates = { "system:presence": attendeeUpdate, ...valueManagerUpdates };
 
 			presence.processSignal(
@@ -537,12 +524,13 @@ describe("Presence", () => {
 						setupSpiesAndListeners();
 						const itemRemovedAndItemUpdatedUpdate = {
 							"s:name:testWorkspace": itemRemovedAndItemUpdatedMapUpdate,
-						};
+						} as const satisfies GeneralDatastoreMessageContent;
 						// Act
 						processUpdates(itemRemovedAndItemUpdatedUpdate);
 						// Verify
 						assertSpies();
 					});
+
 					it("with update first", () => {
 						// Setup
 						setupSharedStatesWorkspace();
@@ -552,7 +540,7 @@ describe("Presence", () => {
 						processUpdates(workspace);
 						setupSpiesAndListeners();
 						const itemUpdatedAndItemRemovedUpdate = {
-							"s:name:testWorkspace": itemUpdatedAndItemRemoveddMapUpdate,
+							"s:name:testWorkspace": itemUpdatedAndItemRemovedMapUpdate,
 						};
 						// Act
 						processUpdates(itemUpdatedAndItemRemovedUpdate);
@@ -711,7 +699,7 @@ describe("Presence", () => {
 				const secondWorkspaceUpdate = {
 					"s:name:testWorkspace1": latestUpdateRev2,
 					"n:name:testWorkspace": notificationsUpdate,
-					"s:name:testWorkspace2": itemUpdatedAndItemRemoveddMapUpdate,
+					"s:name:testWorkspace2": itemUpdatedAndItemRemovedMapUpdate,
 				};
 
 				presence.events.on("workspaceActivated", (_, type) => {


### PR DESCRIPTION
- Use `as const satisfies...` on data for value readability at use sites and type correctness check.
   - Use `toOpaqueJson` to bring test data into type alignment
   - Remove unused, malformed `latestMapItemRemovedAndLatestUpdate`
- Use `GeneralDatastoreMessageContent` type for `processUpdates` helper
- Fix `itemUpdatedAndItemRemoveddMapUpdate` typo