### PR TITLE
refactor(client/dds): Enable type-only import/export linter rules and fix violations

### DIFF
--- a/packages/dds/ink/.eslintrc.cjs
+++ b/packages/dds/ink/.eslintrc.cjs
@@ -8,4 +8,17 @@ module.exports = {
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
+	rules: {
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
+	},
 };

--- a/packages/dds/ink/src/index.ts
+++ b/packages/dds/ink/src/index.ts
@@ -6,7 +6,7 @@
 export { Ink } from "./ink.js";
 export { InkCanvas } from "./inkCanvas.js";
 export { InkFactory } from "./inkFactory.js";
-export {
+export type {
 	IClearOperation,
 	IColor,
 	ICreateStrokeOperation,

--- a/packages/dds/ink/src/ink.ts
+++ b/packages/dds/ink/src/ink.ts
@@ -3,26 +3,26 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
 import {
 	MessageType,
-	ISequencedDocumentMessage,
+	type ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
-import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/internal";
+import type { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/internal";
 import {
-	IFluidSerializer,
+	type IFluidSerializer,
 	SharedObject,
 	createSingleBlobSummary,
 } from "@fluidframework/shared-object-base/internal";
 import { v4 as uuid } from "uuid";
 
 import { InkFactory } from "./inkFactory.js";
-import {
+import type {
 	IClearOperation,
 	ICreateStrokeOperation,
 	IInk,
@@ -33,7 +33,7 @@ import {
 	IPen,
 	IStylusOperation,
 } from "./interfaces.js";
-import { ISerializableInk, InkData } from "./snapshot.js";
+import { type ISerializableInk, InkData } from "./snapshot.js";
 
 /**
  * Filename where the snapshot is stored.

--- a/packages/dds/ink/src/inkCanvas.ts
+++ b/packages/dds/ink/src/inkCanvas.ts
@@ -3,7 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { IColor, IInk, IInkPoint, IInkStroke, IPen, IStylusOperation } from "./interfaces.js";
+import type {
+	IColor,
+	IInk,
+	IInkPoint,
+	IInkStroke,
+	IPen,
+	IStylusOperation,
+} from "./interfaces.js";
 
 interface IPoint {
 	x: number;

--- a/packages/dds/ink/src/inkFactory.ts
+++ b/packages/dds/ink/src/inkFactory.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	IChannelAttributes,
 	IChannelFactory,
 	IFluidDataStoreRuntime,
 	IChannelServices,
 } from "@fluidframework/datastore-definitions/internal";
-import { ISharedObject } from "@fluidframework/shared-object-base/internal";
+import type { ISharedObject } from "@fluidframework/shared-object-base/internal";
 
 import { Ink } from "./ink.js";
 import { pkgVersion } from "./packageVersion.js";

--- a/packages/dds/ink/src/interfaces.ts
+++ b/packages/dds/ink/src/interfaces.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	ISharedObject,
 	ISharedObjectEvents,
 } from "@fluidframework/shared-object-base/internal";

--- a/packages/dds/ink/src/snapshot.ts
+++ b/packages/dds/ink/src/snapshot.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IInkStroke } from "./interfaces.js";
+import type { IInkStroke } from "./interfaces.js";
 
 /**
  * Ink snapshot interface.

--- a/packages/dds/ink/src/test/ink.spec.ts
+++ b/packages/dds/ink/src/test/ink.spec.ts
@@ -9,7 +9,7 @@ import { AttachState } from "@fluidframework/container-definitions";
 import {
 	MockContainerRuntimeFactory,
 	MockContainerRuntimeFactoryForReconnection,
-	MockContainerRuntimeForReconnection,
+	type MockContainerRuntimeForReconnection,
 	MockFluidDataStoreRuntime,
 	MockSharedObjectServices,
 	MockStorage,
@@ -17,7 +17,7 @@ import {
 
 import { Ink } from "../ink.js";
 import { InkFactory } from "../inkFactory.js";
-import { IPen } from "../interfaces.js";
+import type { IPen } from "../interfaces.js";
 
 describe("Ink", () => {
 	let ink: Ink;

--- a/packages/dds/matrix/.eslintrc.cjs
+++ b/packages/dds/matrix/.eslintrc.cjs
@@ -12,6 +12,17 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/no-shadow": "off",
 		"space-before-function-paren": "off", // Off because it conflicts with typescript-formatter
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
 	},
 	overrides: [
 		{

--- a/packages/dds/shared-object-base/.eslintrc.cjs
+++ b/packages/dds/shared-object-base/.eslintrc.cjs
@@ -8,4 +8,17 @@ module.exports = {
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
+	rules: {
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
+	},
 };

--- a/packages/dds/shared-object-base/src/gcHandleVisitor.ts
+++ b/packages/dds/shared-object-base/src/gcHandleVisitor.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { type IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
-import { type ISerializedHandle } from "@fluidframework/runtime-utils/internal";
+import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
+import type { ISerializedHandle } from "@fluidframework/runtime-utils/internal";
 
 import { FluidSerializer } from "./serializer.js";
 

--- a/packages/dds/shared-object-base/src/handle.ts
+++ b/packages/dds/shared-object-base/src/handle.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { type IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
+import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
 import { FluidObjectHandle } from "@fluidframework/datastore/internal";
 // eslint-disable-next-line import/no-deprecated
 import type { IFluidDataStoreRuntimeExperimental } from "@fluidframework/datastore-definitions/internal";
 import { isFluidHandle } from "@fluidframework/runtime-utils";
 
-import { ISharedObject } from "./types.js";
+import type { ISharedObject } from "./types.js";
 
 /**
  * Handle for a shared object. See also `SharedObjectHandle`.

--- a/packages/dds/shared-object-base/src/index.ts
+++ b/packages/dds/shared-object-base/src/index.ts
@@ -3,16 +3,16 @@
  * Licensed under the MIT License.
  */
 
-export { ISharedObjectHandle, isISharedObjectHandle } from "./handle.js";
-export { FluidSerializer, IFluidSerializer } from "./serializer.js";
+export { type ISharedObjectHandle, isISharedObjectHandle } from "./handle.js";
+export { FluidSerializer, type IFluidSerializer } from "./serializer.js";
 export {
 	SharedObject,
 	SharedObjectCore,
-	ISharedObjectKind,
-	SharedObjectKind,
+	type ISharedObjectKind,
+	type SharedObjectKind,
 	createSharedObjectKind,
 } from "./sharedObject.js";
-export { ISharedObject, ISharedObjectEvents } from "./types.js";
+export type { ISharedObject, ISharedObjectEvents } from "./types.js";
 export {
 	createSingleBlobSummary,
 	makeHandlesSerializable,
@@ -23,12 +23,12 @@ export {
 } from "./utils.js";
 export { ValueType } from "./valueType.js";
 export {
-	SharedKernel,
+	type SharedKernel,
 	thisWrap,
-	KernelArgs,
+	type KernelArgs,
 	makeSharedObjectKind,
-	SharedKernelFactory,
-	FactoryOut,
-	SharedObjectOptions,
+	type SharedKernelFactory,
+	type FactoryOut,
+	type SharedObjectOptions,
 	mergeAPIs,
 } from "./sharedObjectKernel.js";

--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidHandle } from "@fluidframework/core-interfaces";
-import {
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import type {
 	IFluidHandleContext,
-	type IFluidHandleInternal,
+	IFluidHandleInternal,
 } from "@fluidframework/core-interfaces/internal";
 import { assert, shallowCloneObject } from "@fluidframework/core-utils/internal";
 import {

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -3,34 +3,34 @@
  * Licensed under the MIT License.
  */
 
-import { EventEmitterEventType } from "@fluid-internal/client-utils";
+import type { EventEmitterEventType } from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import type { IDeltaManager } from "@fluidframework/container-definitions/internal";
-import { ITelemetryBaseProperties, type ErasedType } from "@fluidframework/core-interfaces";
-import {
-	type IFluidHandleInternal,
-	type IFluidLoadable,
+import type { ITelemetryBaseProperties, ErasedType } from "@fluidframework/core-interfaces";
+import type {
+	IFluidHandleInternal,
+	IFluidLoadable,
 } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
-import {
+import type {
 	IChannelServices,
 	IChannelStorageService,
-	type IChannel,
+	IChannel,
 	IChannelAttributes,
-	type IChannelFactory,
+	IChannelFactory,
 	IFluidDataStoreRuntime,
-	type IDeltaHandler,
-	type IFluidDataStoreRuntimeInternalConfig,
+	IDeltaHandler,
+	IFluidDataStoreRuntimeInternalConfig,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	type IDocumentMessage,
+import type {
+	IDocumentMessage,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import {
-	IExperimentalIncrementalSummaryContext,
-	ISummaryTreeWithStats,
-	ITelemetryContext,
-	IGarbageCollectionData,
+	type IExperimentalIncrementalSummaryContext,
+	type ISummaryTreeWithStats,
+	type ITelemetryContext,
+	type IGarbageCollectionData,
 	blobCountPropertyName,
 	totalBlobSizePropertyName,
 	type IRuntimeMessageCollection,
@@ -38,13 +38,13 @@ import {
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	toDeltaManagerInternal,
-	TelemetryContext,
+	type TelemetryContext,
 } from "@fluidframework/runtime-utils/internal";
 import {
-	ITelemetryLoggerExt,
+	type ITelemetryLoggerExt,
 	DataProcessingError,
 	EventEmitterWithErrorHandling,
-	MonitoringContext,
+	type MonitoringContext,
 	SampledTelemetryHelper,
 	createChildLogger,
 	loggerToMonitoringContext,
@@ -57,8 +57,8 @@ import { v4 as uuid } from "uuid";
 
 import { GCHandleVisitor } from "./gcHandleVisitor.js";
 import { SharedObjectHandle } from "./handle.js";
-import { FluidSerializer, IFluidSerializer } from "./serializer.js";
-import { ISharedObject, ISharedObjectEvents } from "./types.js";
+import { FluidSerializer, type IFluidSerializer } from "./serializer.js";
+import type { ISharedObject, ISharedObjectEvents } from "./types.js";
 import { bindHandles, makeHandlesSerializable, parseHandles } from "./utils.js";
 
 /**

--- a/packages/dds/shared-object-base/src/sharedObjectKernel.ts
+++ b/packages/dds/shared-object-base/src/sharedObjectKernel.ts
@@ -6,31 +6,31 @@
 import type { TypedEventEmitter } from "@fluid-internal/client-utils";
 import type { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { assert, fail } from "@fluidframework/core-utils/internal";
-import {
+import type {
 	IChannelStorageService,
-	type IChannel,
-	type IChannelAttributes,
-	type IChannelFactory,
-	type IChannelServices,
-	type IFluidDataStoreRuntime,
+	IChannel,
+	IChannelAttributes,
+	IChannelFactory,
+	IChannelServices,
+	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor/internal";
-import {
+import type {
 	ISummaryTreeWithStats,
 	ITelemetryContext,
-	type IExperimentalIncrementalSummaryContext,
-	type IRuntimeMessageCollection,
+	IExperimentalIncrementalSummaryContext,
+	IRuntimeMessageCollection,
 } from "@fluidframework/runtime-definitions/internal";
 import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
-import { IFluidSerializer } from "./serializer.js";
+import type { IFluidSerializer } from "./serializer.js";
 import {
 	createSharedObjectKind,
 	SharedObject,
 	type ISharedObjectKind,
 	type SharedObjectKind,
 } from "./sharedObject.js";
-import { ISharedObjectEvents, type ISharedObject } from "./types.js";
+import type { ISharedObjectEvents, ISharedObject } from "./types.js";
 import type { IChannelView } from "./utils.js";
 
 /**

--- a/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
+++ b/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
@@ -8,23 +8,23 @@ import { strict as assert } from "node:assert";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { generatePairwiseOptions } from "@fluid-private/test-pairwise-generator";
 import { AttachState } from "@fluidframework/container-definitions";
-import {
-	type IChannelAttributes,
-	type IFluidDataStoreRuntime,
-	type IFluidDataStoreRuntimeEvents,
+import type {
+	IChannelAttributes,
+	IFluidDataStoreRuntime,
+	IFluidDataStoreRuntimeEvents,
 	IChannelServices,
 	IChannelStorageService,
 	IDeltaConnection,
 } from "@fluidframework/datastore-definitions/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
-import {
-	type IExperimentalIncrementalSummaryContext,
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type {
+	IExperimentalIncrementalSummaryContext,
 	ISummaryTreeWithStats,
-	type ITelemetryContext,
+	ITelemetryContext,
 } from "@fluidframework/runtime-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 
-import { IFluidSerializer } from "../serializer.js";
+import type { IFluidSerializer } from "../serializer.js";
 import { SharedObject } from "../sharedObject.js";
 
 /* eslint-disable-next-line @typescript-eslint/ban-types --

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -7,14 +7,14 @@ import { strict as assert } from "node:assert";
 
 // Add IFluidHandle import for mock handle
 import type { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
-import {
+import type {
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 	IFluidDataStoreRuntimeInternalConfig,
 } from "@fluidframework/datastore-definitions/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
-import {
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type {
 	IGarbageCollectionData,
 	ISummaryTreeWithStats,
 } from "@fluidframework/runtime-definitions/internal";
@@ -26,7 +26,7 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 import sinon from "sinon";
 
-import { FluidSerializer, IFluidSerializer } from "../serializer.js";
+import { FluidSerializer, type IFluidSerializer } from "../serializer.js";
 import { SharedObject, SharedObjectCore } from "../sharedObject.js";
 
 class MySharedObject extends SharedObject {

--- a/packages/dds/shared-object-base/src/test/utils.ts
+++ b/packages/dds/shared-object-base/src/test/utils.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest } from "@fluidframework/core-interfaces";
-import { IFluidHandleContext, type IResponse } from "@fluidframework/core-interfaces/internal";
-import { Serializable } from "@fluidframework/datastore-definitions/internal";
+import type { IRequest } from "@fluidframework/core-interfaces";
+import type { IFluidHandleContext, IResponse } from "@fluidframework/core-interfaces/internal";
+import type { Serializable } from "@fluidframework/datastore-definitions/internal";
 import { create404Response } from "@fluidframework/runtime-utils/internal";
 
 export class MockHandleContext implements IFluidHandleContext {

--- a/packages/dds/shared-object-base/src/types.ts
+++ b/packages/dds/shared-object-base/src/types.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	IErrorEvent,
 	IEventProvider,
 	IEventThisPlaceHolder,
 } from "@fluidframework/core-interfaces";
-import { IChannel } from "@fluidframework/datastore-definitions/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type { IChannel } from "@fluidframework/datastore-definitions/internal";
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 
 /**
  * Events emitted by {@link ISharedObject}.

--- a/packages/dds/shared-object-base/src/utils.ts
+++ b/packages/dds/shared-object-base/src/utils.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { IChannel } from "@fluidframework/datastore-definitions/internal";
-import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/internal";
+import type { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/internal";
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils/internal";
 
-import { IFluidSerializer } from "./serializer.js";
+import type { IFluidSerializer } from "./serializer.js";
 
 /**
  * Given a mostly-plain object that may have handle objects embedded within, return a string representation of an object

--- a/packages/dds/shared-summary-block/.eslintrc.cjs
+++ b/packages/dds/shared-summary-block/.eslintrc.cjs
@@ -8,4 +8,17 @@ module.exports = {
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},
+	rules: {
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
+	},
 };

--- a/packages/dds/shared-summary-block/src/index.ts
+++ b/packages/dds/shared-summary-block/src/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export { ISharedSummaryBlock } from "./interfaces.js";
+export type { ISharedSummaryBlock } from "./interfaces.js";
 export { SharedSummaryBlock } from "./sharedSummaryBlockFactory.js";

--- a/packages/dds/shared-summary-block/src/interfaces.ts
+++ b/packages/dds/shared-summary-block/src/interfaces.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
-import { ISharedObject } from "@fluidframework/shared-object-base/internal";
+import type { Jsonable } from "@fluidframework/datastore-definitions/internal";
+import type { ISharedObject } from "@fluidframework/shared-object-base/internal";
 
 /**
  * Shared summary block interface. A shared summary block is part of the summary but it does not generate any ops.

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
@@ -3,22 +3,22 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	Jsonable,
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
 	IChannelStorageService,
 } from "@fluidframework/datastore-definitions/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
-import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/internal";
+import type { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions/internal";
 import {
-	IFluidSerializer,
+	type IFluidSerializer,
 	SharedObject,
 	createSingleBlobSummary,
 } from "@fluidframework/shared-object-base/internal";
 
-import { ISharedSummaryBlock } from "./interfaces.js";
+import type { ISharedSummaryBlock } from "./interfaces.js";
 
 const snapshotFileName = "header";
 

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlockFactory.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlockFactory.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	IChannelAttributes,
 	IChannelFactory,
 	IFluidDataStoreRuntime,

--- a/packages/dds/shared-summary-block/src/test/sharedSummaryBlock.spec.ts
+++ b/packages/dds/shared-summary-block/src/test/sharedSummaryBlock.spec.ts
@@ -6,13 +6,13 @@
 import { strict as assert } from "node:assert";
 
 import { AttachState } from "@fluidframework/container-definitions";
-import { ISummaryBlob } from "@fluidframework/driver-definitions";
+import type { ISummaryBlob } from "@fluidframework/driver-definitions";
 import {
 	MockFluidDataStoreRuntime,
 	MockSharedObjectServices,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { ISharedSummaryBlock } from "../interfaces.js";
+import type { ISharedSummaryBlock } from "../interfaces.js";
 import { SharedSummaryBlockFactory } from "../sharedSummaryBlockFactory.js";
 
 interface ITestInterface {

--- a/packages/dds/test-dds-utils/.eslintrc.cjs
+++ b/packages/dds/test-dds-utils/.eslintrc.cjs
@@ -12,5 +12,17 @@ module.exports = {
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		// This package implements test utils to be run under Node.JS.
 		"import/no-nodejs-modules": "off",
+
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
+		"@typescript-eslint/consistent-type-exports": [
+			"error",
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ fixStyle: "inline-type-imports" },
+		],
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		// #endregion
 	},
 };

--- a/packages/dds/test-dds-utils/src/ddsFuzzHandle.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHandle.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
+import type { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import {
 	FluidHandleBase,
 	generateHandleContextPath,

--- a/packages/dds/test-dds-utils/src/fuzzSerializer.ts
+++ b/packages/dds/test-dds-utils/src/fuzzSerializer.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	IFluidHandleContext,
-	type IFluidHandleInternal,
+	IFluidHandleInternal,
 } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import {

--- a/packages/dds/test-dds-utils/src/squashFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/squashFuzzHarness.ts
@@ -17,7 +17,7 @@ import { done } from "@fluid-private/stochastic-test-utils";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { IChannelFactory } from "@fluidframework/datastore-definitions/internal";
 
-import { type Client } from "./clientLoading.js";
+import type { Client } from "./clientLoading.js";
 import { PoisonedDDSFuzzHandle } from "./ddsFuzzHandle.js";
 import {
 	setupClientContext,

--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -24,9 +24,10 @@ module.exports = {
 			},
 		],
 
-		// #region TODO: Remove these overrides once this config has been updated to extend the "strict" base config.
-
+		// TODO: Remove this override once this config has been updated to extend the "strict" base config.
 		"@typescript-eslint/explicit-member-accessibility": "error",
+
+		// #region TODO: remove these once eslint-config-fluid has been updated to 5.8.0
 		"@typescript-eslint/consistent-type-exports": [
 			"error",
 			{ fixMixedExportsWithInlineTypeSpecifier: true },


### PR DESCRIPTION
In preparation for these rules becoming default in the next release of our eslint configuration.

Type-only imports offer a number of benefits and are considered a best practice. More details can be found here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html