### PR TITLE
test(benchmarks): Increase pipeline timeout threshold since we have more tests

### DIFF
--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -101,6 +101,7 @@ stages:
     - job: perf_unit_tests_runtime
       displayName: Perf unit tests - runtime
       pool: ${{ parameters.poolBuild }}
+      timeoutInMinutes: ${{ coalesce(endpointObject.timeoutInMinutes, 90) }}
       steps:
       - template: /tools/pipelines/templates/include-test-perf-benchmarks.yml@self
         parameters:


### PR DESCRIPTION
Increase benchmark test timeout threshold to accommodate the growing number of test cases. This change ensures that longer test execution times do not result in premature timeouts, improving test reliability and coverage.

Example pipeline run: https://dev.azure.com/fluidframework/internal/_build/results?buildId=344698&view=results