### PR TITLE
server(fix): efficient telemetry session pruning

### DIFF
--- a/server/routerlicious/packages/services-core/src/collabSession.ts
+++ b/server/routerlicious/packages/services-core/src/collabSession.ts
@@ -130,6 +130,18 @@ export interface ICollaborationSessionManager {
 	 * Get a list of all active sessions.
 	 */
 	getAllSessions(): Promise<ICollaborationSession[]>;
+	/**
+	 * Iterate over all active sessions, calling the provided callback for each session.
+	 *
+	 * @remarks
+	 * This is useful for cases where the number of sessions is large and you want to process
+	 * them in smaller batches to avoid memory issues or timeouts.
+	 *
+	 * The callback should be designed to handle each session independently and not rely on the order of processing.
+	 *
+	 * @param callback - Function to call for each session.
+	 */
+	iterateAllSessions<T>(callback: (session: ICollaborationSession) => Promise<T>): Promise<T[]>;
 }
 
 /**

--- a/server/routerlicious/packages/services/src/redisSessionManager.ts
+++ b/server/routerlicious/packages/services/src/redisSessionManager.ts
@@ -124,13 +124,24 @@ export class RedisCollaborationSessionManager implements ICollaborationSessionMa
 	}
 
 	public async getAllSessions(): Promise<ICollaborationSession[]> {
+		const sessions: ICollaborationSession[] = [];
+		await this.iterateAllSessions(async (session: ICollaborationSession) => {
+			sessions.push(session);
+		});
+		return sessions;
+	}
+
+	public async iterateAllSessions<T>(
+		callback: (session: ICollaborationSession) => Promise<T>,
+	): Promise<T[]> {
 		// Use HSCAN to iterate over te key:value pairs of the hashmap
 		// in batches to get all sessions with minimal impact on Redis.
 		const sessionJsonScanStream = this.redisClientConnectionManager
 			.getRedisClient()
 			.hscanStream(this.prefix, { count: this.options.maxScanBatchSize });
+
 		return new Promise((resolve, reject) => {
-			const sessions: ICollaborationSession[] = [];
+			const callbackPs: Promise<T>[] = [];
 			sessionJsonScanStream.on("data", (result: string[]) => {
 				if (!result) {
 					// When redis scan is done, it pushes null to the stream.
@@ -145,11 +156,14 @@ export class RedisCollaborationSessionManager implements ICollaborationSessionMa
 				for (let i = 0; i < result.length; i += 2) {
 					const fieldKey = result[i];
 					const sessionJson = result[i + 1];
-					sessions.push(this.getFullSession(fieldKey, JSON.parse(sessionJson)));
+					const fullSession = this.getFullSession(fieldKey, JSON.parse(sessionJson));
+					// Call the callback for each session.
+					// We do not await the callback here to allow for concurrent processing of sessions.
+					callbackPs.push(callback(fullSession));
 				}
 			});
 			sessionJsonScanStream.on("end", () => {
-				resolve(sessions);
+				resolve(Promise.all(callbackPs));
 			});
 			sessionJsonScanStream.on("error", (error) => {
 				reject(error);

--- a/server/routerlicious/packages/services/src/test/sessionTracker.spec.ts
+++ b/server/routerlicious/packages/services/src/test/sessionTracker.spec.ts
@@ -29,6 +29,7 @@ describe("CollaborationSessionTracker", () => {
 			addOrUpdateSession: sinon.stub(),
 			removeSession: sinon.stub(),
 			getAllSessions: sinon.stub(),
+			iterateAllSessions: sinon.stub(),
 		} as unknown as sinon.SinonStubbedInstance<ICollaborationSessionManager>;
 
 		sessionTracker = new CollaborationSessionTracker(clientManager, sessionManager);
@@ -137,6 +138,7 @@ describe("CollaborationSessionTracker", () => {
 
 			try {
 				await sessionTracker.endClientSession(client, sessionId);
+				assert.fail("Expected error to be thrown");
 			} catch (error) {
 				assert.equal((error as Error).message, "Test error");
 			}
@@ -203,7 +205,7 @@ describe("CollaborationSessionTracker", () => {
 				},
 			};
 
-			sessionManager.getAllSessions.resolves([session]);
+			sessionManager.iterateAllSessions.callsArgWithAsync(0, session);
 			clientManager.getClients.resolves([]);
 
 			await sessionTracker.pruneInactiveSessions();
@@ -215,7 +217,7 @@ describe("CollaborationSessionTracker", () => {
 		});
 
 		it("should handle errors during pruning", async () => {
-			sessionManager.getAllSessions.rejects(new Error("Test error"));
+			sessionManager.iterateAllSessions.rejects(new Error("Test error"));
 			clientManager.getClients.resolves([]);
 
 			try {


### PR DESCRIPTION
## Description

The current method for pruning Nexus' tracked sessions for telemetry is very innefficient because it loads all sessions into memory, then filters those sessions, then prunes them. Loading all sessions into memory causes the job to crash because that's usually _a lot of sessions_. Instead, we can process each batch of sessions as they stream in, which should reduce memory pressure, or at least allow the queue to resolve.
