### PR TITLE
Enable more rehydration testing in tree

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/fuzz/move.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/move.fuzz.spec.ts
@@ -78,12 +78,13 @@ describe("Fuzz - move", () => {
 		},
 		detachedStartOptions: {
 			numOpsBeforeAttach: 5,
-			rehydrateDisabled: true,
+			// AB#43127: fully allowing rehydrate after attach is currently not supported in tests (but should be in prod) due to limitations in the test mocks.
+			attachingBeforeRehydrateDisable: true,
 		},
 		reconnectProbability: 0.1,
 		idCompressorFactory: deterministicIdCompressorFactory(0xdeadbeef),
 		// TODO: AB#31176 tracks failing seeds when trying to synchronize with move edits.
-		skip: [37],
+		skip: [38],
 	};
 	createDDSFuzzSuite(model, options);
 });

--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -64,10 +64,9 @@ describe("Fuzz - Top-Level", () => {
 				clientAddProbability: 0,
 				maxNumberOfClients: 3,
 			},
-			// AB#7162: enabling rehydrate in these tests hits 0x744 and 0x79d. Disabling rehydrate for now
-			// and using the default number of ops before attach.
 			detachedStartOptions: {
 				numOpsBeforeAttach: 5,
+				// AB#43127: fully allowing rehydrate after attach is currently not supported in tests (but should be in prod) due to limitations in the test mocks.
 				attachingBeforeRehydrateDisable: true,
 			},
 			reconnectProbability: 0.1,
@@ -98,9 +97,10 @@ describe("Fuzz - Top-Level", () => {
 				flushMode: FlushMode.TurnBased,
 				enableGroupedBatching: true,
 			},
-			// AB#7162: see comment above.
 			detachedStartOptions: {
 				numOpsBeforeAttach: 5,
+				// AB#43127: fully allowing rehydrate after attach is currently not supported in tests (but should be in prod) due to limitations in the test mocks.
+				attachingBeforeRehydrateDisable: true,
 			},
 			saveFailures: {
 				directory: failureDirectory,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
@@ -147,7 +147,7 @@ describe("Fuzz - revert", () => {
 			numberOfClients: 3,
 			detachedStartOptions: {
 				numOpsBeforeAttach: 0,
-				rehydrateDisabled: true,
+				// AB#43127: fully allowing rehydrate after attach is currently not supported in tests (but should be in prod) due to limitations in the test mocks.
 				attachingBeforeRehydrateDisable: true,
 			},
 			emitter,
@@ -202,7 +202,7 @@ describe("Fuzz - revert", () => {
 			numberOfClients: 3,
 			detachedStartOptions: {
 				numOpsBeforeAttach: 0,
-				rehydrateDisabled: true,
+				// AB#43127: fully allowing rehydrate after attach is currently not supported in tests (but should be in prod) due to limitations in the test mocks.
 				attachingBeforeRehydrateDisable: true,
 			},
 			emitter,


### PR DESCRIPTION
## Description

Updates more tree fuzz tests to use `attachingBeforeRehydrateDisable`. This allows these tests to exercise the rehydration path more (but only until the container is attached).

See https://github.com/microsoft/FluidFramework/pull/24943 for more details.

## Breaking Changes

None