### PR TITLE
fix(api-markdown-documenter): Restore support for escaped text from TSDoc parser

### DIFF
--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -17,6 +17,7 @@ import {
 	type DocInlineTag,
 	type DocHtmlEndTag,
 	type DocHtmlStartTag,
+	type DocEscapedText,
 } from "@microsoft/tsdoc";
 
 import type { Link } from "../Link.js";
@@ -225,6 +226,9 @@ function transformTsdocParagraphContent(
 		case DocNodeKind.CodeSpan: {
 			return [transformTsdocCodeSpan(node as DocCodeSpan, options)];
 		}
+		case DocNodeKind.EscapedText: {
+			return [transformTsdocEscapedText(node as DocEscapedText, options)];
+		}
 		case DocNodeKind.HtmlStartTag:
 		case DocNodeKind.HtmlEndTag: {
 			return transformTsdocHtmlTag(node as DocHtmlStartTag | DocHtmlEndTag, options);
@@ -303,6 +307,16 @@ function transformTsdocPlainText(
 	options: TsdocNodeTransformOptions,
 ): PlainTextNode {
 	return new PlainTextNode(node.text);
+}
+
+/**
+ * Converts a {@link @microsoft/tsdoc#DocEscapedText} to a {@link PlainTextNode}.
+ */
+function transformTsdocEscapedText(
+	node: DocEscapedText,
+	options: TsdocNodeTransformOptions,
+): PlainTextNode {
+	return new PlainTextNode(node.decodedText);
 }
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/TsdocNodeTransforms.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/TsdocNodeTransforms.test.ts
@@ -52,6 +52,16 @@ describe("Tsdoc node transformation tests", () => {
 			]);
 		});
 
+		it("Escaped text", () => {
+			// `@` is escaped to make TSDoc treat it as normal text, rather than as the start of a tag.
+			const context = parser.parseString("/** \\@foo */");
+			const summarySection = context.docComment.summarySection;
+
+			const result = transformTsdocSection(summarySection, transformOptions);
+
+			expect(result).to.deep.equal([new ParagraphNode([new PlainTextNode("@foo")])]);
+		});
+
 		it("Multi-paragraph comment", () => {
 			const comment = `/**
  * This is a simple comment.

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.html
@@ -11,6 +11,7 @@
       </section>
       <section>
         <p>A test abstract getter property.</p>
+        <p>@escapedTag</p>
       </section>
       <section>
         <h2 id="abstractpropertygetter-signature">Signature</h2><code>abstract get abstractPropertyGetter(): TestMappedType;</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.html
@@ -48,7 +48,10 @@
               <td><a href="/test-suite-a/testabstractclass-class/abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
               <td><a href="/test-suite-a/testmappedtype-typealias/">TestMappedType</a></td>
-              <td>A test abstract getter property.</td>
+              <td>
+                <p>A test abstract getter property.</p>
+                <p>@escapedTag</p>
+              </td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class/protectedproperty-property">protectedProperty</a></td>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testabstractclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testabstractclass-class.html
@@ -48,7 +48,10 @@
               <td><a href="/test-suite-a/testabstractclass-class#abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
               <td><a href="/test-suite-a/testmappedtype-typealias">TestMappedType</a></td>
-              <td>A test abstract getter property.</td>
+              <td>
+                <p>A test abstract getter property.</p>
+                <p>@escapedTag</p>
+              </td>
             </tr>
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class#protectedproperty-property">protectedProperty</a></td>
@@ -134,6 +137,7 @@
           <h3 id="abstractpropertygetter-property">abstractPropertyGetter</h3>
           <section>
             <p>A test abstract getter property.</p>
+            <p>@escapedTag</p>
           </section>
           <section>
             <h4 id="abstractpropertygetter-signature">Signature</h4><code>abstract get abstractPropertyGetter(): TestMappedType;</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
@@ -742,7 +742,10 @@
                 <td><a href="docs/test-suite-a#testabstractclass-abstractpropertygetter-property">abstractPropertyGetter</a></td>
                 <td><code>readonly</code></td>
                 <td><a href="docs/test-suite-a#testmappedtype-typealias">TestMappedType</a></td>
-                <td>A test abstract getter property.</td>
+                <td>
+                  <p>A test abstract getter property.</p>
+                  <p>@escapedTag</p>
+                </td>
               </tr>
               <tr>
                 <td><a href="docs/test-suite-a#testabstractclass-protectedproperty-property">protectedProperty</a></td>
@@ -828,6 +831,7 @@
             <h4 id="testabstractclass-abstractpropertygetter-property">abstractPropertyGetter</h4>
             <section>
               <p>A test abstract getter property.</p>
+              <p>@escapedTag</p>
             </section>
             <section>
               <h5 id="abstractpropertygetter-signature">Signature</h5><code>abstract get abstractPropertyGetter(): TestMappedType;</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-abstractpropertygetter-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-abstractpropertygetter-property.html
@@ -8,6 +8,7 @@
       <h2>abstractPropertyGetter</h2>
       <section>
         <p>A test abstract getter property.</p>
+        <p>@escapedTag</p>
       </section>
       <section>
         <h3 id="abstractpropertygetter-signature">Signature</h3><code>abstract get abstractPropertyGetter(): TestMappedType;</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-class.html
@@ -45,7 +45,10 @@
               <td><a href="docs/test-suite-a/testabstractclass-abstractpropertygetter-property">abstractPropertyGetter</a></td>
               <td><code>readonly</code></td>
               <td><a href="docs/test-suite-a/testmappedtype-typealias">TestMappedType</a></td>
-              <td>A test abstract getter property.</td>
+              <td>
+                <p>A test abstract getter property.</p>
+                <p>@escapedTag</p>
+              </td>
             </tr>
             <tr>
               <td><a href="docs/test-suite-a/testabstractclass-protectedproperty-property">protectedProperty</a></td>

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/abstractpropertygetter-property.md
@@ -4,6 +4,8 @@
 
 A test abstract getter property.
 
+@escapedTag
+
 ## Signature {#abstractpropertygetter-signature}
 
 ```typescript

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.md
@@ -20,7 +20,7 @@ export declare abstract class TestAbstractClass
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [abstractPropertyGetter](/test-suite-a/testabstractclass-class/abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias/) | A test abstract getter property. |
+| [abstractPropertyGetter](/test-suite-a/testabstractclass-class/abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias/) | <p>A test abstract getter property.</p><p>@escapedTag</p> |
 | [protectedProperty](/test-suite-a/testabstractclass-class/protectedproperty-property) | `readonly` | [TestEnum](/test-suite-a/testenum-enum/) | A test protected property. |
 
 ## Methods

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testabstractclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testabstractclass-class.md
@@ -20,7 +20,7 @@ export declare abstract class TestAbstractClass
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [abstractPropertyGetter](/test-suite-a/testabstractclass-class#abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
+| [abstractPropertyGetter](/test-suite-a/testabstractclass-class#abstractpropertygetter-property) | `readonly` | [TestMappedType](/test-suite-a/testmappedtype-typealias) | <p>A test abstract getter property.</p><p>@escapedTag</p> |
 | [protectedProperty](/test-suite-a/testabstractclass-class#protectedproperty-property) | `readonly` | [TestEnum](/test-suite-a/testenum-enum) | A test protected property. |
 
 ## Methods
@@ -55,6 +55,8 @@ protected constructor(privateProperty: number, protectedProperty: TestEnum);
 ### abstractPropertyGetter {#abstractpropertygetter-property}
 
 A test abstract getter property.
+
+@escapedTag
 
 #### Signature {#abstractpropertygetter-signature}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
@@ -451,7 +451,7 @@ export declare abstract class TestAbstractClass
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [abstractPropertyGetter](docs/test-suite-a#testabstractclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/test-suite-a#testmappedtype-typealias) | A test abstract getter property. |
+| [abstractPropertyGetter](docs/test-suite-a#testabstractclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/test-suite-a#testmappedtype-typealias) | <p>A test abstract getter property.</p><p>@escapedTag</p> |
 | [protectedProperty](docs/test-suite-a#testabstractclass-protectedproperty-property) | `readonly` | [TestEnum](docs/test-suite-a#testenum-enum) | A test protected property. |
 
 ### Methods
@@ -486,6 +486,8 @@ protected constructor(privateProperty: number, protectedProperty: TestEnum);
 #### abstractPropertyGetter {#testabstractclass-abstractpropertygetter-property}
 
 A test abstract getter property.
+
+@escapedTag
 
 ##### Signature {#abstractpropertygetter-signature}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-abstractpropertygetter-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-abstractpropertygetter-property.md
@@ -2,6 +2,8 @@
 
 A test abstract getter property.
 
+@escapedTag
+
 ### Signature {#abstractpropertygetter-signature}
 
 ```typescript

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testabstractclass-class.md
@@ -18,7 +18,7 @@ export declare abstract class TestAbstractClass
 
 | Property | Modifiers | Type | Description |
 | - | - | - | - |
-| [abstractPropertyGetter](docs/test-suite-a/testabstractclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/test-suite-a/testmappedtype-typealias) | A test abstract getter property. |
+| [abstractPropertyGetter](docs/test-suite-a/testabstractclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/test-suite-a/testmappedtype-typealias) | <p>A test abstract getter property.</p><p>@escapedTag</p> |
 | [protectedProperty](docs/test-suite-a/testabstractclass-protectedproperty-property) | `readonly` | [TestEnum](docs/test-suite-a/testenum-enum) | A test protected property. |
 
 ### Methods

--- a/tools/api-markdown-documenter/src/test/test-data/simple-suite-test/test-suite-a.api.json
+++ b/tools/api-markdown-documenter/src/test/test-data/simple-suite-test/test-suite-a.api.json
@@ -240,7 +240,7 @@
 						{
 							"kind": "Property",
 							"canonicalReference": "test-suite-a!TestAbstractClass#abstractPropertyGetter:member",
-							"docComment": "/**\n * A test abstract getter property.\n */\n",
+							"docComment": "/**\n * A test abstract getter property.\n *\n * \\@escapedTag\n */\n",
 							"excerptTokens": [
 								{
 									"kind": "Content",


### PR DESCRIPTION
Support for `DocEscapedText` input was removed in a previous PR, but is required to support escaped contents in TSDoc comments. This PR restores the support and adds test cases.