### PR TITLE
Delegate to schema to check compatibility of insertable content

### DIFF
--- a/packages/dds/tree/src/simple-tree/core/index.ts
+++ b/packages/dds/tree/src/simple-tree/core/index.ts
@@ -30,6 +30,7 @@ export {
 	isTreeNodeSchemaClass,
 	privateDataSymbol,
 	getTreeNodeSchemaPrivateData,
+	CompatibilityLevel,
 } from "./treeNodeSchema.js";
 export type {
 	TreeNodeSchema,
@@ -45,6 +46,7 @@ export type {
 	TreeNodeSchemaCorePrivate,
 	TreeNodeSchemaPrivateData,
 	TreeNodeSchemaInitializedData,
+	FlexContent,
 } from "./treeNodeSchema.js";
 export {
 	isAnnotatedAllowedTypes,

--- a/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
@@ -451,9 +451,18 @@ export type FlexContent = [NodeData, Map<FieldKey, UnhydratedFlexTreeField>];
 /**
  * Indicates a compatibility level for inferring a schema to apply to insertable data.
  * @remarks
- * Only the highest compatibility options are used.
- * This approach allows adding new possible matching at a new lower compatibility level as a non breaking change,
- * since that way they can't make a case that was compatible before ambiguous now.
+ * Each schema allowed at a location in the tree has its compatibility level checked against the data being inserted.
+ * The compatibility is considered unambiguous if there is a single schema with a higher compatibility than all others.
+ *
+ * This approach allows adding new compatible formats as a non breaking change.
+ * If the new format was already compatible with some other schema, it can still be added as non-breaking as long as a lower compatibility level is used.
+ * For example, support for constructing maps from record like objects was added in Fluid Framework 2.2.
+ * This format (an object with fields) was already compatible with Object nodes at compatibility level Normal so the new format support for maps was added at compatibility level Low.
+ * This ensures that existing code that was using object literals as insertable content where both objects and maps were allowed will continue to work,
+ * assuming the objects are intended as ObjectNodes.
+ * However new code can now be written using record like objects to construct maps, as long as the schema does not also allow Object nodes which are compatible with the data in that location.
+ *
+ * @see {@link ITreeConfigurationOptions.preventAmbiguity} for a related setting which interacts with this in a somewhat complex way.
  */
 export enum CompatibilityLevel {
 	/**

--- a/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeSchema.ts
@@ -4,12 +4,12 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import type { SimpleNodeSchemaBase } from "../simpleSchema.js";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
+import type { SimpleNodeSchemaBase } from "../simpleSchema.js";
 import type { TreeNode } from "./treeNode.js";
 import type { InternalTreeNode, Unhydrated } from "./types.js";
 import type { UnionToIntersection } from "../../util/index.js";
-import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import type {
 	ImplicitAnnotatedAllowedTypes,
 	NormalizedAnnotatedAllowedTypes,

--- a/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
@@ -248,6 +248,7 @@ export function createTreeNodeSchemaPrivateData(
 	childAnnotatedAllowedTypes: readonly ImplicitAnnotatedAllowedTypes[],
 ): TreeNodeSchemaPrivateData {
 	const schemaValid = schemaAsTreeNodeValid(schema);
+	schemaValid.markMostDerived();
 
 	return {
 		idempotentInitialize: () => schemaValid.oneTimeInitialize().oneTimeInitialized,

--- a/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
@@ -248,6 +248,8 @@ export function createTreeNodeSchemaPrivateData(
 	childAnnotatedAllowedTypes: readonly ImplicitAnnotatedAllowedTypes[],
 ): TreeNodeSchemaPrivateData {
 	const schemaValid = schemaAsTreeNodeValid(schema);
+	// Since this closes over the schema, ensure this schema is marked as most derived
+	// so if some other subclass is used later, it will error instead of giving inconsistent results.
 	schemaValid.markMostDerived();
 
 	return {

--- a/packages/dds/tree/src/simple-tree/createContext.ts
+++ b/packages/dds/tree/src/simple-tree/createContext.ts
@@ -36,9 +36,11 @@ export function getUnhydratedContext(schema: ImplicitFieldSchema): Context {
  */
 export function getTreeNodeSchemaInitializedData(
 	schema: TreeNodeSchema,
+	handler: Pick<TreeNodeSchemaInitializedData, "toFlexContent" | "shallowCompatibilityTest">,
 ): TreeNodeSchemaInitializedData {
 	const data = getTreeNodeSchemaPrivateData(schema);
 	return {
+		...handler,
 		context: getUnhydratedContext(schema),
 		childAnnotatedAllowedTypes: data.childAnnotatedAllowedTypes.map(
 			normalizeAnnotatedAllowedTypes,

--- a/packages/dds/tree/src/simple-tree/insertableContentHandler.ts
+++ b/packages/dds/tree/src/simple-tree/insertableContentHandler.ts
@@ -1,0 +1,56 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert } from "@fluidframework/core-utils/internal";
+
+import type { FieldKey } from "../core/index.js";
+import { FieldKinds } from "../feature-libraries/index.js";
+import { brand } from "../util/index.js";
+
+import {
+	createField,
+	type UnhydratedFlexTreeField,
+	unannotateImplicitAllowedTypes,
+	normalizeAllowedTypes,
+	type FlexContent,
+} from "./core/index.js";
+import { getUnhydratedContext } from "./createContext.js";
+
+import type { MapNodeSchema, RecordNodeSchema } from "./node-kinds/index.js";
+import {
+	unhydratedFlexTreeFromInsertableNode,
+	type InsertableContent,
+} from "./unhydratedFlexTreeFromInsertable.js";
+
+/**
+ * Converts record-like data to a FlexContent representation for map/record schema.
+ */
+export function recordLikeDataToFlexContent(
+	fieldsIterator: Iterable<readonly [string, InsertableContent]>,
+	schema: MapNodeSchema | RecordNodeSchema,
+): FlexContent {
+	const allowedChildTypes = normalizeAllowedTypes(unannotateImplicitAllowedTypes(schema.info));
+	const context = getUnhydratedContext(schema).flexContext;
+
+	const transformedFields = new Map<FieldKey, UnhydratedFlexTreeField>();
+	for (const item of fieldsIterator) {
+		const [key, value] = item;
+		assert(!transformedFields.has(brand(key)), 0x84c /* Keys should not be duplicated */);
+
+		// Omit undefined values - an entry with an undefined value is equivalent to one that has been removed or omitted
+		if (value !== undefined) {
+			const child = unhydratedFlexTreeFromInsertableNode(value, allowedChildTypes);
+			const field = createField(context, FieldKinds.optional.identifier, brand(key), [child]);
+			transformedFields.set(brand(key), field);
+		}
+	}
+
+	return [
+		{
+			type: brand(schema.identifier),
+		},
+		transformedFields,
+	];
+}

--- a/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
@@ -5,10 +5,13 @@
 
 import { assert } from "@fluidframework/core-utils/internal";
 
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
+
 import { type TreeValue, ValueSchema } from "../core/index.js";
 import {
 	type FlexTreeNode,
 	isFlexTreeNode,
+	isTreeValue,
 	valueSchemaAllows,
 } from "../feature-libraries/index.js";
 
@@ -22,10 +25,14 @@ import {
 	type TreeNodeSchemaPrivateData,
 	privateDataSymbol,
 	type TreeNodeSchemaInitializedData,
+	CompatibilityLevel,
+	type FlexContent,
 } from "./core/index.js";
 import type { SimpleLeafNodeSchema } from "./simpleSchema.js";
-import type { JsonCompatibleReadOnlyObject } from "../util/index.js";
+import { brand, type JsonCompatibleReadOnlyObject } from "../util/index.js";
 import { getTreeNodeSchemaInitializedData } from "./createContext.js";
+import type { FactoryContent } from "./unhydratedFlexTreeFromInsertable.js";
+import { isFluidHandle } from "@fluidframework/runtime-utils";
 
 /**
  * Instances of this class are schema for leaf nodes.
@@ -49,7 +56,14 @@ export class LeafNodeSchema<Name extends string, const T extends ValueSchema>
 	public readonly childTypes: ReadonlySet<TreeNodeSchema> = new Set();
 	public readonly [privateDataSymbol]: TreeNodeSchemaPrivateData = {
 		idempotentInitialize: () =>
-			(this.#initializedData ??= getTreeNodeSchemaInitializedData(this)),
+			(this.#initializedData ??= getTreeNodeSchemaInitializedData(this, {
+				shallowCompatibilityTest: (data: FactoryContent): CompatibilityLevel =>
+					shallowCompatibilityTest(this, data),
+				toFlexContent: (
+					data: FactoryContent,
+					allowedTypes: ReadonlySet<TreeNodeSchema>,
+				): FlexContent => leafToFlexContent(data, this, allowedTypes),
+			})),
 		childAnnotatedAllowedTypes: [],
 	};
 	#initializedData: TreeNodeSchemaInitializedData | undefined;
@@ -116,3 +130,109 @@ export const numberSchema = makeLeaf("number", ValueSchema.Number);
 export const booleanSchema = makeLeaf("boolean", ValueSchema.Boolean);
 export const nullSchema = makeLeaf("null", ValueSchema.Null);
 export const handleSchema = makeLeaf("handle", ValueSchema.FluidHandle);
+
+/**
+ * Checks if data might be schema-compatible.
+ *
+ * @returns false if `data` is incompatible with `type` based on a cheap/shallow check.
+ *
+ * Note that this may return true for cases where data is incompatible, but it must not return false in cases where the data is compatible.
+ */
+function shallowCompatibilityTest(
+	schema: TreeNodeSchema,
+	data: FactoryContent,
+): CompatibilityLevel {
+	if (isTreeValue(data)) {
+		return allowsValue(schema, data) ? CompatibilityLevel.Normal : CompatibilityLevel.None;
+	}
+
+	return CompatibilityLevel.None;
+}
+
+function allowsValue(schema: TreeNodeSchema, value: TreeValue): boolean {
+	if (schema.kind === NodeKind.Leaf) {
+		return valueSchemaAllows(schema.info as ValueSchema, value);
+	}
+	return false;
+}
+
+/**
+ * Transforms data under a Leaf schema.
+ * @param data - The tree data to be transformed. Must be a {@link TreeValue}.
+ * @param schema - The schema associated with the value.
+ * @param allowedTypes - The allowed types specified by the parent.
+ * Used to determine which fallback values may be appropriate.
+ */
+export function leafToFlexContent(
+	data: FactoryContent,
+	schema: TreeNodeSchema,
+	allowedTypes: ReadonlySet<TreeNodeSchema>,
+): FlexContent {
+	assert(schema.kind === NodeKind.Leaf, 0x921 /* Expected a leaf schema. */);
+	if (!isTreeValue(data)) {
+		// This rule exists to protect against useless `toString` output like `[object Object]`.
+		// In this case, that's actually reasonable behavior, since object input is not compatible with Leaf schemas.
+		// eslint-disable-next-line @typescript-eslint/no-base-to-string
+		throw new UsageError(`Input data is incompatible with leaf schema: ${data}`);
+	}
+
+	const mappedValue = mapValueWithFallbacks(data, allowedTypes);
+	const mappedSchema = [...allowedTypes].find((type) => allowsValue(type, mappedValue));
+
+	assert(mappedSchema !== undefined, 0x84a /* Unsupported schema for provided primitive. */);
+
+	const result: FlexContent = [
+		{
+			value: mappedValue,
+			type: brand(mappedSchema.identifier),
+		},
+		new Map(),
+	];
+
+	return result;
+}
+
+/**
+ * Checks an incoming {@link TreeLeafValue} to ensure it is compatible with its requirements.
+ * For unsupported values with a schema-compatible replacement, return the replacement value.
+ * For unsupported values without a schema-compatible replacement, throw.
+ * For supported values, return the input.
+ */
+function mapValueWithFallbacks(
+	value: TreeLeafValue,
+	allowedTypes: ReadonlySet<TreeNodeSchema>,
+): TreeValue {
+	switch (typeof value) {
+		case "number": {
+			if (Object.is(value, -0)) {
+				// Our serialized data format does not support -0.
+				// Map such input to +0.
+				return 0;
+			} else if (!Number.isFinite(value)) {
+				// Our serialized data format does not support NaN nor +/-∞.
+				// If the schema supports `null`, fall back to that. Otherwise, throw.
+				// This is intended to match JSON's behavior for such values.
+				if (allowedTypes.has(nullSchema)) {
+					return null;
+				} else {
+					throw new UsageError(`Received unsupported numeric value: ${value}.`);
+				}
+			} else {
+				return value;
+			}
+		}
+		case "string":
+		// TODO:
+		// This should detect invalid strings. Something like @stdlib/regexp-utf16-unpaired-surrogate could be used to do this.
+		// See SchemaFactory.string for details.
+		case "boolean":
+			return value;
+		case "object": {
+			if (value === null || isFluidHandle(value)) {
+				return value;
+			}
+		}
+		default:
+			throw new UsageError(`Received unsupported leaf value: ${value}.`);
+	}
+}

--- a/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
@@ -4,8 +4,8 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
 
 import { type TreeValue, ValueSchema } from "../core/index.js";
 import {
@@ -32,7 +32,6 @@ import type { SimpleLeafNodeSchema } from "./simpleSchema.js";
 import { brand, type JsonCompatibleReadOnlyObject } from "../util/index.js";
 import { getTreeNodeSchemaInitializedData } from "./createContext.js";
 import type { FactoryContent } from "./unhydratedFlexTreeFromInsertable.js";
-import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
 
 /**
  * Instances of this class are schema for leaf nodes.

--- a/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
+++ b/packages/dds/tree/src/simple-tree/leafNodeSchema.ts
@@ -32,7 +32,7 @@ import type { SimpleLeafNodeSchema } from "./simpleSchema.js";
 import { brand, type JsonCompatibleReadOnlyObject } from "../util/index.js";
 import { getTreeNodeSchemaInitializedData } from "./createContext.js";
 import type { FactoryContent } from "./unhydratedFlexTreeFromInsertable.js";
-import { isFluidHandle } from "@fluidframework/runtime-utils";
+import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
 
 /**
  * Instances of this class are schema for leaf nodes.

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -7,13 +7,12 @@ import { Lazy, oob, fail } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { EmptyKey } from "../../../core/index.js";
-import {
-	FieldKinds,
-	isTreeValue,
-	type FlexibleFieldContent,
-	type FlexTreeNode,
-	type FlexTreeSequenceField,
+import type {
+	FlexibleFieldContent,
+	FlexTreeNode,
+	FlexTreeSequenceField,
 } from "../../../feature-libraries/index.js";
+import { FieldKinds, isTreeValue } from "../../../feature-libraries/index.js";
 import {
 	CompatibilityLevel,
 	type WithType,

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -1290,8 +1290,8 @@ function validateIndexRange(
 }
 
 /**
- * Transforms data under an Array schema.
- * @param data - The tree data to be transformed.
+ * Transforms data for a child of an array.
+ * @param child - The tree data to be transformed.
  * @param allowedTypes - The set of types allowed by the parent context. Used to validate the input tree.
  */
 function arrayChildToFlexTree(
@@ -1312,9 +1312,10 @@ function arrayChildToFlexTree(
 }
 
 /**
- * Transforms data under an Array schema.
+ * {@link TreeNodeSchemaInitializedData.toFlexContent} for Array nodes.
+ *
  * @param data - The tree data to be transformed. Must be an iterable.
- * @param schema - The schema associated with the value.
+ * @param schema - The schema to comply with.
  */
 function arrayToFlexContent(data: FactoryContent, schema: ArrayNodeSchema): FlexContent {
 	if (!(typeof data === "object" && data !== null && Symbol.iterator in data)) {
@@ -1354,9 +1355,7 @@ function arrayToFlexContent(data: FactoryContent, schema: ArrayNodeSchema): Flex
 }
 
 /**
- * Transforms data under an Object schema.
- * @param data - The tree data to be transformed. Must be a Record-like object.
- * @param schema - The schema associated with the value.
+ * {@link TreeNodeSchemaInitializedData.shallowCompatibilityTest} for Array nodes.
  */
 function shallowCompatibilityTest(
 	data: FactoryContent,

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -1366,7 +1366,7 @@ function shallowCompatibilityTest(
 	}
 
 	if (data instanceof Map) {
-		// Maps are iterable, so type checking does allow constructing an ArrayNode from a map if the array's type is an array that includes the key and value types of the map.
+		// Maps are iterable, so type checking does allow constructing an ArrayNode from a map if the ArrayNode's type is an array that includes the key and value types of the map.
 		return CompatibilityLevel.Low;
 	}
 

--- a/packages/dds/tree/src/simple-tree/node-kinds/common.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/common.ts
@@ -5,9 +5,9 @@
 
 import { assert } from "@fluidframework/core-utils/internal";
 
-import type { FieldKey } from "../core/index.js";
-import { FieldKinds } from "../feature-libraries/index.js";
-import { brand } from "../util/index.js";
+import type { FieldKey } from "../../core/index.js";
+import { FieldKinds } from "../../feature-libraries/index.js";
+import { brand } from "../../util/index.js";
 
 import {
 	createField,
@@ -15,14 +15,18 @@ import {
 	unannotateImplicitAllowedTypes,
 	normalizeAllowedTypes,
 	type FlexContent,
-} from "./core/index.js";
-import { getUnhydratedContext } from "./createContext.js";
+} from "../core/index.js";
+import { getUnhydratedContext } from "../createContext.js";
 
-import type { MapNodeSchema, RecordNodeSchema } from "./node-kinds/index.js";
+import type { MapNodeSchema, RecordNodeSchema } from "./index.js";
 import {
 	unhydratedFlexTreeFromInsertableNode,
 	type InsertableContent,
-} from "./unhydratedFlexTreeFromInsertable.js";
+} from "../unhydratedFlexTreeFromInsertable.js";
+
+/**
+ * Utilities shared by multiple node kinds.
+ */
 
 /**
  * Converts record-like data to a FlexContent representation for map/record schema.

--- a/packages/dds/tree/src/simple-tree/node-kinds/common.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/common.ts
@@ -17,12 +17,12 @@ import {
 	type FlexContent,
 } from "../core/index.js";
 import { getUnhydratedContext } from "../createContext.js";
-
-import type { MapNodeSchema, RecordNodeSchema } from "./index.js";
 import {
 	unhydratedFlexTreeFromInsertableNode,
 	type InsertableContent,
 } from "../unhydratedFlexTreeFromInsertable.js";
+import type { MapNodeSchema } from "./map/index.js";
+import type { RecordNodeSchema } from "./record/index.js";
 
 /**
  * Utilities shared by multiple node kinds.

--- a/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
@@ -359,7 +359,7 @@ function shallowCompatibilityTest(data: FactoryContent): CompatibilityLevel {
 	}
 
 	if (isReadonlyArray(data)) {
-		// Arrays are iterable, so type checking does allow constructing an array from a MapNode if the array's type is key values pairs for the map.
+		// Arrays are iterable, so type checking does allow constructing a MapNode from an array if the array's type is key values pairs for the map.
 		return CompatibilityLevel.Low;
 	}
 

--- a/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
@@ -360,10 +360,6 @@ function shallowCompatibilityTest(data: FactoryContent): CompatibilityLevel {
 		return CompatibilityLevel.None;
 	}
 
-	if (data instanceof Map) {
-		return CompatibilityLevel.Normal;
-	}
-
 	if (isReadonlyArray(data)) {
 		// Arrays are iterable, so type checking does allow constructing an array from a MapNode from an if the array's type is key values pairs for the map.
 		return CompatibilityLevel.Low;

--- a/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
@@ -359,7 +359,7 @@ function shallowCompatibilityTest(data: FactoryContent): CompatibilityLevel {
 	}
 
 	if (isReadonlyArray(data)) {
-		// Arrays are iterable, so type checking does allow constructing an array from a MapNode from an if the array's type is key values pairs for the map.
+		// Arrays are iterable, so type checking does allow constructing an array from a MapNode if the array's type is key values pairs for the map.
 		return CompatibilityLevel.Low;
 	}
 

--- a/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
@@ -351,9 +351,7 @@ export type MapNodeInsertableData<T extends ImplicitAllowedTypes> =
 	| RestrictiveStringRecord<InsertableTreeNodeFromImplicitAllowedTypes<T>>;
 
 /**
- * Transforms data under an Object schema.
- * @param data - The tree data to be transformed. Must be a Record-like object.
- * @param schema - The schema associated with the value.
+ * {@link TreeNodeSchemaInitializedData.shallowCompatibilityTest} for Map nodes.
  */
 function shallowCompatibilityTest(data: FactoryContent): CompatibilityLevel {
 	if (isTreeValue(data)) {
@@ -374,9 +372,11 @@ function shallowCompatibilityTest(data: FactoryContent): CompatibilityLevel {
 }
 
 /**
+ * {@link TreeNodeSchemaInitializedData.toFlexContent} for Map nodes.
+ *
  * Transforms data under a Map schema.
- * @param data - The tree data to be transformed. Must be an iterable.
- * @param schema - The schema associated with the value.
+ * @param data - The tree data to be transformed. Must be an iterable or Record like object.
+ * @param schema - The schema to comply with.
  */
 function mapToFlexContent(data: FactoryContent, schema: MapNodeSchema): FlexContent {
 	if (!(typeof data === "object" && data !== null)) {

--- a/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
@@ -4,15 +4,19 @@
  */
 
 import { Lazy } from "@fluidframework/core-utils/internal";
-import type {
-	FlexibleNodeContent,
-	FlexTreeNode,
-	FlexTreeOptionalField,
-	OptionalFieldEditBuilder,
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
+
+import {
+	isTreeValue,
+	type FlexibleNodeContent,
+	type FlexTreeNode,
+	type FlexTreeOptionalField,
+	type OptionalFieldEditBuilder,
 } from "../../../feature-libraries/index.js";
 import { tryGetTreeNodeForField } from "../../getTreeNodeForField.js";
 import { createFieldSchema, FieldKind } from "../../fieldSchema.js";
 import {
+	CompatibilityLevel,
 	getKernel,
 	type InnerNode,
 	NodeKind,
@@ -38,6 +42,8 @@ import {
 	type TreeNodeSchemaCorePrivate,
 	privateDataSymbol,
 	createTreeNodeSchemaPrivateData,
+	type FlexContent,
+	type TreeNodeSchemaPrivateData,
 } from "../../core/index.js";
 import {
 	unhydratedFlexTreeFromInsertable,
@@ -48,11 +54,17 @@ import { prepareForInsertion } from "../../prepareForInsertion.js";
 import {
 	brand,
 	count,
+	isReadonlyArray,
 	type JsonCompatibleReadOnlyObject,
 	type RestrictiveStringRecord,
 } from "../../../util/index.js";
 import { getTreeNodeSchemaInitializedData } from "../../createContext.js";
-import type { MapNodeCustomizableSchema, MapNodePojoEmulationSchema } from "./mapNodeTypes.js";
+import type {
+	MapNodeCustomizableSchema,
+	MapNodePojoEmulationSchema,
+	MapNodeSchema,
+} from "./mapNodeTypes.js";
+import { recordLikeDataToFlexContent } from "../../insertableContentHandler.js";
 
 /**
  * A map of string keys to tree objects.
@@ -257,6 +269,8 @@ export function mapSchema<
 		() => new Set([...lazyChildTypes.value].map((type) => type.identifier)),
 	);
 
+	let privateData: TreeNodeSchemaPrivateData | undefined;
+
 	class Schema
 		extends CustomMapNodeBase<UnannotateImplicitAllowedTypes<T>>
 		implements TreeMapNode<UnannotateImplicitAllowedTypes<T>>
@@ -287,7 +301,11 @@ export function mapSchema<
 		protected static override constructorCached: MostDerivedData | undefined = undefined;
 
 		protected static override oneTimeSetup(): TreeNodeSchemaInitializedData {
-			return getTreeNodeSchemaInitializedData(this);
+			const schema = this as MapNodeSchema;
+			return getTreeNodeSchemaInitializedData(this, {
+				shallowCompatibilityTest,
+				toFlexContent: (data: FactoryContent): FlexContent => mapToFlexContent(data, schema),
+			});
 		}
 
 		public static readonly identifier = identifier;
@@ -309,7 +327,9 @@ export function mapSchema<
 			return Schema.constructorCached?.constructor as unknown as typeof schemaErased;
 		}
 
-		public static readonly [privateDataSymbol] = createTreeNodeSchemaPrivateData(this, [info]);
+		public static get [privateDataSymbol](): TreeNodeSchemaPrivateData {
+			return (privateData ??= createTreeNodeSchemaPrivateData(this, [info]));
+		}
 	}
 	const schemaErased: MapNodeCustomizableSchema<
 		TName,
@@ -329,3 +349,51 @@ export function mapSchema<
 export type MapNodeInsertableData<T extends ImplicitAllowedTypes> =
 	| Iterable<readonly [string, InsertableTreeNodeFromImplicitAllowedTypes<T>]>
 	| RestrictiveStringRecord<InsertableTreeNodeFromImplicitAllowedTypes<T>>;
+
+/**
+ * Transforms data under an Object schema.
+ * @param data - The tree data to be transformed. Must be a Record-like object.
+ * @param schema - The schema associated with the value.
+ */
+function shallowCompatibilityTest(data: FactoryContent): CompatibilityLevel {
+	if (isTreeValue(data)) {
+		return CompatibilityLevel.None;
+	}
+
+	if (data instanceof Map) {
+		return CompatibilityLevel.Normal;
+	}
+
+	if (isReadonlyArray(data)) {
+		// Arrays are iterable, so type checking does allow constructing an array from a MapNode from an if the array's type is key values pairs for the map.
+		return CompatibilityLevel.Low;
+	}
+
+	if (Symbol.iterator in data) {
+		return CompatibilityLevel.Normal;
+	}
+
+	// When not unioned with an ObjectNode, allow objects to be used to create maps.
+	return CompatibilityLevel.Low;
+}
+
+/**
+ * Transforms data under a Map schema.
+ * @param data - The tree data to be transformed. Must be an iterable.
+ * @param schema - The schema associated with the value.
+ */
+function mapToFlexContent(data: FactoryContent, schema: MapNodeSchema): FlexContent {
+	if (!(typeof data === "object" && data !== null)) {
+		throw new UsageError(`Input data is incompatible with Map schema: ${data}`);
+	}
+
+	const fieldsIterator = (
+		Symbol.iterator in data
+			? // Support iterables of key value pairs (including Map objects)
+				data
+			: // Support record objects for JSON style Map data
+				Object.entries(data)
+	) as Iterable<readonly [string, InsertableContent]>;
+
+	return recordLikeDataToFlexContent(fieldsIterator, schema);
+}

--- a/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
@@ -64,7 +64,7 @@ import type {
 	MapNodePojoEmulationSchema,
 	MapNodeSchema,
 } from "./mapNodeTypes.js";
-import { recordLikeDataToFlexContent } from "../../insertableContentHandler.js";
+import { recordLikeDataToFlexContent } from "../common.js";
 
 /**
  * A map of string keys to tree objects.

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -19,7 +19,6 @@ import {
 	type RestrictiveStringRecord,
 	type FlattenKeys,
 	type JsonCompatibleReadOnlyObject,
-	isReadonlyArray,
 	brand,
 } from "../../../util/index.js";
 

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -729,14 +729,6 @@ function shallowCompatibilityTest(
 		return CompatibilityLevel.None;
 	}
 
-	if (data instanceof Map) {
-		return CompatibilityLevel.None;
-	}
-
-	if (isReadonlyArray(data)) {
-		return CompatibilityLevel.None;
-	}
-
 	if (Symbol.iterator in data) {
 		return CompatibilityLevel.None;
 	}

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -86,7 +86,7 @@ import {
 	type FactoryContentObject,
 	type InsertableContent,
 } from "../../unhydratedFlexTreeFromInsertable.js";
-import { isFluidHandle } from "@fluidframework/runtime-utils";
+import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
 import { convertFieldKind } from "../../toStoredSchema.js";
 
 /**

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -668,9 +668,11 @@ export function createUnknownOptionalFieldPolicy(
 }
 
 /**
+ * {@link TreeNodeSchemaInitializedData.toFlexContent} for Map nodes.
+ *
  * Transforms data under an Object schema.
  * @param data - The tree data to be transformed. Must be a Record-like object.
- * @param schema - The schema associated with the value.
+ * @param schema - The schema to comply with.
  */
 function objectToFlexContent(
 	data: FactoryContent,
@@ -716,9 +718,7 @@ function objectToFlexContent(
 }
 
 /**
- * Transforms data under an Object schema.
- * @param data - The tree data to be transformed. Must be a Record-like object.
- * @param schema - The schema associated with the value.
+ * {@link TreeNodeSchemaInitializedData.shallowCompatibilityTest} for Object nodes.
  */
 function shallowCompatibilityTest(
 	data: FactoryContent,

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -5,6 +5,7 @@
 
 import { assert, Lazy, fail, debugAssert } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
 
 import type { FieldKey, SchemaPolicy } from "../../../core/index.js";
 import {
@@ -15,12 +16,12 @@ import {
 	type FlexTreeOptionalField,
 	type FlexTreeRequiredField,
 } from "../../../feature-libraries/index.js";
-import {
-	type RestrictiveStringRecord,
-	type FlattenKeys,
-	type JsonCompatibleReadOnlyObject,
-	brand,
+import type {
+	RestrictiveStringRecord,
+	FlattenKeys,
+	JsonCompatibleReadOnlyObject,
 } from "../../../util/index.js";
+import { brand } from "../../../util/index.js";
 
 import {
 	CompatibilityLevel,
@@ -86,7 +87,6 @@ import {
 	type FactoryContentObject,
 	type InsertableContent,
 } from "../../unhydratedFlexTreeFromInsertable.js";
-import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
 import { convertFieldKind } from "../../toStoredSchema.js";
 
 /**

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNodeTypes.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNodeTypes.ts
@@ -101,7 +101,9 @@ export const ObjectNodeSchema = {
 /**
  * {@link ObjectNodeSchema} with data that is not part of the package-exported API surface.
  */
-export type ObjectNodeSchemaPrivate = ObjectNodeSchema & ObjectNodeSchemaInternalData;
+export type ObjectNodeSchemaPrivate = ObjectNodeSchema &
+	ObjectNodeSchemaInternalData &
+	TreeNodeSchemaCorePrivate;
 
 export function isObjectNodeSchema(schema: TreeNodeSchema): schema is ObjectNodeSchemaPrivate {
 	return schema.kind === NodeKind.Object;

--- a/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
@@ -421,9 +421,7 @@ function* recordIterator<TAllowedTypes extends ImplicitAllowedTypes>(
 }
 
 /**
- * Transforms data under an Object schema.
- * @param data - The tree data to be transformed. Must be a Record-like object.
- * @param schema - The schema associated with the value.
+ * {@link TreeNodeSchemaInitializedData.shallowCompatibilityTest} for Record nodes.
  */
 function shallowCompatibilityTest(data: FactoryContent): CompatibilityLevel {
 	if (isTreeValue(data)) {
@@ -438,9 +436,11 @@ function shallowCompatibilityTest(data: FactoryContent): CompatibilityLevel {
 }
 
 /**
+ * {@link TreeNodeSchemaInitializedData.toFlexContent} for Record nodes.
+ *
  * Transforms data under a Record schema.
  * @param data - The tree data to be transformed. Must be a Record-like object.
- * @param schema - The schema associated with the value.
+ * @param schema - The schema to comply with.
  */
 function recordToFlexContent(data: FactoryContent, schema: RecordNodeSchema): FlexContent {
 	if (!(typeof data === "object" && data !== null)) {

--- a/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
@@ -438,7 +438,7 @@ function shallowCompatibilityTest(data: FactoryContent): CompatibilityLevel {
 }
 
 /**
- * Transforms data under an Object schema.
+ * Transforms data under a Record schema.
  * @param data - The tree data to be transformed. Must be a Record-like object.
  * @param schema - The schema associated with the value.
  */

--- a/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
@@ -56,7 +56,7 @@ import {
 	type FlexTreeOptionalField,
 } from "../../../feature-libraries/index.js";
 import { prepareForInsertion } from "../../prepareForInsertion.js";
-import { recordLikeDataToFlexContent } from "../../insertableContentHandler.js";
+import { recordLikeDataToFlexContent } from "../common.js";
 
 /**
  * Create a proxy which implements the {@link TreeRecordNode} API.

--- a/packages/dds/tree/src/simple-tree/unhydratedFlexTreeFromInsertable.ts
+++ b/packages/dds/tree/src/simple-tree/unhydratedFlexTreeFromInsertable.ts
@@ -4,75 +4,23 @@
  */
 
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
-import { assert, fail, unreachableCase } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
-import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
+import { assert } from "@fluidframework/core-utils/internal";
 
-import {
-	EmptyKey,
-	type FieldKey,
-	type NodeData,
-	type TreeValue,
-	type ValueSchema,
-} from "../core/index.js";
-import { FieldKinds, isTreeValue, valueSchemaAllows } from "../feature-libraries/index.js";
-import { brand, isReadonlyArray, hasSingle } from "../util/index.js";
+import { hasSingle } from "../util/index.js";
 
-import { nullSchema } from "./leafNodeSchema.js";
+import { type ImplicitFieldSchema, normalizeFieldSchema, FieldKind } from "./fieldSchema.js";
 import {
-	isConstant,
-	type ImplicitFieldSchema,
-	normalizeFieldSchema,
-	FieldKind,
-	extractFieldProvider,
-	type ContextualFieldProvider,
-} from "./fieldSchema.js";
-import {
-	createField,
+	CompatibilityLevel,
 	getKernel,
+	getTreeNodeSchemaPrivateData,
 	isTreeNode,
-	NodeKind,
 	type TreeNode,
 	type TreeNodeSchema,
 	type Unhydrated,
-	type UnhydratedFlexTreeField,
 	UnhydratedFlexTreeNode,
-	UnhydratedSequenceField,
-	type ImplicitAllowedTypes,
-	unannotateImplicitAllowedTypes,
-	normalizeAllowedTypes,
-	type TreeLeafValue,
 } from "./core/index.js";
 import { getUnhydratedContext } from "./createContext.js";
-import { convertFieldKind } from "./toStoredSchema.js";
-
-// Required to prevent the introduction of new circular dependencies
-// TODO: Having the schema provide their own policy functions for compatibility which
-// `unhydratedFlexTreeFromInsertable` invokes instead of manually handling each kind would remove this bad
-// dependency, and reduce coupling.
-/* eslint-disable import/no-internal-modules */
-import { isArrayNodeSchema, type ArrayNodeSchema } from "./node-kinds/array/arrayNodeTypes.js";
-import { isMapNodeSchema, type MapNodeSchema } from "./node-kinds/map/mapNodeTypes.js";
-import {
-	isObjectNodeSchema,
-	type ObjectNodeSchemaPrivate,
-} from "./node-kinds/object/objectNodeTypes.js";
-import {
-	isRecordNodeSchema,
-	type RecordNodeSchema,
-} from "./node-kinds/record/recordNodeTypes.js";
-/* eslint-enable import/no-internal-modules */
-
-/**
- * Module notes:
- *
- * The flow of the below code is in terms of the structure of the input data. We then verify that the associated
- * schema is appropriate for that kind of data. This is fine while we have a 1:1 mapping of kind of input data to
- * the kind of schema we expect for it (e.g. an input that is an array always need to be associated with a sequence in
- * the schema). If/when we begin accepting kinds of input data that are ambiguous (e.g. accepting an input that is an
- * array of key/value tuples to instantiate a map) we may need to rethink the structure here to be based more on the
- * schema than on the input data.
- */
 
 /**
  * Transforms an input {@link TypedNode} tree to an {@link UnhydratedFlexTreeNode}.
@@ -125,7 +73,7 @@ export function unhydratedFlexTreeFromInsertable<TIn extends InsertableContent |
 /**
  * Copy content from `data` into a UnhydratedFlexTreeNode.
  */
-function unhydratedFlexTreeFromInsertableNode(
+export function unhydratedFlexTreeFromInsertableNode(
 	data: InsertableContent,
 	allowedTypes: ReadonlySet<TreeNodeSchema>,
 ): UnhydratedFlexTreeNode {
@@ -144,320 +92,10 @@ function unhydratedFlexTreeFromInsertableNode(
 	}
 
 	const schema = getType(data, allowedTypes);
-
-	let result: FlexContent;
-	switch (schema.kind) {
-		case NodeKind.Leaf:
-			result = leafToFlexContent(data, schema, allowedTypes);
-			break;
-		case NodeKind.Array:
-			assert(isArrayNodeSchema(schema), 0x922 /* Expected an array schema. */);
-			result = arrayToFlexContent(data, schema);
-			break;
-		case NodeKind.Map:
-			assert(isMapNodeSchema(schema), 0x923 /* Expected a Map schema. */);
-			result = mapToFlexContent(data, schema);
-			break;
-		case NodeKind.Object:
-			assert(isObjectNodeSchema(schema), 0x924 /* Expected an Object schema. */);
-			result = objectToFlexContent(data, schema);
-			break;
-		case NodeKind.Record:
-			assert(isRecordNodeSchema(schema), 0xbdd /* Expected a Record schema. */);
-			result = recordToFlexContent(data, schema);
-			break;
-		default:
-			unreachableCase(schema.kind);
-	}
+	const handler = getTreeNodeSchemaPrivateData(schema).idempotentInitialize();
+	const result = handler.toFlexContent(data, allowedTypes);
 
 	return new UnhydratedFlexTreeNode(...result, getUnhydratedContext(schema));
-}
-
-type FlexContent = [NodeData, Map<FieldKey, UnhydratedFlexTreeField>];
-
-/**
- * Transforms data under a Leaf schema.
- * @param data - The tree data to be transformed. Must be a {@link TreeValue}.
- * @param schema - The schema associated with the value.
- * @param allowedTypes - The allowed types specified by the parent.
- * Used to determine which fallback values may be appropriate.
- */
-function leafToFlexContent(
-	data: FactoryContent,
-	schema: TreeNodeSchema,
-	allowedTypes: ReadonlySet<TreeNodeSchema>,
-): FlexContent {
-	assert(schema.kind === NodeKind.Leaf, 0x921 /* Expected a leaf schema. */);
-	if (!isTreeValue(data)) {
-		// This rule exists to protect against useless `toString` output like `[object Object]`.
-		// In this case, that's actually reasonable behavior, since object input is not compatible with Leaf schemas.
-		// eslint-disable-next-line @typescript-eslint/no-base-to-string
-		throw new UsageError(`Input data is incompatible with leaf schema: ${data}`);
-	}
-
-	const mappedValue = mapValueWithFallbacks(data, allowedTypes);
-	const mappedSchema = getType(mappedValue, allowedTypes);
-
-	assert(
-		allowsValue(mappedSchema, mappedValue),
-		0x84a /* Unsupported schema for provided primitive. */,
-	);
-
-	return [
-		{
-			value: mappedValue,
-			type: brand(mappedSchema.identifier),
-		},
-		new Map<FieldKey, UnhydratedFlexTreeField>(),
-	];
-}
-
-/**
- * Checks an incoming {@link TreeLeafValue} to ensure it is compatible with its requirements.
- * For unsupported values with a schema-compatible replacement, return the replacement value.
- * For unsupported values without a schema-compatible replacement, throw.
- * For supported values, return the input.
- */
-function mapValueWithFallbacks(
-	value: TreeLeafValue,
-	allowedTypes: ReadonlySet<TreeNodeSchema>,
-): TreeValue {
-	switch (typeof value) {
-		case "number": {
-			if (Object.is(value, -0)) {
-				// Our serialized data format does not support -0.
-				// Map such input to +0.
-				return 0;
-			} else if (!Number.isFinite(value)) {
-				// Our serialized data format does not support NaN nor +/-∞.
-				// If the schema supports `null`, fall back to that. Otherwise, throw.
-				// This is intended to match JSON's behavior for such values.
-				if (allowedTypes.has(nullSchema)) {
-					return null;
-				} else {
-					throw new UsageError(`Received unsupported numeric value: ${value}.`);
-				}
-			} else {
-				return value;
-			}
-		}
-		case "string":
-		// TODO:
-		// This should detect invalid strings. Something like @stdlib/regexp-utf16-unpaired-surrogate could be used to do this.
-		// See SchemaFactory.string for details.
-		case "boolean":
-			return value;
-		case "object": {
-			if (value === null || isFluidHandle(value)) {
-				return value;
-			}
-		}
-		default:
-			throw new UsageError(`Received unsupported leaf value: ${value}.`);
-	}
-}
-
-/**
- * Transforms data under an Array schema.
- * @param data - The tree data to be transformed.
- * @param allowedTypes - The set of types allowed by the parent context. Used to validate the input tree.
- */
-function arrayChildToFlexTree(
-	child: InsertableContent,
-	allowedTypes: ReadonlySet<TreeNodeSchema>,
-): UnhydratedFlexTreeNode {
-	// We do not support undefined sequence entries.
-	// If we encounter an undefined entry, use null instead if supported by the schema, otherwise throw.
-	let childWithFallback = child;
-	if (child === undefined) {
-		if (allowedTypes.has(nullSchema)) {
-			childWithFallback = null;
-		} else {
-			throw new TypeError(`Received unsupported array entry value: ${child}.`);
-		}
-	}
-	return unhydratedFlexTreeFromInsertableNode(childWithFallback, allowedTypes);
-}
-
-/**
- * Transforms data under an Array schema.
- * @param data - The tree data to be transformed. Must be an iterable.
- * @param schema - The schema associated with the value.
- */
-function arrayToFlexContent(data: FactoryContent, schema: ArrayNodeSchema): FlexContent {
-	if (!(typeof data === "object" && data !== null && Symbol.iterator in data)) {
-		throw new UsageError(`Input data is incompatible with Array schema: ${data}`);
-	}
-
-	const allowedChildTypes = normalizeAllowedTypes(schema.info as ImplicitAllowedTypes);
-
-	const mappedData = Array.from(data, (child) =>
-		arrayChildToFlexTree(child, allowedChildTypes),
-	);
-
-	const context = getUnhydratedContext(schema).flexContext;
-
-	// Array nodes have a single `EmptyKey` field:
-	const fieldsEntries =
-		mappedData.length === 0
-			? []
-			: ([
-					[
-						EmptyKey,
-						new UnhydratedSequenceField(
-							context,
-							FieldKinds.sequence.identifier,
-							EmptyKey,
-							mappedData,
-						),
-					],
-				] as const);
-
-	return [
-		{
-			type: brand(schema.identifier),
-		},
-		new Map(fieldsEntries),
-	];
-}
-
-/**
- * Transforms data under a Map schema.
- * @param data - The tree data to be transformed. Must be an iterable.
- * @param schema - The schema associated with the value.
- */
-function mapToFlexContent(data: FactoryContent, schema: MapNodeSchema): FlexContent {
-	if (!(typeof data === "object" && data !== null)) {
-		throw new UsageError(`Input data is incompatible with Map schema: ${data}`);
-	}
-
-	const fieldsIterator = (
-		Symbol.iterator in data
-			? // Support iterables of key value pairs (including Map objects)
-				data
-			: // Support record objects for JSON style Map data
-				Object.entries(data)
-	) as Iterable<readonly [string, InsertableContent]>;
-
-	return recordLikeDataToFlexContent(fieldsIterator, schema);
-}
-
-/**
- * Transforms data under an Object schema.
- * @param data - The tree data to be transformed. Must be a Record-like object.
- * @param schema - The schema associated with the value.
- */
-function objectToFlexContent(
-	data: FactoryContent,
-	schema: ObjectNodeSchemaPrivate,
-): FlexContent {
-	if (
-		typeof data !== "object" ||
-		data === null ||
-		Symbol.iterator in data ||
-		isFluidHandle(data)
-	) {
-		throw new UsageError(`Input data is incompatible with Object schema: ${data}`);
-	}
-
-	const fields = new Map<FieldKey, UnhydratedFlexTreeField>();
-	const context = getUnhydratedContext(schema).flexContext;
-
-	for (const [key, fieldInfo] of schema.flexKeyMap) {
-		const value = getFieldProperty(data, key);
-
-		let children: UnhydratedFlexTreeNode[] | ContextualFieldProvider;
-		if (value === undefined) {
-			const defaultProvider =
-				fieldInfo.schema.props?.defaultProvider ??
-				fail(0xbb1 /* missing field has no default provider */);
-			const fieldProvider = extractFieldProvider(defaultProvider);
-			children = isConstant(fieldProvider) ? fieldProvider() : fieldProvider;
-		} else {
-			children = [
-				unhydratedFlexTreeFromInsertableNode(value, fieldInfo.schema.allowedTypeSet),
-			];
-		}
-
-		const kind =
-			convertFieldKind.get(fieldInfo.schema.kind) ?? fail(0xbb2 /* Invalid field kind */);
-		fields.set(
-			fieldInfo.storedKey,
-			createField(context, kind.identifier, fieldInfo.storedKey, children),
-		);
-	}
-
-	return [{ type: brand(schema.identifier) }, fields];
-}
-
-/**
- * Transforms data under an Object schema.
- * @param data - The tree data to be transformed. Must be a Record-like object.
- * @param schema - The schema associated with the value.
- */
-function recordToFlexContent(data: FactoryContent, schema: RecordNodeSchema): FlexContent {
-	if (!(typeof data === "object" && data !== null)) {
-		throw new UsageError(`Input data is incompatible with Record schema: ${data}`);
-	}
-
-	const fieldsIterator: Iterable<readonly [string, InsertableContent]> = Object.entries(data);
-	return recordLikeDataToFlexContent(fieldsIterator, schema);
-}
-
-/**
- * Converts record-like data to a FlexContent representation for map/record schema.
- */
-function recordLikeDataToFlexContent(
-	fieldsIterator: Iterable<readonly [string, InsertableContent]>,
-	schema: MapNodeSchema | RecordNodeSchema,
-): FlexContent {
-	const allowedChildTypes = normalizeAllowedTypes(unannotateImplicitAllowedTypes(schema.info));
-	const context = getUnhydratedContext(schema).flexContext;
-
-	const transformedFields = new Map<FieldKey, UnhydratedFlexTreeField>();
-	for (const item of fieldsIterator) {
-		const [key, value] = item;
-		assert(!transformedFields.has(brand(key)), 0x84c /* Keys should not be duplicated */);
-
-		// Omit undefined values - an entry with an undefined value is equivalent to one that has been removed or omitted
-		if (value !== undefined) {
-			const child = unhydratedFlexTreeFromInsertableNode(value, allowedChildTypes);
-			const field = createField(context, FieldKinds.optional.identifier, brand(key), [child]);
-			transformedFields.set(brand(key), field);
-		}
-	}
-
-	return [
-		{
-			type: brand(schema.identifier),
-		},
-		transformedFields,
-	];
-}
-
-/**
- * Check {@link FactoryContentObject} for a property which could be store a field.
- *
- * @returns If the property exists, return its value. Otherwise, returns undefined.
- * @remarks
- * The currently policy is to only consider own properties.
- * See {@link InsertableObjectFromSchemaRecord} for where this policy is documented in the public API.
- *
- * Explicit undefined values are treated the same as missing properties to allow explicit use of undefined with defaulted identifiers.
- *
- * @privateRemarks
- * If we ever want to have an optional field which defaults to something other than undefined, this will need changes.
- * It would need to adjusting the handling of explicit undefined in contexts where undefined is allowed, and a default provider also exists.
- */
-function getFieldProperty(
-	data: FactoryContentObject,
-	key: string | symbol,
-): InsertableContent | undefined {
-	// This policy only allows own properties.
-	if (Object.hasOwnProperty.call(data, key)) {
-		return (data as Record<string, InsertableContent>)[key as string];
-	}
-	return undefined;
 }
 
 function getType(
@@ -492,10 +130,13 @@ export function getPossibleTypes(
 	allowedTypes: ReadonlySet<TreeNodeSchema>,
 	data: FactoryContent,
 ): TreeNodeSchema[] {
+	assert(data !== undefined, 0x889 /* undefined cannot be used as FactoryContent. */);
+
 	let best = CompatibilityLevel.None;
 	const possibleTypes: TreeNodeSchema[] = [];
 	for (const schema of allowedTypes) {
-		const level = shallowCompatibilityTest(schema, data);
+		const handler = getTreeNodeSchemaPrivateData(schema).idempotentInitialize();
+		const level = handler.shallowCompatibilityTest(data);
 		if (level > best) {
 			possibleTypes.length = 0;
 			best = level;
@@ -505,129 +146,6 @@ export function getPossibleTypes(
 		}
 	}
 	return best === CompatibilityLevel.None ? [] : possibleTypes;
-}
-
-/**
- * Indicates a compatibility level for inferring a schema to apply to insertable data.
- * @remarks
- * Only the highest compatibility options are used.
- * This approach allows adding new possible matching at a new lower compatibility level as a non breaking change,
- * since that way they can't make a case that was compatible before ambiguous now.
- */
-enum CompatibilityLevel {
-	/**
-	 * Not compatible. Constructor typing indicates incompatibility.
-	 */
-	None = 0,
-	/**
-	 * Additional compatibility cases added in Fluid Framework 2.2.
-	 */
-	Low = 1,
-	/**
-	 * Compatible in Fluid Framework 2.0.
-	 */
-	Normal = 2,
-}
-
-/**
- * Checks if data might be schema-compatible.
- *
- * @returns false if `data` is incompatible with `type` based on a cheap/shallow check.
- *
- * Note that this may return true for cases where data is incompatible, but it must not return false in cases where the data is compatible.
- */
-function shallowCompatibilityTest(
-	schema: TreeNodeSchema,
-	data: FactoryContent,
-): CompatibilityLevel {
-	assert(data !== undefined, 0x889 /* undefined cannot be used as FactoryContent. */);
-
-	if (isTreeValue(data)) {
-		return allowsValue(schema, data) ? CompatibilityLevel.Normal : CompatibilityLevel.None;
-	}
-	if (schema.kind === NodeKind.Leaf) {
-		return CompatibilityLevel.None;
-	}
-
-	// Typing (of schema based constructors and thus implicit node construction)
-	// allows iterables for constructing maps and arrays.
-	// Some users of this API may have unions of maps and arrays,
-	// and rely on Arrays ending up as array nodes and maps as Map nodes,
-	// despite both being iterable and thus compatible with both.
-	// This uses a priority based system where an array would be parsed as an array when unioned with a map,
-	// but if in a map only context, could still be used as a map.
-
-	if (data instanceof Map) {
-		switch (schema.kind) {
-			case NodeKind.Map:
-				return CompatibilityLevel.Normal;
-			case NodeKind.Array:
-				// Maps are iterable, so type checking does allow constructing an ArrayNode from a map if the array's type is an array that includes the key and value types of the map.
-				return CompatibilityLevel.Low;
-			default:
-				return CompatibilityLevel.None;
-		}
-	}
-
-	if (isReadonlyArray(data)) {
-		switch (schema.kind) {
-			case NodeKind.Array:
-				return CompatibilityLevel.Normal;
-			case NodeKind.Map:
-				// Arrays are iterable, so type checking does allow constructing an array from a MapNode from an if the array's type is key values pairs for the map.
-				return CompatibilityLevel.Low;
-			default:
-				return CompatibilityLevel.None;
-		}
-	}
-
-	const mapOrArray = schema.kind === NodeKind.Array || schema.kind === NodeKind.Map;
-
-	if (Symbol.iterator in data) {
-		return mapOrArray ? CompatibilityLevel.Normal : CompatibilityLevel.None;
-	}
-
-	// At this point, it is assumed data is a record-like object since all the other cases have been eliminated.
-
-	if (schema.kind === NodeKind.Record) {
-		return CompatibilityLevel.Normal;
-	}
-
-	if (schema.kind === NodeKind.Array) {
-		return CompatibilityLevel.None;
-	}
-
-	if (schema.kind === NodeKind.Map) {
-		// When not unioned with an ObjectNode, allow objects to be used to create maps.
-		return CompatibilityLevel.Low;
-	}
-
-	assert(isObjectNodeSchema(schema), 0x9e6 /* unexpected schema kind */);
-
-	// TODO: Improve type inference by making this logic more thorough. Handle at least:
-	// * Types which are strict subsets of other types in the same polymorphic union
-	// * Types which have the same keys but different types for those keys in the polymorphic union
-	// * Types which have the same required fields but different optional fields and enough of those optional fields are populated to disambiguate
-
-	// TODO#7441: Consider allowing data to be inserted which has keys that are extraneous/unknown to the schema (those keys are ignored)
-
-	// If the schema has a required key which is not present in the input object, reject it.
-	for (const [fieldKey, fieldSchema] of schema.fields) {
-		if (fieldSchema.requiresValue) {
-			if (getFieldProperty(data, fieldKey) === undefined) {
-				return CompatibilityLevel.None;
-			}
-		}
-	}
-
-	return CompatibilityLevel.Normal;
-}
-
-function allowsValue(schema: TreeNodeSchema, value: TreeValue): boolean {
-	if (schema.kind === NodeKind.Leaf) {
-		return valueSchemaAllows(schema.info as ValueSchema, value);
-	}
-	return false;
 }
 
 /**

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -100,7 +100,6 @@ export const SharedTree = configuredSharedTree({});
  * 	TreeCompressionStrategy,
  * 	configuredSharedTree,
  * 	typeboxValidator,
- * 	// eslint-disable-next-line import/no-internal-modules
  * } from "@fluidframework/tree/internal";
  * const SharedTree = configuredSharedTree({
  * 	forest: ForestTypeReference,


### PR DESCRIPTION
## Description

Refactor parsing of insertable content, delegating back to schema for compatibility and actual interpretation of the data.

This removes a logical cyclic dependency between that code and the schema kinds.

This will also make future changed which want to further customize insertable types much more straightforward.