### PR TITLE
refactor(odsp-urlResolver): Enable type-only import/export eslint rules and fix violations

### DIFF
--- a/packages/drivers/odsp-urlResolver/.eslintrc.cjs
+++ b/packages/drivers/odsp-urlResolver/.eslintrc.cjs
@@ -11,5 +11,17 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/no-use-before-define": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
+
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
 	},
 };

--- a/packages/drivers/odsp-urlResolver/src/test/fluidAppUrlResolver.spec.ts
+++ b/packages/drivers/odsp-urlResolver/src/test/fluidAppUrlResolver.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
+import type { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
 
 import { FluidAppOdspUrlResolver } from "../urlResolver.js";
 

--- a/packages/drivers/odsp-urlResolver/src/test/spoUrlResolver.spec.ts
+++ b/packages/drivers/odsp-urlResolver/src/test/spoUrlResolver.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
+import type { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/internal";
 
 import { OdspUrlResolver } from "../urlResolver.js";
 

--- a/packages/drivers/odsp-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/odsp-urlResolver/src/urlResolver.ts
@@ -4,9 +4,9 @@
  */
 
 import { fromBase64ToUtf8 } from "@fluid-internal/client-utils";
-import { IRequest } from "@fluidframework/core-interfaces";
+import type { IRequest } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import {
+import type {
 	IContainerPackageInfo,
 	IResolvedUrl,
 	IUrlResolver,
@@ -18,7 +18,7 @@ import {
 	isOdcUrl,
 	isSpoUrl,
 } from "@fluidframework/odsp-driver/internal";
-import { IOdspUrlParts } from "@fluidframework/odsp-driver-definitions/internal";
+import type { IOdspUrlParts } from "@fluidframework/odsp-driver-definitions/internal";
 
 const fluidOfficeAndOneNoteServers = new Set([
 	"dev.fluidpreview.office.net",


### PR DESCRIPTION
In preparation for these rules becoming default in the next release of our eslint configuration.

Type-only imports offer a number of benefits and are considered a best practice. More details can be found here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html