### PR TITLE
Expose DDS's snapshot tree to it during load via IChannelStorageService

### DIFF
--- a/.changeset/tame-monkeys-boil.md
+++ b/.changeset/tame-monkeys-boil.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/datastore-definitions": minor
+"__section": legacy
+---
+New "getSnapshotTree" API on "IChannelStorageService"
+
+A new optional API, `getSnapshotTree` has been added to `IChannelStorageService`. It should return the snapshot tree for a channel. The snapshot tree can be used by a channel to examine its snapshot.

--- a/.changeset/tame-monkeys-boil.md
+++ b/.changeset/tame-monkeys-boil.md
@@ -4,4 +4,4 @@
 ---
 New "getSnapshotTree" API on "IChannelStorageService"
 
-A new optional API, `getSnapshotTree` has been added to `IChannelStorageService`. It should return the snapshot tree for a channel. The snapshot tree can be used by a channel to examine its snapshot.
+A new optional API, `getSnapshotTree` has been added to `IChannelStorageService`. It should return the snapshot tree for a channel. This will help channels examine their snapshot when it consists of dynamic trees and blobs, i.e., the number of tree and blobs and / or their keys are not known in advance.

--- a/.changeset/tame-monkeys-boil.md
+++ b/.changeset/tame-monkeys-boil.md
@@ -4,4 +4,6 @@
 ---
 New "getSnapshotTree" API on "IChannelStorageService"
 
-A new optional API, `getSnapshotTree` has been added to `IChannelStorageService`. It should return the snapshot tree for a channel. This will help channels examine their snapshot when it consists of dynamic trees and blobs, i.e., the number of tree and blobs and / or their keys are not known in advance.
+A new API, `getSnapshotTree` has been added to `IChannelStorageService`.
+It should return the snapshot tree for a channel. This will help channels examine their snapshot when it consists of dynamic trees and blobs, i.e., when the number of tree and blobs and / or their keys are not known in advance.
+This is optional for backwards compatibility, and will become required in the future.

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.legacy.alpha.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.legacy.alpha.api.md
@@ -42,6 +42,7 @@ export interface IChannelServices {
 // @alpha @legacy
 export interface IChannelStorageService {
     contains(path: string): Promise<boolean>;
+    getSnapshotTree?(): ISnapshotTree | undefined;
     list(path: string): Promise<string[]>;
     readBlob(path: string): Promise<ArrayBufferLike>;
 }

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -251,7 +251,8 @@ export interface IChannelStorageService {
 	list(path: string): Promise<string[]>;
 
 	/**
-	 * Returns the snapshot tree for the channel.
+	 * Returns the snapshot tree for the channel. This will help channels examine their snapshot when it consists
+	 * of dynamic trees and blobs, i.e., the number of tree and blobs and / or their keys are not known in advance.
 	 */
 	getSnapshotTree?(): ISnapshotTree | undefined;
 }

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -4,6 +4,7 @@
  */
 
 import type { IFluidLoadable } from "@fluidframework/core-interfaces";
+import type { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import type {
 	IExperimentalIncrementalSummaryContext,
 	IGarbageCollectionData,
@@ -248,6 +249,11 @@ export interface IChannelStorageService {
 	 * Lists the blobs that exist at a specific path.
 	 */
 	list(path: string): Promise<string[]>;
+
+	/**
+	 * Returns the snapshot tree for the channel.
+	 */
+	getSnapshotTree?(): ISnapshotTree | undefined;
 }
 
 /**

--- a/packages/runtime/datastore/src/channelStorageService.ts
+++ b/packages/runtime/datastore/src/channelStorageService.ts
@@ -77,6 +77,10 @@ export class ChannelStorageService implements IChannelStorageService {
 		return Object.keys(tree?.blobs ?? {});
 	}
 
+	public getSnapshotTree(): ISnapshotTree | undefined {
+		return this.tree;
+	}
+
 	private async getIdForPath(path: string): Promise<string | undefined> {
 		return this.flattenedTree[path];
 	}

--- a/packages/runtime/datastore/src/test/channelStorageService.spec.ts
+++ b/packages/runtime/datastore/src/test/channelStorageService.spec.ts
@@ -31,6 +31,7 @@ describe("ChannelStorageService", () => {
 		assert.strictEqual(await ss.contains("/"), false);
 		assert.deepStrictEqual(await ss.list(""), []);
 		logger.assertMatchNone([{ category: "error" }]);
+		assert.deepStrictEqual(ss.getSnapshotTree(), tree);
 	});
 
 	it("Top Level Blob", async () => {
@@ -52,6 +53,7 @@ describe("ChannelStorageService", () => {
 		assert.deepStrictEqual(await ss.list(""), ["foo"]);
 		assert.deepStrictEqual(await ss.readBlob("foo"), stringToBuffer("bar", "utf8"));
 		logger.assertMatchNone([{ category: "error" }]);
+		assert.deepStrictEqual(ss.getSnapshotTree(), tree);
 	});
 
 	it("Nested Blob", async () => {
@@ -78,5 +80,6 @@ describe("ChannelStorageService", () => {
 		assert.deepStrictEqual(await ss.list("nested/"), ["foo"]);
 		assert.deepStrictEqual(await ss.readBlob("nested/foo"), stringToBuffer("bar", "utf8"));
 		logger.assertMatchNone([{ category: "error" }]);
+		assert.deepStrictEqual(ss.getSnapshotTree(), tree);
 	});
 });

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -610,6 +610,8 @@ export class MockStorage implements IChannelStorageService {
     // (undocumented)
     static createFromSummary(summaryTree: ISummaryTree): MockStorage;
     // (undocumented)
+    getSnapshotTree(): ISnapshotTree | undefined;
+    // (undocumented)
     list(path: string): Promise<string[]>;
     // (undocumented)
     readBlob(path: string): Promise<ArrayBufferLike>;

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -154,7 +154,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Class_MockStorage": {
+				"forwardCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -120,6 +120,7 @@
 		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/datastore-definitions": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",
+		"@fluidframework/driver-utils": "workspace:~",
 		"@fluidframework/id-compressor": "workspace:~",
 		"@fluidframework/routerlicious-driver": "workspace:~",
 		"@fluidframework/runtime-definitions": "workspace:~",

--- a/packages/runtime/test-runtime-utils/src/mockStorage.ts
+++ b/packages/runtime/test-runtime-utils/src/mockStorage.ts
@@ -7,7 +7,8 @@ import { stringToBuffer } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils/internal";
 import { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import { ISummaryTree } from "@fluidframework/driver-definitions";
-import { IBlob, ITree } from "@fluidframework/driver-definitions/internal";
+import { IBlob, ITree, type ISnapshotTree } from "@fluidframework/driver-definitions/internal";
+import { buildSnapshotTree } from "@fluidframework/driver-utils/internal";
 import {
 	convertSummaryTreeToITree,
 	listBlobsAtTreePath,
@@ -43,7 +44,14 @@ export class MockStorage implements IChannelStorageService {
 		}
 	}
 
-	constructor(protected tree?: ITree) {}
+	private readonly snapshotTree: ISnapshotTree | undefined;
+
+	constructor(protected tree?: ITree) {
+		if (tree === undefined) {
+			return;
+		}
+		this.snapshotTree = buildSnapshotTree(tree.entries, new Map());
+	}
 
 	public async readBlob(path: string): Promise<ArrayBufferLike> {
 		const blob = MockStorage.readBlobCore(this.tree, path.split("/"));
@@ -57,5 +65,9 @@ export class MockStorage implements IChannelStorageService {
 
 	public async list(path: string): Promise<string[]> {
 		return listBlobsAtTreePath(this.tree, path);
+	}
+
+	public getSnapshotTree(): ISnapshotTree | undefined {
+		return this.snapshotTree;
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -274,6 +274,7 @@ declare type current_as_old_for_Class_MockSharedObjectServices = requireAssignab
  * typeValidation.broken:
  * "Class_MockStorage": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockStorage = requireAssignableTo<TypeOnly<old.MockStorage>, TypeOnly<current.MockStorage>>
 
 /*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12807,6 +12807,9 @@ importers:
       '@fluidframework/driver-definitions':
         specifier: workspace:~
         version: link:../../common/driver-definitions
+      '@fluidframework/driver-utils':
+        specifier: workspace:~
+        version: link:../../loader/driver-utils
       '@fluidframework/id-compressor':
         specifier: workspace:~
         version: link:../id-compressor


### PR DESCRIPTION
## Description
Added `getSnapshotTree` API to `IChannelStorageService` to let DDS access their snapshot tree. This will help DDSes examine their summary where the summary consists of dynamic subtrees / blobs. Currently, all the DDSes store their data in fixed blobs, so they can download these specific blobs via their name.

However, there can be scenarios where a DDS writes their data in dynamic trees / blobs similar to the container runtime where its channels subtree's contents depends on number of data stores and their ids. In such cases, without having access to the snapshot tree, it will need to write the path of all its blob into its summary tree (into a blob with specific name) and use that to fetch them during load.
For example, shared tree is implementing incremental summarization of its data where the number and paths of blobs will change dynamically. Having access to the snapshot tree is important for it to fetch the contents of all the blobs in its summary tree. PR for shared tree's incremental summarization - https://github.com/microsoft/FluidFramework/pull/24949.

[AB#43434](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/43434)