### PR TITLE
Fix tenant isolation in blob cache by scoping cache keys per tenant

### DIFF
--- a/server/historian/packages/historian-base/src/routes/git/blobs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/blobs.ts
@@ -103,7 +103,6 @@ export function create(
 		},
 	);
 
-	// here
 	router.post(
 		"/repos/:ignored?/:tenantId/git/blobs",
 		validateRequestParams("tenantId"),
@@ -147,7 +146,6 @@ export function create(
 
 	/**
 	 * Retrieves the given blob as an image
-	 * here
 	 */
 	router.get(
 		"/repos/:ignored?/:tenantId/git/blobs/raw/:sha",

--- a/server/historian/packages/historian-base/src/routes/git/blobs.ts
+++ b/server/historian/packages/historian-base/src/routes/git/blobs.ts
@@ -85,7 +85,7 @@ export function create(
 			cache,
 			ephemeralDocumentTTLSec,
 		});
-		return service.getBlob(sha, useCache);
+		return service.getBlob(tenantId, sha, useCache);
 	}
 
 	/**
@@ -103,6 +103,7 @@ export function create(
 		},
 	);
 
+	// here
 	router.post(
 		"/repos/:ignored?/:tenantId/git/blobs",
 		validateRequestParams("tenantId"),
@@ -146,6 +147,7 @@ export function create(
 
 	/**
 	 * Retrieves the given blob as an image
+	 * here
 	 */
 	router.get(
 		"/repos/:ignored?/:tenantId/git/blobs/raw/:sha",

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -449,7 +449,7 @@ export class RestGitService {
 
 				const blobsP = Promise.all(
 					quorumValuesSha.map(async (quorumSha) => {
-						const blob = await this.getBlob(quorumSha, useCache);
+						const blob = await this.getBlob(this.tenantId, quorumSha, useCache);
 						blobs.set(blob.sha, blob);
 					}),
 				);
@@ -488,7 +488,7 @@ export class RestGitService {
 		const blobsP: Promise<git.IBlob>[] = [];
 		for (const entry of tree.tree) {
 			if (entry.type === "blob" && endsWith(entry.path, includeBlobs)) {
-				const blobP = this.getBlob(entry.sha, useCache);
+				const blobP = this.getBlob(this.tenantId, entry.sha, useCache);
 				blobsP.push(blobP);
 			}
 		}

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -129,9 +129,10 @@ export class RestGitService {
 		);
 	}
 
-	public async getBlob(sha: string, useCache: boolean): Promise<git.IBlob> {
+	public async getBlob(tenantId: string, sha: string, useCache: boolean): Promise<git.IBlob> {
+		const cacheKey = `${tenantId}:${sha}`;
 		return this.resolve(
-			sha,
+			cacheKey,
 			async () =>
 				this.get<git.IBlob>(
 					`/repos/${this.getRepoPath()}/git/blobs/${encodeURIComponent(sha)}`,
@@ -147,7 +148,7 @@ export class RestGitService {
 		);
 
 		// Fetch the full blob so we can have it in cache
-		this.getBlob(createResults.sha, true).catch((error) => {
+		this.getBlob(this.tenantId, createResults.sha, true).catch((error) => {
 			winston.error(`Error fetching blob ${createResults.sha}`);
 			Lumberjack.error(`Error fetching blob: ${createResults.sha}`, this.lumberProperties);
 		});


### PR DESCRIPTION
This change addresses a security vulnerability where the blob cache in Historian was shared across tenants, allowing any tenant with knowledge of a blob’s SHA1 to retrieve its contents — even if the blob was uploaded by a different tenant.

[AB#39443](https://dev.azure.com/fluidframework/internal/_workitems/edit/39443)