### PR TITLE
fix(test-end-to-end-tests): Fix flaky groupIdOffline test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
@@ -221,6 +221,7 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 			{ configProvider },
 			{ [LoaderHeader.version]: summaryVersion },
 		)) as IContainerExperimental;
+		await provider.ensureSynchronized();
 		const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
 		const handleA2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
 		const handleB2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectB");


### PR DESCRIPTION
## Description 
Fixes [AB#43128](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/32549): "Failing Test: odsp_0 | GroupId offline Non-Compat | GroupId offline with older snapshot" 

This test would occasionally a lot with `handleA2` and `handleB2` being undefined. This was due to the second container not being synchronized after load. This change adds `await provider.ensureSynchronized()` to make sure the loaded container is synced before trying to `get()` from root directory. To verify the change I ran it around 20 times in a row and it passed every time (failed 8 out 10 runs before change). 
