### PR TITLE
Add ConverterDataObjectFactory

### DIFF
--- a/packages/framework/aqueduct/api-report/aqueduct.legacy.alpha.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.legacy.alpha.api.md
@@ -65,6 +65,7 @@ export class DataObjectFactory<TObj extends DataObject<I>, I extends DataObjectT
 
 // @alpha @legacy
 export interface DataObjectFactoryProps<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> {
+    readonly afterBindRuntime?: (runtime: IFluidDataStoreChannel) => Promise<void>;
     readonly ctor: new (props: IDataObjectProps<I>) => TObj;
     readonly optionalProviders?: FluidObjectSymbolProvider<I["OptionalProviders"]>;
     readonly policies?: Partial<IFluidDataStorePolicies>;
@@ -122,6 +123,7 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> implements IFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry> {
     constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects?: readonly IChannelFactory[], optionalProviders?: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime);
     constructor(props: DataObjectFactoryProps<TObj, I>);
+    readonly afterBindRuntime?: (runtime: IFluidDataStoreChannel) => Promise<void>;
     createChildInstance(parentContext: IFluidDataStoreContext, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
     createInstance(runtime: IContainerRuntimeBase, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
     // (undocumented)

--- a/packages/framework/aqueduct/src/data-object-factories/converterDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/converterDataObjectFactory.ts
@@ -1,0 +1,158 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	DataStoreMessageType,
+	FluidDataStoreRuntime,
+} from "@fluidframework/datastore/internal";
+import type { ISharedDirectory } from "@fluidframework/map/internal";
+import type {
+	IFluidDataStoreChannel,
+	IRuntimeMessageCollection,
+	IRuntimeMessagesContent,
+} from "@fluidframework/runtime-definitions/internal";
+
+import {
+	type DataObject,
+	type DataObjectTypes,
+	type PureDataObject,
+	dataObjectRootDirectoryId,
+} from "../data-objects/index.js";
+
+import { DataObjectFactory } from "./dataObjectFactory.js";
+import type { DataObjectFactoryProps } from "./pureDataObjectFactory.js";
+
+/**
+ * Represents the properties required to create a ConverterDataObjectFactory.
+ * @internal
+ */
+export interface ConverterDataObjectFactoryProps<
+	TObj extends PureDataObject<I>,
+	TConversionData,
+	I extends DataObjectTypes = DataObjectTypes,
+> extends DataObjectFactoryProps<TObj, I> {
+	/**
+	 * Used for determining whether or not a conversion is necessary based on the current state.
+	 */
+	isConversionNeeded: (root: ISharedDirectory) => Promise<boolean>;
+
+	/**
+	 * Data required for running conversion. This is necessary because the conversion must happen synchronously.
+	 */
+	asyncGetDataForConversion: (root: ISharedDirectory) => Promise<TConversionData>;
+
+	/**
+	 * Convert the DataObject upon resolve (i.e. on retrieval of the DataStore).
+	 * @param data - Provided by the "asyncGetDataForConversion" function
+	 */
+	convertDataObject: (
+		runtime: FluidDataStoreRuntime,
+		root: ISharedDirectory,
+		data: TConversionData,
+	) => void;
+
+	/**
+	 * If not provided, the Container will be closed after conversion due to underlying changes affecting the data model.
+	 */
+	refreshDataObject?: () => Promise<void>;
+}
+
+/**
+ * ConverterDataObjectFactory is the IFluidDataStoreFactory for converting DataObjects.
+ * See ConverterDataObjectFactoryProps for more information on how to utilize this factory.
+ *
+ * @internal
+ */
+export class ConverterDataObjectFactory<
+	TObj extends DataObject<I>,
+	TConversionData,
+	I extends DataObjectTypes = DataObjectTypes,
+> extends DataObjectFactory<TObj, I> {
+	private convertLock = false;
+
+	public constructor(props: ConverterDataObjectFactoryProps<TObj, TConversionData, I>) {
+		const submitConversionOp = (runtime: FluidDataStoreRuntime): void => {
+			// ! TODO: potentially add new DataStoreMessageType.Conversion
+			runtime.submitMessage(DataStoreMessageType.ChannelOp, "conversion", undefined);
+		};
+
+		const fullConvertDataStore = async (runtime: IFluidDataStoreChannel): Promise<void> => {
+			const realRuntime = runtime as FluidDataStoreRuntime;
+			const root = (await realRuntime.getChannel(
+				dataObjectRootDirectoryId,
+			)) as ISharedDirectory;
+			if (!this.convertLock && (await props.isConversionNeeded(root))) {
+				this.convertLock = true;
+				const data = await props.asyncGetDataForConversion(root);
+
+				// ! TODO: ensure these ops aren't sent immediately AB#41625
+				submitConversionOp(realRuntime);
+				props.convertDataObject(realRuntime, root, data);
+				this.convertLock = false;
+			}
+		};
+
+		const runtimeClass = props.runtimeClass ?? FluidDataStoreRuntime;
+
+		super({
+			...props,
+			afterBindRuntime: fullConvertDataStore,
+			runtimeClass: class ConverterDataStoreRuntime extends runtimeClass {
+				private conversionOpSeqNum = -1;
+				private readonly seqNumsToSkip = new Set<number>();
+
+				public processMessages(messageCollection: IRuntimeMessageCollection): void {
+					let contents: IRuntimeMessagesContent[] = [];
+					const sequenceNumber = messageCollection.envelope.sequenceNumber;
+
+					// ! TODO: add loser validation AB#41626
+					if (
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+						messageCollection.envelope.type === DataStoreMessageType.ChannelOp &&
+						messageCollection.messagesContent.some((val) => val.contents === "conversion")
+					) {
+						if (this.conversionOpSeqNum === -1) {
+							// This is the first conversion op we've seen
+							this.conversionOpSeqNum = sequenceNumber;
+						} else {
+							// Skip seqNums that lost the race
+							this.seqNumsToSkip.add(sequenceNumber);
+						}
+					}
+
+					contents = messageCollection.messagesContent.filter(
+						(val) => val.contents !== "conversion",
+					);
+
+					if (this.seqNumsToSkip.has(sequenceNumber) || contents.length === 0) {
+						return;
+					}
+
+					super.processMessages({
+						...messageCollection,
+						messagesContent: contents,
+					});
+				}
+
+				public reSubmit(
+					type2: DataStoreMessageType,
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					content: any,
+					localOpMetadata: unknown,
+				): void {
+					if (
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+						type2 === DataStoreMessageType.ChannelOp &&
+						content === "conversion"
+					) {
+						submitConversionOp(this);
+						return;
+					}
+					super.reSubmit(type2, content, localOpMetadata);
+				}
+			},
+		});
+	}
+}

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -189,6 +189,11 @@ export interface DataObjectFactoryProps<
 	 * These policies define specific behaviors or constraints for the data object.
 	 */
 	readonly policies?: Partial<IFluidDataStorePolicies>;
+
+	/**
+	 * If provided, this function is to be run after the data store becomes bound to the runtime (i.e. finished initializing).
+	 */
+	readonly afterBindRuntime?: (runtime: IFluidDataStoreChannel) => Promise<void>;
 }
 
 /**
@@ -213,6 +218,11 @@ export class PureDataObjectFactory<
 	 * {@inheritDoc @fluidframework/runtime-definitions#IFluidDataStoreFactory."type"}
 	 */
 	public readonly type: string;
+
+	/**
+	 * {@inheritDoc @fluidframework/runtime-definitions#IFluidDataStoreFactory."afterBindRuntime"}
+	 */
+	public readonly afterBindRuntime?: (runtime: IFluidDataStoreChannel) => Promise<void>;
 
 	/**
 	 * @remarks Use the props object based constructor instead.
@@ -266,6 +276,8 @@ export class PureDataObjectFactory<
 		if (newProps.registryEntries !== undefined) {
 			this.registry = new FluidDataStoreRegistry(newProps.registryEntries);
 		}
+
+		this.afterBindRuntime = newProps.afterBindRuntime;
 	}
 
 	/**

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -13,6 +13,11 @@ import { PureDataObject } from "./pureDataObject.js";
 import type { DataObjectTypes } from "./types.js";
 
 /**
+ * @internal
+ */
+export const dataObjectRootDirectoryId = "root";
+
+/**
  * DataObject is a base data store that is primed with a root directory. It
  * ensures that it is created and ready before you can access it.
  *
@@ -28,7 +33,6 @@ export abstract class DataObject<
 	I extends DataObjectTypes = DataObjectTypes,
 > extends PureDataObject<I> {
 	private internalRoot: ISharedDirectory | undefined;
-	private readonly rootDirectoryId = "root";
 
 	/**
 	 * The root directory will either be ready or will return an error. If an error is thrown
@@ -50,7 +54,7 @@ export abstract class DataObject<
 		if (existing) {
 			// data store has a root directory so we just need to set it before calling initializingFromExisting
 			this.internalRoot = (await this.runtime.getChannel(
-				this.rootDirectoryId,
+				dataObjectRootDirectoryId,
 			)) as ISharedDirectory;
 
 			// This will actually be an ISharedMap if the channel was previously created by the older version of
@@ -66,7 +70,7 @@ export abstract class DataObject<
 			}
 		} else {
 			// Create a root directory and register it before calling initializingFirstTime
-			this.internalRoot = SharedDirectory.create(this.runtime, this.rootDirectoryId);
+			this.internalRoot = SharedDirectory.create(this.runtime, dataObjectRootDirectoryId);
 			this.internalRoot.bindToContext();
 		}
 

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -13,6 +13,7 @@ import { PureDataObject } from "./pureDataObject.js";
 import type { DataObjectTypes } from "./types.js";
 
 /**
+ * ID of the root ISharedDirectory. Every DataObject contains this ISharedDirectory and adds further DDSes underneath it.
  * @internal
  */
 export const dataObjectRootDirectoryId = "root";

--- a/packages/framework/aqueduct/src/data-objects/index.ts
+++ b/packages/framework/aqueduct/src/data-objects/index.ts
@@ -4,7 +4,7 @@
  */
 
 export { createDataObjectKind } from "./createDataObjectKind.js";
-export { DataObject } from "./dataObject.js";
+export { DataObject, dataObjectRootDirectoryId } from "./dataObject.js";
 export { PureDataObject } from "./pureDataObject.js";
 export { TreeDataObject } from "./treeDataObject.js";
 export type { DataObjectKind, DataObjectTypes, IDataObjectProps } from "./types.js";

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -689,6 +689,8 @@ export abstract class FluidDataStoreContext
 			channel.dispose();
 		}
 
+		await factory.afterBindRuntime?.(channel);
+
 		return channel;
 	}
 

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -182,6 +182,7 @@ export const IFluidDataStoreFactory: keyof IProvideFluidDataStoreFactory;
 
 // @alpha @legacy
 export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
+    afterBindRuntime?(runtime: IFluidDataStoreChannel): Promise<void>;
     createDataStore?(context: IFluidDataStoreContext): {
         readonly runtime: IFluidDataStoreChannel;
     };

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -82,4 +82,9 @@ export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
 	createDataStore?(context: IFluidDataStoreContext): {
 		readonly runtime: IFluidDataStoreChannel;
 	};
+
+	/**
+	 * Function to be run after the data store becomes bound to the runtime (i.e. finished initializing).
+	 */
+	afterBindRuntime?(runtime: IFluidDataStoreChannel): Promise<void>;
 }


### PR DESCRIPTION
**This PR is not close to a final version of the ConverterDataObjectFactory**. It simply serves as the skeleton for the DataObject migration functionality.
There are a number of `TODO` placeholders for various edge case handling. High level feature is tracked by [AB#41618](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/41618)

[AB#41619](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/41619)