### PR TITLE
(compat): Replace Driver layer dependency with Loader layer in the Runtime

### DIFF
--- a/.changeset/curvy-dingos-fail.md
+++ b/.changeset/curvy-dingos-fail.md
@@ -2,8 +2,18 @@
 "@fluidframework/runtime-definitions": minor
 "__section": deprecation
 ---
-Deprecated all properties except "readBlob" on "IRuntimeStorageService"
+Introduced new interface "IRuntimeStorageService" to replace "IDocumentStorageService" between Runtime and DataStore layers
 
-`IRuntimeStorageService` is a duplicate of `IDocumentStorageService`. It is exposed by the `ContainerRuntime` to the `DataStore` layer and will only contain the `readBlob` property which it needs.
+Added an interface `IRuntimeStorageService` which will replace `IDocumentStorageService` in the `DataStore` layer. This is exposed by the `Runtime` layer to the `DataStore` layer. This new interface will only contain properties that are needed and used by the `DataStore` layer.
 
-All other properties are deprecated and will be removed in a future release.
+The following properties from `IRuntimeStorageService` are deprecated as they are not needed by the `DataStore` layer. These be removed in a future release:
+
+- `disposed`
+- `dispose`
+- `policies`
+- `getSnapshotTree`
+- `getSnapshot`
+- `getVersions`
+- `createBlob`
+- `uploadSummaryWithContext`
+- `downloadSummary`

--- a/.changeset/curvy-dingos-fail.md
+++ b/.changeset/curvy-dingos-fail.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/container-definitions": minor
+"__section": deprecation
+---
+Deprecated all properties except "readBlob" on "IRuntimeStorageService"
+
+`IRuntimeStorageService` is a duplicate of `IDocumentStorageService`. It will be exposed by the `ContainerRuntime` to the `DataStore` layer and will only contain the `readBlob` property which it needs.
+All other properties are deprecated and will be removed in a future release.

--- a/.changeset/curvy-dingos-fail.md
+++ b/.changeset/curvy-dingos-fail.md
@@ -4,5 +4,6 @@
 ---
 Deprecated all properties except "readBlob" on "IRuntimeStorageService"
 
-`IRuntimeStorageService` is a duplicate of `IDocumentStorageService`. It will be exposed by the `ContainerRuntime` to the `DataStore` layer and will only contain the `readBlob` property which it needs.
+`IRuntimeStorageService` is a duplicate of `IDocumentStorageService`. It is exposed by the `ContainerRuntime` to the `DataStore` layer and will only contain the `readBlob` property which it needs.
+
 All other properties are deprecated and will be removed in a future release.

--- a/.changeset/curvy-dingos-fail.md
+++ b/.changeset/curvy-dingos-fail.md
@@ -1,6 +1,6 @@
 ---
 "@fluidframework/runtime-definitions": minor
-"__section": deprecation
+"__section": legacy
 ---
 Introduced new interface "IRuntimeStorageService" to replace "IDocumentStorageService" between Runtime and DataStore layers
 

--- a/.changeset/curvy-dingos-fail.md
+++ b/.changeset/curvy-dingos-fail.md
@@ -1,5 +1,5 @@
 ---
-"@fluidframework/container-definitions": minor
+"@fluidframework/runtime-definitions": minor
 "__section": deprecation
 ---
 Deprecated all properties except "readBlob" on "IRuntimeStorageService"

--- a/.changeset/few-snakes-travel.md
+++ b/.changeset/few-snakes-travel.md
@@ -1,6 +1,6 @@
 ---
 "@fluidframework/container-definitions": minor
-"__section": deprecation
+"__section": legacy
 ---
 Introduced new interface "IContainerStorageService" to replace "IDocumentStorageService" between Loader and Runtime layers
 

--- a/.changeset/few-snakes-travel.md
+++ b/.changeset/few-snakes-travel.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/container-definitions": minor
+"__section": deprecation
+---
+Deprecated "policies" and "downloadSummary" on "IRuntimeStorageService"
+
+`IRuntimeStorageService` is a duplicate of `IDocumentStorageService`. It is exposed to the `ContainerRuntime` via a property on `IContainerContext`.
+The property `downloadSummary`  on `IRuntimeStorageService` is deprecated as it is unused in the Runtime layer. No replacement is provided and this will be removed in a future release.
+The property `policies`  on `IRuntimeStorageService` is deprecated. The Runtime only needs `maximumCacheDurationMs` property from it which is added directly on `IRuntimeStorageService`.

--- a/.changeset/few-snakes-travel.md
+++ b/.changeset/few-snakes-travel.md
@@ -10,3 +10,5 @@ The following properties from `IContainerStorageService` are deprecated as they 
 
 - `policies` - The Runtime only needs `maximumCacheDurationMs` property from it which is added directly on `IContainerStorageService`.
 - `downloadSummary`
+- `disposed`
+- `dispose`

--- a/.changeset/few-snakes-travel.md
+++ b/.changeset/few-snakes-travel.md
@@ -2,8 +2,8 @@
 "@fluidframework/container-definitions": minor
 "__section": deprecation
 ---
-Deprecated "policies" and "downloadSummary" on "IRuntimeStorageService"
+Deprecated "policies" and "downloadSummary" on "IContainerStorageService"
 
-`IRuntimeStorageService` is a duplicate of `IDocumentStorageService`. It is exposed to the `ContainerRuntime` via a property on `IContainerContext`.
-The property `downloadSummary`  on `IRuntimeStorageService` is deprecated as it is unused in the Runtime layer. No replacement is provided and this will be removed in a future release.
-The property `policies`  on `IRuntimeStorageService` is deprecated. The Runtime only needs `maximumCacheDurationMs` property from it which is added directly on `IRuntimeStorageService`.
+`IContainerStorageService` is a duplicate of `IDocumentStorageService`. It is exposed to the `ContainerRuntime` via a property on `IContainerContext` and will only contain properties needs by it.
+The property `downloadSummary`  on `IContainerStorageService` is deprecated as it is unused in the Runtime layer. No replacement is provided and this will be removed in a future release.
+The property `policies`  on `IContainerStorageService` is deprecated. The Runtime only needs `maximumCacheDurationMs` property from it which is added directly on `IContainerStorageService`. `policies` will be removed in a future release.

--- a/.changeset/few-snakes-travel.md
+++ b/.changeset/few-snakes-travel.md
@@ -2,10 +2,11 @@
 "@fluidframework/container-definitions": minor
 "__section": deprecation
 ---
-Deprecated "policies" and "downloadSummary" on "IContainerStorageService"
+Introduced new interface "IContainerStorageService" to replace "IDocumentStorageService" between Loader and Runtime layers
 
-`IContainerStorageService` is a duplicate of `IDocumentStorageService`. It is exposed by the `ContainerContext` to the `Runtime` layer and will only contain properties needed by it.
+Added an interface `IContainerStorageService` which will replace `IDocumentStorageService` in the `Runtime` layer. This is exposed by the `Loader` layer to the `Runtime` layer via `ContainerContext`. This will help remove `Runtime` layer's dependency on the `Driver` layer and replace it with the `Loader` layer that it already maintains. This new interface will only contain properties that are needed and used by the `Runtime` layer.
 
-The property `downloadSummary`  on `IContainerStorageService` is deprecated as it is unused in the Runtime layer. No replacement is provided and this will be removed in a future release.
+The following properties from `IContainerStorageService` are deprecated as they are not needed by the `DataStore` layer. These be removed in a future release:
 
-The property `policies`  on `IContainerStorageService` is deprecated. The Runtime only needs `maximumCacheDurationMs` property from it which is added directly on `IContainerStorageService`. `policies` will be removed in a future release.
+- `policies` - The Runtime only needs `maximumCacheDurationMs` property from it which is added directly on `IContainerStorageService`.
+- `downloadSummary`

--- a/.changeset/few-snakes-travel.md
+++ b/.changeset/few-snakes-travel.md
@@ -4,6 +4,8 @@
 ---
 Deprecated "policies" and "downloadSummary" on "IContainerStorageService"
 
-`IContainerStorageService` is a duplicate of `IDocumentStorageService`. It is exposed to the `ContainerRuntime` via a property on `IContainerContext` and will only contain properties needs by it.
+`IContainerStorageService` is a duplicate of `IDocumentStorageService`. It is exposed by the `ContainerContext` to the `Runtime` layer and will only contain properties needed by it.
+
 The property `downloadSummary`  on `IContainerStorageService` is deprecated as it is unused in the Runtime layer. No replacement is provided and this will be removed in a future release.
+
 The property `policies`  on `IContainerStorageService` is deprecated. The Runtime only needs `maximumCacheDurationMs` property from it which is added directly on `IContainerStorageService`. `policies` will be removed in a future release.

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
@@ -202,8 +202,12 @@ export type IContainerPolicies = {
 };
 
 // @alpha @legacy
-export interface IContainerStorageService extends Partial<IDisposable> {
+export interface IContainerStorageService {
     createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
+    // @deprecated
+    dispose?(error?: Error): void;
+    // @deprecated
+    readonly disposed?: boolean;
     // @deprecated
     downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
     getSnapshot?(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot>;

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
@@ -154,7 +154,7 @@ export interface IContainerContext {
     readonly scope: FluidObject;
     readonly snapshotWithContents?: ISnapshot;
     // (undocumented)
-    readonly storage: IRuntimeStorageService;
+    readonly storage: IContainerStorageService;
     // (undocumented)
     readonly submitBatchFn: (batch: IBatchMessage[], referenceSequenceNumber?: number) => number;
     // @deprecated (undocumented)
@@ -200,6 +200,21 @@ export interface IContainerLoadMode {
 export type IContainerPolicies = {
     maxClientLeaveWaitTime?: number;
 };
+
+// @alpha @legacy
+export interface IContainerStorageService extends Partial<IDisposable> {
+    createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
+    // @deprecated
+    downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
+    getSnapshot?(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot>;
+    getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
+    getVersions(versionId: string | null, count: number, scenarioName?: string, fetchSource?: FetchSource): Promise<IVersion[]>;
+    readonly maximumCacheDurationMs?: IDocumentStorageServicePolicies["maximumCacheDurationMs"];
+    // @deprecated
+    readonly policies?: IDocumentStorageServicePolicies | undefined;
+    readBlob(id: string): Promise<ArrayBufferLike>;
+    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
+}
 
 // @public
 export type ICriticalContainerError = IErrorBase_2;
@@ -404,21 +419,6 @@ export const IRuntimeFactory: keyof IProvideRuntimeFactory;
 // @alpha @legacy
 export interface IRuntimeFactory extends IProvideRuntimeFactory {
     instantiateRuntime(context: IContainerContext, existing: boolean): Promise<IRuntime>;
-}
-
-// @alpha @legacy
-export interface IRuntimeStorageService extends Partial<IDisposable> {
-    createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
-    // @deprecated
-    downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
-    getSnapshot?(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot>;
-    getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
-    getVersions(versionId: string | null, count: number, scenarioName?: string, fetchSource?: FetchSource): Promise<IVersion[]>;
-    readonly maximumCacheDurationMs?: IDocumentStorageServicePolicies["maximumCacheDurationMs"];
-    // @deprecated
-    readonly policies?: IDocumentStorageServicePolicies | undefined;
-    readBlob(id: string): Promise<ArrayBufferLike>;
-    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
 }
 
 // @public

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
@@ -154,7 +154,7 @@ export interface IContainerContext {
     readonly scope: FluidObject;
     readonly snapshotWithContents?: ISnapshot;
     // (undocumented)
-    readonly storage: IDocumentStorageService;
+    readonly storage: IRuntimeStorageService;
     // (undocumented)
     readonly submitBatchFn: (batch: IBatchMessage[], referenceSequenceNumber?: number) => number;
     // @deprecated (undocumented)
@@ -404,6 +404,21 @@ export const IRuntimeFactory: keyof IProvideRuntimeFactory;
 // @alpha @legacy
 export interface IRuntimeFactory extends IProvideRuntimeFactory {
     instantiateRuntime(context: IContainerContext, existing: boolean): Promise<IRuntime>;
+}
+
+// @alpha @legacy
+export interface IRuntimeStorageService extends Partial<IDisposable> {
+    createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
+    // @deprecated
+    downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
+    getSnapshot?(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot>;
+    getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
+    getVersions(versionId: string | null, count: number, scenarioName?: string, fetchSource?: FetchSource): Promise<IVersion[]>;
+    readonly maximumCacheDurationMs?: IDocumentStorageServicePolicies["maximumCacheDurationMs"];
+    // @deprecated
+    readonly policies?: IDocumentStorageServicePolicies | undefined;
+    readBlob(id: string): Promise<ArrayBufferLike>;
+    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
 }
 
 // @public

--- a/packages/common/container-definitions/src/index.ts
+++ b/packages/common/container-definitions/src/index.ts
@@ -66,7 +66,7 @@ export type {
 	IRuntime,
 	IGetPendingLocalStateProps,
 } from "./runtime.js";
-export { AttachState, IRuntimeFactory, type IRuntimeStorageService } from "./runtime.js";
+export { AttachState, IRuntimeFactory, type IContainerStorageService } from "./runtime.js";
 
 export type {
 	/**

--- a/packages/common/container-definitions/src/index.ts
+++ b/packages/common/container-definitions/src/index.ts
@@ -66,7 +66,7 @@ export type {
 	IRuntime,
 	IGetPendingLocalStateProps,
 } from "./runtime.js";
-export { AttachState, IRuntimeFactory } from "./runtime.js";
+export { AttachState, IRuntimeFactory, type IRuntimeStorageService } from "./runtime.js";
 
 export type {
 	/**

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -145,7 +145,7 @@ export interface IBatchMessage {
  * @legacy
  * @alpha
  */
-export interface IRuntimeStorageService extends Partial<IDisposable> {
+export interface IContainerStorageService extends Partial<IDisposable> {
 	/**
 	 * Policies implemented/instructed by driver.
 	 *
@@ -250,7 +250,7 @@ export interface IContainerContext {
 	readonly options: Record<string | number, any>;
 	readonly clientId: string | undefined;
 	readonly clientDetails: IClientDetails;
-	readonly storage: IRuntimeStorageService;
+	readonly storage: IContainerStorageService;
 	readonly connected: boolean;
 	readonly baseSnapshot: ISnapshotTree | undefined;
 	/**

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -145,12 +145,31 @@ export interface IBatchMessage {
  * @legacy
  * @alpha
  */
-export interface IContainerStorageService extends Partial<IDisposable> {
+export interface IContainerStorageService {
+	/**
+	 * Whether or not the object has been disposed.
+	 * If true, the object should be considered invalid, and its other state should be disregarded.
+	 *
+	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
+	 * it is unused in the Runtime layer.
+	 */
+	readonly disposed?: boolean;
+
+	/**
+	 * Dispose of the object and its resources.
+	 * @param error - Optional error indicating the reason for the disposal, if the object was
+	 * disposed as the result of an error.
+	 *
+	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
+	 * it is unused in the Runtime layer.
+	 */
+	dispose?(error?: Error): void;
+
 	/**
 	 * Policies implemented/instructed by driver.
 	 *
-	 * @deprecated - This will be removed in a future release. The Runtime only needs `maximumCacheDurationMs` policy
-	 * which is added as a separate property.
+	 * @deprecated - This will be removed in a future release. The Runtime layer only needs `maximumCacheDurationMs`
+	 * policy which is added as a separate property.
 	 */
 	readonly policies?: IDocumentStorageServicePolicies | undefined;
 

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -14,7 +14,6 @@ import type {
 	ISummaryTree,
 } from "@fluidframework/driver-definitions";
 import type {
-	IDocumentStorageService,
 	ISnapshot,
 	IDocumentMessage,
 	ISnapshotTree,
@@ -22,6 +21,12 @@ import type {
 	IVersion,
 	MessageType,
 	ISequencedDocumentMessage,
+	ICreateBlobResponse,
+	ISummaryContext,
+	ISnapshotFetchOptions,
+	FetchSource,
+	IDocumentStorageServicePolicies,
+	ISummaryHandle,
 } from "@fluidframework/driver-definitions/internal";
 
 import type { IAudience } from "./audience.js";
@@ -130,6 +135,97 @@ export interface IBatchMessage {
 }
 
 /**
+ * Interface to provide access to snapshots and policies to the Runtime layer. This should follow the Loader / Runtime
+ * layer compatibility rules.
+ *
+ * @remarks It contains a subset of APIs from {@link @fluidframework/driver-definitions#IDocumentStorageService} but
+ * allows the Runtime to not support layer compatibility with the Driver layer. Instead, it supports compatibility
+ * with the Loader layer which it already does.
+ *
+ * @legacy
+ * @alpha
+ */
+export interface IRuntimeStorageService extends Partial<IDisposable> {
+	/**
+	 * Policies implemented/instructed by driver.
+	 *
+	 * @deprecated - This will be removed in a future release. The Runtime only needs `maximumCacheDurationMs` policy
+	 * which is added as a separate property.
+	 */
+	readonly policies?: IDocumentStorageServicePolicies | undefined;
+
+	/**
+	 * See {@link @fluidframework/driver-definitions#IDocumentStorageServicePolicies.maximumCacheDurationMs}
+	 */
+	readonly maximumCacheDurationMs?: IDocumentStorageServicePolicies["maximumCacheDurationMs"];
+
+	/**
+	 * Returns the snapshot tree.
+	 * @param version - Version of the snapshot to be fetched.
+	 * @param scenarioName - scenario in which this api is called. This will be recorded by server and would help
+	 * in debugging purposes to see why this call was made.
+	 */
+	// TODO: use `undefined` instead.
+	// eslint-disable-next-line @rushstack/no-new-null
+	getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
+
+	/**
+	 * Returns the snapshot which can contain other artifacts too like blob contents, ops etc. It is different from
+	 * `getSnapshotTree` api in that, that API only returns the snapshot tree from the snapshot.
+	 * @param snapshotFetchOptions - Options specified by the caller to specify and want certain behavior from the
+	 * driver when fetching the snapshot.
+	 */
+	getSnapshot?(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot>;
+
+	/**
+	 * Retrieves all versions of the document starting at the specified versionId - or null if from the head
+	 * @param versionId - Version id of the requested version.
+	 * @param count - Number of the versions to be fetched.
+	 * @param scenarioName - scenario in which this api is called. This will be recorded by server and would help
+	 * in debugging purposes to see why this call was made.
+	 * @param fetchSource - Callers can specify the source of the response. For ex. Driver may choose to cache
+	 * requests and serve data from cache. That will result in stale info returned. Callers can disable this
+	 * functionality by passing fetchSource = noCache and ensuring that driver will return latest information
+	 * from storage.
+	 */
+	getVersions(
+		// TODO: use `undefined` instead.
+		// eslint-disable-next-line @rushstack/no-new-null
+		versionId: string | null,
+		count: number,
+		scenarioName?: string,
+		fetchSource?: FetchSource,
+	): Promise<IVersion[]>;
+
+	/**
+	 * Creates a blob out of the given buffer
+	 */
+	createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
+
+	/**
+	 * Reads the object with the given ID, returns content in arrayBufferLike
+	 */
+	readBlob(id: string): Promise<ArrayBufferLike>;
+
+	/**
+	 * Uploads a summary tree to storage using the given context for reference of previous summary handle.
+	 * The ISummaryHandles in the uploaded tree should have paths to indicate which summary object they are
+	 * referencing from the previously acked summary.
+	 * Returns the uploaded summary handle.
+	 */
+	uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
+
+	/**
+	 * Retrieves the commit that matches the packfile handle. If the packfile has already been committed and the
+	 * server has deleted it this call may result in a broken promise.
+	 *
+	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
+	 * it is unused in the Runtime and below layers.
+	 */
+	downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
+}
+
+/**
  * IContainerContext is fundamentally just the set of things that an IRuntimeFactory (and IRuntime) will consume from the
  * loader layer.
  * It gets passed into the {@link (IRuntimeFactory:interface).instantiateRuntime} call.
@@ -154,7 +250,7 @@ export interface IContainerContext {
 	readonly options: Record<string | number, any>;
 	readonly clientId: string | undefined;
 	readonly clientDetails: IClientDetails;
-	readonly storage: IDocumentStorageService;
+	readonly storage: IRuntimeStorageService;
 	readonly connected: boolean;
 	readonly baseSnapshot: ISnapshotTree | undefined;
 	/**

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -18,7 +18,7 @@ import {
 	ILoader,
 	ILoaderOptions,
 	IDeltaManager,
-	type IRuntimeStorageService,
+	type IContainerStorageService,
 } from "@fluidframework/container-definitions/internal";
 import { type FluidObject } from "@fluidframework/core-interfaces";
 import { type ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
@@ -85,7 +85,7 @@ export class ContainerContext implements IContainerContext, IProvideLayerCompatD
 		public readonly baseSnapshot: ISnapshotTree | undefined,
 		private readonly _version: IVersion | undefined,
 		public readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
-		public readonly storage: IRuntimeStorageService,
+		public readonly storage: IContainerStorageService,
 		public readonly quorum: IQuorumClients,
 		public readonly audience: IAudience,
 		public readonly loader: ILoader,

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -18,12 +18,12 @@ import {
 	ILoader,
 	ILoaderOptions,
 	IDeltaManager,
+	type IRuntimeStorageService,
 } from "@fluidframework/container-definitions/internal";
 import { type FluidObject } from "@fluidframework/core-interfaces";
 import { type ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
 import { IClientDetails, IQuorumClients } from "@fluidframework/driver-definitions";
 import {
-	IDocumentStorageService,
 	ISnapshot,
 	IDocumentMessage,
 	ISnapshotTree,
@@ -85,7 +85,7 @@ export class ContainerContext implements IContainerContext, IProvideLayerCompatD
 		public readonly baseSnapshot: ISnapshotTree | undefined,
 		private readonly _version: IVersion | undefined,
 		public readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
-		public readonly storage: IDocumentStorageService,
+		public readonly storage: IRuntimeStorageService,
 		public readonly quorum: IQuorumClients,
 		public readonly audience: IAudience,
 		public readonly loader: ILoader,

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -6,7 +6,7 @@
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
 import {
 	ISnapshotTreeWithBlobContents,
-	type IRuntimeStorageService,
+	type IContainerStorageService,
 } from "@fluidframework/container-definitions/internal";
 import { IDisposable } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
@@ -48,7 +48,10 @@ export interface ISerializableBlobContents {
  * container attach state.
  */
 export class ContainerStorageAdapter
-	implements ISerializedStateManagerDocumentStorageService, IRuntimeStorageService, IDisposable
+	implements
+		ISerializedStateManagerDocumentStorageService,
+		IContainerStorageService,
+		IDisposable
 {
 	private _storageService: IDocumentStorageService & Partial<IDisposable>;
 

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -252,7 +252,8 @@ export class ContainerStorageAdapter
 	/**
 	 * {@link IRuntimeStorageService.downloadSummary}.
 	 *
-	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned.
+	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
+	 * it is unused in the Runtime and below layers.
 	 */
 	public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
 		return this._storageService.downloadSummary(handle);

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -4,7 +4,10 @@
  */
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
-import { ISnapshotTreeWithBlobContents } from "@fluidframework/container-definitions/internal";
+import {
+	ISnapshotTreeWithBlobContents,
+	type IRuntimeStorageService,
+} from "@fluidframework/container-definitions/internal";
 import { IDisposable } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { ISummaryHandle, ISummaryTree } from "@fluidframework/driver-definitions";
@@ -45,10 +48,7 @@ export interface ISerializableBlobContents {
  * container attach state.
  */
 export class ContainerStorageAdapter
-	implements
-		ISerializedStateManagerDocumentStorageService,
-		IDocumentStorageService,
-		IDisposable
+	implements ISerializedStateManagerDocumentStorageService, IRuntimeStorageService, IDisposable
 {
 	private _storageService: IDocumentStorageService & Partial<IDisposable>;
 
@@ -159,6 +159,10 @@ export class ContainerStorageAdapter
 		return undefined;
 	}
 
+	public get maximumCacheDurationMs(): IDocumentStorageServicePolicies["maximumCacheDurationMs"] {
+		return this.policies?.maximumCacheDurationMs;
+	}
+
 	public async getSnapshotTree(
 		version?: IVersion,
 		scenarioName?: string,
@@ -241,12 +245,17 @@ export class ContainerStorageAdapter
 		return this._storageService.uploadSummaryWithContext(summary, context);
 	}
 
-	public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
-		return this._storageService.downloadSummary(handle);
-	}
-
 	public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
 		return this._storageService.createBlob(file);
+	}
+
+	/**
+	 * {@link IRuntimeStorageService.downloadSummary}.
+	 *
+	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned.
+	 */
+	public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
+		return this._storageService.downloadSummary(handle);
 	}
 }
 

--- a/packages/runtime/container-runtime-definitions/api-report/container-runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime-definitions/api-report/container-runtime-definitions.legacy.alpha.api.md
@@ -24,7 +24,7 @@ export interface IContainerRuntime extends IProvideFluidDataStoreRegistry, ICont
     // (undocumented)
     readonly scope: FluidObject;
     // (undocumented)
-    readonly storage: IRuntimeStorageService;
+    readonly storage: IContainerStorageService;
 }
 
 // @alpha @sealed @legacy (undocumented)

--- a/packages/runtime/container-runtime-definitions/api-report/container-runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime-definitions/api-report/container-runtime-definitions.legacy.alpha.api.md
@@ -24,7 +24,7 @@ export interface IContainerRuntime extends IProvideFluidDataStoreRegistry, ICont
     // (undocumented)
     readonly scope: FluidObject;
     // (undocumented)
-    readonly storage: IDocumentStorageService;
+    readonly storage: IRuntimeStorageService;
 }
 
 // @alpha @sealed @legacy (undocumented)

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -5,7 +5,7 @@
 
 import type { AttachState } from "@fluidframework/container-definitions";
 import type {
-	IRuntimeStorageService,
+	IContainerStorageService,
 	IDeltaManager,
 } from "@fluidframework/container-definitions/internal";
 import type {
@@ -181,7 +181,7 @@ export interface IContainerRuntime
 	readonly clientDetails: IClientDetails;
 	readonly connected: boolean;
 	readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-	readonly storage: IRuntimeStorageService;
+	readonly storage: IContainerStorageService;
 	readonly flushMode: FlushMode;
 	readonly scope: FluidObject;
 	/**

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -4,7 +4,10 @@
  */
 
 import type { AttachState } from "@fluidframework/container-definitions";
-import type { IDeltaManager } from "@fluidframework/container-definitions/internal";
+import type {
+	IRuntimeStorageService,
+	IDeltaManager,
+} from "@fluidframework/container-definitions/internal";
 import type {
 	FluidObject,
 	IEvent,
@@ -15,7 +18,6 @@ import type {
 import type { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import type { IClientDetails } from "@fluidframework/driver-definitions";
 import type {
-	IDocumentStorageService,
 	IDocumentMessage,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
@@ -179,7 +181,7 @@ export interface IContainerRuntime
 	readonly clientDetails: IClientDetails;
 	readonly connected: boolean;
 	readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-	readonly storage: IDocumentStorageService;
+	readonly storage: IRuntimeStorageService;
 	readonly flushMode: FlushMode;
 	readonly scope: FluidObject;
 	/**

--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -6,7 +6,7 @@
 import { bufferToString, createEmitter, stringToBuffer } from "@fluid-internal/client-utils";
 import {
 	AttachState,
-	type IRuntimeStorageService,
+	type IContainerStorageService,
 } from "@fluidframework/container-definitions/internal";
 import {
 	IContainerRuntime,
@@ -217,7 +217,7 @@ export class BlobManager {
 	private stopAttaching: boolean = false;
 
 	private readonly routeContext: IFluidHandleContext;
-	private readonly storage: Pick<IRuntimeStorageService, "createBlob" | "readBlob">;
+	private readonly storage: Pick<IContainerStorageService, "createBlob" | "readBlob">;
 	// Called when a blob node is requested. blobPath is the path of the blob's node in GC's graph.
 	// blobPath's format - `/<basePath>/<blobId>`.
 	private readonly blobRequested: (blobPath: string) => void;
@@ -236,7 +236,7 @@ export class BlobManager {
 		readonly routeContext: IFluidHandleContext;
 
 		blobManagerLoadInfo: IBlobManagerLoadInfo;
-		readonly storage: Pick<IRuntimeStorageService, "createBlob" | "readBlob">;
+		readonly storage: Pick<IContainerStorageService, "createBlob" | "readBlob">;
 		/**
 		 * Submit a BlobAttach op. When a blob is uploaded, there is a short grace period before which the blob is
 		 * deleted. The BlobAttach op notifies the server that blob is in use. The server will then not delete the
@@ -420,7 +420,7 @@ export class BlobManager {
 			assert(this.redirectTable.has(blobId), 0x383 /* requesting unknown blobs */);
 
 			// Blobs created while the container is detached are stored in IDetachedBlobStorage.
-			// The 'IRuntimeStorageService.readBlob()' call below will retrieve these via localId.
+			// The 'IContainerStorageService.readBlob()' call below will retrieve these via localId.
 			storageId = blobId;
 		} else {
 			const attachedStorageId = this.redirectTable.get(blobId);
@@ -491,7 +491,7 @@ export class BlobManager {
 		blob: ArrayBufferLike,
 	): Promise<IFluidHandleInternalPayloadPending<ArrayBufferLike>> {
 		// Blobs created while the container is detached are stored in IDetachedBlobStorage.
-		// The 'IRuntimeStorageService.createBlob()' call below will respond with a localId.
+		// The 'IContainerStorageService.createBlob()' call below will respond with a localId.
 		const response = await this.storage.createBlob(blob);
 		this.setRedirection(response.id, undefined);
 		return this.getBlobHandle(response.id);

--- a/packages/runtime/container-runtime/src/blobManager/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager/blobManager.ts
@@ -4,7 +4,10 @@
  */
 
 import { bufferToString, createEmitter, stringToBuffer } from "@fluid-internal/client-utils";
-import { AttachState } from "@fluidframework/container-definitions";
+import {
+	AttachState,
+	type IRuntimeStorageService,
+} from "@fluidframework/container-definitions/internal";
 import {
 	IContainerRuntime,
 	IContainerRuntimeEvents,
@@ -20,10 +23,7 @@ import type {
 	PayloadState,
 } from "@fluidframework/core-interfaces/internal";
 import { assert, Deferred } from "@fluidframework/core-utils/internal";
-import {
-	IDocumentStorageService,
-	ICreateBlobResponse,
-} from "@fluidframework/driver-definitions/internal";
+import { ICreateBlobResponse } from "@fluidframework/driver-definitions/internal";
 import { canRetryOnError, runWithRetry } from "@fluidframework/driver-utils/internal";
 import {
 	IGarbageCollectionData,
@@ -217,7 +217,7 @@ export class BlobManager {
 	private stopAttaching: boolean = false;
 
 	private readonly routeContext: IFluidHandleContext;
-	private readonly storage: IDocumentStorageService;
+	private readonly storage: Pick<IRuntimeStorageService, "createBlob" | "readBlob">;
 	// Called when a blob node is requested. blobPath is the path of the blob's node in GC's graph.
 	// blobPath's format - `/<basePath>/<blobId>`.
 	private readonly blobRequested: (blobPath: string) => void;
@@ -236,7 +236,7 @@ export class BlobManager {
 		readonly routeContext: IFluidHandleContext;
 
 		blobManagerLoadInfo: IBlobManagerLoadInfo;
-		readonly storage: IDocumentStorageService;
+		readonly storage: Pick<IRuntimeStorageService, "createBlob" | "readBlob">;
 		/**
 		 * Submit a BlobAttach op. When a blob is uploaded, there is a short grace period before which the blob is
 		 * deleted. The BlobAttach op notifies the server that blob is in use. The server will then not delete the
@@ -420,7 +420,7 @@ export class BlobManager {
 			assert(this.redirectTable.has(blobId), 0x383 /* requesting unknown blobs */);
 
 			// Blobs created while the container is detached are stored in IDetachedBlobStorage.
-			// The 'IDocumentStorageService.readBlob()' call below will retrieve these via localId.
+			// The 'IRuntimeStorageService.readBlob()' call below will retrieve these via localId.
 			storageId = blobId;
 		} else {
 			const attachedStorageId = this.redirectTable.get(blobId);
@@ -491,7 +491,7 @@ export class BlobManager {
 		blob: ArrayBufferLike,
 	): Promise<IFluidHandleInternalPayloadPending<ArrayBufferLike>> {
 		// Blobs created while the container is detached are stored in IDetachedBlobStorage.
-		// The 'IDocumentStorageService.createBlob()' call below will respond with a localId.
+		// The 'IRuntimeStorageService.createBlob()' call below will respond with a localId.
 		const response = await this.storage.createBlob(blob);
 		this.setRedirection(response.id, undefined);
 		return this.getBlobHandle(response.id);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -22,6 +22,7 @@ import type {
 	IDeltaManager,
 	IDeltaManagerFull,
 	ILoader,
+	IRuntimeStorageService,
 } from "@fluidframework/container-definitions/internal";
 import { isIDeltaManagerFull } from "@fluidframework/container-definitions/internal";
 import type {
@@ -71,7 +72,6 @@ import type {
 } from "@fluidframework/driver-definitions";
 import { SummaryType } from "@fluidframework/driver-definitions";
 import type {
-	IDocumentStorageService,
 	IDocumentMessage,
 	ISequencedDocumentMessage,
 	ISignalMessage,
@@ -1205,7 +1205,7 @@ export class ContainerRuntime
 
 	private readonly isSummarizerClient: boolean;
 
-	public get storage(): IDocumentStorageService {
+	public get storage(): IRuntimeStorageService {
 		return this._storage;
 	}
 
@@ -1497,7 +1497,7 @@ export class ContainerRuntime
 		existing: boolean,
 
 		blobManagerLoadInfo: IBlobManagerLoadInfo,
-		private readonly _storage: IDocumentStorageService,
+		private readonly _storage: IRuntimeStorageService,
 		private readonly createIdCompressorFn: () => IIdCompressor & IIdCompressorCore,
 
 		private readonly documentsSchemaController: DocumentsSchemaController,
@@ -1794,7 +1794,7 @@ export class ContainerRuntime
 
 		// eslint-disable-next-line unicorn/consistent-destructuring
 		if (context.attachState === AttachState.Attached) {
-			const maxSnapshotCacheDurationMs = this._storage?.policies?.maximumCacheDurationMs;
+			const maxSnapshotCacheDurationMs = this._storage.policies?.maximumCacheDurationMs;
 			if (
 				maxSnapshotCacheDurationMs !== undefined &&
 				maxSnapshotCacheDurationMs > 5 * 24 * 60 * 60 * 1000

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1794,7 +1794,7 @@ export class ContainerRuntime
 
 		// eslint-disable-next-line unicorn/consistent-destructuring
 		if (context.attachState === AttachState.Attached) {
-			const maxSnapshotCacheDurationMs = this._storage.policies?.maximumCacheDurationMs;
+			const maxSnapshotCacheDurationMs = this._storage?.policies?.maximumCacheDurationMs;
 			if (
 				maxSnapshotCacheDurationMs !== undefined &&
 				maxSnapshotCacheDurationMs > 5 * 24 * 60 * 60 * 1000

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -22,7 +22,7 @@ import type {
 	IDeltaManager,
 	IDeltaManagerFull,
 	ILoader,
-	IRuntimeStorageService,
+	IContainerStorageService,
 } from "@fluidframework/container-definitions/internal";
 import { isIDeltaManagerFull } from "@fluidframework/container-definitions/internal";
 import type {
@@ -1205,7 +1205,7 @@ export class ContainerRuntime
 
 	private readonly isSummarizerClient: boolean;
 
-	public get storage(): IRuntimeStorageService {
+	public get storage(): IContainerStorageService {
 		return this._storage;
 	}
 
@@ -1497,7 +1497,7 @@ export class ContainerRuntime
 		existing: boolean,
 
 		blobManagerLoadInfo: IBlobManagerLoadInfo,
-		private readonly _storage: IRuntimeStorageService,
+		private readonly _storage: IContainerStorageService,
 		private readonly createIdCompressorFn: () => IIdCompressor & IIdCompressorCore,
 
 		private readonly documentsSchemaController: DocumentsSchemaController,

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -8,6 +8,7 @@ import { AttachState, IAudience } from "@fluidframework/container-definitions";
 import {
 	IDeltaManager,
 	isIDeltaManagerFull,
+	type IRuntimeStorageService,
 	type IDeltaManagerFull,
 	type ReadOnlyInfo,
 } from "@fluidframework/container-definitions/internal";
@@ -25,7 +26,6 @@ import {
 import { assert, LazyPromise, unreachableCase } from "@fluidframework/core-utils/internal";
 import { IClientDetails, IQuorumClients } from "@fluidframework/driver-definitions";
 import {
-	IDocumentStorageService,
 	type ISnapshot,
 	IDocumentMessage,
 	ISnapshotTree,
@@ -146,7 +146,7 @@ export interface IFluidDataStoreContextInternal extends IFluidDataStoreContext {
 export interface IFluidDataStoreContextProps {
 	readonly id: string;
 	readonly parentContext: IFluidParentContextPrivate;
-	readonly storage: IDocumentStorageService;
+	readonly storage: IRuntimeStorageService;
 	readonly scope: FluidObject;
 	readonly createSummarizerNodeFn: CreateChildSummarizerNodeFn;
 	/**
@@ -424,7 +424,7 @@ export abstract class FluidDataStoreContext
 	 * The parent which provided this information currently can be the container runtime or a datastore (if the datastore this context is for is nested under another one).
 	 */
 	private readonly parentContext: IFluidParentContextPrivate;
-	public readonly storage: IDocumentStorageService;
+	public readonly storage: IRuntimeStorageService;
 	public readonly scope: FluidObject;
 	/**
 	 * The loading group to which the data store belongs to.

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -8,7 +8,6 @@ import { AttachState, IAudience } from "@fluidframework/container-definitions";
 import {
 	IDeltaManager,
 	isIDeltaManagerFull,
-	type IRuntimeStorageService,
 	type IDeltaManagerFull,
 	type ReadOnlyInfo,
 } from "@fluidframework/container-definitions/internal";
@@ -63,6 +62,7 @@ import {
 	type IRuntimeMessageCollection,
 	type IFluidDataStoreFactory,
 	type PackagePath,
+	type IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	addBlobToSummary,

--- a/packages/runtime/container-runtime/src/storageServiceWithAttachBlobs.ts
+++ b/packages/runtime/container-runtime/src/storageServiceWithAttachBlobs.ts
@@ -28,8 +28,17 @@ export class StorageServiceWithAttachBlobs implements IRuntimeStorageService {
 		private readonly attachBlobs: Map<string, ArrayBufferLike>,
 	) {}
 
+	/**
+	 * {@link IRuntimeStorageService.policies}.
+	 * @deprecated - This will be removed in a future release. The Runtime only needs `maximumCacheDurationMs` policy
+	 * which is added as a separate property.
+	 */
 	public get policies(): IDocumentStorageServicePolicies | undefined {
 		return this.internalStorageService.policies;
+	}
+
+	public get maximumCacheDurationMs(): IDocumentStorageServicePolicies["maximumCacheDurationMs"] {
+		return this.internalStorageService.maximumCacheDurationMs;
 	}
 
 	public async readBlob(id: string): Promise<ArrayBufferLike> {
@@ -86,6 +95,11 @@ export class StorageServiceWithAttachBlobs implements IRuntimeStorageService {
 		return this.internalStorageService.createBlob(file);
 	}
 
+	/**
+	 * {@link IRuntimeStorageService.downloadSummary}.
+	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
+	 * it is unused in the Runtime and below layers.
+	 */
 	public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
 		return this.internalStorageService.downloadSummary(handle);
 	}

--- a/packages/runtime/container-runtime/src/storageServiceWithAttachBlobs.ts
+++ b/packages/runtime/container-runtime/src/storageServiceWithAttachBlobs.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import {
 	type FetchSource,
 	type ICreateBlobResponse,
@@ -16,6 +15,7 @@ import {
 	type ISummaryTree,
 	type IVersion,
 } from "@fluidframework/driver-definitions/internal";
+import type { IRuntimeStorageService } from "@fluidframework/runtime-definitions/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 /**
@@ -30,15 +30,10 @@ export class StorageServiceWithAttachBlobs implements IRuntimeStorageService {
 
 	/**
 	 * {@link IRuntimeStorageService.policies}.
-	 * @deprecated - This will be removed in a future release. The Runtime only needs `maximumCacheDurationMs` policy
-	 * which is added as a separate property.
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
 	 */
 	public get policies(): IDocumentStorageServicePolicies | undefined {
 		return this.internalStorageService.policies;
-	}
-
-	public get maximumCacheDurationMs(): IDocumentStorageServicePolicies["maximumCacheDurationMs"] {
-		return this.internalStorageService.maximumCacheDurationMs;
 	}
 
 	public async readBlob(id: string): Promise<ArrayBufferLike> {
@@ -52,6 +47,10 @@ export class StorageServiceWithAttachBlobs implements IRuntimeStorageService {
 		return this.internalStorageService.readBlob(id);
 	}
 
+	/**
+	 * {@link IRuntimeStorageService.getSnapshotTree}.
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 */
 	public async getSnapshotTree(
 		version?: IVersion,
 		scenarioName?: string,
@@ -60,6 +59,10 @@ export class StorageServiceWithAttachBlobs implements IRuntimeStorageService {
 		return this.internalStorageService.getSnapshotTree(version, scenarioName);
 	}
 
+	/**
+	 * {@link IRuntimeStorageService.getSnapshot}.
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 */
 	public async getSnapshot(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot> {
 		if (this.internalStorageService.getSnapshot !== undefined) {
 			return this.internalStorageService.getSnapshot(snapshotFetchOptions);
@@ -69,6 +72,10 @@ export class StorageServiceWithAttachBlobs implements IRuntimeStorageService {
 		);
 	}
 
+	/**
+	 * {@link IRuntimeStorageService.getVersions}.
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 */
 	public async getVersions(
 		// eslint-disable-next-line @rushstack/no-new-null
 		versionId: string | null,
@@ -84,6 +91,10 @@ export class StorageServiceWithAttachBlobs implements IRuntimeStorageService {
 		);
 	}
 
+	/**
+	 * {@link IRuntimeStorageService.uploadSummaryWithContext}.
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 */
 	public async uploadSummaryWithContext(
 		summary: ISummaryTree,
 		context: ISummaryContext,
@@ -91,14 +102,17 @@ export class StorageServiceWithAttachBlobs implements IRuntimeStorageService {
 		return this.internalStorageService.uploadSummaryWithContext(summary, context);
 	}
 
+	/**
+	 * {@link IRuntimeStorageService.createBlob}.
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 */
 	public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
 		return this.internalStorageService.createBlob(file);
 	}
 
 	/**
 	 * {@link IRuntimeStorageService.downloadSummary}.
-	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
-	 * it is unused in the Runtime and below layers.
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
 	 */
 	public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
 		return this.internalStorageService.downloadSummary(handle);

--- a/packages/runtime/container-runtime/src/storageServiceWithAttachBlobs.ts
+++ b/packages/runtime/container-runtime/src/storageServiceWithAttachBlobs.ts
@@ -3,23 +3,30 @@
  * Licensed under the MIT License.
  */
 
+import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import {
-	IDocumentStorageService,
-	IDocumentStorageServicePolicies,
+	type FetchSource,
+	type ICreateBlobResponse,
+	type IDocumentStorageServicePolicies,
+	type ISnapshot,
+	type ISnapshotFetchOptions,
+	type ISnapshotTree,
+	type ISummaryContext,
+	type ISummaryHandle,
+	type ISummaryTree,
+	type IVersion,
 } from "@fluidframework/driver-definitions/internal";
-import { DocumentStorageServiceProxy } from "@fluidframework/driver-utils/internal";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 /**
- * IDocumentStorageService proxy which intercepts requests if they can be satisfied by the blobs received in the
+ * IRuntimeStorageService proxy which intercepts requests if they can be satisfied by the blobs received in the
  * attach message. We use this to avoid an unnecessary request to the storage service.
  */
-export class StorageServiceWithAttachBlobs extends DocumentStorageServiceProxy {
+export class StorageServiceWithAttachBlobs implements IRuntimeStorageService {
 	constructor(
-		internalStorageService: IDocumentStorageService,
+		private readonly internalStorageService: IRuntimeStorageService,
 		private readonly attachBlobs: Map<string, ArrayBufferLike>,
-	) {
-		super(internalStorageService);
-	}
+	) {}
 
 	public get policies(): IDocumentStorageServicePolicies | undefined {
 		return this.internalStorageService.policies;
@@ -32,7 +39,54 @@ export class StorageServiceWithAttachBlobs extends DocumentStorageServiceProxy {
 		}
 
 		// Note that it is intentional not to cache the result of this readBlob - we'll trust the real
-		// IDocumentStorageService to cache appropriately, no need to double-cache.
+		// IRuntimeStorageService to cache appropriately, no need to double-cache.
 		return this.internalStorageService.readBlob(id);
+	}
+
+	public async getSnapshotTree(
+		version?: IVersion,
+		scenarioName?: string,
+		// eslint-disable-next-line @rushstack/no-new-null
+	): Promise<ISnapshotTree | null> {
+		return this.internalStorageService.getSnapshotTree(version, scenarioName);
+	}
+
+	public async getSnapshot(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot> {
+		if (this.internalStorageService.getSnapshot !== undefined) {
+			return this.internalStorageService.getSnapshot(snapshotFetchOptions);
+		}
+		throw new UsageError(
+			"getSnapshot api should exist on internal storage in documentStorageServiceProxy class",
+		);
+	}
+
+	public async getVersions(
+		// eslint-disable-next-line @rushstack/no-new-null
+		versionId: string | null,
+		count: number,
+		scenarioName?: string,
+		fetchSource?: FetchSource,
+	): Promise<IVersion[]> {
+		return this.internalStorageService.getVersions(
+			versionId,
+			count,
+			scenarioName,
+			fetchSource,
+		);
+	}
+
+	public async uploadSummaryWithContext(
+		summary: ISummaryTree,
+		context: ISummaryContext,
+	): Promise<string> {
+		return this.internalStorageService.uploadSummaryWithContext(summary, context);
+	}
+
+	public async createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse> {
+		return this.internalStorageService.createBlob(file);
+	}
+
+	public async downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree> {
+		return this.internalStorageService.downloadSummary(handle);
 	}
 }

--- a/packages/runtime/container-runtime/src/summary/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryFormat.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import { SummaryType } from "@fluidframework/driver-definitions";
 import {
@@ -15,6 +14,7 @@ import {
 	ISummaryTreeWithStats,
 	channelsTreeName,
 	gcTreeKey,
+	type IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 
 import { blobsTreeName } from "../blobManager/index.js";

--- a/packages/runtime/container-runtime/src/summary/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryFormat.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import { SummaryType } from "@fluidframework/driver-definitions";
 import {
-	IDocumentStorageService,
 	ISnapshotTree,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
@@ -287,7 +287,7 @@ export function wrapSummaryInChannelsTree(summarizeResult: ISummaryTreeWithStats
 }
 
 export async function getFluidDataStoreAttributes(
-	storage: IDocumentStorageService,
+	storage: IRuntimeStorageService,
 	snapshot: ISnapshotTree,
 ): Promise<ReadFluidDataStoreAttributes> {
 	const attributes = await readAndParse<ReadFluidDataStoreAttributes>(

--- a/packages/runtime/container-runtime/src/test/blobHandles.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobHandles.spec.ts
@@ -6,9 +6,11 @@
 import { strict as assert } from "node:assert";
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
-import { AttachState } from "@fluidframework/container-definitions";
+import {
+	AttachState,
+	type IRuntimeStorageService,
+} from "@fluidframework/container-definitions/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
-import type { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { BlobManager, IBlobManagerRuntime } from "../blobManager/index.js";
@@ -79,7 +81,7 @@ describe("BlobHandles", () => {
 			stashedBlobs: {},
 			localBlobIdGenerator: () => "localId",
 			isBlobDeleted: () => false,
-			storage: failProxy<IDocumentStorageService>({
+			storage: failProxy<IRuntimeStorageService>({
 				createBlob: async () => {
 					return { id: "blobId" };
 				},
@@ -118,7 +120,7 @@ describe("BlobHandles", () => {
 			},
 			stashedBlobs: {},
 			localBlobIdGenerator: () => "localId",
-			storage: failProxy<IDocumentStorageService>({
+			storage: failProxy<IRuntimeStorageService>({
 				createBlob: async () => {
 					count++;
 					return { id: "blobId", minTTLInSeconds: count < 3 ? -1 : undefined };

--- a/packages/runtime/container-runtime/src/test/blobHandles.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobHandles.spec.ts
@@ -6,11 +6,9 @@
 import { strict as assert } from "node:assert";
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
-import {
-	AttachState,
-	type IRuntimeStorageService,
-} from "@fluidframework/container-definitions/internal";
+import { AttachState } from "@fluidframework/container-definitions/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
+import type { IRuntimeStorageService } from "@fluidframework/runtime-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { BlobManager, IBlobManagerRuntime } from "../blobManager/index.js";
@@ -18,6 +16,7 @@ import {
 	ContainerFluidHandleContext,
 	IContainerHandleContextRuntime,
 } from "../containerHandleContext.js";
+
 export const failProxy = <T extends object>(handler: Partial<T> = {}): T => {
 	const proxy: T = new Proxy<T>(handler as T, {
 		get: (t, p, r) => {

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -11,7 +11,10 @@ import {
 	bufferToString,
 	gitHashFile,
 } from "@fluid-internal/client-utils";
-import { AttachState } from "@fluidframework/container-definitions";
+import {
+	AttachState,
+	type IRuntimeStorageService,
+} from "@fluidframework/container-definitions/internal";
 import { IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions/internal";
 import { ConfigTypes, IConfigProviderBase, IErrorBase } from "@fluidframework/core-interfaces";
 import {
@@ -20,7 +23,6 @@ import {
 } from "@fluidframework/core-interfaces/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
 import { IClientDetails, SummaryType } from "@fluidframework/driver-definitions";
-import { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
 import type { ISequencedMessageEnvelope } from "@fluidframework/runtime-definitions/internal";
 import {
 	isFluidHandleInternalPayloadPending,
@@ -49,7 +51,7 @@ import {
 
 const MIN_TTL = 24 * 60 * 60; // same as ODSP
 abstract class BaseMockBlobStorage
-	implements Pick<IDocumentStorageService, "readBlob" | "createBlob">
+	implements Pick<IRuntimeStorageService, "readBlob" | "createBlob">
 {
 	public blobs: Map<string, ArrayBufferLike> = new Map();
 	public abstract createBlob(blob: ArrayBufferLike);
@@ -111,16 +113,16 @@ export class MockRuntime
 
 	public disposed: boolean = false;
 
-	public get storage(): IDocumentStorageService {
+	public get storage(): IRuntimeStorageService {
 		return (this.attachState === AttachState.Detached
 			? this.detachedStorage
-			: this.attachedStorage) as unknown as IDocumentStorageService;
+			: this.attachedStorage) as unknown as IRuntimeStorageService;
 	}
 
 	private processing = false;
 	public unprocessedBlobs = new Set();
 
-	public getStorage(): IDocumentStorageService {
+	public getStorage(): IRuntimeStorageService {
 		return {
 			createBlob: async (blob: ArrayBufferLike) => {
 				if (this.processing) {
@@ -141,7 +143,7 @@ export class MockRuntime
 				return P;
 			},
 			readBlob: async (id: string) => this.storage.readBlob(id),
-		} as unknown as IDocumentStorageService;
+		} as unknown as IRuntimeStorageService;
 	}
 
 	public sendBlobAttachOp(localId: string, blobId?: string): void {

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -11,10 +11,7 @@ import {
 	bufferToString,
 	gitHashFile,
 } from "@fluid-internal/client-utils";
-import {
-	AttachState,
-	type IRuntimeStorageService,
-} from "@fluidframework/container-definitions/internal";
+import { AttachState } from "@fluidframework/container-definitions/internal";
 import { IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions/internal";
 import { ConfigTypes, IConfigProviderBase, IErrorBase } from "@fluidframework/core-interfaces";
 import {
@@ -23,7 +20,10 @@ import {
 } from "@fluidframework/core-interfaces/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
 import { IClientDetails, SummaryType } from "@fluidframework/driver-definitions";
-import type { ISequencedMessageEnvelope } from "@fluidframework/runtime-definitions/internal";
+import type {
+	IRuntimeStorageService,
+	ISequencedMessageEnvelope,
+} from "@fluidframework/runtime-definitions/internal";
 import {
 	isFluidHandleInternalPayloadPending,
 	isFluidHandlePayloadPending,

--- a/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
@@ -7,12 +7,10 @@ import { strict as assert } from "node:assert";
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
 import { generatePairwiseOptions } from "@fluid-private/test-pairwise-generator";
-import {
-	AttachState,
-	type IRuntimeStorageService,
-} from "@fluidframework/container-definitions/internal";
+import { AttachState } from "@fluidframework/container-definitions/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
 import { ICreateBlobResponse } from "@fluidframework/driver-definitions/internal";
+import type { IRuntimeStorageService } from "@fluidframework/runtime-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { BlobManager, IBlobManagerRuntime, type IPendingBlobs } from "../blobManager/index.js";

--- a/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
@@ -7,10 +7,12 @@ import { strict as assert } from "node:assert";
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
 import { generatePairwiseOptions } from "@fluid-private/test-pairwise-generator";
-import { AttachState } from "@fluidframework/container-definitions";
+import {
+	AttachState,
+	type IRuntimeStorageService,
+} from "@fluidframework/container-definitions/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
 import { ICreateBlobResponse } from "@fluidframework/driver-definitions/internal";
-import type { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { BlobManager, IBlobManagerRuntime, type IPendingBlobs } from "../blobManager/index.js";
@@ -51,7 +53,7 @@ function createBlobManager(overrides?: Partial<ConstructorParameters<typeof Blob
 			blobManagerLoadInfo: {},
 			stashedBlobs: undefined,
 			localBlobIdGenerator: undefined,
-			storage: failProxy<IDocumentStorageService>(),
+			storage: failProxy<IRuntimeStorageService>(),
 			sendBlobAttachOp: () => {},
 			blobRequested: () => {},
 			isBlobDeleted: () => false,
@@ -94,7 +96,7 @@ describe("BlobManager.stashed", () => {
 		const blobManager = createBlobManager({
 			sendBlobAttachOp(_localId, _storageId) {},
 			stashedBlobs: {},
-			storage: failProxy<IDocumentStorageService>({
+			storage: failProxy<IRuntimeStorageService>({
 				createBlob: async () => {
 					return createResponse.promise;
 				},
@@ -108,7 +110,7 @@ describe("BlobManager.stashed", () => {
 		const pendingBlobs = await pendingBlobsP;
 		const blobManager2 = createBlobManager({
 			stashedBlobs: pendingBlobs,
-			storage: failProxy<IDocumentStorageService>({
+			storage: failProxy<IRuntimeStorageService>({
 				createBlob: async () => {
 					return createResponse.promise;
 				},
@@ -122,7 +124,7 @@ describe("BlobManager.stashed", () => {
 		const blobManager = createBlobManager({
 			sendBlobAttachOp(_localId, _storageId) {},
 			stashedBlobs: {},
-			storage: failProxy<IDocumentStorageService>({
+			storage: failProxy<IRuntimeStorageService>({
 				createBlob: async () => {
 					return createResponse.promise;
 				},
@@ -141,7 +143,7 @@ describe("BlobManager.stashed", () => {
 		const createResponse2 = new Deferred<ICreateBlobResponse>();
 		const blobManager2 = createBlobManager({
 			stashedBlobs: pendingBlobs,
-			storage: failProxy<IDocumentStorageService>({
+			storage: failProxy<IRuntimeStorageService>({
 				createBlob: async () => {
 					return createResponse2.promise;
 				},
@@ -183,7 +185,7 @@ describe("BlobManager.stashed", () => {
 					blob: "a",
 				},
 			},
-			storage: failProxy<IDocumentStorageService>({
+			storage: failProxy<IRuntimeStorageService>({
 				createBlob: async () => {
 					return createResponse.promise;
 				},
@@ -212,7 +214,7 @@ describe("BlobManager.stashed", () => {
 			stashedBlobs: {
 				olderThanTTL,
 			},
-			storage: failProxy<IDocumentStorageService>({
+			storage: failProxy<IRuntimeStorageService>({
 				createBlob: async () => {
 					return createResponse.promise;
 				},
@@ -252,7 +254,7 @@ describe("BlobManager.stashed", () => {
 			stashedBlobs: {
 				storageIdWithoutUploadTime,
 			},
-			storage: failProxy<IDocumentStorageService>({
+			storage: failProxy<IRuntimeStorageService>({
 				createBlob: async () => {
 					return createResponse.promise;
 				},
@@ -295,7 +297,7 @@ describe("BlobManager.stashed", () => {
 
 		const blobManager = createBlobManager({
 			stashedBlobs,
-			storage: failProxy<IDocumentStorageService>({
+			storage: failProxy<IRuntimeStorageService>({
 				createBlob: async (b) => {
 					await letUploadsComplete.promise;
 					return { id: `id:${bufferToString(b, "utf8")}` };

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -15,6 +15,7 @@ import {
 	ContainerErrorTypes,
 	IContainerContext,
 	type IBatchMessage,
+	type IRuntimeStorageService,
 } from "@fluidframework/container-definitions/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import {
@@ -31,7 +32,6 @@ import {
 } from "@fluidframework/core-interfaces/internal";
 import { ISummaryTree } from "@fluidframework/driver-definitions";
 import {
-	IDocumentStorageService,
 	ISnapshot,
 	ISummaryContext,
 	type ISnapshotTree,
@@ -233,7 +233,7 @@ describe("Runtime", () => {
 	const mockClientId = "mockClientId";
 
 	// Mock the storage layer so "submitSummary" works.
-	const defaultMockStorage: Partial<IDocumentStorageService> = {
+	const defaultMockStorage: Partial<IRuntimeStorageService> = {
 		uploadSummaryWithContext: async (summary: ISummaryTree, context: ISummaryContext) => {
 			return "fakeHandle";
 		},
@@ -242,7 +242,7 @@ describe("Runtime", () => {
 		params: {
 			settings?: Record<string, ConfigTypes>;
 			logger?: ITelemetryBaseLogger;
-			mockStorage?: Partial<IDocumentStorageService>;
+			mockStorage?: Partial<IRuntimeStorageService>;
 			loadedFromVersion?: IVersion;
 			baseSnapshot?: ISnapshotTree;
 			connected?: boolean;
@@ -289,7 +289,7 @@ describe("Runtime", () => {
 			},
 			clientId,
 			connected,
-			storage: mockStorage as IDocumentStorageService,
+			storage: mockStorage as IRuntimeStorageService,
 			baseSnapshot,
 		} satisfies Partial<IContainerContext>;
 
@@ -2110,7 +2110,7 @@ describe("Runtime", () => {
 					summaryRefSeq: 100,
 					summaryLogger: createChildLogger({}),
 				};
-				class MockStorageService implements Partial<IDocumentStorageService> {
+				class MockStorageService implements Partial<IRuntimeStorageService> {
 					/**
 					 * This always returns the same snapshot. Basically, when container runtime receives an ack for the
 					 * deleted snapshot and tries to fetch the latest snapshot, return the latest snapshot.

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -15,7 +15,6 @@ import {
 	ContainerErrorTypes,
 	IContainerContext,
 	type IBatchMessage,
-	type IRuntimeStorageService,
 } from "@fluidframework/container-definitions/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import {
@@ -56,6 +55,7 @@ import {
 	type IEnvelope,
 	type ITelemetryContext,
 	type ISummarizeInternalResult,
+	type IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	IFluidErrorBase,

--- a/packages/runtime/container-runtime/src/test/createChildDataStoreSync.spec.ts
+++ b/packages/runtime/container-runtime/src/test/createChildDataStoreSync.spec.ts
@@ -5,9 +5,9 @@
 
 import { strict as assert } from "node:assert";
 
+import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import { FluidErrorTypes } from "@fluidframework/core-interfaces/internal";
 import { isPromiseLike, LazyPromise } from "@fluidframework/core-utils/internal";
-import { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
 import {
 	IFluidDataStoreChannel,
 	IFluidDataStoreFactory,
@@ -67,7 +67,7 @@ describe("createChildDataStore", () => {
 		const registry = createRegistry(namedEntries);
 		const createSummarizerNodeFn = () =>
 			new Proxy({} as unknown as ISummarizerNodeWithGC, { get: throwNYI });
-		const storage = new Proxy({} as unknown as IDocumentStorageService, { get: throwNYI });
+		const storage = new Proxy({} as unknown as IRuntimeStorageService, { get: throwNYI });
 
 		const parentContext = {
 			clientDetails: {

--- a/packages/runtime/container-runtime/src/test/createChildDataStoreSync.spec.ts
+++ b/packages/runtime/container-runtime/src/test/createChildDataStoreSync.spec.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "node:assert";
 
-import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import { FluidErrorTypes } from "@fluidframework/core-interfaces/internal";
 import { isPromiseLike, LazyPromise } from "@fluidframework/core-utils/internal";
 import {
@@ -15,6 +14,7 @@ import {
 	type NamedFluidDataStoreRegistryEntries,
 	type IContainerRuntimeBase,
 	type ISummarizerNodeWithGC,
+	type IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 import { isFluidError } from "@fluidframework/telemetry-utils/internal";
 import {

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -7,7 +7,10 @@ import { strict as assert } from "node:assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";
-import { ContainerErrorTypes } from "@fluidframework/container-definitions/internal";
+import {
+	ContainerErrorTypes,
+	type IRuntimeStorageService,
+} from "@fluidframework/container-definitions/internal";
 import {
 	FluidObject,
 	Tagged,
@@ -17,11 +20,7 @@ import { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import { LazyPromise } from "@fluidframework/core-utils/internal";
 import { DataStoreMessageType, FluidObjectHandle } from "@fluidframework/datastore/internal";
 import { ISummaryBlob, SummaryType } from "@fluidframework/driver-definitions";
-import {
-	IDocumentStorageService,
-	IBlob,
-	ISnapshotTree,
-} from "@fluidframework/driver-definitions/internal";
+import { IBlob, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import {
 	IGarbageCollectionData,
 	CreateChildSummarizerNodeFn,
@@ -84,7 +83,7 @@ describe("Data Store Context Tests", () => {
 
 	describe("LocalFluidDataStoreContext", () => {
 		let localDataStoreContext: LocalFluidDataStoreContext;
-		const storage = {} as unknown as IDocumentStorageService;
+		const storage = {} as unknown as IRuntimeStorageService;
 		const scope = {} as unknown as FluidObject;
 		const makeLocallyVisibleFn = () => {};
 		let parentContext: IFluidParentContextPrivate;
@@ -521,7 +520,7 @@ describe("Data Store Context Tests", () => {
 	describe("RemoteDataStoreContext", () => {
 		let remoteDataStoreContext: RemoteFluidDataStoreContext;
 		let dataStoreAttributes: ReadFluidDataStoreAttributes;
-		const storage: Partial<IDocumentStorageService> = {};
+		const storage: Partial<IRuntimeStorageService> = {};
 		const scope = {} as unknown as FluidObject;
 		let summarizerNode: IRootSummarizerNodeWithGC;
 		let parentContext: IFluidParentContextPrivate;
@@ -613,7 +612,7 @@ describe("Data Store Context Tests", () => {
 						snapshot: snapshotTree,
 						parentContext,
 						storage: new StorageServiceWithAttachBlobs(
-							storage as IDocumentStorageService,
+							storage as IRuntimeStorageService,
 							attachBlobs,
 						),
 						scope,
@@ -657,7 +656,7 @@ describe("Data Store Context Tests", () => {
 						id: invalidId,
 						pkg: ["TestDataStore1"],
 						parentContext,
-						storage: storage as IDocumentStorageService,
+						storage: storage as IRuntimeStorageService,
 						scope,
 						createSummarizerNodeFn,
 						snapshot: undefined,
@@ -737,7 +736,7 @@ describe("Data Store Context Tests", () => {
 					snapshot: snapshotTree,
 					parentContext,
 					storage: new StorageServiceWithAttachBlobs(
-						storage as IDocumentStorageService,
+						storage as IRuntimeStorageService,
 						attachBlobs,
 					),
 					scope,
@@ -782,7 +781,7 @@ describe("Data Store Context Tests", () => {
 					snapshot: snapshotTree,
 					parentContext,
 					storage: new StorageServiceWithAttachBlobs(
-						storage as IDocumentStorageService,
+						storage as IRuntimeStorageService,
 						attachBlobs,
 					),
 					scope,
@@ -831,7 +830,7 @@ describe("Data Store Context Tests", () => {
 					snapshot: snapshotTree,
 					parentContext,
 					storage: new StorageServiceWithAttachBlobs(
-						storage as IDocumentStorageService,
+						storage as IRuntimeStorageService,
 						attachBlobs,
 					),
 					scope,
@@ -885,7 +884,7 @@ describe("Data Store Context Tests", () => {
 					snapshot: snapshotTree,
 					parentContext,
 					storage: new StorageServiceWithAttachBlobs(
-						storage as IDocumentStorageService,
+						storage as IRuntimeStorageService,
 						attachBlobs,
 					),
 					scope,
@@ -960,7 +959,7 @@ describe("Data Store Context Tests", () => {
 					snapshot: snapshotTree,
 					parentContext,
 					storage: new StorageServiceWithAttachBlobs(
-						storage as IDocumentStorageService,
+						storage as IRuntimeStorageService,
 						attachBlobs,
 					),
 					scope,
@@ -980,7 +979,7 @@ describe("Data Store Context Tests", () => {
 
 	describe("LocalDetachedFluidDataStoreContext", () => {
 		let localDataStoreContext: LocalDetachedFluidDataStoreContext;
-		const storage = {} as unknown as IDocumentStorageService;
+		const storage = {} as unknown as IRuntimeStorageService;
 		const scope = {} as unknown as FluidObject;
 		let factory: IFluidDataStoreFactory;
 		const makeLocallyVisibleFn = () => {};

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -7,10 +7,7 @@ import { strict as assert } from "node:assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";
-import {
-	ContainerErrorTypes,
-	type IRuntimeStorageService,
-} from "@fluidframework/container-definitions/internal";
+import { ContainerErrorTypes } from "@fluidframework/container-definitions/internal";
 import {
 	FluidObject,
 	Tagged,
@@ -33,6 +30,7 @@ import {
 	SummarizeInternalFn,
 	channelsTreeName,
 	type IContainerRuntimeBase,
+	type IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	GCDataBuilder,

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -5,8 +5,8 @@
 
 import { strict as assert } from "node:assert";
 
+import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import { FluidObject } from "@fluidframework/core-interfaces";
-import { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
 import {
 	CreateChildSummarizerNodeFn,
 	CreateSummarizerNodeSource,
@@ -44,7 +44,7 @@ describe("Data Store Creation Tests", () => {
 		 * ```
 		 */
 
-		let storage: IDocumentStorageService;
+		let storage: IRuntimeStorageService;
 		let scope: FluidObject;
 		const makeLocallyVisibleFn = () => {};
 		let parentContext: IFluidParentContextPrivate;

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "node:assert";
 
-import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import { FluidObject } from "@fluidframework/core-interfaces";
 import {
 	CreateChildSummarizerNodeFn,
@@ -16,6 +15,7 @@ import {
 	IFluidDataStoreRegistry,
 	NamedFluidDataStoreRegistryEntries,
 	SummarizeInternalFn,
+	type IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import {

--- a/packages/runtime/container-runtime/src/test/dataStoreCreationHelper.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreationHelper.ts
@@ -4,7 +4,6 @@
  */
 
 import type { ILayerCompatDetails } from "@fluid-internal/client-utils";
-import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import type { FluidObject, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import type { IClientDetails } from "@fluidframework/driver-definitions/internal";
 import {
@@ -14,6 +13,7 @@ import {
 	type IFluidDataStoreFactory,
 	type IFluidDataStoreRegistry,
 	type IGarbageCollectionData,
+	type IRuntimeStorageService,
 	type ISummarizerNodeWithGC,
 	type SummarizeInternalFn,
 } from "@fluidframework/runtime-definitions/internal";

--- a/packages/runtime/container-runtime/src/test/dataStoreCreationHelper.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreationHelper.ts
@@ -4,11 +4,9 @@
  */
 
 import type { ILayerCompatDetails } from "@fluid-internal/client-utils";
+import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import type { FluidObject, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import type {
-	IClientDetails,
-	IDocumentStorageService,
-} from "@fluidframework/driver-definitions/internal";
+import type { IClientDetails } from "@fluidframework/driver-definitions/internal";
 import {
 	CreateSummarizerNodeSource,
 	type CreateChildSummarizerNodeFn,
@@ -102,7 +100,7 @@ export function createSummarizerNodeAndGetCreateFn(dataStoreId: string): {
 const defaultCreateProps = {
 	id: "dataStoreId",
 	pkg: ["dataStorePkg"],
-	storage: {} as unknown as IDocumentStorageService,
+	storage: {} as unknown as IRuntimeStorageService,
 	scope: {} as unknown as FluidObject,
 	snapshotTree: undefined,
 	makeLocallyVisibleFn: () => {},

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import {
 	IChannel,
 	IChannelAttributes,
@@ -20,6 +19,7 @@ import {
 	IFluidDataStoreContext,
 	ISummarizeResult,
 	type IRuntimeMessageCollection,
+	type IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 import { addBlobToSummary } from "@fluidframework/runtime-utils/internal";
 import {

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -3,16 +3,14 @@
  * Licensed under the MIT License.
  */
 
+import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import {
 	IChannel,
 	IChannelAttributes,
 	IChannelFactory,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	IDocumentStorageService,
-	ISnapshotTree,
-} from "@fluidframework/driver-definitions/internal";
+import { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import {
 	IExperimentalIncrementalSummaryContext,
@@ -85,7 +83,7 @@ export function createChannelServiceEndpoints(
 	submitFn: (content: unknown, localOpMetadata: unknown) => void,
 	dirtyFn: () => void,
 	isAttachedAndVisible: () => boolean,
-	storageService: IDocumentStorageService,
+	storageService: IRuntimeStorageService,
 	logger: ITelemetryLoggerExt,
 	tree?: ISnapshotTree,
 	extraBlobs?: Map<string, ArrayBufferLike>,

--- a/packages/runtime/datastore/src/channelStorageService.ts
+++ b/packages/runtime/datastore/src/channelStorageService.ts
@@ -3,12 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
-import {
-	IDocumentStorageService,
-	ISnapshotTree,
-} from "@fluidframework/driver-definitions/internal";
+import { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import { getNormalizedObjectStoragePathParts } from "@fluidframework/runtime-utils/internal";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
@@ -31,7 +29,7 @@ export class ChannelStorageService implements IChannelStorageService {
 
 	constructor(
 		private readonly tree: ISnapshotTree | undefined,
-		private readonly storage: Pick<IDocumentStorageService, "readBlob">,
+		private readonly storage: Pick<IRuntimeStorageService, "readBlob">,
 		private readonly logger: ITelemetryLoggerExt,
 		private readonly extraBlobs?: Map<string, ArrayBufferLike>,
 	) {

--- a/packages/runtime/datastore/src/channelStorageService.ts
+++ b/packages/runtime/datastore/src/channelStorageService.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
 import { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
+import type { IRuntimeStorageService } from "@fluidframework/runtime-definitions/internal";
 import { getNormalizedObjectStoragePathParts } from "@fluidframework/runtime-utils/internal";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -3,16 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import { ISnapshotTreeWithBlobContents } from "@fluidframework/container-definitions/internal";
+import {
+	ISnapshotTreeWithBlobContents,
+	type IRuntimeStorageService,
+} from "@fluidframework/container-definitions/internal";
 import { assert, Lazy, LazyPromise } from "@fluidframework/core-utils/internal";
 import {
 	IChannel,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	IDocumentStorageService,
-	ISnapshotTree,
-} from "@fluidframework/driver-definitions/internal";
+import { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import {
 	ITelemetryContext,
 	IFluidDataStoreContext,
@@ -216,7 +216,7 @@ export class RehydratedLocalChannelContext extends LocalChannelContextBase {
 		registry: ISharedObjectRegistry,
 		runtime: IFluidDataStoreRuntime,
 		dataStoreContext: IFluidDataStoreContext,
-		storageService: IDocumentStorageService,
+		storageService: IRuntimeStorageService,
 		logger: ITelemetryLoggerExt,
 		submitFn: (content: unknown, localOpMetadata: unknown) => void,
 		dirtyFn: (address: string) => void,
@@ -329,7 +329,7 @@ export class LocalChannelContext extends LocalChannelContextBase {
 		public readonly channel: IChannel,
 		runtime: IFluidDataStoreRuntime,
 		dataStoreContext: IFluidDataStoreContext,
-		storageService: IDocumentStorageService,
+		storageService: IRuntimeStorageService,
 		logger: ITelemetryLoggerExt,
 		submitFn: (content: unknown, localOpMetadata: unknown) => void,
 		dirtyFn: (address: string) => void,

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -3,10 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	ISnapshotTreeWithBlobContents,
-	type IRuntimeStorageService,
-} from "@fluidframework/container-definitions/internal";
+import { ISnapshotTreeWithBlobContents } from "@fluidframework/container-definitions/internal";
 import { assert, Lazy, LazyPromise } from "@fluidframework/core-utils/internal";
 import {
 	IChannel,
@@ -20,6 +17,7 @@ import {
 	ISummarizeResult,
 	type IPendingMessagesState,
 	type IRuntimeMessageCollection,
+	type IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	ITelemetryLoggerExt,

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -3,10 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	AttachState,
-	type IRuntimeStorageService,
-} from "@fluidframework/container-definitions/internal";
+import { AttachState } from "@fluidframework/container-definitions/internal";
 import { assert, LazyPromise } from "@fluidframework/core-utils/internal";
 import {
 	IChannel,
@@ -24,6 +21,7 @@ import {
 	ISummarizerNodeWithGC,
 	type IPendingMessagesState,
 	type IRuntimeMessageCollection,
+	type IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	ITelemetryLoggerExt,

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -3,16 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import { AttachState } from "@fluidframework/container-definitions";
+import {
+	AttachState,
+	type IRuntimeStorageService,
+} from "@fluidframework/container-definitions/internal";
 import { assert, LazyPromise } from "@fluidframework/core-utils/internal";
 import {
 	IChannel,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions/internal";
-import {
-	IDocumentStorageService,
-	ISnapshotTree,
-} from "@fluidframework/driver-definitions/internal";
+import { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import {
 	IExperimentalIncrementalSummaryContext,
 	ITelemetryContext,
@@ -61,7 +61,7 @@ export class RemoteChannelContext implements IChannelContext {
 	constructor(
 		runtime: IFluidDataStoreRuntime,
 		dataStoreContext: IFluidDataStoreContext,
-		storageService: IDocumentStorageService,
+		storageService: IRuntimeStorageService,
 		submitFn: (content: unknown, localOpMetadata: unknown) => void,
 		dirtyFn: (address: string) => void,
 		private readonly id: string,

--- a/packages/runtime/datastore/src/test/channelStorageService.spec.ts
+++ b/packages/runtime/datastore/src/test/channelStorageService.spec.ts
@@ -6,8 +6,8 @@
 import { strict as assert } from "node:assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
-import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
 import { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
+import type { IRuntimeStorageService } from "@fluidframework/runtime-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { ChannelStorageService } from "../channelStorageService.js";

--- a/packages/runtime/datastore/src/test/channelStorageService.spec.ts
+++ b/packages/runtime/datastore/src/test/channelStorageService.spec.ts
@@ -6,10 +6,8 @@
 import { strict as assert } from "node:assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
-import {
-	IDocumentStorageService,
-	ISnapshotTree,
-} from "@fluidframework/driver-definitions/internal";
+import type { IRuntimeStorageService } from "@fluidframework/container-definitions/internal";
+import { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { ChannelStorageService } from "../channelStorageService.js";
@@ -20,7 +18,7 @@ describe("ChannelStorageService", () => {
 			blobs: {},
 			trees: {},
 		};
-		const storage: Pick<IDocumentStorageService, "readBlob"> = {
+		const storage: Pick<IRuntimeStorageService, "readBlob"> = {
 			readBlob: async (id: string) => {
 				throw new Error("not implemented");
 			},
@@ -41,7 +39,7 @@ describe("ChannelStorageService", () => {
 			},
 			trees: {},
 		};
-		const storage: Pick<IDocumentStorageService, "readBlob"> = {
+		const storage: Pick<IRuntimeStorageService, "readBlob"> = {
 			readBlob: async (id: string) => {
 				return stringToBuffer(id, "utf8");
 			},
@@ -68,7 +66,7 @@ describe("ChannelStorageService", () => {
 				},
 			},
 		};
-		const storage: Pick<IDocumentStorageService, "readBlob"> = {
+		const storage: Pick<IRuntimeStorageService, "readBlob"> = {
 			readBlob: async (id: string) => {
 				return stringToBuffer(id, "utf8");
 			},

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -134,7 +134,7 @@ export interface IExperimentalIncrementalSummaryContext {
 }
 
 // @alpha @legacy
-export interface IFluidDataStoreChannel extends IDisposable {
+export interface IFluidDataStoreChannel extends IDisposable_2 {
     // (undocumented)
     applyStashedOp(content: any): Promise<unknown>;
     readonly entryPoint: IFluidHandleInternal<FluidObject>;
@@ -399,7 +399,7 @@ export interface ISummaryStats {
 // @alpha @legacy
 export interface ISummaryTreeWithStats {
     stats: ISummaryStats;
-    summary: ISummaryTree;
+    summary: ISummaryTree_2;
 }
 
 // @alpha @legacy

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -242,7 +242,7 @@ export interface IFluidParentContext extends IProvideFluidHandleContext, Partial
     readonly scope: FluidObject;
     setChannelDirty(address: string): void;
     // (undocumented)
-    readonly storage: IDocumentStorageService;
+    readonly storage: IRuntimeStorageService;
     submitMessage(type: string, content: any, localOpMetadata: unknown): void;
     submitSignal: (type: string, content: unknown, targetClientId?: string) => void;
     // (undocumented)

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -300,6 +300,25 @@ export interface IRuntimeMessagesContent {
 }
 
 // @alpha @legacy
+export interface IRuntimeStorageService extends Partial<IDisposable> {
+    // @deprecated (undocumented)
+    createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
+    // @deprecated (undocumented)
+    downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
+    // @deprecated (undocumented)
+    getSnapshot?(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot>;
+    // @deprecated (undocumented)
+    getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
+    // @deprecated (undocumented)
+    getVersions(versionId: string | null, count: number, scenarioName?: string, fetchSource?: FetchSource): Promise<IVersion[]>;
+    // @deprecated (undocumented)
+    readonly policies?: IDocumentStorageServicePolicies | undefined;
+    readBlob(id: string): Promise<ArrayBufferLike>;
+    // @deprecated (undocumented)
+    uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
+}
+
+// @alpha @legacy
 export type ISequencedMessageEnvelope = Omit<ISequencedDocumentMessage, "contents" | "clientSequenceNumber">;
 
 // @alpha @legacy

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -134,7 +134,7 @@ export interface IExperimentalIncrementalSummaryContext {
 }
 
 // @alpha @legacy
-export interface IFluidDataStoreChannel extends IDisposable_2 {
+export interface IFluidDataStoreChannel extends IDisposable {
     // (undocumented)
     applyStashedOp(content: any): Promise<unknown>;
     readonly entryPoint: IFluidHandleInternal<FluidObject>;
@@ -300,9 +300,13 @@ export interface IRuntimeMessagesContent {
 }
 
 // @alpha @legacy
-export interface IRuntimeStorageService extends Partial<IDisposable> {
+export interface IRuntimeStorageService {
     // @deprecated (undocumented)
     createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
+    // @deprecated
+    dispose?(error?: Error): void;
+    // @deprecated
+    readonly disposed?: boolean;
     // @deprecated (undocumented)
     downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
     // @deprecated (undocumented)

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -403,7 +403,7 @@ export interface ISummaryStats {
 // @alpha @legacy
 export interface ISummaryTreeWithStats {
     stats: ISummaryStats;
-    summary: ISummaryTree_2;
+    summary: ISummaryTree;
 }
 
 // @alpha @legacy

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -4,10 +4,7 @@
  */
 
 import type { AttachState, IAudience } from "@fluidframework/container-definitions";
-import type {
-	IRuntimeStorageService,
-	IDeltaManager,
-} from "@fluidframework/container-definitions/internal";
+import type { IDeltaManager } from "@fluidframework/container-definitions/internal";
 import type {
 	FluidObject,
 	IDisposable,
@@ -39,7 +36,11 @@ import type {
 	IGarbageCollectionData,
 	IGarbageCollectionDetailsBase,
 } from "./garbageCollectionDefinitions.js";
-import type { IInboundSignalMessage, IRuntimeMessageCollection } from "./protocol.js";
+import type {
+	IInboundSignalMessage,
+	IRuntimeMessageCollection,
+	IRuntimeStorageService,
+} from "./protocol.js";
 import type {
 	CreateChildSummarizerNodeParam,
 	ISummarizerNodeWithGC,

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -4,7 +4,10 @@
  */
 
 import type { AttachState, IAudience } from "@fluidframework/container-definitions";
-import type { IDeltaManager } from "@fluidframework/container-definitions/internal";
+import type {
+	IRuntimeStorageService,
+	IDeltaManager,
+} from "@fluidframework/container-definitions/internal";
 import type {
 	FluidObject,
 	IDisposable,
@@ -21,7 +24,6 @@ import type {
 } from "@fluidframework/core-interfaces/internal";
 import type { IClientDetails, IQuorumClients } from "@fluidframework/driver-definitions";
 import type {
-	IDocumentStorageService,
 	IDocumentMessage,
 	ISnapshotTree,
 	ISequencedDocumentMessage,
@@ -563,7 +565,7 @@ export interface IFluidParentContext
 	 */
 	readonly isReadOnly?: () => boolean;
 	readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-	readonly storage: IDocumentStorageService;
+	readonly storage: IRuntimeStorageService;
 	readonly baseLogger: ITelemetryBaseLogger;
 	readonly clientDetails: IClientDetails;
 	readonly idCompressor?: IIdCompressor;

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -57,6 +57,7 @@ export type {
 	IRuntimeMessageCollection,
 	IRuntimeMessagesContent,
 	ISequencedMessageEnvelope,
+	IRuntimeStorageService,
 } from "./protocol.js";
 export {
 	encodeHandlesInContainerRuntime,

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -3,11 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import type { TypedMessage } from "@fluidframework/core-interfaces/internal";
+import type { IDisposable, TypedMessage } from "@fluidframework/core-interfaces/internal";
 import type {
 	ITree,
 	ISignalMessage,
 	ISequencedDocumentMessage,
+	IDocumentStorageServicePolicies,
+	IVersion,
+	ISnapshotTree,
+	ISnapshotFetchOptions,
+	ISnapshot,
+	FetchSource,
+	ICreateBlobResponse,
+	ISummaryTree,
+	ISummaryHandle,
+	ISummaryContext,
 } from "@fluidframework/driver-definitions/internal";
 
 /**
@@ -127,4 +137,60 @@ export interface IRuntimeMessageCollection {
 	 * The contents of the messages in the collection
 	 */
 	readonly messagesContent: readonly IRuntimeMessagesContent[];
+}
+
+/**
+ * Interface to provide access to snapshot blobs to DataStore layer.
+ *
+ * @legacy
+ * @alpha
+ */
+export interface IRuntimeStorageService extends Partial<IDisposable> {
+	/**
+	 * Reads the object with the given ID, returns content in arrayBufferLike
+	 */
+	readBlob(id: string): Promise<ArrayBufferLike>;
+
+	/**
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 */
+	readonly policies?: IDocumentStorageServicePolicies | undefined;
+
+	/**
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 */
+	// eslint-disable-next-line @rushstack/no-new-null
+	getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
+
+	/**
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 */
+	getSnapshot?(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot>;
+
+	/**
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 */
+	getVersions(
+		// TODO: use `undefined` instead.
+		// eslint-disable-next-line @rushstack/no-new-null
+		versionId: string | null,
+		count: number,
+		scenarioName?: string,
+		fetchSource?: FetchSource,
+	): Promise<IVersion[]>;
+
+	/**
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 */
+	createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
+
+	/**
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 */
+	uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
+
+	/**
+	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 */
+	downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
 }

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { IDisposable, TypedMessage } from "@fluidframework/core-interfaces/internal";
+import type { TypedMessage } from "@fluidframework/core-interfaces/internal";
 import type {
 	ITree,
 	ISignalMessage,
@@ -145,30 +145,53 @@ export interface IRuntimeMessageCollection {
  * @legacy
  * @alpha
  */
-export interface IRuntimeStorageService extends Partial<IDisposable> {
+export interface IRuntimeStorageService {
 	/**
 	 * Reads the object with the given ID, returns content in arrayBufferLike
 	 */
 	readBlob(id: string): Promise<ArrayBufferLike>;
 
 	/**
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 * Whether or not the object has been disposed.
+	 * If true, the object should be considered invalid, and its other state should be disregarded.
+	 *
+	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
+	 * it is unused in the DataStore layer.
+	 */
+	readonly disposed?: boolean;
+
+	/**
+	 * Dispose of the object and its resources.
+	 * @param error - Optional error indicating the reason for the disposal, if the object was
+	 * disposed as the result of an error.
+	 *
+	 * @deprecated - This API is deprecated and will be removed in a future release. No replacement is planned as
+	 * it is unused in the DataStore layer.
+	 */
+	dispose?(error?: Error): void;
+
+	/**
+	 * @deprecated - This will be removed in a future release. No replacement is planned as
+	 * it is unused in the DataStore layer.
 	 */
 	readonly policies?: IDocumentStorageServicePolicies | undefined;
 
 	/**
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 * @deprecated - This will be removed in a future release. No replacement is planned as
+	 * it is unused in the DataStore layer.
 	 */
 	// eslint-disable-next-line @rushstack/no-new-null
 	getSnapshotTree(version?: IVersion, scenarioName?: string): Promise<ISnapshotTree | null>;
 
 	/**
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 * @deprecated - This will be removed in a future release. No replacement is planned as
+	 * it is unused in the DataStore layer.
 	 */
 	getSnapshot?(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot>;
 
 	/**
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 * @deprecated - This will be removed in a future release. No replacement is planned as
+	 * it is unused in the DataStore layer.
 	 */
 	getVersions(
 		// TODO: use `undefined` instead.
@@ -180,17 +203,20 @@ export interface IRuntimeStorageService extends Partial<IDisposable> {
 	): Promise<IVersion[]>;
 
 	/**
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 * @deprecated - This will be removed in a future release. No replacement is planned as
+	 * it is unused in the DataStore layer.
 	 */
 	createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
 
 	/**
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 * @deprecated - This will be removed in a future release. No replacement is planned as
+	 * it is unused in the DataStore layer.
 	 */
 	uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
 
 	/**
-	 * @deprecated - This will be removed in a future release. The DataStore layer does not need this.
+	 * @deprecated - This will be removed in a future release. No replacement is planned as
+	 * it is unused in the DataStore layer.
 	 */
 	downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
 }

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -4,9 +4,9 @@
  */
 
 import type { TelemetryBaseEventPropertyType } from "@fluidframework/core-interfaces";
-import type { ISummaryTree } from "@fluidframework/driver-definitions";
 import type {
 	ISnapshotTree,
+	ISummaryTree,
 	ITree,
 	SummaryTree,
 	ISequencedDocumentMessage,

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -363,7 +363,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     // (undocumented)
     setChannelDirty(address: string): void;
     // (undocumented)
-    storage: IDocumentStorageService;
+    storage: IRuntimeStorageService;
     // (undocumented)
     submitMessage(type: string, content: any, localOpMetadata: unknown): void;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -4,10 +4,7 @@
  */
 
 import { AttachState, IAudience } from "@fluidframework/container-definitions";
-import {
-	IDeltaManager,
-	type IRuntimeStorageService,
-} from "@fluidframework/container-definitions/internal";
+import { IDeltaManager } from "@fluidframework/container-definitions/internal";
 import { FluidObject } from "@fluidframework/core-interfaces";
 import {
 	IFluidHandleContext,
@@ -28,6 +25,7 @@ import {
 	IFluidDataStoreContext,
 	IFluidDataStoreRegistry,
 	IGarbageCollectionDetailsBase,
+	type IRuntimeStorageService,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	ITelemetryLoggerExt,

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -4,7 +4,10 @@
  */
 
 import { AttachState, IAudience } from "@fluidframework/container-definitions";
-import { IDeltaManager } from "@fluidframework/container-definitions/internal";
+import {
+	IDeltaManager,
+	type IRuntimeStorageService,
+} from "@fluidframework/container-definitions/internal";
 import { FluidObject } from "@fluidframework/core-interfaces";
 import {
 	IFluidHandleContext,
@@ -12,7 +15,6 @@ import {
 } from "@fluidframework/core-interfaces/internal";
 import { IClientDetails, IQuorumClients } from "@fluidframework/driver-definitions";
 import {
-	IDocumentStorageService,
 	IDocumentMessage,
 	ISnapshotTree,
 	ISequencedDocumentMessage,
@@ -53,7 +55,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 		new MockDeltaManager(() => this.clientId);
 
 	public containerRuntime: IContainerRuntimeBase = undefined as any;
-	public storage: IDocumentStorageService = undefined as any;
+	public storage: IRuntimeStorageService = undefined as any;
 	public IFluidDataStoreRegistry: IFluidDataStoreRegistry = undefined as any;
 	public IFluidHandleContext: IFluidHandleContext = undefined as any;
 	public idCompressor: IIdCompressorCore & IIdCompressor = undefined as any;


### PR DESCRIPTION
Runtime communicates with the Driver layer via `IDocumentStorageService` interface which requires layer compat support across the Runtime / Driver boundary. However, the Loader layer has a `ContainerStorageAdapter` which re-implements `IDocumentStorageService` which is then passed to the Runtime layer.

This PR adds an `IContainerStorageService` interface which is basically a duplicate of `IDocumentStorageService` and only has properties used by the `Runtime` layer. `ContainerStorageAdapter` now implements `IContainerStorageService` and will ensure that it maintains compatibility with the Runtime layer. So, if anything changes in the `IDocumentStorageService` interface APIs, `ContainerStorageAdapter` will still maintain the compatibility with Runtime via `IContainerStorageService`.

This will remove the Runtime layer's dependency on Driver layer and replace it with the Loader layer dependency which is already maintained.

Also, added an `IRuntimeStorageService` interface similar to `IContainerStorageService` to be used by the `DataStore` layer. It will only have `readBlob` API as the other APIs are not used by `DataStore` layer.

[AB#33773](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/33773)