### PR TITLE
Fix escapes in markdown

### DIFF
--- a/RELEASE_NOTES/2.0.0-internal.7.1.0.md
+++ b/RELEASE_NOTES/2.0.0-internal.7.1.0.md
@@ -56,7 +56,7 @@ Forest summaries now include detached fields. This breaks existing documents.
 
 ## tree2: SharedTreeFactory type changed
 
-The 'type' field for @fluid-experimental/tree2's exported `IChannelFactory`s has been changed to not overlap with @fluid-experimental/tree's channel type. This breaks existing tree2 documents: upon loading them, an error with message "Channel Factory SharedTree not registered" will be thrown. If using the typed-tree API, the message will instead be "Channel Factory SharedTree:<subtype> not registered" where <subtype> is the subtype used by the application when constructing their `TypedTreeFactory`.
+The 'type' field for @fluid-experimental/tree2's exported `IChannelFactory`s has been changed to not overlap with @fluid-experimental/tree's channel type. This breaks existing tree2 documents: upon loading them, an error with message "Channel Factory SharedTree not registered" will be thrown. If using the typed-tree API, the message will instead be "Channel Factory SharedTree:<subtype\> not registered" where <subtype\> is the subtype used by the application when constructing their `TypedTreeFactory`.
 
 Applications which want to support such documents could add an explicit registry entry to their `ISharedObjectRegistry` which maps the type shown in the error message to a factory producing @fluid-experimental/tree2.
 

--- a/packages/dds/tree/CHANGELOG.md
+++ b/packages/dds/tree/CHANGELOG.md
@@ -2822,7 +2822,7 @@ Dependency updates only.
 
   The 'type' field for @fluid-experimental/tree2's exported `IChannelFactory`s has been changed to not overlap with @fluid-experimental/tree's channel type.
   This breaks existing tree2 documents: upon loading them, an error with message "Channel Factory SharedTree not registered" will be thrown.
-  If using the typed-tree API, the message will instead be "Channel Factory SharedTree:<subtype> not registered" where <subtype> is the subtype used by
+  If using the typed-tree API, the message will instead be "Channel Factory SharedTree:<subtype\> not registered" where <subtype\> is the subtype used by
   the application when constructing their `TypedTreeFactory`.
 
   Applications which want to support such documents could add an explicit registry entry to their `ISharedObjectRegistry` which maps the type shown in the error message to a factory producing @fluid-experimental/tree2.


### PR DESCRIPTION
## Description

VS Code refused to render these markdown files, with its preview erroring. This fixed them to no longer look like they have unpaired html tags by escaping the \> character.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

