### PR TITLE
feat(eslint-config-fluid): Promote import rules from `strict` ruleset to `recommended` ruleset

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @fluidframework/eslint-config-fluid Changelog
 
+## [5.8.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.8_0)
+
+Promotes the following rules from the `strict` ruleset to the `recommended` ruleset:
+
+-   [@typescript-eslint/consistent-type-exports](https://typescript-eslint.io/rules/consistent-type-exports/)
+-   [@typescript-eslint/consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports/)
+-   [@typescript-eslint/no-import-type-side-effects](https://typescript-eslint.io/rules/no-import-type-side-effects/)
+
 ## [5.7.4](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.7.4)
 
 Updates the contexts in which `jsdoc/require-jsdoc` is applied to make it less overzealous.

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "5.7.4",
+	"version": "5.8.0",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -104,10 +104,16 @@
             "error"
         ],
         "@typescript-eslint/consistent-type-exports": [
-            "off"
+            "error",
+            {
+                "fixMixedExportsWithInlineTypeSpecifier": true
+            }
         ],
         "@typescript-eslint/consistent-type-imports": [
-            "off"
+            "error",
+            {
+                "fixStyle": "separate-type-imports"
+            }
         ],
         "@typescript-eslint/dot-notation": [
             "error"
@@ -211,6 +217,9 @@
             "error"
         ],
         "@typescript-eslint/no-implied-eval": [
+            "error"
+        ],
+        "@typescript-eslint/no-import-type-side-effects": [
             "error"
         ],
         "@typescript-eslint/no-inferrable-types": [

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -106,10 +106,16 @@
             "error"
         ],
         "@typescript-eslint/consistent-type-exports": [
-            "off"
+            "error",
+            {
+                "fixMixedExportsWithInlineTypeSpecifier": true
+            }
         ],
         "@typescript-eslint/consistent-type-imports": [
-            "off"
+            "error",
+            {
+                "fixStyle": "separate-type-imports"
+            }
         ],
         "@typescript-eslint/dot-notation": [
             "error"
@@ -213,6 +219,9 @@
             "error"
         ],
         "@typescript-eslint/no-implied-eval": [
+            "error"
+        ],
+        "@typescript-eslint/no-import-type-side-effects": [
             "error"
         ],
         "@typescript-eslint/no-inferrable-types": [

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -104,10 +104,16 @@
             "error"
         ],
         "@typescript-eslint/consistent-type-exports": [
-            "off"
+            "error",
+            {
+                "fixMixedExportsWithInlineTypeSpecifier": true
+            }
         ],
         "@typescript-eslint/consistent-type-imports": [
-            "off"
+            "error",
+            {
+                "fixStyle": "separate-type-imports"
+            }
         ],
         "@typescript-eslint/dot-notation": [
             "error"
@@ -211,6 +217,9 @@
             "error"
         ],
         "@typescript-eslint/no-implied-eval": [
+            "error"
+        ],
+        "@typescript-eslint/no-import-type-side-effects": [
             "error"
         ],
         "@typescript-eslint/no-inferrable-types": [

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -104,10 +104,16 @@
             "error"
         ],
         "@typescript-eslint/consistent-type-exports": [
-            "off"
+            "error",
+            {
+                "fixMixedExportsWithInlineTypeSpecifier": true
+            }
         ],
         "@typescript-eslint/consistent-type-imports": [
-            "off"
+            "error",
+            {
+                "fixStyle": "separate-type-imports"
+            }
         ],
         "@typescript-eslint/dot-notation": [
             "error"
@@ -211,6 +217,9 @@
             "error"
         ],
         "@typescript-eslint/no-implied-eval": [
+            "error"
+        ],
+        "@typescript-eslint/no-import-type-side-effects": [
             "error"
         ],
         "@typescript-eslint/no-inferrable-types": [

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -190,6 +190,38 @@ module.exports = {
 		 */
 		"jsdoc/require-description": ["error", { checkConstructors: false }],
 
+		/**
+		 * Requires that type-only exports be done using `export type`. Being explicit allows the TypeScript
+		 * `isolatedModules` flag to be used, and isolated modules are needed to adopt modern build tools like swc.
+		 *
+		 * @see {@link https://typescript-eslint.io/rules/consistent-type-exports/}
+		 */
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{
+				// Makes it easier to tell, at a glance, the impact of a change to individual exports.
+				fixMixedExportsWithInlineTypeSpecifier: true,
+			},
+		],
+
+		/**
+		 * Requires that type-only imports be done using `import type`. Being explicit allows the TypeScript
+		 * `isolatedModules` flag to be used, and isolated modules are needed to adopt modern build tools like swc.
+		 *
+		 * @see {@link https://typescript-eslint.io/rules/consistent-type-imports/}
+		 */
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "separate-type-imports" },
+		],
+
+		/**
+		 * Ensures that type-only import statements do not result in runtime side-effects.
+		 *
+		 * @see {@link https://typescript-eslint.io/rules/no-import-type-side-effects/}
+		 */
+		"@typescript-eslint/no-import-type-side-effects": "error",
+
 		// #endregion
 	},
 	overrides: [

--- a/common/build/eslint-config-fluid/strict.js
+++ b/common/build/eslint-config-fluid/strict.js
@@ -74,38 +74,6 @@ module.exports = {
 				],
 
 				/**
-				 * Requires that type-only exports be done using `export type`. Being explicit allows the TypeScript
-				 * `isolatedModules` flag to be used, and isolated modules are needed to adopt modern build tools like swc.
-				 *
-				 * @see {@link https://typescript-eslint.io/rules/consistent-type-exports/}
-				 */
-				"@typescript-eslint/consistent-type-exports": [
-					"error",
-					{
-						// Makes it easier to tell, at a glance, the impact of a change to individual exports.
-						fixMixedExportsWithInlineTypeSpecifier: true,
-					},
-				],
-
-				/**
-				 * Requires that type-only imports be done using `import type`. Being explicit allows the TypeScript
-				 * `isolatedModules` flag to be used, and isolated modules are needed to adopt modern build tools like swc.
-				 *
-				 * @see {@link https://typescript-eslint.io/rules/consistent-type-imports/}
-				 */
-				"@typescript-eslint/consistent-type-imports": [
-					"error",
-					{ fixStyle: "separate-type-imports" },
-				],
-
-				/**
-				 * Ensures that type-only import statements do not result in runtime side-effects.
-				 *
-				 * @see {@link https://typescript-eslint.io/rules/no-import-type-side-effects/}
-				 */
-				"@typescript-eslint/no-import-type-side-effects": "error",
-
-				/**
 				 * Prefer Record to index-signature object style. That is, prefer:
 				 *
 				 * ```ts


### PR DESCRIPTION
Promotes the following rules from the `strict` ruleset to the `recommended` ruleset:

- [@typescript-eslint/consistent-type-exports](https://typescript-eslint.io/rules/consistent-type-exports/)
- [@typescript-eslint/consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports/)
- [@typescript-eslint/no-import-type-side-effects](https://typescript-eslint.io/rules/no-import-type-side-effects/)

These rules together have the potential to optimize bundler behavior, so prioritizing these across the repo seems like a good idea.

I will integrate into client next week and fix violations. Violations to these rules are generally easy to resolve via eslint's auto-fix, so applying them across the repo at once should not be too difficult.