### PR TITLE
refactor(matrix): Use explicit type imports/exports where appropriate

### DIFF
--- a/packages/dds/matrix/src/handlecache.ts
+++ b/packages/dds/matrix/src/handlecache.ts
@@ -6,10 +6,10 @@
 /* eslint-disable no-bitwise */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { IVectorConsumer } from "@tiny-calc/nano";
+import type { IVectorConsumer } from "@tiny-calc/nano";
 
-import { Handle, isHandleValid } from "./handletable.js";
-import { PermutationSegment, PermutationVector } from "./permutationvector.js";
+import { type Handle, isHandleValid } from "./handletable.js";
+import type { PermutationSegment, PermutationVector } from "./permutationvector.js";
 import { ensureRange } from "./range.js";
 
 /**

--- a/packages/dds/matrix/src/index.ts
+++ b/packages/dds/matrix/src/index.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-export { ISharedMatrixEvents, ISharedMatrix } from "./matrix.js";
-export { MatrixItem } from "./ops.js";
+export type { ISharedMatrixEvents, ISharedMatrix } from "./matrix.js";
+export type { MatrixItem } from "./ops.js";
 export { SharedMatrixFactory, SharedMatrix } from "./runtime.js";
 
 // TODO: We temporarily duplicate these contracts from 'framework/undo-redo' to unblock development
 //       of SharedMatrix undo while we decide on the correct layering for undo.
-export { IUndoConsumer, IRevertible } from "./types.js";
+export type { IUndoConsumer, IRevertible } from "./types.js";

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -3,41 +3,41 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	IEvent,
 	IEventThisPlaceHolder,
-	type IEventProvider,
+	IEventProvider,
 } from "@fluidframework/core-interfaces";
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
-import {
+import type {
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
-	type IChannel,
+	IChannel,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
-	Client,
-	IJSONSegment,
-	IMergeTreeOp,
+	type Client,
+	type IJSONSegment,
+	type IMergeTreeOp,
 	type ISegmentInternal,
 	type LocalReferencePosition,
 	MergeTreeDeltaType,
 	ReferenceType,
 	segmentIsRemoved,
 } from "@fluidframework/merge-tree/internal";
-import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/internal";
+import type { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/internal";
 import {
 	ObjectStoragePartition,
 	SummaryTreeBuilder,
 } from "@fluidframework/runtime-utils/internal";
 import {
-	IFluidSerializer,
-	ISharedObjectEvents,
+	type IFluidSerializer,
+	type ISharedObjectEvents,
 	SharedObject,
 } from "@fluidframework/shared-object-base/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
-import {
+import type {
 	IMatrixConsumer,
 	IMatrixProducer,
 	IMatrixReader,
@@ -46,20 +46,20 @@ import {
 import Deque from "double-ended-queue";
 
 import type { HandleCache } from "./handlecache.js";
-import { Handle, isHandleValid } from "./handletable.js";
+import { type Handle, isHandleValid } from "./handletable.js";
 import {
-	ISetOp,
-	MatrixItem,
+	type ISetOp,
+	type MatrixItem,
 	MatrixOp,
-	MatrixSetOrVectorOp,
+	type MatrixSetOrVectorOp,
 	SnapshotPath,
-	VectorOp,
+	type VectorOp,
 } from "./ops.js";
 import { PermutationVector, reinsertSegmentIntoVector } from "./permutationvector.js";
 import { ensureRange } from "./range.js";
 import { deserializeBlob } from "./serialization.js";
 import { SparseArray2D, type RecurArray } from "./sparsearray2d.js";
-import { IUndoConsumer } from "./types.js";
+import type { IUndoConsumer } from "./types.js";
 import { MatrixUndoProvider } from "./undoprovider.js";
 
 interface ISetOpMetadata {

--- a/packages/dds/matrix/src/ops.ts
+++ b/packages/dds/matrix/src/ops.ts
@@ -8,8 +8,8 @@
  * Use caustion when making changes and consider backward and forward compatibility of your changes!
  */
 
-import { Serializable } from "@fluidframework/datastore-definitions/internal";
-import { IMergeTreeOp } from "@fluidframework/merge-tree/internal";
+import type { Serializable } from "@fluidframework/datastore-definitions/internal";
+import type { IMergeTreeOp } from "@fluidframework/merge-tree/internal";
 
 export enum MatrixOp {
 	spliceCols,

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -3,39 +3,39 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidHandle, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import type { IFluidHandle, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import {
+import type {
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
 	BaseSegment,
 	Client,
-	IJSONSegment,
-	IMergeTreeDeltaCallbackArgs,
-	IMergeTreeDeltaOpArgs,
-	IMergeTreeMaintenanceCallbackArgs,
-	ISegment,
+	type IJSONSegment,
+	type IMergeTreeDeltaCallbackArgs,
+	type IMergeTreeDeltaOpArgs,
+	type IMergeTreeMaintenanceCallbackArgs,
+	type ISegment,
 	MergeTreeDeltaType,
 	MergeTreeMaintenanceType,
 	segmentIsRemoved,
 	type IMergeTreeInsertMsg,
 	type IMergeTreeRemoveMsg,
 } from "@fluidframework/merge-tree/internal";
-import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/internal";
+import type { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/internal";
 import {
 	ObjectStoragePartition,
 	SummaryTreeBuilder,
 } from "@fluidframework/runtime-utils/internal";
-import { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
+import type { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { HandleCache } from "./handlecache.js";
 import { Handle, HandleTable, isHandleValid } from "./handletable.js";
 import { deserializeBlob } from "./serialization.js";
-import { VectorUndoProvider } from "./undoprovider.js";
+import type { VectorUndoProvider } from "./undoprovider.js";
 
 const enum SnapshotPath {
 	segments = "segments",

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -125,7 +125,6 @@ export class PermutationSegment extends BaseSegment {
 	}
 }
 
-// eslint-disable-next-line import/no-deprecated
 export class PermutationVector extends Client {
 	private handleTable = new HandleTable<never>(); // Tracks available storage handles for rows.
 	public readonly handleCache = new HandleCache(this);

--- a/packages/dds/matrix/src/runtime.ts
+++ b/packages/dds/matrix/src/runtime.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	IChannel,
 	IChannelAttributes,
 	IChannelFactory,

--- a/packages/dds/matrix/src/serialization.ts
+++ b/packages/dds/matrix/src/serialization.ts
@@ -4,13 +4,13 @@
  */
 
 import { bufferToString } from "@fluid-internal/client-utils";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
-import {
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import type {
 	IChannelStorageService,
 	Serializable,
 } from "@fluidframework/datastore-definitions/internal";
 import { BlobTreeEntry } from "@fluidframework/driver-utils/internal";
-import { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
+import type { IFluidSerializer } from "@fluidframework/shared-object-base/internal";
 
 export const serializeBlob = <T>(
 	handle: IFluidHandle,

--- a/packages/dds/matrix/src/serialization.ts
+++ b/packages/dds/matrix/src/serialization.ts
@@ -28,6 +28,5 @@ export async function deserializeBlob(
 ): Promise<any> {
 	const blob = await storage.readBlob(path);
 	const utf8 = bufferToString(blob, "utf8");
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 	return serializer.parse(utf8);
 }

--- a/packages/dds/matrix/src/sparsearray2d.ts
+++ b/packages/dds/matrix/src/sparsearray2d.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable no-bitwise */
 
-import { IMatrixReader, IMatrixWriter, type IMatrixProducer } from "@tiny-calc/nano";
+import type { IMatrixReader, IMatrixWriter, IMatrixProducer } from "@tiny-calc/nano";
 
 // Build a lookup table that maps a uint8 to the corresponding uint16 where 0s
 // are interleaved between the original bits. (e.g., 1111... -> 01010101...).

--- a/packages/dds/matrix/src/test/dirname.cts
+++ b/packages/dds/matrix/src/test/dirname.cts
@@ -11,5 +11,4 @@
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
 // Disabled inline until the next version of the config is published.
-// eslint-disable-next-line unicorn/prefer-module
 export const _dirname = __dirname;

--- a/packages/dds/matrix/src/test/dirname.cts
+++ b/packages/dds/matrix/src/test/dirname.cts
@@ -10,5 +10,4 @@
 //   - Export '__dirname' from a .cjs file in the same directory.
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
-// Disabled inline until the next version of the config is published.
 export const _dirname = __dirname;

--- a/packages/dds/matrix/src/test/fuzz.ts
+++ b/packages/dds/matrix/src/test/fuzz.ts
@@ -5,20 +5,19 @@
 
 import { strict as assert } from "node:assert";
 
+import type { AsyncGenerator, Generator } from "@fluid-private/stochastic-test-utils";
 import {
-	AsyncGenerator,
-	Generator,
 	combineReducers,
 	createWeightedGenerator,
 	takeAsync,
 } from "@fluid-private/stochastic-test-utils";
-import { DDSFuzzTestState, type DDSFuzzModel } from "@fluid-private/test-dds-utils";
+import type { DDSFuzzTestState, DDSFuzzModel } from "@fluid-private/test-dds-utils";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { Serializable } from "@fluidframework/datastore-definitions/internal";
 import { isFluidHandle, toFluidHandleInternal } from "@fluidframework/runtime-utils/internal";
 
-import { MatrixItem } from "../ops.js";
-import { SharedMatrixFactory, SharedMatrix } from "../runtime.js";
+import type { MatrixItem } from "../ops.js";
+import { SharedMatrix, type SharedMatrixFactory } from "../runtime.js";
 
 /**
  * Supported cell values used within the fuzz model.

--- a/packages/dds/matrix/src/test/matrix.applyStashedOp.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.applyStashedOp.spec.ts
@@ -5,17 +5,17 @@
 
 import { strict as assert } from "node:assert";
 
-import { ISummaryTree } from "@fluidframework/driver-definitions";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type { ISummaryTree } from "@fluidframework/driver-definitions";
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
 	MockContainerRuntimeFactoryForReconnection,
-	MockContainerRuntimeForReconnection,
-	MockDeltaConnection,
+	type MockContainerRuntimeForReconnection,
+	type MockDeltaConnection,
 	MockFluidDataStoreRuntime,
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { SharedMatrix } from "../index.js";
+import type { SharedMatrix } from "../index.js";
 
 import { extract, matrixFactory } from "./utils.js";
 

--- a/packages/dds/matrix/src/test/matrix.big.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.big.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { AttachState } from "@fluidframework/container-definitions";
-import { IChannelServices } from "@fluidframework/datastore-definitions/internal";
+import type { IChannelServices } from "@fluidframework/datastore-definitions/internal";
 import {
 	MockContainerRuntimeFactory,
 	MockEmptyDeltaConnection,
@@ -12,7 +12,7 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { SharedMatrix } from "../index.js";
+import type { SharedMatrix } from "../index.js";
 
 import { checkCorners, expectSize, setCorners, matrixFactory } from "./utils.js";
 

--- a/packages/dds/matrix/src/test/matrix.fuzz.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.fuzz.spec.ts
@@ -6,13 +6,13 @@
 import * as path from "node:path";
 
 import {
-	DDSFuzzModel,
-	DDSFuzzSuiteOptions,
 	createDDSFuzzSuite,
+	type DDSFuzzModel,
+	type DDSFuzzSuiteOptions,
 } from "@fluid-private/test-dds-utils";
 import { FlushMode } from "@fluidframework/runtime-definitions/internal";
 
-import { SharedMatrixFactory } from "../runtime.js";
+import type { SharedMatrixFactory } from "../runtime.js";
 
 import { _dirname } from "./dirname.cjs";
 import { baseSharedMatrixModel, type Operation } from "./fuzz.js";

--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -5,18 +5,18 @@
 
 import { strict as assert } from "node:assert";
 
-import { IGCTestProvider, runGCTests } from "@fluid-private/test-dds-utils";
+import { type IGCTestProvider, runGCTests } from "@fluid-private/test-dds-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
-import {
+import type {
 	IChannelServices,
-	type IChannel,
+	IChannel,
 } from "@fluidframework/datastore-definitions/internal";
 import type { ISegmentInternal } from "@fluidframework/merge-tree/internal";
 import {
 	MockContainerRuntimeFactory,
 	MockContainerRuntimeFactoryForReconnection,
-	MockContainerRuntimeForReconnection,
+	type MockContainerRuntimeForReconnection,
 	MockEmptyDeltaConnection,
 	MockFluidDataStoreRuntime,
 	MockHandle,
@@ -25,8 +25,8 @@ import {
 
 import {
 	type ISharedMatrix,
-	MatrixItem,
-	SharedMatrix,
+	type MatrixItem,
+	type SharedMatrix,
 	SharedMatrixFactory,
 } from "../index.js";
 import { SharedMatrix as SharedMatrixClass } from "../matrix.js";

--- a/packages/dds/matrix/src/test/matrix.stress.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.stress.spec.ts
@@ -5,16 +5,16 @@
 
 import { strict as assert } from "node:assert";
 
-import { IChannelServices } from "@fluidframework/datastore-definitions/internal";
+import type { IChannelServices } from "@fluidframework/datastore-definitions/internal";
 import {
 	MockContainerRuntimeFactoryForReconnection,
-	MockContainerRuntimeForReconnection,
+	type MockContainerRuntimeForReconnection,
 	MockFluidDataStoreRuntime,
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 import { Random } from "best-random";
 
-import { SharedMatrix, type MatrixItem } from "../index.js";
+import type { MatrixItem, SharedMatrix } from "../index.js";
 import { SharedMatrix as SharedMatrixClass } from "../matrix.js";
 
 import { UndoRedoStackManager } from "./undoRedoStackManager.js";

--- a/packages/dds/matrix/src/test/matrix.undo.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.undo.spec.ts
@@ -14,7 +14,7 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { MatrixItem, SharedMatrix, type ISharedMatrix } from "../index.js";
+import type { MatrixItem, ISharedMatrix, SharedMatrix } from "../index.js";
 
 import { TestConsumer } from "./testconsumer.js";
 import { UndoRedoStackManager } from "./undoRedoStackManager.js";

--- a/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
@@ -11,7 +11,7 @@ import {
 	isInPerformanceTestingMode,
 } from "@fluid-tools/benchmark";
 
-import { SharedMatrix } from "../../index.js";
+import type { SharedMatrix } from "../../index.js";
 import { UndoRedoStackManager } from "../undoRedoStackManager.js";
 import { createLocalMatrix } from "../utils.js";
 

--- a/packages/dds/matrix/src/test/testconsumer.ts
+++ b/packages/dds/matrix/src/test/testconsumer.ts
@@ -4,9 +4,9 @@
  */
 
 import { DenseVector, RowMajorMatrix } from "@tiny-calc/micro";
-import { IMatrixConsumer, IMatrixProducer, IMatrixReader } from "@tiny-calc/nano";
+import type { IMatrixConsumer, IMatrixProducer, IMatrixReader } from "@tiny-calc/nano";
 
-import { MatrixItem } from "../index.js";
+import type { MatrixItem } from "../index.js";
 
 /**
  * IMatrixConsumer implementation that applies change notifications to it's own

--- a/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
@@ -12,7 +12,7 @@ import {
 	type BenchmarkTimer,
 } from "@fluid-tools/benchmark";
 
-import { SharedMatrix } from "../../index.js";
+import type { SharedMatrix } from "../../index.js";
 import { UndoRedoStackManager } from "../undoRedoStackManager.js";
 import { createLocalMatrix } from "../utils.js";
 

--- a/packages/dds/matrix/src/test/undoRedoStackManager.ts
+++ b/packages/dds/matrix/src/test/undoRedoStackManager.ts
@@ -9,7 +9,7 @@
 
 import { EventEmitter } from "@fluid-internal/client-utils";
 
-import { IRevertible } from "../types.js";
+import type { IRevertible } from "../types.js";
 
 enum UndoRedoMode {
 	None,

--- a/packages/dds/matrix/src/test/utils.ts
+++ b/packages/dds/matrix/src/test/utils.ts
@@ -7,14 +7,14 @@ import { strict as assert } from "node:assert";
 
 import type { IChannel } from "@fluidframework/datastore-definitions/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
-import {
+import type {
 	IMatrixConsumer,
 	IMatrixProducer,
 	IMatrixReader,
 	IMatrixWriter,
 } from "@tiny-calc/nano";
 
-import { SharedMatrix, ISharedMatrix } from "../index.js";
+import { type ISharedMatrix, SharedMatrix } from "../index.js";
 
 /**
  * Convenience export of SharedMatrix's factory for usage in tests.

--- a/packages/dds/matrix/src/undoprovider.ts
+++ b/packages/dds/matrix/src/undoprovider.ts
@@ -5,11 +5,11 @@
 
 import { assert } from "@fluidframework/core-utils/internal";
 import {
-	IMergeTreeDeltaCallbackArgs,
-	ITrackingGroup,
-	MergeTreeDeltaRevertible,
+	type IMergeTreeDeltaCallbackArgs,
+	type ITrackingGroup,
+	type MergeTreeDeltaRevertible,
 	MergeTreeDeltaType,
-	MergeTreeRevertibleDriver,
+	type MergeTreeRevertibleDriver,
 	TrackingGroup,
 	appendToMergeTreeDeltaRevertibles,
 	discardMergeTreeDeltaRevertible,

--- a/packages/dds/matrix/src/undoprovider.ts
+++ b/packages/dds/matrix/src/undoprovider.ts
@@ -16,11 +16,11 @@ import {
 	revertMergeTreeDeltaRevertibles,
 } from "@fluidframework/merge-tree/internal";
 
-import { Handle, isHandleValid } from "./handletable.js";
-import { SharedMatrix } from "./matrix.js";
-import { MatrixItem } from "./ops.js";
-import { PermutationSegment, PermutationVector } from "./permutationvector.js";
-import { IUndoConsumer } from "./types.js";
+import { type Handle, isHandleValid } from "./handletable.js";
+import type { SharedMatrix } from "./matrix.js";
+import type { MatrixItem } from "./ops.js";
+import type { PermutationSegment, PermutationVector } from "./permutationvector.js";
+import type { IUndoConsumer } from "./types.js";
 
 export class VectorUndoProvider {
 	// 'currentGroup' and 'currentOp' are used while applying an IRevertable.revert() to coalesce


### PR DESCRIPTION
In preparation for enabling stricter eslint rules across the repo. Also removes a few unused eslint disable directives.

Type-only imports offer a number of benefits and are considered a best practice. More details can be found here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html