### PR TITLE
Cap getDeltas response by total size of 700MB to prevent OOMs in Alfred

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/services/deltaService.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/services/deltaService.ts
@@ -11,6 +11,7 @@ import {
 	ISequencedOperationMessage,
 	ITenantManager,
 } from "@fluidframework/server-services-core";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
 
 /**
  * @internal
@@ -81,6 +82,13 @@ export class DeltaService implements IDeltaService {
 			const size = Buffer.byteLength(JSON.stringify(delta.operation), "utf8");
 
 			if (maxSizeBytes !== undefined && totalSize + size > maxSizeBytes) {
+				Lumberjack.error("queryDeltas: response size limit exceeded", {
+					collectionName,
+					query,
+					opsReturned: result.length, // The number of ops that were successfully added to the result before hitting the size limit.
+					totalSizeBytes: totalSize,
+					maxSizeBytes,
+				});
 				break;
 			}
 


### PR DESCRIPTION
This change limits the total size of ops returned by `getDeltas` to 700MB. It adds an optional `maxSizeBytes` param to `queryDeltas` which is set to 700MB. This prevents large responses from causing memory issues in Alfred.