### PR TITLE
Mongo AMI connection string usage

### DIFF
--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -777,6 +777,11 @@ export class MongoDbFactory implements core.IDbFactory {
 			options.maxPoolSize = this.connectionPoolMaxSize;
 		}
 
+		Lumberjack.info("TEST: Connecting to MongoDB", {
+			operationsDbEndpoint: this.operationsDbEndpoint.substring(150),
+			globalDbEndpoint: this.globalDbEndpoint?.substring(150),
+		});
+
 		const connection = await MongoClient.connect(
 			global && this.globalDbEndpoint ? this.globalDbEndpoint : this.operationsDbEndpoint,
 			options,

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -642,8 +642,11 @@ const DefaultServerSelectionTimeoutMS = 30000;
 
 interface IMongoDBConfig {
 	operationsDbEndpoint: string;
+	operationsDbEndpointAmi: string;
 	globalDbEndpoint?: string;
 	globalDbEnabled?: boolean;
+	globalDbEndpointAmi?: string;
+	cosmosAmiEnabled?: boolean;
 	connectionPoolMinSize?: number;
 	connectionPoolMaxSize?: number;
 	directConnection?: boolean;
@@ -692,8 +695,11 @@ export class MongoDbFactory implements core.IDbFactory {
 	constructor(config: IMongoDBConfig) {
 		const {
 			operationsDbEndpoint,
+			operationsDbEndpointAmi,
 			globalDbEnabled,
 			globalDbEndpoint,
+			globalDbEndpointAmi,
+			cosmosAmiEnabled,
 			connectionPoolMinSize,
 			connectionPoolMaxSize,
 			directConnection,
@@ -711,10 +717,13 @@ export class MongoDbFactory implements core.IDbFactory {
 			consecutiveFailedThresholdForLowerTotalRequests,
 		} = config;
 		if (globalDbEnabled) {
-			this.globalDbEndpoint = globalDbEndpoint;
+			this.globalDbEndpoint = cosmosAmiEnabled ? globalDbEndpointAmi : globalDbEndpoint;
 		}
-		assert(!!operationsDbEndpoint, `No endpoint provided`);
-		this.operationsDbEndpoint = operationsDbEndpoint;
+		assert(
+			cosmosAmiEnabled ? !!operationsDbEndpointAmi : !!operationsDbEndpoint,
+			`No endpoint provided`
+		);
+		this.operationsDbEndpoint = cosmosAmiEnabled ? operationsDbEndpointAmi : operationsDbEndpoint;
 		this.connectionPoolMinSize = connectionPoolMinSize;
 		this.connectionPoolMaxSize = connectionPoolMaxSize;
 		this.connectionNotAvailableMode = connectionNotAvailableMode ?? "ruleBehavior";

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -642,7 +642,7 @@ const DefaultServerSelectionTimeoutMS = 30000;
 
 interface IMongoDBConfig {
 	operationsDbEndpoint: string;
-	operationsDbEndpointAmi: string;
+	operationsDbEndpointAmi?: string;
 	globalDbEndpoint?: string;
 	globalDbEnabled?: boolean;
 	globalDbEndpointAmi?: string;
@@ -723,7 +723,7 @@ export class MongoDbFactory implements core.IDbFactory {
 			mongoAmiEnabled ? !!operationsDbEndpointAmi : !!operationsDbEndpoint,
 			`No endpoint provided`,
 		);
-		this.operationsDbEndpoint = mongoAmiEnabled
+		this.operationsDbEndpoint = mongoAmiEnabled && operationsDbEndpointAmi
 			? operationsDbEndpointAmi
 			: operationsDbEndpoint;
 		this.connectionPoolMinSize = connectionPoolMinSize;
@@ -776,11 +776,6 @@ export class MongoDbFactory implements core.IDbFactory {
 		if (this.connectionPoolMaxSize) {
 			options.maxPoolSize = this.connectionPoolMaxSize;
 		}
-
-		Lumberjack.info("TEST: Connecting to MongoDB", {
-			operationsDbEndpoint: this.operationsDbEndpoint?.substring(150),
-			globalDbEndpoint: this.globalDbEndpoint?.substring(150),
-		});
 
 		const connection = await MongoClient.connect(
 			global && this.globalDbEndpoint ? this.globalDbEndpoint : this.operationsDbEndpoint,

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -778,7 +778,7 @@ export class MongoDbFactory implements core.IDbFactory {
 		}
 
 		Lumberjack.info("TEST: Connecting to MongoDB", {
-			operationsDbEndpoint: this.operationsDbEndpoint.substring(150),
+			operationsDbEndpoint: this.operationsDbEndpoint?.substring(150),
 			globalDbEndpoint: this.globalDbEndpoint?.substring(150),
 		});
 

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -723,9 +723,10 @@ export class MongoDbFactory implements core.IDbFactory {
 			mongoAmiEnabled ? !!operationsDbEndpointAmi : !!operationsDbEndpoint,
 			`No endpoint provided`,
 		);
-		this.operationsDbEndpoint = mongoAmiEnabled && operationsDbEndpointAmi
-			? operationsDbEndpointAmi
-			: operationsDbEndpoint;
+		this.operationsDbEndpoint =
+			mongoAmiEnabled && operationsDbEndpointAmi
+				? operationsDbEndpointAmi
+				: operationsDbEndpoint;
 		this.connectionPoolMinSize = connectionPoolMinSize;
 		this.connectionPoolMaxSize = connectionPoolMaxSize;
 		this.connectionNotAvailableMode = connectionNotAvailableMode ?? "ruleBehavior";

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -721,9 +721,11 @@ export class MongoDbFactory implements core.IDbFactory {
 		}
 		assert(
 			mongoAmiEnabled ? !!operationsDbEndpointAmi : !!operationsDbEndpoint,
-			`No endpoint provided`
+			`No endpoint provided`,
 		);
-		this.operationsDbEndpoint = mongoAmiEnabled ? operationsDbEndpointAmi : operationsDbEndpoint;
+		this.operationsDbEndpoint = mongoAmiEnabled
+			? operationsDbEndpointAmi
+			: operationsDbEndpoint;
 		this.connectionPoolMinSize = connectionPoolMinSize;
 		this.connectionPoolMaxSize = connectionPoolMaxSize;
 		this.connectionNotAvailableMode = connectionNotAvailableMode ?? "ruleBehavior";

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -646,7 +646,7 @@ interface IMongoDBConfig {
 	globalDbEndpoint?: string;
 	globalDbEnabled?: boolean;
 	globalDbEndpointAmi?: string;
-	cosmosAmiEnabled?: boolean;
+	mongoAmiEnabled?: boolean;
 	connectionPoolMinSize?: number;
 	connectionPoolMaxSize?: number;
 	directConnection?: boolean;
@@ -699,7 +699,7 @@ export class MongoDbFactory implements core.IDbFactory {
 			globalDbEnabled,
 			globalDbEndpoint,
 			globalDbEndpointAmi,
-			cosmosAmiEnabled,
+			mongoAmiEnabled,
 			connectionPoolMinSize,
 			connectionPoolMaxSize,
 			directConnection,
@@ -717,13 +717,13 @@ export class MongoDbFactory implements core.IDbFactory {
 			consecutiveFailedThresholdForLowerTotalRequests,
 		} = config;
 		if (globalDbEnabled) {
-			this.globalDbEndpoint = cosmosAmiEnabled ? globalDbEndpointAmi : globalDbEndpoint;
+			this.globalDbEndpoint = mongoAmiEnabled ? globalDbEndpointAmi : globalDbEndpoint;
 		}
 		assert(
-			cosmosAmiEnabled ? !!operationsDbEndpointAmi : !!operationsDbEndpoint,
+			mongoAmiEnabled ? !!operationsDbEndpointAmi : !!operationsDbEndpoint,
 			`No endpoint provided`
 		);
-		this.operationsDbEndpoint = cosmosAmiEnabled ? operationsDbEndpointAmi : operationsDbEndpoint;
+		this.operationsDbEndpoint = mongoAmiEnabled ? operationsDbEndpointAmi : operationsDbEndpoint;
 		this.connectionPoolMinSize = connectionPoolMinSize;
 		this.connectionPoolMaxSize = connectionPoolMaxSize;
 		this.connectionNotAvailableMode = connectionNotAvailableMode ?? "ruleBehavior";


### PR DESCRIPTION
## Description

Changes to use AMI connection string for mongo db if enabled.
