### PR TITLE
build(server): Update Typetests (#25016)

### DIFF
--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -33,7 +33,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@5.0.0",
+		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@7.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -36,7 +36,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@5.0.0",
+		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@7.0.0",
 		"@types/node": "^18.19.39",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",
@@ -53,11 +53,7 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_KafkaOrdererConnection": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/kafka-orderer/src/test/types/validateServerKafkaOrdererPrevious.generated.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/test/types/validateServerKafkaOrdererPrevious.generated.ts
@@ -40,7 +40,6 @@ declare type current_as_old_for_Class_KafkaOrderer = requireAssignableTo<TypeOnl
  * typeValidation.broken:
  * "Class_KafkaOrdererConnection": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_KafkaOrdererConnection = requireAssignableTo<TypeOnly<old.KafkaOrdererConnection>, TypeOnly<current.KafkaOrdererConnection>>
 
 /*

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -68,7 +68,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@5.0.0",
+		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/async": "^3.2.9",
 		"@types/lodash": "^4.14.118",
@@ -83,21 +83,7 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_DocumentContext": {
-				"forwardCompat": false
-			},
-			"Class_DocumentLambdaFactory": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"Class_KafkaRunner": {
-				"forwardCompat": false
-			},
-			"Class_PartitionManager": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/lambdas-driver/src/test/types/validateServerLambdasDriverPrevious.generated.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/test/types/validateServerLambdasDriverPrevious.generated.ts
@@ -22,7 +22,6 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * typeValidation.broken:
  * "Class_DocumentContext": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_DocumentContext = requireAssignableTo<TypeOnly<old.DocumentContext>, TypeOnly<current.DocumentContext>>
 
 /*
@@ -41,8 +40,7 @@ declare type current_as_old_for_Class_DocumentContext = requireAssignableTo<Type
  * typeValidation.broken:
  * "Class_DocumentLambdaFactory": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
-declare type old_as_current_for_Class_DocumentLambdaFactory = requireAssignableTo<TypeOnly<old.DocumentLambdaFactory>, TypeOnly<current.DocumentLambdaFactory>>
+declare type old_as_current_for_Class_DocumentLambdaFactory = requireAssignableTo<TypeOnly<old.DocumentLambdaFactory<never>>, TypeOnly<current.DocumentLambdaFactory<never>>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
@@ -51,8 +49,7 @@ declare type old_as_current_for_Class_DocumentLambdaFactory = requireAssignableT
  * typeValidation.broken:
  * "Class_DocumentLambdaFactory": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
-declare type current_as_old_for_Class_DocumentLambdaFactory = requireAssignableTo<TypeOnly<current.DocumentLambdaFactory>, TypeOnly<old.DocumentLambdaFactory>>
+declare type current_as_old_for_Class_DocumentLambdaFactory = requireAssignableTo<TypeOnly<current.DocumentLambdaFactory<never>>, TypeOnly<old.DocumentLambdaFactory<never>>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -61,7 +58,6 @@ declare type current_as_old_for_Class_DocumentLambdaFactory = requireAssignableT
  * typeValidation.broken:
  * "Class_KafkaRunner": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_KafkaRunner = requireAssignableTo<TypeOnly<old.KafkaRunner>, TypeOnly<current.KafkaRunner>>
 
 /*
@@ -98,7 +94,6 @@ declare type current_as_old_for_Class_KafkaRunnerFactory = requireAssignableTo<T
  * typeValidation.broken:
  * "Class_PartitionManager": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_PartitionManager = requireAssignableTo<TypeOnly<old.PartitionManager>, TypeOnly<current.PartitionManager>>
 
 /*

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -81,7 +81,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@5.0.0",
+		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/async": "^3.2.9",
 		"@types/json-stringify-safe": "^5.0.0",
@@ -103,11 +103,7 @@
 		"webpack": "^5.94.0"
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_ScriptoriumLambda": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/lambdas/src/test/types/validateServerLambdasPrevious.generated.ts
+++ b/server/routerlicious/packages/lambdas/src/test/types/validateServerLambdasPrevious.generated.ts
@@ -164,6 +164,24 @@ declare type current_as_old_for_Class_DocumentCheckpointManager = requireAssigna
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Class_LambdaCircuitBreaker": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_LambdaCircuitBreaker = requireAssignableTo<TypeOnly<old.LambdaCircuitBreaker>, TypeOnly<current.LambdaCircuitBreaker>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_LambdaCircuitBreaker": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_LambdaCircuitBreaker = requireAssignableTo<TypeOnly<current.LambdaCircuitBreaker>, TypeOnly<old.LambdaCircuitBreaker>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Class_MoiraLambda": {"forwardCompat": false}
  */
 declare type old_as_current_for_Class_MoiraLambda = requireAssignableTo<TypeOnly<old.MoiraLambda>, TypeOnly<current.MoiraLambda>>
@@ -256,7 +274,6 @@ declare type current_as_old_for_Class_ScribeLambdaFactory = requireAssignableTo<
  * typeValidation.broken:
  * "Class_ScriptoriumLambda": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_ScriptoriumLambda = requireAssignableTo<TypeOnly<old.ScriptoriumLambda>, TypeOnly<current.ScriptoriumLambda>>
 
 /*
@@ -393,6 +410,15 @@ declare type current_as_old_for_ClassStatics_DeliLambdaFactory = requireAssignab
  * "ClassStatics_DocumentCheckpointManager": {"backCompat": false}
  */
 declare type current_as_old_for_ClassStatics_DocumentCheckpointManager = requireAssignableTo<TypeOnly<typeof current.DocumentCheckpointManager>, TypeOnly<typeof old.DocumentCheckpointManager>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "ClassStatics_LambdaCircuitBreaker": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_LambdaCircuitBreaker = requireAssignableTo<TypeOnly<typeof current.LambdaCircuitBreaker>, TypeOnly<typeof old.LambdaCircuitBreaker>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
@@ -537,6 +563,24 @@ declare type current_as_old_for_Function_isDocumentSessionValid = requireAssigna
  * "Function_isDocumentValid": {"backCompat": false}
  */
 declare type current_as_old_for_Function_isDocumentValid = requireAssignableTo<TypeOnly<typeof current.isDocumentValid>, TypeOnly<typeof old.isDocumentValid>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_circuitBreakerOptions": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_circuitBreakerOptions = requireAssignableTo<TypeOnly<old.circuitBreakerOptions>, TypeOnly<current.circuitBreakerOptions>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_circuitBreakerOptions": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_circuitBreakerOptions = requireAssignableTo<TypeOnly<current.circuitBreakerOptions>, TypeOnly<old.circuitBreakerOptions>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -807,6 +851,15 @@ declare type current_as_old_for_Variable_createNackMessage = requireAssignableTo
  * "Variable_createRoomLeaveMessage": {"backCompat": false}
  */
 declare type current_as_old_for_Variable_createRoomLeaveMessage = requireAssignableTo<TypeOnly<typeof current.createRoomLeaveMessage>, TypeOnly<typeof old.createRoomLeaveMessage>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Variable_createRuntimeMessage": {"backCompat": false}
+ */
+declare type current_as_old_for_Variable_createRuntimeMessage = requireAssignableTo<TypeOnly<typeof current.createRuntimeMessage>, TypeOnly<typeof old.createRuntimeMessage>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@5.0.0",
+		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@7.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.1",
@@ -97,11 +97,7 @@
 		"webpack-cli": "^5.1.4"
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_LocalOrdererManager": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/local-server/src/test/types/validateServerLocalServerPrevious.generated.ts
+++ b/server/routerlicious/packages/local-server/src/test/types/validateServerLocalServerPrevious.generated.ts
@@ -40,7 +40,6 @@ declare type current_as_old_for_Class_LocalDeltaConnectionServer = requireAssign
  * typeValidation.broken:
  * "Class_LocalOrdererManager": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_LocalOrdererManager = requireAssignableTo<TypeOnly<old.LocalOrdererManager>, TypeOnly<current.LocalOrdererManager>>
 
 /*

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -82,7 +82,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@5.0.0",
+		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@7.0.0",
 		"@types/mocha": "^10.0.1",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
@@ -94,23 +94,7 @@
 		"webpack": "^5.94.0"
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_LocalContext": {
-				"forwardCompat": false
-			},
-			"Class_LocalKafka": {
-				"forwardCompat": false
-			},
-			"Class_LocalLambdaController": {
-				"forwardCompat": false
-			},
-			"Class_LocalOrderer": {
-				"forwardCompat": false
-			},
-			"Interface_IKafkaSubscriber": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/memory-orderer/src/test/types/validateServerMemoryOrdererPrevious.generated.ts
+++ b/server/routerlicious/packages/memory-orderer/src/test/types/validateServerMemoryOrdererPrevious.generated.ts
@@ -22,7 +22,6 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * typeValidation.broken:
  * "Class_LocalContext": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_LocalContext = requireAssignableTo<TypeOnly<old.LocalContext>, TypeOnly<current.LocalContext>>
 
 /*
@@ -41,7 +40,6 @@ declare type current_as_old_for_Class_LocalContext = requireAssignableTo<TypeOnl
  * typeValidation.broken:
  * "Class_LocalKafka": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_LocalKafka = requireAssignableTo<TypeOnly<old.LocalKafka>, TypeOnly<current.LocalKafka>>
 
 /*
@@ -60,7 +58,6 @@ declare type current_as_old_for_Class_LocalKafka = requireAssignableTo<TypeOnly<
  * typeValidation.broken:
  * "Class_LocalLambdaController": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_LocalLambdaController = requireAssignableTo<TypeOnly<old.LocalLambdaController>, TypeOnly<current.LocalLambdaController>>
 
 /*
@@ -97,7 +94,6 @@ declare type current_as_old_for_Class_LocalNodeFactory = requireAssignableTo<Typ
  * typeValidation.broken:
  * "Class_LocalOrderer": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_LocalOrderer = requireAssignableTo<TypeOnly<old.LocalOrderer>, TypeOnly<current.LocalOrderer>>
 
 /*
@@ -368,7 +364,6 @@ declare type current_as_old_for_Interface_IConnectMessage = requireAssignableTo<
  * typeValidation.broken:
  * "Interface_IKafkaSubscriber": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IKafkaSubscriber = requireAssignableTo<TypeOnly<old.IKafkaSubscriber>, TypeOnly<current.IKafkaSubscriber>>
 
 /*

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -69,7 +69,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@5.0.0",
+		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@7.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/assert": "^1.5.1",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -92,7 +92,7 @@
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/server-local-server": "workspace:~",
-		"@fluidframework/server-routerlicious-base-previous": "npm:@fluidframework/server-routerlicious-base@5.0.0",
+		"@fluidframework/server-routerlicious-base-previous": "npm:@fluidframework/server-routerlicious-base@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/body-parser": "^1.19.2",
 		"@types/bytes": "^3.0.0",
@@ -130,30 +130,7 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_AlfredResources": {
-				"forwardCompat": false
-			},
-			"Class_NexusResources": {
-				"forwardCompat": false
-			},
-			"Class_OrdererManager": {
-				"forwardCompat": false
-			},
-			"Class_RiddlerResources": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"Class_TenantManager": {
-				"forwardCompat": false
-			},
-			"ClassStatics_RiddlerResources": {
-				"backCompat": false
-			},
-			"Interface_ITenantDocument": {
-				"backCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/routerlicious-base/src/test/types/validateServerRouterliciousBasePrevious.generated.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/types/validateServerRouterliciousBasePrevious.generated.ts
@@ -22,7 +22,6 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * typeValidation.broken:
  * "Class_AlfredResources": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_AlfredResources = requireAssignableTo<TypeOnly<old.AlfredResources>, TypeOnly<current.AlfredResources>>
 
 /*
@@ -149,7 +148,6 @@ declare type current_as_old_for_Class_MongoTenantRepository = requireAssignableT
  * typeValidation.broken:
  * "Class_NexusResources": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_NexusResources = requireAssignableTo<TypeOnly<old.NexusResources>, TypeOnly<current.NexusResources>>
 
 /*
@@ -204,7 +202,6 @@ declare type current_as_old_for_Class_NexusRunnerFactory = requireAssignableTo<T
  * typeValidation.broken:
  * "Class_OrdererManager": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_OrdererManager = requireAssignableTo<TypeOnly<old.OrdererManager>, TypeOnly<current.OrdererManager>>
 
 /*
@@ -241,7 +238,6 @@ declare type current_as_old_for_Class_OrderingResourcesFactory = requireAssignab
  * typeValidation.broken:
  * "Class_RiddlerResources": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_RiddlerResources = requireAssignableTo<TypeOnly<old.RiddlerResources>, TypeOnly<current.RiddlerResources>>
 
 /*
@@ -251,7 +247,6 @@ declare type old_as_current_for_Class_RiddlerResources = requireAssignableTo<Typ
  * typeValidation.broken:
  * "Class_RiddlerResources": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_RiddlerResources = requireAssignableTo<TypeOnly<current.RiddlerResources>, TypeOnly<old.RiddlerResources>>
 
 /*
@@ -315,7 +310,6 @@ declare type current_as_old_for_Class_RiddlerRunnerFactory = requireAssignableTo
  * typeValidation.broken:
  * "Class_TenantManager": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_TenantManager = requireAssignableTo<TypeOnly<old.TenantManager>, TypeOnly<current.TenantManager>>
 
 /*
@@ -442,7 +436,6 @@ declare type current_as_old_for_ClassStatics_OrderingResourcesFactory = requireA
  * typeValidation.broken:
  * "ClassStatics_RiddlerResources": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_RiddlerResources = requireAssignableTo<TypeOnly<typeof current.RiddlerResources>, TypeOnly<typeof old.RiddlerResources>>
 
 /*
@@ -605,7 +598,6 @@ declare type old_as_current_for_Interface_ITenantDocument = requireAssignableTo<
  * typeValidation.broken:
  * "Interface_ITenantDocument": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ITenantDocument = requireAssignableTo<TypeOnly<current.ITenantDocument>, TypeOnly<old.ITenantDocument>>
 
 /*

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -64,7 +64,6 @@
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/server-local-server": "workspace:~",
-		"@fluidframework/server-routerlicious-previous": "npm:@fluidframework/server-routerlicious@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/nconf": "^0.10.2",
 		"@types/node": "^18.19.39",
@@ -83,8 +82,8 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {},
 		"disabled": true,
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@5.0.0",
+		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@7.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/debug": "^4.1.5",
 		"@types/jsrsasign": "^10.5.12",
@@ -94,23 +94,7 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_NetworkError": {
-				"backCompat": false
-			},
-			"ClassStatics_NetworkError": {
-				"backCompat": false
-			},
-			"Enum_InternalErrorCode": {
-				"backCompat": false
-			},
-			"Interface_INetworkErrorDetails": {
-				"backCompat": false
-			},
-			"Interface_ITimeoutContext": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/services-client/src/test/types/validateServerServicesClientPrevious.generated.ts
+++ b/server/routerlicious/packages/services-client/src/test/types/validateServerServicesClientPrevious.generated.ts
@@ -103,7 +103,6 @@ declare type old_as_current_for_Class_NetworkError = requireAssignableTo<TypeOnl
  * typeValidation.broken:
  * "Class_NetworkError": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_NetworkError = requireAssignableTo<TypeOnly<current.NetworkError>, TypeOnly<old.NetworkError>>
 
 /*
@@ -221,7 +220,6 @@ declare type current_as_old_for_ClassStatics_Historian = requireAssignableTo<Typ
  * typeValidation.broken:
  * "ClassStatics_NetworkError": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_NetworkError = requireAssignableTo<TypeOnly<typeof current.NetworkError>, TypeOnly<typeof old.NetworkError>>
 
 /*
@@ -276,7 +274,6 @@ declare type old_as_current_for_Enum_InternalErrorCode = requireAssignableTo<Typ
  * typeValidation.broken:
  * "Enum_InternalErrorCode": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Enum_InternalErrorCode = requireAssignableTo<TypeOnly<current.InternalErrorCode>, TypeOnly<old.InternalErrorCode>>
 
 /*
@@ -296,6 +293,15 @@ declare type old_as_current_for_Enum_RestLessFieldNames = requireAssignableTo<Ty
  * "Enum_RestLessFieldNames": {"backCompat": false}
  */
 declare type current_as_old_for_Enum_RestLessFieldNames = requireAssignableTo<TypeOnly<current.RestLessFieldNames>, TypeOnly<old.RestLessFieldNames>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Function_convertAxiosErrorToNetorkError": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_convertAxiosErrorToNetorkError = requireAssignableTo<TypeOnly<typeof current.convertAxiosErrorToNetorkError>, TypeOnly<typeof old.convertAxiosErrorToNetorkError>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
@@ -455,9 +461,27 @@ declare type current_as_old_for_Function_mergeSortedArrays = requireAssignableTo
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Function_parseToken": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_parseToken = requireAssignableTo<TypeOnly<typeof current.parseToken>, TypeOnly<typeof old.parseToken>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Function_promiseTimeout": {"backCompat": false}
  */
 declare type current_as_old_for_Function_promiseTimeout = requireAssignableTo<TypeOnly<typeof current.promiseTimeout>, TypeOnly<typeof old.promiseTimeout>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Function_setupAxiosInterceptorsForAbortSignals": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_setupAxiosInterceptorsForAbortSignals = requireAssignableTo<TypeOnly<typeof current.setupAxiosInterceptorsForAbortSignals>, TypeOnly<typeof old.setupAxiosInterceptorsForAbortSignals>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
@@ -491,6 +515,24 @@ declare type current_as_old_for_Function_validateTokenClaimsExpiration = require
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Interface_IAbortControllerContext": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IAbortControllerContext = requireAssignableTo<TypeOnly<old.IAbortControllerContext>, TypeOnly<current.IAbortControllerContext>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IAbortControllerContext": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_IAbortControllerContext = requireAssignableTo<TypeOnly<current.IAbortControllerContext>, TypeOnly<old.IAbortControllerContext>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Interface_IAlfredTenant": {"forwardCompat": false}
  */
 declare type old_as_current_for_Interface_IAlfredTenant = requireAssignableTo<TypeOnly<old.IAlfredTenant>, TypeOnly<current.IAlfredTenant>>
@@ -503,6 +545,24 @@ declare type old_as_current_for_Interface_IAlfredTenant = requireAssignableTo<Ty
  * "Interface_IAlfredTenant": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_IAlfredTenant = requireAssignableTo<TypeOnly<current.IAlfredTenant>, TypeOnly<old.IAlfredTenant>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IBasicRestWrapperMetricProps": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IBasicRestWrapperMetricProps = requireAssignableTo<TypeOnly<old.IBasicRestWrapperMetricProps>, TypeOnly<current.IBasicRestWrapperMetricProps>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IBasicRestWrapperMetricProps": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_IBasicRestWrapperMetricProps = requireAssignableTo<TypeOnly<current.IBasicRestWrapperMetricProps>, TypeOnly<old.IBasicRestWrapperMetricProps>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -700,7 +760,6 @@ declare type old_as_current_for_Interface_INetworkErrorDetails = requireAssignab
  * typeValidation.broken:
  * "Interface_INetworkErrorDetails": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_INetworkErrorDetails = requireAssignableTo<TypeOnly<current.INetworkErrorDetails>, TypeOnly<old.INetworkErrorDetails>>
 
 /*
@@ -800,7 +859,6 @@ declare type current_as_old_for_Interface_ISummaryUploadManager = requireAssigna
  * typeValidation.broken:
  * "Interface_ITimeoutContext": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ITimeoutContext = requireAssignableTo<TypeOnly<old.ITimeoutContext>, TypeOnly<current.ITimeoutContext>>
 
 /*
@@ -1132,6 +1190,15 @@ declare type current_as_old_for_Variable_buildTreePath = requireAssignableTo<Typ
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Variable_CallingServiceHeaderName": {"backCompat": false}
+ */
+declare type current_as_old_for_Variable_CallingServiceHeaderName = requireAssignableTo<TypeOnly<typeof current.CallingServiceHeaderName>, TypeOnly<typeof old.CallingServiceHeaderName>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Variable_canDeleteDoc": {"backCompat": false}
  */
 declare type current_as_old_for_Variable_canDeleteDoc = requireAssignableTo<TypeOnly<typeof current.canDeleteDoc>, TypeOnly<typeof old.canDeleteDoc>>
@@ -1231,6 +1298,15 @@ declare type current_as_old_for_Variable_getAuthorizationTokenFromCredentials = 
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Variable_getGlobalAbortControllerContext": {"backCompat": false}
+ */
+declare type current_as_old_for_Variable_getGlobalAbortControllerContext = requireAssignableTo<TypeOnly<typeof current.getGlobalAbortControllerContext>, TypeOnly<typeof old.getGlobalAbortControllerContext>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Variable_getGlobalTimeoutContext": {"backCompat": false}
  */
 declare type current_as_old_for_Variable_getGlobalTimeoutContext = requireAssignableTo<TypeOnly<typeof current.getGlobalTimeoutContext>, TypeOnly<typeof old.getGlobalTimeoutContext>>
@@ -1258,9 +1334,27 @@ declare type current_as_old_for_Variable_LatestSummaryId = requireAssignableTo<T
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Variable_setGlobalAbortControllerContext": {"backCompat": false}
+ */
+declare type current_as_old_for_Variable_setGlobalAbortControllerContext = requireAssignableTo<TypeOnly<typeof current.setGlobalAbortControllerContext>, TypeOnly<typeof old.setGlobalAbortControllerContext>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Variable_setGlobalTimeoutContext": {"backCompat": false}
  */
 declare type current_as_old_for_Variable_setGlobalTimeoutContext = requireAssignableTo<TypeOnly<typeof current.setGlobalTimeoutContext>, TypeOnly<typeof old.setGlobalTimeoutContext>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Variable_TelemetryContextHeaderName": {"backCompat": false}
+ */
+declare type current_as_old_for_Variable_TelemetryContextHeaderName = requireAssignableTo<TypeOnly<typeof current.TelemetryContextHeaderName>, TypeOnly<typeof old.TelemetryContextHeaderName>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -48,7 +48,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@5.0.0",
+		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@7.0.0",
 		"@types/mocha": "^10.0.1",
 		"@types/sinon": "^17.0.3",
 		"c8": "^8.0.1",
@@ -69,53 +69,7 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_CombinedProducer": {
-				"forwardCompat": false
-			},
-			"Class_MongoManager": {
-				"forwardCompat": false
-			},
-			"Class_TokenRevocationError": {
-				"backCompat": false
-			},
-			"Class_TokenRevokedError": {
-				"backCompat": false
-			},
-			"ClassStatics_TokenRevocationError": {
-				"backCompat": false
-			},
-			"ClassStatics_TokenRevokedError": {
-				"backCompat": false
-			},
-			"Interface_IBoxcarMessage": {
-				"backCompat": false
-			},
-			"Interface_IContext": {
-				"forwardCompat": false
-			},
-			"Interface_IOrdererConnection": {
-				"forwardCompat": false
-			},
-			"Interface_IOrdererManager": {
-				"forwardCompat": false
-			},
-			"Interface_IProducer": {
-				"forwardCompat": false
-			},
-			"Interface_ITenantConfig": {
-				"forwardCompat": false
-			},
-			"Interface_ITenantManager": {
-				"forwardCompat": false
-			},
-			"Interface_IEncryptedTenantKeys": {
-				"backCompat": false
-			},
-			"Enum_EncryptionKeyVersion": {
-				"backCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -76,7 +76,6 @@ declare type current_as_old_for_Class_CombinedLambda = requireAssignableTo<TypeO
  * typeValidation.broken:
  * "Class_CombinedProducer": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_CombinedProducer = requireAssignableTo<TypeOnly<old.CombinedProducer>, TypeOnly<current.CombinedProducer>>
 
 /*
@@ -185,7 +184,6 @@ declare type current_as_old_for_Class_MongoDocumentRepository = requireAssignabl
  * typeValidation.broken:
  * "Class_MongoManager": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MongoManager = requireAssignableTo<TypeOnly<old.MongoManager>, TypeOnly<current.MongoManager>>
 
 /*
@@ -249,7 +247,6 @@ declare type old_as_current_for_Class_TokenRevocationError = requireAssignableTo
  * typeValidation.broken:
  * "Class_TokenRevocationError": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_TokenRevocationError = requireAssignableTo<TypeOnly<current.TokenRevocationError>, TypeOnly<old.TokenRevocationError>>
 
 /*
@@ -268,7 +265,6 @@ declare type old_as_current_for_Class_TokenRevokedError = requireAssignableTo<Ty
  * typeValidation.broken:
  * "Class_TokenRevokedError": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_TokenRevokedError = requireAssignableTo<TypeOnly<current.TokenRevokedError>, TypeOnly<old.TokenRevokedError>>
 
 /*
@@ -386,7 +382,6 @@ declare type current_as_old_for_ClassStatics_ThrottlingError = requireAssignable
  * typeValidation.broken:
  * "ClassStatics_TokenRevocationError": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_TokenRevocationError = requireAssignableTo<TypeOnly<typeof current.TokenRevocationError>, TypeOnly<typeof old.TokenRevocationError>>
 
 /*
@@ -396,7 +391,6 @@ declare type current_as_old_for_ClassStatics_TokenRevocationError = requireAssig
  * typeValidation.broken:
  * "ClassStatics_TokenRevokedError": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_TokenRevokedError = requireAssignableTo<TypeOnly<typeof current.TokenRevokedError>, TypeOnly<typeof old.TokenRevokedError>>
 
 /*
@@ -433,7 +427,6 @@ declare type old_as_current_for_Enum_EncryptionKeyVersion = requireAssignableTo<
  * typeValidation.broken:
  * "Enum_EncryptionKeyVersion": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Enum_EncryptionKeyVersion = requireAssignableTo<TypeOnly<current.EncryptionKeyVersion>, TypeOnly<old.EncryptionKeyVersion>>
 
 /*
@@ -558,6 +551,15 @@ declare type current_as_old_for_Function_extractBoxcar = requireAssignableTo<Typ
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Function_isCompleteBoxcarMessage": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_isCompleteBoxcarMessage = requireAssignableTo<TypeOnly<typeof current.isCompleteBoxcarMessage>, TypeOnly<typeof old.isCompleteBoxcarMessage>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Function_isRetryEnabled": {"backCompat": false}
  */
 declare type current_as_old_for_Function_isRetryEnabled = requireAssignableTo<TypeOnly<typeof current.isRetryEnabled>, TypeOnly<typeof old.isRetryEnabled>>
@@ -641,7 +643,6 @@ declare type old_as_current_for_Interface_IBoxcarMessage = requireAssignableTo<T
  * typeValidation.broken:
  * "Interface_IBoxcarMessage": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IBoxcarMessage = requireAssignableTo<TypeOnly<current.IBoxcarMessage>, TypeOnly<old.IBoxcarMessage>>
 
 /*
@@ -679,6 +680,24 @@ declare type old_as_current_for_Interface_ICache = requireAssignableTo<TypeOnly<
  * "Interface_ICache": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_ICache = requireAssignableTo<TypeOnly<current.ICache>, TypeOnly<old.ICache>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ICheck": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_ICheck = requireAssignableTo<TypeOnly<old.ICheck>, TypeOnly<current.ICheck>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ICheck": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_ICheck = requireAssignableTo<TypeOnly<current.ICheck>, TypeOnly<old.ICheck>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -811,6 +830,78 @@ declare type current_as_old_for_Interface_IClusterDrainingChecker = requireAssig
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Interface_ICollaborationSession": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_ICollaborationSession = requireAssignableTo<TypeOnly<old.ICollaborationSession>, TypeOnly<current.ICollaborationSession>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ICollaborationSession": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_ICollaborationSession = requireAssignableTo<TypeOnly<current.ICollaborationSession>, TypeOnly<old.ICollaborationSession>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ICollaborationSessionClient": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_ICollaborationSessionClient = requireAssignableTo<TypeOnly<old.ICollaborationSessionClient>, TypeOnly<current.ICollaborationSessionClient>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ICollaborationSessionClient": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_ICollaborationSessionClient = requireAssignableTo<TypeOnly<current.ICollaborationSessionClient>, TypeOnly<old.ICollaborationSessionClient>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ICollaborationSessionManager": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_ICollaborationSessionManager = requireAssignableTo<TypeOnly<old.ICollaborationSessionManager>, TypeOnly<current.ICollaborationSessionManager>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ICollaborationSessionManager": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_ICollaborationSessionManager = requireAssignableTo<TypeOnly<current.ICollaborationSessionManager>, TypeOnly<old.ICollaborationSessionManager>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ICollaborationSessionTracker": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_ICollaborationSessionTracker = requireAssignableTo<TypeOnly<old.ICollaborationSessionTracker>, TypeOnly<current.ICollaborationSessionTracker>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ICollaborationSessionTracker": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_ICollaborationSessionTracker = requireAssignableTo<TypeOnly<current.ICollaborationSessionTracker>, TypeOnly<old.ICollaborationSessionTracker>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Interface_ICollection": {"forwardCompat": false}
  */
 declare type old_as_current_for_Interface_ICollection = requireAssignableTo<TypeOnly<old.ICollection<never>>, TypeOnly<current.ICollection<never>>>
@@ -849,7 +940,6 @@ declare type current_as_old_for_Interface_IConsumer = requireAssignableTo<TypeOn
  * typeValidation.broken:
  * "Interface_IContext": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IContext = requireAssignableTo<TypeOnly<old.IContext>, TypeOnly<current.IContext>>
 
 /*
@@ -1046,6 +1136,24 @@ declare type current_as_old_for_Interface_IDeltaService = requireAssignableTo<Ty
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Interface_IDenyList": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IDenyList = requireAssignableTo<TypeOnly<old.IDenyList>, TypeOnly<current.IDenyList>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IDenyList": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_IDenyList = requireAssignableTo<TypeOnly<current.IDenyList>, TypeOnly<old.IDenyList>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Interface_IDisableNackMessagesControlMessageContents": {"forwardCompat": false}
  */
 declare type old_as_current_for_Interface_IDisableNackMessagesControlMessageContents = requireAssignableTo<TypeOnly<old.IDisableNackMessagesControlMessageContents>, TypeOnly<current.IDisableNackMessagesControlMessageContents>>
@@ -1190,6 +1298,24 @@ declare type current_as_old_for_Interface_IDocumentStorage = requireAssignableTo
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Interface_IEncryptedPrivateTenantKeys": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IEncryptedPrivateTenantKeys = requireAssignableTo<TypeOnly<old.IEncryptedPrivateTenantKeys>, TypeOnly<current.IEncryptedPrivateTenantKeys>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IEncryptedPrivateTenantKeys": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_IEncryptedPrivateTenantKeys = requireAssignableTo<TypeOnly<current.IEncryptedPrivateTenantKeys>, TypeOnly<old.IEncryptedPrivateTenantKeys>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Interface_IEncryptedTenantKeys": {"forwardCompat": false}
  */
 declare type old_as_current_for_Interface_IEncryptedTenantKeys = requireAssignableTo<TypeOnly<old.IEncryptedTenantKeys>, TypeOnly<current.IEncryptedTenantKeys>>
@@ -1201,7 +1327,6 @@ declare type old_as_current_for_Interface_IEncryptedTenantKeys = requireAssignab
  * typeValidation.broken:
  * "Interface_IEncryptedTenantKeys": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IEncryptedTenantKeys = requireAssignableTo<TypeOnly<current.IEncryptedTenantKeys>, TypeOnly<old.IEncryptedTenantKeys>>
 
 /*
@@ -1227,6 +1352,42 @@ declare type current_as_old_for_Interface_IExtendClientControlMessageContents = 
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Interface_IFluidAccessToken": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IFluidAccessToken = requireAssignableTo<TypeOnly<old.IFluidAccessToken>, TypeOnly<current.IFluidAccessToken>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IFluidAccessToken": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_IFluidAccessToken = requireAssignableTo<TypeOnly<current.IFluidAccessToken>, TypeOnly<old.IFluidAccessToken>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IFluidAccessTokenGenerator": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IFluidAccessTokenGenerator = requireAssignableTo<TypeOnly<old.IFluidAccessTokenGenerator>, TypeOnly<current.IFluidAccessTokenGenerator>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IFluidAccessTokenGenerator": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_IFluidAccessTokenGenerator = requireAssignableTo<TypeOnly<current.IFluidAccessTokenGenerator>, TypeOnly<old.IFluidAccessTokenGenerator>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Interface_IHttpServer": {"forwardCompat": false}
  */
 declare type old_as_current_for_Interface_IHttpServer = requireAssignableTo<TypeOnly<old.IHttpServer>, TypeOnly<current.IHttpServer>>
@@ -1239,6 +1400,24 @@ declare type old_as_current_for_Interface_IHttpServer = requireAssignableTo<Type
  * "Interface_IHttpServer": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_IHttpServer = requireAssignableTo<TypeOnly<current.IHttpServer>, TypeOnly<old.IHttpServer>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IInvalidTokenError": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IInvalidTokenError = requireAssignableTo<TypeOnly<old.IInvalidTokenError>, TypeOnly<current.IInvalidTokenError>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IInvalidTokenError": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_IInvalidTokenError = requireAssignableTo<TypeOnly<current.IInvalidTokenError>, TypeOnly<old.IInvalidTokenError>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -1445,7 +1624,6 @@ declare type current_as_old_for_Interface_IOrderer = requireAssignableTo<TypeOnl
  * typeValidation.broken:
  * "Interface_IOrdererConnection": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IOrdererConnection = requireAssignableTo<TypeOnly<old.IOrdererConnection>, TypeOnly<current.IOrdererConnection>>
 
 /*
@@ -1464,7 +1642,6 @@ declare type current_as_old_for_Interface_IOrdererConnection = requireAssignable
  * typeValidation.broken:
  * "Interface_IOrdererManager": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IOrdererManager = requireAssignableTo<TypeOnly<old.IOrdererManager>, TypeOnly<current.IOrdererManager>>
 
 /*
@@ -1625,9 +1802,26 @@ declare type current_as_old_for_Interface_IPendingMessage = requireAssignableTo<
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Interface_IPlainTextAndEncryptedTenantKeys": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IPlainTextAndEncryptedTenantKeys = requireAssignableTo<TypeOnly<old.IPlainTextAndEncryptedTenantKeys>, TypeOnly<current.IPlainTextAndEncryptedTenantKeys>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IPlainTextAndEncryptedTenantKeys": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_IPlainTextAndEncryptedTenantKeys = requireAssignableTo<TypeOnly<current.IPlainTextAndEncryptedTenantKeys>, TypeOnly<old.IPlainTextAndEncryptedTenantKeys>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Interface_IProducer": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IProducer = requireAssignableTo<TypeOnly<old.IProducer>, TypeOnly<current.IProducer>>
 
 /*
@@ -1710,6 +1904,42 @@ declare type old_as_current_for_Interface_IRawOperationMessageBatch = requireAss
  * "Interface_IRawOperationMessageBatch": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_IRawOperationMessageBatch = requireAssignableTo<TypeOnly<current.IRawOperationMessageBatch>, TypeOnly<old.IRawOperationMessageBatch>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IReadinessCheck": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IReadinessCheck = requireAssignableTo<TypeOnly<old.IReadinessCheck>, TypeOnly<current.IReadinessCheck>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IReadinessCheck": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_IReadinessCheck = requireAssignableTo<TypeOnly<current.IReadinessCheck>, TypeOnly<old.IReadinessCheck>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IReadinessStatus": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IReadinessStatus = requireAssignableTo<TypeOnly<old.IReadinessStatus>, TypeOnly<current.IReadinessStatus>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IReadinessStatus": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_IReadinessStatus = requireAssignableTo<TypeOnly<current.IReadinessStatus>, TypeOnly<old.IReadinessStatus>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -2132,7 +2362,6 @@ declare type current_as_old_for_Interface_ITenant = requireAssignableTo<TypeOnly
  * typeValidation.broken:
  * "Interface_ITenantConfig": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ITenantConfig = requireAssignableTo<TypeOnly<old.ITenantConfig>, TypeOnly<current.ITenantConfig>>
 
 /*
@@ -2205,7 +2434,6 @@ declare type current_as_old_for_Interface_ITenantKeys = requireAssignableTo<Type
  * typeValidation.broken:
  * "Interface_ITenantManager": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ITenantManager = requireAssignableTo<TypeOnly<old.ITenantManager>, TypeOnly<current.ITenantManager>>
 
 /*
@@ -2234,6 +2462,24 @@ declare type old_as_current_for_Interface_ITenantOrderer = requireAssignableTo<T
  * "Interface_ITenantOrderer": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_ITenantOrderer = requireAssignableTo<TypeOnly<current.ITenantOrderer>, TypeOnly<old.ITenantOrderer>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ITenantPrivateKeys": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_ITenantPrivateKeys = requireAssignableTo<TypeOnly<old.ITenantPrivateKeys>, TypeOnly<current.ITenantPrivateKeys>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_ITenantPrivateKeys": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_ITenantPrivateKeys = requireAssignableTo<TypeOnly<current.ITenantPrivateKeys>, TypeOnly<old.ITenantPrivateKeys>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -2699,6 +2945,15 @@ declare type current_as_old_for_Variable_clientConnectivityStorageId = requireAs
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Variable_clusterDrainingRetryTimeInMs": {"backCompat": false}
+ */
+declare type current_as_old_for_Variable_clusterDrainingRetryTimeInMs = requireAssignableTo<TypeOnly<typeof current.clusterDrainingRetryTimeInMs>, TypeOnly<typeof old.clusterDrainingRetryTimeInMs>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Variable_DefaultServiceConfiguration": {"backCompat": false}
  */
 declare type current_as_old_for_Variable_DefaultServiceConfiguration = requireAssignableTo<TypeOnly<typeof current.DefaultServiceConfiguration>, TypeOnly<typeof old.DefaultServiceConfiguration>>
@@ -2720,6 +2975,15 @@ declare type current_as_old_for_Variable_httpUsageStorageId = requireAssignableT
  * "Variable_MaxBatchSize": {"backCompat": false}
  */
 declare type current_as_old_for_Variable_MaxBatchSize = requireAssignableTo<TypeOnly<typeof current.MaxBatchSize>, TypeOnly<typeof old.MaxBatchSize>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Variable_MaxKafkaMessageSize": {"backCompat": false}
+ */
+declare type current_as_old_for_Variable_MaxKafkaMessageSize = requireAssignableTo<TypeOnly<typeof current.MaxKafkaMessageSize>, TypeOnly<typeof old.MaxKafkaMessageSize>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -43,7 +43,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@5.0.0",
+		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",
 		"@types/lru-cache": "^5.1.0",
@@ -65,11 +65,7 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_KafkaNodeProducer": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/test/types/validateServerServicesOrderingKafkanodePrevious.generated.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/test/types/validateServerServicesOrderingKafkanodePrevious.generated.ts
@@ -40,7 +40,6 @@ declare type current_as_old_for_Class_KafkaNodeConsumer = requireAssignableTo<Ty
  * typeValidation.broken:
  * "Class_KafkaNodeProducer": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_KafkaNodeProducer = requireAssignableTo<TypeOnly<old.KafkaNodeProducer>, TypeOnly<current.KafkaNodeProducer>>
 
 /*

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -43,7 +43,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@5.0.0",
+		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/amqplib": "^0.5.17",
 		"@types/debug": "^4.1.5",
@@ -66,11 +66,7 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_RdkafkaConsumer": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/test/types/validateServerServicesOrderingRdkafkaPrevious.generated.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/test/types/validateServerServicesOrderingRdkafkaPrevious.generated.ts
@@ -22,7 +22,6 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * typeValidation.broken:
  * "Class_RdkafkaConsumer": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_RdkafkaConsumer = requireAssignableTo<TypeOnly<old.RdkafkaConsumer>, TypeOnly<current.RdkafkaConsumer>>
 
 /*

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -36,7 +36,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@5.0.0",
+		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",
 		"@types/lru-cache": "^5.1.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@5.0.0",
+		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/body-parser": "^1.19.2",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-shared/src/test/types/validateServerServicesSharedPrevious.generated.ts
+++ b/server/routerlicious/packages/services-shared/src/test/types/validateServerServicesSharedPrevious.generated.ts
@@ -182,6 +182,24 @@ declare type current_as_old_for_Class_SocketIoWebServerFactory = requireAssignab
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Class_StartupCheck": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_StartupCheck = requireAssignableTo<TypeOnly<old.StartupCheck>, TypeOnly<current.StartupCheck>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_StartupCheck": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_StartupCheck = requireAssignableTo<TypeOnly<current.StartupCheck>, TypeOnly<old.StartupCheck>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Class_WebServer": {"forwardCompat": false}
  */
 declare type old_as_current_for_Class_WebServer = requireAssignableTo<TypeOnly<old.WebServer>, TypeOnly<current.WebServer>>
@@ -317,6 +335,15 @@ declare type current_as_old_for_ClassStatics_SocketIoWebServerFactory = requireA
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "ClassStatics_StartupCheck": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_StartupCheck = requireAssignableTo<TypeOnly<typeof current.StartupCheck>, TypeOnly<typeof old.StartupCheck>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "ClassStatics_WebServer": {"backCompat": false}
  */
 declare type current_as_old_for_ClassStatics_WebServer = requireAssignableTo<TypeOnly<typeof current.WebServer>, TypeOnly<typeof old.WebServer>>
@@ -344,9 +371,27 @@ declare type current_as_old_for_ClassStatics_WholeSummaryWriteGitManager = requi
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Function_closeRedisClientConnections": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_closeRedisClientConnections = requireAssignableTo<TypeOnly<typeof current.closeRedisClientConnections>, TypeOnly<typeof old.closeRedisClientConnections>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Function_containsPathTraversal": {"backCompat": false}
  */
 declare type current_as_old_for_Function_containsPathTraversal = requireAssignableTo<TypeOnly<typeof current.containsPathTraversal>, TypeOnly<typeof old.containsPathTraversal>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Function_createHealthCheckEndpoints": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_createHealthCheckEndpoints = requireAssignableTo<TypeOnly<typeof current.createHealthCheckEndpoints>, TypeOnly<typeof old.createHealthCheckEndpoints>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -63,7 +63,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@5.0.0",
+		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@7.0.0",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.19.39",
 		"@types/sinon": "^17.0.3",
@@ -78,27 +78,7 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_Lumber": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"Enum_BaseTelemetryProperties": {
-				"backCompat": false
-			},
-			"Enum_HttpProperties": {
-				"backCompat": false
-			},
-			"Enum_LumberEventName": {
-				"backCompat": false
-			},
-			"Interface_ITelemetryContextProperties": {
-				"forwardCompat": false
-			},
-			"Enum_CommonProperties": {
-				"backCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/services-telemetry/src/test/types/validateServerServicesTelemetryPrevious.generated.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/types/validateServerServicesTelemetryPrevious.generated.ts
@@ -94,7 +94,6 @@ declare type current_as_old_for_Class_LambdaSchemaValidator = requireAssignableT
  * typeValidation.broken:
  * "Class_Lumber": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_Lumber = requireAssignableTo<TypeOnly<old.Lumber>, TypeOnly<current.Lumber>>
 
 /*
@@ -104,7 +103,6 @@ declare type old_as_current_for_Class_Lumber = requireAssignableTo<TypeOnly<old.
  * typeValidation.broken:
  * "Class_Lumber": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_Lumber = requireAssignableTo<TypeOnly<current.Lumber>, TypeOnly<old.Lumber>>
 
 /*
@@ -357,7 +355,6 @@ declare type old_as_current_for_Enum_BaseTelemetryProperties = requireAssignable
  * typeValidation.broken:
  * "Enum_BaseTelemetryProperties": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Enum_BaseTelemetryProperties = requireAssignableTo<TypeOnly<current.BaseTelemetryProperties>, TypeOnly<old.BaseTelemetryProperties>>
 
 /*
@@ -376,7 +373,6 @@ declare type old_as_current_for_Enum_CommonProperties = requireAssignableTo<Type
  * typeValidation.broken:
  * "Enum_CommonProperties": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Enum_CommonProperties = requireAssignableTo<TypeOnly<current.CommonProperties>, TypeOnly<old.CommonProperties>>
 
 /*
@@ -395,7 +391,6 @@ declare type old_as_current_for_Enum_HttpProperties = requireAssignableTo<TypeOn
  * typeValidation.broken:
  * "Enum_HttpProperties": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Enum_HttpProperties = requireAssignableTo<TypeOnly<current.HttpProperties>, TypeOnly<old.HttpProperties>>
 
 /*
@@ -432,7 +427,6 @@ declare type old_as_current_for_Enum_LumberEventName = requireAssignableTo<TypeO
  * typeValidation.broken:
  * "Enum_LumberEventName": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Enum_LumberEventName = requireAssignableTo<TypeOnly<current.LumberEventName>, TypeOnly<old.LumberEventName>>
 
 /*
@@ -515,6 +509,15 @@ declare type current_as_old_for_Enum_ThrottlingTelemetryProperties = requireAssi
  * "Function_handleError": {"backCompat": false}
  */
 declare type current_as_old_for_Function_handleError = requireAssignableTo<TypeOnly<typeof current.handleError>, TypeOnly<typeof old.handleError>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Function_isTelemetryContextProperties": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_isTelemetryContextProperties = requireAssignableTo<TypeOnly<typeof current.isTelemetryContextProperties>, TypeOnly<typeof old.isTelemetryContextProperties>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -631,7 +634,6 @@ declare type current_as_old_for_Interface_ITelemetryContext = requireAssignableT
  * typeValidation.broken:
  * "Interface_ITelemetryContextProperties": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ITelemetryContextProperties = requireAssignableTo<TypeOnly<old.ITelemetryContextProperties>, TypeOnly<current.ITelemetryContextProperties>>
 
 /*

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@5.0.0",
+		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",
 		"@types/express": "^4.17.21",
@@ -106,11 +106,7 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_AsyncLocalStorageTimeoutContext": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/services-utils/src/test/types/validateServerServicesUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/services-utils/src/test/types/validateServerServicesUtilsPrevious.generated.ts
@@ -20,6 +20,24 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Class_AsyncLocalStorageAbortControllerContext": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_AsyncLocalStorageAbortControllerContext = requireAssignableTo<TypeOnly<old.AsyncLocalStorageAbortControllerContext>, TypeOnly<current.AsyncLocalStorageAbortControllerContext>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_AsyncLocalStorageAbortControllerContext": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_AsyncLocalStorageAbortControllerContext = requireAssignableTo<TypeOnly<current.AsyncLocalStorageAbortControllerContext>, TypeOnly<old.AsyncLocalStorageAbortControllerContext>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Class_AsyncLocalStorageContextProvider": {"forwardCompat": false}
  */
 declare type old_as_current_for_Class_AsyncLocalStorageContextProvider = requireAssignableTo<TypeOnly<old.AsyncLocalStorageContextProvider<never>>, TypeOnly<current.AsyncLocalStorageContextProvider<never>>>
@@ -58,7 +76,6 @@ declare type current_as_old_for_Class_AsyncLocalStorageTelemetryContext = requir
  * typeValidation.broken:
  * "Class_AsyncLocalStorageTimeoutContext": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_AsyncLocalStorageTimeoutContext = requireAssignableTo<TypeOnly<old.AsyncLocalStorageTimeoutContext>, TypeOnly<current.AsyncLocalStorageTimeoutContext>>
 
 /*
@@ -69,6 +86,24 @@ declare type old_as_current_for_Class_AsyncLocalStorageTimeoutContext = requireA
  * "Class_AsyncLocalStorageTimeoutContext": {"backCompat": false}
  */
 declare type current_as_old_for_Class_AsyncLocalStorageTimeoutContext = requireAssignableTo<TypeOnly<current.AsyncLocalStorageTimeoutContext>, TypeOnly<old.AsyncLocalStorageTimeoutContext>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_DenyList": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_DenyList = requireAssignableTo<TypeOnly<old.DenyList>, TypeOnly<current.DenyList>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_DenyList": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_DenyList = requireAssignableTo<TypeOnly<current.DenyList>, TypeOnly<old.DenyList>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -165,6 +200,24 @@ declare type current_as_old_for_Class_RedisClientConnectionManager = requireAssi
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Class_ResponseSizeMiddleware": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_ResponseSizeMiddleware = requireAssignableTo<TypeOnly<old.ResponseSizeMiddleware>, TypeOnly<current.ResponseSizeMiddleware>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_ResponseSizeMiddleware": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_ResponseSizeMiddleware = requireAssignableTo<TypeOnly<current.ResponseSizeMiddleware>, TypeOnly<old.ResponseSizeMiddleware>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Class_ScheduledJob": {"forwardCompat": false}
  */
 declare type old_as_current_for_Class_ScheduledJob = requireAssignableTo<TypeOnly<old.ScheduledJob>, TypeOnly<current.ScheduledJob>>
@@ -237,6 +290,15 @@ declare type current_as_old_for_Class_WinstonLumberjackEngine = requireAssignabl
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "ClassStatics_AsyncLocalStorageAbortControllerContext": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_AsyncLocalStorageAbortControllerContext = requireAssignableTo<TypeOnly<typeof current.AsyncLocalStorageAbortControllerContext>, TypeOnly<typeof old.AsyncLocalStorageAbortControllerContext>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "ClassStatics_AsyncLocalStorageContextProvider": {"backCompat": false}
  */
 declare type current_as_old_for_ClassStatics_AsyncLocalStorageContextProvider = requireAssignableTo<TypeOnly<typeof current.AsyncLocalStorageContextProvider>, TypeOnly<typeof old.AsyncLocalStorageContextProvider>>
@@ -258,6 +320,15 @@ declare type current_as_old_for_ClassStatics_AsyncLocalStorageTelemetryContext =
  * "ClassStatics_AsyncLocalStorageTimeoutContext": {"backCompat": false}
  */
 declare type current_as_old_for_ClassStatics_AsyncLocalStorageTimeoutContext = requireAssignableTo<TypeOnly<typeof current.AsyncLocalStorageTimeoutContext>, TypeOnly<typeof old.AsyncLocalStorageTimeoutContext>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "ClassStatics_DenyList": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_DenyList = requireAssignableTo<TypeOnly<typeof current.DenyList>, TypeOnly<typeof old.DenyList>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
@@ -303,6 +374,15 @@ declare type current_as_old_for_ClassStatics_InMemoryApiCounters = requireAssign
  * "ClassStatics_RedisClientConnectionManager": {"backCompat": false}
  */
 declare type current_as_old_for_ClassStatics_RedisClientConnectionManager = requireAssignableTo<TypeOnly<typeof current.RedisClientConnectionManager>, TypeOnly<typeof old.RedisClientConnectionManager>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "ClassStatics_ResponseSizeMiddleware": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_ResponseSizeMiddleware = requireAssignableTo<TypeOnly<typeof current.ResponseSizeMiddleware>, TypeOnly<typeof old.ResponseSizeMiddleware>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
@@ -372,6 +452,15 @@ declare type current_as_old_for_Function_alternativeMorganLoggerMiddleware = req
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Function_configureGlobalAbortControllerContext": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_configureGlobalAbortControllerContext = requireAssignableTo<TypeOnly<typeof current.configureGlobalAbortControllerContext>, TypeOnly<typeof old.configureGlobalAbortControllerContext>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Function_configureGlobalTelemetryContext": {"backCompat": false}
  */
 declare type current_as_old_for_Function_configureGlobalTelemetryContext = requireAssignableTo<TypeOnly<typeof current.configureGlobalTelemetryContext>, TypeOnly<typeof old.configureGlobalTelemetryContext>>
@@ -408,6 +497,15 @@ declare type current_as_old_for_Function_deleteSummarizedOps = requireAssignable
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Function_denyListMiddleware": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_denyListMiddleware = requireAssignableTo<TypeOnly<typeof current.denyListMiddleware>, TypeOnly<typeof old.denyListMiddleware>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Function_executeApiWithMetric": {"backCompat": false}
  */
 declare type current_as_old_for_Function_executeApiWithMetric = requireAssignableTo<TypeOnly<typeof current.executeApiWithMetric>, TypeOnly<typeof old.executeApiWithMetric>>
@@ -420,6 +518,15 @@ declare type current_as_old_for_Function_executeApiWithMetric = requireAssignabl
  * "Function_executeOnInterval": {"backCompat": false}
  */
 declare type current_as_old_for_Function_executeOnInterval = requireAssignableTo<TypeOnly<typeof current.executeOnInterval>, TypeOnly<typeof old.executeOnInterval>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Function_extractTokenFromHeader": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_extractTokenFromHeader = requireAssignableTo<TypeOnly<typeof current.extractTokenFromHeader>, TypeOnly<typeof old.extractTokenFromHeader>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
@@ -489,6 +596,15 @@ declare type current_as_old_for_Function_getHostIp = requireAssignableTo<TypeOnl
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Function_getJtiClaimFromAccessToken": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_getJtiClaimFromAccessToken = requireAssignableTo<TypeOnly<typeof current.getJtiClaimFromAccessToken>, TypeOnly<typeof old.getJtiClaimFromAccessToken>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Function_getNumberFromConfig": {"backCompat": false}
  */
 declare type current_as_old_for_Function_getNumberFromConfig = requireAssignableTo<TypeOnly<typeof current.getNumberFromConfig>, TypeOnly<typeof old.getNumberFromConfig>>
@@ -519,6 +635,33 @@ declare type current_as_old_for_Function_getRandomName = requireAssignableTo<Typ
  * "Function_getTelemetryContextPropertiesWithHttpInfo": {"backCompat": false}
  */
 declare type current_as_old_for_Function_getTelemetryContextPropertiesWithHttpInfo = requireAssignableTo<TypeOnly<typeof current.getTelemetryContextPropertiesWithHttpInfo>, TypeOnly<typeof old.getTelemetryContextPropertiesWithHttpInfo>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Function_getValidAccessToken": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_getValidAccessToken = requireAssignableTo<TypeOnly<typeof current.getValidAccessToken>, TypeOnly<typeof old.getValidAccessToken>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Function_isKeylessFluidAccessClaimEnabled": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_isKeylessFluidAccessClaimEnabled = requireAssignableTo<TypeOnly<typeof current.isKeylessFluidAccessClaimEnabled>, TypeOnly<typeof old.isKeylessFluidAccessClaimEnabled>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Function_isTokenValid": {"backCompat": false}
+ */
+declare type current_as_old_for_Function_isTokenValid = requireAssignableTo<TypeOnly<typeof current.isTokenValid>, TypeOnly<typeof old.isTokenValid>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
@@ -741,6 +884,15 @@ declare type current_as_old_for_Interface_IWinstonConfig = requireAssignableTo<T
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Variable_bindAbortControllerContext": {"backCompat": false}
+ */
+declare type current_as_old_for_Variable_bindAbortControllerContext = requireAssignableTo<TypeOnly<typeof current.bindAbortControllerContext>, TypeOnly<typeof old.bindAbortControllerContext>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Variable_bindCorrelationId": {"backCompat": false}
  */
 declare type current_as_old_for_Variable_bindCorrelationId = requireAssignableTo<TypeOnly<typeof current.bindCorrelationId>, TypeOnly<typeof old.bindCorrelationId>>
@@ -807,6 +959,15 @@ declare type current_as_old_for_Variable_getRedisClusterRetryStrategy = requireA
  * "Variable_getThrottleConfig": {"backCompat": false}
  */
 declare type current_as_old_for_Variable_getThrottleConfig = requireAssignableTo<TypeOnly<typeof current.getThrottleConfig>, TypeOnly<typeof old.getThrottleConfig>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Variable_logHttpMetrics": {"backCompat": false}
+ */
+declare type current_as_old_for_Variable_logHttpMetrics = requireAssignableTo<TypeOnly<typeof current.logHttpMetrics>, TypeOnly<typeof old.logHttpMetrics>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -81,7 +81,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@5.0.0",
+		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@7.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/amqplib": "^0.5.17",
 		"@types/debug": "^4.1.5",
@@ -108,20 +108,7 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_MongoDb": {
-				"forwardCompat": false
-			},
-			"Class_TenantManager": {
-				"forwardCompat": false
-			},
-			"Class_WebServer": {
-				"backCompat": false
-			},
-			"ClassStatics_WebServer": {
-				"backCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/services/src/test/types/validateServerServicesPrevious.generated.ts
+++ b/server/routerlicious/packages/services/src/test/types/validateServerServicesPrevious.generated.ts
@@ -56,6 +56,24 @@ declare type current_as_old_for_Class_ClientManager = requireAssignableTo<TypeOn
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Class_CollaborationSessionTracker": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_CollaborationSessionTracker = requireAssignableTo<TypeOnly<old.CollaborationSessionTracker>, TypeOnly<current.CollaborationSessionTracker>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_CollaborationSessionTracker": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_CollaborationSessionTracker = requireAssignableTo<TypeOnly<current.CollaborationSessionTracker>, TypeOnly<old.CollaborationSessionTracker>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Class_DeltaManager": {"forwardCompat": false}
  */
 declare type old_as_current_for_Class_DeltaManager = requireAssignableTo<TypeOnly<old.DeltaManager>, TypeOnly<current.DeltaManager>>
@@ -148,7 +166,6 @@ declare type current_as_old_for_Class_MongoCollection = requireAssignableTo<Type
  * typeValidation.broken:
  * "Class_MongoDb": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MongoDb = requireAssignableTo<TypeOnly<old.MongoDb>, TypeOnly<current.MongoDb>>
 
 /*
@@ -249,6 +266,24 @@ declare type old_as_current_for_Class_RedisCache = requireAssignableTo<TypeOnly<
  * "Class_RedisCache": {"backCompat": false}
  */
 declare type current_as_old_for_Class_RedisCache = requireAssignableTo<TypeOnly<current.RedisCache>, TypeOnly<old.RedisCache>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_RedisCollaborationSessionManager": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_RedisCollaborationSessionManager = requireAssignableTo<TypeOnly<old.RedisCollaborationSessionManager>, TypeOnly<current.RedisCollaborationSessionManager>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_RedisCollaborationSessionManager": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_RedisCollaborationSessionManager = requireAssignableTo<TypeOnly<current.RedisCollaborationSessionManager>, TypeOnly<old.RedisCollaborationSessionManager>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -437,7 +472,6 @@ declare type current_as_old_for_Class_Tenant = requireAssignableTo<TypeOnly<curr
  * typeValidation.broken:
  * "Class_TenantManager": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_TenantManager = requireAssignableTo<TypeOnly<old.TenantManager>, TypeOnly<current.TenantManager>>
 
 /*
@@ -501,7 +535,6 @@ declare type old_as_current_for_Class_WebServer = requireAssignableTo<TypeOnly<o
  * typeValidation.broken:
  * "Class_WebServer": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_WebServer = requireAssignableTo<TypeOnly<current.WebServer>, TypeOnly<old.WebServer>>
 
 /*
@@ -557,6 +590,15 @@ declare type current_as_old_for_ClassStatics_BasicWebServerFactory = requireAssi
  * "ClassStatics_ClientManager": {"backCompat": false}
  */
 declare type current_as_old_for_ClassStatics_ClientManager = requireAssignableTo<TypeOnly<typeof current.ClientManager>, TypeOnly<typeof old.ClientManager>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "ClassStatics_CollaborationSessionTracker": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_CollaborationSessionTracker = requireAssignableTo<TypeOnly<typeof current.CollaborationSessionTracker>, TypeOnly<typeof old.CollaborationSessionTracker>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
@@ -656,6 +698,15 @@ declare type current_as_old_for_ClassStatics_NodeCodeLoader = requireAssignableT
  * "ClassStatics_RedisCache": {"backCompat": false}
  */
 declare type current_as_old_for_ClassStatics_RedisCache = requireAssignableTo<TypeOnly<typeof current.RedisCache>, TypeOnly<typeof old.RedisCache>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "ClassStatics_RedisCollaborationSessionManager": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_RedisCollaborationSessionManager = requireAssignableTo<TypeOnly<typeof current.RedisCollaborationSessionManager>, TypeOnly<typeof old.RedisCollaborationSessionManager>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
@@ -781,7 +832,6 @@ declare type current_as_old_for_ClassStatics_ThrottlerHelper = requireAssignable
  * typeValidation.broken:
  * "ClassStatics_WebServer": {"backCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_WebServer = requireAssignableTo<TypeOnly<typeof current.WebServer>, TypeOnly<typeof old.WebServer>>
 
 /*
@@ -936,6 +986,24 @@ declare type old_as_current_for_Interface_INodeClusterConfig = requireAssignable
  * "Interface_INodeClusterConfig": {"backCompat": false}
  */
 declare type current_as_old_for_Interface_INodeClusterConfig = requireAssignableTo<TypeOnly<current.INodeClusterConfig>, TypeOnly<old.INodeClusterConfig>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IRedisCollaborationSessionManagerOptions": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Interface_IRedisCollaborationSessionManagerOptions = requireAssignableTo<TypeOnly<old.IRedisCollaborationSessionManagerOptions>, TypeOnly<current.IRedisCollaborationSessionManagerOptions>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Interface_IRedisCollaborationSessionManagerOptions": {"backCompat": false}
+ */
+declare type current_as_old_for_Interface_IRedisCollaborationSessionManagerOptions = requireAssignableTo<TypeOnly<current.IRedisCollaborationSessionManagerOptions>, TypeOnly<old.IRedisCollaborationSessionManagerOptions>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@5.0.0",
+		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@7.0.0",
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.19.39",
@@ -89,17 +89,7 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_TestContext": {
-				"forwardCompat": false
-			},
-			"Class_TestProducer": {
-				"forwardCompat": false
-			},
-			"Class_TestTenantManager": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "public"
 	}
 }

--- a/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
@@ -92,6 +92,24 @@ declare type current_as_old_for_Class_TestCache = requireAssignableTo<TypeOnly<c
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "Class_TestCheck": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_TestCheck = requireAssignableTo<TypeOnly<old.TestCheck>, TypeOnly<current.TestCheck>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_TestCheck": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_TestCheck = requireAssignableTo<TypeOnly<current.TestCheck>, TypeOnly<old.TestCheck>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "Class_TestClientManager": {"forwardCompat": false}
  */
 declare type old_as_current_for_Class_TestClientManager = requireAssignableTo<TypeOnly<old.TestClientManager>, TypeOnly<current.TestClientManager>>
@@ -104,6 +122,24 @@ declare type old_as_current_for_Class_TestClientManager = requireAssignableTo<Ty
  * "Class_TestClientManager": {"backCompat": false}
  */
 declare type current_as_old_for_Class_TestClientManager = requireAssignableTo<TypeOnly<current.TestClientManager>, TypeOnly<old.TestClientManager>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_TestClusterDrainingStatusChecker": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_TestClusterDrainingStatusChecker = requireAssignableTo<TypeOnly<old.TestClusterDrainingStatusChecker>, TypeOnly<current.TestClusterDrainingStatusChecker>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_TestClusterDrainingStatusChecker": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_TestClusterDrainingStatusChecker = requireAssignableTo<TypeOnly<current.TestClusterDrainingStatusChecker>, TypeOnly<old.TestClusterDrainingStatusChecker>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -148,7 +184,6 @@ declare type current_as_old_for_Class_TestConsumer = requireAssignableTo<TypeOnl
  * typeValidation.broken:
  * "Class_TestContext": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_TestContext = requireAssignableTo<TypeOnly<old.TestContext>, TypeOnly<current.TestContext>>
 
 /*
@@ -231,6 +266,24 @@ declare type old_as_current_for_Class_TestDocumentStorage = requireAssignableTo<
  * "Class_TestDocumentStorage": {"backCompat": false}
  */
 declare type current_as_old_for_Class_TestDocumentStorage = requireAssignableTo<TypeOnly<current.TestDocumentStorage>, TypeOnly<old.TestDocumentStorage>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_TestFluidAccessTokenGenerator": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_TestFluidAccessTokenGenerator = requireAssignableTo<TypeOnly<old.TestFluidAccessTokenGenerator>, TypeOnly<current.TestFluidAccessTokenGenerator>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_TestFluidAccessTokenGenerator": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_TestFluidAccessTokenGenerator = requireAssignableTo<TypeOnly<current.TestFluidAccessTokenGenerator>, TypeOnly<old.TestFluidAccessTokenGenerator>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -329,7 +382,6 @@ declare type current_as_old_for_Class_TestNotImplementedDocumentRepository = req
  * typeValidation.broken:
  * "Class_TestProducer": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_TestProducer = requireAssignableTo<TypeOnly<old.TestProducer>, TypeOnly<current.TestProducer>>
 
 /*
@@ -358,6 +410,24 @@ declare type old_as_current_for_Class_TestPublisher = requireAssignableTo<TypeOn
  * "Class_TestPublisher": {"backCompat": false}
  */
 declare type current_as_old_for_Class_TestPublisher = requireAssignableTo<TypeOnly<current.TestPublisher>, TypeOnly<old.TestPublisher>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_TestReadinessCheck": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_TestReadinessCheck = requireAssignableTo<TypeOnly<old.TestReadinessCheck>, TypeOnly<current.TestReadinessCheck>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_TestReadinessCheck": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_TestReadinessCheck = requireAssignableTo<TypeOnly<current.TestReadinessCheck>, TypeOnly<old.TestReadinessCheck>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -402,7 +472,6 @@ declare type current_as_old_for_Class_TestTenant = requireAssignableTo<TypeOnly<
  * typeValidation.broken:
  * "Class_TestTenantManager": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_TestTenantManager = requireAssignableTo<TypeOnly<old.TestTenantManager>, TypeOnly<current.TestTenantManager>>
 
 /*
@@ -527,9 +596,27 @@ declare type current_as_old_for_ClassStatics_TestCache = requireAssignableTo<Typ
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "ClassStatics_TestCheck": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_TestCheck = requireAssignableTo<TypeOnly<typeof current.TestCheck>, TypeOnly<typeof old.TestCheck>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "ClassStatics_TestClientManager": {"backCompat": false}
  */
 declare type current_as_old_for_ClassStatics_TestClientManager = requireAssignableTo<TypeOnly<typeof current.TestClientManager>, TypeOnly<typeof old.TestClientManager>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "ClassStatics_TestClusterDrainingStatusChecker": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_TestClusterDrainingStatusChecker = requireAssignableTo<TypeOnly<typeof current.TestClusterDrainingStatusChecker>, TypeOnly<typeof old.TestClusterDrainingStatusChecker>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
@@ -599,6 +686,15 @@ declare type current_as_old_for_ClassStatics_TestDocumentStorage = requireAssign
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
+ * "ClassStatics_TestFluidAccessTokenGenerator": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_TestFluidAccessTokenGenerator = requireAssignableTo<TypeOnly<typeof current.TestFluidAccessTokenGenerator>, TypeOnly<typeof old.TestFluidAccessTokenGenerator>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
  * "ClassStatics_TestHistorian": {"backCompat": false}
  */
 declare type current_as_old_for_ClassStatics_TestHistorian = requireAssignableTo<TypeOnly<typeof current.TestHistorian>, TypeOnly<typeof old.TestHistorian>>
@@ -656,6 +752,15 @@ declare type current_as_old_for_ClassStatics_TestProducer = requireAssignableTo<
  * "ClassStatics_TestPublisher": {"backCompat": false}
  */
 declare type current_as_old_for_ClassStatics_TestPublisher = requireAssignableTo<TypeOnly<typeof current.TestPublisher>, TypeOnly<typeof old.TestPublisher>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "ClassStatics_TestReadinessCheck": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_TestReadinessCheck = requireAssignableTo<TypeOnly<typeof current.TestReadinessCheck>, TypeOnly<typeof old.TestReadinessCheck>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/gitresources-previous':
-        specifier: npm:@fluidframework/gitresources@5.0.0
-        version: '@fluidframework/gitresources@5.0.0'
+        specifier: npm:@fluidframework/gitresources@7.0.0
+        version: '@fluidframework/gitresources@7.0.0'
       '@microsoft/api-extractor':
         specifier: ^7.45.1
         version: 7.45.1(patch_hash=f66stvskxun56mencgf6l5564y)(@types/node@22.10.7)
@@ -130,8 +130,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-kafka-orderer-previous':
-        specifier: npm:@fluidframework/server-kafka-orderer@5.0.0
-        version: '@fluidframework/server-kafka-orderer@5.0.0'
+        specifier: npm:@fluidframework/server-kafka-orderer@7.0.0
+        version: '@fluidframework/server-kafka-orderer@7.0.0'
       '@types/node':
         specifier: ^18.19.39
         version: 18.19.39
@@ -236,8 +236,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-lambdas-previous':
-        specifier: npm:@fluidframework/server-lambdas@5.0.0
-        version: '@fluidframework/server-lambdas@5.0.0(debug@4.3.4)'
+        specifier: npm:@fluidframework/server-lambdas@7.0.0
+        version: '@fluidframework/server-lambdas@7.0.0'
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -342,8 +342,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-lambdas-driver-previous':
-        specifier: npm:@fluidframework/server-lambdas-driver@5.0.0
-        version: '@fluidframework/server-lambdas-driver@5.0.0'
+        specifier: npm:@fluidframework/server-lambdas-driver@7.0.0
+        version: '@fluidframework/server-lambdas-driver@7.0.0'
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -433,8 +433,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-local-server-previous':
-        specifier: npm:@fluidframework/server-local-server@5.0.0
-        version: '@fluidframework/server-local-server@5.0.0'
+        specifier: npm:@fluidframework/server-local-server@7.0.0
+        version: '@fluidframework/server-local-server@7.0.0'
       '@microsoft/api-extractor':
         specifier: ^7.45.1
         version: 7.45.1(patch_hash=f66stvskxun56mencgf6l5564y)(@types/node@18.19.39)
@@ -569,8 +569,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-memory-orderer-previous':
-        specifier: npm:@fluidframework/server-memory-orderer@5.0.0
-        version: '@fluidframework/server-memory-orderer@5.0.0'
+        specifier: npm:@fluidframework/server-memory-orderer@7.0.0
+        version: '@fluidframework/server-memory-orderer@7.0.0'
       '@types/mocha':
         specifier: ^10.0.1
         version: 10.0.1
@@ -627,8 +627,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/protocol-base-previous':
-        specifier: npm:@fluidframework/protocol-base@5.0.0
-        version: '@fluidframework/protocol-base@5.0.0'
+        specifier: npm:@fluidframework/protocol-base@7.0.0
+        version: '@fluidframework/protocol-base@7.0.0'
       '@microsoft/api-extractor':
         specifier: ^7.45.1
         version: 7.45.1(patch_hash=f66stvskxun56mencgf6l5564y)(@types/node@18.19.39)
@@ -741,9 +741,6 @@ importers:
       '@fluidframework/server-local-server':
         specifier: workspace:~
         version: link:../local-server
-      '@fluidframework/server-routerlicious-previous':
-        specifier: npm:@fluidframework/server-routerlicious@5.0.0
-        version: '@fluidframework/server-routerlicious@5.0.0'
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -890,8 +887,8 @@ importers:
         specifier: workspace:~
         version: link:../local-server
       '@fluidframework/server-routerlicious-base-previous':
-        specifier: npm:@fluidframework/server-routerlicious-base@5.0.0
-        version: '@fluidframework/server-routerlicious-base@5.0.0'
+        specifier: npm:@fluidframework/server-routerlicious-base@7.0.0
+        version: '@fluidframework/server-routerlicious-base@7.0.0'
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1062,8 +1059,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-previous':
-        specifier: npm:@fluidframework/server-services@5.0.0
-        version: '@fluidframework/server-services@5.0.0'
+        specifier: npm:@fluidframework/server-services@7.0.0
+        version: '@fluidframework/server-services@7.0.0'
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1165,8 +1162,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-client-previous':
-        specifier: npm:@fluidframework/server-services-client@5.0.0
-        version: '@fluidframework/server-services-client@5.0.0'
+        specifier: npm:@fluidframework/server-services-client@7.0.0
+        version: '@fluidframework/server-services-client@7.0.0'
       '@microsoft/api-extractor':
         specifier: ^7.45.1
         version: 7.45.1(patch_hash=f66stvskxun56mencgf6l5564y)(@types/node@18.19.39)
@@ -1256,8 +1253,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-core-previous':
-        specifier: npm:@fluidframework/server-services-core@5.0.0
-        version: '@fluidframework/server-services-core@5.0.0'
+        specifier: npm:@fluidframework/server-services-core@7.0.0
+        version: '@fluidframework/server-services-core@7.0.0'
       '@types/mocha':
         specifier: ^10.0.1
         version: 10.0.1
@@ -1329,8 +1326,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-ordering-kafkanode-previous':
-        specifier: npm:@fluidframework/server-services-ordering-kafkanode@5.0.0
-        version: '@fluidframework/server-services-ordering-kafkanode@5.0.0'
+        specifier: npm:@fluidframework/server-services-ordering-kafkanode@7.0.0
+        version: '@fluidframework/server-services-ordering-kafkanode@7.0.0'
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1408,8 +1405,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-ordering-rdkafka-previous':
-        specifier: npm:@fluidframework/server-services-ordering-rdkafka@5.0.0
-        version: '@fluidframework/server-services-ordering-rdkafka@5.0.0'
+        specifier: npm:@fluidframework/server-services-ordering-rdkafka@7.0.0
+        version: '@fluidframework/server-services-ordering-rdkafka@7.0.0'
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1469,8 +1466,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-ordering-zookeeper-previous':
-        specifier: npm:@fluidframework/server-services-ordering-zookeeper@5.0.0
-        version: '@fluidframework/server-services-ordering-zookeeper@5.0.0'
+        specifier: npm:@fluidframework/server-services-ordering-zookeeper@7.0.0
+        version: '@fluidframework/server-services-ordering-zookeeper@7.0.0'
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1596,8 +1593,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-shared-previous':
-        specifier: npm:@fluidframework/server-services-shared@5.0.0
-        version: '@fluidframework/server-services-shared@5.0.0'
+        specifier: npm:@fluidframework/server-services-shared@7.0.0
+        version: '@fluidframework/server-services-shared@7.0.0'
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1681,8 +1678,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-telemetry-previous':
-        specifier: npm:@fluidframework/server-services-telemetry@5.0.0
-        version: '@fluidframework/server-services-telemetry@5.0.0'
+        specifier: npm:@fluidframework/server-services-telemetry@7.0.0
+        version: '@fluidframework/server-services-telemetry@7.0.0'
       '@types/mocha':
         specifier: ^10.0.1
         version: 10.0.1
@@ -1787,8 +1784,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-utils-previous':
-        specifier: npm:@fluidframework/server-services-utils@5.0.0
-        version: '@fluidframework/server-services-utils@5.0.0'
+        specifier: npm:@fluidframework/server-services-utils@7.0.0
+        version: '@fluidframework/server-services-utils@7.0.0'
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1911,8 +1908,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-test-utils-previous':
-        specifier: npm:@fluidframework/server-test-utils@5.0.0
-        version: '@fluidframework/server-test-utils@5.0.0'
+        specifier: npm:@fluidframework/server-test-utils@7.0.0
+        version: '@fluidframework/server-test-utils@7.0.0'
       '@types/lodash':
         specifier: ^4.14.118
         version: 4.14.195
@@ -2451,65 +2448,62 @@ packages:
   '@fluidframework/eslint-config-fluid@5.7.4':
     resolution: {integrity: sha512-2JD0fKhR0wk8kWkUmjNY6FcavLxs0/oQ413z0gFHUSzd8UTkwTYumFQWpDBEoAvXqQw4nUOTAbicNIqHY25EyQ==}
 
-  '@fluidframework/gitresources@5.0.0':
-    resolution: {integrity: sha512-nfam1KT+EUqFCENHcxrU9VwUfbhUC83UcLuOsdLpn9I7VuClL+w8KMWosoYauZraO9gDhTo2kCErjgQji5GzGA==}
+  '@fluidframework/gitresources@7.0.0':
+    resolution: {integrity: sha512-APAxqCF/+2ljC8th0PoXzdUAo2EJapdTk9KNm6dp7dFD5hxYWoscFqdyu5K+bvMxmhrIpGd0f//nbb7rZq7bog==}
 
-  '@fluidframework/protocol-base@5.0.0':
-    resolution: {integrity: sha512-q5qQt269nUYQERwX5lntfEXVv7jbxFmGAZC1z1I5hZmkvSC6PJGF6GzXAtP43/eq0+hCftxmIT0jus+kLL/K4w==}
+  '@fluidframework/protocol-base@7.0.0':
+    resolution: {integrity: sha512-LUSTKQBJVnemMLMQUuoszHvl46XBfflI8U9R8kW+12T2W/Vvt+ldML7203MvNg4E/sFScGfqqZS5OzYn0z1TIw==}
 
   '@fluidframework/protocol-definitions@3.2.0':
     resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
 
-  '@fluidframework/server-kafka-orderer@5.0.0':
-    resolution: {integrity: sha512-WQaKMj6UWr4LTIf4Rib296qoTaws5e0ZWn5zxDLykDoFGTs14D4xvgBBiRMYDI66u5cy8rJq08BlPm+krntF+Q==}
+  '@fluidframework/server-kafka-orderer@7.0.0':
+    resolution: {integrity: sha512-/j2FC448ExnnZzR56FcpYiDjWFtW9jhYZxmWZ+OTc+/P01z9p1fp79TCH5jD4zsTmJWF5uRz/ZCxwAbDvDyirg==}
 
-  '@fluidframework/server-lambdas-driver@5.0.0':
-    resolution: {integrity: sha512-tnMxsxKr2zajQ64Ew7zcTKclK2Rkp7cqK4ghiuYkzhdbt7ZxIMVmkSW3B5/DXDSxVoi4VR6q1BA6cMnGJMcwsw==}
+  '@fluidframework/server-lambdas-driver@7.0.0':
+    resolution: {integrity: sha512-HNXeXUWYIR+jjGMAB61gCWsryuwqysA2o7/bwvdZuM4avqfm75dJUheB6N04uG5GfRfvesMHU68452YHIf6FYQ==}
 
-  '@fluidframework/server-lambdas@5.0.0':
-    resolution: {integrity: sha512-t0ouLtYi2y5DBYbp+WT4mIGXTSYK/1Yz+cb0prOtAUxYqsn+TAG/hr2DE8OyzHdL0RHZp/y2KX7X1jZhPxxGDg==}
+  '@fluidframework/server-lambdas@7.0.0':
+    resolution: {integrity: sha512-D5yzSZWpCojgZR2dfczSHa8lix2V39l1P5mwVrfmrTZE8tL+a3POnXtxcRJPT7QeRImfrMMDBdIBXE5dwFxNjQ==}
 
-  '@fluidframework/server-local-server@5.0.0':
-    resolution: {integrity: sha512-v+IBLojcZm1azQhiSEPCt3A2/xByiqDQ7/0gdkFenGrnEvnJ/9r/vv6ON0vAWFqDXov1Nu6kwEGA1bXIZTeHQw==}
+  '@fluidframework/server-local-server@7.0.0':
+    resolution: {integrity: sha512-ygCDPr3pE8HCakMtdYOlv8X6jpyzqval1hbf45v3egBI5LmolA+RDxKGA/nNKo525u13kGglPWvsuC/8tN82qA==}
 
-  '@fluidframework/server-memory-orderer@5.0.0':
-    resolution: {integrity: sha512-S5G2TwHXlewGkZ3jAtUKr/vpku0LPvhApktOVtAidIGHlKJP0kjLiom/KZihKZT5h2KqIhFBy56JgkXPFYkNeQ==}
+  '@fluidframework/server-memory-orderer@7.0.0':
+    resolution: {integrity: sha512-HmimZuGDYabOma6Tdn5jHpk2IRNEtxbUdUuNkR3qqZxPaqewTj3qeCOXRTMMGyEEaUg5Gmw19LrOROeDRcG6pA==}
 
-  '@fluidframework/server-routerlicious-base@5.0.0':
-    resolution: {integrity: sha512-j1l8hEi8EWiC2L5AN9DgeJe1vF79yP4AU3jd+rXNPeSOfR2vYO5aQxmosgJGkHPJYG8AWQ72VEi6YPE4jFlS7w==}
+  '@fluidframework/server-routerlicious-base@7.0.0':
+    resolution: {integrity: sha512-eGSyMPacPaEfbmGZKD/Gg/3kakq2jx2pR9LHuWTA9NxdhJX2tEpnKgFe3u+4Ss99yPXuG4xTdKr529y+QY1BNw==}
 
-  '@fluidframework/server-routerlicious@5.0.0':
-    resolution: {integrity: sha512-9zAuSxDBgl4SLYU0ZJPBDBmZLE2M+wbuIyZjBGy/JE5FlAs17DvdZLkh0bDty8Wp5AgHk9FW44KZNXwrBsUG1g==}
+  '@fluidframework/server-services-client@7.0.0':
+    resolution: {integrity: sha512-gzEvH6wNpRuMsyZhY22JrOHbTFsPGSzjLIlAWmnT7UT0znYGCDaMC39WPbOLLm7O8JSvmUblGe2Vx8N1+gCOgQ==}
 
-  '@fluidframework/server-services-client@5.0.0':
-    resolution: {integrity: sha512-Cijcy/WUL4U20XAVmN3tDMCYmjmwAmAl6drXBYzN6QvnwMN4PsNjwgsZdEHN+2D7wEs4o/Wb+g9DNv+Lu5EmLg==}
+  '@fluidframework/server-services-core@7.0.0':
+    resolution: {integrity: sha512-LdPERvJ/8nyXOxDPJ0VsWBHsGjwaCve7kdOcMTBk26UQhsHKtSl1D4ZuStoremzzQZBnA0FuksoZsA2yDizwAg==}
 
-  '@fluidframework/server-services-core@5.0.0':
-    resolution: {integrity: sha512-ztrGdRStwlfBFVsm+kChu6VuI764O4TbEEE1RX4gXpLlOsUVZfgYfeUiysdk5Zh7svDKT9n5LdE6VdjLvwb7IA==}
+  '@fluidframework/server-services-ordering-kafkanode@7.0.0':
+    resolution: {integrity: sha512-8eRuJ5BstEh1bHX2DNIDe9CcjJvk9p6Ox4ZmoSMR9hO2eQfx6TFmJBQd4yPv3M1MrpzdWA8IChDqVt/iYByhEA==}
 
-  '@fluidframework/server-services-ordering-kafkanode@5.0.0':
-    resolution: {integrity: sha512-pbNHMD3bZ3gs8pMlQvauTMn7SiGxm46HenlnQBRlbZb+FF+PbEhf1doyJab5JllVTR0HnIso0LLxf9MHK63Mdg==}
+  '@fluidframework/server-services-ordering-rdkafka@7.0.0':
+    resolution: {integrity: sha512-kk8w3+wJT3VGZCbndznlSyebClrijy555KbOPEdHgOvwLVjuitk0tgpqo0fkGk6PGWdikWUAxnat8fONNoFusA==}
 
-  '@fluidframework/server-services-ordering-rdkafka@5.0.0':
-    resolution: {integrity: sha512-BNq5i6Loro7OdT/Xuo1QsPDxPLySkezBXELKnyzTnJBzziNu81jmTAutJJkNDiPkv6aZNquk657q5S1mcm8FGQ==}
+  '@fluidframework/server-services-ordering-zookeeper@7.0.0':
+    resolution: {integrity: sha512-p69vyn+50j22f3irItp7LFCvHoIYZFVX08EcOjS0UOQu6KrMZd04TNk19WQf1wQ49xqEUI6kD88z7rgyMior3g==}
 
-  '@fluidframework/server-services-ordering-zookeeper@5.0.0':
-    resolution: {integrity: sha512-HZad4lMJjMduUySfTBQKN4bvgrpWrVpWRBkc3DvWOjP3NUwBf+VA6ndiN2x3fpqlyMgdyXNfgZyNrijMJpvADA==}
+  '@fluidframework/server-services-shared@7.0.0':
+    resolution: {integrity: sha512-kO2/34/4rPPfjnyadaSaIXotWT4ZWMcGxiqruIbuU05zV+OCieUrla3YnE8GFtQ5hCGPMDE6+InfoUcEb8GN9Q==}
 
-  '@fluidframework/server-services-shared@5.0.0':
-    resolution: {integrity: sha512-Qrmxq8IeUTq9n+5rpR4LY0MPZfKWXCw/MQj0Sc5xe0bx8tnPmqQ1W43uOC+or4HcWmigSYKkhPfp73BSzvNrfw==}
+  '@fluidframework/server-services-telemetry@7.0.0':
+    resolution: {integrity: sha512-C3PNyfBWmWboAkSvExELdwyW8dQ9RBIUPhh1P016pf76NRIk2ZypLloVh7K2WA5fo6Tv+gRYhnT2gThXhNm5IA==}
 
-  '@fluidframework/server-services-telemetry@5.0.0':
-    resolution: {integrity: sha512-lWymor6/GVgZpjtBOEUzCmjNJoro/oK2MKoT0MFgg70bhTgWKAOLRAkJZgq8GLGPCHW7ntZ/D+ve763kPu27CQ==}
+  '@fluidframework/server-services-utils@7.0.0':
+    resolution: {integrity: sha512-/hwQbeVx3prXNTReSVGbGmDZTbAKPDUVhHB5CY9eG9nKbo8FnkXUbaOXpgX1xECAWhzer0K4Qj//93G95TAY8w==}
 
-  '@fluidframework/server-services-utils@5.0.0':
-    resolution: {integrity: sha512-5yuVl3Wqj8GpcT1NX+GFsvIwP3nSWD/KJP0J1EQi499T5RWwdsoCcDtZhe1T968NbPQAx/gnXyMtEVy5MfTkWA==}
+  '@fluidframework/server-services@7.0.0':
+    resolution: {integrity: sha512-DAWBCcWyI/5kRaUs71MUR94mnZAdDy7czmD8b+eKxLNw7tyTdrM0N0uuGkYK2T+yy4UBJ8apiTyByIfmrw3XJA==}
 
-  '@fluidframework/server-services@5.0.0':
-    resolution: {integrity: sha512-iFh8ML/0FycJNtqNFc1uYZnA16DHXxd5kLlt6oY1lDVNeV1JgsI+6mefhp1QK++j1T3jcSe6d5MWs72nm8VUsw==}
-
-  '@fluidframework/server-test-utils@5.0.0':
-    resolution: {integrity: sha512-FOZ1Faw6x8VALUZh/nY6zKCfpgbPK/ylpKf/uQ2oOV9sxGNQfo5NXyHlQP1b78wfx2OYyHY5njtvYl7i9tz/zg==}
+  '@fluidframework/server-test-utils@7.0.0':
+    resolution: {integrity: sha512-ACUoJDbL3sckzeDe/1DGUamYI9IIGyYyeP88MfEnunqgz9FoDrdn3Jae2Vl1SSBYLtck8IxG86rSOh0kbXcPHQ==}
 
   '@gitbeaker/core@38.12.1':
     resolution: {integrity: sha512-8XMVcBIdVAAoxn7JtqmZ2Ee8f+AZLcCPmqEmPFOXY2jPS84y/DERISg/+sbhhb18iRy+ZsZhpWgQ/r3CkYNJOQ==}
@@ -9332,7 +9326,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@changesets/assemble-release-plan@6.0.4':
     dependencies:
@@ -9341,7 +9335,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.1
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@changesets/changelog-git@0.2.0':
     dependencies:
@@ -9399,7 +9393,7 @@ snapshots:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@changesets/get-release-plan@4.0.4':
     dependencies:
@@ -9983,9 +9977,9 @@ snapshots:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.1.6)
       eslint-config-biome: 1.9.4
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
@@ -10001,32 +9995,32 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluidframework/gitresources@5.0.0': {}
+  '@fluidframework/gitresources@7.0.0': {}
 
-  '@fluidframework/protocol-base@5.0.0':
+  '@fluidframework/protocol-base@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
+      '@fluidframework/gitresources': 7.0.0
       '@fluidframework/protocol-definitions': 3.2.0
       events_pkg: events@3.3.0
 
   '@fluidframework/protocol-definitions@3.2.0': {}
 
-  '@fluidframework/server-kafka-orderer@5.0.0':
+  '@fluidframework/server-kafka-orderer@7.0.0':
     dependencies:
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-core': 7.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/server-lambdas-driver@5.0.0':
+  '@fluidframework/server-lambdas-driver@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
       assert: 2.1.0
-      async: 3.2.5
+      async: 3.2.6
       events: 3.3.0
       lodash: 4.17.21
       nconf: 0.12.1
@@ -10034,97 +10028,129 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/server-lambdas@5.0.0(debug@4.3.4)':
+  '@fluidframework/server-lambdas@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
-      '@fluidframework/protocol-base': 5.0.0
+      '@fluidframework/gitresources': 7.0.0
+      '@fluidframework/protocol-base': 7.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas-driver': 5.0.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
+      '@fluidframework/server-lambdas-driver': 7.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
       '@types/semver': 7.7.0
       assert: 2.1.0
-      async: 3.2.5
-      axios: 1.8.4(debug@4.3.4)
+      async: 3.2.6
+      axios: 1.8.4
       buffer: 6.0.3
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       json-stringify-safe: 5.0.1
       lodash: 4.17.21
       nconf: 0.12.1
-      semver: 7.7.1
+      opossum: 8.1.4
+      semver: 7.7.2
+      serialize-error: 8.1.0
       sha.js: 2.4.11
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/server-local-server@5.0.0':
+  '@fluidframework/server-lambdas@7.0.0(debug@4.4.1)':
+    dependencies:
+      '@fluidframework/common-utils': 3.1.0
+      '@fluidframework/gitresources': 7.0.0
+      '@fluidframework/protocol-base': 7.0.0
+      '@fluidframework/protocol-definitions': 3.2.0
+      '@fluidframework/server-lambdas-driver': 7.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
+      '@types/semver': 7.7.0
+      assert: 2.1.0
+      async: 3.2.6
+      axios: 1.8.4(debug@4.4.1)
+      buffer: 6.0.3
+      double-ended-queue: 2.1.0-0
+      events: 3.3.0
+      json-stringify-safe: 5.0.1
+      lodash: 4.17.21
+      nconf: 0.12.1
+      opossum: 8.1.4
+      semver: 7.7.2
+      serialize-error: 8.1.0
+      sha.js: 2.4.11
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/server-local-server@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 5.0.0(debug@4.3.4)
-      '@fluidframework/server-memory-orderer': 5.0.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      '@fluidframework/server-test-utils': 5.0.0
-      debug: 4.3.4
+      '@fluidframework/server-lambdas': 7.0.0(debug@4.4.1)
+      '@fluidframework/server-memory-orderer': 7.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
+      '@fluidframework/server-test-utils': 7.0.0
+      debug: 4.4.1
       events_pkg: events@3.3.0
       jsrsasign: 11.0.0
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/server-memory-orderer@5.0.0':
+  '@fluidframework/server-memory-orderer@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/protocol-base': 5.0.0
+      '@fluidframework/protocol-base': 7.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 5.0.0(debug@4.3.4)
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
+      '@fluidframework/server-lambdas': 7.0.0(debug@4.4.1)
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
       '@types/debug': 4.1.12
       '@types/double-ended-queue': 2.1.7
       '@types/lodash': 4.14.202
       '@types/node': 18.19.39
       '@types/ws': 6.0.4
       assert: 2.1.0
-      debug: 4.3.4
+      debug: 4.4.1
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lodash: 4.17.21
       sillyname: 0.1.0
-      uuid: 9.0.1
+      uuid: 11.1.0
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/server-routerlicious-base@5.0.0':
+  '@fluidframework/server-routerlicious-base@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
+      '@fluidframework/gitresources': 7.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-kafka-orderer': 5.0.0
-      '@fluidframework/server-lambdas': 5.0.0(debug@4.3.4)
-      '@fluidframework/server-lambdas-driver': 5.0.0
-      '@fluidframework/server-memory-orderer': 5.0.0
-      '@fluidframework/server-services': 5.0.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-ordering-kafkanode': 5.0.0
-      '@fluidframework/server-services-ordering-rdkafka': 5.0.0
-      '@fluidframework/server-services-ordering-zookeeper': 5.0.0
-      '@fluidframework/server-services-shared': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      '@fluidframework/server-services-utils': 5.0.0
+      '@fluidframework/server-kafka-orderer': 7.0.0
+      '@fluidframework/server-lambdas': 7.0.0
+      '@fluidframework/server-lambdas-driver': 7.0.0
+      '@fluidframework/server-memory-orderer': 7.0.0
+      '@fluidframework/server-services': 7.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-services-ordering-kafkanode': 7.0.0
+      '@fluidframework/server-services-ordering-rdkafka': 7.0.0
+      '@fluidframework/server-services-ordering-zookeeper': 7.0.0
+      '@fluidframework/server-services-shared': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
+      '@fluidframework/server-services-utils': 7.0.0
+      '@socket.io/redis-emitter': 4.1.1
       body-parser: 1.20.3
       bytes: 3.1.2
       compression: 1.7.4
@@ -10139,7 +10165,7 @@ snapshots:
       serialize-error: 8.1.0
       sha.js: 2.4.11
       sillyname: 0.1.0
-      uuid: 9.0.1
+      uuid: 11.1.0
       winston: 3.9.0
       ws: 7.5.10
     transitivePeerDependencies:
@@ -10149,72 +10175,44 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/server-routerlicious@5.0.0':
+  '@fluidframework/server-services-client@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
+      '@fluidframework/gitresources': 7.0.0
+      '@fluidframework/protocol-base': 7.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-kafka-orderer': 5.0.0
-      '@fluidframework/server-lambdas': 5.0.0(debug@4.3.4)
-      '@fluidframework/server-lambdas-driver': 5.0.0
-      '@fluidframework/server-memory-orderer': 5.0.0
-      '@fluidframework/server-routerlicious-base': 5.0.0
-      '@fluidframework/server-services': 5.0.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-shared': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      '@fluidframework/server-services-utils': 5.0.0
-      commander: 2.20.3
-      express: 4.21.2
-      ioredis: 5.6.1
-      nconf: 0.12.1
-      winston: 3.9.0
-    transitivePeerDependencies:
-      - aws-crt
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-
-  '@fluidframework/server-services-client@5.0.0':
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
-      '@fluidframework/protocol-base': 5.0.0
-      '@fluidframework/protocol-definitions': 3.2.0
-      axios: 1.8.4(debug@4.3.4)
+      axios: 1.8.4(debug@4.4.1)
       crc-32: 1.2.0
-      debug: 4.3.4
+      debug: 4.4.1
       json-stringify-safe: 5.0.1
       jsrsasign: 11.0.0
       jwt-decode: 4.0.0
       sillyname: 0.1.0
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/server-services-core@5.0.0':
+  '@fluidframework/server-services-core@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
+      '@fluidframework/gitresources': 7.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
       '@types/nconf': 0.10.6
       '@types/node': 18.19.39
-      debug: 4.3.4
+      debug: 4.4.1
       events: 3.3.0
       nconf: 0.12.1
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/server-services-ordering-kafkanode@5.0.0':
+  '@fluidframework/server-services-ordering-kafkanode@7.0.0':
     dependencies:
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-ordering-zookeeper': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-services-ordering-zookeeper': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
       events_pkg: events@3.3.0
       kafka-node: 5.0.0
       nconf: 0.12.1
@@ -10222,12 +10220,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/server-services-ordering-rdkafka@5.0.0':
+  '@fluidframework/server-services-ordering-rdkafka@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
+      '@fluidframework/server-services-utils': 7.0.0
       events_pkg: events@3.3.0
       nconf: 0.12.1
       node-rdkafka: 3.4.0
@@ -10235,28 +10234,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/server-services-ordering-zookeeper@5.0.0':
+  '@fluidframework/server-services-ordering-zookeeper@7.0.0':
     dependencies:
-      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-core': 7.0.0
       zookeeper: 5.6.0
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/server-services-shared@5.0.0':
+  '@fluidframework/server-services-shared@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
-      '@fluidframework/protocol-base': 5.0.0
+      '@fluidframework/gitresources': 7.0.0
+      '@fluidframework/protocol-base': 7.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      '@fluidframework/server-services-utils': 5.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
+      '@fluidframework/server-services-utils': 7.0.0
       '@socket.io/redis-adapter': 8.3.0(socket.io-adapter@2.5.5)
       '@socket.io/sticky': 1.0.4
       body-parser: 1.20.3
-      debug: 4.3.4
+      debug: 4.4.1
       events: 3.3.0
+      express: 4.21.2
       fast-redact: 3.3.0
       ioredis: 5.6.1
       lodash: 4.17.21
@@ -10266,28 +10266,28 @@ snapshots:
       socket.io: 4.8.0
       socket.io-adapter: 2.5.5
       socket.io-parser: 4.2.4
-      uuid: 9.0.1
+      uuid: 11.1.0
       winston: 3.9.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/server-services-telemetry@5.0.0':
+  '@fluidframework/server-services-telemetry@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       json-stringify-safe: 5.0.1
       path-browserify: 1.0.1
       serialize-error: 8.1.0
-      uuid: 9.0.1
+      uuid: 11.1.0
 
-  '@fluidframework/server-services-utils@5.0.0':
+  '@fluidframework/server-services-utils@7.0.0':
     dependencies:
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      debug: 4.3.4
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
+      debug: 4.4.1
       express: 4.21.2
       ioredis: 5.6.1
       json-stringify-safe: 5.0.1
@@ -10297,28 +10297,28 @@ snapshots:
       serialize-error: 8.1.0
       sillyname: 0.1.0
       split: 1.0.1
-      uuid: 9.0.1
+      uuid: 11.1.0
       winston: 3.9.0
       winston-transport: 4.6.0
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/server-services@5.0.0':
+  '@fluidframework/server-services@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-ordering-kafkanode': 5.0.0
-      '@fluidframework/server-services-ordering-rdkafka': 5.0.0
-      '@fluidframework/server-services-shared': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      '@fluidframework/server-services-utils': 5.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-services-ordering-kafkanode': 7.0.0
+      '@fluidframework/server-services-ordering-rdkafka': 7.0.0
+      '@fluidframework/server-services-shared': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
+      '@fluidframework/server-services-utils': 7.0.0
       '@socket.io/redis-emitter': 4.1.1
       '@types/lodash': 4.14.202
       amqplib: 0.10.3
-      axios: 1.8.4(debug@4.3.4)
-      debug: 4.3.4
+      axios: 1.8.4(debug@4.4.1)
+      debug: 4.4.1
       events: 3.3.0
       ioredis: 5.6.1
       lodash: 4.17.21
@@ -10327,7 +10327,7 @@ snapshots:
       nconf: 0.12.1
       socket.io: 4.8.0
       telegrafjs: 0.1.3
-      uuid: 9.0.1
+      uuid: 11.1.0
       winston: 3.9.0
     transitivePeerDependencies:
       - aws-crt
@@ -10335,24 +10335,24 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/server-test-utils@5.0.0':
+  '@fluidframework/server-test-utils@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
-      '@fluidframework/protocol-base': 5.0.0
+      '@fluidframework/gitresources': 7.0.0
+      '@fluidframework/protocol-base': 7.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-services-telemetry': 7.0.0
       '@types/ioredis-mock': 8.2.6(ioredis@5.6.1)
       assert: 2.1.0
-      debug: 4.3.4
+      debug: 4.4.1
       events: 3.3.0
       ioredis: 5.6.1
       ioredis-mock: 8.9.0(@types/ioredis-mock@8.2.6(ioredis@5.6.1))(ioredis@5.6.1)
       lodash: 4.17.21
       string-hash: 1.1.3
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10674,7 +10674,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -10884,7 +10884,7 @@ snapshots:
       proc-log: 3.0.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.7.1
+      semver: 7.7.2
       which: 3.0.1
     transitivePeerDependencies:
       - bluebird
@@ -11181,7 +11181,7 @@ snapshots:
 
   '@pm2/agent@2.0.4':
     dependencies:
-      async: 3.2.5
+      async: 3.2.6
       chalk: 3.0.0
       dayjs: 1.8.36
       debug: 4.3.4
@@ -12129,7 +12129,7 @@ snapshots:
       debug: 4.4.1
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.7.1
+      semver: 7.7.2
       ts-api-utils: 1.0.3(typescript@5.1.6)
     optionalDependencies:
       typescript: 5.1.6
@@ -12160,7 +12160,7 @@ snapshots:
       '@typescript-eslint/types': 6.7.5
       '@typescript-eslint/typescript-estree': 6.7.5(typescript@5.1.6)
       eslint: 8.55.0
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -12629,9 +12629,25 @@ snapshots:
       fast-deep-equal: 3.1.3
       is-buffer: 2.0.5
 
+  axios@1.8.4:
+    dependencies:
+      follow-redirects: 1.15.6(debug@4.3.4)
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axios@1.8.4(debug@4.3.4):
     dependencies:
       follow-redirects: 1.15.6(debug@4.3.4)
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.8.4(debug@4.4.1):
+    dependencies:
+      follow-redirects: 1.15.6(debug@4.4.1)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -12668,7 +12684,7 @@ snapshots:
     dependencies:
       arg-parser: 1.2.0
       commander: 9.5.0
-      semver: 7.7.1
+      semver: 7.7.2
 
   binary-extensions@2.2.0: {}
 
@@ -13593,7 +13609,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.0.3
       has-symbols: 1.0.3
-      hasown: 2.0.1
+      hasown: 2.0.2
       internal-slot: 1.0.7
       is-array-buffer: 3.0.4
       is-callable: 1.2.7
@@ -13649,11 +13665,11 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.4
       has-tostringtag: 1.0.2
-      hasown: 2.0.1
+      hasown: 2.0.2
 
   es-shim-unscopables@1.0.2:
     dependencies:
-      hasown: 2.0.1
+      hasown: 2.0.2
 
   es-to-primitive@1.2.1:
     dependencies:
@@ -13701,33 +13717,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.55.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.10.1
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.1.6)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13737,13 +13753,13 @@ snapshots:
       eslint: 8.55.0
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     dependencies:
       debug: 4.4.1
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       get-tsconfig: 4.10.1
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -14126,6 +14142,10 @@ snapshots:
     optionalDependencies:
       debug: 4.3.4
 
+  follow-redirects@1.15.6(debug@4.4.1):
+    optionalDependencies:
+      debug: 4.4.1
+
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
@@ -14241,7 +14261,7 @@ snapshots:
       function-bind: 1.1.2
       has-proto: 1.0.3
       has-symbols: 1.0.3
-      hasown: 2.0.1
+      hasown: 2.0.2
 
   get-package-type@0.1.0: {}
 
@@ -14302,7 +14322,7 @@ snapshots:
 
   gitlog@4.0.8:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.1
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -14646,7 +14666,7 @@ snapshots:
   internal-slot@1.0.7:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.1
+      hasown: 2.0.2
       side-channel: 1.0.4
 
   interpret@1.4.0: {}
@@ -14723,7 +14743,7 @@ snapshots:
 
   is-bun-module@1.3.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   is-callable@1.2.7: {}
 
@@ -15041,7 +15061,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.1
+      semver: 7.7.2
 
   jsrsasign@11.0.0: {}
 
@@ -15306,7 +15326,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   make-error@1.3.6: {}
 
@@ -15889,7 +15909,7 @@ snapshots:
 
   nconf@0.12.1:
     dependencies:
-      async: 3.2.5
+      async: 3.2.6
       ini: 2.0.0
       secure-keys: 1.0.0
       yargs: 16.2.0
@@ -16005,7 +16025,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.1
+      semver: 7.7.2
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -16071,7 +16091,7 @@ snapshots:
     dependencies:
       hosted-git-info: 6.1.1
       proc-log: 3.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       validate-npm-package-name: 5.0.1
 
   npm-packlist@7.0.4:
@@ -16083,7 +16103,7 @@ snapshots:
       npm-install-checks: 6.1.1
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 10.1.0
-      semver: 7.7.1
+      semver: 7.7.2
 
   npm-registry-fetch@14.0.5:
     dependencies:
@@ -16334,7 +16354,7 @@ snapshots:
       ky: 1.7.4
       registry-auth-token: 5.0.3
       registry-url: 6.0.1
-      semver: 7.7.1
+      semver: 7.7.2
 
   package-json@8.1.1:
     dependencies:
@@ -16505,7 +16525,7 @@ snapshots:
 
   pm2-axon-rpc@0.7.1:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -16513,7 +16533,7 @@ snapshots:
     dependencies:
       amp: 0.3.1
       amp-message: 0.1.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.1
       escape-string-regexp: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -16529,8 +16549,8 @@ snapshots:
 
   pm2-sysmonit@1.2.8:
     dependencies:
-      async: 3.2.5
-      debug: 4.4.0(supports-color@8.1.1)
+      async: 3.2.6
+      debug: 4.4.1
       pidusage: 2.0.21
       systeminformation: 5.21.24
       tx2: 1.0.5
@@ -16744,7 +16764,7 @@ snapshots:
 
   rc-config-loader@4.1.3:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.1
       js-yaml: 4.1.0
       json5: 2.2.3
       require-from-string: 2.0.2
@@ -16844,7 +16864,7 @@ snapshots:
 
   rechoir@0.6.2:
     dependencies:
-      resolve: 1.22.8
+      resolve: 1.22.10
 
   rechoir@0.8.0:
     dependencies:
@@ -16964,7 +16984,7 @@ snapshots:
     dependencies:
       debug: 4.4.1
       module-details-from-path: 1.0.3
-      resolve: 1.22.8
+      resolve: 1.22.10
     transitivePeerDependencies:
       - supports-color
 
@@ -17104,7 +17124,7 @@ snapshots:
 
   semver-diff@4.0.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   semver-utils@1.1.4: {}
 
@@ -17397,7 +17417,7 @@ snapshots:
       get-stdin: 9.0.0
       git-hooks-list: 3.1.0
       is-plain-obj: 4.1.0
-      semver: 7.7.1
+      semver: 7.7.2
       sort-object-keys: 1.1.3
       tinyglobby: 0.2.10
 
@@ -18010,7 +18030,7 @@ snapshots:
       is-yarn-global: 0.4.1
       latest-version: 7.0.0
       pupa: 3.1.0
-      semver: 7.7.1
+      semver: 7.7.2
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
 
@@ -18053,7 +18073,8 @@ snapshots:
 
   uuid@3.4.0: {}
 
-  uuid@9.0.1: {}
+  uuid@9.0.1:
+    optional: true
 
   v8-to-istanbul@9.1.0:
     dependencies:


### PR DESCRIPTION
This PR cherry-picks https://github.com/microsoft/FluidFramework/pull/25016 to update the typetests to the latest server packages (7.0.0)