### PR TITLE
Enable rehydration in top-level tree tests

### DIFF
--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -382,6 +382,12 @@ export interface DDSFuzzSuiteOptions {
 	detachedStartOptions: {
 		numOpsBeforeAttach: number;
 		rehydrateDisabled?: true;
+		/**
+		 * If true, disable rehydrating DDSes while they are in the "attaching" state.
+		 *
+		 * BEWARE: The harness has known correctness issues with rehydration when there are outstanding id compressor ops. DDSes that use id-compressor
+		 * should set this to `true` if they test rehydration. AB#43127 has more context.
+		 */
 		attachingBeforeRehydrateDisable?: true;
 	};
 
@@ -774,7 +780,9 @@ export function mixinAttach<
 			state.isDetached = false;
 			assert.equal(state.clients.length, 1);
 			const clientA: ClientWithStashData<TChannelFactory> = state.clients[0];
-			finalizeAllocatedIds(clientA);
+			if (clientA.dataStoreRuntime.attachState === AttachState.Detached) {
+				finalizeAllocatedIds(clientA);
+			}
 			clientA.dataStoreRuntime.setAttachState(AttachState.Attached);
 			const services: IChannelServices = {
 				deltaConnection: clientA.dataStoreRuntime.createDeltaConnection(),
@@ -818,6 +826,11 @@ export function mixinAttach<
 
 			state.containerRuntimeFactory.removeContainerRuntime(clientA.containerRuntime);
 
+			// TODO: AB#43127: Using a detached load here is not right with respect to id compressor ops in all cases.
+			// The general strategy that the mocks use for resubmit does not align with the production implementation,
+			// and that should probably be rectified here. The immediate problem with using `loadDetached` here is that
+			// it finalizes IDs, which is only OK if this rehydrate is happening while the container is detached (not attaching).
+			// See comment on `attachingBeforeRehydrateDisable` for more context.
 			const summarizerClient = await loadDetached(
 				state.containerRuntimeFactory,
 				clientA,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -68,7 +68,7 @@ describe("Fuzz - Top-Level", () => {
 			// and using the default number of ops before attach.
 			detachedStartOptions: {
 				numOpsBeforeAttach: 5,
-				rehydrateDisabled: true,
+				attachingBeforeRehydrateDisable: true,
 			},
 			reconnectProbability: 0.1,
 			idCompressorFactory: deterministicIdCompressorFactory(0xdeadbeef),


### PR DESCRIPTION
## Description

Relaxes tree's `rehydrateDisabled` to `attachingBeforeRehydrateDisable`. This allows the top-level fuzz tests to test scenarios where a container is serialized/rehydrated before being attached.

I've also added comments around relevant places in the DDS fuzz harness referencing [AB#43127](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/43127)--its current logic is just not correct w.r.t the intersection of id-compressor ops and rehydration-while-attaching.