### PR TITLE
Update E2E exclusive lock behavior 

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -111,6 +111,8 @@ parameters:
 
 stages:
 - stage: ${{ parameters.stageId}}
+  ${{ if or(eq(parameters.stageId, 'e2e_routerlicious'), eq(parameters.stageId, 'e2e_frs') }}:
+    lockBehavior: sequential
   condition: ${{ parameters.condition }}
   displayName: ${{ parameters.stageDisplayName }}
   dependsOn: ${{ parameters.stageDependencies }}

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -111,7 +111,7 @@ parameters:
 
 stages:
 - stage: ${{ parameters.stageId}}
-  ${{ if or(eq(parameters.stageId, 'e2e_routerlicious'), eq(parameters.stageId, 'e2e_frs') }}:
+  ${{ if or(eq(parameters.stageId, 'e2e_routerlicious'), eq(parameters.stageId, 'e2e_frs')) }}:
     lockBehavior: sequential
   condition: ${{ parameters.condition }}
   displayName: ${{ parameters.stageDisplayName }}

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -100,7 +100,6 @@ stages:
         r11sSelfSignedCertSecureFile: wu2-ppe-tls-certificate.pem
       ${{ else }}:
         r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
-      lockBehavior: sequential
       stageVariables:
         - group: e2e-r11s-lock
       splitTestVariants:
@@ -136,7 +135,6 @@ stages:
       continueOnError: true
       testCommand: test:realsvc:frs:report
       r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
-      lockBehavior: sequential
       stageVariables:
         - group: e2e-frs-lock
       splitTestVariants:

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -45,7 +45,6 @@ variables:
 - name: DisableCodeQL
   value: true
 
-lockBehavior: sequential
 stages:
 
   - template: /tools/pipelines/templates/include-test-real-service.yml@self
@@ -101,6 +100,7 @@ stages:
         r11sSelfSignedCertSecureFile: wu2-ppe-tls-certificate.pem
       ${{ else }}:
         r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
+      lockBehavior: sequential
       stageVariables:
         - group: e2e-r11s-lock
       splitTestVariants:
@@ -136,6 +136,7 @@ stages:
       continueOnError: true
       testCommand: test:realsvc:frs:report
       r11sSelfSignedCertSecureFile: wu2-tls-certificate.pem
+      lockBehavior: sequential
       stageVariables:
         - group: e2e-frs-lock
       splitTestVariants:


### PR DESCRIPTION
Instead of forcing all stages to wait for a lock before running the e2e tests, only lock the necessary stages to run sequentially. 