### PR TITLE
refactor(odsp-driver): Enable type-only import/export eslint rules and fix violations

### DIFF
--- a/packages/drivers/odsp-driver/.eslintrc.cjs
+++ b/packages/drivers/odsp-driver/.eslintrc.cjs
@@ -17,6 +17,18 @@ module.exports = {
 		// This library uses and serializes "utf-8".
 		"unicorn/text-encoding-identifier-case": "off",
 		"@fluid-internal/fluid/no-unchecked-record-access": "warn",
+
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
 	},
 	overrides: [
 		{

--- a/packages/drivers/odsp-driver/src/checkUrl.ts
+++ b/packages/drivers/odsp-driver/src/checkUrl.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { DriverPreCheckInfo } from "@fluidframework/driver-definitions/internal";
+import type { DriverPreCheckInfo } from "@fluidframework/driver-definitions/internal";
 
 import { getLocatorFromOdspUrl } from "./odspFluidFileLink.js";
 

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -4,18 +4,18 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import {
+import type {
 	ISnapshot,
 	ISnapshotTree,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import { ReadBuffer } from "./ReadBufferUtils.js";
 import { measure } from "./odspUtils.js";
 import {
-	NodeCore,
-	NodeTypes,
+	type NodeCore,
+	type NodeTypes,
 	TreeBuilder,
 	assertBlobCoreInstance,
 	assertBoolInstance,

--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -5,7 +5,7 @@
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils/internal";
-import {
+import type {
 	ISnapshot,
 	IBlob,
 	ISnapshotTree,
@@ -15,7 +15,7 @@ import {
 import { TreeBuilderSerializer } from "./WriteBufferUtils.js";
 import { snapshotMinReadVersion } from "./compactSnapshotParser.js";
 import {
-	NodeCore,
+	type NodeCore,
 	addBoolProperty,
 	addDictionaryStringProperty,
 	addNumberProperty,

--- a/packages/drivers/odsp-driver/src/contracts.ts
+++ b/packages/drivers/odsp-driver/src/contracts.ts
@@ -3,14 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	ISnapshot,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
-import { HostStoragePolicy } from "@fluidframework/odsp-driver-definitions/internal";
+import type { HostStoragePolicy } from "@fluidframework/odsp-driver-definitions/internal";
 
 // eslint-disable-next-line import/no-deprecated
-import { ISnapshotContents } from "./odspPublicUtils.js";
+import type { ISnapshotContents } from "./odspPublicUtils.js";
 
 /**
  * Interface for error responses for the WebSocket connection

--- a/packages/drivers/odsp-driver/src/contractsPublic.ts
+++ b/packages/drivers/odsp-driver/src/contractsPublic.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IOdspUrlParts } from "@fluidframework/odsp-driver-definitions/internal";
+import type { IOdspUrlParts } from "@fluidframework/odsp-driver-definitions/internal";
 
 /**
  * @legacy

--- a/packages/drivers/odsp-driver/src/createFile/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile/createFile.ts
@@ -4,32 +4,32 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISummaryTree } from "@fluidframework/driver-definitions";
-import { ISnapshot } from "@fluidframework/driver-definitions/internal";
+import type { ISummaryTree } from "@fluidframework/driver-definitions";
+import type { ISnapshot } from "@fluidframework/driver-definitions/internal";
 import { NonRetryableError } from "@fluidframework/driver-utils/internal";
 import {
-	IFileEntry,
-	IOdspResolvedUrl,
-	InstrumentedStorageTokenFetcher,
+	type IFileEntry,
+	type IOdspResolvedUrl,
+	type InstrumentedStorageTokenFetcher,
 	OdspErrorTypes,
-	ShareLinkInfoType,
+	type ShareLinkInfoType,
 	type IOdspUrlParts,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	loggerToMonitoringContext,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { ICreateFileResponse, type IRenameFileResponse } from "./../contracts.js";
+import type { ICreateFileResponse, IRenameFileResponse } from "./../contracts.js";
 import { ClpCompliantAppHeader } from "./../contractsPublic.js";
 import { createOdspUrl } from "./../createOdspUrl.js";
-import { EpochTracker } from "./../epochTracker.js";
+import type { EpochTracker } from "./../epochTracker.js";
 import { getHeadersWithAuth } from "./../getUrlAndHeadersWithAuth.js";
 import { OdspDriverUrlResolver } from "./../odspDriverUrlResolver.js";
 import { checkForKnownServerFarmType, getApiRoot } from "./../odspUrlHelper.js";
 import {
-	INewFileInfo,
+	type INewFileInfo,
 	appendNavParam,
 	buildOdspShareLinkReqParams,
 	createCacheSnapshotKey,

--- a/packages/drivers/odsp-driver/src/createFile/createNewContainerOnExistingFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile/createNewContainerOnExistingFile.ts
@@ -3,27 +3,27 @@
  * Licensed under the MIT License.
  */
 
-import { ISummaryTree } from "@fluidframework/driver-definitions";
-import { ISnapshot } from "@fluidframework/driver-definitions/internal";
+import type { ISummaryTree } from "@fluidframework/driver-definitions";
+import type { ISnapshot } from "@fluidframework/driver-definitions/internal";
 import { UsageError } from "@fluidframework/driver-utils/internal";
-import {
+import type {
 	IFileEntry,
 	IOdspResolvedUrl,
 	InstrumentedStorageTokenFetcher,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { IWriteSummaryResponse } from "./../contracts.js";
+import type { IWriteSummaryResponse } from "./../contracts.js";
 import { ClpCompliantAppHeader, FileMetadataHeader } from "./../contractsPublic.js";
 import { createOdspUrl } from "./../createOdspUrl.js";
-import { EpochTracker } from "./../epochTracker.js";
+import type { EpochTracker } from "./../epochTracker.js";
 import { OdspDriverUrlResolver } from "./../odspDriverUrlResolver.js";
 import { getApiRoot } from "./../odspUrlHelper.js";
 import {
-	IExistingFileInfo,
+	type IExistingFileInfo,
 	createCacheSnapshotKey,
 	snapshotWithLoadingGroupIdSupported,
 } from "./../odspUtils.js";

--- a/packages/drivers/odsp-driver/src/createFile/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createFile/createNewUtils.ts
@@ -6,31 +6,31 @@
 import { Uint8ArrayToString, stringToBuffer } from "@fluid-internal/client-utils";
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
-	ISummaryBlob,
-	ISummaryTree,
+	type ISummaryBlob,
+	type ISummaryTree,
 	type SummaryObject,
 	SummaryType,
 } from "@fluidframework/driver-definitions";
-import { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
+import type { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import {
 	getDocAttributesFromProtocolSummary,
 	getGitType,
 	isCombinedAppAndProtocolSummary,
 } from "@fluidframework/driver-utils/internal";
-import { InstrumentedStorageTokenFetcher } from "@fluidframework/odsp-driver-definitions/internal";
+import type { InstrumentedStorageTokenFetcher } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 
-import {
+import type {
 	IOdspSummaryPayload,
 	IOdspSummaryTree,
 	OdspSummaryTreeEntry,
 	OdspSummaryTreeValue,
 } from "./../contracts.js";
-import { EpochTracker, FetchType } from "./../epochTracker.js";
+import type { EpochTracker, FetchType } from "./../epochTracker.js";
 import { getHeadersWithAuth } from "./../getUrlAndHeadersWithAuth.js";
 import { checkForKnownServerFarmType } from "./../odspUrlHelper.js";
 import { getWithRetryForTokenRefresh, maxUmpPostBodySize } from "./../odspUtils.js";

--- a/packages/drivers/odsp-driver/src/createFile/index.ts
+++ b/packages/drivers/odsp-driver/src/createFile/index.ts
@@ -3,11 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 export async function useCreateNewModule<T = void>(
 	odspLogger: ITelemetryLoggerExt,
 	func: (
+		// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 		m: typeof import("./createNewModule.js") /* webpackChunkName: "createNewModule" */,
 	) => Promise<T>,
 ): Promise<T> {

--- a/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
+++ b/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest } from "@fluidframework/core-interfaces";
+import type { IRequest } from "@fluidframework/core-interfaces";
 import {
 	DriverHeader,
 	type IContainerPackageInfo,
 } from "@fluidframework/driver-definitions/internal";
-import { ISharingLinkKind } from "@fluidframework/odsp-driver-definitions/internal";
+import type { ISharingLinkKind } from "@fluidframework/odsp-driver-definitions/internal";
 
 import { buildOdspShareLinkReqParams, getContainerPackageName } from "./odspUtils.js";
 

--- a/packages/drivers/odsp-driver/src/createOdspUrl.ts
+++ b/packages/drivers/odsp-driver/src/createOdspUrl.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { OdspFluidDataStoreLocator } from "./contractsPublic.js";
+import type { OdspFluidDataStoreLocator } from "./contractsPublic.js";
 
 /*
  * Per https://github.com/microsoft/FluidFramework/issues/1556, isolating createOdspUrl() in its own file.

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -11,20 +11,20 @@ import {
 	ThrottlingError,
 } from "@fluidframework/driver-utils/internal";
 import {
-	ICacheEntry,
-	IEntry,
-	IFileEntry,
-	IOdspError,
-	IOdspErrorAugmentations,
-	IOdspResolvedUrl,
-	IPersistedCache,
+	type ICacheEntry,
+	type IEntry,
+	type IFileEntry,
+	type IOdspError,
+	type IOdspErrorAugmentations,
+	type IOdspResolvedUrl,
+	type IPersistedCache,
 	OdspErrorTypes,
 	maximumCacheDurationMs,
 	snapshotKey,
 	snapshotWithLoadingGroupIdKey,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	PerformanceEvent,
 	isFluidError,
 	loggerToMonitoringContext,
@@ -33,12 +33,12 @@ import {
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 
-import { IVersionedValueWithEpoch, persistedCacheValueVersion } from "./contracts.js";
+import { type IVersionedValueWithEpoch, persistedCacheValueVersion } from "./contracts.js";
 import { ClpCompliantAppHeader } from "./contractsPublic.js";
-import { INonPersistentCache, IOdspCache, IPersistedFileCache } from "./odspCache.js";
+import type { INonPersistentCache, IOdspCache, IPersistedFileCache } from "./odspCache.js";
 import { patchOdspResolvedUrl } from "./odspLocationRedirection.js";
 import {
-	IOdspResponse,
+	type IOdspResponse,
 	fetchAndParseAsJSONHelper,
 	fetchArray,
 	fetchHelper,

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -6,9 +6,9 @@
 import { fromUtf8ToBase64 } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils/internal";
 import { getW3CData } from "@fluidframework/driver-base/internal";
-import { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
+import type { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import {
-	DriverErrorTelemetryProps,
+	type DriverErrorTelemetryProps,
 	NonRetryableError,
 	isRuntimeMessage,
 } from "@fluidframework/driver-utils/internal";
@@ -18,13 +18,13 @@ import {
 } from "@fluidframework/odsp-doclib-utils/internal";
 import {
 	type IOdspError,
-	IOdspResolvedUrl,
-	ISnapshotOptions,
-	InstrumentedStorageTokenFetcher,
+	type IOdspResolvedUrl,
+	type ISnapshotOptions,
+	type InstrumentedStorageTokenFetcher,
 	OdspErrorTypes,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	PerformanceEvent,
 	isFluidError,
 	wrapError,
@@ -32,25 +32,25 @@ import {
 import { v4 as uuid } from "uuid";
 
 import {
-	ISnapshotContentsWithProps,
+	type ISnapshotContentsWithProps,
 	currentReadVersion,
 	parseCompactSnapshotResponse,
 } from "./compactSnapshotParser.js";
 import {
-	IOdspSnapshot,
-	ISnapshotCachedEntry2,
-	IVersionedValueWithEpoch,
+	type IOdspSnapshot,
+	type ISnapshotCachedEntry2,
+	type IVersionedValueWithEpoch,
 	persistedCacheValueVersion,
 } from "./contracts.js";
 import { ClpCompliantAppHeader } from "./contractsPublic.js";
-import { EpochTracker } from "./epochTracker.js";
+import type { EpochTracker } from "./epochTracker.js";
 import { getQueryString } from "./getQueryString.js";
 import { getHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
 import { mockify } from "./mockify.js";
 import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "./odspSnapshotParser.js";
 import { checkForKnownServerFarmType } from "./odspUrlHelper.js";
 import {
-	IOdspResponse,
+	type IOdspResponse,
 	fetchAndParseAsJSONHelper,
 	fetchHelper,
 	getWithRetryForTokenRefresh,

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -7,14 +7,14 @@ import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { NonRetryableError, runWithRetry } from "@fluidframework/driver-utils/internal";
 import {
-	IOdspUrlParts,
+	type IOdspUrlParts,
 	OdspErrorTypes,
-	OdspResourceTokenFetchOptions,
-	TokenFetcher,
+	type OdspResourceTokenFetchOptions,
+	type TokenFetcher,
 	type IOdspResolvedUrl,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	PerformanceEvent,
 	isFluidError,
 } from "@fluidframework/telemetry-utils/internal";

--- a/packages/drivers/odsp-driver/src/getQueryString.ts
+++ b/packages/drivers/odsp-driver/src/getQueryString.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ISnapshotOptions } from "@fluidframework/odsp-driver-definitions/internal";
+import type { ISnapshotOptions } from "@fluidframework/odsp-driver-definitions/internal";
 
 /**
  * Generates query string from the given query parameters.

--- a/packages/drivers/odsp-driver/src/index.ts
+++ b/packages/drivers/odsp-driver/src/index.ts
@@ -8,16 +8,16 @@ export { OdcApiSiteOrigin, OdcFileSiteOrigin } from "./constants.js";
 
 export {
 	ClpCompliantAppHeader,
-	IClpCompliantAppHeader,
-	ISharingLinkHeader,
-	OdspFluidDataStoreLocator,
+	type IClpCompliantAppHeader,
+	type ISharingLinkHeader,
+	type OdspFluidDataStoreLocator,
 	SharingLinkHeader,
 } from "./contractsPublic.js";
 
 // public utils
 export { checkUrl } from "./checkUrl.js";
 export { createOdspUrl } from "./createOdspUrl.js";
-export { getHashedDocumentId, ISnapshotContents } from "./odspPublicUtils.js";
+export { getHashedDocumentId, type ISnapshotContents } from "./odspPublicUtils.js";
 export { getOdspUrlParts, isOdcUrl, isSpoUrl } from "./odspUrlHelper.js";
 
 // prefetch latest snapshot before container load
@@ -37,7 +37,7 @@ export { createOdspCreateContainerRequest } from "./createOdspCreateContainerReq
 export { OdspDriverUrlResolver } from "./odspDriverUrlResolver.js";
 export {
 	OdspDriverUrlResolverForShareLink,
-	ShareLinkFetcherProps,
+	type ShareLinkFetcherProps,
 } from "./odspDriverUrlResolverForShareLink.js";
 
 // It's used by URL resolve code, but also has some public functions
@@ -48,22 +48,22 @@ export {
 	storeLocatorInOdspUrl,
 } from "./odspFluidFileLink.js";
 
-export {
+export type {
 	IOdspCache,
 	IPersistedFileCache,
 	INonPersistentCache,
 	IPrefetchSnapshotContents,
 } from "./odspCache.js";
-export {
+export type {
 	ICacheAndTracker,
-	type EpochTracker,
+	EpochTracker,
 	FetchType,
 	FetchTypeInternal,
 } from "./epochTracker.js";
-export { IOdspResponse, isOdspResolvedUrl } from "./odspUtils.js";
+export { type IOdspResponse, isOdspResolvedUrl } from "./odspUtils.js";
 export { SnapshotFormatSupportType } from "./fetchSnapshot.js";
 export {
-	ISnapshotContentsWithProps,
+	type ISnapshotContentsWithProps,
 	parseCompactSnapshotResponse,
 } from "./compactSnapshotParser.js";
 

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDeltaStorageService.ts
@@ -4,13 +4,13 @@
  */
 
 import { validateMessages } from "@fluidframework/driver-base/internal";
-import {
+import type {
 	IDocumentDeltaStorageService,
 	IStream,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import { Queue, emptyMessageStream } from "@fluidframework/driver-utils/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 /**
  * Implementation of IDocumentDeltaStorageService that will return snapshot ops when fetching messages

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentService.ts
@@ -4,8 +4,8 @@
  */
 
 import { TypedEventEmitter, type ILayerCompatDetails } from "@fluid-internal/client-utils";
-import { IClient } from "@fluidframework/driver-definitions";
-import {
+import type { IClient } from "@fluidframework/driver-definitions";
+import type {
 	IDocumentDeltaStorageService,
 	IDocumentService,
 	IDocumentServiceEvents,
@@ -13,8 +13,8 @@ import {
 	IResolvedUrl,
 } from "@fluidframework/driver-definitions/internal";
 import { UsageError } from "@fluidframework/driver-utils/internal";
-import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
+import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import { LocalOdspDeltaStorageService } from "./localOdspDeltaStorageService.js";
 import { LocalOdspDocumentStorageService } from "./localOdspDocumentStorageManager.js";

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentServiceFactory.ts
@@ -3,13 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import { ISummaryTree } from "@fluidframework/driver-definitions";
-import { IDocumentService, IResolvedUrl } from "@fluidframework/driver-definitions/internal";
+import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import type { ISummaryTree } from "@fluidframework/driver-definitions";
+import type {
+	IDocumentService,
+	IResolvedUrl,
+} from "@fluidframework/driver-definitions/internal";
 import { UsageError } from "@fluidframework/driver-utils/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
-import { ICacheAndTracker } from "../epochTracker.js";
+import type { ICacheAndTracker } from "../epochTracker.js";
 import { OdspDocumentServiceFactoryCore } from "../odspDocumentServiceFactoryCore.js";
 import { createOdspLogger, getOdspResolvedUrl } from "../odspUtils.js";
 

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspDocumentStorageManager.ts
@@ -4,8 +4,8 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISummaryTree } from "@fluidframework/driver-definitions";
-import {
+import type { ISummaryTree } from "@fluidframework/driver-definitions";
+import type {
 	ISnapshot,
 	ISnapshotFetchOptions,
 	ISummaryContext,
@@ -13,12 +13,12 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 import { UsageError } from "@fluidframework/driver-utils/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 
 import { parseCompactSnapshotResponse } from "../compactSnapshotParser.js";
-import { IOdspSnapshot } from "../contracts.js";
+import type { IOdspSnapshot } from "../contracts.js";
 import { OdspDocumentStorageServiceBase } from "../odspDocumentStorageServiceBase.js";
 import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "../odspSnapshotParser.js";
 

--- a/packages/drivers/odsp-driver/src/localOdspDriver/localOdspLayerCompatState.ts
+++ b/packages/drivers/odsp-driver/src/localOdspDriver/localOdspLayerCompatState.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type ILayerCompatDetails } from "@fluid-internal/client-utils";
+import type { ILayerCompatDetails } from "@fluid-internal/client-utils";
 
 import { pkgVersion } from "../packageVersion.js";
 

--- a/packages/drivers/odsp-driver/src/odspCache.ts
+++ b/packages/drivers/odsp-driver/src/odspCache.ts
@@ -4,14 +4,14 @@
  */
 
 import { PromiseCache } from "@fluidframework/core-utils/internal";
-import { ISnapshot } from "@fluidframework/driver-definitions/internal";
+import type { ISnapshot } from "@fluidframework/driver-definitions/internal";
 import {
-	ICacheEntry,
-	IEntry,
-	IFileEntry,
-	IOdspResolvedUrl,
-	IPersistedCache,
-	ISocketStorageDiscovery,
+	type ICacheEntry,
+	type IEntry,
+	type IFileEntry,
+	type IOdspResolvedUrl,
+	type IPersistedCache,
+	type ISocketStorageDiscovery,
 	getKeyForCacheEntry,
 } from "@fluidframework/odsp-driver-definitions/internal";
 

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -4,14 +4,14 @@
  */
 
 import { performanceNow } from "@fluid-internal/client-utils";
-import { ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
+import type { ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
-import { IClient } from "@fluidframework/driver-definitions";
-import {
+import type { IClient } from "@fluidframework/driver-definitions";
+import type {
 	IDocumentDeltaConnection,
 	IDocumentServicePolicies,
 	IResolvedUrl,
-	type IAnyDriverError,
+	IAnyDriverError,
 	ISequencedDocumentMessage,
 	ISignalMessage,
 } from "@fluidframework/driver-definitions/internal";
@@ -21,27 +21,27 @@ import {
 } from "@fluidframework/driver-utils/internal";
 import { hasFacetCodes } from "@fluidframework/odsp-doclib-utils/internal";
 import {
-	HostStoragePolicy,
+	type HostStoragePolicy,
 	type IOdspError,
-	IOdspResolvedUrl,
-	ISocketStorageDiscovery,
-	InstrumentedStorageTokenFetcher,
+	type IOdspResolvedUrl,
+	type ISocketStorageDiscovery,
+	type InstrumentedStorageTokenFetcher,
 	OdspErrorTypes,
-	TokenFetchOptions,
+	type TokenFetchOptions,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	IFluidErrorBase,
-	MonitoringContext,
+	type IFluidErrorBase,
+	type MonitoringContext,
 	normalizeError,
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 
 import { policyLabelsUpdatesSignalType } from "./contracts.js";
-import { EpochTracker } from "./epochTracker.js";
-import { IOdspCache } from "./odspCache.js";
+import type { EpochTracker } from "./epochTracker.js";
+import type { IOdspCache } from "./odspCache.js";
 import { OdspDocumentDeltaConnection } from "./odspDocumentDeltaConnection.js";
 import {
-	TokenFetchOptionsEx,
+	type TokenFetchOptionsEx,
 	getJoinSessionCacheKey,
 	getWithRetryForTokenRefresh,
 } from "./odspUtils.js";

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -3,26 +3,26 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
+import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { validateMessages } from "@fluidframework/driver-base/internal";
-import {
+import type {
 	IDeltasFetchResult,
 	IDocumentDeltaStorageService,
-	type IStream,
+	IStream,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import { requestOps, streamObserver } from "@fluidframework/driver-utils/internal";
-import { InstrumentedStorageTokenFetcher } from "@fluidframework/odsp-driver-definitions/internal";
+import type { InstrumentedStorageTokenFetcher } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 
-import { IDeltaStorageGetResponse, ISequencedDeltaOpMessage } from "./contracts.js";
-import { EpochTracker } from "./epochTracker.js";
-import { OdspDocumentStorageService } from "./odspDocumentStorageManager.js";
+import type { IDeltaStorageGetResponse, ISequencedDeltaOpMessage } from "./contracts.js";
+import type { EpochTracker } from "./epochTracker.js";
+import type { OdspDocumentStorageService } from "./odspDocumentStorageManager.js";
 import { getWithRetryForTokenRefresh } from "./odspUtils.js";
 
 /**

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -4,11 +4,11 @@
  */
 
 import { TypedEventEmitter, performanceNow } from "@fluid-internal/client-utils";
-import { IEvent } from "@fluidframework/core-interfaces";
+import type { IEvent } from "@fluidframework/core-interfaces";
 import { assert, Deferred } from "@fluidframework/core-utils/internal";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base/internal";
-import { IClient } from "@fluidframework/driver-definitions";
-import {
+import type { IClient } from "@fluidframework/driver-definitions";
+import type {
 	IAnyDriverError,
 	IConnect,
 	IDocumentMessage,
@@ -18,17 +18,17 @@ import {
 	ISignalMessage,
 } from "@fluidframework/driver-definitions/internal";
 import { createGenericNetworkError } from "@fluidframework/driver-utils/internal";
-import { OdspError } from "@fluidframework/odsp-driver-definitions/internal";
+import type { OdspError } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	IFluidErrorBase,
-	ITelemetryLoggerExt,
+	type IFluidErrorBase,
+	type ITelemetryLoggerExt,
 	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
-import { Socket } from "socket.io-client";
+import type { Socket } from "socket.io-client";
 import { v4 as uuid } from "uuid";
 
-import { IFlushOpsResponse, IGetOpsResponse, IOdspSocketError } from "./contracts.js";
-import { EpochTracker } from "./epochTracker.js";
+import type { IFlushOpsResponse, IGetOpsResponse, IOdspSocketError } from "./contracts.js";
+import type { EpochTracker } from "./epochTracker.js";
 import { errorObjectFromSocketError } from "./odspError.js";
 import { pkgVersion } from "./packageVersion.js";
 import { SocketIOClientStatic } from "./socketModule.js";

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -5,8 +5,8 @@
 
 import { TypedEventEmitter, type ILayerCompatDetails } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils/internal";
-import { IClient } from "@fluidframework/driver-definitions";
-import {
+import type { IClient } from "@fluidframework/driver-definitions";
+import type {
 	IDocumentDeltaConnection,
 	IDocumentDeltaStorageService,
 	IDocumentService,
@@ -16,7 +16,7 @@ import {
 	IResolvedUrl,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
-import {
+import type {
 	HostStoragePolicy,
 	IEntry,
 	IOdspResolvedUrl,
@@ -24,14 +24,14 @@ import {
 	TokenFetchOptions,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
-	MonitoringContext,
+	type ITelemetryLoggerExt,
+	type MonitoringContext,
 	createChildMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { HostStoragePolicyInternal } from "./contracts.js";
-import { EpochTracker } from "./epochTracker.js";
-import { IOdspCache } from "./odspCache.js";
+import type { HostStoragePolicyInternal } from "./contracts.js";
+import type { EpochTracker } from "./epochTracker.js";
+import type { IOdspCache } from "./odspCache.js";
 import type { OdspDelayLoadedDeltaStream } from "./odspDelayLoadedDeltaStream.js";
 import {
 	OdspDeltaStorageService,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IDocumentServiceFactory } from "@fluidframework/driver-definitions/internal";
-import {
+import type { IDocumentServiceFactory } from "@fluidframework/driver-definitions/internal";
+import type {
 	HostStoragePolicy,
 	IPersistedCache,
 	OdspResourceTokenFetchOptions,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import { PromiseCache } from "@fluidframework/core-utils/internal";
-import { ISummaryTree } from "@fluidframework/driver-definitions";
-import {
+import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import type { PromiseCache } from "@fluidframework/core-utils/internal";
+import type { ISummaryTree } from "@fluidframework/driver-definitions";
+import type {
 	IDocumentService,
 	IDocumentServiceFactory,
 	IResolvedUrl,
@@ -16,34 +16,34 @@ import {
 	isCombinedAppAndProtocolSummary,
 } from "@fluidframework/driver-utils/internal";
 import {
-	HostStoragePolicy,
-	IFileEntry,
-	IOdspUrlParts,
-	IPersistedCache,
-	IRelaySessionAwareDriverFactory,
-	ISharingLinkKind,
-	ISocketStorageDiscovery,
-	OdspResourceTokenFetchOptions,
+	type HostStoragePolicy,
+	type IFileEntry,
+	type IOdspUrlParts,
+	type IPersistedCache,
+	type IRelaySessionAwareDriverFactory,
+	type ISharingLinkKind,
+	type ISocketStorageDiscovery,
+	type OdspResourceTokenFetchOptions,
 	SharingLinkRole,
 	SharingLinkScope,
-	TokenFetchOptions,
-	TokenFetcher,
+	type TokenFetchOptions,
+	type TokenFetcher,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import { PerformanceEvent, createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 
 import { useCreateNewModule } from "./createFile/index.js";
-import { ICacheAndTracker, createOdspCacheAndTracker } from "./epochTracker.js";
+import { type ICacheAndTracker, createOdspCacheAndTracker } from "./epochTracker.js";
 import {
-	INonPersistentCache,
-	IPrefetchSnapshotContents,
+	type INonPersistentCache,
+	type IPrefetchSnapshotContents,
 	LocalPersistentCache,
 	NonPersistentCache,
 } from "./odspCache.js";
 import { OdspDocumentService } from "./odspDocumentService.js";
 import {
-	IExistingFileInfo,
-	INewFileInfo,
+	type IExistingFileInfo,
+	type INewFileInfo,
 	createOdspLogger,
 	getJoinSessionCacheKey,
 	getOdspResolvedUrl,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -7,26 +7,26 @@ import { performanceNow } from "@fluid-internal/client-utils";
 import { LogLevel } from "@fluidframework/core-interfaces";
 import { assert, delay } from "@fluidframework/core-utils/internal";
 import { promiseRaceWithWinner } from "@fluidframework/driver-base/internal";
-import { ISummaryTree } from "@fluidframework/driver-definitions";
+import type { ISummaryTree } from "@fluidframework/driver-definitions";
 import {
 	FetchSource,
-	ISnapshot,
-	ISnapshotFetchOptions,
-	ISummaryContext,
-	ICreateBlobResponse,
-	IVersion,
-	ISnapshotTree,
+	type ISnapshot,
+	type ISnapshotFetchOptions,
+	type ISummaryContext,
+	type ICreateBlobResponse,
+	type IVersion,
+	type ISnapshotTree,
 } from "@fluidframework/driver-definitions/internal";
 import { NonRetryableError, RateLimiter } from "@fluidframework/driver-utils/internal";
 import {
-	IOdspResolvedUrl,
-	ISnapshotOptions,
-	InstrumentedStorageTokenFetcher,
+	type IOdspResolvedUrl,
+	type ISnapshotOptions,
+	type InstrumentedStorageTokenFetcher,
 	OdspErrorTypes,
 	getKeyForCacheEntry,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	PerformanceEvent,
 	generateStack,
 	loggerToMonitoringContext,
@@ -35,7 +35,7 @@ import {
 	type IConfigProvider,
 } from "@fluidframework/telemetry-utils/internal";
 
-import {
+import type {
 	HostStoragePolicyInternal,
 	IDocumentStorageGetVersionsResponse,
 	// eslint-disable-next-line import/no-deprecated
@@ -44,22 +44,22 @@ import {
 	IVersionedValueWithEpoch,
 } from "./contracts.js";
 import { useCreateNewModule } from "./createFile/index.js";
-import { EpochTracker } from "./epochTracker.js";
+import type { EpochTracker } from "./epochTracker.js";
 import {
-	ISnapshotRequestAndResponseOptions,
-	SnapshotFormatSupportType,
+	type ISnapshotRequestAndResponseOptions,
+	type SnapshotFormatSupportType,
 	downloadSnapshot,
 	getTreeStats,
 	fetchSnapshot,
 	fetchSnapshotWithRedeem,
 } from "./fetchSnapshot.js";
 import { getHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
-import { IOdspCache, IPrefetchSnapshotContents } from "./odspCache.js";
-import { FlushResult } from "./odspDocumentDeltaConnection.js";
+import type { IOdspCache, IPrefetchSnapshotContents } from "./odspCache.js";
+import type { FlushResult } from "./odspDocumentDeltaConnection.js";
 import { OdspDocumentStorageServiceBase } from "./odspDocumentStorageServiceBase.js";
 import type { OdspSummaryUploadManager } from "./odspSummaryUploadManager.js";
 import {
-	IOdspResponse,
+	type IOdspResponse,
 	createCacheSnapshotKey,
 	getWithRetryForTokenRefresh,
 	isInstanceOfISnapshot,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -4,23 +4,23 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISummaryHandle, ISummaryTree } from "@fluidframework/driver-definitions";
+import type { ISummaryHandle, ISummaryTree } from "@fluidframework/driver-definitions";
 import {
-	FetchSource,
-	FiveDaysMs,
-	IDocumentStorageService,
-	IDocumentStorageServicePolicies,
-	ISnapshot,
-	ISnapshotFetchOptions,
-	ISummaryContext,
+	type FetchSource,
+	type FiveDaysMs,
+	type IDocumentStorageService,
+	type IDocumentStorageServicePolicies,
+	type ISnapshot,
+	type ISnapshotFetchOptions,
+	type ISummaryContext,
 	LoaderCachingPolicy,
-	ISnapshotTree,
-	ICreateBlobResponse,
-	IVersion,
-	ISequencedDocumentMessage,
+	type ISnapshotTree,
+	type ICreateBlobResponse,
+	type IVersion,
+	type ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import { maximumCacheDurationMs } from "@fluidframework/odsp-driver-definitions/internal";
-import { IConfigProvider } from "@fluidframework/telemetry-utils/internal";
+import type { IConfigProvider } from "@fluidframework/telemetry-utils/internal";
 
 class BlobCache {
 	// Save the timeout so we can cancel and reschedule it as needed

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -3,17 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest } from "@fluidframework/core-interfaces";
+import type { IRequest } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import {
 	DriverHeader,
-	IContainerPackageInfo,
-	IResolvedUrl,
-	IUrlResolver,
+	type IContainerPackageInfo,
+	type IResolvedUrl,
+	type IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
 import { NonRetryableError } from "@fluidframework/driver-utils/internal";
 import {
-	IOdspResolvedUrl,
+	type IOdspResolvedUrl,
 	OdspErrorTypes,
 } from "@fluidframework/odsp-driver-definitions/internal";
 

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -3,22 +3,22 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import type { IRequest, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { PromiseCache } from "@fluidframework/core-utils/internal";
-import {
+import type {
 	IContainerPackageInfo,
 	IResolvedUrl,
 	IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
-import {
+import type {
 	IOdspResolvedUrl,
 	IdentityType,
 	OdspResourceTokenFetchOptions,
 	TokenFetcher,
 } from "@fluidframework/odsp-driver-definitions/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
-import { OdspFluidDataStoreLocator, SharingLinkHeader } from "./contractsPublic.js";
+import { type OdspFluidDataStoreLocator, SharingLinkHeader } from "./contractsPublic.js";
 import { createOdspUrl } from "./createOdspUrl.js";
 import { getFileLink } from "./getFileLink.js";
 import { OdspDriverUrlResolver } from "./odspDriverUrlResolver.js";

--- a/packages/drivers/odsp-driver/src/odspError.ts
+++ b/packages/drivers/odsp-driver/src/odspError.ts
@@ -5,13 +5,16 @@
 
 import { NonRetryableError } from "@fluidframework/driver-utils/internal";
 import { createOdspNetworkError } from "@fluidframework/odsp-doclib-utils/internal";
-import { OdspError, OdspErrorTypes } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	IFluidErrorBase,
+	type OdspError,
+	OdspErrorTypes,
+} from "@fluidframework/odsp-driver-definitions/internal";
+import {
+	type IFluidErrorBase,
 	getCircularReplacer,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { IOdspSocketError } from "./contracts.js";
+import type { IOdspSocketError } from "./contracts.js";
 import { pkgVersion as driverVersion } from "./packageVersion.js";
 
 /**

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -6,7 +6,7 @@
 import { fromBase64ToUtf8, fromUtf8ToBase64 } from "@fluid-internal/client-utils";
 
 import { OdcApiSiteOrigin, OdcFileSiteOrigin } from "./constants.js";
-import { OdspFluidDataStoreLocator } from "./contractsPublic.js";
+import type { OdspFluidDataStoreLocator } from "./contractsPublic.js";
 
 const fluidSignature = "1";
 const fluidSignatureParamName = "fluid";

--- a/packages/drivers/odsp-driver/src/odspLayerCompatState.ts
+++ b/packages/drivers/odsp-driver/src/odspLayerCompatState.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type ILayerCompatDetails } from "@fluid-internal/client-utils";
+import type { ILayerCompatDetails } from "@fluid-internal/client-utils";
 
 import { pkgVersion } from "./packageVersion.js";
 

--- a/packages/drivers/odsp-driver/src/odspLocationRedirection.ts
+++ b/packages/drivers/odsp-driver/src/odspLocationRedirection.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
-import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
+import type { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
+import type { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
 
 import { getOdspResolvedUrl } from "./odspUtils.js";
 

--- a/packages/drivers/odsp-driver/src/odspPublicUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspPublicUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { IsoBuffer, hashFile } from "@fluid-internal/client-utils";
-import {
+import type {
 	ISnapshotTree,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";

--- a/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
@@ -5,9 +5,9 @@
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
+import type { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 
-import { IOdspSnapshot, IOdspSnapshotCommit } from "./contracts.js";
+import type { IOdspSnapshot, IOdspSnapshotCommit } from "./contracts.js";
 
 /**
  * Build a tree hierarchy base on a flat tree

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -5,21 +5,25 @@
 
 import { Uint8ArrayToString } from "@fluid-internal/client-utils";
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
-import { ISummaryTree, SummaryType, SummaryObject } from "@fluidframework/driver-definitions";
-import { ISummaryContext } from "@fluidframework/driver-definitions/internal";
+import {
+	type ISummaryTree,
+	SummaryType,
+	type SummaryObject,
+} from "@fluidframework/driver-definitions";
+import type { ISummaryContext } from "@fluidframework/driver-definitions/internal";
 import {
 	getGitType,
 	isCombinedAppAndProtocolSummary,
 } from "@fluidframework/driver-utils/internal";
-import { InstrumentedStorageTokenFetcher } from "@fluidframework/odsp-driver-definitions/internal";
+import type { InstrumentedStorageTokenFetcher } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
-	MonitoringContext,
+	type ITelemetryLoggerExt,
+	type MonitoringContext,
 	PerformanceEvent,
 	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 
-import {
+import type {
 	IOdspSummaryPayload,
 	IOdspSummaryTree,
 	IOdspSummaryTreeBaseEntry,
@@ -27,7 +31,7 @@ import {
 	OdspSummaryTreeEntry,
 	OdspSummaryTreeValue,
 } from "./contracts.js";
-import { EpochTracker } from "./epochTracker.js";
+import type { EpochTracker } from "./epochTracker.js";
 import { getHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
 import { getWithRetryForTokenRefresh } from "./odspUtils.js";
 

--- a/packages/drivers/odsp-driver/src/odspUrlHelper.ts
+++ b/packages/drivers/odsp-driver/src/odspUrlHelper.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IOdspUrlParts } from "@fluidframework/odsp-driver-definitions/internal";
+import type { IOdspUrlParts } from "@fluidframework/odsp-driver-definitions/internal";
 
 // Centralized store for all ODC/SPO logic
 

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -4,12 +4,12 @@
  */
 
 import { performanceNow } from "@fluid-internal/client-utils";
-import {
+import type {
 	ITelemetryBaseLogger,
 	ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import {
+import type {
 	IResolvedUrl,
 	ISnapshot,
 	IContainerPackageInfo,
@@ -28,17 +28,17 @@ import {
 	throwOdspNetworkError,
 } from "@fluidframework/odsp-doclib-utils/internal";
 import {
-	ICacheEntry,
-	IOdspResolvedUrl,
-	IOdspUrlParts,
-	ISharingLinkKind,
-	InstrumentedStorageTokenFetcher,
-	InstrumentedTokenFetcher,
+	type ICacheEntry,
+	type IOdspResolvedUrl,
+	type IOdspUrlParts,
+	type ISharingLinkKind,
+	type InstrumentedStorageTokenFetcher,
+	type InstrumentedTokenFetcher,
 	OdspErrorTypes,
 	authHeaderFromTokenResponse,
-	OdspResourceTokenFetchOptions,
-	TokenFetchOptions,
-	TokenFetcher,
+	type OdspResourceTokenFetchOptions,
+	type TokenFetchOptions,
+	type TokenFetcher,
 	isTokenFromCache,
 	snapshotKey,
 	tokenFromResponse,
@@ -47,7 +47,7 @@ import {
 import {
 	type IConfigProvider,
 	type IFluidErrorBase,
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	PerformanceEvent,
 	TelemetryDataTag,
 	createChildLogger,
@@ -56,7 +56,7 @@ import {
 
 import { storeLocatorInOdspUrl } from "./odspFluidFileLink.js";
 // eslint-disable-next-line import/no-deprecated
-import { ISnapshotContents } from "./odspPublicUtils.js";
+import type { ISnapshotContents } from "./odspPublicUtils.js";
 import { pkgVersion as driverVersion } from "./packageVersion.js";
 
 export const getWithRetryForTokenRefreshRepeat = "getWithRetryForTokenRefreshRepeat";

--- a/packages/drivers/odsp-driver/src/opsCaching.ts
+++ b/packages/drivers/odsp-driver/src/opsCaching.ts
@@ -4,7 +4,7 @@
  */
 
 import { performanceNow } from "@fluid-internal/client-utils";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 // ISequencedDocumentMessage
 export interface IMessage {

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -4,16 +4,16 @@
  */
 
 import { performanceNow } from "@fluid-internal/client-utils";
-import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert, Deferred } from "@fluidframework/core-utils/internal";
-import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
+import type { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
 import {
-	IOdspResolvedUrl,
-	IOdspUrlParts,
-	IPersistedCache,
-	ISnapshotOptions,
-	OdspResourceTokenFetchOptions,
-	TokenFetcher,
+	type IOdspResolvedUrl,
+	type IOdspUrlParts,
+	type IPersistedCache,
+	type ISnapshotOptions,
+	type OdspResourceTokenFetchOptions,
+	type TokenFetcher,
 	getKeyForCacheEntry,
 	type InstrumentedStorageTokenFetcher,
 } from "@fluidframework/odsp-driver-definitions/internal";
@@ -22,15 +22,15 @@ import {
 	createChildMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { IVersionedValueWithEpoch } from "./contracts.js";
+import type { IVersionedValueWithEpoch } from "./contracts.js";
 import {
-	ISnapshotRequestAndResponseOptions,
-	SnapshotFormatSupportType,
+	type ISnapshotRequestAndResponseOptions,
+	type SnapshotFormatSupportType,
 	downloadSnapshot,
 	fetchSnapshotWithRedeem,
 } from "./fetchSnapshot.js";
-import { IPrefetchSnapshotContents } from "./odspCache.js";
-import { OdspDocumentServiceFactory } from "./odspDocumentServiceFactory.js";
+import type { IPrefetchSnapshotContents } from "./odspCache.js";
+import type { OdspDocumentServiceFactory } from "./odspDocumentServiceFactory.js";
 import {
 	createCacheSnapshotKey,
 	createOdspLogger,

--- a/packages/drivers/odsp-driver/src/retryErrorsStorageAdapter.ts
+++ b/packages/drivers/odsp-driver/src/retryErrorsStorageAdapter.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable } from "@fluidframework/core-interfaces";
-import { ISummaryHandle, ISummaryTree } from "@fluidframework/driver-definitions";
-import {
+import type { IDisposable } from "@fluidframework/core-interfaces";
+import type { ISummaryHandle, ISummaryTree } from "@fluidframework/driver-definitions";
+import type {
 	FetchSource,
 	IDocumentStorageService,
 	IDocumentStorageServicePolicies,
@@ -17,7 +17,7 @@ import {
 	IVersion,
 } from "@fluidframework/driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	LoggingError,
 	UsageError,
 } from "@fluidframework/telemetry-utils/internal";

--- a/packages/drivers/odsp-driver/src/retryUtils.ts
+++ b/packages/drivers/odsp-driver/src/retryUtils.ts
@@ -10,7 +10,7 @@ import {
 	getRetryDelayFromError,
 } from "@fluidframework/driver-utils/internal";
 import { OdspErrorTypes } from "@fluidframework/odsp-driver-definitions/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import { Odsp409Error } from "./epochTracker.js";
 

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -6,12 +6,15 @@
 import { strict as assert } from "node:assert";
 
 import { bufferToString, fromBase64ToUtf8 } from "@fluid-internal/client-utils";
-import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
-import { ISnapshot, IDocumentAttributes } from "@fluidframework/driver-definitions/internal";
+import { type ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
+import type {
+	ISnapshot,
+	IDocumentAttributes,
+} from "@fluidframework/driver-definitions/internal";
 import {
-	IFileEntry,
-	IOdspResolvedUrl,
-	ISharingLinkKind,
+	type IFileEntry,
+	type IOdspResolvedUrl,
+	type ISharingLinkKind,
 	SharingLinkRole,
 	SharingLinkScope,
 } from "@fluidframework/odsp-driver-definitions/internal";
@@ -29,8 +32,8 @@ import {
 import { getLocatorFromOdspUrl } from "../odspFluidFileLink.js";
 import { getHashedDocumentId } from "../odspPublicUtils.js";
 import {
-	IExistingFileInfo,
-	INewFileInfo,
+	type IExistingFileInfo,
+	type INewFileInfo,
 	createCacheSnapshotKey,
 	getOdspResolvedUrl,
 } from "../odspUtils.js";

--- a/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/deltaStorageService.spec.ts
@@ -6,15 +6,18 @@
 import { strict as assert } from "node:assert";
 
 import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import {
+import type {
 	IDeltasFetchResult,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
-import {
+import type {
 	IFileEntry,
 	IOdspResolvedUrl,
 } from "@fluidframework/odsp-driver-definitions/internal";
-import { ITelemetryLoggerExt, MockLogger } from "@fluidframework/telemetry-utils/internal";
+import {
+	type ITelemetryLoggerExt,
+	MockLogger,
+} from "@fluidframework/telemetry-utils/internal";
 
 import { EpochTracker } from "../epochTracker.js";
 import { LocalPersistentCache } from "../odspCache.js";
@@ -22,7 +25,7 @@ import {
 	OdspDeltaStorageService,
 	OdspDeltaStorageWithCache,
 } from "../odspDeltaStorageService.js";
-import { OdspDocumentStorageService } from "../odspDocumentStorageManager.js";
+import type { OdspDocumentStorageService } from "../odspDocumentStorageManager.js";
 
 import { mockFetchOk } from "./mockFetch.js";
 

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -5,11 +5,11 @@
 
 import { strict as assert } from "node:assert";
 
-import { IDocumentStorageServicePolicies } from "@fluidframework/driver-definitions/internal";
+import type { IDocumentStorageServicePolicies } from "@fluidframework/driver-definitions/internal";
 import {
-	ICacheEntry,
-	IEntry,
-	IOdspResolvedUrl,
+	type ICacheEntry,
+	type IEntry,
+	type IOdspResolvedUrl,
 	OdspErrorTypes,
 	maximumCacheDurationMs,
 } from "@fluidframework/odsp-driver-definitions/internal";
@@ -18,7 +18,7 @@ import {
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { IVersionedValueWithEpoch, persistedCacheValueVersion } from "../contracts.js";
+import { type IVersionedValueWithEpoch, persistedCacheValueVersion } from "../contracts.js";
 import { EpochTracker } from "../epochTracker.js";
 import { LocalPersistentCache } from "../odspCache.js";
 import { getHashedDocumentId } from "../odspPublicUtils.js";

--- a/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTestsWithRedemption.spec.ts
@@ -7,8 +7,8 @@ import { strict as assert } from "node:assert";
 
 import { Deferred } from "@fluidframework/core-utils/internal";
 import {
-	IEntry,
-	IOdspResolvedUrl,
+	type IEntry,
+	type IOdspResolvedUrl,
 	OdspErrorTypes,
 	snapshotKey,
 } from "@fluidframework/odsp-driver-definitions/internal";
@@ -19,7 +19,7 @@ import { LocalPersistentCache } from "../odspCache.js";
 import { getHashedDocumentId } from "../odspPublicUtils.js";
 
 import {
-	MockResponse,
+	type MockResponse,
 	mockFetchMultiple,
 	mockFetchSingle,
 	notFound,

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -8,9 +8,9 @@
 import { strict as assert } from "node:assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
-import { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
+import type { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import {
-	IOdspResolvedUrl,
+	type IOdspResolvedUrl,
 	OdspErrorTypes,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
@@ -22,16 +22,23 @@ import {
 import { stub } from "sinon";
 
 import { convertToCompactSnapshot } from "../compactSnapshotWriter.js";
-import { HostStoragePolicyInternal } from "../contracts.js";
+import type { HostStoragePolicyInternal } from "../contracts.js";
 import { createOdspUrl } from "../createOdspUrl.js";
 import { EpochTracker } from "../epochTracker.js";
-import { downloadSnapshot, ISnapshotRequestAndResponseOptions } from "../fetchSnapshot.js";
+import {
+	downloadSnapshot,
+	type ISnapshotRequestAndResponseOptions,
+} from "../fetchSnapshot.js";
 import { mockify } from "../mockify.js";
 import { LocalPersistentCache, NonPersistentCache } from "../odspCache.js";
 import { OdspDocumentStorageService } from "../odspDocumentStorageManager.js";
 import { OdspDriverUrlResolver } from "../odspDriverUrlResolver.js";
 import { getHashedDocumentId } from "../odspPublicUtils.js";
-import { INewFileInfo, IOdspResponse, createCacheSnapshotKey } from "../odspUtils.js";
+import {
+	type INewFileInfo,
+	type IOdspResponse,
+	createCacheSnapshotKey,
+} from "../odspUtils.js";
 
 import {
 	createResponse,

--- a/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getFileLink.spec.ts
@@ -11,7 +11,7 @@ import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 import { getFileLink } from "../getFileLink.js";
 
 import {
-	MockResponse,
+	type MockResponse,
 	createResponse,
 	mockFetchMultiple,
 	mockFetchSingle,

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -6,18 +6,18 @@
 import { strict as assert } from "node:assert";
 
 import { delay } from "@fluidframework/core-utils/internal";
-import { ISnapshot } from "@fluidframework/driver-definitions/internal";
+import type { ISnapshot } from "@fluidframework/driver-definitions/internal";
 import {
-	ICacheEntry,
-	IOdspResolvedUrl,
+	type ICacheEntry,
+	type IOdspResolvedUrl,
 	maximumCacheDurationMs,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 
 import {
-	HostStoragePolicyInternal,
-	IOdspSnapshot,
-	IVersionedValueWithEpoch,
+	type HostStoragePolicyInternal,
+	type IOdspSnapshot,
+	type IVersionedValueWithEpoch,
 	persistedCacheValueVersion,
 } from "../contracts.js";
 import { createOdspUrl } from "../createOdspUrl.js";
@@ -29,7 +29,7 @@ import {
 } from "../odspDocumentStorageManager.js";
 import { OdspDriverUrlResolver } from "../odspDriverUrlResolver.js";
 import { getHashedDocumentId } from "../odspPublicUtils.js";
-import { INewFileInfo } from "../odspUtils.js";
+import type { INewFileInfo } from "../odspUtils.js";
 
 import { createResponse, mockFetchSingle, notFound } from "./mockFetch.js";
 

--- a/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
@@ -6,17 +6,17 @@
 import { strict as assert } from "node:assert";
 
 import type { IClient } from "@fluidframework/driver-definitions";
-import {
+import type {
 	IResolvedUrl,
-	type IAnyDriverError,
+	IAnyDriverError,
 } from "@fluidframework/driver-definitions/internal";
-import {
+import type {
 	IOdspResolvedUrl,
 	ISocketStorageDiscovery,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 import { stub, type SinonStub } from "sinon";
-import { Socket } from "socket.io-client";
+import type { Socket } from "socket.io-client";
 
 import { createOdspUrl } from "../createOdspUrl.js";
 import { mockify } from "../mockify.js";

--- a/packages/drivers/odsp-driver/src/test/joinSessionPeriodicCall.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/joinSessionPeriodicCall.spec.ts
@@ -5,18 +5,18 @@
 
 import { strict as assert } from "node:assert";
 
-import { IClient } from "@fluidframework/driver-definitions";
-import { ISocketStorageDiscovery } from "@fluidframework/odsp-driver-definitions/internal";
+import type { IClient } from "@fluidframework/driver-definitions";
+import type { ISocketStorageDiscovery } from "@fluidframework/odsp-driver-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
-import { SinonFakeTimers, SinonStub, stub, useFakeTimers } from "sinon";
+import { type SinonFakeTimers, type SinonStub, stub, useFakeTimers } from "sinon";
 
-import { OdspFluidDataStoreLocator } from "../contractsPublic.js";
+import type { OdspFluidDataStoreLocator } from "../contractsPublic.js";
 import { createOdspUrl } from "../createOdspUrl.js";
 import { mockify } from "../mockify.js";
 import { LocalPersistentCache } from "../odspCache.js";
 import * as odspDocumentDeltaConnection from "../odspDocumentDeltaConnection.js";
-import { OdspDocumentDeltaConnection } from "../odspDocumentDeltaConnection.js";
-import { OdspDocumentService } from "../odspDocumentService.js";
+import type { OdspDocumentDeltaConnection } from "../odspDocumentDeltaConnection.js";
+import type { OdspDocumentService } from "../odspDocumentService.js";
 import { OdspDocumentServiceFactory } from "../odspDocumentServiceFactory.js";
 import { OdspDriverUrlResolver } from "../odspDriverUrlResolver.js";
 import { fetchJoinSession } from "../vroom.js";

--- a/packages/drivers/odsp-driver/src/test/jsonSnapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/jsonSnapshotFormatTests.spec.ts
@@ -6,7 +6,7 @@
 // eslint-disable-next-line unicorn/prefer-node-protocol
 import { strict as assert } from "assert";
 
-import { IOdspSnapshot } from "../contracts.js";
+import type { IOdspSnapshot } from "../contracts.js";
 import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "../odspSnapshotParser.js";
 
 const snapshotTree: IOdspSnapshot = {

--- a/packages/drivers/odsp-driver/src/test/localOdspDriver.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/localOdspDriver.spec.ts
@@ -6,14 +6,14 @@
 import { strict as assert } from "node:assert";
 import fs from "node:fs";
 
-import { IClient, SummaryType } from "@fluidframework/driver-definitions";
-import {
+import { type IClient, SummaryType } from "@fluidframework/driver-definitions";
+import type {
 	DriverError,
 	IStream,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import {
-	IOdspResolvedUrl,
+	type IOdspResolvedUrl,
 	OdspErrorTypes,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";

--- a/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
@@ -5,11 +5,11 @@
 
 import { strict as assert } from "node:assert";
 
-import { IRequest } from "@fluidframework/core-interfaces";
-import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
-import { IDocumentService } from "@fluidframework/driver-definitions/internal";
+import type { IRequest } from "@fluidframework/core-interfaces";
+import { type ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
+import type { IDocumentService } from "@fluidframework/driver-definitions/internal";
 import {
-	IOdspResolvedUrl,
+	type IOdspResolvedUrl,
 	OdspErrorTypes,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import { MockLogger, isFluidError } from "@fluidframework/telemetry-utils/internal";

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -5,9 +5,9 @@
 
 import { strict as assert } from "node:assert";
 
-import { IRequest } from "@fluidframework/core-interfaces";
+import type { IRequest } from "@fluidframework/core-interfaces";
 import { DriverHeader } from "@fluidframework/driver-definitions/internal";
-import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
+import type { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
 
 import { createOdspCreateContainerRequest } from "../createOdspCreateContainerRequest.js";
 import { createOdspUrl } from "../createOdspUrl.js";

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -7,8 +7,8 @@
 
 import { strict as assert } from "node:assert";
 
-import { IRequest } from "@fluidframework/core-interfaces";
-import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
+import type { IRequest } from "@fluidframework/core-interfaces";
+import type { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
 import { stub } from "sinon";
 
 import { SharingLinkHeader } from "../contractsPublic.js";

--- a/packages/drivers/odsp-driver/src/test/odspError.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspError.spec.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "node:assert";
 
-import { IThrottlingWarning } from "@fluidframework/core-interfaces/internal";
-import {
+import type { IThrottlingWarning } from "@fluidframework/core-interfaces/internal";
+import type {
 	IAuthorizationError,
 	IGenericNetworkError,
 } from "@fluidframework/driver-definitions/internal";
@@ -15,10 +15,13 @@ import {
 	createOdspNetworkError,
 	throwOdspNetworkError,
 } from "@fluidframework/odsp-doclib-utils/internal";
-import { OdspError, OdspErrorTypes } from "@fluidframework/odsp-driver-definitions/internal";
-import { IFluidErrorBase } from "@fluidframework/telemetry-utils/internal";
+import {
+	type OdspError,
+	OdspErrorTypes,
+} from "@fluidframework/odsp-driver-definitions/internal";
+import type { IFluidErrorBase } from "@fluidframework/telemetry-utils/internal";
 
-import { IOdspSocketError } from "../contracts.js";
+import type { IOdspSocketError } from "../contracts.js";
 import { errorObjectFromSocketError } from "../odspError.js";
 import { fetchAndParseAsJSONHelper, getWithRetryForTokenRefresh } from "../odspUtils.js";
 import { pkgVersion } from "../packageVersion.js";

--- a/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/opsCaching.spec.ts
@@ -6,15 +6,15 @@
 import { strict as assert } from "node:assert";
 
 import { delay } from "@fluidframework/core-utils/internal";
-import {
+import type {
 	IStream,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { OdspDeltaStorageWithCache } from "../odspDeltaStorageService.js";
-import { OdspDocumentStorageService } from "../odspDocumentStorageManager.js";
-import { CacheEntry, ICache, IMessage, OpsCache } from "../opsCaching.js";
+import type { OdspDocumentStorageService } from "../odspDocumentStorageManager.js";
+import { type CacheEntry, type ICache, type IMessage, OpsCache } from "../opsCaching.js";
 
 export type MyDataInput = IMessage & { data: string };
 

--- a/packages/drivers/odsp-driver/src/test/prefetchSnapshotTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/prefetchSnapshotTests.spec.ts
@@ -8,33 +8,33 @@
 import { strict as assert } from "node:assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
-import { PromiseCache } from "@fluidframework/core-utils/internal";
+import type { PromiseCache } from "@fluidframework/core-utils/internal";
 import {
 	FetchSource,
-	ISnapshot,
-	ISnapshotTree,
+	type ISnapshot,
+	type ISnapshotTree,
 } from "@fluidframework/driver-definitions/internal";
 import {
-	ICacheEntry,
-	IOdspResolvedUrl,
+	type ICacheEntry,
+	type IOdspResolvedUrl,
 	getKeyForCacheEntry,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { convertToCompactSnapshot } from "../compactSnapshotWriter.js";
 import {
-	HostStoragePolicyInternal,
-	IOdspSnapshot,
-	IVersionedValueWithEpoch,
+	type HostStoragePolicyInternal,
+	type IOdspSnapshot,
+	type IVersionedValueWithEpoch,
 	persistedCacheValueVersion,
 } from "../contracts.js";
 import { createOdspUrl } from "../createOdspUrl.js";
-import { IPrefetchSnapshotContents, LocalPersistentCache } from "../odspCache.js";
+import { type IPrefetchSnapshotContents, LocalPersistentCache } from "../odspCache.js";
 import { OdspDocumentServiceFactory } from "../odspDocumentServiceFactory.js";
-import { OdspDocumentStorageService } from "../odspDocumentStorageManager.js";
+import type { OdspDocumentStorageService } from "../odspDocumentStorageManager.js";
 import { OdspDriverUrlResolver } from "../odspDriverUrlResolver.js";
 import { getHashedDocumentId } from "../odspPublicUtils.js";
-import { INewFileInfo, createCacheSnapshotKey } from "../odspUtils.js";
+import { type INewFileInfo, createCacheSnapshotKey } from "../odspUtils.js";
 import { prefetchLatestSnapshot } from "../prefetchLatestSnapshot.js";
 
 import { createResponse, mockFetchSingle, notFound } from "./mockFetch.js";

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
-import {
+import type {
 	ISnapshot,
 	ISnapshotTree,
 	ISequencedDocumentMessage,

--- a/packages/drivers/odsp-driver/src/test/socketTests/deltaConnectionUpdateTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/deltaConnectionUpdateTests.spec.ts
@@ -5,20 +5,23 @@
 
 import { strict as assert } from "node:assert";
 
-import { IClient } from "@fluidframework/driver-definitions";
-import { ISignalMessage } from "@fluidframework/driver-definitions/internal";
-import { ISocketStorageDiscovery } from "@fluidframework/odsp-driver-definitions/internal";
-import { ITelemetryLoggerExt, MockLogger } from "@fluidframework/telemetry-utils/internal";
-import { SinonFakeTimers, type SinonStub, stub, useFakeTimers } from "sinon";
-import { Socket } from "socket.io-client";
+import type { IClient } from "@fluidframework/driver-definitions";
+import type { ISignalMessage } from "@fluidframework/driver-definitions/internal";
+import type { ISocketStorageDiscovery } from "@fluidframework/odsp-driver-definitions/internal";
+import {
+	type ITelemetryLoggerExt,
+	MockLogger,
+} from "@fluidframework/telemetry-utils/internal";
+import { type SinonFakeTimers, type SinonStub, stub, useFakeTimers } from "sinon";
+import type { Socket } from "socket.io-client";
 
-import { OdspFluidDataStoreLocator } from "../../contractsPublic.js";
+import type { OdspFluidDataStoreLocator } from "../../contractsPublic.js";
 import { createOdspUrl } from "../../createOdspUrl.js";
 import { EpochTracker } from "../../epochTracker.js";
 import { mockify } from "../../mockify.js";
 import { LocalPersistentCache } from "../../odspCache.js";
-import { OdspDocumentDeltaConnection } from "../../odspDocumentDeltaConnection.js";
-import { OdspDocumentService } from "../../odspDocumentService.js";
+import type { OdspDocumentDeltaConnection } from "../../odspDocumentDeltaConnection.js";
+import type { OdspDocumentService } from "../../odspDocumentService.js";
 import { OdspDocumentServiceFactory } from "../../odspDocumentServiceFactory.js";
 import { OdspDriverUrlResolver } from "../../odspDriverUrlResolver.js";
 import { getHashedDocumentId } from "../../odspPublicUtils.js";

--- a/packages/drivers/odsp-driver/src/test/socketTests/socketMock.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/socketMock.ts
@@ -4,17 +4,17 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { IEvent } from "@fluidframework/core-interfaces";
+import type { IEvent } from "@fluidframework/core-interfaces";
 import {
-	IAnyDriverError,
-	IConnect,
-	IConnected,
+	type IAnyDriverError,
+	type IConnect,
+	type IConnected,
 	ScopeType,
 } from "@fluidframework/driver-definitions/internal";
 import { createGenericNetworkError } from "@fluidframework/driver-utils/internal";
 import { v4 as uuid } from "uuid";
 
-import { IOdspSocketError } from "../../contracts.js";
+import type { IOdspSocketError } from "../../contracts.js";
 import { pkgVersion as driverVersion } from "../../packageVersion.js";
 
 export interface SocketMockEvents extends IEvent {

--- a/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
@@ -5,25 +5,25 @@
 
 import { strict as assert } from "node:assert";
 
-import { IClient } from "@fluidframework/driver-definitions";
-import { IAnyDriverError } from "@fluidframework/driver-definitions/internal";
+import type { IClient } from "@fluidframework/driver-definitions";
+import type { IAnyDriverError } from "@fluidframework/driver-definitions/internal";
 import { createOdspNetworkError } from "@fluidframework/odsp-doclib-utils/internal";
 import {
-	IOdspResolvedUrl,
+	type IOdspResolvedUrl,
 	OdspErrorTypes,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	MockLogger,
 	isFluidError,
 } from "@fluidframework/telemetry-utils/internal";
 import { stub } from "sinon";
-import { Socket } from "socket.io-client";
+import type { Socket } from "socket.io-client";
 import { v4 as uuid } from "uuid";
 
 import { EpochTracker } from "../../epochTracker.js";
 import { mockify } from "../../mockify.js";
-import { LocalPersistentCache } from "../../odspCache.js";
+import type { LocalPersistentCache } from "../../odspCache.js";
 import { OdspDocumentDeltaConnection } from "../../odspDocumentDeltaConnection.js";
 import { getHashedDocumentId } from "../../odspPublicUtils.js";
 import { SocketIOClientStatic } from "../../socketModule.js";

--- a/packages/drivers/odsp-driver/src/test/zipItDataRepresentationTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/zipItDataRepresentationTests.spec.ts
@@ -13,9 +13,9 @@ import { TreeBuilderSerializer } from "../WriteBufferUtils.js";
 import {
 	BlobCore,
 	BlobShallowCopy,
-	IStringElement,
+	type IStringElement,
 	NodeCore,
-	NodeTypes,
+	type NodeTypes,
 	TreeBuilder,
 	assertBlobCoreInstance,
 	assertBoolInstance,

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -3,22 +3,22 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
-import {
+import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
+import type {
 	IOdspUrlParts,
 	ISocketStorageDiscovery,
 	InstrumentedStorageTokenFetcher,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 
-import { EpochTracker } from "./epochTracker.js";
+import type { EpochTracker } from "./epochTracker.js";
 import { mockify } from "./mockify.js";
 import { getApiRoot } from "./odspUrlHelper.js";
-import { TokenFetchOptionsEx } from "./odspUtils.js";
+import type { TokenFetchOptionsEx } from "./odspUtils.js";
 import { runWithRetry } from "./retryUtils.js";
 
 interface IJoinSessionBody {

--- a/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
+++ b/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
@@ -12,9 +12,9 @@ import { Uint8ArrayToArrayBuffer, Uint8ArrayToString } from "@fluid-internal/cli
 import { assert } from "@fluidframework/core-utils/internal";
 import { NonRetryableError } from "@fluidframework/driver-utils/internal";
 import { OdspErrorTypes } from "@fluidframework/odsp-driver-definitions/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
-import { ReadBuffer } from "./ReadBufferUtils.js";
+import type { ReadBuffer } from "./ReadBufferUtils.js";
 import { measure } from "./odspUtils.js";
 import { pkgVersion as driverVersion } from "./packageVersion.js";
 


### PR DESCRIPTION
In preparation for these rules becoming default in the next release of our eslint configuration.

Type-only imports offer a number of benefits and are considered a best practice. More details can be found here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html