### PR TITLE
Add acceptance condition to delete and move Shared Array ops

### DIFF
--- a/packages/dds/legacy-dds/src/test/array/arrayFuzzTests.spec.ts
+++ b/packages/dds/legacy-dds/src/test/array/arrayFuzzTests.spec.ts
@@ -26,6 +26,5 @@ describe("SharedArray fuzz", () => {
 		},
 		defaultTestCount: 50,
 		saveFailures: { directory: path.join(_dirname, "../../src/test/results") },
-		skip: [6, 10, 17, 31, 40],
 	});
 });


### PR DESCRIPTION
Fixing failing shared array fuzz tests seeds by adding an acceptance condition to move and delete ops which just requires non zero length before generating those ops.