### PR TITLE
Parse credentials separately for e2e and stress tests 

### DIFF
--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -53,7 +53,7 @@ interface IOdspTestDriverConfig extends TokenConfig {
 	options: HostStoragePolicy | undefined;
 }
 
-// specific a range of user name from <prefix><start> to <prefix><start + count - 1> all having the same passwordAdd commentMore actions
+// specific a range of user name from <prefix><start> to <prefix><start + count - 1> all having the same password
 interface LoginTenantRange {
 	prefix: string;
 	start: number;
@@ -139,7 +139,7 @@ export function getOdspCredentials(
 			if (tenantInfo === undefined) {
 				throw new Error("tenantInfo should not be undefined when getting odsp credentials");
 			}
-			// Translate all the user from that user to the full user principle name by appending the tenant domainAdd commentMore actions
+			// Translate all the user from that user to the full user principal name by appending the tenant domain
 			const range = tenantInfo.range;
 
 			// Return the set of account to choose from a single tenant


### PR DESCRIPTION
The correct format parsing for stress test credentials was mistakenly removed in #23382. Add this back to work alongside parsing for the new tenant format.  