### PR TITLE
Make bypassCache option in tenant key retrival configurable 

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -115,7 +115,7 @@ export function create(
 	router.get("/tenants/:id/keys", (request, response) => {
 		const tenantId = request.params.id;
 		const includeDisabledTenant = getIncludeDisabledFlag(request);
-		const tenantP = manager.getTenantKeys(tenantId, includeDisabledTenant);
+		const tenantP = manager.getTenantKeys(tenantId, includeDisabledTenant, bypassCache);
 		handleResponse(tenantP, response);
 	});
 

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -31,6 +31,7 @@ export function create(
 	riddlerStorageRequestMetricInterval: number,
 	tenantKeyGenerator: ITenantKeyGenerator,
 	cache?: ICache,
+	bypassCache: boolean = false,
 ): Router {
 	const router: Router = Router();
 	const manager = new TenantManager(
@@ -61,6 +62,7 @@ export function create(
 					tenantId,
 					request.body.token,
 					includeDisabledTenant,
+					bypassCache,
 				);
 				handleResponse(validP, response);
 			},

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
@@ -37,6 +37,7 @@ export function create(
 	startupCheck: IReadinessCheck,
 	cache?: ICache,
 	readinessCheck?: IReadinessCheck,
+	bypassCache: boolean = false,
 ) {
 	// Express app configuration
 	const app: express.Express = express();
@@ -75,6 +76,7 @@ export function create(
 			riddlerStorageRequestMetricInterval,
 			tenantKeyGenerator,
 			cache,
+			bypassCache,
 		),
 	);
 

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
@@ -57,6 +57,8 @@ export class RiddlerRunner implements IRunner {
 		// Don't include application logic in primary thread when Node.js cluster module is enabled.
 		const includeAppLogic = !(cluster.isPrimary && usingClusterModule);
 
+		const bypassCache: boolean = this.config?.get("riddler:bypassCache") ?? false;
+
 		if (includeAppLogic) {
 			// Create the HTTP server and attach alfred to it
 			const riddler = app.create(
@@ -72,6 +74,7 @@ export class RiddlerRunner implements IRunner {
 				this.startupCheck,
 				this.cache,
 				this.readinessCheck,
+				bypassCache,
 			);
 			riddler.set("port", this.port);
 

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -277,6 +277,7 @@ export class TenantManager {
 			[BaseTelemetryProperties.tenantId]: tenantId,
 			includeDisabledTenant,
 			isKeylessAccessValidation,
+			bypassCache,
 		};
 
 		// Try validating with Key 1

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -774,6 +774,7 @@ export class TenantManager {
 	): IPlainTextAndEncryptedTenantKeys & {
 		encryptionKeyVersion: EncryptionKeyVersion | undefined;
 	} {
+		lumberProperties.usePrivateKeys = usePrivateKeys;
 		const encryptedTenantKey1 =
 			usePrivateKeys && tenantDocument.privateKeys
 				? tenantDocument.privateKeys.key

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/tenantManager.ts
@@ -162,7 +162,7 @@ export class TenantManager {
 		includeDisabledTenant = false,
 		forceGenerateTokenWithPrivateKey = false,
 	): Promise<IFluidAccessToken> {
-		const lumberProperties = {
+		const lumberProperties: Record<string, any> = {
 			[BaseTelemetryProperties.tenantId]: tenantId,
 			includeDisabledTenant,
 			documentId,
@@ -183,6 +183,7 @@ export class TenantManager {
 		// If the tenant is a keyless tenant, always use the private keys to sign the token
 		const isTenantPrivateKeyAccessEnabled =
 			this.isTenantPrivateKeyAccessEnabled(tenantDocument);
+		lumberProperties.usePrivateKeys = isTenantPrivateKeyAccessEnabled;
 
 		// If private keys access is not enabled, and the requester is trying to generate a token with private keys, throw an error.
 		// The forceGenerateTokenWithPrivateKey flag is not used anywhere ahead as private keys are given preference to sign tokens over shared keys if both are enabled.
@@ -775,7 +776,6 @@ export class TenantManager {
 	): IPlainTextAndEncryptedTenantKeys & {
 		encryptionKeyVersion: EncryptionKeyVersion | undefined;
 	} {
-		lumberProperties.usePrivateKeys = usePrivateKeys;
 		const encryptedTenantKey1 =
 			usePrivateKeys && tenantDocument.privateKeys
 				? tenantDocument.privateKeys.key


### PR DESCRIPTION
## Description

Make bypassCache flag configuration when retrieving tenant keys. It helps to disable cache and see if keys in DB are corrupted. Also add usePrivateKeys to log properties.

