### PR TITLE
Add an optional summary time or sync between different filesystems

### DIFF
--- a/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
+++ b/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
@@ -551,6 +551,8 @@ export interface IWholeSummaryPayload {
     // (undocumented)
     sequenceNumber: number;
     // (undocumented)
+    summaryTime?: string;
+    // (undocumented)
     type: IWholeSummaryPayloadType;
 }
 

--- a/server/routerlicious/packages/services-client/src/storageContracts.ts
+++ b/server/routerlicious/packages/services-client/src/storageContracts.ts
@@ -29,6 +29,8 @@ export interface IWholeSummaryPayload {
 	message: string;
 	sequenceNumber: number;
 	entries: WholeSummaryTreeEntry[];
+	// Optional, an ISO8601 date string representing the time of the summary.
+	summaryTime?: string;
 }
 
 /**


### PR DESCRIPTION
## Description

For hybrid system, identical sha between different file system is ensential. Sha is based on summary content and often changed by the time of commit, which created at runtime. This change introduced an optional parameter to try to propose a fixed sha everytime.

## Breaking Changes

N/A


