### PR TITLE
feat(container-loader): add optional connection retry timeout 

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -406,7 +406,7 @@ export class ConnectionManager implements IConnectionManager {
 		reconnectAllowed: boolean,
 		private readonly logger: ITelemetryLoggerExt,
 		private readonly props: IConnectionManagerFactoryArgs,
-		private readonly _retryConnectionTimeoutMs?: number,
+		private readonly retryConnectionTimeoutMs?: number,
 	) {
 		this.clientDetails = this.client.details;
 		this.defaultReconnectionMode = this.client.mode;
@@ -706,9 +706,9 @@ export class ConnectionManager implements IConnectionManager {
 				}
 
 				// Check if the calculated delay would exceed the remaining timeout
-				if (this._retryConnectionTimeoutMs !== undefined) {
+				if (this.retryConnectionTimeoutMs !== undefined) {
 					const elapsedTime = performanceNow() - connectStartTime;
-					const remainingTime = this._retryConnectionTimeoutMs - elapsedTime;
+					const remainingTime = this.retryConnectionTimeoutMs - elapsedTime;
 
 					if (delayMs >= remainingTime) {
 						this.logger.sendTelemetryEvent({
@@ -717,7 +717,7 @@ export class ConnectionManager implements IConnectionManager {
 							duration: formatTick(elapsedTime),
 							calculatedDelayMs: delayMs,
 							remainingTimeMs: remainingTime,
-							timeoutMs: this._retryConnectionTimeoutMs,
+							timeoutMs: this.retryConnectionTimeoutMs,
 						});
 						// Throw the error immediately since waiting would exceed our timeout
 						throw normalizeError(origError, { props: fatalConnectErrorProp });

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -712,7 +712,7 @@ export class ConnectionManager implements IConnectionManager {
 
 					if (delayMs >= remainingTime) {
 						this.logger.sendTelemetryEvent({
-							eventName: "ConnectionCalculatedDelayExceedsTimeout",
+							eventName: "RetryDelayExceedsConnectionTimeout",
 							attempts: connectRepeatCount,
 							duration: formatTick(elapsedTime),
 							calculatedDelayMs: delayMs,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -248,7 +248,7 @@ export interface IContainerCreateProps {
 	readonly protocolHandlerBuilder?: ProtocolHandlerBuilder;
 
 	/**
-	 * Optional property for specifiying a timeout for retry connection loop.
+	 * Optional property for specifying a timeout for retry connection loop.
 	 * If provided, the connection manager will use this value as the maximum time to wait
 	 * for a successful connection before giving up throwing the most recent error.
 	 */

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -249,8 +249,12 @@ export interface IContainerCreateProps {
 
 	/**
 	 * Optional property for specifying a timeout for retry connection loop.
-	 * If provided, the connection manager will use this value as the maximum time to wait
+	 *
+	 * If provided, container will use this value as the maximum time to wait
 	 * for a successful connection before giving up throwing the most recent error.
+	 *
+	 * If not provided, default behavior will be to retry until non-retryable error occurs
+	 * OR if connection attempt is cancelled.
 	 */
 	readonly retryConnectionTimeoutMs?: number;
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -253,8 +253,7 @@ export interface IContainerCreateProps {
 	 * If provided, container will use this value as the maximum time to wait
 	 * for a successful connection before giving up throwing the most recent error.
 	 *
-	 * If not provided, default behavior will be to retry until non-retryable error occurs
-	 * OR if connection attempt is cancelled.
+	 * If not provided, default behavior will be to retry until non-retryable error occurs.
 	 */
 	readonly retryConnectionTimeoutMs?: number;
 }

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -246,6 +246,13 @@ export interface IContainerCreateProps {
 	 * protocol implementation for handling the quorum and/or the audience.
 	 */
 	readonly protocolHandlerBuilder?: ProtocolHandlerBuilder;
+
+	/**
+	 * Optional property for specifiying a timeout for retry connection loop.
+	 * If provided, the connection manager will use this value as the maximum time to wait
+	 * for a successful connection before giving up throwing the most recent error.
+	 */
+	readonly retryConnectionTimeoutMs?: number;
 }
 
 /**
@@ -608,6 +615,7 @@ export class Container
 	private attachmentData: AttachmentData = { state: AttachState.Detached };
 	private readonly serializedStateManager: SerializedStateManager;
 	private readonly _containerId: string;
+	private readonly _retryConnectionTimeoutMs: number | undefined;
 
 	private lastVisible: number | undefined;
 	private readonly visibilityEventHandler: (() => void) | undefined;
@@ -790,12 +798,14 @@ export class Container
 			scope,
 			subLogger,
 			protocolHandlerBuilder,
+			retryConnectionTimeoutMs,
 		} = createProps;
 
 		this.connectionTransitionTimes[ConnectionState.Disconnected] = performanceNow();
 		const pendingLocalState = loadProps?.pendingLocalState;
 
 		this._canReconnect = canReconnect ?? true;
+		this._retryConnectionTimeoutMs = retryConnectionTimeoutMs;
 		this.clientDetailsOverride = clientDetailsOverride;
 		this.urlResolver = urlResolver;
 		this.serviceFactory = documentServiceFactory;
@@ -2061,6 +2071,7 @@ export class Container
 					this._canReconnect,
 					createChildLogger({ logger: this.subLogger, namespace: "ConnectionManager" }),
 					props,
+					this._retryConnectionTimeoutMs,
 				),
 		);
 


### PR DESCRIPTION
## Description 
Fixes [AB#42777](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/42777)

This feature adds an optional create prop `retryConnectionTimeoutMs` that will set the maximum amount of time that should be spent attempting to retry establishing connection to the service before throwing the latest error. This is useful for Loop Web Service, who has a short timeout period for requests (60s) and would rather surface connection errors to their clients rather than generic timeout 500 error messages. 