### PR TITLE
refactor(tinylicious-driver): Enable type-only import/export eslint rules and fix violations

### DIFF
--- a/packages/drivers/tinylicious-driver/.eslintrc.cjs
+++ b/packages/drivers/tinylicious-driver/.eslintrc.cjs
@@ -10,5 +10,17 @@ module.exports = {
 	},
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
+
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
 	},
 };

--- a/packages/drivers/tinylicious-driver/src/insecureTinyliciousTokenProvider.ts
+++ b/packages/drivers/tinylicious-driver/src/insecureTinyliciousTokenProvider.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { ITokenClaims, ScopeType } from "@fluidframework/driver-definitions/internal";
-import { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
+import { type ITokenClaims, ScopeType } from "@fluidframework/driver-definitions/internal";
+import type { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
 import { KJUR as jsrsasign } from "jsrsasign";
 import { v4 as uuid } from "uuid";
 

--- a/packages/drivers/tinylicious-driver/src/insecureTinyliciousUrlResolver.ts
+++ b/packages/drivers/tinylicious-driver/src/insecureTinyliciousUrlResolver.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest } from "@fluidframework/core-interfaces";
+import type { IRequest } from "@fluidframework/core-interfaces";
 import {
 	DriverHeader,
-	IResolvedUrl,
-	IUrlResolver,
+	type IResolvedUrl,
+	type IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
 
 /**

--- a/packages/drivers/tinylicious-driver/src/test/insecureTinyliciousUrlResolverTest.spec.ts
+++ b/packages/drivers/tinylicious-driver/src/test/insecureTinyliciousUrlResolverTest.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { IRequest } from "@fluidframework/core-interfaces";
+import type { IRequest } from "@fluidframework/core-interfaces";
 import { DriverHeader } from "@fluidframework/driver-definitions/internal";
 
 import { InsecureTinyliciousUrlResolver } from "../insecureTinyliciousUrlResolver.js";


### PR DESCRIPTION
In preparation for these rules becoming default in the next release of our eslint configuration.

Type-only imports offer a number of benefits and are considered a best practice. More details can be found here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html
