### PR TITLE
build(client): Update typetests after 2.51.0 release

### DIFF
--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -95,7 +95,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.56.0",
-		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.50.0",
+		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.51.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -133,7 +133,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
-		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@2.50.0",
+		"@fluid-internal/client-utils-previous": "npm:@fluid-internal/client-utils@2.51.0",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -100,7 +100,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.50.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -125,7 +125,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.50.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -122,7 +122,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@2.50.0",
+		"@fluidframework/core-utils-previous": "npm:@fluidframework/core-utils@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -95,7 +95,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.50.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -113,7 +113,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.50.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.51.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -131,7 +131,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/container-definitions": "workspace:~",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.50.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -157,7 +157,7 @@
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.50.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.51.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -161,7 +161,7 @@
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.50.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.51.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@tiny-calc/micro": "0.0.0-alpha.5",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -154,7 +154,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.50.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.51.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.50.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.51.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.50.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.51.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -170,7 +170,7 @@
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.50.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.51.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -138,7 +138,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.50.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.51.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.50.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.51.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -136,7 +136,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.50.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.51.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -196,7 +196,7 @@
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tree-previous": "npm:@fluidframework/tree@2.50.0",
+		"@fluidframework/tree-previous": "npm:@fluidframework/tree@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
 		"@types/easy-table": "^0.0.32",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -94,7 +94,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.50.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -111,7 +111,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.50.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -101,7 +101,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.50.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jest": "29.5.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.50.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/node": "^18.19.0",
 		"concurrently": "^8.2.1",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -141,7 +141,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.50.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -95,7 +95,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.50.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.50.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -88,7 +88,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.50.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.50.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -136,7 +136,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.50.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -86,7 +86,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.50.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/nconf": "^0.10.0",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -99,7 +99,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.50.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -103,7 +103,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.56.0",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.50.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.51.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -136,7 +136,7 @@
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.56.0",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.50.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.51.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -124,6 +124,42 @@ declare type old_as_current_for_Class_PureDataObjectFactory = requireAssignableT
 declare type current_as_old_for_Class_PureDataObjectFactory = requireAssignableTo<TypeOnly<current.PureDataObjectFactory<never>>, TypeOnly<old.PureDataObjectFactory<never>>>
 
 /*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_TreeDataObject": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_TreeDataObject = requireAssignableTo<TypeOnly<old.TreeDataObject>, TypeOnly<current.TreeDataObject>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_TreeDataObject": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_TreeDataObject = requireAssignableTo<TypeOnly<current.TreeDataObject>, TypeOnly<old.TreeDataObject>>
+
+/*
+ * Validate forward compatibility by using the old type in place of the current type.
+ * If this test starts failing, it indicates a change that is not forward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_TreeDataObjectFactory": {"forwardCompat": false}
+ */
+declare type old_as_current_for_Class_TreeDataObjectFactory = requireAssignableTo<TypeOnly<old.TreeDataObjectFactory<never>>, TypeOnly<current.TreeDataObjectFactory<never>>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "Class_TreeDataObjectFactory": {"backCompat": false}
+ */
+declare type current_as_old_for_Class_TreeDataObjectFactory = requireAssignableTo<TypeOnly<current.TreeDataObjectFactory<never>>, TypeOnly<old.TreeDataObjectFactory<never>>>
+
+/*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
@@ -176,6 +212,24 @@ declare type current_as_old_for_ClassStatics_PureDataObject = requireAssignableT
  * "ClassStatics_PureDataObjectFactory": {"backCompat": false}
  */
 declare type current_as_old_for_ClassStatics_PureDataObjectFactory = requireAssignableTo<TypeOnly<typeof current.PureDataObjectFactory>, TypeOnly<typeof old.PureDataObjectFactory>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "ClassStatics_TreeDataObject": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_TreeDataObject = requireAssignableTo<TypeOnly<typeof current.TreeDataObject>, TypeOnly<typeof old.TreeDataObject>>
+
+/*
+ * Validate backward compatibility by using the current type in place of the old type.
+ * If this test starts failing, it indicates a change that is not backward compatible.
+ * To acknowledge the breaking change, add the following to package.json under
+ * typeValidation.broken:
+ * "ClassStatics_TreeDataObjectFactory": {"backCompat": false}
+ */
+declare type current_as_old_for_ClassStatics_TreeDataObjectFactory = requireAssignableTo<TypeOnly<typeof current.TreeDataObjectFactory>, TypeOnly<typeof old.TreeDataObjectFactory>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -93,7 +93,7 @@
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
 		"@fluid-tools/build-cli": "^0.56.0",
-		"@fluidframework/app-insights-logger-previous": "npm:@fluidframework/app-insights-logger@2.50.0",
+		"@fluidframework/app-insights-logger-previous": "npm:@fluidframework/app-insights-logger@2.51.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -121,7 +121,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.50.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.51.0",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -128,7 +128,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.50.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -127,7 +127,7 @@
 		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/runtime-utils": "workspace:~",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.50.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -111,7 +111,7 @@
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-runtime-utils": "workspace:~",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.50.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^10.0.10",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -190,7 +190,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.50.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -131,7 +131,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.50.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -91,7 +91,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.50.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -197,7 +197,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.50.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -91,7 +91,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.50.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -137,7 +137,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.50.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "7.52.8",

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -145,7 +145,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.50.0",
+		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -98,7 +98,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.50.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -133,7 +133,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.50.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -137,7 +137,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.50.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.10",
@@ -153,11 +153,7 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"Class_MockStorage": {
-				"forwardCompat": false
-			}
-		},
+		"broken": {},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -274,7 +274,6 @@ declare type current_as_old_for_Class_MockSharedObjectServices = requireAssignab
  * typeValidation.broken:
  * "Class_MockStorage": {"forwardCompat": false}
  */
-// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockStorage = requireAssignableTo<TypeOnly<old.MockStorage>, TypeOnly<current.MockStorage>>
 
 /*

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -105,7 +105,7 @@
 		"@arethetypeswrong/cli": "^0.17.1",
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.56.0",
-		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.50.0",
+		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.51.0",
 		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -109,7 +109,7 @@
 		"@fluidframework/container-runtime-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.50.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -145,7 +145,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.50.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -135,7 +135,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@2.50.0",
+		"@fluidframework/devtools-core-previous": "npm:@fluidframework/devtools-core@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@fluidframework/id-compressor": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -127,7 +127,7 @@
 		"@fluid-tools/build-cli": "^0.56.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
-		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@2.50.0",
+		"@fluidframework/devtools-previous": "npm:@fluidframework/devtools@2.51.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/chai": "^4.0.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -50,7 +50,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "~1.9.3",
 		"@fluid-tools/build-cli": "^0.56.0",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.50.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.51.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -135,7 +135,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.50.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.50.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/isomorphic-fetch": "^0.0.39",
 		"@types/mocha": "^10.0.10",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -130,7 +130,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.50.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^10.0.10",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -114,7 +114,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.56.0",
 		"@fluidframework/eslint-config-fluid": "^5.7.4",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.50.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.51.0",
 		"@microsoft/api-extractor": "7.52.8",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^10.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@22.10.1)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-service-utils-previous':
-        specifier: npm:@fluidframework/azure-service-utils@2.50.0
-        version: '@fluidframework/azure-service-utils@2.50.0'
+        specifier: npm:@fluidframework/azure-service-utils@2.51.0
+        version: '@fluidframework/azure-service-utils@2.51.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -7367,8 +7367,8 @@ importers:
         specifier: ~1.9.3
         version: 1.9.4
       '@fluid-internal/client-utils-previous':
-        specifier: npm:@fluid-internal/client-utils@2.50.0
-        version: '@fluid-internal/client-utils@2.50.0'
+        specifier: npm:@fluid-internal/client-utils@2.51.0
+        version: '@fluid-internal/client-utils@2.51.0'
       '@fluid-internal/mocha-test-setup':
         specifier: workspace:~
         version: link:../../test/mocha-test-setup
@@ -7494,8 +7494,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@22.10.1)
       '@fluidframework/container-definitions-previous':
-        specifier: npm:@fluidframework/container-definitions@2.50.0
-        version: '@fluidframework/container-definitions@2.50.0'
+        specifier: npm:@fluidframework/container-definitions@2.51.0
+        version: '@fluidframework/container-definitions@2.51.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -7536,8 +7536,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)
       '@fluidframework/core-interfaces-previous':
-        specifier: npm:@fluidframework/core-interfaces@2.50.0
-        version: '@fluidframework/core-interfaces@2.50.0'
+        specifier: npm:@fluidframework/core-interfaces@2.51.0
+        version: '@fluidframework/core-interfaces@2.51.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -7602,8 +7602,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)
       '@fluidframework/core-utils-previous':
-        specifier: npm:@fluidframework/core-utils@2.50.0
-        version: '@fluidframework/core-utils@2.50.0'
+        specifier: npm:@fluidframework/core-utils@2.51.0
+        version: '@fluidframework/core-utils@2.51.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -7675,8 +7675,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@22.10.1)
       '@fluidframework/driver-definitions-previous':
-        specifier: npm:@fluidframework/driver-definitions@2.50.0
-        version: '@fluidframework/driver-definitions@2.50.0'
+        specifier: npm:@fluidframework/driver-definitions@2.51.0
+        version: '@fluidframework/driver-definitions@2.51.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -7745,8 +7745,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)
       '@fluidframework/cell-previous':
-        specifier: npm:@fluidframework/cell@2.50.0
-        version: '@fluidframework/cell@2.50.0'
+        specifier: npm:@fluidframework/cell@2.51.0
+        version: '@fluidframework/cell@2.51.0'
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../common/container-definitions
@@ -7839,8 +7839,8 @@ importers:
         specifier: workspace:~
         version: link:../../common/container-definitions
       '@fluidframework/counter-previous':
-        specifier: npm:@fluidframework/counter@2.50.0
-        version: '@fluidframework/counter@2.50.0'
+        specifier: npm:@fluidframework/counter@2.51.0
+        version: '@fluidframework/counter@2.51.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -8148,8 +8148,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/map-previous':
-        specifier: npm:@fluidframework/map@2.50.0
-        version: '@fluidframework/map@2.50.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/map@2.51.0
+        version: '@fluidframework/map@2.51.0(debug@4.4.0)'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8272,8 +8272,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/matrix-previous':
-        specifier: npm:@fluidframework/matrix@2.50.0
-        version: '@fluidframework/matrix@2.50.0'
+        specifier: npm:@fluidframework/matrix@2.51.0
+        version: '@fluidframework/matrix@2.51.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8393,8 +8393,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/merge-tree-previous':
-        specifier: npm:@fluidframework/merge-tree@2.50.0
-        version: '@fluidframework/merge-tree@2.50.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/merge-tree@2.51.0
+        version: '@fluidframework/merge-tree@2.51.0(debug@4.4.0)'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8499,8 +8499,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/ordered-collection-previous':
-        specifier: npm:@fluidframework/ordered-collection@2.50.0
-        version: '@fluidframework/ordered-collection@2.50.0'
+        specifier: npm:@fluidframework/ordered-collection@2.51.0
+        version: '@fluidframework/ordered-collection@2.51.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8684,8 +8684,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/register-collection-previous':
-        specifier: npm:@fluidframework/register-collection@2.50.0
-        version: '@fluidframework/register-collection@2.50.0'
+        specifier: npm:@fluidframework/register-collection@2.51.0
+        version: '@fluidframework/register-collection@2.51.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8799,8 +8799,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/sequence-previous':
-        specifier: npm:@fluidframework/sequence@2.50.0
-        version: '@fluidframework/sequence@2.50.0'
+        specifier: npm:@fluidframework/sequence@2.51.0
+        version: '@fluidframework/sequence@2.51.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8917,8 +8917,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/shared-object-base-previous':
-        specifier: npm:@fluidframework/shared-object-base@2.50.0
-        version: '@fluidframework/shared-object-base@2.50.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/shared-object-base@2.51.0
+        version: '@fluidframework/shared-object-base@2.51.0(debug@4.4.0)'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9020,8 +9020,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/shared-summary-block-previous':
-        specifier: npm:@fluidframework/shared-summary-block@2.50.0
-        version: '@fluidframework/shared-summary-block@2.50.0'
+        specifier: npm:@fluidframework/shared-summary-block@2.51.0
+        version: '@fluidframework/shared-summary-block@2.51.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9129,8 +9129,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/task-manager-previous':
-        specifier: npm:@fluidframework/task-manager@2.50.0
-        version: '@fluidframework/task-manager@2.50.0'
+        specifier: npm:@fluidframework/task-manager@2.51.0
+        version: '@fluidframework/task-manager@2.51.0'
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -9368,8 +9368,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tree-previous':
-        specifier: npm:@fluidframework/tree@2.50.0
-        version: '@fluidframework/tree@2.50.0'
+        specifier: npm:@fluidframework/tree@2.51.0
+        version: '@fluidframework/tree@2.51.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9465,8 +9465,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)
       '@fluidframework/debugger-previous':
-        specifier: npm:@fluidframework/debugger@2.50.0
-        version: '@fluidframework/debugger@2.50.0'
+        specifier: npm:@fluidframework/debugger@2.51.0
+        version: '@fluidframework/debugger@2.51.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -9532,8 +9532,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)
       '@fluidframework/driver-base-previous':
-        specifier: npm:@fluidframework/driver-base@2.50.0
-        version: '@fluidframework/driver-base@2.50.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/driver-base@2.51.0
+        version: '@fluidframework/driver-base@2.51.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -9611,8 +9611,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)
       '@fluidframework/driver-web-cache-previous':
-        specifier: npm:@fluidframework/driver-web-cache@2.50.0
-        version: '@fluidframework/driver-web-cache@2.50.0'
+        specifier: npm:@fluidframework/driver-web-cache@2.51.0
+        version: '@fluidframework/driver-web-cache@2.51.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -9687,8 +9687,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/file-driver-previous':
-        specifier: npm:@fluidframework/file-driver@2.50.0
-        version: '@fluidframework/file-driver@2.50.0'
+        specifier: npm:@fluidframework/file-driver@2.51.0
+        version: '@fluidframework/file-driver@2.51.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9781,8 +9781,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/local-driver-previous':
-        specifier: npm:@fluidframework/local-driver@2.50.0
-        version: '@fluidframework/local-driver@2.50.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/local-driver@2.51.0
+        version: '@fluidframework/local-driver@2.51.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9884,8 +9884,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-driver-previous':
-        specifier: npm:@fluidframework/odsp-driver@2.50.0
-        version: '@fluidframework/odsp-driver@2.50.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-driver@2.51.0
+        version: '@fluidframework/odsp-driver@2.51.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -9954,8 +9954,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-driver-definitions-previous':
-        specifier: npm:@fluidframework/odsp-driver-definitions@2.50.0
-        version: '@fluidframework/odsp-driver-definitions@2.50.0'
+        specifier: npm:@fluidframework/odsp-driver-definitions@2.51.0
+        version: '@fluidframework/odsp-driver-definitions@2.51.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@22.10.1)
@@ -10021,8 +10021,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-urlresolver-previous':
-        specifier: npm:@fluidframework/odsp-urlresolver@2.50.0
-        version: '@fluidframework/odsp-urlresolver@2.50.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-urlresolver@2.51.0
+        version: '@fluidframework/odsp-urlresolver@2.51.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10097,8 +10097,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/replay-driver-previous':
-        specifier: npm:@fluidframework/replay-driver@2.50.0
-        version: '@fluidframework/replay-driver@2.50.0'
+        specifier: npm:@fluidframework/replay-driver@2.51.0
+        version: '@fluidframework/replay-driver@2.51.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10188,8 +10188,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/routerlicious-driver-previous':
-        specifier: npm:@fluidframework/routerlicious-driver@2.50.0
-        version: '@fluidframework/routerlicious-driver@2.50.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/routerlicious-driver@2.51.0
+        version: '@fluidframework/routerlicious-driver@2.51.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10279,8 +10279,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/routerlicious-urlresolver-previous':
-        specifier: npm:@fluidframework/routerlicious-urlresolver@2.50.0
-        version: '@fluidframework/routerlicious-urlresolver@2.50.0'
+        specifier: npm:@fluidframework/routerlicious-urlresolver@2.51.0
+        version: '@fluidframework/routerlicious-urlresolver@2.51.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10364,8 +10364,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/tinylicious-driver-previous':
-        specifier: npm:@fluidframework/tinylicious-driver@2.50.0
-        version: '@fluidframework/tinylicious-driver@2.50.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tinylicious-driver@2.51.0
+        version: '@fluidframework/tinylicious-driver@2.51.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -10449,8 +10449,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/agent-scheduler-previous':
-        specifier: npm:@fluidframework/agent-scheduler@2.50.0
-        version: '@fluidframework/agent-scheduler@2.50.0'
+        specifier: npm:@fluidframework/agent-scheduler@2.51.0
+        version: '@fluidframework/agent-scheduler@2.51.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10643,8 +10643,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/aqueduct-previous':
-        specifier: npm:@fluidframework/aqueduct@2.50.0
-        version: '@fluidframework/aqueduct@2.50.0'
+        specifier: npm:@fluidframework/aqueduct@2.51.0
+        version: '@fluidframework/aqueduct@2.51.0'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -10828,8 +10828,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/app-insights-logger-previous':
-        specifier: npm:@fluidframework/app-insights-logger@2.50.0
-        version: '@fluidframework/app-insights-logger@2.50.0(tslib@1.14.1)'
+        specifier: npm:@fluidframework/app-insights-logger@2.51.0
+        version: '@fluidframework/app-insights-logger@2.51.0(tslib@1.14.1)'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -11295,8 +11295,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/fluid-static-previous':
-        specifier: npm:@fluidframework/fluid-static@2.50.0
-        version: '@fluidframework/fluid-static@2.50.0'
+        specifier: npm:@fluidframework/fluid-static@2.51.0
+        version: '@fluidframework/fluid-static@2.51.0'
       '@fluidframework/map':
         specifier: workspace:~
         version: link:../../dds/map
@@ -11556,8 +11556,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/request-handler-previous':
-        specifier: npm:@fluidframework/request-handler@2.50.0
-        version: '@fluidframework/request-handler@2.50.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/request-handler@2.51.0
+        version: '@fluidframework/request-handler@2.51.0(debug@4.4.0)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -11638,8 +11638,8 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/runtime-utils
       '@fluidframework/synthesize-previous':
-        specifier: npm:@fluidframework/synthesize@2.50.0
-        version: '@fluidframework/synthesize@2.50.0'
+        specifier: npm:@fluidframework/synthesize@2.51.0
+        version: '@fluidframework/synthesize@2.51.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -11720,8 +11720,8 @@ importers:
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
       '@fluidframework/undo-redo-previous':
-        specifier: npm:@fluidframework/undo-redo@2.50.0
-        version: '@fluidframework/undo-redo@2.50.0'
+        specifier: npm:@fluidframework/undo-redo@2.51.0
+        version: '@fluidframework/undo-redo@2.51.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -11829,8 +11829,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)
       '@fluidframework/container-loader-previous':
-        specifier: npm:@fluidframework/container-loader@2.50.0
-        version: '@fluidframework/container-loader@2.50.0'
+        specifier: npm:@fluidframework/container-loader@2.51.0
+        version: '@fluidframework/container-loader@2.51.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -11932,8 +11932,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)
       '@fluidframework/driver-utils-previous':
-        specifier: npm:@fluidframework/driver-utils@2.50.0
-        version: '@fluidframework/driver-utils@2.50.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/driver-utils@2.51.0
+        version: '@fluidframework/driver-utils@2.51.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -12114,8 +12114,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)
       '@fluidframework/container-runtime-previous':
-        specifier: npm:@fluidframework/container-runtime@2.50.0
-        version: '@fluidframework/container-runtime@2.50.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/container-runtime@2.51.0
+        version: '@fluidframework/container-runtime@2.51.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -12205,8 +12205,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@22.10.1)
       '@fluidframework/container-runtime-definitions-previous':
-        specifier: npm:@fluidframework/container-runtime-definitions@2.50.0
-        version: '@fluidframework/container-runtime-definitions@2.50.0'
+        specifier: npm:@fluidframework/container-runtime-definitions@2.51.0
+        version: '@fluidframework/container-runtime-definitions@2.51.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -12287,8 +12287,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)
       '@fluidframework/datastore-previous':
-        specifier: npm:@fluidframework/datastore@2.50.0
-        version: '@fluidframework/datastore@2.50.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/datastore@2.51.0
+        version: '@fluidframework/datastore@2.51.0(debug@4.4.0)'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -12375,8 +12375,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@22.10.1)
       '@fluidframework/datastore-definitions-previous':
-        specifier: npm:@fluidframework/datastore-definitions@2.50.0
-        version: '@fluidframework/datastore-definitions@2.50.0'
+        specifier: npm:@fluidframework/datastore-definitions@2.51.0
+        version: '@fluidframework/datastore-definitions@2.51.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -12448,8 +12448,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/id-compressor-previous':
-        specifier: npm:@fluidframework/id-compressor@2.50.0
-        version: '@fluidframework/id-compressor@2.50.0'
+        specifier: npm:@fluidframework/id-compressor@2.51.0
+        version: '@fluidframework/id-compressor@2.51.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -12524,8 +12524,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/runtime-definitions-previous':
-        specifier: npm:@fluidframework/runtime-definitions@2.50.0
-        version: '@fluidframework/runtime-definitions@2.50.0'
+        specifier: npm:@fluidframework/runtime-definitions@2.51.0
+        version: '@fluidframework/runtime-definitions@2.51.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@22.10.1)
@@ -12600,8 +12600,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/runtime-utils-previous':
-        specifier: npm:@fluidframework/runtime-utils@2.50.0
-        version: '@fluidframework/runtime-utils@2.50.0(debug@4.4.0)'
+        specifier: npm:@fluidframework/runtime-utils@2.51.0
+        version: '@fluidframework/runtime-utils@2.51.0(debug@4.4.0)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -12718,8 +12718,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils-previous':
-        specifier: npm:@fluidframework/test-runtime-utils@2.50.0
-        version: '@fluidframework/test-runtime-utils@2.50.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/test-runtime-utils@2.51.0
+        version: '@fluidframework/test-runtime-utils@2.51.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -12797,8 +12797,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluidframework/azure-client-previous':
-        specifier: npm:@fluidframework/azure-client@2.50.0
-        version: '@fluidframework/azure-client@2.50.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/azure-client@2.51.0
+        version: '@fluidframework/azure-client@2.51.0(encoding@0.1.13)'
       '@fluidframework/azure-local-service':
         specifier: workspace:~
         version: link:../../../azure/packages/azure-local-service
@@ -13275,8 +13275,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/test-utils
       '@fluidframework/tinylicious-client-previous':
-        specifier: npm:@fluidframework/tinylicious-client@2.50.0
-        version: '@fluidframework/tinylicious-client@2.50.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tinylicious-client@2.51.0
+        version: '@fluidframework/tinylicious-client@2.51.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -14596,8 +14596,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/test-utils-previous':
-        specifier: npm:@fluidframework/test-utils@2.50.0
-        version: '@fluidframework/test-utils@2.50.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/test-utils@2.51.0
+        version: '@fluidframework/test-utils@2.51.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -14899,8 +14899,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@22.10.1)
       '@fluidframework/devtools-previous':
-        specifier: npm:@fluidframework/devtools@2.50.0
-        version: '@fluidframework/devtools@2.50.0'
+        specifier: npm:@fluidframework/devtools@2.51.0
+        version: '@fluidframework/devtools@2.51.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -15219,8 +15219,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@22.10.1)
       '@fluidframework/devtools-core-previous':
-        specifier: npm:@fluidframework/devtools-core@2.50.0
-        version: '@fluidframework/devtools-core@2.50.0'
+        specifier: npm:@fluidframework/devtools-core@2.51.0
+        version: '@fluidframework/devtools-core@2.51.0'
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
@@ -15714,8 +15714,8 @@ importers:
         specifier: ^0.56.0
         version: 0.56.0(@types/node@18.19.67)(encoding@0.1.13)(typescript@5.4.5)(webpack-cli@5.1.4)
       '@fluid-tools/fetch-tool-previous':
-        specifier: npm:@fluid-tools/fetch-tool@2.50.0
-        version: '@fluid-tools/fetch-tool@2.50.0(encoding@0.1.13)'
+        specifier: npm:@fluid-tools/fetch-tool@2.51.0
+        version: '@fluid-tools/fetch-tool@2.51.0(encoding@0.1.13)'
       '@fluidframework/build-common':
         specifier: ^2.0.3
         version: 2.0.3
@@ -15796,8 +15796,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/fluid-runner-previous':
-        specifier: npm:@fluidframework/fluid-runner@2.50.0
-        version: '@fluidframework/fluid-runner@2.50.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/fluid-runner@2.51.0
+        version: '@fluidframework/fluid-runner@2.51.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -16008,8 +16008,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/odsp-doclib-utils-previous':
-        specifier: npm:@fluidframework/odsp-doclib-utils@2.50.0
-        version: '@fluidframework/odsp-doclib-utils@2.50.0(debug@4.4.0)(encoding@0.1.13)'
+        specifier: npm:@fluidframework/odsp-doclib-utils@2.51.0
+        version: '@fluidframework/odsp-doclib-utils@2.51.0(debug@4.4.0)(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -16093,8 +16093,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/telemetry-utils-previous':
-        specifier: npm:@fluidframework/telemetry-utils@2.50.0
-        version: '@fluidframework/telemetry-utils@2.50.0'
+        specifier: npm:@fluidframework/telemetry-utils@2.51.0
+        version: '@fluidframework/telemetry-utils@2.51.0'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -16190,8 +16190,8 @@ importers:
         specifier: ^5.7.4
         version: 5.7.4(eslint@8.55.0)(typescript@5.4.5)
       '@fluidframework/tool-utils-previous':
-        specifier: npm:@fluidframework/tool-utils@2.50.0
-        version: '@fluidframework/tool-utils@2.50.0(encoding@0.1.13)'
+        specifier: npm:@fluidframework/tool-utils@2.51.0
+        version: '@fluidframework/tool-utils@2.51.0(encoding@0.1.13)'
       '@microsoft/api-extractor':
         specifier: 7.52.8
         version: 7.52.8(patch_hash=ldzfpsbo3oeejrejk775zxplmi)(@types/node@18.19.67)
@@ -17310,14 +17310,14 @@ packages:
       '@types/react': '>=16.8.0 <19.0.0'
       react: '>=16.8.0 <19.0.0'
 
-  '@fluid-internal/client-utils@2.50.0':
-    resolution: {integrity: sha512-4cisKUVNfcqFXJPu/HtC8nIWFWS0auWWYfsyDPXH5Nid70hRVgY9Yw58glwXaknCckk8tS1TJAMVc4xKgmogPw==}
+  '@fluid-internal/client-utils@2.51.0':
+    resolution: {integrity: sha512-ZNFgaaLZZ8rqnioA5j2QEKVIh+A8YK0K40Qeqw3B3ETpAz9NvTSI9ZacioYzfG5NZTU+UrxVKqA/yUTE+n5drA==}
 
   '@fluid-internal/eslint-plugin-fluid@0.1.5':
     resolution: {integrity: sha512-p0nVeMiEfLL2deQJQaRUxid08jgV5wEkh9h9WXNosR1BRq9nFCjD8nZpC1K+YhjwQZEvgGDE+s+28VR2lAg61Q==}
 
-  '@fluid-internal/test-driver-definitions@2.50.0':
-    resolution: {integrity: sha512-zhX6SvEjuUw3pkhEFbV/ImhNZ/+x1xCmJIlTE4CqyC42tDg8VmvVwATE6mQloce9PMAHv8nBgkLBE4PbFIIKAA==}
+  '@fluid-internal/test-driver-definitions@2.51.0':
+    resolution: {integrity: sha512-9M1w176hXRrIkNOucjXkGTo4W3sL4ufA0T+mOcravn0dy0hLc549MPOFx9zHkbbsS8smbJ8q9xS/UzhBOv9F1A==}
 
   '@fluid-tools/benchmark@0.51.0':
     resolution: {integrity: sha512-Hych9VQu9RrBlYwBHvb2J20GHIs8abpzx1TgypHHIsYDxqK7IVrQ/NRYTE+e8XvXwVHbiuBWQrtpK9oB9bGm2Q==}
@@ -17331,8 +17331,8 @@ packages:
     resolution: {integrity: sha512-6wEiUol3I21ZcYcr9XdsruKNxO2PO57BgPCKsQkOthWS/ZrHsP+NFoMaVwatjjMRuNipzMzk4HPx4pDCf9tbqg==}
     hasBin: true
 
-  '@fluid-tools/fetch-tool@2.50.0':
-    resolution: {integrity: sha512-0HfrO7zP5Tp/yb9nvPUlnXy6iwJi/1o38obLmVL1cPlmAK2l9r635yIdQ2BhjarhIZ0O0Bu1FAkMnSibzPxWdQ==}
+  '@fluid-tools/fetch-tool@2.51.0':
+    resolution: {integrity: sha512-m5MmEYukS+73+p2tethR8Ti5UlxGnh5jWkgn12xmV4QgGC83y1eh4etIJFDCvcpu07dEqOYfn0SHhZvckimD+w==}
     hasBin: true
 
   '@fluid-tools/version-tools@0.56.0':
@@ -17340,26 +17340,26 @@ packages:
     engines: {node: '>=20.15.1'}
     hasBin: true
 
-  '@fluidframework/agent-scheduler@2.50.0':
-    resolution: {integrity: sha512-ZDFuQx3MFNaIJrFz6Pay7d8fE9aNNXZ6LRMJ+In85KaiAKZzHm45uDF3nR3HAwS908uOLAm6fg7TxVmHwTEphA==}
+  '@fluidframework/agent-scheduler@2.51.0':
+    resolution: {integrity: sha512-me50Q5I1+Lh6qoDk8tnKl+qjC497XLjLRfb++SilCIaPas7DcYnRkOMhjFPaTUl6kyfVyp/duzGDY1gpP7xuSw==}
 
-  '@fluidframework/app-insights-logger@2.50.0':
-    resolution: {integrity: sha512-PvnPelBZLf52s67Ja/wKs6M+6S1gt7jWjHJJ9hLV+CVrYcC/a5Ppq3QTV/XbXWUOIGi0kjt+gJV+ZFisl5gFXA==}
+  '@fluidframework/app-insights-logger@2.51.0':
+    resolution: {integrity: sha512-liGiB75vLUPbNsek4fcLOL1GFLoyOrsARYU4cHIPJJNTbp6S+czeBCv8EVF5TMCUbXTD9np8CrnFlvl5bCv/BA==}
 
   '@fluidframework/aqueduct@1.4.0':
     resolution: {integrity: sha512-b3I3fWGAWuXQbyuEFeeEi3GVVUOYPWJfFaB4httsu5Jn4C0QSkKxftkielDlor9/7rCJYjHc4IEWViaVO+kBbA==}
 
-  '@fluidframework/aqueduct@2.50.0':
-    resolution: {integrity: sha512-kmE8BvF5s0LHxtJnqUB5ByHROFwh03B70Yy+WD9zsFdpauY0OiQIPvohtdbn8AwoZdSlu9i9tcIz9YwXnsKKTg==}
+  '@fluidframework/aqueduct@2.51.0':
+    resolution: {integrity: sha512-vB60ntFax2u5zuDKjn9ciQe/MYlyFYbN0m9trvf8y8FVYxQM8VMswlOlNQGFK/HKOyjk2iIJv3aJt7y5rZ6Nrw==}
 
   '@fluidframework/azure-client@1.2.0':
     resolution: {integrity: sha512-jpfYF6I1uwwCqOc8X0fOgZz4Lj91QFzKV4S9lM7jSW84GxytlL3nDanj9+EYC+vLn4liRVaOCA3zRwpkDNXRWg==}
 
-  '@fluidframework/azure-client@2.50.0':
-    resolution: {integrity: sha512-Qh9yTt3OAAynVxZ1UYoqV7+bd/XTrpGIOPhM5QEPOBYK6vcY99ncNWtZXIy+uCIFeoGEwjDTYIWDGL+3QWjyHg==}
+  '@fluidframework/azure-client@2.51.0':
+    resolution: {integrity: sha512-qLglOjaTZ+k0bPR/KBvw73ZKoo+kCrVlD9Mj7jzoj3lfDe04hXPKh51EUtMS5D84U/4ViH3cYgT8u8LhzrHcyA==}
 
-  '@fluidframework/azure-service-utils@2.50.0':
-    resolution: {integrity: sha512-S9i4sBAJySfj1JCR4Yb9OGOwbwomeiDHuo4hwjy1I1fHhlZVYiQJF2xY2ndIyORVyHgqX2zTENVg+wnNqc1OQA==}
+  '@fluidframework/azure-service-utils@2.51.0':
+    resolution: {integrity: sha512-dGoMSghD+x1ZFaGzDxoHgpMvEFSVAqL5DKTSPDhssACjcERAUYbS8YMWQuYPGdjUcoUtag2DQRd75L1sbaFLhA==}
 
   '@fluidframework/build-common@2.0.3':
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
@@ -17373,8 +17373,8 @@ packages:
   '@fluidframework/bundle-size-tools@0.56.0':
     resolution: {integrity: sha512-rFHMONltOXxErRSndoK/fx6XOsG76y/VsgjK+BD9IHwMZnovAjHRnBexdleq6RDCLWh9Gz3wQghfjsvFsQp9UA==}
 
-  '@fluidframework/cell@2.50.0':
-    resolution: {integrity: sha512-IFahAU+MtcWE8QhINJ/tGJyoUd8LhInPWFSdSSNI2rC7Lw9bFy9GVzKQC2tqur0mai1wK8NikIvw7vZMY4K22g==}
+  '@fluidframework/cell@2.51.0':
+    resolution: {integrity: sha512-HS4cod9cTq0Oir0pf3WAL3H67R0f5NBFSUf5L45zR+fcNDhSP6aBBeyeWHb4/xonhQE6ZLiyP5jxGcRZh3jcLw==}
 
   '@fluidframework/common-definitions@0.20.1':
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
@@ -17394,26 +17394,26 @@ packages:
   '@fluidframework/container-definitions@1.4.0':
     resolution: {integrity: sha512-UwyxdX739ltQhQ9Zr2n7mBKN2eYEVnY7GCsV60ZfLUawb021eeL0rVZZgT0t3BiTCCilBMl4Bw4KQ8XyYu2g/w==}
 
-  '@fluidframework/container-definitions@2.50.0':
-    resolution: {integrity: sha512-pn+NaCuwTo8P8qC2PADUbUjZ6V+PXAFcIRuogMKNlzh6q2LvIcJdg7uhqHWT+yWMHs50Tb+Ltytu8jk0cT15Ug==}
+  '@fluidframework/container-definitions@2.51.0':
+    resolution: {integrity: sha512-rGrmgllqr9YS0DzNI4CMy1YKWTFcboulpuxoIOOUc4EtwNoJNRx0m35Ipc8mCvY+EoixQ7lItUzyYbHhp424Fw==}
 
   '@fluidframework/container-loader@1.4.0':
     resolution: {integrity: sha512-D54tW/W5EXLb2nRUGCNd8bID9t9KVkQJmtnHfnQ/JggpaBWODaQRp2tCDtidwo8y6bkiqIheMGjIdjgP9SqJzw==}
 
-  '@fluidframework/container-loader@2.50.0':
-    resolution: {integrity: sha512-0eJj5Ha1bzxQY2VGfnrJxRoTkFKNwouVAOq4wRAcYum4yRG1TKl2o4cXNxeb7JGqPvNtKahsNQOZCudQMFUkTg==}
+  '@fluidframework/container-loader@2.51.0':
+    resolution: {integrity: sha512-zvhDw8h5SSSjsMwmImbijGmrW/0NeD1w0mNK4JA6Uc629hH7rNW1JyMEbyn9khtLSFgHJFbD+BEN7cS2HxEdyQ==}
 
   '@fluidframework/container-runtime-definitions@1.4.0':
     resolution: {integrity: sha512-0rlswYsMVQiD1/btlJ5Ebf3rfTyFd06E2/zRJiKWiaMzgmn9QqF7OoVtiJfAIUsyey+dR8hnI0IFlB1IMfIPOg==}
 
-  '@fluidframework/container-runtime-definitions@2.50.0':
-    resolution: {integrity: sha512-S7KJHydgNVzupcIvhzDOyuf9H8cXDcQfFKh9iIe1eJKqk6KsCoETHyMxyWDBuA7k2IM7xLPYINcYoQ1V6l9msQ==}
+  '@fluidframework/container-runtime-definitions@2.51.0':
+    resolution: {integrity: sha512-1DtezZDmkAI86GFqSyRWUeHkWosG9f2fVjUH0HBwJhSJN/4Fq9dCF2oQmOm1p3dgZ1d8puwRwLY62r0PA8oyyw==}
 
   '@fluidframework/container-runtime@1.4.0':
     resolution: {integrity: sha512-KENgBxuPD7GdNmdjmsyVJpPKZwfXoRlzAxaMNhGdMSbi6oXDrd1LSekY5tchhsLWBpB5ucZpuvmSgbU+h9z3HQ==}
 
-  '@fluidframework/container-runtime@2.50.0':
-    resolution: {integrity: sha512-/2+gKrc7SbSwEnWCjJaV7GkPArMLIhJfRIV2xs9pkpi5PLBD4fm/6JlsAGyrUEg9Ux/w/yBx05bb1qDruZKbCg==}
+  '@fluidframework/container-runtime@2.51.0':
+    resolution: {integrity: sha512-zRln5uSUyj3siECoyS4l+PvLySJxPRT+VJ9iQPXYemGdD0bXKn8YR6X8YPPfhOyzCmaC0W/GTwURR3sBO8fPzw==}
 
   '@fluidframework/container-utils@1.4.0':
     resolution: {integrity: sha512-OKYpvuzz5N62gQn8JELMyuKEwJAlToiLNWJP/dn/PS1HCKux5C/Mg7Twdi19DCgXP/hp5qvzAd+EHPqYWxMUGg==}
@@ -17421,72 +17421,72 @@ packages:
   '@fluidframework/core-interfaces@1.4.0':
     resolution: {integrity: sha512-PDIglmsa9BgFh7Xhfs32KA3Q34/arTVHF4m3M0IuAByP4z8Oi2lVuNENZnBEk+IJMcrUhUDk5Q9LH8KGfoAw+Q==}
 
-  '@fluidframework/core-interfaces@2.50.0':
-    resolution: {integrity: sha512-FaNl8QoS5c4Xzi0MUWGlyairH22g54kcouOQMW5Lm4ZVwbxltcNpX+qwf2td5IjbvI/Uke7XIlsr3CprQ4+adQ==}
+  '@fluidframework/core-interfaces@2.51.0':
+    resolution: {integrity: sha512-h2fuMsbpyvUCIyc0E8tfBCq7+7fxFQJx5POjWt4c1S1+y8iIQ+/akSRVxVzCQVyXSGGQ0DMgkuPl4+GiGtTK8g==}
 
-  '@fluidframework/core-utils@2.50.0':
-    resolution: {integrity: sha512-HyXq8ieM2EAzHvDSzjbN++5esZnoMqSYsoU4tHvfCzAJnwdWzXQhqjI0tcxRypAJqNsSZCMJ/ldPw7cvia2qFQ==}
+  '@fluidframework/core-utils@2.51.0':
+    resolution: {integrity: sha512-vS5OzyUQtSKStoc0Ls7z5M+7apdjnxNEWNTDE8Zb6bC0KJBkqe3bqiIUmqt8YTCEmS6znPoCCJ6lg4lIW4BGeA==}
 
-  '@fluidframework/counter@2.50.0':
-    resolution: {integrity: sha512-nEFhajIcLAnvyxy+qxYBsLMepnbED2Jg39VCSgm7goxMwyZIXQtkjykwcMaS2RhHf41uwCf7bd66MEfz4b5M+w==}
+  '@fluidframework/counter@2.51.0':
+    resolution: {integrity: sha512-9F8IjDfzMlYmbu3qgkgp6if9LOoDqrPBbmrDL/iHwqk1MF8UjAmvothu5YisQpEps51gDRA9MQgGguGVtOVUjg==}
 
   '@fluidframework/datastore-definitions@1.4.0':
     resolution: {integrity: sha512-Xmebp+XFyK2K8EIauQx10UdwOXYskuSyQt8pSZ6ggTMMFpUsnx44tSR8I8KacSFoYkrWzG/G64osRu23SPCcjQ==}
 
-  '@fluidframework/datastore-definitions@2.50.0':
-    resolution: {integrity: sha512-CdRcqkRWjqNLUVfhr/PA/SIvSoa9cBoIgpFQGHKzWcO+G0m7NLHDRnP0EOnxcOYeplV6OJ4PKwNssIrNoNk3Vg==}
+  '@fluidframework/datastore-definitions@2.51.0':
+    resolution: {integrity: sha512-K2MAptH4TE8tox4cpcDrCbavh6/g94UfQKPF00utLYL9qZTbBntzAfIyIysz0t6pAnobEBozhS5PXoN3e4pURw==}
 
   '@fluidframework/datastore@1.4.0':
     resolution: {integrity: sha512-xV8cfmNzGAcpbQMrtEXTe7N6h6IkybrStrguyhZB6zBFzaPw3RNeAsMTiSxEMeVkU4UFcnI/ZU2rMalzVVC3Tg==}
 
-  '@fluidframework/datastore@2.50.0':
-    resolution: {integrity: sha512-Nyr7cx0MwcdVdt0lC1HZA494cMXJ887JAY/8hKoBApUARWdMA40+Z+vUKi2gt1zFsVIWJIUa6Ej79n6T6lS+zw==}
+  '@fluidframework/datastore@2.51.0':
+    resolution: {integrity: sha512-DDltZntow0EuKPtGIbg1+m/Na6rUdC1G1rgAsDqd00lPak0QoQOggsXATviRZQH1hk0oaCFcKjyG5DFd5TIxDg==}
 
-  '@fluidframework/debugger@2.50.0':
-    resolution: {integrity: sha512-ogphq8og9uydcSQlCJ8Vjxrq4/EnvrkH9hryfIkLw8j2Tkgk1o6/mORI+Dy6Wkr2puJnEieqWCyPkL4SkZTvUA==}
+  '@fluidframework/debugger@2.51.0':
+    resolution: {integrity: sha512-+T38g84+yZW8xmAToMtVQ/6iy6skxYWISAjrfN/DA8ezH6ydn6ke+ZslsrXuwDSHOc02WJEVAozxvgIMgJShew==}
 
-  '@fluidframework/devtools-core@2.50.0':
-    resolution: {integrity: sha512-m3epEZew2UV04DdLu1RcAR1SyojzSnXev1Ic2wN+DF1+r++/qM8jlphqKlN2c93y1dMTsGgQTVwb5IQvF89guA==}
+  '@fluidframework/devtools-core@2.51.0':
+    resolution: {integrity: sha512-7/dUBZsteh6Y75ObKNDMszG3WKtzky87tHeWmeEJxaHVFg/wywpOUBkPLeJVMNL8VjtLJUyMR81F1Nr6bzuwig==}
 
-  '@fluidframework/devtools@2.50.0':
-    resolution: {integrity: sha512-vdpsU0XCX/iHEM5ceX90jwSor5vKqRav1/Ua+sawY6m2T07psg5/Fg23u5jJPbJPB4EIp+K183yhLRo1U4Q3lw==}
+  '@fluidframework/devtools@2.51.0':
+    resolution: {integrity: sha512-J2E7xcVpkCdPi8iWLKRzNzNNHpJmWVhzIV21HnDQpjyYUh5kzsjocy5x8tFSLXJtJ83z5VY6gdQRHAyFcDrZcg==}
 
   '@fluidframework/driver-base@1.4.0':
     resolution: {integrity: sha512-w3fYGp1Bkdjp9he3W3dSPQb1vU+zsRIcZZV9wGNfPA1ii7z9rnXzSgscn39IdLbZqvS2704endNwOIYHyBT34g==}
 
-  '@fluidframework/driver-base@2.50.0':
-    resolution: {integrity: sha512-7DQYXReesp8y4XdmL13tCNcNBVBI0yRjY4iluliRhFpf/c/cDjf0VrMXIZ+fSLObTHeLaxZdZ8QmxOMkimak+Q==}
+  '@fluidframework/driver-base@2.51.0':
+    resolution: {integrity: sha512-S/OIt3l4UWsTNlcM2drWwpKkx7xp+Mve4ChuKiHgJYMtlK0qHzroqLPqQFsWlXpXxRJ4F7diYpKd9VifWGt7CQ==}
 
   '@fluidframework/driver-definitions@1.4.0':
     resolution: {integrity: sha512-ay6Wwl8zGS64fjDsdh2iOeKiVVxT57Opeqjp6DqSglnnJi6AkSfYVoOVlMZ5+vJTfYJN3N4ptjrP/i3Mao9zPA==}
 
-  '@fluidframework/driver-definitions@2.50.0':
-    resolution: {integrity: sha512-iJdOHDywOwHn1KLWgIYaMJhsTESNFch9+GBN7AngjMKVvbC9vELCBQZbnUr8A+2g1PepvNH94Lpfl7E6Zx9/yg==}
+  '@fluidframework/driver-definitions@2.51.0':
+    resolution: {integrity: sha512-3xvXfoFgAvmc3ruFAZAEc9+9FiSg1vAs7Zj7Ai1VI/q/7tV5aTwkm2GVBc4I7fRYZ0IS3xPDNeTv05pnu6BpLQ==}
 
   '@fluidframework/driver-utils@1.4.0':
     resolution: {integrity: sha512-NPTFw54a+EnIzop7iwrHTONdt0UAjW59HhMlYVPMH8/aOBodddHl7oi2Ek96nZLc+6qruHImjJ+0OW+NxNS+Gw==}
 
-  '@fluidframework/driver-utils@2.50.0':
-    resolution: {integrity: sha512-CPVjCS4ApBqA2HRvzLM24wVidkt3u+nQ8HikfhlQycgHO1oJPE6tACl3ZPx/Ca4eoWacGf1JkFsWUGYXTjYhCA==}
+  '@fluidframework/driver-utils@2.51.0':
+    resolution: {integrity: sha512-kJhe5yrQIzcNRIpKFzNx4oD2kDQyBMrptnrnxXlMMUyggsG1+AhvT6cHMfrj593t4ghGCe3vdfSW4sdnzRrK0A==}
 
-  '@fluidframework/driver-web-cache@2.50.0':
-    resolution: {integrity: sha512-UXb/D/JEP9o+jImfRbK2DCFmEqFZ8Dj3egJxXqSdk4KWbJl9bUfQpzReQOqXn+OSiwKwaLMwbkqw5x7pM14LUg==}
+  '@fluidframework/driver-web-cache@2.51.0':
+    resolution: {integrity: sha512-nb04KcRGuV1C5ygLH+bJmdK6JoZYD7nQbxHFwDUdXgcM6SnMp+J6VJyKSvtDPnfkgt/nP8MekPwIKQeSGNXKpg==}
 
   '@fluidframework/eslint-config-fluid@5.7.4':
     resolution: {integrity: sha512-2JD0fKhR0wk8kWkUmjNY6FcavLxs0/oQ413z0gFHUSzd8UTkwTYumFQWpDBEoAvXqQw4nUOTAbicNIqHY25EyQ==}
 
-  '@fluidframework/file-driver@2.50.0':
-    resolution: {integrity: sha512-2euYBpgvRdVV7JBkprxhPZk/l4u6fRwxrpyqUv+7yuc5zhJYWoe9PdYK3/+f5vM+T/V+RH/9hDIOVld9LK1HZw==}
+  '@fluidframework/file-driver@2.51.0':
+    resolution: {integrity: sha512-OLw7ClFyNZGoUXN2HsED+sx9hgV28TyLcIj2sIZEIzPK8yQyi1iRno0f94atKtDkf0031ZvLmwSES81V+7D0/A==}
 
-  '@fluidframework/fluid-runner@2.50.0':
-    resolution: {integrity: sha512-cKdmuQUip+aOzrdNXST5x8yDmVhGHWMDQRwiH4k9Xc+HQUbzVYsIRmKqdZN3U4Mniogc7CX9rRS1dvLUiy3Dqw==}
+  '@fluidframework/fluid-runner@2.51.0':
+    resolution: {integrity: sha512-Bw6GfAySGIXQYuzyqwV3SrB+ddMabWA9tdoOyOzSQ9jtO1PUuLC24y/4XL/GZ4wOusCKqmNBKKLq4Qw5bzjqig==}
     hasBin: true
 
   '@fluidframework/fluid-static@1.4.0':
     resolution: {integrity: sha512-YlSX6Ibm3HquB+swxoIJt6QM1Bd6R9rBHp/HYDR9/9JuQwCIqW1xvF2NHmXPN/TGl51DnbhSB0gtm9k6pYd7pg==}
 
-  '@fluidframework/fluid-static@2.50.0':
-    resolution: {integrity: sha512-o3oJQdi6Ck1+y961bcHEWniXLS7lM84ceTRf4LIMglgw81Sz1CV4w7kQbiFiO5Y5I6kVEMihjygJ0/CeV9qtQw==}
+  '@fluidframework/fluid-static@2.51.0':
+    resolution: {integrity: sha512-diQKnKsKnqEygNicIvTqDZyna1ZnYhZlJQ+QjSGPUx8utkvQ7dFPSAcueir01ni6i09aEl5yl1lvyb9oDxcSQQ==}
 
   '@fluidframework/garbage-collector@1.4.0':
     resolution: {integrity: sha512-bwt1mv3B2PcvVN/JqBkm8MwdRydVboBM7MguQkANDGkmUPD56dRzjBYEdOl3yNZJEO/xJ2v15RPrkf1coI78Bg==}
@@ -17494,50 +17494,44 @@ packages:
   '@fluidframework/gitresources@0.1036.5002':
     resolution: {integrity: sha512-/xdmCca+arU9x9tDGdIl2CCk0DmpWlFjZdcTdWjLNiexKMVKDrHmSw9vCpUMlGmECq8EOO7fyzBnAGM+nu+i0g==}
 
-  '@fluidframework/gitresources@5.0.0':
-    resolution: {integrity: sha512-nfam1KT+EUqFCENHcxrU9VwUfbhUC83UcLuOsdLpn9I7VuClL+w8KMWosoYauZraO9gDhTo2kCErjgQji5GzGA==}
-
   '@fluidframework/gitresources@7.0.0':
     resolution: {integrity: sha512-APAxqCF/+2ljC8th0PoXzdUAo2EJapdTk9KNm6dp7dFD5hxYWoscFqdyu5K+bvMxmhrIpGd0f//nbb7rZq7bog==}
 
-  '@fluidframework/id-compressor@2.50.0':
-    resolution: {integrity: sha512-gLM06fdca2xvh7SmC7j/QIm4ZCLMTu3UqzTyX6j5Qpy/9seMVuZT6Il8lGKG9PBa1Uxyxxlcz0sOUSP1sgJEDw==}
+  '@fluidframework/id-compressor@2.51.0':
+    resolution: {integrity: sha512-4cQRcuRVTPlVoY0KgbVwt5MEbuSaF7L+SXIh5Gj9QLheJ1/imOaOQxFYThmGpEWPPyjzfImBysKqi1FdGjPdkQ==}
 
-  '@fluidframework/local-driver@2.50.0':
-    resolution: {integrity: sha512-URWJy4Tdw3FC8PjUz4x/Y5xXtr1QCwjuFLBbRWEbkyt+v5eAanSNgYo/00s997PFGy60n4FmWaRKfQ1iICuFGw==}
+  '@fluidframework/local-driver@2.51.0':
+    resolution: {integrity: sha512-zz3wwF6zdwQpt4HJwQqzZpGVLVO1grIDGOsx3y+AkEzkDhgsTXCb7ZIqHcLM6vjf5/OS4tnBqBA1beZBFrce1w==}
 
   '@fluidframework/map@1.4.0':
     resolution: {integrity: sha512-KBdHBxCcIvPtsUSqnc5Ztgs2U01FwgnsW8WF3bl+TGt55Xs4esm3+p43WNkET1YU5Q95RVocRVp03dYMN7xelQ==}
 
-  '@fluidframework/map@2.50.0':
-    resolution: {integrity: sha512-XHB2CygdRl/BRVhSLhSB5upYu6huJ12dVii/vNIuAUuiBGMbBJIMPyMJZIUSePymUadjxV9WJVw0qK2kOpHJag==}
+  '@fluidframework/map@2.51.0':
+    resolution: {integrity: sha512-Wmp+bgrKzQRACzN7/jJiJ9Ws1WNjXl12P8xykHmdga4waHG2MJHVeXuJNPkSrW4pZKuGdW4OlEU1KA2KSlsY4w==}
 
-  '@fluidframework/matrix@2.50.0':
-    resolution: {integrity: sha512-qyFU1P8tmfnFWj//d22SX04Zdld7324zY1MwRaHdKNahtZksNF+3UXuPa1EaiSyCp6nYttAW818UM7yp9OXFCg==}
+  '@fluidframework/matrix@2.51.0':
+    resolution: {integrity: sha512-v8c38mhzFqvYexnl982FjcPZZ0RFJEDErcrwsq/l9Gy7Sg+HbHnLfaelrQXTIWWjflAKbUYxtG32AltXVScFPw==}
 
-  '@fluidframework/merge-tree@2.50.0':
-    resolution: {integrity: sha512-j8iqzhn4fEREysZEVb3AmPmLuhJiK/OjZbDcmwKKh0iFaQf8Nn18EtakgcxsuHyOgbLCZvXpEFCvz8C6OJICGg==}
+  '@fluidframework/merge-tree@2.51.0':
+    resolution: {integrity: sha512-/5pFud/k7iQuR+WVIEPuvKjWTtJGJHOMvQQPtDxUk5ziiR3vmkT5q5ahE9kufMCe7nhrLnQz9uH0BH5X6Nd8WA==}
 
-  '@fluidframework/odsp-doclib-utils@2.50.0':
-    resolution: {integrity: sha512-R8Z6Na3+H14P8QSonPHEy8gQtXZ5p/Q1L5t2jM738XL/qkdvG07+LtvGy1CwkoORvkdfHNsiHw4VJkeSa/8fdQ==}
+  '@fluidframework/odsp-doclib-utils@2.51.0':
+    resolution: {integrity: sha512-a8awF0nCrloDPOAlcBrsfeln/pJQabtIOv38rwxTzpcUqDx9l+CaFfTH8hsH+2JBVu9RHyAEgrEwtKWfKlWLjw==}
 
-  '@fluidframework/odsp-driver-definitions@2.50.0':
-    resolution: {integrity: sha512-SxmhCJcbjARd+Y2h63Xpf5/3ixmg6fo8QgMkAcQk+yIZMF3KXY/0QrQUXzKLTYlqXc/mmF7CDL72wk8ZYxG+4w==}
+  '@fluidframework/odsp-driver-definitions@2.51.0':
+    resolution: {integrity: sha512-xIKp7XFV3kxx8gvbfUN0+bPcCsIDUllVHnlBGBGF5uh25ik5rToyGpzDIDu4uEdi9EuAl2GU5IpTpZDOZZd/6A==}
 
-  '@fluidframework/odsp-driver@2.50.0':
-    resolution: {integrity: sha512-0oVVmD5WV5xdOTcOi83wF1Eli0ifHkNBp5vB4fruRJO+tZxjJGFmnQ4oWVkIXtpPhxb34ec7HuleLlepuAE+pA==}
+  '@fluidframework/odsp-driver@2.51.0':
+    resolution: {integrity: sha512-j8NT8+sycyDDM4Iwk/ff5EhzJ7ELBL9gu0vHjQbNWiqwwkw80TxWeP2kFnLtXoUECCmL9db3vstMMMr51nendg==}
 
-  '@fluidframework/odsp-urlresolver@2.50.0':
-    resolution: {integrity: sha512-Hz9WHuk+KXs8aghN65cyb10oU3n7WLZJ8sONyQQ7WHtTy8yAEL1ErL5DpT+w9lA8Megxz9McMK5Jsb/NBqItMg==}
+  '@fluidframework/odsp-urlresolver@2.51.0':
+    resolution: {integrity: sha512-+nNmxiQDG5ALWiuOmDU3zKRxa++/UB39qMEw8yVsjDJmyu97bcZX6pZiF5mTHU9clcc4NHmD+BAhDeI707uQAA==}
 
-  '@fluidframework/ordered-collection@2.50.0':
-    resolution: {integrity: sha512-QLQ63E1ZCFGWeAaFybRYMXDyqQ6yBPwdgczXlw4TSbK8t23MV+0FpHYc6CMm7gTIMROm1XqORBazBjDcoVI8/g==}
+  '@fluidframework/ordered-collection@2.51.0':
+    resolution: {integrity: sha512-hCVVbGu83Klj0Z4fwMNmlZ8luezTbyvOr/ZiMmxC1K+MwmcNKqhXK4mVBsN99ar0Vu8Ak8L12XLwFLsbG3nSSA==}
 
   '@fluidframework/protocol-base@0.1036.5002':
     resolution: {integrity: sha512-mlI9okyLeSusGx7qU32NDJ4GJptSzVo3V6tPDhphPIOPtyOVTBuL4EQRFYdceoSLHlxEdVnQprwhyoRiMNw7Kw==}
-
-  '@fluidframework/protocol-base@5.0.0':
-    resolution: {integrity: sha512-q5qQt269nUYQERwX5lntfEXVv7jbxFmGAZC1z1I5hZmkvSC6PJGF6GzXAtP43/eq0+hCftxmIT0jus+kLL/K4w==}
 
   '@fluidframework/protocol-base@7.0.0':
     resolution: {integrity: sha512-LUSTKQBJVnemMLMQUuoszHvl46XBfflI8U9R8kW+12T2W/Vvt+ldML7203MvNg4E/sFScGfqqZS5OzYn0z1TIw==}
@@ -17551,62 +17545,50 @@ packages:
   '@fluidframework/protocol-definitions@3.2.0':
     resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
 
-  '@fluidframework/register-collection@2.50.0':
-    resolution: {integrity: sha512-syohaYBXh9P9uXeDXLXPf8IHJdQByo1MteJj4LkohclAVlrp1ndGWj9WkGQygHVWQVcjYScAwCulATq76t3egQ==}
+  '@fluidframework/register-collection@2.51.0':
+    resolution: {integrity: sha512-RfLWx9TMykhFK6cEtNMqtXBY19TdvAxDzmussWxL61yedHCPjHvrCYUzPgCDCmPnrSxVGDhW7ToMAaKLkvbW5g==}
 
-  '@fluidframework/replay-driver@2.50.0':
-    resolution: {integrity: sha512-Cs62xsilMSBU51V6Mfe9dmB23XmhkcWhoQwoP3DQZ/9E8uMqQIOWJCVDHzQaeAVwTrBTnwXktvqF81iteUx1EA==}
+  '@fluidframework/replay-driver@2.51.0':
+    resolution: {integrity: sha512-kWaMNOvA4ywQdlGD+Cs8N+OGKdw3tmO2Y0Nf05OTD8rldeEt1/Xiq8FDzWMZxZxg3OQVxWtQKmTuu0eVs0Lh+Q==}
 
   '@fluidframework/request-handler@1.4.0':
     resolution: {integrity: sha512-KDYjQcrdvSuHXBtIG+LkDCcIjiDdw1CKX4iWi/aQrbGOTFVyLzfb2SnEXOBz7sw0YuMhxf+S322KTcX/OWd12w==}
 
-  '@fluidframework/request-handler@2.50.0':
-    resolution: {integrity: sha512-/OFTs13MIWdQbNfBtWSBWkkK3phPJSHLYzl1RZXyAvyywSi84N4VzyjISqlbwWN0By8JrspkgA94yo4MH/+Hkg==}
+  '@fluidframework/request-handler@2.51.0':
+    resolution: {integrity: sha512-uhdUGiQVzYFZrA4oW6VA3jhN/I0w2XVAJ+8wbadWJLELKCraORaxhXCcEZuTlH+BSAaZSVebXj3J4liNEYOf8w==}
 
   '@fluidframework/routerlicious-driver@1.4.0':
     resolution: {integrity: sha512-iyLywWEgo7zWYCiJj0GPzsrn4lmLw65GYJLEod57fBCk9eLRRxhQ2GJuu2k9XGV6nCFadEc1ZEKufDUNIiBPow==}
 
-  '@fluidframework/routerlicious-driver@2.50.0':
-    resolution: {integrity: sha512-fFyuMAwh7MEzPA9dXqvr6i1cuK0D9FFUt0WlWtBtMojqHcCJwgCZq6F1nHTyKbt6tYRgIr+9JzvGZrCwnjHnOg==}
+  '@fluidframework/routerlicious-driver@2.51.0':
+    resolution: {integrity: sha512-3H4aepsj+Np+MWq3oqPT74jYeNPOUFHSgWOVZSbjYTsK+86HjfXyGlyO9swHJLt3oBMpn7tBtCkcChaIh6WEQQ==}
 
-  '@fluidframework/routerlicious-urlresolver@2.50.0':
-    resolution: {integrity: sha512-P41JKJ5T6jgElLaoJoIeH26VoNyWQRAJz4s3VbpYKy+mKStUmoP6WF96RaEZn0nayLDjeReLDecRnXtHG19Xug==}
+  '@fluidframework/routerlicious-urlresolver@2.51.0':
+    resolution: {integrity: sha512-vhm2AhERyucoYm9yUJgpm7YdC7Ro1hGhR36tD0EPmHFRxgW/eXi2rn7mkRQeQS1HJeDg9LzTWOUsLOIbiI+wSw==}
 
   '@fluidframework/runtime-definitions@1.4.0':
     resolution: {integrity: sha512-GewpwBxbeMutnHHXzVWsFYbGQJHKh8dFNqTiW0covMfaOOhXVSM0qzuf7RY7qX9n8Vn/bK3zF4WRo6gx/32fmg==}
 
-  '@fluidframework/runtime-definitions@2.50.0':
-    resolution: {integrity: sha512-Mvr4h+m0LJoJs/OQpg5So4nocmQdVcurulQVV6z+yvvh0gNRzIOi3yECJgOEHmfUPZ2qvzaNeNX2i+cklQAADw==}
+  '@fluidframework/runtime-definitions@2.51.0':
+    resolution: {integrity: sha512-oNMQC52mODul2XU5bCQw0tAIa8jgTcwPp8e2SvNkc3HCUrf9YZMcDtQTJ22poLL7JcTqw8+KN/HvA0SQQD10FA==}
 
   '@fluidframework/runtime-utils@1.4.0':
     resolution: {integrity: sha512-0drnuEdUja1m2401FXcsB9l66x5oCGjgW43mLjZgZFKcz5v5jYZml8OKWAtLmwfI/UNLJ9bQkb/nHQSM0Tf3Rw==}
 
-  '@fluidframework/runtime-utils@2.50.0':
-    resolution: {integrity: sha512-Em82XpTnhGC7hFGDTvx3BmC5fvha4wYBFUQlWApCZ9y5qbprt9SEMB+gRZAD3TZw+YgFEGalKDGBHgfIl7jNXw==}
+  '@fluidframework/runtime-utils@2.51.0':
+    resolution: {integrity: sha512-3ZqJ6hyxP7UaFp/yz0/WVpJQUsBdGiOuMDvSNk92+9Fp8beQ2hLa/yO20Lwgniysv0CuQJoyE9I0X6DfdICzWQ==}
 
-  '@fluidframework/sequence@2.50.0':
-    resolution: {integrity: sha512-NxN59clkaFc4UBNezTEQu+6E714QwOVbq1exHL2sdEFk/ZrjJzDnE1dl8LsPb5Mk1jaTLh8J/h3NvtqdoAw8QQ==}
-
-  '@fluidframework/server-lambdas-driver@5.0.0':
-    resolution: {integrity: sha512-tnMxsxKr2zajQ64Ew7zcTKclK2Rkp7cqK4ghiuYkzhdbt7ZxIMVmkSW3B5/DXDSxVoi4VR6q1BA6cMnGJMcwsw==}
+  '@fluidframework/sequence@2.51.0':
+    resolution: {integrity: sha512-o4L0qzmIdhq2uKSgsYTiGS35YglN8rxew/GqpfZ+W9eJeETcVuWK9QruaBElbRFXeluHC6DUOPu5eBSrL1djTA==}
 
   '@fluidframework/server-lambdas-driver@7.0.0':
     resolution: {integrity: sha512-HNXeXUWYIR+jjGMAB61gCWsryuwqysA2o7/bwvdZuM4avqfm75dJUheB6N04uG5GfRfvesMHU68452YHIf6FYQ==}
 
-  '@fluidframework/server-lambdas@5.0.0':
-    resolution: {integrity: sha512-t0ouLtYi2y5DBYbp+WT4mIGXTSYK/1Yz+cb0prOtAUxYqsn+TAG/hr2DE8OyzHdL0RHZp/y2KX7X1jZhPxxGDg==}
-
   '@fluidframework/server-lambdas@7.0.0':
     resolution: {integrity: sha512-D5yzSZWpCojgZR2dfczSHa8lix2V39l1P5mwVrfmrTZE8tL+a3POnXtxcRJPT7QeRImfrMMDBdIBXE5dwFxNjQ==}
 
-  '@fluidframework/server-local-server@5.0.0':
-    resolution: {integrity: sha512-v+IBLojcZm1azQhiSEPCt3A2/xByiqDQ7/0gdkFenGrnEvnJ/9r/vv6ON0vAWFqDXov1Nu6kwEGA1bXIZTeHQw==}
-
   '@fluidframework/server-local-server@7.0.0':
     resolution: {integrity: sha512-ygCDPr3pE8HCakMtdYOlv8X6jpyzqval1hbf45v3egBI5LmolA+RDxKGA/nNKo525u13kGglPWvsuC/8tN82qA==}
-
-  '@fluidframework/server-memory-orderer@5.0.0':
-    resolution: {integrity: sha512-S5G2TwHXlewGkZ3jAtUKr/vpku0LPvhApktOVtAidIGHlKJP0kjLiom/KZihKZT5h2KqIhFBy56JgkXPFYkNeQ==}
 
   '@fluidframework/server-memory-orderer@7.0.0':
     resolution: {integrity: sha512-HmimZuGDYabOma6Tdn5jHpk2IRNEtxbUdUuNkR3qqZxPaqewTj3qeCOXRTMMGyEEaUg5Gmw19LrOROeDRcG6pA==}
@@ -17614,14 +17596,8 @@ packages:
   '@fluidframework/server-services-client@0.1036.5002':
     resolution: {integrity: sha512-2d0RSUXvfNlFgHVLiehiU4LgJheqGXlspIgug6U6nvPdwFGtQSbButh2SysBDFilIJ9E6Bacdd0P0e+4HRpCaQ==}
 
-  '@fluidframework/server-services-client@5.0.0':
-    resolution: {integrity: sha512-Cijcy/WUL4U20XAVmN3tDMCYmjmwAmAl6drXBYzN6QvnwMN4PsNjwgsZdEHN+2D7wEs4o/Wb+g9DNv+Lu5EmLg==}
-
   '@fluidframework/server-services-client@7.0.0':
     resolution: {integrity: sha512-gzEvH6wNpRuMsyZhY22JrOHbTFsPGSzjLIlAWmnT7UT0znYGCDaMC39WPbOLLm7O8JSvmUblGe2Vx8N1+gCOgQ==}
-
-  '@fluidframework/server-services-core@5.0.0':
-    resolution: {integrity: sha512-ztrGdRStwlfBFVsm+kChu6VuI764O4TbEEE1RX4gXpLlOsUVZfgYfeUiysdk5Zh7svDKT9n5LdE6VdjLvwb7IA==}
 
   '@fluidframework/server-services-core@7.0.0':
     resolution: {integrity: sha512-LdPERvJ/8nyXOxDPJ0VsWBHsGjwaCve7kdOcMTBk26UQhsHKtSl1D4ZuStoremzzQZBnA0FuksoZsA2yDizwAg==}
@@ -17629,17 +17605,11 @@ packages:
   '@fluidframework/server-services-shared@7.0.0':
     resolution: {integrity: sha512-kO2/34/4rPPfjnyadaSaIXotWT4ZWMcGxiqruIbuU05zV+OCieUrla3YnE8GFtQ5hCGPMDE6+InfoUcEb8GN9Q==}
 
-  '@fluidframework/server-services-telemetry@5.0.0':
-    resolution: {integrity: sha512-lWymor6/GVgZpjtBOEUzCmjNJoro/oK2MKoT0MFgg70bhTgWKAOLRAkJZgq8GLGPCHW7ntZ/D+ve763kPu27CQ==}
-
   '@fluidframework/server-services-telemetry@7.0.0':
     resolution: {integrity: sha512-C3PNyfBWmWboAkSvExELdwyW8dQ9RBIUPhh1P016pf76NRIk2ZypLloVh7K2WA5fo6Tv+gRYhnT2gThXhNm5IA==}
 
   '@fluidframework/server-services-utils@7.0.0':
     resolution: {integrity: sha512-/hwQbeVx3prXNTReSVGbGmDZTbAKPDUVhHB5CY9eG9nKbo8FnkXUbaOXpgX1xECAWhzer0K4Qj//93G95TAY8w==}
-
-  '@fluidframework/server-test-utils@5.0.0':
-    resolution: {integrity: sha512-FOZ1Faw6x8VALUZh/nY6zKCfpgbPK/ylpKf/uQ2oOV9sxGNQfo5NXyHlQP1b78wfx2OYyHY5njtvYl7i9tz/zg==}
 
   '@fluidframework/server-test-utils@7.0.0':
     resolution: {integrity: sha512-ACUoJDbL3sckzeDe/1DGUamYI9IIGyYyeP88MfEnunqgz9FoDrdn3Jae2Vl1SSBYLtck8IxG86rSOh0kbXcPHQ==}
@@ -17647,51 +17617,51 @@ packages:
   '@fluidframework/shared-object-base@1.4.0':
     resolution: {integrity: sha512-NI94dsIyZL7s76UN/UVawd0JqV106cS84MaW1r9Qv91+QGU8aq/KCS3j8R9ZZ8pWFQ46sX9BT4CKa4hy4xZedw==}
 
-  '@fluidframework/shared-object-base@2.50.0':
-    resolution: {integrity: sha512-VDVMGZyPUDUgzgwJod+tB7u6Bi6QcG3Ryfd2oqTN+h6Jp7CiW/M+Ktra69uTFFg4hvSOoIQc6+K+txxecVpsyg==}
+  '@fluidframework/shared-object-base@2.51.0':
+    resolution: {integrity: sha512-SaOxJlN5tIrwv9j8ytXJUX/h3Y+XF/+xRCLEwmUAOnDDnHKOEToLMH0sofG0OCJNmZ0i18KHBIijA/kYouTPEg==}
 
-  '@fluidframework/shared-summary-block@2.50.0':
-    resolution: {integrity: sha512-q28QqRNayzxfSVh/LFIM8+X2cIHfWobO06vWm6yxd/7PL37miECKoq5SJPf5CfduD8GgJhRMFljJsbh7BmjDQA==}
+  '@fluidframework/shared-summary-block@2.51.0':
+    resolution: {integrity: sha512-5O558NlbTZu1EekaRFNBeCYncafYQK5R67J3yZAmdhVxhhtOQTpWvRGEQTku2g+frzNgxqeb1isnQp8IFiPiHA==}
 
   '@fluidframework/synthesize@1.4.0':
     resolution: {integrity: sha512-0pdq28pZ/cA/OVOp7KiUv8/bDxltwQy2ca7UJQGuyRDF9n1QcXoWC98liu2fB3/imahdfDi5pZ6l2vw/nIiFkA==}
 
-  '@fluidframework/synthesize@2.50.0':
-    resolution: {integrity: sha512-bwHEbmxeolm5ETHjM75s2u38TaigYjd/QBoKxTypkkwMWP/CYwBV/OUyX3fuonsJ9VFBjH14YxuWyo7zzm0cYA==}
+  '@fluidframework/synthesize@2.51.0':
+    resolution: {integrity: sha512-JOT7IPxLodV5oimbrM6PyULkN40s/fO4QPk0b6oAAP1w8FXaFqP/9QZx6panq/m8m53qrKQ4Gj/bR2GBS4958w==}
 
-  '@fluidframework/task-manager@2.50.0':
-    resolution: {integrity: sha512-+0wVUnQUbyFXYp9EVXKFRVMzS0u7Q8gxnTAe8Ip5uFNR2Ezqx93YKMWYJhK3FfY0ZlmBzsPcM0+xq9x6/VL+JA==}
+  '@fluidframework/task-manager@2.51.0':
+    resolution: {integrity: sha512-7Dg+dtF0ZxhCAjB1BKKc8HYNVRZD82lkuaz8Vgz3ie8e+2lzYa3nlNp6SSBfMnO1cgTO6RuvREbzWQzuF4Md7Q==}
 
   '@fluidframework/telemetry-utils@1.4.0':
     resolution: {integrity: sha512-WXG1ThL+WJLGdBtUGlCPPlIrHxqnc+zy+YHrYtqFnlIp+75W3W+YApR5dyP1uCfvapISoBPo0htK3WNIiyj8Rw==}
 
-  '@fluidframework/telemetry-utils@2.50.0':
-    resolution: {integrity: sha512-9R0W2sHD+CJlgL2F5KUxqJBNL5ve5jipnuLbznemQfxwOsayMVGiu3Y7WjNL/Qvk8V0jnmC6kNBuKfxsyLf3fg==}
+  '@fluidframework/telemetry-utils@2.51.0':
+    resolution: {integrity: sha512-AvHYNd/VzfHYNQsCnFU8pRacmBZwch8dvLcbe8txivIGWm7JXQxdmF7dS6Qvuo6Yu1tNVsYF2fcX8Ncf36RnDA==}
 
-  '@fluidframework/test-runtime-utils@2.50.0':
-    resolution: {integrity: sha512-fu7eagGBiPKzv6UGHg7Ak1RNDltZoMwsHNnOVg1QcqTcklf/PHbcLlw+e3e5T5kXoDoBPJjgNS665uCMAeJmkA==}
+  '@fluidframework/test-runtime-utils@2.51.0':
+    resolution: {integrity: sha512-s03idBq50n8FwJYry5VUChGBwoop6fygKINl9kmnpExzJiFlMHSftY8Uz6mfKiJ9N/uCXgP7DBe+LjsOO9xMzA==}
 
   '@fluidframework/test-tools@1.0.195075':
     resolution: {integrity: sha512-N7FiXKoz6uQhDJhJxSunya5uP/GWNEp0ohYs0Jkb8Mmnow1SKuxl29x3rC9Kf5zORjUk8krCjam50+d8aPFGaw==}
     hasBin: true
 
-  '@fluidframework/test-utils@2.50.0':
-    resolution: {integrity: sha512-edNdGJDrNn7M3f3xxIhIKowq249Ax0E5RK+lN9goA+KZuFfyGZIif7A3xKVxbgXEtXG62+2Uk2c19VD/gid7jA==}
+  '@fluidframework/test-utils@2.51.0':
+    resolution: {integrity: sha512-szVM2+ydRDQlvBbDCcYaGNDMJveqQCqS7iYw5AvBkbGuyWpF3aptTillQOl9C8F5ySLA//TA8zFIpiJFFZAM3w==}
 
-  '@fluidframework/tinylicious-client@2.50.0':
-    resolution: {integrity: sha512-E7PBlsZ5uR4qeG6B+dUH0Kh1xomj68A/jELCWneSEIWTcBkrJIaQwjK+zGOo3dk2TrZ4W8J5O6TYsQksrKVkAw==}
+  '@fluidframework/tinylicious-client@2.51.0':
+    resolution: {integrity: sha512-EvUdUtSsLdpyPDhiGJJcA6x6UUDLtyZEO5HOJkVyR/+3L7hw9Bo0rGY6iQ81wlXwcjgIuzbzKwWTy7bqzaHpWA==}
 
-  '@fluidframework/tinylicious-driver@2.50.0':
-    resolution: {integrity: sha512-bEO/uHSdmCafQZoNHFK0bLP3e2t3szQWSBp8flJ6I2LPa9LcEpXo4c6+LFT7JVx6qk4c8FdJehmqCBZzw5+93Q==}
+  '@fluidframework/tinylicious-driver@2.51.0':
+    resolution: {integrity: sha512-zF8WO9Bwt744m7E8T6Mbuvjr+lBNz/kF+eyvYy2AEMq3LNu0FLudAkp8koXHNxe/77cppEKKX0gY7QpNN9KN2g==}
 
-  '@fluidframework/tool-utils@2.50.0':
-    resolution: {integrity: sha512-7Wb0h7YZGPZA9NLVyESBDoaY2zN5ULFS0u8fZksvIamjWFu2aoxNIWy5qokrWoQNu5HKoWkEMoO10RORPyicSA==}
+  '@fluidframework/tool-utils@2.51.0':
+    resolution: {integrity: sha512-qVgI7yEwGQcipUsUHRImNBtFbAZGogAe1gebMbCv/vqdU4MKnK0j1+JBrPUhkjea/r7xdKAevZ7yud7mqPUITQ==}
 
-  '@fluidframework/tree@2.50.0':
-    resolution: {integrity: sha512-mXBdkH0oIiVPXtz89qev1wr84GBIJgmC3MpQUDKPSuA9jwmZuPrMpKvtzDrip9T0rA3SyGaOGvjh2bNNwXh/7A==}
+  '@fluidframework/tree@2.51.0':
+    resolution: {integrity: sha512-ga25Cu5KqZ/DqSWmiVgwLVjtOl+OGf646tlvgZLczPfunfXO+lzHkybjyy+HKe0Fk0YZ3YFqyzPW6+hkzc+IlA==}
 
-  '@fluidframework/undo-redo@2.50.0':
-    resolution: {integrity: sha512-Mmm0Vko7FifYpkiLPXSSwk89arqrR9utAVsNb7LCu0iexG5+G0uw4oz1r1kcuFRRahhn8Jo9IyxMUkCaZC2oDw==}
+  '@fluidframework/undo-redo@2.51.0':
+    resolution: {integrity: sha512-SuNZfbQVHcJTCjblChj2FEGe9X6zDHd0icOuUuARbljgV3asXGrOIYv7OVKDUb8YbXk0U07tVDhBkgU3rMZNLw==}
 
   '@fluidframework/view-interfaces@1.4.0':
     resolution: {integrity: sha512-YD0HE6rMpG6h/ELR717flLZ4Th0Ik0UUkECgaouW+Qy+Of+uPbi4KVoKRqTEEKzZqBFSbvSR5x3TlbmcXiEZnw==}
@@ -27070,10 +27040,6 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    hasBin: true
-
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -29425,10 +29391,10 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
 
-  '@fluid-internal/client-utils@2.50.0':
+  '@fluid-internal/client-utils@2.51.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
       '@types/events_pkg': '@types/events@3.0.3'
       base64-js: 1.5.1
       buffer: 6.0.3
@@ -29445,10 +29411,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluid-internal/test-driver-definitions@2.50.0':
+  '@fluid-internal/test-driver-definitions@2.51.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
 
   '@fluid-tools/benchmark@0.51.0':
     dependencies:
@@ -29669,24 +29635,24 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluid-tools/fetch-tool@2.50.0(encoding@0.1.13)':
+  '@fluid-tools/fetch-tool@2.51.0(encoding@0.1.13)':
     dependencies:
       '@azure/identity': 4.5.0
       '@azure/identity-cache-persistence': 1.1.1
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-runtime': 2.50.0(debug@4.4.0)
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore': 2.50.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/odsp-doclib-utils': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.50.0
-      '@fluidframework/odsp-urlresolver': 2.50.0(encoding@0.1.13)
-      '@fluidframework/routerlicious-driver': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/routerlicious-urlresolver': 2.50.0
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/tool-utils': 2.50.0(encoding@0.1.13)
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-runtime': 2.51.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore': 2.51.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/odsp-doclib-utils': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.51.0
+      '@fluidframework/odsp-urlresolver': 2.51.0(encoding@0.1.13)
+      '@fluidframework/routerlicious-driver': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/routerlicious-urlresolver': 2.51.0
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/tool-utils': 2.51.0(encoding@0.1.13)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -29726,27 +29692,27 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/agent-scheduler@2.50.0':
+  '@fluidframework/agent-scheduler@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore': 2.50.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/map': 2.50.0(debug@4.4.0)
-      '@fluidframework/register-collection': 2.50.0
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
-      uuid: 9.0.1
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore': 2.51.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/map': 2.51.0(debug@4.4.0)
+      '@fluidframework/register-collection': 2.51.0
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
+      uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/app-insights-logger@2.50.0(tslib@1.14.1)':
+  '@fluidframework/app-insights-logger@2.51.0(tslib@1.14.1)':
     dependencies:
-      '@fluidframework/core-interfaces': 2.50.0
+      '@fluidframework/core-interfaces': 2.51.0
       '@microsoft/applicationinsights-web': 2.8.18(tslib@1.14.1)
       '@ungap/structured-clone': 1.2.1
     transitivePeerDependencies:
@@ -29774,24 +29740,24 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/aqueduct@2.50.0':
+  '@fluidframework/aqueduct@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/container-runtime': 2.50.0(debug@4.4.0)
-      '@fluidframework/container-runtime-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore': 2.50.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/map': 2.50.0(debug@4.4.0)
-      '@fluidframework/request-handler': 2.50.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/synthesize': 2.50.0
-      '@fluidframework/telemetry-utils': 2.50.0
-      '@fluidframework/tree': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/container-runtime': 2.51.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore': 2.51.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/map': 2.51.0(debug@4.4.0)
+      '@fluidframework/request-handler': 2.51.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/synthesize': 2.51.0
+      '@fluidframework/telemetry-utils': 2.51.0
+      '@fluidframework/tree': 2.51.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -29820,16 +29786,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/azure-client@2.50.0(encoding@0.1.13)':
+  '@fluidframework/azure-client@2.51.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/container-loader': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/fluid-static': 2.50.0
-      '@fluidframework/routerlicious-driver': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/container-loader': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/fluid-static': 2.51.0
+      '@fluidframework/routerlicious-driver': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/telemetry-utils': 2.51.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -29837,11 +29803,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/azure-service-utils@2.50.0':
+  '@fluidframework/azure-service-utils@2.51.0':
     dependencies:
-      '@fluidframework/driver-definitions': 2.50.0
+      '@fluidframework/driver-definitions': 2.51.0
       jsrsasign: 11.1.0
-      uuid: 9.0.1
+      uuid: 11.1.0
 
   '@fluidframework/build-common@2.0.3': {}
 
@@ -29931,15 +29897,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@fluidframework/cell@2.50.0':
+  '@fluidframework/cell@2.51.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -29986,10 +29952,10 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       events: 3.3.0
 
-  '@fluidframework/container-definitions@2.50.0':
+  '@fluidframework/container-definitions@2.51.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
 
   '@fluidframework/container-loader@1.4.0':
     dependencies:
@@ -30013,21 +29979,21 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/container-loader@2.50.0':
+  '@fluidframework/container-loader@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
       '@types/events_pkg': '@types/events@3.0.3'
       '@ungap/structured-clone': 1.2.1
       debug: 4.4.0(supports-color@8.1.1)
       double-ended-queue: 2.1.0-0
       events_pkg: events@3.3.0
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30040,13 +30006,13 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
 
-  '@fluidframework/container-runtime-definitions@2.50.0':
+  '@fluidframework/container-runtime-definitions@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/runtime-definitions': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/runtime-definitions': 2.51.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30074,25 +30040,25 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/container-runtime@2.50.0(debug@4.4.0)':
+  '@fluidframework/container-runtime@2.51.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/container-runtime-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore': 2.50.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/id-compressor': 2.50.0
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/container-runtime-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore': 2.51.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/id-compressor': 2.51.0
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
       '@tylerbu/sorted-btree-es6': 1.8.0
       double-ended-queue: 2.1.0-0
       lz4js: 0.2.0
       semver-ts: 1.0.3
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30109,19 +30075,19 @@ snapshots:
 
   '@fluidframework/core-interfaces@1.4.0': {}
 
-  '@fluidframework/core-interfaces@2.50.0': {}
+  '@fluidframework/core-interfaces@2.51.0': {}
 
-  '@fluidframework/core-utils@2.50.0': {}
+  '@fluidframework/core-utils@2.51.0': {}
 
-  '@fluidframework/counter@2.50.0':
+  '@fluidframework/counter@2.51.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30135,13 +30101,13 @@ snapshots:
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
 
-  '@fluidframework/datastore-definitions@2.50.0':
+  '@fluidframework/datastore-definitions@2.51.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/id-compressor': 2.50.0
-      '@fluidframework/runtime-definitions': 2.50.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/id-compressor': 2.51.0
+      '@fluidframework/runtime-definitions': 2.51.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30167,62 +30133,62 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/datastore@2.50.0(debug@4.4.0)':
+  '@fluidframework/datastore@2.51.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/id-compressor': 2.50.0
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
-      uuid: 9.0.1
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/id-compressor': 2.51.0
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
+      uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/debugger@2.50.0':
+  '@fluidframework/debugger@2.51.0':
     dependencies:
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/replay-driver': 2.50.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/replay-driver': 2.51.0
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/devtools-core@2.50.0':
+  '@fluidframework/devtools-core@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/aqueduct': 2.50.0
-      '@fluidframework/cell': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/container-loader': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/counter': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/map': 2.50.0(debug@4.4.0)
-      '@fluidframework/matrix': 2.50.0
-      '@fluidframework/sequence': 2.50.0
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
-      '@fluidframework/tree': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/aqueduct': 2.51.0
+      '@fluidframework/cell': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/container-loader': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/counter': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/map': 2.51.0(debug@4.4.0)
+      '@fluidframework/matrix': 2.51.0
+      '@fluidframework/sequence': 2.51.0
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
+      '@fluidframework/tree': 2.51.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/devtools@2.50.0':
+  '@fluidframework/devtools@2.51.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/devtools-core': 2.50.0
-      '@fluidframework/fluid-static': 2.50.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/devtools-core': 2.51.0
+      '@fluidframework/fluid-static': 2.51.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30239,14 +30205,14 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/driver-base@2.50.0(debug@4.4.0)':
+  '@fluidframework/driver-base@2.51.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30257,9 +30223,9 @@ snapshots:
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
 
-  '@fluidframework/driver-definitions@2.50.0':
+  '@fluidframework/driver-definitions@2.51.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.50.0
+      '@fluidframework/core-interfaces': 2.51.0
 
   '@fluidframework/driver-utils@1.4.0':
     dependencies:
@@ -30277,26 +30243,26 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/driver-utils@2.50.0(debug@4.4.0)':
+  '@fluidframework/driver-utils@2.51.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/telemetry-utils': 2.51.0
       axios: 1.8.4(debug@4.4.0)
       lz4js: 0.2.0
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/driver-web-cache@2.50.0':
+  '@fluidframework/driver-web-cache@2.51.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/odsp-driver-definitions': 2.50.0
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/odsp-driver-definitions': 2.51.0
+      '@fluidframework/telemetry-utils': 2.51.0
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -30312,9 +30278,9 @@ snapshots:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint-config-biome: 1.9.4
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
@@ -30330,28 +30296,28 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluidframework/file-driver@2.50.0':
+  '@fluidframework/file-driver@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/replay-driver': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/replay-driver': 2.51.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/fluid-runner@2.50.0(encoding@0.1.13)':
+  '@fluidframework/fluid-runner@2.51.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/aqueduct': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/container-loader': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/odsp-driver': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.50.0
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluidframework/aqueduct': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/container-loader': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/odsp-driver': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.51.0
+      '@fluidframework/telemetry-utils': 2.51.0
       '@json2csv/plainjs': 7.0.6
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -30379,23 +30345,24 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/fluid-static@2.50.0':
+  '@fluidframework/fluid-static@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/aqueduct': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/container-loader': 2.50.0
-      '@fluidframework/container-runtime': 2.50.0(debug@4.4.0)
-      '@fluidframework/container-runtime-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/request-handler': 2.50.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/aqueduct': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/container-loader': 2.51.0
+      '@fluidframework/container-runtime': 2.51.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/request-handler': 2.51.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
+      '@fluidframework/tree': 2.51.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30408,38 +30375,36 @@ snapshots:
 
   '@fluidframework/gitresources@0.1036.5002': {}
 
-  '@fluidframework/gitresources@5.0.0': {}
-
   '@fluidframework/gitresources@7.0.0': {}
 
-  '@fluidframework/id-compressor@2.50.0':
+  '@fluidframework/id-compressor@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/telemetry-utils': 2.51.0
       '@tylerbu/sorted-btree-es6': 1.8.0
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/local-driver@2.50.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/local-driver@2.51.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/protocol-base': 5.0.0
-      '@fluidframework/routerlicious-driver': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/server-local-server': 5.0.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-test-utils': 5.0.0
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/protocol-base': 7.0.0
+      '@fluidframework/routerlicious-driver': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/server-local-server': 7.0.0
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/server-services-core': 7.0.0
+      '@fluidframework/server-test-utils': 7.0.0
+      '@fluidframework/telemetry-utils': 2.51.0
       jsrsasign: 11.1.0
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -30464,37 +30429,37 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/map@2.50.0(debug@4.4.0)':
+  '@fluidframework/map@2.51.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/merge-tree': 2.50.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/merge-tree': 2.51.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/matrix@2.50.0':
+  '@fluidframework/matrix@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/merge-tree': 2.50.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/merge-tree': 2.51.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
       '@tiny-calc/nano': 0.0.0-alpha.5
       double-ended-queue: 2.1.0-0
       tslib: 1.14.1
@@ -30502,54 +30467,54 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/merge-tree@2.50.0(debug@4.4.0)':
+  '@fluidframework/merge-tree@2.51.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/odsp-doclib-utils@2.50.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/odsp-doclib-utils@2.51.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/odsp-driver-definitions': 2.50.0
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/odsp-driver-definitions': 2.51.0
+      '@fluidframework/telemetry-utils': 2.51.0
       isomorphic-fetch: 3.0.0(encoding@0.1.13)
     transitivePeerDependencies:
       - debug
       - encoding
       - supports-color
 
-  '@fluidframework/odsp-driver-definitions@2.50.0':
+  '@fluidframework/odsp-driver-definitions@2.51.0':
     dependencies:
-      '@fluidframework/driver-definitions': 2.50.0
+      '@fluidframework/driver-definitions': 2.51.0
 
-  '@fluidframework/odsp-driver@2.50.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/odsp-driver@2.51.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/odsp-doclib-utils': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.50.0
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/odsp-doclib-utils': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.51.0
+      '@fluidframework/telemetry-utils': 2.51.0
       socket.io-client: 4.7.5
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -30557,14 +30522,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/odsp-urlresolver@2.50.0(encoding@0.1.13)':
+  '@fluidframework/odsp-urlresolver@2.51.0(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/odsp-driver': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/odsp-driver-definitions': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/odsp-driver': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/odsp-driver-definitions': 2.51.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -30572,18 +30537,18 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/ordered-collection@2.50.0':
+  '@fluidframework/ordered-collection@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
-      uuid: 9.0.1
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
+      uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30594,13 +30559,6 @@ snapshots:
       '@fluidframework/gitresources': 0.1036.5002
       '@fluidframework/protocol-definitions': 0.1028.2000
       lodash: 4.17.21
-
-  '@fluidframework/protocol-base@5.0.0':
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
-      '@fluidframework/protocol-definitions': 3.2.0
-      events_pkg: events@3.3.0
 
   '@fluidframework/protocol-base@7.0.0':
     dependencies:
@@ -30619,28 +30577,28 @@ snapshots:
 
   '@fluidframework/protocol-definitions@3.2.0': {}
 
-  '@fluidframework/register-collection@2.50.0':
+  '@fluidframework/register-collection@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/replay-driver@2.50.0':
+  '@fluidframework/replay-driver@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30655,13 +30613,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/request-handler@2.50.0(debug@4.4.0)':
+  '@fluidframework/request-handler@2.51.0(debug@4.4.0)':
     dependencies:
-      '@fluidframework/container-runtime-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -30691,20 +30649,20 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/routerlicious-driver@2.50.0(debug@4.4.0)(encoding@0.1.13)':
+  '@fluidframework/routerlicious-driver@2.51.0(debug@4.4.0)(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/server-services-client': 7.0.0
+      '@fluidframework/telemetry-utils': 2.51.0
       cross-fetch: 3.1.8(encoding@0.1.13)
       json-stringify-safe: 5.0.1
       socket.io-client: 4.7.5
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -30712,11 +30670,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/routerlicious-urlresolver@2.50.0':
+  '@fluidframework/routerlicious-urlresolver@2.51.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
       nconf: 0.12.1
 
   '@fluidframework/runtime-definitions@1.4.0':
@@ -30728,13 +30686,13 @@ snapshots:
       '@fluidframework/driver-definitions': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
 
-  '@fluidframework/runtime-definitions@2.50.0':
+  '@fluidframework/runtime-definitions@2.51.0':
     dependencies:
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/id-compressor': 2.50.0
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/id-compressor': 2.51.0
+      '@fluidframework/telemetry-utils': 2.51.0
     transitivePeerDependencies:
       - supports-color
 
@@ -30754,53 +30712,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/runtime-utils@2.50.0(debug@4.4.0)':
+  '@fluidframework/runtime-utils@2.51.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/container-runtime-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/container-runtime-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/telemetry-utils': 2.51.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/sequence@2.50.0':
+  '@fluidframework/sequence@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/merge-tree': 2.50.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/merge-tree': 2.51.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
       double-ended-queue: 2.1.0-0
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - debug
-      - supports-color
-
-  '@fluidframework/server-lambdas-driver@5.0.0':
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      assert: 2.1.0
-      async: 3.2.6
-      events: 3.3.0
-      lodash: 4.17.21
-      nconf: 0.12.1
-      serialize-error: 8.1.0
-    transitivePeerDependencies:
       - supports-color
 
   '@fluidframework/server-lambdas-driver@7.0.0':
@@ -30816,33 +30759,6 @@ snapshots:
       nconf: 0.12.1
       serialize-error: 8.1.0
     transitivePeerDependencies:
-      - supports-color
-
-  '@fluidframework/server-lambdas@5.0.0(debug@4.4.0)':
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
-      '@fluidframework/protocol-base': 5.0.0
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas-driver': 5.0.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      '@types/semver': 7.7.0
-      assert: 2.1.0
-      async: 3.2.6
-      axios: 1.8.4(debug@4.4.0)
-      buffer: 6.0.3
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      json-stringify-safe: 5.0.1
-      lodash: 4.17.21
-      nconf: 0.12.1
-      semver: 7.7.1
-      sha.js: 2.4.11
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - debug
       - supports-color
 
   '@fluidframework/server-lambdas@7.0.0(debug@4.4.0)':
@@ -30874,25 +30790,6 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/server-local-server@5.0.0':
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 5.0.0(debug@4.4.0)
-      '@fluidframework/server-memory-orderer': 5.0.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      '@fluidframework/server-test-utils': 5.0.0
-      debug: 4.4.0(supports-color@8.1.1)
-      events_pkg: events@3.3.0
-      jsrsasign: 11.1.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@fluidframework/server-local-server@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
@@ -30907,33 +30804,6 @@ snapshots:
       events_pkg: events@3.3.0
       jsrsasign: 11.1.0
       uuid: 11.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@fluidframework/server-memory-orderer@5.0.0':
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/protocol-base': 5.0.0
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 5.0.0(debug@4.4.0)
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      '@types/debug': 4.1.12
-      '@types/double-ended-queue': 2.1.7
-      '@types/lodash': 4.17.13
-      '@types/node': 18.19.67
-      '@types/ws': 6.0.4
-      assert: 2.1.0
-      debug: 4.4.0(supports-color@8.1.1)
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lodash: 4.17.21
-      sillyname: 0.1.0
-      uuid: 9.0.1
-      ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -30984,23 +30854,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/server-services-client@5.0.0':
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
-      '@fluidframework/protocol-base': 5.0.0
-      '@fluidframework/protocol-definitions': 3.2.0
-      axios: 1.8.4(debug@4.4.0)
-      crc-32: 1.2.0
-      debug: 4.4.0(supports-color@8.1.1)
-      json-stringify-safe: 5.0.1
-      jsrsasign: 11.1.0
-      jwt-decode: 4.0.0
-      sillyname: 0.1.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@fluidframework/server-services-client@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
@@ -31015,21 +30868,6 @@ snapshots:
       jwt-decode: 4.0.0
       sillyname: 0.1.0
       uuid: 11.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@fluidframework/server-services-core@5.0.0':
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      '@types/nconf': 0.10.7
-      '@types/node': 18.19.67
-      debug: 4.4.0(supports-color@8.1.1)
-      events: 3.3.0
-      nconf: 0.12.1
     transitivePeerDependencies:
       - supports-color
 
@@ -31080,14 +30918,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/server-services-telemetry@5.0.0':
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      json-stringify-safe: 5.0.1
-      path-browserify: 1.0.1
-      serialize-error: 8.1.0
-      uuid: 9.0.1
-
   '@fluidframework/server-services-telemetry@7.0.0':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
@@ -31115,27 +30945,6 @@ snapshots:
       uuid: 11.1.0
       winston: 3.17.0
       winston-transport: 4.9.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@fluidframework/server-test-utils@5.0.0':
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 5.0.0
-      '@fluidframework/protocol-base': 5.0.0
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 5.0.0
-      '@fluidframework/server-services-core': 5.0.0
-      '@fluidframework/server-services-telemetry': 5.0.0
-      '@types/ioredis-mock': 8.2.6(ioredis@5.6.1)
-      assert: 2.1.0
-      debug: 4.4.0(supports-color@8.1.1)
-      events: 3.3.0
-      ioredis: 5.6.1
-      ioredis-mock: 8.9.0(@types/ioredis-mock@8.2.6(ioredis@5.6.1))(ioredis@5.6.1)
-      lodash: 4.17.21
-      string-hash: 1.1.3
-      uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -31179,54 +30988,54 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/shared-object-base@2.50.0(debug@4.4.0)':
+  '@fluidframework/shared-object-base@2.51.0(debug@4.4.0)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore': 2.50.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/id-compressor': 2.50.0
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
-      uuid: 9.0.1
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore': 2.51.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/id-compressor': 2.51.0
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
+      uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/shared-summary-block@2.50.0':
+  '@fluidframework/shared-summary-block@2.51.0':
     dependencies:
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
 
   '@fluidframework/synthesize@1.4.0': {}
 
-  '@fluidframework/synthesize@2.50.0':
+  '@fluidframework/synthesize@2.51.0':
     dependencies:
-      '@fluidframework/core-utils': 2.50.0
+      '@fluidframework/core-utils': 2.51.0
 
-  '@fluidframework/task-manager@2.50.0':
+  '@fluidframework/task-manager@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/container-runtime-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/container-runtime-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -31241,33 +31050,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/telemetry-utils@2.50.0':
+  '@fluidframework/telemetry-utils@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
       debug: 4.4.0(supports-color@8.1.1)
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/test-runtime-utils@2.50.0(encoding@0.1.13)':
+  '@fluidframework/test-runtime-utils@2.51.0(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/container-runtime-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/id-compressor': 2.50.0
-      '@fluidframework/routerlicious-driver': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/container-runtime-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/id-compressor': 2.51.0
+      '@fluidframework/routerlicious-driver': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
       jsrsasign: 11.1.0
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -31277,52 +31087,52 @@ snapshots:
 
   '@fluidframework/test-tools@1.0.195075': {}
 
-  '@fluidframework/test-utils@2.50.0(encoding@0.1.13)':
+  '@fluidframework/test-utils@2.51.0(encoding@0.1.13)':
     dependencies:
-      '@fluid-internal/test-driver-definitions': 2.50.0
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/container-loader': 2.50.0
-      '@fluidframework/container-runtime': 2.50.0(debug@4.4.0)
-      '@fluidframework/container-runtime-definitions': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore': 2.50.0(debug@4.4.0)
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/local-driver': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/map': 2.50.0(debug@4.4.0)
-      '@fluidframework/odsp-driver': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/request-handler': 2.50.0(debug@4.4.0)
-      '@fluidframework/routerlicious-driver': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/test-driver-definitions': 2.51.0
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/container-loader': 2.51.0
+      '@fluidframework/container-runtime': 2.51.0(debug@4.4.0)
+      '@fluidframework/container-runtime-definitions': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore': 2.51.0(debug@4.4.0)
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/local-driver': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/map': 2.51.0(debug@4.4.0)
+      '@fluidframework/odsp-driver': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/request-handler': 2.51.0(debug@4.4.0)
+      '@fluidframework/routerlicious-driver': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
       best-random: 1.0.3
       debug: 4.4.0(supports-color@8.1.1)
       mocha: 10.8.2
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tinylicious-client@2.50.0(encoding@0.1.13)':
+  '@fluidframework/tinylicious-client@2.51.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/container-definitions': 2.50.0
-      '@fluidframework/container-loader': 2.50.0
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/fluid-static': 2.50.0
-      '@fluidframework/map': 2.50.0(debug@4.4.0)
-      '@fluidframework/routerlicious-driver': 2.50.0(debug@4.4.0)(encoding@0.1.13)
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
-      '@fluidframework/tinylicious-driver': 2.50.0(encoding@0.1.13)
+      '@fluidframework/container-definitions': 2.51.0
+      '@fluidframework/container-loader': 2.51.0
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/fluid-static': 2.51.0
+      '@fluidframework/map': 2.51.0(debug@4.4.0)
+      '@fluidframework/routerlicious-driver': 2.51.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
+      '@fluidframework/tinylicious-driver': 2.51.0(encoding@0.1.13)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -31330,14 +31140,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tinylicious-driver@2.50.0(encoding@0.1.13)':
+  '@fluidframework/tinylicious-driver@2.51.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/routerlicious-driver': 2.50.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/routerlicious-driver': 2.51.0(debug@4.4.0)(encoding@0.1.13)
       jsrsasign: 11.1.0
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -31345,12 +31155,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tool-utils@2.50.0(encoding@0.1.13)':
+  '@fluidframework/tool-utils@2.51.0(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/driver-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/odsp-doclib-utils': 2.50.0(debug@4.4.0)(encoding@0.1.13)
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/driver-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/odsp-doclib-utils': 2.51.0(debug@4.4.0)(encoding@0.1.13)
       async-mutex: 0.3.2
       debug: 4.4.0(supports-color@8.1.1)
       jwt-decode: 4.0.0
@@ -31359,35 +31169,35 @@ snapshots:
       - encoding
       - supports-color
 
-  '@fluidframework/tree@2.50.0':
+  '@fluidframework/tree@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/container-runtime': 2.50.0(debug@4.4.0)
-      '@fluidframework/core-interfaces': 2.50.0
-      '@fluidframework/core-utils': 2.50.0
-      '@fluidframework/datastore-definitions': 2.50.0
-      '@fluidframework/driver-definitions': 2.50.0
-      '@fluidframework/id-compressor': 2.50.0
-      '@fluidframework/runtime-definitions': 2.50.0
-      '@fluidframework/runtime-utils': 2.50.0(debug@4.4.0)
-      '@fluidframework/shared-object-base': 2.50.0(debug@4.4.0)
-      '@fluidframework/telemetry-utils': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/container-runtime': 2.51.0(debug@4.4.0)
+      '@fluidframework/core-interfaces': 2.51.0
+      '@fluidframework/core-utils': 2.51.0
+      '@fluidframework/datastore-definitions': 2.51.0
+      '@fluidframework/driver-definitions': 2.51.0
+      '@fluidframework/id-compressor': 2.51.0
+      '@fluidframework/runtime-definitions': 2.51.0
+      '@fluidframework/runtime-utils': 2.51.0(debug@4.4.0)
+      '@fluidframework/shared-object-base': 2.51.0(debug@4.4.0)
+      '@fluidframework/telemetry-utils': 2.51.0
       '@sinclair/typebox': 0.34.13
       '@tylerbu/sorted-btree-es6': 1.8.0
       '@types/ungap__structured-clone': 1.2.0
       '@ungap/structured-clone': 1.2.1
-      uuid: 9.0.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@fluidframework/undo-redo@2.50.0':
+  '@fluidframework/undo-redo@2.51.0':
     dependencies:
-      '@fluid-internal/client-utils': 2.50.0
-      '@fluidframework/map': 2.50.0(debug@4.4.0)
-      '@fluidframework/matrix': 2.50.0
-      '@fluidframework/merge-tree': 2.50.0(debug@4.4.0)
-      '@fluidframework/sequence': 2.50.0
+      '@fluid-internal/client-utils': 2.51.0
+      '@fluidframework/map': 2.51.0(debug@4.4.0)
+      '@fluidframework/matrix': 2.51.0
+      '@fluidframework/merge-tree': 2.51.0(debug@4.4.0)
+      '@fluidframework/sequence': 2.51.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -36324,33 +36134,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.55.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.0
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.4.5)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36364,13 +36174,13 @@ snapshots:
       eslint: 8.55.0
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       get-tsconfig: 4.10.0
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -43478,8 +43288,6 @@ snapshots:
   uuid@11.1.0: {}
 
   uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
This PR updates typetests after the 2.51.0 release.

Commands:
`pnpm exec flub typetests -g client --reset --normalize --previous`
`pnpm install --no-frozen-lockfile`
`pnpm run build`