### PR TITLE
Remove lock from e2e odsp stage

### DIFF
--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -167,8 +167,6 @@ stages:
       timeoutInMinutes: 360
       continueOnError: true
       testCommand: test:realsvc:odsp:report
-      stageVariables:
-        - group: e2e-odsp-lock
       splitTestVariants:
         - name: Non-compat
           flags: --compatVersion=0 --tenantIndex=0


### PR DESCRIPTION
As a follow up to #23382, remove the exclusive lock on the ODSP test stage in the end-to-end tests. This is no longer needed, since our new tenant pool has multiple tenants available at once. 

[AB#38994](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/38994) 