### PR TITLE
refactor(api-markdown-documenter): Update `SpanNode` to require formatting and clean up usages

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -14,6 +14,13 @@ It has been removed and is no longer used by the system.
 This type previously supported an unsafe escape hatch for text escaping.
 This support is no longer needed and has been removed.
 
+### `SpanNode` now requires formatting options
+
+This type's formatting options were previously optional, which encouraged using the type as general purpose grouping mechanism for children.
+This resulted in unnecessary hierarchy in the generated trees.
+
+Formatting options are now required when constructing `SpanNode`s.
+
 ### `LineBreakNode` removed from `BlockContent`
 
 Block Content items are implicitly separated by a line break, so allowing `LineBreakNode`s in that context is redundant.
@@ -44,6 +51,14 @@ If this type is required, it can be re-introduced via the Documentation Domain's
 The `DocumentationNodeType` enum has been removed.
 Enumerations of supported node kinds in various contexts is now handled via type unions like `BlockContent` and `PhrasingContent`.
 String literal types makes typing much simpler to reason about, and more inline with `unist` patterns.
+
+### `TextFormatting` no longer permits *disabling* formatting
+
+This type previously allowed formatting to be disabled at lower scopes in the tree.
+E.g., some parent context could set `bold`, and a lower context could *unset* it.
+This functionality was unused, does not align with Markdown nor HTML, and made transformation logic more complicated than it strictly needs to be.
+
+This support has been removed.
 
 ## 0.20.0
 

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -843,9 +843,9 @@ export abstract class TableRowNode extends DocumentationParentNodeBase<TableCell
 
 // @public @sealed
 export interface TextFormatting {
-    readonly bold?: boolean;
-    readonly italic?: boolean;
-    readonly strikethrough?: boolean;
+    readonly bold?: true;
+    readonly italic?: true;
+    readonly strikethrough?: true;
 }
 
 // @public

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -360,6 +360,7 @@ export namespace DocumentWriter {
 export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeBlockNodeContent> {
     constructor(children: FencedCodeBlockNodeContent[], language?: string);
     static createFromPlainText(text: string, language?: string): FencedCodeBlockNode;
+    static readonly Empty: FencedCodeBlockNode;
     readonly language?: string;
     readonly type = "fencedCode";
 }
@@ -771,10 +772,10 @@ function shouldItemBeIncluded(apiItem: ApiItem, config: ApiItemTransformationCon
 
 // @public
 export class SpanNode extends DocumentationParentNodeBase<PhrasingContent> {
-    constructor(children: PhrasingContent[], formatting?: TextFormatting);
-    static createFromPlainText(text: string, formatting?: TextFormatting): SpanNode;
+    constructor(children: PhrasingContent[], formatting: TextFormatting);
+    static createFromPlainText(text: string, formatting: TextFormatting): SpanNode;
     static readonly Empty: SpanNode;
-    readonly textFormatting?: TextFormatting;
+    readonly textFormatting: TextFormatting;
     readonly type = "span";
 }
 

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -360,7 +360,6 @@ export namespace DocumentWriter {
 export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeBlockNodeContent> {
     constructor(children: FencedCodeBlockNodeContent[], language?: string);
     static createFromPlainText(text: string, language?: string): FencedCodeBlockNode;
-    static readonly Empty: FencedCodeBlockNode;
     readonly language?: string;
     readonly type = "fencedCode";
 }

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -821,9 +821,9 @@ export abstract class TableRowNode extends DocumentationParentNodeBase<TableCell
 
 // @public @sealed
 export interface TextFormatting {
-    readonly bold?: boolean;
-    readonly italic?: boolean;
-    readonly strikethrough?: boolean;
+    readonly bold?: true;
+    readonly italic?: true;
+    readonly strikethrough?: true;
 }
 
 // @public

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -360,7 +360,6 @@ export namespace DocumentWriter {
 export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeBlockNodeContent> {
     constructor(children: FencedCodeBlockNodeContent[], language?: string);
     static createFromPlainText(text: string, language?: string): FencedCodeBlockNode;
-    static readonly Empty: FencedCodeBlockNode;
     readonly language?: string;
     readonly type = "fencedCode";
 }

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -360,6 +360,7 @@ export namespace DocumentWriter {
 export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeBlockNodeContent> {
     constructor(children: FencedCodeBlockNodeContent[], language?: string);
     static createFromPlainText(text: string, language?: string): FencedCodeBlockNode;
+    static readonly Empty: FencedCodeBlockNode;
     readonly language?: string;
     readonly type = "fencedCode";
 }
@@ -749,10 +750,10 @@ function shouldItemBeIncluded(apiItem: ApiItem, config: ApiItemTransformationCon
 
 // @public
 export class SpanNode extends DocumentationParentNodeBase<PhrasingContent> {
-    constructor(children: PhrasingContent[], formatting?: TextFormatting);
-    static createFromPlainText(text: string, formatting?: TextFormatting): SpanNode;
+    constructor(children: PhrasingContent[], formatting: TextFormatting);
+    static createFromPlainText(text: string, formatting: TextFormatting): SpanNode;
     static readonly Empty: SpanNode;
-    readonly textFormatting?: TextFormatting;
+    readonly textFormatting: TextFormatting;
     readonly type = "span";
 }
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -351,8 +351,7 @@ export function createTypeParametersSection(
  * @param excerpt - The TSDoc excerpt to render.
  * @param config - See {@link ApiItemTransformationConfiguration}.
  *
- * @returns A span containing the rendered contents, if non-empty.
- * Otherwise, will return `undefined`.
+ * @returns The rendered contents, if any.
  */
 export function createExcerptSpanWithHyperlinks(
 	excerpt: Excerpt,

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
@@ -329,9 +329,7 @@ export function createTypeParametersSummaryTable(
 			apiParameter.constraintExcerpt,
 			config,
 		);
-		return constraintSpan === undefined
-			? TableBodyCellNode.Empty
-			: new TableBodyCellNode([constraintSpan]);
+		return new TableBodyCellNode(constraintSpan);
 	}
 
 	function createTypeDefaultCell(apiParameter: TypeParameter): TableBodyCellNode {
@@ -339,9 +337,7 @@ export function createTypeParametersSummaryTable(
 			apiParameter.defaultTypeExcerpt,
 			config,
 		);
-		return excerptSpan === undefined
-			? TableBodyCellNode.Empty
-			: new TableBodyCellNode([excerptSpan]);
+		return new TableBodyCellNode(excerptSpan);
 	}
 
 	const bodyRows: TableBodyRowNode[] = [];
@@ -798,7 +794,7 @@ export function createTypeParameterSummaryCell(
  * @remarks This content will be generated as links to type signature documentation for other items local to the same
  * API suite (model).
  *
- * @param typeExcerpty - An excerpt describing the type to be displayed in the cell.
+ * @param typeExcerpt - An excerpt describing the type to be displayed in the cell.
  * @param config - See {@link ApiItemTransformationConfiguration}.
  */
 export function createTypeExcerptCell(
@@ -806,9 +802,7 @@ export function createTypeExcerptCell(
 	config: ApiItemTransformationConfiguration,
 ): TableBodyCellNode {
 	const excerptSpan = createExcerptSpanWithHyperlinks(typeExcerpt, config);
-	return excerptSpan === undefined
-		? TableBodyCellNode.Empty
-		: new TableBodyCellNode([excerptSpan]);
+	return new TableBodyCellNode(excerptSpan);
 }
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
@@ -225,13 +225,13 @@ describe("ApiItem to Documentation transformation tests", () => {
 									new TableBodyRowNode([
 										TableBodyCellNode.createFromPlainText("testParameter"),
 										TableBodyCellNode.Empty,
-										new TableBodyCellNode([SpanNode.createFromPlainText("TTypeParameter")]),
+										new TableBodyCellNode([new PlainTextNode("TTypeParameter")]),
 										TableBodyCellNode.createFromPlainText("A test parameter"),
 									]),
 									new TableBodyRowNode([
 										TableBodyCellNode.createFromPlainText("testOptionalParameter"),
 										TableBodyCellNode.createFromPlainText("optional"),
-										new TableBodyCellNode([SpanNode.createFromPlainText("TTypeParameter")]),
+										new TableBodyCellNode([new PlainTextNode("TTypeParameter")]),
 										TableBodyCellNode.createFromPlainText("An optional parameter"),
 									]),
 								],
@@ -256,7 +256,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 							new ParagraphNode([
 								SpanNode.createFromPlainText("Return type", { bold: true }),
 								new PlainTextNode(": "),
-								SpanNode.createFromPlainText("TTypeParameter"),
+								new PlainTextNode("TTypeParameter"),
 							]),
 						],
 						{
@@ -333,7 +333,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 								]),
 								new TableBodyCellNode([new CodeSpanNode("optional")]),
 								TableBodyCellNode.createFromPlainText("0"),
-								new TableBodyCellNode([SpanNode.createFromPlainText("number")]),
+								new TableBodyCellNode([new PlainTextNode("number")]),
 								TableBodyCellNode.createFromPlainText("Test optional property"),
 							]),
 						],
@@ -364,11 +364,9 @@ describe("ApiItem to Documentation transformation tests", () => {
 										"typescript",
 									),
 									new ParagraphNode([
-										new SpanNode([
-											SpanNode.createFromPlainText("Type", { bold: true }),
-											new PlainTextNode(": "),
-											SpanNode.createFromPlainText("number"),
-										]),
+										SpanNode.createFromPlainText("Type", { bold: true }),
+										new PlainTextNode(": "),
+										new PlainTextNode("number"),
 									]),
 								],
 								{

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/SpanToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/SpanToHtml.test.ts
@@ -25,7 +25,7 @@ describe("Span to HTML transformation tests", () => {
 		const node1 = new PlainTextNode(text1);
 		const node2 = new PlainTextNode(text2);
 
-		const span = new SpanNode([node1, node2]);
+		const span = new SpanNode([node1, node2], {});
 		const expected = h("span", [text1, text2]);
 		assertTransformation(span, expected);
 	});

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/SpanToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/SpanToHtml.test.ts
@@ -62,13 +62,15 @@ describe("Span to HTML transformation tests", () => {
 				node1,
 				new SpanNode([node2, node3], {
 					bold: true,
-					strikethrough: false,
 				}),
 			],
 			{ strikethrough: true },
 		);
 
-		const expected = h("span", [h("s", [text1]), h("span", [h("br"), h("b", [text2])])]);
+		const expected = h("span", [
+			h("s", [text1]),
+			h("span", [h("br"), h("b", [h("s", [text2])])]),
+		]);
 
 		assertTransformation(span, expected);
 	});

--- a/tools/api-markdown-documenter/src/documentation-domain/FencedCodeBlockNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/FencedCodeBlockNode.ts
@@ -39,11 +39,6 @@ export type FencedCodeBlockNodeContent = PlainTextNode | LineBreakNode;
  */
 export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeBlockNodeContent> {
 	/**
-	 * Static singleton representing an empty Code Span node.
-	 */
-	public static readonly Empty: FencedCodeBlockNode = new FencedCodeBlockNode([]);
-
-	/**
 	 * {@inheritDoc DocumentationNode."type"}
 	 */
 	public readonly type = "fencedCode";

--- a/tools/api-markdown-documenter/src/documentation-domain/FencedCodeBlockNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/FencedCodeBlockNode.ts
@@ -39,6 +39,11 @@ export type FencedCodeBlockNodeContent = PlainTextNode | LineBreakNode;
  */
 export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeBlockNodeContent> {
 	/**
+	 * Static singleton representing an empty Code Span node.
+	 */
+	public static readonly Empty: FencedCodeBlockNode = new FencedCodeBlockNode([]);
+
+	/**
 	 * {@inheritDoc DocumentationNode."type"}
 	 */
 	public readonly type = "fencedCode";

--- a/tools/api-markdown-documenter/src/documentation-domain/SpanNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/SpanNode.ts
@@ -44,7 +44,7 @@ export class SpanNode extends DocumentationParentNodeBase<PhrasingContent> {
 	/**
 	 * Static singleton representing an empty Span Text node.
 	 */
-	public static readonly Empty: SpanNode = new SpanNode([]);
+	public static readonly Empty: SpanNode = new SpanNode([], {});
 
 	/**
 	 * {@inheritDoc DocumentationNode."type"}
@@ -56,9 +56,9 @@ export class SpanNode extends DocumentationParentNodeBase<PhrasingContent> {
 	 *
 	 * @defaultValue Inherit formatting from ancestry, if any exists.
 	 */
-	public readonly textFormatting?: TextFormatting;
+	public readonly textFormatting: TextFormatting;
 
-	public constructor(children: PhrasingContent[], formatting?: TextFormatting) {
+	public constructor(children: PhrasingContent[], formatting: TextFormatting) {
 		super(children);
 		this.textFormatting = formatting;
 	}
@@ -67,7 +67,7 @@ export class SpanNode extends DocumentationParentNodeBase<PhrasingContent> {
 	 * Generates an `SpanNode` from the provided string.
 	 * @param text - The node contents.
 	 */
-	public static createFromPlainText(text: string, formatting?: TextFormatting): SpanNode {
+	public static createFromPlainText(text: string, formatting: TextFormatting): SpanNode {
 		return new SpanNode(createNodesFromPlainText(text), formatting);
 	}
 }

--- a/tools/api-markdown-documenter/src/documentation-domain/TextFormatting.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/TextFormatting.ts
@@ -11,23 +11,17 @@
  */
 export interface TextFormatting {
 	/**
-	 * Whether or not the text should be rendered in italics.
-	 *
-	 * @defaultValue Inherit formatting from ancestry, if any exists.
+	 * Display the associated content in italics.
 	 */
-	readonly italic?: boolean;
+	readonly italic?: true;
 
 	/**
-	 * Whether or not the text should be rendered in bold.
-	 *
-	 * @defaultValue Inherit formatting from ancestry, if any exists.
+	 * Display the associated content in bold.
 	 */
-	readonly bold?: boolean;
+	readonly bold?: true;
 
 	/**
-	 * Whether or not the text should be rendered with a strikethrough.
-	 *
-	 * @defaultValue Inherit formatting from ancestry, if any exists.
+	 * Display the associated content with a strikethrough.
 	 */
-	readonly strikethrough?: boolean;
+	readonly strikethrough?: true;
 }

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderSpan.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderSpan.test.ts
@@ -20,12 +20,12 @@ describe("Span Markdown rendering tests", () => {
 			expect(testRender(SpanNode.Empty)).to.equal("");
 		});
 
-		it("Simple span", () => {
+		it("Span with no formatting", () => {
 			const text1 = "This is some text. ";
 			const text2 = "This is more text!";
 			const node1 = new PlainTextNode(text1);
 			const node2 = new PlainTextNode(text2);
-			const span = new SpanNode([node1, node2]);
+			const span = new SpanNode([node1, node2], {});
 			expect(testRender(span)).to.equal(`${text1}${text2}`);
 		});
 
@@ -49,12 +49,12 @@ describe("Span Markdown rendering tests", () => {
 			expect(testRender(SpanNode.Empty, { insideTable: true })).to.equal("");
 		});
 
-		it("Simple span", () => {
+		it("Span with no formatting", () => {
 			const text1 = "This is some text. ";
 			const text2 = "This is more text!";
 			const node1 = new PlainTextNode(text1);
 			const node2 = new PlainTextNode(text2);
-			const span = new SpanNode([node1, node2]);
+			const span = new SpanNode([node1, node2], {});
 			expect(testRender(span, { insideTable: true })).to.equal(`${text1}${text2}`);
 		});
 

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderTableCell.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderTableCell.test.ts
@@ -36,11 +36,9 @@ describe("Table Markdown rendering tests", () => {
 			const input = new TableBodyCellNode([
 				new PlainTextNode("Hello world!"),
 				LineBreakNode.Singleton,
-				new SpanNode([
-					SpanNode.createFromPlainText("Meaning of life", { bold: true }),
-					new PlainTextNode(": "),
-					SpanNode.createFromPlainText("42", { italic: true }),
-				]),
+				SpanNode.createFromPlainText("Meaning of life", { bold: true }),
+				new PlainTextNode(": "),
+				SpanNode.createFromPlainText("42", { italic: true }),
 			]);
 
 			const result = testRender(input);

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/index.html
@@ -138,25 +138,25 @@
             <tr>
               <td><a href="/test-suite-a/testfunction-function">testFunction(testParameter, testOptionalParameter)</a></td>
               <td><code>Alpha</code></td>
-              <td><span>TTypeParameter</span></td>
+              <td>TTypeParameter</td>
               <td>Test function</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testfunctionreturninginlinetype-function">testFunctionReturningInlineType()</a></td>
               <td></td>
-              <td><span>{ foo: number; bar: <a href="/test-suite-a/testenum-enum/">TestEnum</a>; }</span></td>
+              <td>{ foo: number; bar: <a href="/test-suite-a/testenum-enum/">TestEnum</a>; }</td>
               <td>Test function that returns an inline type</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testfunctionreturningintersectiontype-function">testFunctionReturningIntersectionType()</a></td>
               <td><code>Deprecated</code></td>
-              <td><span><a href="/test-suite-a/testemptyinterface-interface/">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;number></span></td>
+              <td><a href="/test-suite-a/testemptyinterface-interface/">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;number></td>
               <td>Test function that returns an inline type</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testfunctionreturninguniontype-function">testFunctionReturningUnionType()</a></td>
               <td></td>
-              <td><span>string | <a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></td>
+              <td>string | <a href="/test-suite-a/testinterface-interface/">TestInterface</a></td>
               <td>Test function that returns an inline type</td>
             </tr>
           </tbody>
@@ -186,7 +186,7 @@
               <td><a href="/test-suite-a/testconstwithemptydeprecatedblock-variable">testConstWithEmptyDeprecatedBlock</a></td>
               <td><code>Deprecated</code></td>
               <td><code>readonly</code></td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>I have a <code>@deprecated</code> tag with an empty comment block.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.html
@@ -28,12 +28,12 @@
           <tbody>
             <tr>
               <td>privateProperty</td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td></td>
             </tr>
             <tr>
               <td>protectedProperty</td>
-              <td><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></td>
+              <td><a href="/test-suite-a/testenum-enum/">TestEnum</a></td>
               <td></td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="abstractpropertygetter-signature">Signature</h2><code>abstract get abstractPropertyGetter(): TestMappedType;</code>
-        <p><span><span><b>Type</b></span>: <span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span></span></p>
+        <p><span><b>Type</b></span>: <a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.html
@@ -47,13 +47,13 @@
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span></td>
+              <td><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></td>
               <td>A test abstract getter property.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></td>
+              <td><a href="/test-suite-a/testenum-enum/">TestEnum</a></td>
               <td>A test protected property.</td>
             </tr>
           </tbody>
@@ -74,19 +74,19 @@
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class/publicabstractmethod-method">publicAbstractMethod()</a></td>
               <td></td>
-              <td><span>void</span></td>
+              <td>void</td>
               <td>A test public abstract method.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class/sealedmethod-method">sealedMethod()</a></td>
               <td><code>sealed</code></td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>A test <code>@sealed</code> method.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class/virtualmethod-method">virtualMethod()</a></td>
               <td><code>virtual</code></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>A test <code>@virtual</code> method.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/protectedproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/protectedproperty-property.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="protectedproperty-signature">Signature</h2><code>protected readonly protectedProperty: TestEnum;</code>
-        <p><span><span><b>Type</b></span>: <span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></span></p>
+        <p><span><b>Type</b></span>: <a href="/test-suite-a/testenum-enum/">TestEnum</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/sealedmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/sealedmethod-method.html
@@ -18,7 +18,7 @@
       <section>
         <h2 id="sealedmethod-returns">Returns</h2>
         <p>A string!</p>
-        <p><span><b>Return type</b></span>: <span>string</span></p>
+        <p><span><b>Return type</b></span>: string</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/virtualmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/virtualmethod-method.html
@@ -18,7 +18,7 @@
       <section>
         <h2 id="virtualmethod-returns">Returns</h2>
         <p>A number!</p>
-        <p><span><b>Return type</b></span>: <span>number</span></p>
+        <p><span><b>Return type</b></span>: number</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/_constructor_-constructor.html
@@ -32,12 +32,12 @@
           <tbody>
             <tr>
               <td>privateProperty</td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>See <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a>'s constructor.</td>
             </tr>
             <tr>
               <td>protectedProperty</td>
-              <td><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></td>
+              <td><a href="/test-suite-a/testenum-enum/">TestEnum</a></td>
               <td>
                 <p>Some notes about the parameter.</p>
                 <p>See <a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a>.</p>
@@ -45,12 +45,12 @@
             </tr>
             <tr>
               <td>testClassProperty</td>
-              <td><span>TTypeParameterB</span></td>
+              <td>TTypeParameterB</td>
               <td>See <a href="/test-suite-a/testclass-class/testclassproperty-property">testClassProperty</a>.</td>
             </tr>
             <tr>
               <td>testClassEventProperty</td>
-              <td><span>() => void</span></td>
+              <td>() => void</td>
               <td>See <a href="/test-suite-a/testclass-class/testclasseventproperty-property">testClassEventProperty</a>.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/abstractpropertygetter-property.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="abstractpropertygetter-signature">Signature</h2><code>get abstractPropertyGetter(): TestMappedType;</code>
-        <p><span><span><b>Type</b></span>: <span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span></span></p>
+        <p><span><b>Type</b></span>: <a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/index.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testclass-signature">Signature</h2><code>export declare class TestClass&#x3C;TTypeParameterA, TTypeParameterB> extends TestAbstractClass</code>
-        <p><span><span><b>Extends</b></span>: <span><a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a></span></span></p>
+        <p><span><b>Extends</b></span>: <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a></p>
         <section>
           <h3>Type Parameters</h3>
           <table>
@@ -71,7 +71,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testclass-class/testclassstaticproperty-property">testClassStaticProperty</a></td>
-              <td><span>(foo: number) => string</span></td>
+              <td>(foo: number) => string</td>
               <td>Test static class property</td>
             </tr>
           </tbody>
@@ -90,7 +90,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testclass-class/testclassstaticmethod-method">testClassStaticMethod(foo)</a></td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>Test class static method</td>
             </tr>
           </tbody>
@@ -111,7 +111,7 @@
             <tr>
               <td><a href="/test-suite-a/testclass-class/testclasseventproperty-property">testClassEventProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span>() => void</span></td>
+              <td>() => void</td>
               <td>Test class event property</td>
             </tr>
           </tbody>
@@ -132,19 +132,19 @@
             <tr>
               <td><a href="/test-suite-a/testclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span></td>
+              <td><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></td>
               <td>A test abstract getter property.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testclass-class/testclassgetterproperty-property">testClassGetterProperty</a></td>
               <td><code>virtual</code></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test class property with both a getter and a setter.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testclass-class/testclassproperty-property">testClassProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span>TTypeParameterB</span></td>
+              <td>TTypeParameterB</td>
               <td>Test class property</td>
             </tr>
           </tbody>
@@ -165,19 +165,19 @@
             <tr>
               <td><a href="/test-suite-a/testclass-class/publicabstractmethod-method">publicAbstractMethod()</a></td>
               <td></td>
-              <td><span>void</span></td>
+              <td>void</td>
               <td>A test public abstract method.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testclass-class/testclassmethod-method">testClassMethod(input)</a></td>
               <td><code>sealed</code></td>
-              <td><span>TTypeParameterA</span></td>
+              <td>TTypeParameterA</td>
               <td>Test class method</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testclass-class/virtualmethod-method">virtualMethod()</a></td>
               <td></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Overrides <a href="/test-suite-a/testabstractclass-class/virtualmethod-method">virtualMethod()</a>.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclasseventproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclasseventproperty-property.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testclasseventproperty-signature">Signature</h2><code>readonly testClassEventProperty: () => void;</code>
-        <p><span><span><b>Type</b></span>: <span>() => void</span></span></p>
+        <p><span><b>Type</b></span>: () => void</p>
       </section>
       <section>
         <h2 id="testclasseventproperty-remarks">Remarks</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testclassgetterproperty-signature">Signature</h2><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br><br>set testClassGetterProperty(newValue: number);</code>
-        <p><span><span><b>Type</b></span>: <span>number</span></span></p>
+        <p><span><b>Type</b></span>: number</p>
       </section>
       <section>
         <h2 id="testclassgetterproperty-remarks">Remarks</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassmethod-method.html
@@ -32,7 +32,7 @@
           <tbody>
             <tr>
               <td>input</td>
-              <td><span>TTypeParameterA</span></td>
+              <td>TTypeParameterA</td>
               <td></td>
             </tr>
           </tbody>
@@ -40,7 +40,7 @@
       </section>
       <section>
         <h2 id="testclassmethod-returns">Returns</h2>
-        <p><span><b>Return type</b></span>: <span>TTypeParameterA</span></p>
+        <p><span><b>Return type</b></span>: TTypeParameterA</p>
       </section>
       <section>
         <h2 id="testclassmethod-throws">Throws</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassproperty-property.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testclassproperty-signature">Signature</h2><code>readonly testClassProperty: TTypeParameterB;</code>
-        <p><span><span><b>Type</b></span>: <span>TTypeParameterB</span></span></p>
+        <p><span><b>Type</b></span>: TTypeParameterB</p>
       </section>
       <section>
         <h2 id="testclassproperty-remarks">Remarks</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticmethod-method.html
@@ -28,7 +28,7 @@
           <tbody>
             <tr>
               <td>foo</td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Some number</td>
             </tr>
           </tbody>
@@ -37,7 +37,7 @@
       <section>
         <h2 id="testclassstaticmethod-returns">Returns</h2>
         <p>- Some string</p>
-        <p><span><b>Return type</b></span>: <span>string</span></p>
+        <p><span><b>Return type</b></span>: string</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassstaticproperty-property.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testclassstaticproperty-signature">Signature</h2><code>static testClassStaticProperty: (foo: number) => string;</code>
-        <p><span><span><b>Type</b></span>: <span>(foo: number) => string</span></span></p>
+        <p><span><b>Type</b></span>: (foo: number) => string</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/virtualmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/virtualmethod-method.html
@@ -17,7 +17,7 @@
       </section>
       <section>
         <h2 id="virtualmethod-returns">Returns</h2>
-        <p><span><b>Return type</b></span>: <span>number</span></p>
+        <p><span><b>Return type</b></span>: number</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
@@ -17,7 +17,7 @@
       </section>
       <section>
         <h2 id="testconstwithemptydeprecatedblock-signature">Signature</h2><code>testConstWithEmptyDeprecatedBlock: string</code>
-        <p><span><span><b>Type</b></span>: <span>string</span></span></p>
+        <p><span><b>Type</b></span>: string</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunction-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunction-function.html
@@ -31,8 +31,8 @@
             <tbody>
               <tr>
                 <td>TTypeParameter</td>
-                <td><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></td>
-                <td><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></td>
+                <td><a href="/test-suite-a/testinterface-interface/">TestInterface</a></td>
+                <td><a href="/test-suite-a/testinterface-interface/">TestInterface</a></td>
                 <td>A test type parameter</td>
               </tr>
             </tbody>
@@ -58,13 +58,13 @@
             <tr>
               <td>testParameter</td>
               <td></td>
-              <td><span>TTypeParameter</span></td>
+              <td>TTypeParameter</td>
               <td>A test parameter</td>
             </tr>
             <tr>
               <td>testOptionalParameter</td>
               <td>optional</td>
-              <td><span>TTypeParameter</span></td>
+              <td>TTypeParameter</td>
               <td></td>
             </tr>
           </tbody>
@@ -73,7 +73,7 @@
       <section>
         <h2 id="testfunction-returns">Returns</h2>
         <p>The provided parameter</p>
-        <p><span><b>Return type</b></span>: <span>TTypeParameter</span></p>
+        <p><span><b>Return type</b></span>: TTypeParameter</p>
       </section>
       <section>
         <h2 id="testfunction-throws">Throws</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturninginlinetype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturninginlinetype-function.html
@@ -18,7 +18,7 @@
       <section>
         <h2 id="testfunctionreturninginlinetype-returns">Returns</h2>
         <p>An inline type</p>
-        <p><span><b>Return type</b></span>: <span>{ foo: number; bar: <a href="/test-suite-a/testenum-enum/">TestEnum</a>; }</span></p>
+        <p><span><b>Return type</b></span>: { foo: number; bar: <a href="/test-suite-a/testenum-enum/">TestEnum</a>; }</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturningintersectiontype-function.html
@@ -22,7 +22,7 @@
       <section>
         <h2 id="testfunctionreturningintersectiontype-returns">Returns</h2>
         <p>an intersection type</p>
-        <p><span><b>Return type</b></span>: <span><a href="/test-suite-a/testemptyinterface-interface/">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;number></span></p>
+        <p><span><b>Return type</b></span>: <a href="/test-suite-a/testemptyinterface-interface/">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;number></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturninguniontype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testfunctionreturninguniontype-function.html
@@ -18,7 +18,7 @@
       <section>
         <h2 id="testfunctionreturninguniontype-returns">Returns</h2>
         <p>A union type</p>
-        <p><span><b>Return type</b></span>: <span>string | <a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></p>
+        <p><span><b>Return type</b></span>: string | <a href="/test-suite-a/testinterface-interface/">TestInterface</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_new_-constructsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/_new_-constructsignature.html
@@ -17,7 +17,7 @@
       </section>
       <section>
         <h2 id="_new_-returns">Returns</h2>
-        <p><span><b>Return type</b></span>: <span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></p>
+        <p><span><b>Return type</b></span>: <a href="/test-suite-a/testinterface-interface/">TestInterface</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/getterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/getterproperty-property.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="getterproperty-signature">Signature</h2><code>get getterProperty(): boolean;</code>
-        <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+        <p><span><b>Type</b></span>: boolean</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/index.html
@@ -32,7 +32,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface/_new_-constructsignature">new (): TestInterface</a></td>
-              <td><span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span></td>
+              <td><a href="/test-suite-a/testinterface-interface/">TestInterface</a></td>
               <td>Test construct signature.</td>
             </tr>
           </tbody>
@@ -53,7 +53,7 @@
             <tr>
               <td><a href="/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature">testClassEventProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span>() => void</span></td>
+              <td>() => void</td>
               <td>Test interface event property</td>
             </tr>
           </tbody>
@@ -76,35 +76,35 @@
               <td><a href="/test-suite-a/testinterface-interface/getterproperty-property">getterProperty</a></td>
               <td><code>readonly</code></td>
               <td></td>
-              <td><span>boolean</span></td>
+              <td>boolean</td>
               <td>A test getter-only interface property.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature">propertyWithBadInheritDocTarget</a></td>
               <td></td>
               <td></td>
-              <td><span>boolean</span></td>
+              <td>boolean</td>
               <td></td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface/setterproperty-property">setterProperty</a></td>
               <td></td>
               <td></td>
-              <td><span>boolean</span></td>
+              <td>boolean</td>
               <td>A test property with a getter and a setter.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature">testInterfaceProperty</a></td>
               <td></td>
               <td></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test interface property</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></td>
               <td><code>optional</code></td>
               <td>0</td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test optional property</td>
             </tr>
           </tbody>
@@ -123,7 +123,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface/testinterfacemethod-methodsignature">testInterfaceMethod()</a></td>
-              <td><span>void</span></td>
+              <td>void</td>
               <td>Test interface method</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/propertywithbadinheritdoctarget-propertysignature.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h2 id="propertywithbadinheritdoctarget-signature">Signature</h2><code>propertyWithBadInheritDocTarget: boolean;</code>
-        <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+        <p><span><b>Type</b></span>: boolean</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="setterproperty-signature">Signature</h2><code>get setterProperty(): boolean;<br><br><br>set setterProperty(newValue: boolean);</code>
-        <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+        <p><span><b>Type</b></span>: boolean</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testclasseventproperty-propertysignature.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testclasseventproperty-signature">Signature</h2><code>readonly testClassEventProperty: () => void;</code>
-        <p><span><span><b>Type</b></span>: <span>() => void</span></span></p>
+        <p><span><b>Type</b></span>: () => void</p>
       </section>
       <section>
         <h2 id="testclasseventproperty-remarks">Remarks</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testinterfaceproperty-propertysignature.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testinterfaceproperty-signature">Signature</h2><code>testInterfaceProperty: number;</code>
-        <p><span><span><b>Type</b></span>: <span>number</span></span></p>
+        <p><span><b>Type</b></span>: number</p>
       </section>
       <section>
         <h2 id="testinterfaceproperty-remarks">Remarks</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/testoptionalinterfaceproperty-propertysignature.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testoptionalinterfaceproperty-signature">Signature</h2><code>testOptionalInterfaceProperty?: number;</code>
-        <p><span><span><b>Type</b></span>: <span>number</span></span></p>
+        <p><span><b>Type</b></span>: number</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/index.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testinterfaceextendingotherinterfaces-signature">Signature</h2><code>export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter&#x3C;number></code>
-        <p><span><span><b>Extends</b></span>: <span><a href="/test-suite-a/testinterface-interface/">TestInterface</a></span>, <span><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></span>, <span><a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;number></span></span></p>
+        <p><span><b>Extends</b></span>: <a href="/test-suite-a/testinterface-interface/">TestInterface</a>, <a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a>, <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;number></p>
       </section>
       <section>
         <h2 id="testinterfaceextendingotherinterfaces-remarks">Remarks</h2>
@@ -33,7 +33,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature">testMethod(input)</a></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test interface method accepting a string and returning a number.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfaceextendingotherinterfaces-interface/testmethod-methodsignature.html
@@ -32,7 +32,7 @@
           <tbody>
             <tr>
               <td>input</td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>A string</td>
             </tr>
           </tbody>
@@ -41,7 +41,7 @@
       <section>
         <h2 id="testmethod-returns">Returns</h2>
         <p>A number</p>
-        <p><span><b>Return type</b></span>: <span>number</span></p>
+        <p><span><b>Return type</b></span>: number</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/index.html
@@ -49,7 +49,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature">testProperty</a></td>
-              <td><span>T</span></td>
+              <td>T</td>
               <td>A test interface property using generic type parameter</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterfacewithtypeparameter-interface/testproperty-propertysignature.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testproperty-signature">Signature</h2><code>testProperty: T;</code>
-        <p><span><span><b>Type</b></span>: <span>T</span></span></p>
+        <p><span><b>Type</b></span>: T</p>
       </section>
       <section>
         <h2 id="testproperty-remarks">Remarks</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.html
@@ -113,7 +113,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testnamespace-namespace/testfunction-function">testFunction(testParameter)</a></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test function</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/_constructor_-constructor.html
@@ -28,7 +28,7 @@
           <tbody>
             <tr>
               <td>testClassProperty</td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>See <a href="/test-suite-a/testclass-class/testclassproperty-property">testClassProperty</a></td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/index.html
@@ -47,7 +47,7 @@
             <tr>
               <td><a href="/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property">testClassProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>Test interface property</td>
             </tr>
           </tbody>
@@ -66,7 +66,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method">testClassMethod(testParameter)</a></td>
-              <td><span>Promise&#x3C;string></span></td>
+              <td>Promise&#x3C;string></td>
               <td>Test class method</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassmethod-method.html
@@ -28,7 +28,7 @@
           <tbody>
             <tr>
               <td>testParameter</td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>A string</td>
             </tr>
           </tbody>
@@ -37,7 +37,7 @@
       <section>
         <h2 id="testclassmethod-returns">Returns</h2>
         <p>A Promise</p>
-        <p><span><b>Return type</b></span>: <span>Promise&#x3C;string></span></p>
+        <p><span><b>Return type</b></span>: Promise&#x3C;string></p>
       </section>
       <section>
         <h2 id="testclassmethod-throws">Throws</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testclass-class/testclassproperty-property.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testclassproperty-signature">Signature</h2><code>readonly testClassProperty: string;</code>
-        <p><span><span><b>Type</b></span>: <span>string</span></span></p>
+        <p><span><b>Type</b></span>: string</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testfunction-function.html
@@ -28,7 +28,7 @@
           <tbody>
             <tr>
               <td>testParameter</td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td></td>
             </tr>
           </tbody>
@@ -37,7 +37,7 @@
       <section>
         <h2 id="testfunction-returns">Returns</h2>
         <p>A number</p>
-        <p><span><b>Return type</b></span>: <span>number</span></p>
+        <p><span><b>Return type</b></span>: number</p>
       </section>
       <section>
         <h2 id="testfunction-throws">Throws</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/index.html
@@ -17,7 +17,7 @@
       </section>
       <section>
         <h2 id="testinterface-signature">Signature</h2><code>interface TestInterface extends TestInterfaceWithTypeParameter&#x3C;TestEnum></code>
-        <p><span><span><b>Extends</b></span>: <span><a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;<a href="/test-suite-a/testnamespace-namespace/testenum-enum/">TestEnum</a>></span></span></p>
+        <p><span><b>Extends</b></span>: <a href="/test-suite-a/testinterfacewithtypeparameter-interface/">TestInterfaceWithTypeParameter</a>&#x3C;<a href="/test-suite-a/testnamespace-namespace/testenum-enum/">TestEnum</a>></p>
       </section>
       <section>
         <h2>Properties</h2>
@@ -34,7 +34,7 @@
             <tr>
               <td><a href="/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature">testInterfaceProperty</a></td>
               <td><code>Alpha</code></td>
-              <td><span>boolean</span></td>
+              <td>boolean</td>
               <td>Test interface property</td>
             </tr>
           </tbody>
@@ -55,7 +55,7 @@
             <tr>
               <td><a href="/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfacemethod-methodsignature">testInterfaceMethod()</a></td>
               <td><code>Alpha</code></td>
-              <td><span>void</span></td>
+              <td>void</td>
               <td>Test interface method</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/testinterface-interface/testinterfaceproperty-propertysignature.html
@@ -17,7 +17,7 @@
       </section>
       <section>
         <h2 id="testinterfaceproperty-signature">Signature</h2><code>testInterfaceProperty: boolean;</code>
-        <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+        <p><span><b>Type</b></span>: boolean</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/foo-interface/bar-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/foo-interface/bar-propertysignature.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="bar-signature">Signature</h2><code>bar: TestEnum;</code>
-        <p><span><span><b>Type</b></span>: <span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></span></p>
+        <p><span><b>Type</b></span>: <a href="/test-suite-a/testenum-enum/">TestEnum</a></p>
       </section>
       <section>
         <h2 id="bar-remarks">Remarks</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/foo-interface/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-b/foo-interface/index.html
@@ -28,7 +28,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-b/foo-interface/bar-propertysignature">bar</a></td>
-              <td><span><a href="/test-suite-a/testenum-enum/">TestEnum</a></span></td>
+              <td><a href="/test-suite-a/testenum-enum/">TestEnum</a></td>
               <td>Test Enum</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/index.html
@@ -138,25 +138,25 @@
             <tr>
               <td><a href="/test-suite-a/#testfunction-function">testFunction(testParameter, testOptionalParameter)</a></td>
               <td><code>Alpha</code></td>
-              <td><span>TTypeParameter</span></td>
+              <td>TTypeParameter</td>
               <td>Test function</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/#testfunctionreturninginlinetype-function">testFunctionReturningInlineType()</a></td>
               <td></td>
-              <td><span>{ foo: number; bar: <a href="/test-suite-a/testenum-enum">TestEnum</a>; }</span></td>
+              <td>{ foo: number; bar: <a href="/test-suite-a/testenum-enum">TestEnum</a>; }</td>
               <td>Test function that returns an inline type</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/#testfunctionreturningintersectiontype-function">testFunctionReturningIntersectionType()</a></td>
               <td><code>Deprecated</code></td>
-              <td><span><a href="/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></td>
+              <td><a href="/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></td>
               <td>Test function that returns an inline type</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/#testfunctionreturninguniontype-function">testFunctionReturningUnionType()</a></td>
               <td></td>
-              <td><span>string | <a href="/test-suite-a/testinterface-interface">TestInterface</a></span></td>
+              <td>string | <a href="/test-suite-a/testinterface-interface">TestInterface</a></td>
               <td>Test function that returns an inline type</td>
             </tr>
           </tbody>
@@ -186,7 +186,7 @@
               <td><a href="/test-suite-a/#testconstwithemptydeprecatedblock-variable">testConstWithEmptyDeprecatedBlock</a></td>
               <td><code>Deprecated</code></td>
               <td><code>readonly</code></td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>I have a <code>@deprecated</code> tag with an empty comment block.</td>
             </tr>
           </tbody>
@@ -247,8 +247,8 @@
                 <tbody>
                   <tr>
                     <td>TTypeParameter</td>
-                    <td><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span></td>
-                    <td><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span></td>
+                    <td><a href="/test-suite-a/testinterface-interface">TestInterface</a></td>
+                    <td><a href="/test-suite-a/testinterface-interface">TestInterface</a></td>
                     <td>A test type parameter</td>
                   </tr>
                 </tbody>
@@ -274,13 +274,13 @@
                 <tr>
                   <td>testParameter</td>
                   <td></td>
-                  <td><span>TTypeParameter</span></td>
+                  <td>TTypeParameter</td>
                   <td>A test parameter</td>
                 </tr>
                 <tr>
                   <td>testOptionalParameter</td>
                   <td>optional</td>
-                  <td><span>TTypeParameter</span></td>
+                  <td>TTypeParameter</td>
                   <td></td>
                 </tr>
               </tbody>
@@ -289,7 +289,7 @@
           <section>
             <h4 id="testfunction-returns">Returns</h4>
             <p>The provided parameter</p>
-            <p><span><b>Return type</b></span>: <span>TTypeParameter</span></p>
+            <p><span><b>Return type</b></span>: TTypeParameter</p>
           </section>
           <section>
             <h4 id="testfunction-throws">Throws</h4>
@@ -307,7 +307,7 @@
           <section>
             <h4 id="testfunctionreturninginlinetype-returns">Returns</h4>
             <p>An inline type</p>
-            <p><span><b>Return type</b></span>: <span>{ foo: number; bar: <a href="/test-suite-a/testenum-enum">TestEnum</a>; }</span></p>
+            <p><span><b>Return type</b></span>: { foo: number; bar: <a href="/test-suite-a/testenum-enum">TestEnum</a>; }</p>
           </section>
         </section>
         <section>
@@ -325,7 +325,7 @@
           <section>
             <h4 id="testfunctionreturningintersectiontype-returns">Returns</h4>
             <p>an intersection type</p>
-            <p><span><b>Return type</b></span>: <span><a href="/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></p>
+            <p><span><b>Return type</b></span>: <a href="/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></p>
           </section>
         </section>
         <section>
@@ -339,7 +339,7 @@
           <section>
             <h4 id="testfunctionreturninguniontype-returns">Returns</h4>
             <p>A union type</p>
-            <p><span><b>Return type</b></span>: <span>string | <a href="/test-suite-a/testinterface-interface">TestInterface</a></span></p>
+            <p><span><b>Return type</b></span>: string | <a href="/test-suite-a/testinterface-interface">TestInterface</a></p>
           </section>
         </section>
       </section>
@@ -371,7 +371,7 @@
           </section>
           <section>
             <h4 id="testconstwithemptydeprecatedblock-signature">Signature</h4><code>testConstWithEmptyDeprecatedBlock: string</code>
-            <p><span><span><b>Type</b></span>: <span>string</span></span></p>
+            <p><span><b>Type</b></span>: string</p>
           </section>
         </section>
       </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testabstractclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testabstractclass-class.html
@@ -47,13 +47,13 @@
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class#abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></td>
+              <td><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></td>
               <td>A test abstract getter property.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class#protectedproperty-property">protectedProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></td>
+              <td><a href="/test-suite-a/testenum-enum">TestEnum</a></td>
               <td>A test protected property.</td>
             </tr>
           </tbody>
@@ -74,19 +74,19 @@
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class#publicabstractmethod-method">publicAbstractMethod()</a></td>
               <td></td>
-              <td><span>void</span></td>
+              <td>void</td>
               <td>A test public abstract method.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class#sealedmethod-method">sealedMethod()</a></td>
               <td><code>sealed</code></td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>A test <code>@sealed</code> method.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class#virtualmethod-method">virtualMethod()</a></td>
               <td><code>virtual</code></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>A test <code>@virtual</code> method.</td>
             </tr>
           </tbody>
@@ -115,12 +115,12 @@
               <tbody>
                 <tr>
                   <td>privateProperty</td>
-                  <td><span>number</span></td>
+                  <td>number</td>
                   <td></td>
                 </tr>
                 <tr>
                   <td>protectedProperty</td>
-                  <td><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></td>
+                  <td><a href="/test-suite-a/testenum-enum">TestEnum</a></td>
                   <td></td>
                 </tr>
               </tbody>
@@ -137,7 +137,7 @@
           </section>
           <section>
             <h4 id="abstractpropertygetter-signature">Signature</h4><code>abstract get abstractPropertyGetter(): TestMappedType;</code>
-            <p><span><span><b>Type</b></span>: <span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></span></p>
+            <p><span><b>Type</b></span>: <a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></p>
           </section>
         </section>
         <section>
@@ -147,7 +147,7 @@
           </section>
           <section>
             <h4 id="protectedproperty-signature">Signature</h4><code>protected readonly protectedProperty: TestEnum;</code>
-            <p><span><span><b>Type</b></span>: <span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></span></p>
+            <p><span><b>Type</b></span>: <a href="/test-suite-a/testenum-enum">TestEnum</a></p>
           </section>
         </section>
       </section>
@@ -173,7 +173,7 @@
           <section>
             <h4 id="sealedmethod-returns">Returns</h4>
             <p>A string!</p>
-            <p><span><b>Return type</b></span>: <span>string</span></p>
+            <p><span><b>Return type</b></span>: string</p>
           </section>
         </section>
         <section>
@@ -187,7 +187,7 @@
           <section>
             <h4 id="virtualmethod-returns">Returns</h4>
             <p>A number!</p>
-            <p><span><b>Return type</b></span>: <span>number</span></p>
+            <p><span><b>Return type</b></span>: number</p>
           </section>
         </section>
       </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testclass-class.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testclass-signature">Signature</h2><code>export declare class TestClass&#x3C;TTypeParameterA, TTypeParameterB> extends TestAbstractClass</code>
-        <p><span><span><b>Extends</b></span>: <span><a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a></span></span></p>
+        <p><span><b>Extends</b></span>: <a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a></p>
         <section>
           <h3>Type Parameters</h3>
           <table>
@@ -71,7 +71,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testclass-class#testclassstaticproperty-property">testClassStaticProperty</a></td>
-              <td><span>(foo: number) => string</span></td>
+              <td>(foo: number) => string</td>
               <td>Test static class property</td>
             </tr>
           </tbody>
@@ -90,7 +90,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testclass-class#testclassstaticmethod-method">testClassStaticMethod(foo)</a></td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>Test class static method</td>
             </tr>
           </tbody>
@@ -111,7 +111,7 @@
             <tr>
               <td><a href="/test-suite-a/testclass-class#testclasseventproperty-property">testClassEventProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span>() => void</span></td>
+              <td>() => void</td>
               <td>Test class event property</td>
             </tr>
           </tbody>
@@ -132,19 +132,19 @@
             <tr>
               <td><a href="/test-suite-a/testclass-class#abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></td>
+              <td><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></td>
               <td>A test abstract getter property.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testclass-class#testclassgetterproperty-property">testClassGetterProperty</a></td>
               <td><code>virtual</code></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test class property with both a getter and a setter.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testclass-class#testclassproperty-property">testClassProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span>TTypeParameterB</span></td>
+              <td>TTypeParameterB</td>
               <td>Test class property</td>
             </tr>
           </tbody>
@@ -165,19 +165,19 @@
             <tr>
               <td><a href="/test-suite-a/testclass-class#publicabstractmethod-method">publicAbstractMethod()</a></td>
               <td></td>
-              <td><span>void</span></td>
+              <td>void</td>
               <td>A test public abstract method.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testclass-class#testclassmethod-method">testClassMethod(input)</a></td>
               <td><code>sealed</code></td>
-              <td><span>TTypeParameterA</span></td>
+              <td>TTypeParameterA</td>
               <td>Test class method</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testclass-class#virtualmethod-method">virtualMethod()</a></td>
               <td></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Overrides <a href="/test-suite-a/testabstractclass-class#virtualmethod-method">virtualMethod()</a>.</td>
             </tr>
           </tbody>
@@ -210,12 +210,12 @@
               <tbody>
                 <tr>
                   <td>privateProperty</td>
-                  <td><span>number</span></td>
+                  <td>number</td>
                   <td>See <a href="/test-suite-a/testabstractclass-class">TestAbstractClass</a>'s constructor.</td>
                 </tr>
                 <tr>
                   <td>protectedProperty</td>
-                  <td><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></td>
+                  <td><a href="/test-suite-a/testenum-enum">TestEnum</a></td>
                   <td>
                     <p>Some notes about the parameter.</p>
                     <p>See <a href="/test-suite-a/testabstractclass-class#protectedproperty-property">protectedProperty</a>.</p>
@@ -223,12 +223,12 @@
                 </tr>
                 <tr>
                   <td>testClassProperty</td>
-                  <td><span>TTypeParameterB</span></td>
+                  <td>TTypeParameterB</td>
                   <td>See <a href="/test-suite-a/testclass-class#testclassproperty-property">testClassProperty</a>.</td>
                 </tr>
                 <tr>
                   <td>testClassEventProperty</td>
-                  <td><span>() => void</span></td>
+                  <td>() => void</td>
                   <td>See <a href="/test-suite-a/testclass-class#testclasseventproperty-property">testClassEventProperty</a>.</td>
                 </tr>
               </tbody>
@@ -245,7 +245,7 @@
           </section>
           <section>
             <h4 id="testclasseventproperty-signature">Signature</h4><code>readonly testClassEventProperty: () => void;</code>
-            <p><span><span><b>Type</b></span>: <span>() => void</span></span></p>
+            <p><span><b>Type</b></span>: () => void</p>
           </section>
           <section>
             <h4 id="testclasseventproperty-remarks">Remarks</h4>
@@ -262,7 +262,7 @@
           </section>
           <section>
             <h4 id="abstractpropertygetter-signature">Signature</h4><code>get abstractPropertyGetter(): TestMappedType;</code>
-            <p><span><span><b>Type</b></span>: <span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></span></p>
+            <p><span><b>Type</b></span>: <a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></p>
           </section>
         </section>
         <section>
@@ -272,7 +272,7 @@
           </section>
           <section>
             <h4 id="testclassgetterproperty-signature">Signature</h4><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br><br>set testClassGetterProperty(newValue: number);</code>
-            <p><span><span><b>Type</b></span>: <span>number</span></span></p>
+            <p><span><b>Type</b></span>: number</p>
           </section>
           <section>
             <h4 id="testclassgetterproperty-remarks">Remarks</h4>
@@ -286,7 +286,7 @@
           </section>
           <section>
             <h4 id="testclassproperty-signature">Signature</h4><code>readonly testClassProperty: TTypeParameterB;</code>
-            <p><span><span><b>Type</b></span>: <span>TTypeParameterB</span></span></p>
+            <p><span><b>Type</b></span>: TTypeParameterB</p>
           </section>
           <section>
             <h4 id="testclassproperty-remarks">Remarks</h4>
@@ -300,7 +300,7 @@
           </section>
           <section>
             <h4 id="testclassstaticproperty-signature">Signature</h4><code>static testClassStaticProperty: (foo: number) => string;</code>
-            <p><span><span><b>Type</b></span>: <span>(foo: number) => string</span></span></p>
+            <p><span><b>Type</b></span>: (foo: number) => string</p>
           </section>
         </section>
       </section>
@@ -340,7 +340,7 @@
               <tbody>
                 <tr>
                   <td>input</td>
-                  <td><span>TTypeParameterA</span></td>
+                  <td>TTypeParameterA</td>
                   <td></td>
                 </tr>
               </tbody>
@@ -348,7 +348,7 @@
           </section>
           <section>
             <h4 id="testclassmethod-returns">Returns</h4>
-            <p><span><b>Return type</b></span>: <span>TTypeParameterA</span></p>
+            <p><span><b>Return type</b></span>: TTypeParameterA</p>
           </section>
           <section>
             <h4 id="testclassmethod-throws">Throws</h4>
@@ -377,7 +377,7 @@
               <tbody>
                 <tr>
                   <td>foo</td>
-                  <td><span>number</span></td>
+                  <td>number</td>
                   <td>Some number</td>
                 </tr>
               </tbody>
@@ -386,7 +386,7 @@
           <section>
             <h4 id="testclassstaticmethod-returns">Returns</h4>
             <p>- Some string</p>
-            <p><span><b>Return type</b></span>: <span>string</span></p>
+            <p><span><b>Return type</b></span>: string</p>
           </section>
         </section>
         <section>
@@ -399,7 +399,7 @@
           </section>
           <section>
             <h4 id="virtualmethod-returns">Returns</h4>
-            <p><span><b>Return type</b></span>: <span>number</span></p>
+            <p><span><b>Return type</b></span>: number</p>
           </section>
         </section>
       </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterface-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterface-interface.html
@@ -32,7 +32,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface#_new_-constructsignature">new (): TestInterface</a></td>
-              <td><span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span></td>
+              <td><a href="/test-suite-a/testinterface-interface">TestInterface</a></td>
               <td>Test construct signature.</td>
             </tr>
           </tbody>
@@ -53,7 +53,7 @@
             <tr>
               <td><a href="/test-suite-a/testinterface-interface#testclasseventproperty-propertysignature">testClassEventProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span>() => void</span></td>
+              <td>() => void</td>
               <td>Test interface event property</td>
             </tr>
           </tbody>
@@ -76,35 +76,35 @@
               <td><a href="/test-suite-a/testinterface-interface#getterproperty-property">getterProperty</a></td>
               <td><code>readonly</code></td>
               <td></td>
-              <td><span>boolean</span></td>
+              <td>boolean</td>
               <td>A test getter-only interface property.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface#propertywithbadinheritdoctarget-propertysignature">propertyWithBadInheritDocTarget</a></td>
               <td></td>
               <td></td>
-              <td><span>boolean</span></td>
+              <td>boolean</td>
               <td></td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface#setterproperty-property">setterProperty</a></td>
               <td></td>
               <td></td>
-              <td><span>boolean</span></td>
+              <td>boolean</td>
               <td>A test property with a getter and a setter.</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface#testinterfaceproperty-propertysignature">testInterfaceProperty</a></td>
               <td></td>
               <td></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test interface property</td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface#testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></td>
               <td><code>optional</code></td>
               <td>0</td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test optional property</td>
             </tr>
           </tbody>
@@ -123,7 +123,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testinterface-interface#testinterfacemethod-methodsignature">testInterfaceMethod()</a></td>
-              <td><span>void</span></td>
+              <td>void</td>
               <td>Test interface method</td>
             </tr>
           </tbody>
@@ -162,7 +162,7 @@
           </section>
           <section>
             <h4 id="_new_-returns">Returns</h4>
-            <p><span><b>Return type</b></span>: <span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span></p>
+            <p><span><b>Return type</b></span>: <a href="/test-suite-a/testinterface-interface">TestInterface</a></p>
           </section>
         </section>
       </section>
@@ -175,7 +175,7 @@
           </section>
           <section>
             <h4 id="testclasseventproperty-signature">Signature</h4><code>readonly testClassEventProperty: () => void;</code>
-            <p><span><span><b>Type</b></span>: <span>() => void</span></span></p>
+            <p><span><b>Type</b></span>: () => void</p>
           </section>
           <section>
             <h4 id="testclasseventproperty-remarks">Remarks</h4>
@@ -192,14 +192,14 @@
           </section>
           <section>
             <h4 id="getterproperty-signature">Signature</h4><code>get getterProperty(): boolean;</code>
-            <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+            <p><span><b>Type</b></span>: boolean</p>
           </section>
         </section>
         <section>
           <h3 id="propertywithbadinheritdoctarget-propertysignature">propertyWithBadInheritDocTarget</h3>
           <section>
             <h4 id="propertywithbadinheritdoctarget-signature">Signature</h4><code>propertyWithBadInheritDocTarget: boolean;</code>
-            <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+            <p><span><b>Type</b></span>: boolean</p>
           </section>
         </section>
         <section>
@@ -209,7 +209,7 @@
           </section>
           <section>
             <h4 id="setterproperty-signature">Signature</h4><code>get setterProperty(): boolean;<br><br><br>set setterProperty(newValue: boolean);</code>
-            <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+            <p><span><b>Type</b></span>: boolean</p>
           </section>
         </section>
         <section>
@@ -219,7 +219,7 @@
           </section>
           <section>
             <h4 id="testinterfaceproperty-signature">Signature</h4><code>testInterfaceProperty: number;</code>
-            <p><span><span><b>Type</b></span>: <span>number</span></span></p>
+            <p><span><b>Type</b></span>: number</p>
           </section>
           <section>
             <h4 id="testinterfaceproperty-remarks">Remarks</h4>
@@ -233,7 +233,7 @@
           </section>
           <section>
             <h4 id="testoptionalinterfaceproperty-signature">Signature</h4><code>testOptionalInterfaceProperty?: number;</code>
-            <p><span><span><b>Type</b></span>: <span>number</span></span></p>
+            <p><span><b>Type</b></span>: number</p>
           </section>
         </section>
       </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="testinterfaceextendingotherinterfaces-signature">Signature</h2><code>export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter&#x3C;number></code>
-        <p><span><span><b>Extends</b></span>: <span><a href="/test-suite-a/testinterface-interface">TestInterface</a></span>, <span><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></span>, <span><a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></span></p>
+        <p><span><b>Extends</b></span>: <a href="/test-suite-a/testinterface-interface">TestInterface</a>, <a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a>, <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></p>
       </section>
       <section>
         <h2 id="testinterfaceextendingotherinterfaces-remarks">Remarks</h2>
@@ -33,7 +33,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testinterfaceextendingotherinterfaces-interface#testmethod-methodsignature">testMethod(input)</a></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test interface method accepting a string and returning a number.</td>
             </tr>
           </tbody>
@@ -66,7 +66,7 @@
               <tbody>
                 <tr>
                   <td>input</td>
-                  <td><span>string</span></td>
+                  <td>string</td>
                   <td>A string</td>
                 </tr>
               </tbody>
@@ -75,7 +75,7 @@
           <section>
             <h4 id="testmethod-returns">Returns</h4>
             <p>A number</p>
-            <p><span><b>Return type</b></span>: <span>number</span></p>
+            <p><span><b>Return type</b></span>: number</p>
           </section>
         </section>
       </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterfacewithtypeparameter-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterfacewithtypeparameter-interface.html
@@ -49,7 +49,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testinterfacewithtypeparameter-interface#testproperty-propertysignature">testProperty</a></td>
-              <td><span>T</span></td>
+              <td>T</td>
               <td>A test interface property using generic type parameter</td>
             </tr>
           </tbody>
@@ -64,7 +64,7 @@
           </section>
           <section>
             <h4 id="testproperty-signature">Signature</h4><code>testProperty: T;</code>
-            <p><span><span><b>Type</b></span>: <span>T</span></span></p>
+            <p><span><b>Type</b></span>: T</p>
           </section>
           <section>
             <h4 id="testproperty-remarks">Remarks</h4>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.html
@@ -113,7 +113,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testnamespace-namespace/#testfunction-function">testFunction(testParameter)</a></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test function</td>
             </tr>
           </tbody>
@@ -182,7 +182,7 @@
               <tbody>
                 <tr>
                   <td>testParameter</td>
-                  <td><span>number</span></td>
+                  <td>number</td>
                   <td></td>
                 </tr>
               </tbody>
@@ -191,7 +191,7 @@
           <section>
             <h4 id="testfunction-returns">Returns</h4>
             <p>A number</p>
-            <p><span><b>Return type</b></span>: <span>number</span></p>
+            <p><span><b>Return type</b></span>: number</p>
           </section>
           <section>
             <h4 id="testfunction-throws">Throws</h4>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testclass-class.html
@@ -47,7 +47,7 @@
             <tr>
               <td><a href="/test-suite-a/testnamespace-namespace/testclass-class#testclassproperty-property">testClassProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>Test interface property</td>
             </tr>
           </tbody>
@@ -66,7 +66,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testnamespace-namespace/testclass-class#testclassmethod-method">testClassMethod(testParameter)</a></td>
-              <td><span>Promise&#x3C;string></span></td>
+              <td>Promise&#x3C;string></td>
               <td>Test class method</td>
             </tr>
           </tbody>
@@ -95,7 +95,7 @@
               <tbody>
                 <tr>
                   <td>testClassProperty</td>
-                  <td><span>string</span></td>
+                  <td>string</td>
                   <td>See <a href="/test-suite-a/testclass-class#testclassproperty-property">testClassProperty</a></td>
                 </tr>
               </tbody>
@@ -112,7 +112,7 @@
           </section>
           <section>
             <h4 id="testclassproperty-signature">Signature</h4><code>readonly testClassProperty: string;</code>
-            <p><span><span><b>Type</b></span>: <span>string</span></span></p>
+            <p><span><b>Type</b></span>: string</p>
           </section>
         </section>
       </section>
@@ -139,7 +139,7 @@
               <tbody>
                 <tr>
                   <td>testParameter</td>
-                  <td><span>string</span></td>
+                  <td>string</td>
                   <td>A string</td>
                 </tr>
               </tbody>
@@ -148,7 +148,7 @@
           <section>
             <h4 id="testclassmethod-returns">Returns</h4>
             <p>A Promise</p>
-            <p><span><b>Return type</b></span>: <span>Promise&#x3C;string></span></p>
+            <p><span><b>Return type</b></span>: Promise&#x3C;string></p>
           </section>
           <section>
             <h4 id="testclassmethod-throws">Throws</h4>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testinterface-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/testinterface-interface.html
@@ -17,7 +17,7 @@
       </section>
       <section>
         <h2 id="testinterface-signature">Signature</h2><code>interface TestInterface extends TestInterfaceWithTypeParameter&#x3C;TestEnum></code>
-        <p><span><span><b>Extends</b></span>: <span><a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;<a href="/test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a>></span></span></p>
+        <p><span><b>Extends</b></span>: <a href="/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;<a href="/test-suite-a/testnamespace-namespace/testenum-enum">TestEnum</a>></p>
       </section>
       <section>
         <h2>Properties</h2>
@@ -34,7 +34,7 @@
             <tr>
               <td><a href="/test-suite-a/testnamespace-namespace/testinterface-interface#testinterfaceproperty-propertysignature">testInterfaceProperty</a></td>
               <td><code>Alpha</code></td>
-              <td><span>boolean</span></td>
+              <td>boolean</td>
               <td>Test interface property</td>
             </tr>
           </tbody>
@@ -55,7 +55,7 @@
             <tr>
               <td><a href="/test-suite-a/testnamespace-namespace/testinterface-interface#testinterfacemethod-methodsignature">testInterfaceMethod()</a></td>
               <td><code>Alpha</code></td>
-              <td><span>void</span></td>
+              <td>void</td>
               <td>Test interface method</td>
             </tr>
           </tbody>
@@ -73,7 +73,7 @@
           </section>
           <section>
             <h4 id="testinterfaceproperty-signature">Signature</h4><code>testInterfaceProperty: boolean;</code>
-            <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+            <p><span><b>Type</b></span>: boolean</p>
           </section>
         </section>
       </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-b/foo-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-b/foo-interface.html
@@ -28,7 +28,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-b/foo-interface#bar-propertysignature">bar</a></td>
-              <td><span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></td>
+              <td><a href="/test-suite-a/testenum-enum">TestEnum</a></td>
               <td>Test Enum</td>
             </tr>
           </tbody>
@@ -43,7 +43,7 @@
           </section>
           <section>
             <h4 id="bar-signature">Signature</h4><code>bar: TestEnum;</code>
-            <p><span><span><b>Type</b></span>: <span><a href="/test-suite-a/testenum-enum">TestEnum</a></span></span></p>
+            <p><span><b>Type</b></span>: <a href="/test-suite-a/testenum-enum">TestEnum</a></p>
           </section>
           <section>
             <h4 id="bar-remarks">Remarks</h4>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
@@ -136,19 +136,19 @@
           <tr>
             <td><a href="docs/test-suite-a#testfunctionreturninginlinetype-function">testFunctionReturningInlineType()</a></td>
             <td></td>
-            <td><span>{ foo: number; bar: <a href="docs/test-suite-a#testenum-enum">TestEnum</a>; }</span></td>
+            <td>{ foo: number; bar: <a href="docs/test-suite-a#testenum-enum">TestEnum</a>; }</td>
             <td>Test function that returns an inline type</td>
           </tr>
           <tr>
             <td><a href="docs/test-suite-a#testfunctionreturningintersectiontype-function">testFunctionReturningIntersectionType()</a></td>
             <td><code>Deprecated</code></td>
-            <td><span><a href="docs/test-suite-a#testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="docs/test-suite-a#testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></td>
+            <td><a href="docs/test-suite-a#testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="docs/test-suite-a#testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></td>
             <td>Test function that returns an inline type</td>
           </tr>
           <tr>
             <td><a href="docs/test-suite-a#testfunctionreturninguniontype-function">testFunctionReturningUnionType()</a></td>
             <td></td>
-            <td><span>string | <a href="docs/test-suite-a#testinterface-interface">TestInterface</a></span></td>
+            <td>string | <a href="docs/test-suite-a#testinterface-interface">TestInterface</a></td>
             <td>Test function that returns an inline type</td>
           </tr>
         </tbody>
@@ -178,7 +178,7 @@
             <td><a href="docs/test-suite-a#testconstwithemptydeprecatedblock-variable">testConstWithEmptyDeprecatedBlock</a></td>
             <td><code>Deprecated</code></td>
             <td><code>readonly</code></td>
-            <td><span>string</span></td>
+            <td>string</td>
             <td>I have a <code>@deprecated</code> tag with an empty comment block.</td>
           </tr>
         </tbody>
@@ -249,7 +249,7 @@
             <tbody>
               <tr>
                 <td><a href="docs/test-suite-a#testinterface-_new_-constructsignature">new (): TestInterface</a></td>
-                <td><span><a href="docs/test-suite-a#testinterface-interface">TestInterface</a></span></td>
+                <td><a href="docs/test-suite-a#testinterface-interface">TestInterface</a></td>
                 <td>Test construct signature.</td>
               </tr>
             </tbody>
@@ -270,7 +270,7 @@
               <tr>
                 <td><a href="docs/test-suite-a#testinterface-testclasseventproperty-propertysignature">testClassEventProperty</a></td>
                 <td><code>readonly</code></td>
-                <td><span>() => void</span></td>
+                <td>() => void</td>
                 <td>Test interface event property</td>
               </tr>
             </tbody>
@@ -293,35 +293,35 @@
                 <td><a href="docs/test-suite-a#testinterface-getterproperty-property">getterProperty</a></td>
                 <td><code>readonly</code></td>
                 <td></td>
-                <td><span>boolean</span></td>
+                <td>boolean</td>
                 <td>A test getter-only interface property.</td>
               </tr>
               <tr>
                 <td><a href="docs/test-suite-a#testinterface-propertywithbadinheritdoctarget-propertysignature">propertyWithBadInheritDocTarget</a></td>
                 <td></td>
                 <td></td>
-                <td><span>boolean</span></td>
+                <td>boolean</td>
                 <td></td>
               </tr>
               <tr>
                 <td><a href="docs/test-suite-a#testinterface-setterproperty-property">setterProperty</a></td>
                 <td></td>
                 <td></td>
-                <td><span>boolean</span></td>
+                <td>boolean</td>
                 <td>A test property with a getter and a setter.</td>
               </tr>
               <tr>
                 <td><a href="docs/test-suite-a#testinterface-testinterfaceproperty-propertysignature">testInterfaceProperty</a></td>
                 <td></td>
                 <td></td>
-                <td><span>number</span></td>
+                <td>number</td>
                 <td>Test interface property</td>
               </tr>
               <tr>
                 <td><a href="docs/test-suite-a#testinterface-testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></td>
                 <td><code>optional</code></td>
                 <td>0</td>
-                <td><span>number</span></td>
+                <td>number</td>
                 <td>Test optional property</td>
               </tr>
             </tbody>
@@ -340,7 +340,7 @@
             <tbody>
               <tr>
                 <td><a href="docs/test-suite-a#testinterface-testinterfacemethod-methodsignature">testInterfaceMethod()</a></td>
-                <td><span>void</span></td>
+                <td>void</td>
                 <td>Test interface method</td>
               </tr>
             </tbody>
@@ -379,7 +379,7 @@
             </section>
             <section>
               <h5 id="_new_-returns">Returns</h5>
-              <p><span><b>Return type</b></span>: <span><a href="docs/test-suite-a#testinterface-interface">TestInterface</a></span></p>
+              <p><span><b>Return type</b></span>: <a href="docs/test-suite-a#testinterface-interface">TestInterface</a></p>
             </section>
           </section>
         </section>
@@ -392,7 +392,7 @@
             </section>
             <section>
               <h5 id="testclasseventproperty-signature">Signature</h5><code>readonly testClassEventProperty: () => void;</code>
-              <p><span><span><b>Type</b></span>: <span>() => void</span></span></p>
+              <p><span><b>Type</b></span>: () => void</p>
             </section>
             <section>
               <h5 id="testclasseventproperty-remarks">Remarks</h5>
@@ -409,14 +409,14 @@
             </section>
             <section>
               <h5 id="getterproperty-signature">Signature</h5><code>get getterProperty(): boolean;</code>
-              <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+              <p><span><b>Type</b></span>: boolean</p>
             </section>
           </section>
           <section>
             <h4 id="testinterface-propertywithbadinheritdoctarget-propertysignature">propertyWithBadInheritDocTarget</h4>
             <section>
               <h5 id="propertywithbadinheritdoctarget-signature">Signature</h5><code>propertyWithBadInheritDocTarget: boolean;</code>
-              <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+              <p><span><b>Type</b></span>: boolean</p>
             </section>
           </section>
           <section>
@@ -426,7 +426,7 @@
             </section>
             <section>
               <h5 id="setterproperty-signature">Signature</h5><code>get setterProperty(): boolean;<br><br><br>set setterProperty(newValue: boolean);</code>
-              <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+              <p><span><b>Type</b></span>: boolean</p>
             </section>
           </section>
           <section>
@@ -436,7 +436,7 @@
             </section>
             <section>
               <h5 id="testinterfaceproperty-signature">Signature</h5><code>testInterfaceProperty: number;</code>
-              <p><span><span><b>Type</b></span>: <span>number</span></span></p>
+              <p><span><b>Type</b></span>: number</p>
             </section>
             <section>
               <h5 id="testinterfaceproperty-remarks">Remarks</h5>
@@ -450,7 +450,7 @@
             </section>
             <section>
               <h5 id="testoptionalinterfaceproperty-signature">Signature</h5><code>testOptionalInterfaceProperty?: number;</code>
-              <p><span><span><b>Type</b></span>: <span>number</span></span></p>
+              <p><span><b>Type</b></span>: number</p>
             </section>
           </section>
         </section>
@@ -514,7 +514,7 @@
         </section>
         <section>
           <h3 id="testinterfaceextendingotherinterfaces-signature">Signature</h3><code>export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter&#x3C;number></code>
-          <p><span><span><b>Extends</b></span>: <span><a href="docs/test-suite-a#testinterface-interface">TestInterface</a></span>, <span><a href="docs/test-suite-a#testmappedtype-typealias">TestMappedType</a></span>, <span><a href="docs/test-suite-a#testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></span></p>
+          <p><span><b>Extends</b></span>: <a href="docs/test-suite-a#testinterface-interface">TestInterface</a>, <a href="docs/test-suite-a#testmappedtype-typealias">TestMappedType</a>, <a href="docs/test-suite-a#testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></p>
         </section>
         <section>
           <h3 id="testinterfaceextendingotherinterfaces-remarks">Remarks</h3>
@@ -533,7 +533,7 @@
             <tbody>
               <tr>
                 <td><a href="docs/test-suite-a#testinterfaceextendingotherinterfaces-testmethod-methodsignature">testMethod(input)</a></td>
-                <td><span>number</span></td>
+                <td>number</td>
                 <td>Test interface method accepting a string and returning a number.</td>
               </tr>
             </tbody>
@@ -566,7 +566,7 @@
                 <tbody>
                   <tr>
                     <td>input</td>
-                    <td><span>string</span></td>
+                    <td>string</td>
                     <td>A string</td>
                   </tr>
                 </tbody>
@@ -575,7 +575,7 @@
             <section>
               <h5 id="testmethod-returns">Returns</h5>
               <p>A number</p>
-              <p><span><b>Return type</b></span>: <span>number</span></p>
+              <p><span><b>Return type</b></span>: number</p>
             </section>
           </section>
         </section>
@@ -666,7 +666,7 @@
             <tbody>
               <tr>
                 <td><a href="docs/test-suite-a#testinterfacewithtypeparameter-testproperty-propertysignature">testProperty</a></td>
-                <td><span>T</span></td>
+                <td>T</td>
                 <td>A test interface property using generic type parameter</td>
               </tr>
             </tbody>
@@ -681,7 +681,7 @@
             </section>
             <section>
               <h5 id="testproperty-signature">Signature</h5><code>testProperty: T;</code>
-              <p><span><span><b>Type</b></span>: <span>T</span></span></p>
+              <p><span><b>Type</b></span>: T</p>
             </section>
             <section>
               <h5 id="testproperty-remarks">Remarks</h5>
@@ -733,13 +733,13 @@
               <tr>
                 <td><a href="docs/test-suite-a#testabstractclass-abstractpropertygetter-property">abstractPropertyGetter</a></td>
                 <td><code>readonly</code></td>
-                <td><span><a href="docs/test-suite-a#testmappedtype-typealias">TestMappedType</a></span></td>
+                <td><a href="docs/test-suite-a#testmappedtype-typealias">TestMappedType</a></td>
                 <td>A test abstract getter property.</td>
               </tr>
               <tr>
                 <td><a href="docs/test-suite-a#testabstractclass-protectedproperty-property">protectedProperty</a></td>
                 <td><code>readonly</code></td>
-                <td><span><a href="docs/test-suite-a#testenum-enum">TestEnum</a></span></td>
+                <td><a href="docs/test-suite-a#testenum-enum">TestEnum</a></td>
                 <td>A test protected property.</td>
               </tr>
             </tbody>
@@ -760,19 +760,19 @@
               <tr>
                 <td><a href="docs/test-suite-a#testabstractclass-publicabstractmethod-method">publicAbstractMethod()</a></td>
                 <td></td>
-                <td><span>void</span></td>
+                <td>void</td>
                 <td>A test public abstract method.</td>
               </tr>
               <tr>
                 <td><a href="docs/test-suite-a#testabstractclass-sealedmethod-method">sealedMethod()</a></td>
                 <td><code>sealed</code></td>
-                <td><span>string</span></td>
+                <td>string</td>
                 <td>A test <code>@sealed</code> method.</td>
               </tr>
               <tr>
                 <td><a href="docs/test-suite-a#testabstractclass-virtualmethod-method">virtualMethod()</a></td>
                 <td><code>virtual</code></td>
-                <td><span>number</span></td>
+                <td>number</td>
                 <td>A test <code>@virtual</code> method.</td>
               </tr>
             </tbody>
@@ -801,12 +801,12 @@
                 <tbody>
                   <tr>
                     <td>privateProperty</td>
-                    <td><span>number</span></td>
+                    <td>number</td>
                     <td></td>
                   </tr>
                   <tr>
                     <td>protectedProperty</td>
-                    <td><span><a href="docs/test-suite-a#testenum-enum">TestEnum</a></span></td>
+                    <td><a href="docs/test-suite-a#testenum-enum">TestEnum</a></td>
                     <td></td>
                   </tr>
                 </tbody>
@@ -823,7 +823,7 @@
             </section>
             <section>
               <h5 id="abstractpropertygetter-signature">Signature</h5><code>abstract get abstractPropertyGetter(): TestMappedType;</code>
-              <p><span><span><b>Type</b></span>: <span><a href="docs/test-suite-a#testmappedtype-typealias">TestMappedType</a></span></span></p>
+              <p><span><b>Type</b></span>: <a href="docs/test-suite-a#testmappedtype-typealias">TestMappedType</a></p>
             </section>
           </section>
           <section>
@@ -833,7 +833,7 @@
             </section>
             <section>
               <h5 id="protectedproperty-signature">Signature</h5><code>protected readonly protectedProperty: TestEnum;</code>
-              <p><span><span><b>Type</b></span>: <span><a href="docs/test-suite-a#testenum-enum">TestEnum</a></span></span></p>
+              <p><span><b>Type</b></span>: <a href="docs/test-suite-a#testenum-enum">TestEnum</a></p>
             </section>
           </section>
         </section>
@@ -859,7 +859,7 @@
             <section>
               <h5 id="sealedmethod-returns">Returns</h5>
               <p>A string!</p>
-              <p><span><b>Return type</b></span>: <span>string</span></p>
+              <p><span><b>Return type</b></span>: string</p>
             </section>
           </section>
           <section>
@@ -873,7 +873,7 @@
             <section>
               <h5 id="virtualmethod-returns">Returns</h5>
               <p>A number!</p>
-              <p><span><b>Return type</b></span>: <span>number</span></p>
+              <p><span><b>Return type</b></span>: number</p>
             </section>
           </section>
         </section>
@@ -885,7 +885,7 @@
         </section>
         <section>
           <h3 id="testclass-signature">Signature</h3><code>export declare class TestClass&#x3C;TTypeParameterA, TTypeParameterB> extends TestAbstractClass</code>
-          <p><span><span><b>Extends</b></span>: <span><a href="docs/test-suite-a#testabstractclass-class">TestAbstractClass</a></span></span></p>
+          <p><span><b>Extends</b></span>: <a href="docs/test-suite-a#testabstractclass-class">TestAbstractClass</a></p>
           <section>
             <h4>Type Parameters</h4>
             <table>
@@ -942,7 +942,7 @@
             <tbody>
               <tr>
                 <td><a href="docs/test-suite-a#testclass-testclassstaticproperty-property">testClassStaticProperty</a></td>
-                <td><span>(foo: number) => string</span></td>
+                <td>(foo: number) => string</td>
                 <td>Test static class property</td>
               </tr>
             </tbody>
@@ -961,7 +961,7 @@
             <tbody>
               <tr>
                 <td><a href="docs/test-suite-a#testclass-testclassstaticmethod-method">testClassStaticMethod(foo)</a></td>
-                <td><span>string</span></td>
+                <td>string</td>
                 <td>Test class static method</td>
               </tr>
             </tbody>
@@ -982,7 +982,7 @@
               <tr>
                 <td><a href="docs/test-suite-a#testclass-testclasseventproperty-property">testClassEventProperty</a></td>
                 <td><code>readonly</code></td>
-                <td><span>() => void</span></td>
+                <td>() => void</td>
                 <td>Test class event property</td>
               </tr>
             </tbody>
@@ -1003,19 +1003,19 @@
               <tr>
                 <td><a href="docs/test-suite-a#testclass-abstractpropertygetter-property">abstractPropertyGetter</a></td>
                 <td><code>readonly</code></td>
-                <td><span><a href="docs/test-suite-a#testmappedtype-typealias">TestMappedType</a></span></td>
+                <td><a href="docs/test-suite-a#testmappedtype-typealias">TestMappedType</a></td>
                 <td>A test abstract getter property.</td>
               </tr>
               <tr>
                 <td><a href="docs/test-suite-a#testclass-testclassgetterproperty-property">testClassGetterProperty</a></td>
                 <td><code>virtual</code></td>
-                <td><span>number</span></td>
+                <td>number</td>
                 <td>Test class property with both a getter and a setter.</td>
               </tr>
               <tr>
                 <td><a href="docs/test-suite-a#testclass-testclassproperty-property">testClassProperty</a></td>
                 <td><code>readonly</code></td>
-                <td><span>TTypeParameterB</span></td>
+                <td>TTypeParameterB</td>
                 <td>Test class property</td>
               </tr>
             </tbody>
@@ -1036,19 +1036,19 @@
               <tr>
                 <td><a href="docs/test-suite-a#testclass-publicabstractmethod-method">publicAbstractMethod()</a></td>
                 <td></td>
-                <td><span>void</span></td>
+                <td>void</td>
                 <td>A test public abstract method.</td>
               </tr>
               <tr>
                 <td><a href="docs/test-suite-a#testclass-testclassmethod-method">testClassMethod(input)</a></td>
                 <td><code>sealed</code></td>
-                <td><span>TTypeParameterA</span></td>
+                <td>TTypeParameterA</td>
                 <td>Test class method</td>
               </tr>
               <tr>
                 <td><a href="docs/test-suite-a#testclass-virtualmethod-method">virtualMethod()</a></td>
                 <td></td>
-                <td><span>number</span></td>
+                <td>number</td>
                 <td>Overrides <a href="docs/test-suite-a#testabstractclass-virtualmethod-method">virtualMethod()</a>.</td>
               </tr>
             </tbody>
@@ -1081,12 +1081,12 @@
                 <tbody>
                   <tr>
                     <td>privateProperty</td>
-                    <td><span>number</span></td>
+                    <td>number</td>
                     <td>See <a href="docs/test-suite-a#testabstractclass-class">TestAbstractClass</a>'s constructor.</td>
                   </tr>
                   <tr>
                     <td>protectedProperty</td>
-                    <td><span><a href="docs/test-suite-a#testenum-enum">TestEnum</a></span></td>
+                    <td><a href="docs/test-suite-a#testenum-enum">TestEnum</a></td>
                     <td>
                       <p>Some notes about the parameter.</p>
                       <p>See <a href="docs/test-suite-a#testabstractclass-protectedproperty-property">protectedProperty</a>.</p>
@@ -1094,12 +1094,12 @@
                   </tr>
                   <tr>
                     <td>testClassProperty</td>
-                    <td><span>TTypeParameterB</span></td>
+                    <td>TTypeParameterB</td>
                     <td>See <a href="docs/test-suite-a#testclass-testclassproperty-property">testClassProperty</a>.</td>
                   </tr>
                   <tr>
                     <td>testClassEventProperty</td>
-                    <td><span>() => void</span></td>
+                    <td>() => void</td>
                     <td>See <a href="docs/test-suite-a#testclass-testclasseventproperty-property">testClassEventProperty</a>.</td>
                   </tr>
                 </tbody>
@@ -1116,7 +1116,7 @@
             </section>
             <section>
               <h5 id="testclasseventproperty-signature">Signature</h5><code>readonly testClassEventProperty: () => void;</code>
-              <p><span><span><b>Type</b></span>: <span>() => void</span></span></p>
+              <p><span><b>Type</b></span>: () => void</p>
             </section>
             <section>
               <h5 id="testclasseventproperty-remarks">Remarks</h5>
@@ -1133,7 +1133,7 @@
             </section>
             <section>
               <h5 id="abstractpropertygetter-signature">Signature</h5><code>get abstractPropertyGetter(): TestMappedType;</code>
-              <p><span><span><b>Type</b></span>: <span><a href="docs/test-suite-a#testmappedtype-typealias">TestMappedType</a></span></span></p>
+              <p><span><b>Type</b></span>: <a href="docs/test-suite-a#testmappedtype-typealias">TestMappedType</a></p>
             </section>
           </section>
           <section>
@@ -1143,7 +1143,7 @@
             </section>
             <section>
               <h5 id="testclassgetterproperty-signature">Signature</h5><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br><br>set testClassGetterProperty(newValue: number);</code>
-              <p><span><span><b>Type</b></span>: <span>number</span></span></p>
+              <p><span><b>Type</b></span>: number</p>
             </section>
             <section>
               <h5 id="testclassgetterproperty-remarks">Remarks</h5>
@@ -1157,7 +1157,7 @@
             </section>
             <section>
               <h5 id="testclassproperty-signature">Signature</h5><code>readonly testClassProperty: TTypeParameterB;</code>
-              <p><span><span><b>Type</b></span>: <span>TTypeParameterB</span></span></p>
+              <p><span><b>Type</b></span>: TTypeParameterB</p>
             </section>
             <section>
               <h5 id="testclassproperty-remarks">Remarks</h5>
@@ -1171,7 +1171,7 @@
             </section>
             <section>
               <h5 id="testclassstaticproperty-signature">Signature</h5><code>static testClassStaticProperty: (foo: number) => string;</code>
-              <p><span><span><b>Type</b></span>: <span>(foo: number) => string</span></span></p>
+              <p><span><b>Type</b></span>: (foo: number) => string</p>
             </section>
           </section>
         </section>
@@ -1211,7 +1211,7 @@
                 <tbody>
                   <tr>
                     <td>input</td>
-                    <td><span>TTypeParameterA</span></td>
+                    <td>TTypeParameterA</td>
                     <td></td>
                   </tr>
                 </tbody>
@@ -1219,7 +1219,7 @@
             </section>
             <section>
               <h5 id="testclassmethod-returns">Returns</h5>
-              <p><span><b>Return type</b></span>: <span>TTypeParameterA</span></p>
+              <p><span><b>Return type</b></span>: TTypeParameterA</p>
             </section>
             <section>
               <h5 id="testclassmethod-throws">Throws</h5>
@@ -1248,7 +1248,7 @@
                 <tbody>
                   <tr>
                     <td>foo</td>
-                    <td><span>number</span></td>
+                    <td>number</td>
                     <td>Some number</td>
                   </tr>
                 </tbody>
@@ -1257,7 +1257,7 @@
             <section>
               <h5 id="testclassstaticmethod-returns">Returns</h5>
               <p>- Some string</p>
-              <p><span><b>Return type</b></span>: <span>string</span></p>
+              <p><span><b>Return type</b></span>: string</p>
             </section>
           </section>
           <section>
@@ -1270,7 +1270,7 @@
             </section>
             <section>
               <h5 id="virtualmethod-returns">Returns</h5>
-              <p><span><b>Return type</b></span>: <span>number</span></p>
+              <p><span><b>Return type</b></span>: number</p>
             </section>
           </section>
         </section>
@@ -1415,7 +1415,7 @@
         <section>
           <h3 id="testfunctionreturninginlinetype-returns">Returns</h3>
           <p>An inline type</p>
-          <p><span><b>Return type</b></span>: <span>{ foo: number; bar: <a href="docs/test-suite-a#testenum-enum">TestEnum</a>; }</span></p>
+          <p><span><b>Return type</b></span>: { foo: number; bar: <a href="docs/test-suite-a#testenum-enum">TestEnum</a>; }</p>
         </section>
       </section>
       <section>
@@ -1433,7 +1433,7 @@
         <section>
           <h3 id="testfunctionreturningintersectiontype-returns">Returns</h3>
           <p>an intersection type</p>
-          <p><span><b>Return type</b></span>: <span><a href="docs/test-suite-a#testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="docs/test-suite-a#testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></p>
+          <p><span><b>Return type</b></span>: <a href="docs/test-suite-a#testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="docs/test-suite-a#testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></p>
         </section>
       </section>
       <section>
@@ -1447,7 +1447,7 @@
         <section>
           <h3 id="testfunctionreturninguniontype-returns">Returns</h3>
           <p>A union type</p>
-          <p><span><b>Return type</b></span>: <span>string | <a href="docs/test-suite-a#testinterface-interface">TestInterface</a></span></p>
+          <p><span><b>Return type</b></span>: string | <a href="docs/test-suite-a#testinterface-interface">TestInterface</a></p>
         </section>
       </section>
     </section>
@@ -1479,7 +1479,7 @@
         </section>
         <section>
           <h3 id="testconstwithemptydeprecatedblock-signature">Signature</h3><code>testConstWithEmptyDeprecatedBlock: string</code>
-          <p><span><span><b>Type</b></span>: <span>string</span></span></p>
+          <p><span><b>Type</b></span>: string</p>
         </section>
       </section>
     </section>
@@ -1675,7 +1675,7 @@
             <tbody>
               <tr>
                 <td><a href="docs/test-suite-a#testnamespace-testfunction-function">testFunction(testParameter)</a></td>
-                <td><span>number</span></td>
+                <td>number</td>
                 <td>Test function</td>
               </tr>
             </tbody>
@@ -1763,7 +1763,7 @@
                   <tr>
                     <td><a href="docs/test-suite-a#testnamespace-testclass-testclassproperty-property">testClassProperty</a></td>
                     <td><code>readonly</code></td>
-                    <td><span>string</span></td>
+                    <td>string</td>
                     <td>Test interface property</td>
                   </tr>
                 </tbody>
@@ -1782,7 +1782,7 @@
                 <tbody>
                   <tr>
                     <td><a href="docs/test-suite-a#testnamespace-testclass-testclassmethod-method">testClassMethod(testParameter)</a></td>
-                    <td><span>Promise&#x3C;string></span></td>
+                    <td>Promise&#x3C;string></td>
                     <td>Test class method</td>
                   </tr>
                 </tbody>
@@ -1808,7 +1808,7 @@
                     <tbody>
                       <tr>
                         <td>testClassProperty</td>
-                        <td><span>string</span></td>
+                        <td>string</td>
                         <td>See <a href="docs/test-suite-a#testclass-testclassproperty-property">testClassProperty</a></td>
                       </tr>
                     </tbody>
@@ -1824,7 +1824,7 @@
                   <p>Test interface property</p>
                 </section>
                 <section><a id="testclassproperty-signature"></a><b>Signature</b><code>readonly testClassProperty: string;</code>
-                  <p><span><span><b>Type</b></span>: <span>string</span></span></p>
+                  <p><span><b>Type</b></span>: string</p>
                 </section>
               </section>
             </section>
@@ -1848,7 +1848,7 @@
                     <tbody>
                       <tr>
                         <td>testParameter</td>
-                        <td><span>string</span></td>
+                        <td>string</td>
                         <td>A string</td>
                       </tr>
                     </tbody>
@@ -1856,7 +1856,7 @@
                 </section>
                 <section><a id="testclassmethod-returns"></a><b>Returns</b>
                   <p>A Promise</p>
-                  <p><span><b>Return type</b></span>: <span>Promise&#x3C;string></span></p>
+                  <p><span><b>Return type</b></span>: Promise&#x3C;string></p>
                 </section>
                 <section><a id="testclassmethod-throws"></a><b>Throws</b>
                   <p>An Error when something happens for which an error should be thrown. Except in the cases where another kind of error is thrown. We don't throw this error in those cases.</p>
@@ -1951,7 +1951,7 @@
                 <tbody>
                   <tr>
                     <td>testParameter</td>
-                    <td><span>number</span></td>
+                    <td>number</td>
                     <td></td>
                   </tr>
                 </tbody>
@@ -1960,7 +1960,7 @@
             <section>
               <h5 id="testfunction-returns">Returns</h5>
               <p>A number</p>
-              <p><span><b>Return type</b></span>: <span>number</span></p>
+              <p><span><b>Return type</b></span>: number</p>
             </section>
             <section>
               <h5 id="testfunction-throws">Throws</h5>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-b.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-b.html
@@ -47,7 +47,7 @@
             <tbody>
               <tr>
                 <td><a href="docs/test-suite-b#foo-bar-propertysignature">bar</a></td>
-                <td><span><a href="docs/test-suite-a#testenum-enum">TestEnum</a></span></td>
+                <td><a href="docs/test-suite-a#testenum-enum">TestEnum</a></td>
                 <td>Test Enum</td>
               </tr>
             </tbody>
@@ -62,7 +62,7 @@
             </section>
             <section>
               <h5 id="bar-signature">Signature</h5><code>bar: TestEnum;</code>
-              <p><span><span><b>Type</b></span>: <span><a href="docs/test-suite-a#testenum-enum">TestEnum</a></span></span></p>
+              <p><span><b>Type</b></span>: <a href="docs/test-suite-a#testenum-enum">TestEnum</a></p>
             </section>
             <section>
               <h5 id="bar-remarks">Remarks</h5>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/index.html
@@ -135,19 +135,19 @@
             <tr>
               <td><a href="docs/test-suite-a/testfunctionreturninginlinetype-function">testFunctionReturningInlineType()</a></td>
               <td></td>
-              <td><span>{ foo: number; bar: <a href="docs/test-suite-a/testenum-enum">TestEnum</a>; }</span></td>
+              <td>{ foo: number; bar: <a href="docs/test-suite-a/testenum-enum">TestEnum</a>; }</td>
               <td>Test function that returns an inline type</td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testfunctionreturningintersectiontype-function">testFunctionReturningIntersectionType()</a></td>
               <td><code>Deprecated</code></td>
-              <td><span><a href="docs/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="docs/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></td>
+              <td><a href="docs/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="docs/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></td>
               <td>Test function that returns an inline type</td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testfunctionreturninguniontype-function">testFunctionReturningUnionType()</a></td>
               <td></td>
-              <td><span>string | <a href="docs/test-suite-a/testinterface-interface">TestInterface</a></span></td>
+              <td>string | <a href="docs/test-suite-a/testinterface-interface">TestInterface</a></td>
               <td>Test function that returns an inline type</td>
             </tr>
           </tbody>
@@ -170,7 +170,7 @@
               <td><a href="docs/test-suite-a/testconstwithemptydeprecatedblock-variable">testConstWithEmptyDeprecatedBlock</a></td>
               <td><code>Deprecated</code></td>
               <td><code>readonly</code></td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>I have a <code>@deprecated</code> tag with an empty comment block.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-_constructor_-constructor.html
@@ -25,12 +25,12 @@
           <tbody>
             <tr>
               <td>privateProperty</td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td></td>
             </tr>
             <tr>
               <td>protectedProperty</td>
-              <td><span><a href="docs/test-suite-a/testenum-enum">TestEnum</a></span></td>
+              <td><a href="docs/test-suite-a/testenum-enum">TestEnum</a></td>
               <td></td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-abstractpropertygetter-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-abstractpropertygetter-property.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="abstractpropertygetter-signature">Signature</h3><code>abstract get abstractPropertyGetter(): TestMappedType;</code>
-        <p><span><span><b>Type</b></span>: <span><a href="docs/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></span></p>
+        <p><span><b>Type</b></span>: <a href="docs/test-suite-a/testmappedtype-typealias">TestMappedType</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-class.html
@@ -44,13 +44,13 @@
             <tr>
               <td><a href="docs/test-suite-a/testabstractclass-abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="docs/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></td>
+              <td><a href="docs/test-suite-a/testmappedtype-typealias">TestMappedType</a></td>
               <td>A test abstract getter property.</td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testabstractclass-protectedproperty-property">protectedProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="docs/test-suite-a/testenum-enum">TestEnum</a></span></td>
+              <td><a href="docs/test-suite-a/testenum-enum">TestEnum</a></td>
               <td>A test protected property.</td>
             </tr>
           </tbody>
@@ -71,19 +71,19 @@
             <tr>
               <td><a href="docs/test-suite-a/testabstractclass-publicabstractmethod-method">publicAbstractMethod()</a></td>
               <td></td>
-              <td><span>void</span></td>
+              <td>void</td>
               <td>A test public abstract method.</td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testabstractclass-sealedmethod-method">sealedMethod()</a></td>
               <td><code>sealed</code></td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>A test <code>@sealed</code> method.</td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testabstractclass-virtualmethod-method">virtualMethod()</a></td>
               <td><code>virtual</code></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>A test <code>@virtual</code> method.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-protectedproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-protectedproperty-property.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="protectedproperty-signature">Signature</h3><code>protected readonly protectedProperty: TestEnum;</code>
-        <p><span><span><b>Type</b></span>: <span><a href="docs/test-suite-a/testenum-enum">TestEnum</a></span></span></p>
+        <p><span><b>Type</b></span>: <a href="docs/test-suite-a/testenum-enum">TestEnum</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-sealedmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-sealedmethod-method.html
@@ -15,7 +15,7 @@
       <section>
         <h3 id="sealedmethod-returns">Returns</h3>
         <p>A string!</p>
-        <p><span><b>Return type</b></span>: <span>string</span></p>
+        <p><span><b>Return type</b></span>: string</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-virtualmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-virtualmethod-method.html
@@ -15,7 +15,7 @@
       <section>
         <h3 id="virtualmethod-returns">Returns</h3>
         <p>A number!</p>
-        <p><span><b>Return type</b></span>: <span>number</span></p>
+        <p><span><b>Return type</b></span>: number</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-_constructor_-constructor.html
@@ -29,12 +29,12 @@
           <tbody>
             <tr>
               <td>privateProperty</td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>See <a href="docs/test-suite-a/testabstractclass-class">TestAbstractClass</a>'s constructor.</td>
             </tr>
             <tr>
               <td>protectedProperty</td>
-              <td><span><a href="docs/test-suite-a/testenum-enum">TestEnum</a></span></td>
+              <td><a href="docs/test-suite-a/testenum-enum">TestEnum</a></td>
               <td>
                 <p>Some notes about the parameter.</p>
                 <p>See <a href="docs/test-suite-a/testabstractclass-protectedproperty-property">protectedProperty</a>.</p>
@@ -42,12 +42,12 @@
             </tr>
             <tr>
               <td>testClassProperty</td>
-              <td><span>TTypeParameterB</span></td>
+              <td>TTypeParameterB</td>
               <td>See <a href="docs/test-suite-a/testclass-testclassproperty-property">testClassProperty</a>.</td>
             </tr>
             <tr>
               <td>testClassEventProperty</td>
-              <td><span>() => void</span></td>
+              <td>() => void</td>
               <td>See <a href="docs/test-suite-a/testclass-testclasseventproperty-property">testClassEventProperty</a>.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-abstractpropertygetter-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-abstractpropertygetter-property.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="abstractpropertygetter-signature">Signature</h3><code>get abstractPropertyGetter(): TestMappedType;</code>
-        <p><span><span><b>Type</b></span>: <span><a href="docs/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></span></p>
+        <p><span><b>Type</b></span>: <a href="docs/test-suite-a/testmappedtype-typealias">TestMappedType</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-class.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="testclass-signature">Signature</h3><code>export declare class TestClass&#x3C;TTypeParameterA, TTypeParameterB> extends TestAbstractClass</code>
-        <p><span><span><b>Extends</b></span>: <span><a href="docs/test-suite-a/testabstractclass-class">TestAbstractClass</a></span></span></p>
+        <p><span><b>Extends</b></span>: <a href="docs/test-suite-a/testabstractclass-class">TestAbstractClass</a></p>
         <section>
           <h4>Type Parameters</h4>
           <table>
@@ -68,7 +68,7 @@
           <tbody>
             <tr>
               <td><a href="docs/test-suite-a/testclass-testclassstaticproperty-property">testClassStaticProperty</a></td>
-              <td><span>(foo: number) => string</span></td>
+              <td>(foo: number) => string</td>
               <td>Test static class property</td>
             </tr>
           </tbody>
@@ -87,7 +87,7 @@
           <tbody>
             <tr>
               <td><a href="docs/test-suite-a/testclass-testclassstaticmethod-method">testClassStaticMethod(foo)</a></td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>Test class static method</td>
             </tr>
           </tbody>
@@ -108,7 +108,7 @@
             <tr>
               <td><a href="docs/test-suite-a/testclass-testclasseventproperty-property">testClassEventProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span>() => void</span></td>
+              <td>() => void</td>
               <td>Test class event property</td>
             </tr>
           </tbody>
@@ -129,19 +129,19 @@
             <tr>
               <td><a href="docs/test-suite-a/testclass-abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
-              <td><span><a href="docs/test-suite-a/testmappedtype-typealias">TestMappedType</a></span></td>
+              <td><a href="docs/test-suite-a/testmappedtype-typealias">TestMappedType</a></td>
               <td>A test abstract getter property.</td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testclass-testclassgetterproperty-property">testClassGetterProperty</a></td>
               <td><code>virtual</code></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test class property with both a getter and a setter.</td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testclass-testclassproperty-property">testClassProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span>TTypeParameterB</span></td>
+              <td>TTypeParameterB</td>
               <td>Test class property</td>
             </tr>
           </tbody>
@@ -162,19 +162,19 @@
             <tr>
               <td><a href="docs/test-suite-a/testclass-publicabstractmethod-method">publicAbstractMethod()</a></td>
               <td></td>
-              <td><span>void</span></td>
+              <td>void</td>
               <td>A test public abstract method.</td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testclass-testclassmethod-method">testClassMethod(input)</a></td>
               <td><code>sealed</code></td>
-              <td><span>TTypeParameterA</span></td>
+              <td>TTypeParameterA</td>
               <td>Test class method</td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testclass-virtualmethod-method">virtualMethod()</a></td>
               <td></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Overrides <a href="docs/test-suite-a/testabstractclass-virtualmethod-method">virtualMethod()</a>.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclasseventproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclasseventproperty-property.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="testclasseventproperty-signature">Signature</h3><code>readonly testClassEventProperty: () => void;</code>
-        <p><span><span><b>Type</b></span>: <span>() => void</span></span></p>
+        <p><span><b>Type</b></span>: () => void</p>
       </section>
       <section>
         <h3 id="testclasseventproperty-remarks">Remarks</h3>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclassgetterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclassgetterproperty-property.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="testclassgetterproperty-signature">Signature</h3><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br><br>set testClassGetterProperty(newValue: number);</code>
-        <p><span><span><b>Type</b></span>: <span>number</span></span></p>
+        <p><span><b>Type</b></span>: number</p>
       </section>
       <section>
         <h3 id="testclassgetterproperty-remarks">Remarks</h3>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclassmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclassmethod-method.html
@@ -29,7 +29,7 @@
           <tbody>
             <tr>
               <td>input</td>
-              <td><span>TTypeParameterA</span></td>
+              <td>TTypeParameterA</td>
               <td></td>
             </tr>
           </tbody>
@@ -37,7 +37,7 @@
       </section>
       <section>
         <h3 id="testclassmethod-returns">Returns</h3>
-        <p><span><b>Return type</b></span>: <span>TTypeParameterA</span></p>
+        <p><span><b>Return type</b></span>: TTypeParameterA</p>
       </section>
       <section>
         <h3 id="testclassmethod-throws">Throws</h3>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclassproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclassproperty-property.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="testclassproperty-signature">Signature</h3><code>readonly testClassProperty: TTypeParameterB;</code>
-        <p><span><span><b>Type</b></span>: <span>TTypeParameterB</span></span></p>
+        <p><span><b>Type</b></span>: TTypeParameterB</p>
       </section>
       <section>
         <h3 id="testclassproperty-remarks">Remarks</h3>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclassstaticmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclassstaticmethod-method.html
@@ -25,7 +25,7 @@
           <tbody>
             <tr>
               <td>foo</td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Some number</td>
             </tr>
           </tbody>
@@ -34,7 +34,7 @@
       <section>
         <h3 id="testclassstaticmethod-returns">Returns</h3>
         <p>- Some string</p>
-        <p><span><b>Return type</b></span>: <span>string</span></p>
+        <p><span><b>Return type</b></span>: string</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclassstaticproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclassstaticproperty-property.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="testclassstaticproperty-signature">Signature</h3><code>static testClassStaticProperty: (foo: number) => string;</code>
-        <p><span><span><b>Type</b></span>: <span>(foo: number) => string</span></span></p>
+        <p><span><b>Type</b></span>: (foo: number) => string</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-virtualmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-virtualmethod-method.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h3 id="virtualmethod-returns">Returns</h3>
-        <p><span><b>Return type</b></span>: <span>number</span></p>
+        <p><span><b>Return type</b></span>: number</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testconstwithemptydeprecatedblock-variable.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h3 id="testconstwithemptydeprecatedblock-signature">Signature</h3><code>testConstWithEmptyDeprecatedBlock: string</code>
-        <p><span><span><b>Type</b></span>: <span>string</span></span></p>
+        <p><span><b>Type</b></span>: string</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testfunctionreturninginlinetype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testfunctionreturninginlinetype-function.html
@@ -15,7 +15,7 @@
       <section>
         <h3 id="testfunctionreturninginlinetype-returns">Returns</h3>
         <p>An inline type</p>
-        <p><span><b>Return type</b></span>: <span>{ foo: number; bar: <a href="docs/test-suite-a/testenum-enum">TestEnum</a>; }</span></p>
+        <p><span><b>Return type</b></span>: { foo: number; bar: <a href="docs/test-suite-a/testenum-enum">TestEnum</a>; }</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testfunctionreturningintersectiontype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testfunctionreturningintersectiontype-function.html
@@ -19,7 +19,7 @@
       <section>
         <h3 id="testfunctionreturningintersectiontype-returns">Returns</h3>
         <p>an intersection type</p>
-        <p><span><b>Return type</b></span>: <span><a href="docs/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="docs/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></p>
+        <p><span><b>Return type</b></span>: <a href="docs/test-suite-a/testemptyinterface-interface">TestEmptyInterface</a> &#x26; <a href="docs/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testfunctionreturninguniontype-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testfunctionreturninguniontype-function.html
@@ -15,7 +15,7 @@
       <section>
         <h3 id="testfunctionreturninguniontype-returns">Returns</h3>
         <p>A union type</p>
-        <p><span><b>Return type</b></span>: <span>string | <a href="docs/test-suite-a/testinterface-interface">TestInterface</a></span></p>
+        <p><span><b>Return type</b></span>: string | <a href="docs/test-suite-a/testinterface-interface">TestInterface</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-_new_-constructsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-_new_-constructsignature.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h3 id="_new_-returns">Returns</h3>
-        <p><span><b>Return type</b></span>: <span><a href="docs/test-suite-a/testinterface-interface">TestInterface</a></span></p>
+        <p><span><b>Return type</b></span>: <a href="docs/test-suite-a/testinterface-interface">TestInterface</a></p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-getterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-getterproperty-property.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="getterproperty-signature">Signature</h3><code>get getterProperty(): boolean;</code>
-        <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+        <p><span><b>Type</b></span>: boolean</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-interface.html
@@ -29,7 +29,7 @@
           <tbody>
             <tr>
               <td><a href="docs/test-suite-a/testinterface-_new_-constructsignature">new (): TestInterface</a></td>
-              <td><span><a href="docs/test-suite-a/testinterface-interface">TestInterface</a></span></td>
+              <td><a href="docs/test-suite-a/testinterface-interface">TestInterface</a></td>
               <td>Test construct signature.</td>
             </tr>
           </tbody>
@@ -50,7 +50,7 @@
             <tr>
               <td><a href="docs/test-suite-a/testinterface-testclasseventproperty-propertysignature">testClassEventProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span>() => void</span></td>
+              <td>() => void</td>
               <td>Test interface event property</td>
             </tr>
           </tbody>
@@ -73,35 +73,35 @@
               <td><a href="docs/test-suite-a/testinterface-getterproperty-property">getterProperty</a></td>
               <td><code>readonly</code></td>
               <td></td>
-              <td><span>boolean</span></td>
+              <td>boolean</td>
               <td>A test getter-only interface property.</td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testinterface-propertywithbadinheritdoctarget-propertysignature">propertyWithBadInheritDocTarget</a></td>
               <td></td>
               <td></td>
-              <td><span>boolean</span></td>
+              <td>boolean</td>
               <td></td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testinterface-setterproperty-property">setterProperty</a></td>
               <td></td>
               <td></td>
-              <td><span>boolean</span></td>
+              <td>boolean</td>
               <td>A test property with a getter and a setter.</td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testinterface-testinterfaceproperty-propertysignature">testInterfaceProperty</a></td>
               <td></td>
               <td></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test interface property</td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testinterface-testoptionalinterfaceproperty-propertysignature">testOptionalInterfaceProperty</a></td>
               <td><code>optional</code></td>
               <td>0</td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test optional property</td>
             </tr>
           </tbody>
@@ -120,7 +120,7 @@
           <tbody>
             <tr>
               <td><a href="docs/test-suite-a/testinterface-testinterfacemethod-methodsignature">testInterfaceMethod()</a></td>
-              <td><span>void</span></td>
+              <td>void</td>
               <td>Test interface method</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-propertywithbadinheritdoctarget-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-propertywithbadinheritdoctarget-propertysignature.html
@@ -8,7 +8,7 @@
       <h2>propertyWithBadInheritDocTarget</h2>
       <section>
         <h3 id="propertywithbadinheritdoctarget-signature">Signature</h3><code>propertyWithBadInheritDocTarget: boolean;</code>
-        <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+        <p><span><b>Type</b></span>: boolean</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-setterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-setterproperty-property.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="setterproperty-signature">Signature</h3><code>get setterProperty(): boolean;<br><br><br>set setterProperty(newValue: boolean);</code>
-        <p><span><span><b>Type</b></span>: <span>boolean</span></span></p>
+        <p><span><b>Type</b></span>: boolean</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-testclasseventproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-testclasseventproperty-propertysignature.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="testclasseventproperty-signature">Signature</h3><code>readonly testClassEventProperty: () => void;</code>
-        <p><span><span><b>Type</b></span>: <span>() => void</span></span></p>
+        <p><span><b>Type</b></span>: () => void</p>
       </section>
       <section>
         <h3 id="testclasseventproperty-remarks">Remarks</h3>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-testinterfaceproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-testinterfaceproperty-propertysignature.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="testinterfaceproperty-signature">Signature</h3><code>testInterfaceProperty: number;</code>
-        <p><span><span><b>Type</b></span>: <span>number</span></span></p>
+        <p><span><b>Type</b></span>: number</p>
       </section>
       <section>
         <h3 id="testinterfaceproperty-remarks">Remarks</h3>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-testoptionalinterfaceproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-testoptionalinterfaceproperty-propertysignature.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="testoptionalinterfaceproperty-signature">Signature</h3><code>testOptionalInterfaceProperty?: number;</code>
-        <p><span><span><b>Type</b></span>: <span>number</span></span></p>
+        <p><span><b>Type</b></span>: number</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterfaceextendingotherinterfaces-interface.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="testinterfaceextendingotherinterfaces-signature">Signature</h3><code>export interface TestInterfaceExtendingOtherInterfaces extends TestInterface, TestMappedType, TestInterfaceWithTypeParameter&#x3C;number></code>
-        <p><span><span><b>Extends</b></span>: <span><a href="docs/test-suite-a/testinterface-interface">TestInterface</a></span>, <span><a href="docs/test-suite-a/testmappedtype-typealias">TestMappedType</a></span>, <span><a href="docs/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></span></span></p>
+        <p><span><b>Extends</b></span>: <a href="docs/test-suite-a/testinterface-interface">TestInterface</a>, <a href="docs/test-suite-a/testmappedtype-typealias">TestMappedType</a>, <a href="docs/test-suite-a/testinterfacewithtypeparameter-interface">TestInterfaceWithTypeParameter</a>&#x3C;number></p>
       </section>
       <section>
         <h3 id="testinterfaceextendingotherinterfaces-remarks">Remarks</h3>
@@ -30,7 +30,7 @@
           <tbody>
             <tr>
               <td><a href="docs/test-suite-a/testinterfaceextendingotherinterfaces-testmethod-methodsignature">testMethod(input)</a></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test interface method accepting a string and returning a number.</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterfaceextendingotherinterfaces-testmethod-methodsignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterfaceextendingotherinterfaces-testmethod-methodsignature.html
@@ -29,7 +29,7 @@
           <tbody>
             <tr>
               <td>input</td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>A string</td>
             </tr>
           </tbody>
@@ -38,7 +38,7 @@
       <section>
         <h3 id="testmethod-returns">Returns</h3>
         <p>A number</p>
-        <p><span><b>Return type</b></span>: <span>number</span></p>
+        <p><span><b>Return type</b></span>: number</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterfacewithtypeparameter-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterfacewithtypeparameter-interface.html
@@ -46,7 +46,7 @@
           <tbody>
             <tr>
               <td><a href="docs/test-suite-a/testinterfacewithtypeparameter-testproperty-propertysignature">testProperty</a></td>
-              <td><span>T</span></td>
+              <td>T</td>
               <td>A test interface property using generic type parameter</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterfacewithtypeparameter-testproperty-propertysignature.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterfacewithtypeparameter-testproperty-propertysignature.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="testproperty-signature">Signature</h3><code>testProperty: T;</code>
-        <p><span><span><b>Type</b></span>: <span>T</span></span></p>
+        <p><span><b>Type</b></span>: T</p>
       </section>
       <section>
         <h3 id="testproperty-remarks">Remarks</h3>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-namespace.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-namespace.html
@@ -91,7 +91,7 @@
           <tbody>
             <tr>
               <td><a href="docs/test-suite-a/testnamespace-testfunction-function">testFunction(testParameter)</a></td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td>Test function</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-_constructor_-constructor.html
@@ -25,7 +25,7 @@
           <tbody>
             <tr>
               <td>testClassProperty</td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>See <a href="docs/test-suite-a/testclass-testclassproperty-property">testClassProperty</a></td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-class.html
@@ -44,7 +44,7 @@
             <tr>
               <td><a href="docs/test-suite-a/testnamespace-testclass-testclassproperty-property">testClassProperty</a></td>
               <td><code>readonly</code></td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>Test interface property</td>
             </tr>
           </tbody>
@@ -63,7 +63,7 @@
           <tbody>
             <tr>
               <td><a href="docs/test-suite-a/testnamespace-testclass-testclassmethod-method">testClassMethod(testParameter)</a></td>
-              <td><span>Promise&#x3C;string></span></td>
+              <td>Promise&#x3C;string></td>
               <td>Test class method</td>
             </tr>
           </tbody>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-testclassmethod-method.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-testclassmethod-method.html
@@ -25,7 +25,7 @@
           <tbody>
             <tr>
               <td>testParameter</td>
-              <td><span>string</span></td>
+              <td>string</td>
               <td>A string</td>
             </tr>
           </tbody>
@@ -34,7 +34,7 @@
       <section>
         <h3 id="testclassmethod-returns">Returns</h3>
         <p>A Promise</p>
-        <p><span><b>Return type</b></span>: <span>Promise&#x3C;string></span></p>
+        <p><span><b>Return type</b></span>: Promise&#x3C;string></p>
       </section>
       <section>
         <h3 id="testclassmethod-throws">Throws</h3>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-testclassproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-testclass-testclassproperty-property.html
@@ -11,7 +11,7 @@
       </section>
       <section>
         <h3 id="testclassproperty-signature">Signature</h3><code>readonly testClassProperty: string;</code>
-        <p><span><span><b>Type</b></span>: <span>string</span></span></p>
+        <p><span><b>Type</b></span>: string</p>
       </section>
     </section>
   </body>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-testfunction-function.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-testfunction-function.html
@@ -25,7 +25,7 @@
           <tbody>
             <tr>
               <td>testParameter</td>
-              <td><span>number</span></td>
+              <td>number</td>
               <td></td>
             </tr>
           </tbody>
@@ -34,7 +34,7 @@
       <section>
         <h3 id="testfunction-returns">Returns</h3>
         <p>A number</p>
-        <p><span><b>Return type</b></span>: <span>number</span></p>
+        <p><span><b>Return type</b></span>: number</p>
       </section>
       <section>
         <h3 id="testfunction-throws">Throws</h3>


### PR DESCRIPTION
Updates `SpanNode`s in 2 ways:
1. They now _require_ a `formatting` parameter.
2. They no longer support _disabling_ formatting at a lower scope. This functionality was unused and makes transformations more complicated than they need to be. Subsequent PRs will simplify transformation code (doing so will have a large impact on our test output - a separate PR should make review easier).

This PR also cleans up usages that were just using `SpanNode` as a grouping mechanism to no longer do so. The result is greatly reduced nesting in output trees. See updated HTML test output for an example of the impact.