### PR TITLE
Local Server Stress: Reuse DDSFuzzState per channel to allow mutation

### DIFF
--- a/packages/test/local-server-stress-tests/src/ddsOperations.ts
+++ b/packages/test/local-server-stress-tests/src/ddsOperations.ts
@@ -40,6 +40,12 @@ const createDDSClient = (channel: IChannel): DDSClient<IChannelFactory> => {
 	};
 };
 
+/**
+ * we use a weak map here, so the lifetime of the DDS state is bound to the channel
+ * itself, so after the channel is no longer needed the state can also be garbage collected.
+ */
+const channelToDdsState = new WeakMap<IChannel, DDSFuzzTestState<IChannelFactory>>();
+
 export const covertLocalServerStateToDdsState = async (
 	state: LocalServerStressState,
 ): Promise<DDSFuzzTestState<IChannelFactory>> => {
@@ -50,38 +56,45 @@ export const covertLocalServerStateToDdsState = async (
 			(v) => v.handle !== undefined,
 		),
 	];
-	return {
-		clients: makeUnreachableCodePathProxy("clients"),
-		client: createDDSClient(state.channel),
-		containerRuntimeFactory: makeUnreachableCodePathProxy("containerRuntimeFactory"),
-		isDetached: state.client.container.attachState === AttachState.Detached,
-		summarizerClient: makeUnreachableCodePathProxy("containerRuntimeFactory"),
-		random: {
-			...state.random,
-			handle: () => {
-				/**
-				 * here we do some funky stuff with handles so we can serialize them like json for output, but not bind them,
-				 * as they may not be attached. look at the reduce code to see how we deserialized these fake handles into real
-				 * handles.
-				 */
-				const { tag, handle } = state.random.pick(allHandles);
-				const realHandle = toFluidHandleInternal(handle);
-				return {
-					tag,
-					absolutePath: realHandle.absolutePath,
-					get [fluidHandleSymbol]() {
-						return realHandle[fluidHandleSymbol];
-					},
-					async get() {
-						return realHandle.get();
-					},
-					get isAttached() {
-						return realHandle.isAttached;
-					},
-				};
-			},
+
+	const random = {
+		...state.random,
+		handle: () => {
+			/**
+			 * here we do some funky stuff with handles so we can serialize them like json for output, but not bind them,
+			 * as they may not be attached. look at the reduce code to see how we deserialized these fake handles into real
+			 * handles.
+			 */
+			const { tag, handle } = state.random.pick(allHandles);
+			const realHandle = toFluidHandleInternal(handle);
+			return {
+				tag,
+				absolutePath: realHandle.absolutePath,
+				get [fluidHandleSymbol]() {
+					return realHandle[fluidHandleSymbol];
+				},
+				async get() {
+					return realHandle.get();
+				},
+				get isAttached() {
+					return realHandle.isAttached;
+				},
+			};
 		},
 	};
+
+	const baseState = {
+		...(channelToDdsState.get(state.channel) ?? {
+			clients: makeUnreachableCodePathProxy("clients"),
+			client: createDDSClient(state.channel),
+			containerRuntimeFactory: makeUnreachableCodePathProxy("containerRuntimeFactory"),
+			isDetached: state.client.container.attachState === AttachState.Detached,
+			summarizerClient: makeUnreachableCodePathProxy("containerRuntimeFactory"),
+		}),
+		random,
+	};
+	channelToDdsState.set(state.channel, baseState);
+	return baseState;
 };
 
 export const DDSModelOpGenerator: AsyncGenerator<DDSModelOp, LocalServerStressState> = async (


### PR DESCRIPTION
This change is primarily to support adding tree to the local server stress harness, as the tree model mutates the state to store the current view. This change is also inline with the design of the fuzz harness which support arbitrary state mutation. 