### PR TITLE
refactor(service-client-end-to-end-tests): Add type-only import/export eslint rules and fix violations

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/.eslintrc.cjs
+++ b/packages/service-clients/end-to-end-tests/azure-client/.eslintrc.cjs
@@ -8,6 +8,18 @@ module.exports = {
 	rules: {
 		"prefer-arrow-callback": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
+
+		// #region TODO: remove these once this config has been updated to use our "recommended" base instead of our deprecated minimal one.
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
 	},
 	overrides: [
 		{

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureClientFactory.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureClientFactory.ts
@@ -5,31 +5,31 @@
 
 import {
 	AzureClient,
-	AzureClientPropsInternal,
-	AzureLocalConnectionConfig,
-	AzureRemoteConnectionConfig,
-	ITelemetryBaseLogger,
+	type AzureClientPropsInternal,
+	type AzureLocalConnectionConfig,
+	type AzureRemoteConnectionConfig,
+	type ITelemetryBaseLogger,
 } from "@fluidframework/azure-client/internal";
 import {
 	AzureClient as AzureClientLegacy,
-	AzureLocalConnectionConfig as AzureLocalConnectionConfigLegacy,
-	AzureRemoteConnectionConfig as AzureRemoteConnectionConfigLegacy,
-	ITelemetryBaseLogger as ITelemetryBaseLoggerLegacy,
+	type AzureLocalConnectionConfig as AzureLocalConnectionConfigLegacy,
+	type AzureRemoteConnectionConfig as AzureRemoteConnectionConfigLegacy,
+	type ITelemetryBaseLogger as ITelemetryBaseLoggerLegacy,
 } from "@fluidframework/azure-client-legacy";
 import type { IRuntimeFactory } from "@fluidframework/container-definitions/internal";
-import { IConfigProviderBase } from "@fluidframework/core-interfaces";
+import type { IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { ScopeType } from "@fluidframework/driver-definitions/internal";
 import type {
 	CompatibilityMode,
 	ContainerSchema,
 } from "@fluidframework/fluid-static/internal";
 import {
-	MockLogger,
+	type MockLogger,
 	createChildLogger,
 	createMultiSinkLogger,
 } from "@fluidframework/telemetry-utils/internal";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils/internal";
-import { default as Axios, AxiosResponse, type AxiosRequestConfig } from "axios";
+import { default as Axios, type AxiosResponse, type AxiosRequestConfig } from "axios";
 import { v4 as uuid } from "uuid";
 
 import { createAzureTokenProvider } from "./AzureTokenFactory.js";

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureTokenFactory.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/AzureTokenFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITokenProvider } from "@fluidframework/azure-client";
+import type { ITokenProvider } from "@fluidframework/azure-client";
 import type { ScopeType } from "@fluidframework/driver-definitions/internal";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils/internal";
 

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
@@ -8,13 +8,13 @@ import { EventEmitter } from "@fluid-internal/client-utils";
 import {
 	DataObject,
 	DataObjectFactory,
-	IDataObjectProps,
+	type IDataObjectProps,
 	createDataObjectKind,
 } from "@fluidframework/aqueduct/internal";
-import { type IErrorEvent, IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IErrorEvent, IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter/internal";
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
+import type { Jsonable } from "@fluidframework/datastore-definitions/internal";
+import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 
 class TestDataObjectClass extends DataObject {
 	public static readonly Name = "@fluid-example/test-data-object";

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/audience.spec.ts
@@ -5,13 +5,13 @@
 
 import { strict as assert } from "node:assert";
 
-import { AzureClient, type AzureContainerServices } from "@fluidframework/azure-client";
+import type { AzureClient, AzureContainerServices } from "@fluidframework/azure-client";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { ContainerSchema, type IFluidContainer } from "@fluidframework/fluid-static";
+import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
-import { AxiosResponse } from "axios";
+import type { AxiosResponse } from "axios";
 
 import {
 	createAzureClient,

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
@@ -5,17 +5,17 @@
 
 import { strict as assert } from "node:assert";
 
-import { AzureClient } from "@fluidframework/azure-client";
-import { AzureClient as AzureClientLegacy } from "@fluidframework/azure-client-legacy";
+import type { AzureClient } from "@fluidframework/azure-client";
+import type { AzureClient as AzureClientLegacy } from "@fluidframework/azure-client-legacy";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
+import type { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import {
 	MessageType,
-	ISequencedDocumentMessage,
+	type ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import {
-	ContainerSchema,
+	type ContainerSchema,
 	createTreeContainerRuntimeFactory,
 	isTreeContainerSchema,
 	type IFluidContainer,
@@ -25,7 +25,7 @@ import { SharedMap as SharedMapLegacy } from "@fluidframework/map-legacy";
 import { MockLogger, UsageError } from "@fluidframework/telemetry-utils/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 import { SharedTree } from "@fluidframework/tree/internal";
-import { AxiosResponse } from "axios";
+import type { AxiosResponse } from "axios";
 import type { SinonSandbox } from "sinon";
 import { createSandbox } from "sinon";
 

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/ddsTests.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/ddsTests.spec.ts
@@ -5,13 +5,13 @@
 
 import { strict as assert } from "node:assert";
 
-import { AzureClient } from "@fluidframework/azure-client";
+import type { AzureClient } from "@fluidframework/azure-client";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { ContainerSchema, type IFluidContainer } from "@fluidframework/fluid-static";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import { type ISharedMap, SharedMap } from "@fluidframework/map/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
-import { AxiosResponse } from "axios";
+import type { AxiosResponse } from "axios";
 
 import {
 	createAzureClient,

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.ts
@@ -8,12 +8,12 @@ import { strict as assert } from "node:assert";
 import {
 	AzureClient,
 	type AzureContainerServices,
-	AzureLocalConnectionConfig,
-	AzureRemoteConnectionConfig,
+	type AzureLocalConnectionConfig,
+	type AzureRemoteConnectionConfig,
 } from "@fluidframework/azure-client";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { ContainerSchema, type IFluidContainer } from "@fluidframework/fluid-static";
+import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import {
 	getPresence,
 	type Attendee,
@@ -24,11 +24,11 @@ import {
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
-import { ScopeType } from "../AzureClientFactory.js";
+import type { ScopeType } from "../AzureClientFactory.js";
 import { createAzureTokenProvider } from "../AzureTokenFactory.js";
-import { configProvider } from "../utils.js";
+import type { configProvider } from "../utils.js";
 
-import { MessageFromChild, MessageToChild } from "./messageTypes.js";
+import type { MessageFromChild, MessageToChild } from "./messageTypes.js";
 
 type MessageFromParent = MessageToChild;
 type MessageToParent = Required<MessageFromChild>;

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "node:assert";
-import { fork, ChildProcess } from "node:child_process";
+import { fork, type ChildProcess } from "node:child_process";
 
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/signals.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/signals.spec.ts
@@ -5,10 +5,10 @@
 
 import { strict as assert } from "node:assert";
 
-import { AzureClient, type AzureContainerServices } from "@fluidframework/azure-client";
+import type { AzureClient, AzureContainerServices } from "@fluidframework/azure-client";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { type ContainerSchema, type IFluidContainer } from "@fluidframework/fluid-static";
+import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 import type { AxiosResponse } from "axios";
 

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/tree.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/tree.spec.ts
@@ -5,9 +5,9 @@
 
 import { strict as assert } from "node:assert";
 
-import { AzureClient } from "@fluidframework/azure-client";
+import type { AzureClient } from "@fluidframework/azure-client";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { ContainerSchema, type IFluidContainer } from "@fluidframework/fluid-static";
+import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 import { TreeViewConfiguration, SchemaFactory, type TreeView } from "@fluidframework/tree";
 import {

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/utils.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/utils.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { AzureMember, IAzureAudience } from "@fluidframework/azure-client";
+import type { AzureMember, IAzureAudience } from "@fluidframework/azure-client";
 import type { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
-import { IMember } from "@fluidframework/fluid-static";
-import { ISharedMap, IValueChanged } from "@fluidframework/map/internal";
+import type { IMember } from "@fluidframework/fluid-static";
+import type { ISharedMap, IValueChanged } from "@fluidframework/map/internal";
 
 export const waitForMember = async (
 	audience: IAzureAudience,

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/viewContainerVersion.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/viewContainerVersion.spec.ts
@@ -5,12 +5,12 @@
 
 import { strict as assert } from "node:assert";
 
-import { AzureClient } from "@fluidframework/azure-client";
+import type { AzureClient } from "@fluidframework/azure-client";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { ContainerSchema, type IFluidContainer } from "@fluidframework/fluid-static";
+import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
-import { AxiosResponse } from "axios";
+import type { AxiosResponse } from "axios";
 
 import {
 	createAzureClient,

--- a/packages/service-clients/end-to-end-tests/odsp-client/.eslintrc.cjs
+++ b/packages/service-clients/end-to-end-tests/odsp-client/.eslintrc.cjs
@@ -9,6 +9,18 @@ module.exports = {
 		"prefer-arrow-callback": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
 		"import/namespace": "off",
+
+		// #region TODO: remove these once this config has been updated to use our "recommended" base instead of our deprecated minimal one.
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
 	},
 	parserOptions: {
 		project: ["./src/test/tsconfig.json"],

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspClientFactory.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspClientFactory.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	IConfigProviderBase,
-	type ITelemetryBaseLogger,
+	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import { OdspClient, OdspConnectionConfig } from "@fluidframework/odsp-client/internal";
+import { OdspClient, type OdspConnectionConfig } from "@fluidframework/odsp-client/internal";
 import {
-	MockLogger,
+	type MockLogger,
 	createChildLogger,
 	createMultiSinkLogger,
 } from "@fluidframework/telemetry-utils/internal";

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspTokenFactory.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspTokenFactory.ts
@@ -6,16 +6,16 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import { IOdspTokenProvider } from "@fluidframework/odsp-client/internal";
+import type { IOdspTokenProvider } from "@fluidframework/odsp-client/internal";
 import {
-	IPublicClientConfig,
-	TokenRequestCredentials,
+	type IPublicClientConfig,
+	type TokenRequestCredentials,
 	getFetchTokenUrl,
 	unauthPostAsync,
 } from "@fluidframework/odsp-doclib-utils/internal";
-import { TokenResponse } from "@fluidframework/odsp-driver-definitions/internal";
+import type { TokenResponse } from "@fluidframework/odsp-driver-definitions/internal";
 
-import { IOdspCredentials } from "./OdspClientFactory.js";
+import type { IOdspCredentials } from "./OdspClientFactory.js";
 
 /**
  * This class implements the IOdspTokenProvider interface and provides methods for fetching push and storage tokens.

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/TestDataObject.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/TestDataObject.ts
@@ -6,10 +6,10 @@
 import {
 	DataObject,
 	DataObjectFactory,
-	IDataObjectProps,
+	type IDataObjectProps,
 	createDataObjectKind,
 } from "@fluidframework/aqueduct/internal";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter/internal";
 
 class TestDataObjectClass extends DataObject {

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
@@ -7,10 +7,10 @@ import { strict as assert } from "node:assert";
 
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
-import { ContainerSchema } from "@fluidframework/fluid-static";
+import type { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
+import type { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
-import { OdspClient } from "@fluidframework/odsp-client/internal";
+import type { OdspClient } from "@fluidframework/odsp-client/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
 import { createOdspClient, getCredentials } from "./OdspClientFactory.js";

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/containerCreate.spec.ts
@@ -7,9 +7,9 @@ import { strict as assert } from "node:assert";
 
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { ContainerSchema } from "@fluidframework/fluid-static";
+import type { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
-import { OdspClient } from "@fluidframework/odsp-client/internal";
+import type { OdspClient } from "@fluidframework/odsp-client/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
 import { createOdspClient, getCredentials } from "./OdspClientFactory.js";

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/ddsTests.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/ddsTests.spec.ts
@@ -6,10 +6,10 @@
 import { strict as assert } from "node:assert";
 
 import { ConnectionState } from "@fluidframework/container-loader";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { ContainerSchema } from "@fluidframework/fluid-static";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
-import { OdspClient } from "@fluidframework/odsp-client/internal";
+import type { OdspClient } from "@fluidframework/odsp-client/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
 import { createOdspClient, getCredentials } from "./OdspClientFactory.js";

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/utils.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/utils.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { ISharedMap, IValueChanged } from "@fluidframework/map/internal";
-import { IOdspAudience, OdspMember } from "@fluidframework/odsp-client/internal";
+import type { ISharedMap, IValueChanged } from "@fluidframework/map/internal";
+import type { IOdspAudience, OdspMember } from "@fluidframework/odsp-client/internal";
 
 export const waitForMember = async (
 	audience: IOdspAudience,


### PR DESCRIPTION
In preparation for these rules becoming default in the next release of our eslint configuration.

Type-only imports offer a number of benefits and are considered a best practice. More details can be found here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html