### PR TITLE
test(shared-tree): Remove the report output path to let the benchmark tool to post it to pipeline

### DIFF
--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -129,7 +129,7 @@
 		"test:customBenchmarks": "mocha --config ./.mocharc.customBenchmarks.cjs",
 		"test:customBenchmarks:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:customBenchmarks",
 		"test:memory": "mocha --perfMode --config ./src/test/memory/.mocharc.cjs",
-		"test:memory-profiling:report": "mocha --config ./src/test/memory/.mocharc.cjs",
+		"test:memory-profiling:report": "mocha --perfMode --config ./src/test/memory/.mocharc.cjs",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "cross-env MOCHA_SPEC=dist/test mocha",
 		"test:mocha:esm": "mocha",

--- a/packages/dds/tree/src/test/memory/.mocharc.cjs
+++ b/packages/dds/tree/src/test/memory/.mocharc.cjs
@@ -22,6 +22,7 @@ const extendedConfig = {
 	"node-option": [...baseNodeOptions, "expose-gc", "gc-global", "unhandled-rejections=strict"], // without leading "--"
 	"reporter": "@fluid-tools/benchmark/dist/MochaReporter.js",
 	"reporterOptions": ["reportDir=.memoryTestsOutput/"],
+	"timeout": "90000",
 };
 
 module.exports = extendedConfig;

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -27,6 +27,7 @@ parameters:
 - name: memoryTestPackages
   type: object
   default:
+    - "@fluidframework/tree"
     - "@fluidframework/sequence"
     - "@fluidframework/map"
     - "@fluidframework/matrix"


### PR DESCRIPTION
Remove memory usage report specific output path to let the benchmark tool to generate report on a default path and it will be published to pipeline artifacts. Benchmarks always need the --perfMode flag to execute as such (and not as correctness unit tests). This missing one was an oversight from the past. Adding it.
