### PR TITLE
Revert "test(benchmarks): Increase pipeline timeout threshold since we have more tests"

### DIFF
--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -101,7 +101,6 @@ stages:
     - job: perf_unit_tests_runtime
       displayName: Perf unit tests - runtime
       pool: ${{ parameters.poolBuild }}
-      timeoutInMinutes: ${{ coalesce(endpointObject.timeoutInMinutes, 90) }}
       steps:
       - template: /tools/pipelines/templates/include-test-perf-benchmarks.yml@self
         parameters:


### PR DESCRIPTION
Reverts microsoft/FluidFramework#24937 since it introduces a syntax error that prevents the pipeline from running.