### PR TITLE
Fix minor typos in comments

### DIFF
--- a/packages/dds/matrix/README.md
+++ b/packages/dds/matrix/README.md
@@ -139,7 +139,7 @@ axis is typically within an order of magnitude compared to sequentially accessin
 
 ### Switching From Last Write Win(LWW) to First Write Win(FWW) mode
 
-Shared Matrix allows a one way switch from LWW to FWW. This is introduced in order to handle conflict
+Shared Matrix allows a one-way switch from LWW to FWW. This is introduced in order to handle conflict
 when multiple clients at once initialize a cell. Using FWW, will help clients to receive a `conflict` event in case
 their change was rejected. They can resolve conflict with the new information that they received in the event.
 This event is only emitted when the SetCell Resolution Policy is First Write Win(FWW). This is emitted when two clients

--- a/packages/dds/matrix/README.md
+++ b/packages/dds/matrix/README.md
@@ -139,12 +139,12 @@ axis is typically within an order of magnitude compared to sequentially accessin
 
 ### Switching From Last Write Win(LWW) to First Write Win(FWW) mode
 
-Shared Matrix allows to make to make one way switch from LWW to FWW. This is introduced in order to handle conflict
+Shared Matrix allows a one way switch from LWW to FWW. This is introduced in order to handle conflict
 when multiple clients at once initialize a cell. Using FWW, will help clients to receive a `conflict` event in case
 their change was rejected. They can resolve conflict with the new information that they received in the event.
 This event is only emitted when the SetCell Resolution Policy is First Write Win(FWW). This is emitted when two clients
 race and send changes without observing each other changes, the changes that gets sequenced last would be rejected, and
-only client who's changes rejected would be notified via this event, with expectation that it will merge its changes
+only client whose changes rejected would be notified via this event, with expectation that it will merge its changes
 back by accounting new information (state from winner of the race).
 
 Some cases which documents how the Set op changes are applied or rejected during LWW -> FWW switch as some clients will

--- a/packages/dds/matrix/README.md
+++ b/packages/dds/matrix/README.md
@@ -144,7 +144,7 @@ when multiple clients at once initialize a cell. Using FWW, will help clients to
 their change was rejected. They can resolve conflict with the new information that they received in the event.
 This event is only emitted when the SetCell Resolution Policy is First Write Win(FWW). This is emitted when two clients
 race and send changes without observing each other changes, the changes that gets sequenced last would be rejected, and
-only client whose changes rejected would be notified via this event, with expectation that it will merge its changes
+only client whose changes were rejected would be notified via this event, with expectation that it will merge its changes
 back by accounting new information (state from winner of the race).
 
 Some cases which documents how the Set op changes are applied or rejected during LWW -> FWW switch as some clients will

--- a/packages/dds/merge-tree/docs/Obliterate.md
+++ b/packages/dds/merge-tree/docs/Obliterate.md
@@ -58,7 +58,7 @@ For that reason, naming choices of fields and semantics for the remainder of the
 This should alleviate any back-compat issues if/when we do decide to implement move (esp. fields that end up in ops or snapshots).
 The current proposal is to use the runtime value "null" to represent "out of existence", but this choice is flexible.
 In prose, for terseness that operation will still be called obliterate.
-After describing obliterate's design, this document [digs into how the design can be extended to work for move](##Move).
+After describing obliterate's design, this document [digs into how the design can be extended to work for move](#Move).
 
 Notice that the above examples always insert text at positions strictly inside the removed range.
 If the insert operation was instead before the "1" or after the "2", one can imagine different applications wanting different behavior:
@@ -144,18 +144,18 @@ perspective: if the perspective is from after the segment was moved, the tombsto
 However, these fields need to be independent from `removedSeq` due to the possibility of a removal and a move overlapping, as well as the differences
 in how concurrent inserts are handled into a removed or a moved range.
 
-Segment groups will store `ObliterateInfo`, which will hold the references to a start and end position for a given obliterate, in addition to some other bookeeping information relevant to resolving the obliterate on other clients.
+Segment groups will store `ObliterateInfo`, which will hold the references to a start and end position for a given obliterate, in addition to some other bookkeeping information relevant to resolving the obliterate on other clients.
 
 ```typescript
 export interface ObliterateInfo {
 	/**
 	 * Local references created at the start and end of an obliterated range. Since the end of an obliterate is exclusive, the end reference will be created at the position before the passed-in end position.
-	*/
+	 */
 	start: LocalReferencePosition;
 	end: LocalReferencePosition;
 	/**
 	 * The refSeq at which the obliterate occurs.
-	*/
+	 */
 	refSeq: number;
 	/**
 	 * The clientId that performed the obliterate.

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -285,7 +285,7 @@ export class MergeBlock implements Partial<IMergeNodeInfo> {
 	partialLengths?: PartialSequenceLengths;
 
 	public constructor(public childCount: number) {
-		// Suppression needed due to the way the merge tree children are initalized - we
+		// Suppression needed due to the way the merge tree children are initialized - we
 		// allocate 8 children blocks, but any unused blocks are not counted in the childCount.
 		// Using Array.from leads to unused children being undefined, which are counted in childCount.
 		// eslint-disable-next-line unicorn/no-new-array


### PR DESCRIPTION
Some fixes I've had lingering for a while, encountered while making other changes. Not meant to be a comprehensive edit.
