### PR TITLE
test(azure-client-end-to-end-tests): Add failure mode test

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
@@ -720,16 +720,17 @@ describe("Container create in tree-only mode", () => {
 			},
 		};
 
-		try {
-			await client.createContainer(schema, "2");
-		} catch (error) {
-			assert(error instanceof UsageError);
-			assert.strictEqual(
-				error.message,
-				"Tree-only mode requires exactly 1 SharedTree in initialObjects.",
-			);
-			return;
-		}
-		assert.fail("Expected an error to be thrown for invalid schema");
+		await assert.rejects(
+			async () => client.createContainer(schema, "2"),
+			(error: unknown) => {
+				assert(error instanceof UsageError);
+				assert.strictEqual(
+					error.message,
+					"Tree-only mode requires exactly 1 SharedTree in initialObjects.",
+				);
+				return true;
+			},
+			"Expected an error to be thrown for invalid schema",
+		);
 	});
 });

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
@@ -710,4 +710,26 @@ describe("Container create in tree-only mode", () => {
 
 		assert(SharedTree.is(container.initialObjects.tree));
 	});
+
+	it("throws if invalid schema is encountered", async function () {
+		const client = createClient();
+		const schema = {
+			initialObjects: {
+				tree: SharedTree,
+				map: SharedMap,
+			},
+		};
+
+		try {
+			await client.createContainer(schema, "2");
+		} catch (error) {
+			assert(error instanceof UsageError);
+			assert.strictEqual(
+				error.message,
+				"Tree-only mode requires exactly 1 SharedTree in initialObjects.",
+			);
+			return;
+		}
+		assert.fail("Expected an error to be thrown for invalid schema");
+	});
 });

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
@@ -721,7 +721,7 @@ describe("Container create in tree-only mode", () => {
 		};
 
 		await assert.rejects(
-			async () => client.createContainer(schema, "2"),
+			client.createContainer(schema, "2"),
 			(error: unknown) => {
 				assert(error instanceof UsageError);
 				assert.strictEqual(error.message, invalidSchemaErrorMessage);

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
@@ -682,6 +682,8 @@ for (const testOpts of testMatrix) {
  * Testing creating/loading containers with a tree-based root data object.
  */
 describe("Container create in tree-only mode", () => {
+	const invalidSchemaErrorMessage =
+		"Tree-only mode requires exactly 1 SharedTree in initialObjects.";
 	function createClient(): AzureClient {
 		return createAzureClient(
 			undefined,
@@ -691,9 +693,7 @@ describe("Container create in tree-only mode", () => {
 			undefined,
 			({ schema, compatibilityMode }) => {
 				if (!isTreeContainerSchema(schema)) {
-					throw new UsageError(
-						"Tree-only mode requires exactly 1 SharedTree in initialObjects.",
-					);
+					throw new UsageError(invalidSchemaErrorMessage);
 				}
 				return createTreeContainerRuntimeFactory({ schema, compatibilityMode });
 			},
@@ -724,10 +724,7 @@ describe("Container create in tree-only mode", () => {
 			async () => client.createContainer(schema, "2"),
 			(error: unknown) => {
 				assert(error instanceof UsageError);
-				assert.strictEqual(
-					error.message,
-					"Tree-only mode requires exactly 1 SharedTree in initialObjects.",
-				);
+				assert.strictEqual(error.message, invalidSchemaErrorMessage);
 				return true;
 			},
 			"Expected an error to be thrown for invalid schema",


### PR DESCRIPTION
Add missing test case to ensure use of the provided callback does not regress, since the tree-only-mode input schema is compatible with the existing directory-based mode.