### PR TITLE
refactor(api-markdown-documenter): Remove redundant text property on `PlainTextNode`

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -9,6 +9,12 @@ It doesn't make sense in the context of a general-purpose documentation domain, 
 
 It has been removed and is no longer used by the system.
 
+### `PlainTextNode.text` property removed
+
+`text` was a redundant alias for `value`, which `PlainTextNode` inherits as a literal node.
+This property has now been removed.
+Use `PlainTextNode.value` instead.
+
 ### `PlainTextNode` no longer supports unsafe "escaped" text
 
 This type previously supported an unsafe escape hatch for text escaping.

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -703,7 +703,6 @@ export class PlainTextNode extends DocumentationLiteralNodeBase<string> {
     constructor(text: string);
     static readonly Empty: PlainTextNode;
     get isEmpty(): boolean;
-    get text(): string;
     readonly type = "text";
 }
 

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -681,7 +681,6 @@ export class PlainTextNode extends DocumentationLiteralNodeBase<string> {
     constructor(text: string);
     static readonly Empty: PlainTextNode;
     get isEmpty(): boolean;
-    get text(): string;
     readonly type = "text";
 }
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -846,7 +846,7 @@ function stripTitleFromExampleComment<TNode extends DocumentationParentNode>(
 
 	if (firstChild.isLiteral) {
 		if (firstChild.type === "text") {
-			const text = (firstChild as PlainTextNode).text;
+			const text = (firstChild as PlainTextNode).value;
 			if (text === title) {
 				// Remove from children, and remove any trailing line breaks
 				const newChildren = children.slice(1);

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/PlainTextToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/PlainTextToHtml.ts
@@ -20,6 +20,6 @@ export function plainTextToHtml(
 ): HastText {
 	return {
 		type: "text",
-		value: node.text,
+		value: node.value,
 	};
 }

--- a/tools/api-markdown-documenter/src/documentation-domain/PlainTextNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/PlainTextNode.ts
@@ -36,15 +36,6 @@ export class PlainTextNode extends DocumentationLiteralNodeBase<string> {
 		return this.value.length === 0;
 	}
 
-	/**
-	 * The text to display.
-	 *
-	 * @remarks Must not contain newline characters.
-	 */
-	public get text(): string {
-		return this.value;
-	}
-
 	public constructor(text: string) {
 		super(text);
 

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderPlainText.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderPlainText.ts
@@ -24,7 +24,7 @@ export function renderPlainText(
 	writer: DocumentWriter,
 	context: RenderContext,
 ): void {
-	if (node.text.length === 0) {
+	if (node.value.length === 0) {
 		return;
 	}
 


### PR DESCRIPTION
This property was redundant.