### PR TITLE
fix(fluid-build): Declarative tasks depend on the lock file by default

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
@@ -87,7 +87,7 @@ export interface TaskFileDependencies {
 	 * For fine-grained control, use `inputGlobs` and `outputGlobs` to specify the dependencies in `node_modules`
 	 * and set this to false.
 	 */
-	includeLockFile?: boolean;
+	includeLockFiles?: boolean;
 }
 
 export interface TaskConfig {

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
@@ -80,7 +80,7 @@ export interface TaskFileDependencies {
 
 	/**
 	 * Specify whether the task will depend on the package/workspace lock file, this task will be rebuilt if the lock file
-	 * is changed. Provide an economical but broad way to ensure rebuild when tools or package dependencies changes.
+	 * is changed. Provides an economical but broad way to ensure rebuild when tools or package dependencies changes.
 	 *
 	 * Default is true, and it is equivalent to putting the lock file in the `inputGlobs`.
 	 *

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
@@ -423,7 +423,9 @@ export function getTaskDefinitions(
 				if (script === undefined) {
 					throw new Error(`Script not found for task definition '${name}'`);
 				} else if (script.startsWith("fluid-build ")) {
-					throw new Error(`Script task should not invoke 'fluid-build' in '${name}'`);
+					throw new Error(
+						`Script task should not invoke 'fluid-build' in '${name}'. Did you forget to set 'script: false' in the task definition?`,
+					);
 				}
 			} else {
 				if (full.before.length !== 0 || full.after.length !== 0) {

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
@@ -77,6 +77,17 @@ export interface TaskFileDependencies {
 	 * @defaultValue `["input"]`
 	 */
 	gitignore?: GitIgnoreSetting;
+
+	/**
+	 * Specify whether the task will depend on the package/workspace lock file, this task will be rebuilt if the lock file
+	 * is changed. Provide an economical but broad way to ensure rebuild when tools or package dependencies changes.
+	 *
+	 * Default is true, and it is equivalent to putting the lock file in the `inputGlobs`.
+	 *
+	 * For fine-grained control, use `inputGlobs` and `outputGlobs` to specify the dependencies in `node_modules`
+	 * and set this to false.
+	 */
+	includeLockFile?: boolean;
 }
 
 export interface TaskConfig {

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/declarativeTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/declarativeTask.ts
@@ -34,6 +34,10 @@ export class DeclarativeLeafTask extends LeafWithGlobInputOutputDoneFileTask {
 		return this.taskDefinition.gitignore ?? gitignoreDefaultValue;
 	}
 
+	protected override get includeLockFile(): boolean {
+		return this.taskDefinition.includeLockFile ?? super.includeLockFile;
+	}
+
 	protected async getInputGlobs(): Promise<readonly string[]> {
 		return this.taskDefinition.inputGlobs;
 	}

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/declarativeTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/declarativeTask.ts
@@ -34,8 +34,8 @@ export class DeclarativeLeafTask extends LeafWithGlobInputOutputDoneFileTask {
 		return this.taskDefinition.gitignore ?? gitignoreDefaultValue;
 	}
 
-	protected override get includeLockFile(): boolean {
-		return this.taskDefinition.includeLockFile ?? super.includeLockFile;
+	protected override get includeLockFiles(): boolean {
+		return this.taskDefinition.includeLockFiles ?? super.includeLockFiles;
 	}
 
 	protected async getInputGlobs(): Promise<readonly string[]> {

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -688,7 +688,7 @@ export abstract class LeafWithGlobInputOutputDoneFileTask extends LeafWithFileSt
 	/**
 	 * @returns If the lock file should be included as input files for this task.
 	 */
-	protected get includeLockFile(): boolean {
+	protected get includeLockFiles(): boolean {
 		// Include the lock file by default.
 		return true;
 	}
@@ -709,7 +709,7 @@ export abstract class LeafWithGlobInputOutputDoneFileTask extends LeafWithFileSt
 
 	protected override async getInputFiles(): Promise<string[]> {
 		const inputs = await this.getFiles("input");
-		if (this.includeLockFile) {
+		if (this.includeLockFiles) {
 			const lockFilePath = this.node.pkg.getLockFilePath();
 			if (lockFilePath === undefined) {
 				throw new Error(`Lock file missing for ${this.node.pkg.nameColored}.`);

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -712,7 +712,7 @@ export abstract class LeafWithGlobInputOutputDoneFileTask extends LeafWithFileSt
 		if (this.includeLockFile) {
 			const lockFilePath = this.node.pkg.getLockFilePath();
 			if (lockFilePath === undefined) {
-				throw new Error(`Lock file missing for ${this.node.pkg.nameColored}. `);
+				throw new Error(`Lock file missing for ${this.node.pkg.nameColored}.`);
 			}
 			inputs.push(lockFilePath);
 		}


### PR DESCRIPTION
- Declarative task should depend on the lock file by default, so that the task will be rebuild if dependency changes.
- Add flag to allow that to be disabled and let the task explicitly spell it out.