### PR TITLE
SharedTree: Export base fuzz model

### DIFF
--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -96,7 +96,7 @@
 		"build:test": "npm run build:test:esm && npm run build:test:cjs",
 		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
 		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
-		"check:are-the-types-wrong": "attw --pack .",
+		"check:are-the-types-wrong": "attw --pack . --exclude-entrypoints ./internal/test",
 		"check:biome": "biome check .",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
 		"check:exports:bundle-release-tags": "api-extractor run --config api-extractor/api-extractor-lint-bundle.json",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -62,6 +62,18 @@
 				"types": "./dist/legacy.d.ts",
 				"default": "./dist/index.js"
 			}
+		},
+		"./internal/test": {
+			"allow-ff-test-exports": {
+				"import": {
+					"types": "./lib/test/index.d.ts",
+					"default": "./lib/test/index.js"
+				},
+				"require": {
+					"types": "./dist/test/index.d.ts",
+					"default": "./dist/test/index.js"
+				}
+			}
 		}
 	},
 	"main": "lib/index.js",

--- a/packages/dds/tree/src/test/index.ts
+++ b/packages/dds/tree/src/test/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { baseTreeModel } from "./shared-tree/index.js";

--- a/packages/dds/tree/src/test/shared-tree/fuzz/baseModel.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/baseModel.ts
@@ -14,7 +14,7 @@ import { type EditGeneratorOpWeights, makeOpGenerator } from "./fuzzEditGenerato
 export const runsPerBatch = 50;
 // TODO: Enable other types of ops.
 // AB#11436: Currently manually disposing the view when applying the schema op is causing a double dispose issue. Once this issue has been resolved, re-enable schema ops.
-export const editGeneratorOpWeights: Partial<EditGeneratorOpWeights> = {
+const editGeneratorOpWeights: Partial<EditGeneratorOpWeights> = {
 	set: 3,
 	clear: 1,
 	insert: 5,
@@ -30,7 +30,7 @@ export const editGeneratorOpWeights: Partial<EditGeneratorOpWeights> = {
 	fork: 1,
 	merge: 1,
 };
-export const generatorFactory = () => takeAsync(100, makeOpGenerator(editGeneratorOpWeights));
+const generatorFactory = () => takeAsync(100, makeOpGenerator(editGeneratorOpWeights));
 
 export const baseTreeModel: DDSFuzzModel<
 	SharedTreeFuzzTestFactory,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/baseModel.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/baseModel.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { DDSFuzzModel, DDSFuzzTestState } from "@fluid-private/test-dds-utils";
+import { validateFuzzTreeConsistency } from "../../utils.js";
+import { fuzzReducer } from "./fuzzEditReducers.js";
+import { SharedTreeFuzzTestFactory, createOnCreate } from "./fuzzUtils.js";
+import type { Operation } from "./operationTypes.js";
+import { takeAsync } from "@fluid-private/stochastic-test-utils";
+import { type EditGeneratorOpWeights, makeOpGenerator } from "./fuzzEditGenerators.js";
+
+export const runsPerBatch = 50;
+// TODO: Enable other types of ops.
+// AB#11436: Currently manually disposing the view when applying the schema op is causing a double dispose issue. Once this issue has been resolved, re-enable schema ops.
+export const editGeneratorOpWeights: Partial<EditGeneratorOpWeights> = {
+	set: 3,
+	clear: 1,
+	insert: 5,
+	remove: 5,
+	intraFieldMove: 5,
+	crossFieldMove: 5,
+	start: 1,
+	commit: 1,
+	abort: 1,
+	fieldSelection: { optional: 1, required: 1, sequence: 3, recurse: 3 },
+	schema: 0,
+	nodeConstraint: 3,
+	fork: 1,
+	merge: 1,
+};
+export const generatorFactory = () => takeAsync(100, makeOpGenerator(editGeneratorOpWeights));
+
+export const baseTreeModel: DDSFuzzModel<
+	SharedTreeFuzzTestFactory,
+	Operation,
+	DDSFuzzTestState<SharedTreeFuzzTestFactory>
+> = {
+	workloadName: "SharedTree",
+	factory: new SharedTreeFuzzTestFactory(createOnCreate(undefined)),
+	generatorFactory,
+	reducer: fuzzReducer,
+	validateConsistency: validateFuzzTreeConsistency,
+};

--- a/packages/dds/tree/src/test/shared-tree/fuzz/index.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { baseTreeModel } from "./baseModel.js";

--- a/packages/dds/tree/src/test/shared-tree/index.ts
+++ b/packages/dds/tree/src/test/shared-tree/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { baseTreeModel } from "./fuzz/index.js";

--- a/packages/dds/tree/src/test/tsconfig.json
+++ b/packages/dds/tree/src/test/tsconfig.json
@@ -12,6 +12,8 @@
 		"types": ["node", "mocha"],
 		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
+		"declaration": true,
+		"declarationMap": true,
 	},
 	"include": ["./**/*"],
 	"references": [


### PR DESCRIPTION
The primary goal of this change is to get a base model for tree exported, so it can be consumed in the local server stress tests. There are additional issues consuming the tree model in the local server stress, which i'll address is subsequent PRs. This change matches the pattern used in our other DDS.

I did make a small change the generator to generate 100 ops, to match the what is generally used across our stress runs, and this seems to have uncovered an assert.