### PR TITLE
refactor(merge-tree): Remove unused eslint directives and combine imports

### DIFF
--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -893,7 +893,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		);
 		const canSlideToEndpoint = true;
 		// Destructuring segment + offset is convenient and segment is reassigned
-		// eslint-disable-next-line prefer-const
+
 		const segOff = getSlideToSegoff(
 			{ segment: oldSegment, offset: oldOffset },
 			slidePreference,

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -3,8 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
-import { DoublyLinkedList, ListNode, walkList } from "@fluidframework/core-utils/internal";
+import {
+	assert,
+	DoublyLinkedList,
+	ListNode,
+	walkList,
+} from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { type ISegmentInternal } from "./mergeTreeNodes.js";

--- a/packages/dds/merge-tree/src/test/client.getPosition.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.getPosition.spec.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
 import { strict as assert } from "node:assert";
 
 import { segmentIsRemoved, type ISegmentPrivate } from "../mergeTreeNodes.js";

--- a/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.localReferenceFarm.spec.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
 import { strict as assert } from "node:assert";
 
 import { makeRandom } from "@fluid-private/stochastic-test-utils";


### PR DESCRIPTION
Detected and fixed via `npm run eslint:fix`