### PR TITLE
refactor(client/framework): Enable type-only import/export linter rules and fix violations

### DIFF
--- a/packages/framework/agent-scheduler/.eslintrc.cjs
+++ b/packages/framework/agent-scheduler/.eslintrc.cjs
@@ -10,5 +10,17 @@ module.exports = {
 	},
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
+
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
 	},
 };

--- a/packages/framework/agent-scheduler/src/agent.ts
+++ b/packages/framework/agent-scheduler/src/agent.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IEvent, IEventProvider, IFluidLoadable } from "@fluidframework/core-interfaces";
+import type { IEvent, IEventProvider, IFluidLoadable } from "@fluidframework/core-interfaces";
 
 /**
  * @legacy

--- a/packages/framework/agent-scheduler/src/index.ts
+++ b/packages/framework/agent-scheduler/src/index.ts
@@ -3,6 +3,10 @@
  * Licensed under the MIT License.
  */
 
-export { IAgentScheduler, IAgentSchedulerEvents, IProvideAgentScheduler } from "./agent.js";
+export {
+	IAgentScheduler,
+	type IAgentSchedulerEvents,
+	type IProvideAgentScheduler,
+} from "./agent.js";
 export { AgentSchedulerFactory } from "./scheduler.js";
-export { ITaskSubscriptionEvents, TaskSubscription } from "./taskSubscription.js";
+export { type ITaskSubscriptionEvents, TaskSubscription } from "./taskSubscription.js";

--- a/packages/framework/agent-scheduler/src/scheduler.ts
+++ b/packages/framework/agent-scheduler/src/scheduler.ts
@@ -16,15 +16,15 @@ import { assert } from "@fluidframework/core-utils/internal";
 import {
 	FluidDataStoreRuntime,
 	FluidObjectHandle,
-	ISharedObjectRegistry,
+	type ISharedObjectRegistry,
 } from "@fluidframework/datastore/internal";
-import {
+import type {
 	IChannelFactory,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions/internal";
-import { ISharedMap, IValueChanged, SharedMap } from "@fluidframework/map/internal";
+import { type ISharedMap, type IValueChanged, SharedMap } from "@fluidframework/map/internal";
 import { ConsensusRegisterCollection } from "@fluidframework/register-collection/internal";
-import {
+import type {
 	IFluidDataStoreContext,
 	IFluidDataStoreFactory,
 	NamedFluidDataStoreRegistryEntry,
@@ -37,7 +37,7 @@ import {
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 
-import { IAgentScheduler, IAgentSchedulerEvents } from "./agent.js";
+import type { IAgentScheduler, IAgentSchedulerEvents } from "./agent.js";
 
 // Note: making sure this ID is unique and does not collide with storage provided clientID
 const UnattachedClientId = `${uuid()}_unattached`;

--- a/packages/framework/agent-scheduler/src/taskSubscription.ts
+++ b/packages/framework/agent-scheduler/src/taskSubscription.ts
@@ -4,9 +4,9 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { IEvent } from "@fluidframework/core-interfaces";
+import type { IEvent } from "@fluidframework/core-interfaces";
 
-import { IAgentScheduler } from "./agent.js";
+import type { IAgentScheduler } from "./agent.js";
 
 /**
  * Events emitted by {@link TaskSubscription}.

--- a/packages/framework/attributor/.eslintrc.cjs
+++ b/packages/framework/attributor/.eslintrc.cjs
@@ -8,6 +8,19 @@ module.exports = {
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
+	rules: {
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
+	},
 	overrides: [
 		{
 			// Rules only for test files

--- a/packages/framework/attributor/src/attributor.ts
+++ b/packages/framework/attributor/src/attributor.ts
@@ -3,15 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import { type IDeltaManager } from "@fluidframework/container-definitions/internal";
+import type { IDeltaManager } from "@fluidframework/container-definitions/internal";
 import { assert } from "@fluidframework/core-utils/internal";
-import { type IQuorumClients } from "@fluidframework/driver-definitions";
+import type { IQuorumClients } from "@fluidframework/driver-definitions";
 import {
 	MessageType,
 	type IDocumentMessage,
 	type ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
-import { type AttributionInfo } from "@fluidframework/runtime-definitions/internal";
+import type { AttributionInfo } from "@fluidframework/runtime-definitions/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 /**

--- a/packages/framework/attributor/src/attributorContracts.ts
+++ b/packages/framework/attributor/src/attributorContracts.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import {
-	type AttributionInfo,
-	type AttributionKey,
+import type {
+	AttributionInfo,
+	AttributionKey,
 } from "@fluidframework/runtime-definitions/internal";
 
 // Summary tree keys

--- a/packages/framework/attributor/src/encoders.ts
+++ b/packages/framework/attributor/src/encoders.ts
@@ -4,10 +4,10 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { type IUser } from "@fluidframework/driver-definitions";
-import { type AttributionInfo } from "@fluidframework/runtime-definitions/internal";
+import type { IUser } from "@fluidframework/driver-definitions";
+import type { AttributionInfo } from "@fluidframework/runtime-definitions/internal";
 
-import { type IAttributor } from "./attributor.js";
+import type { IAttributor } from "./attributor.js";
 import { type InternedStringId, MutableStringInterner } from "./stringInterner.js";
 
 export interface Encoder<TDecoded, TEncoded> {

--- a/packages/framework/attributor/src/lz4Encoder.ts
+++ b/packages/framework/attributor/src/lz4Encoder.ts
@@ -4,10 +4,10 @@
  */
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
-import { type Jsonable } from "@fluidframework/datastore-definitions/internal";
+import type { Jsonable } from "@fluidframework/datastore-definitions/internal";
 import { compress, decompress } from "lz4js";
 
-import { type Encoder } from "./encoders.js";
+import type { Encoder } from "./encoders.js";
 
 // TODO: document this
 // eslint-disable-next-line jsdoc/require-description

--- a/packages/framework/attributor/src/mixinAttributor.ts
+++ b/packages/framework/attributor/src/mixinAttributor.ts
@@ -3,15 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import { type IContainerContext } from "@fluidframework/container-definitions/internal";
+import type { IContainerContext } from "@fluidframework/container-definitions/internal";
 import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import type { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
-import { type IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
-import { type FluidObject } from "@fluidframework/core-interfaces";
+import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
+import type { FluidObject } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import {
-	type IContainerRuntimeBase,
-	type NamedFluidDataStoreRegistryEntries,
+import type {
+	IContainerRuntimeBase,
+	NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions/internal";
 import { loggerToMonitoringContext } from "@fluidframework/telemetry-utils/internal";
 

--- a/packages/framework/attributor/src/runtimeAttributor.ts
+++ b/packages/framework/attributor/src/runtimeAttributor.ts
@@ -4,18 +4,18 @@
  */
 
 import { bufferToString } from "@fluid-internal/client-utils";
-import { IDeltaManager } from "@fluidframework/container-definitions/internal";
+import type { IDeltaManager } from "@fluidframework/container-definitions/internal";
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
-import {
+import type {
 	IDocumentMessage,
-	type ISnapshotTree,
+	ISnapshotTree,
 	ISequencedDocumentMessage,
 	IQuorumClients,
 } from "@fluidframework/driver-definitions/internal";
-import {
-	type AttributionInfo,
-	type AttributionKey,
-	type ISummaryTreeWithStats,
+import type {
+	AttributionInfo,
+	AttributionKey,
+	ISummaryTreeWithStats,
 } from "@fluidframework/runtime-definitions/internal";
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils/internal";
 

--- a/packages/framework/attributor/src/runtimeAttributorDataStoreChannel.ts
+++ b/packages/framework/attributor/src/runtimeAttributorDataStoreChannel.ts
@@ -4,31 +4,34 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { AttachState, IDeltaManager } from "@fluidframework/container-definitions/internal";
-import { FluidObject, IRequest, IResponse } from "@fluidframework/core-interfaces";
+import {
+	AttachState,
+	type IDeltaManager,
+} from "@fluidframework/container-definitions/internal";
+import type { FluidObject, IRequest, IResponse } from "@fluidframework/core-interfaces";
 import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
 import { assert, Deferred, unreachableCase } from "@fluidframework/core-utils/internal";
 import { FluidObjectHandle } from "@fluidframework/datastore/internal";
-import { IFluidDataStoreRuntimeEvents } from "@fluidframework/datastore-definitions/internal";
-import {
+import type { IFluidDataStoreRuntimeEvents } from "@fluidframework/datastore-definitions/internal";
+import type {
 	IDocumentMessage,
-	type ISnapshotTree,
+	ISnapshotTree,
 	ISequencedDocumentMessage,
 	IQuorumClients,
 } from "@fluidframework/driver-definitions/internal";
 import {
-	IGarbageCollectionData,
-	IFluidDataStoreChannel,
-	IFluidDataStoreContext,
-	IInboundSignalMessage,
+	type IGarbageCollectionData,
+	type IFluidDataStoreChannel,
+	type IFluidDataStoreContext,
+	type IInboundSignalMessage,
 	VisibilityState,
 	type ISummaryTreeWithStats,
 	type ITelemetryContext,
 	type IRuntimeMessageCollection,
 } from "@fluidframework/runtime-definitions/internal";
 import {
-	ITelemetryLoggerExt,
-	MonitoringContext,
+	type ITelemetryLoggerExt,
+	type MonitoringContext,
 	raiseConnectedEvent,
 	createChildMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";

--- a/packages/framework/attributor/src/runtimeAttributorDataStoreFactory.ts
+++ b/packages/framework/attributor/src/runtimeAttributorDataStoreFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	IFluidDataStoreFactory,
 	IFluidDataStoreChannel,
 	IFluidDataStoreContext,

--- a/packages/framework/attributor/src/test/attribution/sharedString.attribution.spec.ts
+++ b/packages/framework/attributor/src/test/attribution/sharedString.attribution.spec.ts
@@ -22,10 +22,10 @@ import {
 	performFuzzActions,
 	take,
 } from "@fluid-private/stochastic-test-utils";
-import {
-	type Jsonable,
-	type IFluidDataStoreRuntime,
-	type IChannelServices,
+import type {
+	Jsonable,
+	IFluidDataStoreRuntime,
+	IChannelServices,
 } from "@fluidframework/datastore-definitions/internal";
 import {
 	type ISummaryTree,
@@ -33,7 +33,7 @@ import {
 	type IQuorumClients,
 	type ISequencedClient,
 } from "@fluidframework/driver-definitions";
-import { type ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { createInsertOnlyAttributionPolicy } from "@fluidframework/merge-tree/internal";
 import { toDeltaManagerInternal } from "@fluidframework/runtime-utils/internal";
 import { SharedString } from "@fluidframework/sequence/internal";

--- a/packages/framework/attributor/src/test/attributor.spec.ts
+++ b/packages/framework/attributor/src/test/attributor.spec.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "node:assert";
 
-import { type IUser } from "@fluidframework/driver-definitions";
-import { type AttributionInfo } from "@fluidframework/runtime-definitions/internal";
+import type { IUser } from "@fluidframework/driver-definitions";
+import type { AttributionInfo } from "@fluidframework/runtime-definitions/internal";
 
 import { Attributor } from "../attributor.js";
 

--- a/packages/framework/attributor/src/test/attributorSerializer.spec.ts
+++ b/packages/framework/attributor/src/test/attributorSerializer.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { type AttributionInfo } from "@fluidframework/runtime-definitions/internal";
+import type { AttributionInfo } from "@fluidframework/runtime-definitions/internal";
 
 import { Attributor, type IAttributor } from "../attributor.js";
 import {
@@ -14,7 +14,7 @@ import {
 	type SerializedAttributor,
 	chain,
 } from "../encoders.js";
-import { type InternedStringId } from "../stringInterner.js";
+import type { InternedStringId } from "../stringInterner.js";
 
 function makeNoopEncoder<T>(): Encoder<T, T> {
 	return {

--- a/packages/framework/attributor/src/test/lz4Encoder.spec.ts
+++ b/packages/framework/attributor/src/test/lz4Encoder.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { type JsonableTypeWith } from "@fluidframework/datastore-definitions/internal";
+import type { JsonableTypeWith } from "@fluidframework/datastore-definitions/internal";
 
 import { makeLZ4Encoder } from "../lz4Encoder.js";
 

--- a/packages/framework/attributor/src/test/opStreamAttributor.spec.ts
+++ b/packages/framework/attributor/src/test/opStreamAttributor.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { type ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { MockDeltaManager } from "@fluidframework/test-runtime-utils/internal";
 
 import { OpStreamAttributor } from "../attributor.js";

--- a/packages/framework/attributor/src/test/utils.ts
+++ b/packages/framework/attributor/src/test/utils.ts
@@ -4,10 +4,10 @@
  */
 
 import type { IAudience } from "@fluidframework/container-definitions";
-import {
-	type IClient,
-	type IQuorumClients,
-	type ISequencedClient,
+import type {
+	IClient,
+	IQuorumClients,
+	ISequencedClient,
 } from "@fluidframework/driver-definitions";
 import { MockQuorumClients } from "@fluidframework/test-runtime-utils/internal";
 

--- a/packages/framework/dds-interceptions/.eslintrc.cjs
+++ b/packages/framework/dds-interceptions/.eslintrc.cjs
@@ -8,4 +8,17 @@ module.exports = {
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
+	rules: {
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
+	},
 };

--- a/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedDirectoryWithInterception.ts
@@ -4,8 +4,8 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { IDirectory } from "@fluidframework/map/internal";
-import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
+import type { IDirectory } from "@fluidframework/map/internal";
+import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
 
 /**
  * - Create a new object from the passed subDirectory.

--- a/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/map/sharedMapWithInterception.ts
@@ -4,8 +4,8 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISharedMap } from "@fluidframework/map/internal";
-import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
+import type { ISharedMap } from "@fluidframework/map/internal";
+import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
 
 /**
  * - Create a new object from the passed SharedMap.

--- a/packages/framework/dds-interceptions/src/sequence/sharedStringWithInterception.ts
+++ b/packages/framework/dds-interceptions/src/sequence/sharedStringWithInterception.ts
@@ -4,9 +4,9 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import * as MergeTree from "@fluidframework/merge-tree/internal";
-import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
-import { SharedString } from "@fluidframework/sequence/internal";
+import type * as MergeTree from "@fluidframework/merge-tree/internal";
+import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
+import type { SharedString } from "@fluidframework/sequence/internal";
 
 /**
  * - Create a new object from the passed SharedString.

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -6,11 +6,11 @@
 import { strict as assert } from "node:assert";
 
 import {
-	IDirectory,
+	type IDirectory,
 	type ISharedDirectory,
 	SharedDirectory,
 } from "@fluidframework/map/internal";
-import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
+import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import { createDirectoryWithInterception } from "../map/index.js";

--- a/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "node:assert";
 
-import { ISharedMap, SharedMap } from "@fluidframework/map/internal";
-import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
+import { type ISharedMap, SharedMap } from "@fluidframework/map/internal";
+import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import { createSharedMapWithInterception } from "../map/index.js";

--- a/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "node:assert";
 
-import { PropertySet } from "@fluidframework/merge-tree/internal";
-import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
+import type { PropertySet } from "@fluidframework/merge-tree/internal";
+import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
 import { SharedString } from "@fluidframework/sequence/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 

--- a/packages/framework/oldest-client-observer/.eslintrc.cjs
+++ b/packages/framework/oldest-client-observer/.eslintrc.cjs
@@ -8,4 +8,17 @@ module.exports = {
 	parserOptions: {
 		project: "./tsconfig.json",
 	},
+	rules: {
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
+	},
 };

--- a/packages/framework/oldest-client-observer/src/index.ts
+++ b/packages/framework/oldest-client-observer/src/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export {
+export type {
 	IOldestClientObservable,
 	IOldestClientObservableEvents,
 	IOldestClientObserver,

--- a/packages/framework/oldest-client-observer/src/interfaces.ts
+++ b/packages/framework/oldest-client-observer/src/interfaces.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { AttachState } from "@fluidframework/container-definitions";
-import { IEvent, IEventProvider } from "@fluidframework/core-interfaces";
-import { IQuorumClients } from "@fluidframework/driver-definitions";
+import type { AttachState } from "@fluidframework/container-definitions";
+import type { IEvent, IEventProvider } from "@fluidframework/core-interfaces";
+import type { IQuorumClients } from "@fluidframework/driver-definitions";
 
 /**
  * Events emitted by {@link IOldestClientObservable}.

--- a/packages/framework/oldest-client-observer/src/oldestClientObserver.ts
+++ b/packages/framework/oldest-client-observer/src/oldestClientObserver.ts
@@ -6,9 +6,9 @@
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { assert } from "@fluidframework/core-utils/internal";
-import { IQuorumClients } from "@fluidframework/driver-definitions";
+import type { IQuorumClients } from "@fluidframework/driver-definitions";
 
-import {
+import type {
 	IOldestClientObservable,
 	IOldestClientObserver,
 	IOldestClientObserverEvents,

--- a/packages/framework/synthesize/.eslintrc.cjs
+++ b/packages/framework/synthesize/.eslintrc.cjs
@@ -11,5 +11,17 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/no-unsafe-return": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
+
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
 	},
 };

--- a/packages/framework/synthesize/src/IFluidDependencySynthesizer.ts
+++ b/packages/framework/synthesize/src/IFluidDependencySynthesizer.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { AsyncFluidObjectProvider, FluidObjectSymbolProvider } from "./types.js";
+import type { AsyncFluidObjectProvider, FluidObjectSymbolProvider } from "./types.js";
 
 /**
  * @legacy

--- a/packages/framework/synthesize/src/dependencyContainer.ts
+++ b/packages/framework/synthesize/src/dependencyContainer.ts
@@ -6,7 +6,7 @@
 import { LazyPromise } from "@fluidframework/core-utils/internal";
 
 import { IFluidDependencySynthesizer } from "./IFluidDependencySynthesizer.js";
-import {
+import type {
 	AsyncFluidObjectProvider,
 	AsyncOptionalFluidObjectProvider,
 	AsyncRequiredFluidObjectProvider,

--- a/packages/framework/synthesize/src/index.ts
+++ b/packages/framework/synthesize/src/index.ts
@@ -6,9 +6,9 @@
 export { DependencyContainer } from "./dependencyContainer.js";
 export {
 	IFluidDependencySynthesizer,
-	IProvideFluidDependencySynthesizer,
+	type IProvideFluidDependencySynthesizer,
 } from "./IFluidDependencySynthesizer.js";
-export {
+export type {
 	AsyncFluidObjectProvider,
 	AsyncOptionalFluidObjectProvider,
 	AsyncRequiredFluidObjectProvider,

--- a/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
+++ b/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
@@ -6,22 +6,22 @@
 import { strict as assert } from "node:assert";
 
 import {
-	FluidObject,
+	type FluidObject,
 	IFluidLoadable,
-	IProvideFluidLoadable,
+	type IProvideFluidLoadable,
 } from "@fluidframework/core-interfaces";
-import {
+import type {
 	IFluidHandleContext,
 	IProvideFluidHandle,
-	type IFluidHandleInternal,
+	IFluidHandleInternal,
 } from "@fluidframework/core-interfaces/internal";
 import { LazyPromise } from "@fluidframework/core-utils/internal";
 import { FluidObjectHandle } from "@fluidframework/datastore/internal";
 import { toFluidHandleInternal } from "@fluidframework/runtime-utils/internal";
 
-import { IFluidDependencySynthesizer } from "../IFluidDependencySynthesizer.js";
+import type { IFluidDependencySynthesizer } from "../IFluidDependencySynthesizer.js";
 import { DependencyContainer } from "../index.js";
-import {
+import type {
 	AsyncFluidObjectProvider,
 	FluidObjectProvider,
 	FluidObjectSymbolProvider,

--- a/packages/framework/synthesize/src/types.ts
+++ b/packages/framework/synthesize/src/types.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidDependencySynthesizer } from "./IFluidDependencySynthesizer.js";
+import type { IFluidDependencySynthesizer } from "./IFluidDependencySynthesizer.js";
 
 /**
  * This is a condensed version of Record that requires the object has all

--- a/packages/framework/undo-redo/.eslintrc.cjs
+++ b/packages/framework/undo-redo/.eslintrc.cjs
@@ -12,6 +12,18 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/no-use-before-define": "off",
 		"no-case-declarations": "off",
+
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
 	},
 	overrides: [
 		{

--- a/packages/framework/undo-redo/src/index.ts
+++ b/packages/framework/undo-redo/src/index.ts
@@ -84,4 +84,4 @@ export {
 	SharedSegmentSequenceRevertible,
 	SharedSegmentSequenceUndoRedoHandler,
 } from "./sequenceHandler.js";
-export { IRevertible, UndoRedoStackManager } from "./undoRedoStackManager.js";
+export { type IRevertible, UndoRedoStackManager } from "./undoRedoStackManager.js";

--- a/packages/framework/undo-redo/src/mapHandler.ts
+++ b/packages/framework/undo-redo/src/mapHandler.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { ISharedMap, IValueChanged } from "@fluidframework/map/internal";
+import type { ISharedMap, IValueChanged } from "@fluidframework/map/internal";
 
-import { IRevertible, UndoRedoStackManager } from "./undoRedoStackManager.js";
+import type { IRevertible, UndoRedoStackManager } from "./undoRedoStackManager.js";
 
 /**
  * A shared map undo redo handler that will add all local map changes to the provided

--- a/packages/framework/undo-redo/src/sequenceHandler.ts
+++ b/packages/framework/undo-redo/src/sequenceHandler.ts
@@ -4,18 +4,18 @@
  */
 
 import {
-	ISegment,
-	MergeTreeDeltaRevertible,
+	type ISegment,
+	type MergeTreeDeltaRevertible,
 	appendToMergeTreeDeltaRevertibles,
 	discardMergeTreeDeltaRevertible,
 	revertMergeTreeDeltaRevertibles,
 } from "@fluidframework/merge-tree/internal";
-import {
+import type {
 	SequenceDeltaEvent,
-	type ISharedSegmentSequence,
+	ISharedSegmentSequence,
 } from "@fluidframework/sequence/internal";
 
-import { IRevertible, UndoRedoStackManager } from "./undoRedoStackManager.js";
+import type { IRevertible, UndoRedoStackManager } from "./undoRedoStackManager.js";
 
 /**
  * A shared segment sequence undo redo handler that will add all local sequences changes to the provided


### PR DESCRIPTION
In preparation for these rules becoming default in the next release of our eslint configuration.

Type-only imports offer a number of benefits and are considered a best practice. More details can be found here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html