### PR TITLE
Better formalize how two stage schema initialization works

### DIFF
--- a/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
+++ b/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
@@ -13,8 +13,7 @@ import {
 	type NodeFromSchema,
 	type TreeNodeSchema,
 } from "./treeNodeSchema.js";
-import { inPrototypeChain } from "./treeNode.js";
-import { TreeNodeValid } from "./treeNodeValid.js";
+import { schemaAsTreeNodeValid } from "./treeNodeValid.js";
 
 /**
  * Schema for types allowed in some location in a tree (like a field, map entry or array).
@@ -381,16 +380,8 @@ export function markSchemaMostDerived(
 		return;
 	}
 
-	if (!inPrototypeChain(schema, TreeNodeValid)) {
-		// Use JSON.stringify to quote and escape identifier string.
-		throw new UsageError(
-			`Schema for ${JSON.stringify(
-				schema.identifier,
-			)} does not extend a SchemaFactory generated class. This is invalid.`,
-		);
-	}
+	const schemaValid = schemaAsTreeNodeValid(schema);
 
-	const schemaValid = schema as typeof TreeNodeValid & TreeNodeSchema;
 	if (oneTimeInitialize) {
 		schemaValid.oneTimeInitialize();
 	} else {

--- a/packages/dds/tree/src/simple-tree/core/context.ts
+++ b/packages/dds/tree/src/simple-tree/core/context.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { anchorSlot, type TreeNodeSchemaIdentifier } from "../../core/index.js";
+import type { TreeNodeSchemaIdentifier } from "../../core/index.js";
 import type {
 	FlexTreeContext,
 	FlexTreeHydratedContext,
@@ -13,14 +13,6 @@ import type { NormalizedAnnotatedAllowedTypes } from "./allowedTypes.js";
 
 import type { TreeNodeSchema } from "./treeNodeSchema.js";
 import { walkAllowedTypes } from "./walkSchema.js";
-
-/**
- * Creating multiple simple tree contexts for the same branch, and thus with the same underlying AnchorSet does not work due to how TreeNode caching works.
- * This slot is used to detect if one already exists and error if creating a second.
- * @remarks
- * See also {@link ContextSlot} in which the flex-tree context is stored.
- */
-export const SimpleContextSlot = anchorSlot<HydratedContext>();
 
 /**
  * Additional information about a collection of {@link TreeNode}s.

--- a/packages/dds/tree/src/simple-tree/core/index.ts
+++ b/packages/dds/tree/src/simple-tree/core/index.ts
@@ -13,6 +13,7 @@ export {
 	getOrCreateInnerNode,
 	treeNodeFromAnchor,
 	getSimpleNodeSchemaFromInnerNode,
+	SimpleContextSlot,
 } from "./treeNodeKernel.js";
 export { type WithType, typeNameSymbol, typeSchemaSymbol } from "./withType.js";
 export {
@@ -24,7 +25,12 @@ export {
 	privateToken,
 	inPrototypeChain,
 } from "./treeNode.js";
-export { NodeKind, isTreeNodeSchemaClass } from "./treeNodeSchema.js";
+export {
+	NodeKind,
+	isTreeNodeSchemaClass,
+	privateDataSymbol,
+	getTreeNodeSchemaPrivateData,
+} from "./treeNodeSchema.js";
 export type {
 	TreeNodeSchema,
 	TreeNodeSchemaClass,
@@ -36,6 +42,9 @@ export type {
 	InsertableTypedNode,
 	NodeBuilderData,
 	NodeFromSchema,
+	TreeNodeSchemaCorePrivate,
+	TreeNodeSchemaPrivateData,
+	TreeNodeSchemaInitializedData,
 } from "./treeNodeSchema.js";
 export {
 	isAnnotatedAllowedTypes,
@@ -66,7 +75,7 @@ export type {
 	AnnotatedAllowedTypes,
 } from "./allowedTypes.js";
 export { walkAllowedTypes, type SchemaVisitor } from "./walkSchema.js";
-export { Context, HydratedContext, SimpleContextSlot } from "./context.js";
+export { Context, HydratedContext } from "./context.js";
 export {
 	getOrCreateNodeFromInnerNode,
 	getOrCreateNodeFromInnerUnboxedNode,
@@ -85,4 +94,8 @@ export type {
 	ExtractItemType,
 } from "./flexList.js";
 export { isLazy } from "./flexList.js";
-export { TreeNodeValid, type MostDerivedData } from "./treeNodeValid.js";
+export {
+	TreeNodeValid,
+	type MostDerivedData,
+	createTreeNodeSchemaPrivateData,
+} from "./treeNodeValid.js";

--- a/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeKernel.ts
@@ -30,7 +30,7 @@ import {
 	type HydratedFlexTreeNode,
 } from "../../feature-libraries/index.js";
 
-import { SimpleContextSlot, type Context, type HydratedContext } from "./context.js";
+import type { Context, HydratedContext } from "./context.js";
 import type { TreeNode } from "./treeNode.js";
 import type { TreeNodeSchema } from "./treeNodeSchema.js";
 import type { InternalTreeNode, Unhydrated } from "./types.js";
@@ -478,3 +478,11 @@ export function createTreeNodeFromInner(innerNode: InnerNode): TreeNode | TreeVa
 				internal,
 			);
 }
+
+/**
+ * Creating multiple simple tree contexts for the same branch, and thus with the same underlying AnchorSet does not work due to how TreeNode caching works.
+ * This slot is used to detect if one already exists and error if creating a second.
+ * @remarks
+ * See also {@link ContextSlot} in which the flex-tree context is stored.
+ */
+export const SimpleContextSlot = anchorSlot<HydratedContext>();

--- a/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
@@ -354,11 +354,12 @@ export interface TreeNodeSchemaCorePrivate<
 	/**
 	 * Package private data provided by all {@link TreeNodeSchema}.
 	 * @remarks
-	 * This is behind a symbol as this content is not exposed in the API, but is present on all the schema.
-	 * That exposes a risk of name collisions with custom statics users add to schema classes.
-	 * While schema classes already have a bunch of non-exported statics which could collide,
-	 * this reduces the risk, and also provides a symbol which can be tested for to more safely
-	 * access the private data.
+	 * Users can add custom statics to schema classes.
+	 * To reduce the risk of such statics colliding with properties used to implement the schema,
+	 * some of the private APIs are grouped together under this symbol.
+	 *
+	 * Note that there are still some properties which are not under a symbol and thus expose some risk of name collisions.
+	 * See {@link TreeNodeValid} for some such properties.
 	 */
 	readonly [privateDataSymbol]: TreeNodeSchemaPrivateData;
 }

--- a/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
@@ -9,10 +9,15 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { type FlexTreeNode, isFlexTreeNode } from "../../feature-libraries/index.js";
 
 import { markEager } from "./flexList.js";
-import { privateToken, TreeNode } from "./treeNode.js";
+import { inPrototypeChain, privateToken, TreeNode } from "./treeNode.js";
 import type { UnhydratedFlexTreeNode } from "./unhydratedFlexTree.js";
-import type { Context } from "./context.js";
-import { NodeKind, type TreeNodeSchema } from "./treeNodeSchema.js";
+import {
+	NodeKind,
+	type TreeNodeSchema,
+	type TreeNodeSchemaCore,
+	type TreeNodeSchemaInitializedData,
+	type TreeNodeSchemaPrivateData,
+} from "./treeNodeSchema.js";
 import {
 	getSimpleNodeSchemaFromInnerNode,
 	isTreeNode,
@@ -21,6 +26,7 @@ import {
 } from "./treeNodeKernel.js";
 import type { InternalTreeNode } from "./types.js";
 import { typeSchemaSymbol } from "./withType.js";
+import type { ImplicitAnnotatedAllowedTypes } from "./allowedTypes.js";
 
 /**
  * Class which all {@link TreeNode}s must extend.
@@ -64,7 +70,9 @@ export abstract class TreeNodeValid<TInput> extends TreeNode {
 	 * @remarks
 	 * It is valid to dereference LazyItem schema references in this function (or anything that runs after it).
 	 */
-	protected static oneTimeSetup<T>(this: typeof TreeNodeValid<T>): Context {
+	protected static oneTimeSetup<T>(
+		this: typeof TreeNodeValid<T>,
+	): TreeNodeSchemaInitializedData {
 		fail(0xae5 /* Missing oneTimeSetup */);
 	}
 
@@ -163,7 +171,7 @@ export abstract class TreeNodeValid<TInput> extends TreeNode {
 		const cache = this.markMostDerived();
 		cache.oneTimeInitialized ??= this.oneTimeSetup();
 		// TypeScript fails to narrow the type of `oneTimeInitialized` to `Context` here, so use a cast:
-		return cache as MostDerivedData & { oneTimeInitialized: Context };
+		return cache as MostDerivedData & { oneTimeInitialized: TreeNodeSchemaInitializedData };
 	}
 
 	public constructor(input: TInput | InternalTreeNode) {
@@ -188,7 +196,7 @@ export abstract class TreeNodeValid<TInput> extends TreeNode {
 		// The TreeNodeKernel associates itself the TreeNode (result here, not node) so it can be looked up later via getKernel.
 		// If desired this could be put in a non-enumerable symbol property for lookup instead, but that gets messy going through proxies,
 		// so just relying on the WeakMap seems like the cleanest approach.
-		new TreeNodeKernel(result, schema, node, cache.oneTimeInitialized);
+		new TreeNodeKernel(result, schema, node, cache.oneTimeInitialized.context);
 
 		return result;
 	}
@@ -209,7 +217,42 @@ markEager(TreeNodeValid);
  */
 export interface MostDerivedData {
 	readonly constructor: typeof TreeNodeValid & TreeNodeSchema;
-	oneTimeInitialized?: Context;
+	oneTimeInitialized?: TreeNodeSchemaInitializedData;
+}
+
+/**
+ * Cast `schema` to a {@link TreeNodeValid}, asserting it actually extends it.
+ */
+export function schemaAsTreeNodeValid(
+	schema: TreeNodeSchemaCore<string, NodeKind, boolean>,
+): typeof TreeNodeValid & TreeNodeSchema {
+	if (!inPrototypeChain(schema, TreeNodeValid)) {
+		// Use JSON.stringify to quote and escape identifier string.
+		throw new UsageError(
+			`Schema for ${JSON.stringify(
+				schema.identifier,
+			)} does not extend a SchemaFactory generated class. This is invalid.`,
+		);
+	}
+
+	return schema as typeof TreeNodeValid & TreeNodeSchema;
+}
+
+/**
+ * Provides the {@link TreeNodeSchemaPrivateData} for class based implementations of {@link asTreeNodeSchemaCorePrivate}.
+ * @remarks
+ * Such schema must extends {@link TreeNodeValid}.
+ */
+export function createTreeNodeSchemaPrivateData(
+	schema: TreeNodeSchemaCore<string, NodeKind, boolean>,
+	childAnnotatedAllowedTypes: readonly ImplicitAnnotatedAllowedTypes[],
+): TreeNodeSchemaPrivateData {
+	const schemaValid = schemaAsTreeNodeValid(schema);
+
+	return {
+		idempotentInitialize: () => schemaValid.oneTimeInitialize().oneTimeInitialized,
+		childAnnotatedAllowedTypes,
+	};
 }
 
 // #region NodeJS custom inspect for TreeNodes.

--- a/packages/dds/tree/src/simple-tree/createContext.ts
+++ b/packages/dds/tree/src/simple-tree/createContext.ts
@@ -6,7 +6,14 @@
 import { defaultSchemaPolicy } from "../feature-libraries/index.js";
 import { getOrCreate } from "../util/index.js";
 
-import { Context, UnhydratedContext } from "./core/index.js";
+import {
+	Context,
+	getTreeNodeSchemaPrivateData,
+	normalizeAnnotatedAllowedTypes,
+	UnhydratedContext,
+	type TreeNodeSchema,
+	type TreeNodeSchemaInitializedData,
+} from "./core/index.js";
 import { normalizeFieldSchema, type ImplicitFieldSchema } from "./fieldSchema.js";
 import { toStoredSchema } from "./toStoredSchema.js";
 
@@ -22,4 +29,19 @@ export function getUnhydratedContext(schema: ImplicitFieldSchema): Context {
 		const flexContext = new UnhydratedContext(defaultSchemaPolicy, toStoredSchema(schema));
 		return new Context(normalized.annotatedAllowedTypesNormalized, flexContext);
 	});
+}
+
+/**
+ * Utility for creating {@link TreeNodeSchemaInitializedData}.
+ */
+export function getTreeNodeSchemaInitializedData(
+	schema: TreeNodeSchema,
+): TreeNodeSchemaInitializedData {
+	const data = getTreeNodeSchemaPrivateData(schema);
+	return {
+		context: getUnhydratedContext(schema),
+		childAnnotatedAllowedTypes: data.childAnnotatedAllowedTypes.map(
+			normalizeAnnotatedAllowedTypes,
+		),
+	};
 }

--- a/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
@@ -14,7 +14,6 @@ import {
 
 import {
 	NodeKind,
-	type NormalizedAnnotatedAllowedTypes,
 	type TreeNodeSchema,
 	type TreeNodeSchemaNonClass,
 	type NodeSchemaMetadata,

--- a/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
@@ -48,7 +48,6 @@ export class LeafNodeSchema<Name extends string, const T extends ValueSchema>
 	public readonly info: T;
 	public readonly implicitlyConstructable = true as const;
 	public readonly childTypes: ReadonlySet<TreeNodeSchema> = new Set();
-	public readonly childAnnotatedAllowedTypes: readonly NormalizedAnnotatedAllowedTypes[] = [];
 	public readonly [privateDataSymbol]: TreeNodeSchemaPrivateData = {
 		idempotentInitialize: () =>
 			(this.#initializedData ??= getTreeNodeSchemaInitializedData(this)),

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -21,7 +21,6 @@ import {
 	type InternalTreeNode,
 	type TreeNodeSchema,
 	typeSchemaSymbol,
-	type Context,
 	getOrCreateNodeFromInnerNode,
 	getSimpleNodeSchemaFromInnerNode,
 	getOrCreateInnerNode,
@@ -30,9 +29,7 @@ import {
 	type UnhydratedFlexTreeNode,
 	UnhydratedSequenceField,
 	getOrCreateNodeFromInnerUnboxedNode,
-	type NormalizedAnnotatedAllowedTypes,
 	normalizeAllowedTypes,
-	normalizeAnnotatedAllowedTypes,
 	unannotateImplicitAllowedTypes,
 	type ImplicitAllowedTypes,
 	type ImplicitAnnotatedAllowedTypes,
@@ -43,13 +40,17 @@ import {
 	type UnannotateImplicitAllowedTypes,
 	TreeNodeValid,
 	type MostDerivedData,
+	type TreeNodeSchemaInitializedData,
+	type TreeNodeSchemaCorePrivate,
+	privateDataSymbol,
+	createTreeNodeSchemaPrivateData,
 } from "../../core/index.js";
 import {
 	type InsertableContent,
 	unhydratedFlexTreeFromInsertable,
 } from "../../unhydratedFlexTreeFromInsertable.js";
 import { prepareArrayContentForInsertion } from "../../prepareForInsertion.js";
-import { getUnhydratedContext } from "../../createContext.js";
+import { getTreeNodeSchemaInitializedData } from "../../createContext.js";
 import type { System_Unsafe } from "../../api/index.js";
 import type {
 	ArrayNodeCustomizableSchema,
@@ -1106,17 +1107,15 @@ export function arraySchema<
 		ImplicitlyConstructable,
 		TCustomMetadata
 	> &
-		ArrayNodePojoEmulationSchema<TName, T, ImplicitlyConstructable, TCustomMetadata>;
+		ArrayNodePojoEmulationSchema<TName, T, ImplicitlyConstructable, TCustomMetadata> &
+		TreeNodeSchemaCorePrivate;
 
 	const unannotatedTypes = unannotateImplicitAllowedTypes(info);
 
 	const lazyChildTypes = new Lazy(() => normalizeAllowedTypes(unannotatedTypes));
-	const lazyAnnotatedTypes = new Lazy(() => [normalizeAnnotatedAllowedTypes(info)]);
 	const lazyAllowedTypesIdentifiers = new Lazy(
 		() => new Set([...lazyChildTypes.value].map((type) => type.identifier)),
 	);
-
-	let unhydratedContext: Context;
 
 	// This class returns a proxy from its constructor to handle numeric indexing.
 	// Alternatively it could extend a normal class which gets tons of numeric properties added.
@@ -1155,10 +1154,7 @@ export function arraySchema<
 
 		protected static override constructorCached: MostDerivedData | undefined = undefined;
 
-		protected static override oneTimeSetup<T2>(this: typeof TreeNodeValid<T2>): Context {
-			const schema = this as unknown as TreeNodeSchema;
-			unhydratedContext = getUnhydratedContext(schema);
-
+		protected static override oneTimeSetup(): TreeNodeSchemaInitializedData {
 			// First run, do extra validation.
 			// TODO: provide a way for TreeConfiguration to trigger this same validation to ensure it gets run early.
 			// Scan for shadowing inherited members which won't work, but stop scan early to allow shadowing built in (which seems to work ok).
@@ -1184,7 +1180,7 @@ export function arraySchema<
 				}
 			}
 
-			return unhydratedContext;
+			return getTreeNodeSchemaInitializedData(this);
 		}
 
 		public static readonly identifier = identifier;
@@ -1193,9 +1189,6 @@ export function arraySchema<
 			implicitlyConstructable;
 		public static get childTypes(): ReadonlySet<TreeNodeSchema> {
 			return lazyChildTypes.value;
-		}
-		public static get childAnnotatedAllowedTypes(): readonly NormalizedAnnotatedAllowedTypes[] {
-			return lazyAnnotatedTypes.value;
 		}
 		public static readonly metadata: NodeSchemaMetadata<TCustomMetadata> = metadata ?? {};
 		public static readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined =
@@ -1215,6 +1208,8 @@ export function arraySchema<
 		protected get allowedTypes(): ReadonlySet<TreeNodeSchema> {
 			return lazyChildTypes.value;
 		}
+
+		public static readonly [privateDataSymbol] = createTreeNodeSchemaPrivateData(this, [info]);
 	}
 
 	const output: Output = Schema;

--- a/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
@@ -21,13 +21,10 @@ import {
 	typeNameSymbol,
 	type TreeNode,
 	typeSchemaSymbol,
-	type Context,
 	getOrCreateInnerNode,
 	type InternalTreeNode,
 	type UnhydratedFlexTreeNode,
-	type NormalizedAnnotatedAllowedTypes,
 	normalizeAllowedTypes,
-	normalizeAnnotatedAllowedTypes,
 	unannotateImplicitAllowedTypes,
 	type ImplicitAllowedTypes,
 	type ImplicitAnnotatedAllowedTypes,
@@ -37,6 +34,10 @@ import {
 	type UnannotateImplicitAllowedTypes,
 	TreeNodeValid,
 	type MostDerivedData,
+	type TreeNodeSchemaInitializedData,
+	type TreeNodeSchemaCorePrivate,
+	privateDataSymbol,
+	createTreeNodeSchemaPrivateData,
 } from "../../core/index.js";
 import {
 	unhydratedFlexTreeFromInsertable,
@@ -50,7 +51,7 @@ import {
 	type JsonCompatibleReadOnlyObject,
 	type RestrictiveStringRecord,
 } from "../../../util/index.js";
-import { getUnhydratedContext } from "../../createContext.js";
+import { getTreeNodeSchemaInitializedData } from "../../createContext.js";
 import type { MapNodeCustomizableSchema, MapNodePojoEmulationSchema } from "./mapNodeTypes.js";
 
 /**
@@ -252,12 +253,9 @@ export function mapSchema<
 	const lazyChildTypes = new Lazy(() =>
 		normalizeAllowedTypes(unannotateImplicitAllowedTypes(info)),
 	);
-	const lazyAnnotatedTypes = new Lazy(() => [normalizeAnnotatedAllowedTypes(info)]);
 	const lazyAllowedTypesIdentifiers = new Lazy(
 		() => new Set([...lazyChildTypes.value].map((type) => type.identifier)),
 	);
-
-	let unhydratedContext: Context;
 
 	class Schema
 		extends CustomMapNodeBase<UnannotateImplicitAllowedTypes<T>>
@@ -288,10 +286,8 @@ export function mapSchema<
 
 		protected static override constructorCached: MostDerivedData | undefined = undefined;
 
-		protected static override oneTimeSetup<T2>(this: typeof TreeNodeValid<T2>): Context {
-			const schema = this as unknown as TreeNodeSchema;
-			unhydratedContext = getUnhydratedContext(schema);
-			return unhydratedContext;
+		protected static override oneTimeSetup(): TreeNodeSchemaInitializedData {
+			return getTreeNodeSchemaInitializedData(this);
 		}
 
 		public static readonly identifier = identifier;
@@ -300,9 +296,6 @@ export function mapSchema<
 			implicitlyConstructable;
 		public static get childTypes(): ReadonlySet<TreeNodeSchema> {
 			return lazyChildTypes.value;
-		}
-		public static get childAnnotatedAllowedTypes(): readonly NormalizedAnnotatedAllowedTypes[] {
-			return lazyAnnotatedTypes.value;
 		}
 		public static readonly metadata: NodeSchemaMetadata<TCustomMetadata> = metadata ?? {};
 		public static readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined =
@@ -315,6 +308,8 @@ export function mapSchema<
 		public get [typeSchemaSymbol](): typeof schemaErased {
 			return Schema.constructorCached?.constructor as unknown as typeof schemaErased;
 		}
+
+		public static readonly [privateDataSymbol] = createTreeNodeSchemaPrivateData(this, [info]);
 	}
 	const schemaErased: MapNodeCustomizableSchema<
 		TName,
@@ -322,7 +317,8 @@ export function mapSchema<
 		ImplicitlyConstructable,
 		TCustomMetadata
 	> &
-		MapNodePojoEmulationSchema<TName, T, ImplicitlyConstructable, TCustomMetadata> = Schema;
+		MapNodePojoEmulationSchema<TName, T, ImplicitlyConstructable, TCustomMetadata> &
+		TreeNodeSchemaCorePrivate = Schema;
 	return schemaErased;
 }
 

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNodeTypes.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNodeTypes.ts
@@ -14,7 +14,12 @@ import type {
 	ImplicitAnnotatedFieldSchema,
 	UnannotateImplicitFieldSchema,
 } from "../../fieldSchema.js";
-import { NodeKind, type TreeNodeSchemaClass, type TreeNodeSchema } from "../../core/index.js";
+import {
+	NodeKind,
+	type TreeNodeSchemaClass,
+	type TreeNodeSchema,
+	type TreeNodeSchemaCorePrivate,
+} from "../../core/index.js";
 import type { FieldKey } from "../../../core/index.js";
 import type { SimpleObjectFieldSchema, SimpleObjectNodeSchema } from "../../simpleSchema.js";
 
@@ -59,7 +64,7 @@ export type UnannotateSchemaRecord<
 /**
  * Extra data provided on all {@link ObjectNodeSchema} that is not included in the (soon possibly public) ObjectNodeSchema type.
  */
-export interface ObjectNodeSchemaInternalData {
+export interface ObjectNodeSchemaInternalData extends TreeNodeSchemaCorePrivate {
 	/**
 	 * {@inheritdoc SimpleKeyMap}
 	 */

--- a/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
@@ -14,24 +14,25 @@ import {
 	// eslint-disable-next-line import/no-deprecated
 	typeNameSymbol,
 	typeSchemaSymbol,
-	type Context,
 	type UnhydratedFlexTreeNode,
 	getOrCreateInnerNode,
 	getKernel,
 	type InternalTreeNode,
-	type NormalizedAnnotatedAllowedTypes,
 	type NodeSchemaMetadata,
 	type ImplicitAnnotatedAllowedTypes,
 	type UnannotateImplicitAllowedTypes,
 	type ImplicitAllowedTypes,
 	normalizeAllowedTypes,
-	normalizeAnnotatedAllowedTypes,
 	unannotateImplicitAllowedTypes,
 	type TreeNodeFromImplicitAllowedTypes,
 	TreeNodeValid,
 	type MostDerivedData,
+	type TreeNodeSchemaInitializedData,
+	type TreeNodeSchemaCorePrivate,
+	privateDataSymbol,
+	createTreeNodeSchemaPrivateData,
 } from "../../core/index.js";
-import { getUnhydratedContext } from "../../createContext.js";
+import { getTreeNodeSchemaInitializedData } from "../../createContext.js";
 import { tryGetTreeNodeForField } from "../../getTreeNodeForField.js";
 import { createFieldSchema, FieldKind } from "../../fieldSchema.js";
 import {
@@ -257,12 +258,9 @@ export function recordSchema<
 	const lazyChildTypes = new Lazy(() =>
 		normalizeAllowedTypes(unannotateImplicitAllowedTypes(info)),
 	);
-	const lazyAnnotatedTypes = new Lazy(() => [normalizeAnnotatedAllowedTypes(info)]);
 	const lazyAllowedTypesIdentifiers = new Lazy(
 		() => new Set([...lazyChildTypes.value].map((type) => type.identifier)),
 	);
-
-	let unhydratedContext: Context;
 
 	class Schema
 		extends CustomRecordNodeBase<TUnannotatedAllowedTypes>
@@ -312,10 +310,7 @@ export function recordSchema<
 			return unhydratedFlexTreeFromInsertable(input as object, this as typeof Schema);
 		}
 
-		protected static override oneTimeSetup<T2>(this: typeof TreeNodeValid<T2>): Context {
-			const schema = this as unknown as RecordNodeSchema;
-			unhydratedContext = getUnhydratedContext(schema);
-
+		protected static override oneTimeSetup(): TreeNodeSchemaInitializedData {
 			// First run, do extra validation.
 			// TODO: provide a way for TreeConfiguration to trigger this same validation to ensure it gets run early.
 			// Scan for shadowing inherited members which won't work, but stop scan early to allow shadowing built in (which seems to work ok).
@@ -341,7 +336,7 @@ export function recordSchema<
 				}
 			}
 
-			return unhydratedContext;
+			return getTreeNodeSchemaInitializedData(this);
 		}
 
 		public static get allowedTypesIdentifiers(): ReadonlySet<string> {
@@ -356,9 +351,6 @@ export function recordSchema<
 			implicitlyConstructable;
 		public static get childTypes(): ReadonlySet<TreeNodeSchema> {
 			return lazyChildTypes.value;
-		}
-		public static get childAnnotatedAllowedTypes(): readonly NormalizedAnnotatedAllowedTypes[] {
-			return lazyAnnotatedTypes.value;
 		}
 		public static readonly metadata: NodeSchemaMetadata<TCustomMetadata> = metadata ?? {};
 		public static readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined =
@@ -380,6 +372,8 @@ export function recordSchema<
 		public get [Symbol.toStringTag](): string {
 			return identifier;
 		}
+
+		public static readonly [privateDataSymbol] = createTreeNodeSchemaPrivateData(this, [info]);
 	}
 
 	type Output = RecordNodeCustomizableSchema<
@@ -393,7 +387,8 @@ export function recordSchema<
 			TAllowedTypes,
 			TImplicitlyConstructable,
 			TCustomMetadata
-		>;
+		> &
+		TreeNodeSchemaCorePrivate;
 
 	const output: Output = Schema;
 	return output;

--- a/packages/dds/tree/src/simple-tree/toStoredSchema.ts
+++ b/packages/dds/tree/src/simple-tree/toStoredSchema.ts
@@ -23,7 +23,6 @@ import { FieldKinds, type FlexFieldKind } from "../feature-libraries/index.js";
 import { brand, getOrCreate } from "../util/index.js";
 
 import { NodeKind } from "./core/index.js";
-import { LeafNodeSchema } from "./leafNodeSchema.js";
 import { FieldKind, normalizeFieldSchema, type ImplicitFieldSchema } from "./fieldSchema.js";
 import type {
 	SimpleFieldSchema,
@@ -116,7 +115,7 @@ export function getStoredSchema(schema: SimpleNodeSchema): TreeNodeStoredSchema 
 	const kind = schema.kind;
 	switch (kind) {
 		case NodeKind.Leaf: {
-			assert(schema instanceof LeafNodeSchema, 0xa4a /* invalid kind */);
+			assert(schema.kind === NodeKind.Leaf, 0xa4a /* invalid kind */);
 			return new LeafNodeStoredSchema(schema.leafKind);
 		}
 		case NodeKind.Map:

--- a/packages/dds/tree/src/test/simple-tree/treeNodeValid.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/treeNodeValid.spec.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "node:assert";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import {
+	createTreeNodeSchemaPrivateData,
 	type MostDerivedData,
 	TreeNodeValid,
 	// eslint-disable-next-line import/no-internal-modules
@@ -17,18 +18,22 @@ import type { FlexTreeNode } from "../../feature-libraries/index.js";
 import { numberSchema } from "../../simple-tree/leafNodeSchema.js";
 import { validateUsageError } from "../utils.js";
 import { brand } from "../../util/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import { getUnhydratedContext } from "../../simple-tree/createContext.js";
+import {
+	getTreeNodeSchemaInitializedData,
+	getUnhydratedContext,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../simple-tree/createContext.js";
 import {
 	inPrototypeChain,
 	NodeKind,
 	typeNameSymbol,
 	typeSchemaSymbol,
-	type Context,
 	type InternalTreeNode,
 	type TreeNodeSchema,
 	UnhydratedFlexTreeNode,
 	type NormalizedAnnotatedAllowedTypes,
+	type TreeNodeSchemaInitializedData,
+	privateDataSymbol,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../simple-tree/core/index.js";
 
@@ -80,9 +85,9 @@ describe("TreeNodeValid", () => {
 
 			protected static override constructorCached: MostDerivedData | undefined = undefined;
 
-			protected static override oneTimeSetup<T2>(this: typeof TreeNodeValid<T2>): Context {
+			protected static override oneTimeSetup(): TreeNodeSchemaInitializedData {
 				log.push("oneTimeSetup");
-				return getUnhydratedContext(Subclass);
+				return getTreeNodeSchemaInitializedData(this);
 			}
 
 			public static readonly childTypes: ReadonlySet<TreeNodeSchema> = new Set();
@@ -95,6 +100,9 @@ describe("TreeNodeValid", () => {
 			public override get [typeSchemaSymbol](): never {
 				throw new Error("Method not implemented.");
 			}
+
+			public static readonly [privateDataSymbol] = createTreeNodeSchemaPrivateData(this, []);
+
 			public constructor(input: number | InternalTreeNode) {
 				super(input);
 				log.push("done");
@@ -177,23 +185,27 @@ describe("TreeNodeValid", () => {
 			public constructor() {
 				super(0);
 			}
+
+			public static readonly [privateDataSymbol] = createTreeNodeSchemaPrivateData(this, []);
 		}
 
 		class A extends Subclass {
 			protected static override constructorCached: MostDerivedData | undefined = undefined;
 
-			protected static override oneTimeSetup<T2>(this: typeof TreeNodeValid<T2>): Context {
+			protected static override oneTimeSetup(): TreeNodeSchemaInitializedData {
 				log.push("A");
-				return getUnhydratedContext(A);
+				return getTreeNodeSchemaInitializedData(this);
 			}
 		}
 
 		class B extends Subclass {
 			protected static override constructorCached: MostDerivedData | undefined = undefined;
 
-			protected static override oneTimeSetup<T2>(this: typeof TreeNodeValid<T2>): Context {
+			protected static override oneTimeSetup<T2>(
+				this: typeof TreeNodeValid<T2>,
+			): TreeNodeSchemaInitializedData {
 				log.push("B");
-				return getUnhydratedContext(A);
+				return getTreeNodeSchemaInitializedData(B);
 			}
 		}
 
@@ -238,10 +250,11 @@ describe("TreeNodeValid", () => {
 		class A extends Subclass {
 			protected static override constructorCached: MostDerivedData | undefined = undefined;
 
-			protected static override oneTimeSetup<T2>(this: typeof TreeNodeValid<T2>): Context {
+			protected static override oneTimeSetup(): TreeNodeSchemaInitializedData {
 				log.push(this.name);
-				return getUnhydratedContext(this as typeof A);
+				return getTreeNodeSchemaInitializedData(this);
 			}
+			public static readonly [privateDataSymbol] = createTreeNodeSchemaPrivateData(this, []);
 		}
 
 		class B extends A {}


### PR DESCRIPTION
## Description

TreeNodeSchema had a two stage initialization process: some data is only available after it is safe to dereference lazy schema references, and some data is available any time.

Introduce interfaces which explicitly split some of the private (package internal) data into these two categories, and make how it is accessed more consistent across class and non class (leaf) based schema.

This is in precreation for adding more package private schema information to do the dependency inversion in src/simple-tree/unhydratedFlexTreeFromInsertable.ts to fix the bad imports (see its TODO documenting what will be needed).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

