### PR TITLE
Remove bad patterns from import auto-suggestions

### DIFF
--- a/packages/dds/tree/.vscode/Tree.code-workspace
+++ b/packages/dds/tree/.vscode/Tree.code-workspace
@@ -17,6 +17,17 @@
 			"**/node_modules/**/@fluid*/*-previous/*"
 		],
 		"typescript.preferences.importModuleSpecifier": "project-relative",
-		"typescript.preferences.preferTypeOnlyAutoImports": true
+		"typescript.preferences.preferTypeOnlyAutoImports": true,
+		"typescript.preferences.autoImportSpecifierExcludeRegexes": [
+			// Avoid suggesting imports from parent index file, which almost always is a mistake which creates a cyclic dependency.
+			// Importers in almost all cases should import it from a sibling instead (the same place the index file imports it from).
+			"^\\.\\/index\\.js",
+			// Same justification as the ./index.js case, but catches imports from parents further up the directory hierarchy.
+			"\\.\\.\\/index\\.js",
+			// Avoid suggesting imports which reach into a directory, unless the import is for the index file.
+			// Often tests for a specific file will want to violate this, so violating this could occasionally be useful,
+			// but removing it from an auto-import suggestion in all other cases is helpful.
+			"\\/.*\\/(?!index\\.js$)"
+		]
 	}
 }


### PR DESCRIPTION
## Description

Tweak vs-code TypeScript IntelliSense settings for tree workspace to stop recommending import patterns we do not want to use.

With this, almost all cases should only suggest the one correct import instead of having to pick from several when in highly nested directories.

For example, in one test case, now only "./core/index.js" is suggested instead of also including "./core/treeNodeSchema.js", "./index.js" and "../index.js".

Having this take effect requires restarting the TypeScript server.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


