### PR TITLE
refactor(api-markdown-documenter): Align `FencedCodeBlockNode` with Markdown

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -66,7 +66,7 @@ Their `createFromPlainText` static factory functions have also been removed, as 
 
 Additionally, the structure of `ListNode` has been updated to utilize `ListItemNode`s as children to make it easier to group child contents within a single list entry.
 
-### `FencedCodeBlockNode` updated to only allow plain text and line breaks
+### `FencedCodeBlockNode` updated to be a literal node that accepts a string
 
 This matches the requirements for fenced code in Markdown and is all that was required by the system.
 

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -357,9 +357,10 @@ export namespace DocumentWriter {
 }
 
 // @public @sealed
-export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeBlockNodeContent> {
-    constructor(children: FencedCodeBlockNodeContent[], language?: string);
+export class FencedCodeBlockNode extends DocumentationLiteralNodeBase<string> {
+    constructor(value: string, language?: string);
     static createFromPlainText(text: string, language?: string): FencedCodeBlockNode;
+    get isEmpty(): boolean;
     readonly language?: string;
     readonly type = "fencedCode";
 }

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -357,9 +357,10 @@ export namespace DocumentWriter {
 }
 
 // @public @sealed
-export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeBlockNodeContent> {
-    constructor(children: FencedCodeBlockNodeContent[], language?: string);
+export class FencedCodeBlockNode extends DocumentationLiteralNodeBase<string> {
+    constructor(value: string, language?: string);
     static createFromPlainText(text: string, language?: string): FencedCodeBlockNode;
+    get isEmpty(): boolean;
     readonly language?: string;
     readonly type = "fencedCode";
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -326,7 +326,7 @@ function transformTsdocFencedCode(
 	node: DocFencedCode,
 	options: TsdocNodeTransformOptions,
 ): FencedCodeBlockNode {
-	return FencedCodeBlockNode.createFromPlainText(node.code.trim(), node.language);
+	return new FencedCodeBlockNode(node.code.trim(), node.language);
 }
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -96,9 +96,7 @@ export function createSignatureSection(
 		if (signatureExcerpt !== "") {
 			const contents: SectionContent[] = [];
 
-			contents.push(
-				FencedCodeBlockNode.createFromPlainText(signatureExcerpt.trim(), "typescript"),
-			);
+			contents.push(new FencedCodeBlockNode(signatureExcerpt.trim(), "typescript"));
 
 			const renderedHeritageTypes = createHeritageTypesContent(apiItem, config);
 			if (renderedHeritageTypes !== undefined) {

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
@@ -144,12 +144,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 				[
 					wrapInSection([ParagraphNode.createFromPlainText("Test Constant")]),
 					wrapInSection(
-						[
-							FencedCodeBlockNode.createFromPlainText(
-								'TestConst = "Hello world!"',
-								"typescript",
-							),
-						],
+						[new FencedCodeBlockNode('TestConst = "Hello world!"', "typescript")],
 						{
 							title: "Signature",
 							id: `testconst-signature`,
@@ -186,11 +181,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 					wrapInSection(
 						[
 							new FencedCodeBlockNode(
-								[
-									new PlainTextNode(
-										"export declare function testFunction<TTypeParameter>(testParameter: TTypeParameter, testOptionalParameter?: TTypeParameter): TTypeParameter;",
-									),
-								],
+								"export declare function testFunction<TTypeParameter>(testParameter: TTypeParameter, testOptionalParameter?: TTypeParameter): TTypeParameter;",
 								"typescript",
 							),
 							new SectionNode(
@@ -304,12 +295,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 			// Signature section
 			wrapInSection(
-				[
-					FencedCodeBlockNode.createFromPlainText(
-						"export interface TestInterface",
-						"typescript",
-					),
-				],
+				[new FencedCodeBlockNode("export interface TestInterface", "typescript")],
 				{ title: "Signature", id: "testinterface-signature" },
 			),
 
@@ -359,7 +345,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 							// Signature section
 							wrapInSection(
 								[
-									FencedCodeBlockNode.createFromPlainText(
+									new FencedCodeBlockNode(
 										"testOptionalInterfaceProperty?: number;",
 										"typescript",
 									),
@@ -423,12 +409,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 			// Signature section
 			wrapInSection(
-				[
-					FencedCodeBlockNode.createFromPlainText(
-						"export declare namespace TestNamespace",
-						"typescript",
-					),
-				],
+				[new FencedCodeBlockNode("export declare namespace TestNamespace", "typescript")],
 				{ title: "Signature", id: "testnamespace-signature" },
 			),
 
@@ -482,13 +463,10 @@ describe("ApiItem to Documentation transformation tests", () => {
 							// Beta warning
 							wrapInSection([new ParagraphNode([betaWarningSpan])]),
 							// Signature
-							wrapInSection(
-								[FencedCodeBlockNode.createFromPlainText('bar = "bar"', "typescript")],
-								{
-									title: "Signature",
-									id: "bar-signature",
-								},
-							),
+							wrapInSection([new FencedCodeBlockNode('bar = "bar"', "typescript")], {
+								title: "Signature",
+								id: "bar-signature",
+							}),
 						],
 						{
 							title: "bar",
@@ -501,13 +479,10 @@ describe("ApiItem to Documentation transformation tests", () => {
 							// No summary docs on `foo`
 
 							// Signature
-							wrapInSection(
-								[FencedCodeBlockNode.createFromPlainText('foo = "foo"', "typescript")],
-								{
-									title: "Signature",
-									id: "foo-signature",
-								},
-							),
+							wrapInSection([new FencedCodeBlockNode('foo = "foo"', "typescript")], {
+								title: "Signature",
+								id: "foo-signature",
+							}),
 						],
 						{
 							title: "foo",
@@ -624,12 +599,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 										// Signature
 										new SectionNode(
-											[
-												FencedCodeBlockNode.createFromPlainText(
-													'hello = "Hello"',
-													"typescript",
-												),
-											],
+											[new FencedCodeBlockNode('hello = "Hello"', "typescript")],
 											new HeadingNode("Signature", "hello-signature"),
 										),
 									],
@@ -695,12 +665,7 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 										// Signature
 										new SectionNode(
-											[
-												FencedCodeBlockNode.createFromPlainText(
-													'world = "world"',
-													"typescript",
-												),
-											],
+											[new FencedCodeBlockNode('world = "world"', "typescript")],
 											new HeadingNode("Signature", "world-signature"),
 										),
 									],

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/FencedCodeBlockToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/FencedCodeBlockToHtml.ts
@@ -9,7 +9,10 @@
  */
 import type { Element as HastElement } from "hast";
 
-import type { FencedCodeBlockNode } from "../../documentation-domain/index.js";
+import {
+	createNodesFromPlainText,
+	type FencedCodeBlockNode,
+} from "../../documentation-domain/index.js";
 import type { TransformationContext } from "../TransformationContext.js";
 import { transformChildrenUnderTag } from "../Utilities.js";
 
@@ -24,5 +27,9 @@ export function fencedCodeBlockToHtml(
 	context: TransformationContext,
 ): HastElement {
 	// Note that HTML <code> tags don't support language attributes, so we don't pass anything through here.
-	return transformChildrenUnderTag({ name: "code" }, node.children, context);
+	return transformChildrenUnderTag(
+		{ name: "code" },
+		createNodesFromPlainText(node.value),
+		context,
+	);
 }

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/test/FencedCodeBlockToHtml.test.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/test/FencedCodeBlockToHtml.test.ts
@@ -5,11 +5,7 @@
 
 import { h } from "hastscript";
 
-import {
-	FencedCodeBlockNode,
-	LineBreakNode,
-	PlainTextNode,
-} from "../../documentation-domain/index.js";
+import { FencedCodeBlockNode } from "../../documentation-domain/index.js";
 
 import { assertTransformation } from "./Utilities.js";
 
@@ -17,10 +13,7 @@ const brElement = h("br");
 
 describe("FencedCodeBlock HTML rendering tests", () => {
 	it("Simple FencedCodeBlock", () => {
-		const input = new FencedCodeBlockNode(
-			[new PlainTextNode("console.log('hello world');")],
-			"typescript",
-		);
+		const input = new FencedCodeBlockNode("console.log('hello world');", "typescript");
 
 		// Note: HTML <code> elements don't support a language specification like Markdown fenced code blocks do.
 		const expected = h("code", [{ type: "text", value: "console.log('hello world');" }]);
@@ -30,19 +23,13 @@ describe("FencedCodeBlock HTML rendering tests", () => {
 
 	it("Multi-line FencedCodeBlock", () => {
 		const input = new FencedCodeBlockNode(
-			[
-				new PlainTextNode('const foo = "Hello world!'),
-				LineBreakNode.Singleton,
-				new PlainTextNode("console.log(foo);"),
-				LineBreakNode.Singleton,
-				new PlainTextNode("return foo;"),
-			],
+			'const foo = "Hello world!";\nconsole.log(foo);\nreturn foo;',
 			"typescript",
 		);
 
 		// Note: HTML <code> elements don't support a language specification like Markdown fenced code blocks do.
 		const expected = h("code", [
-			{ type: "text", value: 'const foo = "Hello world!' },
+			{ type: "text", value: 'const foo = "Hello world!";' },
 			brElement,
 			{ type: "text", value: "console.log(foo);" },
 			brElement,

--- a/tools/api-markdown-documenter/src/documentation-domain/FencedCodeBlockNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/FencedCodeBlockNode.ts
@@ -3,10 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { DocumentationParentNodeBase } from "./DocumentationNode.js";
+import { DocumentationLiteralNodeBase } from "./DocumentationNode.js";
 import type { LineBreakNode } from "./LineBreakNode.js";
 import type { PlainTextNode } from "./PlainTextNode.js";
-import { createNodesFromPlainText } from "./Utilities.js";
 
 /**
  * The types of child nodes that can be contained within a {@link FencedCodeBlockNode}.
@@ -37,7 +36,7 @@ export type FencedCodeBlockNodeContent = PlainTextNode | LineBreakNode;
  * @sealed
  * @public
  */
-export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeBlockNodeContent> {
+export class FencedCodeBlockNode extends DocumentationLiteralNodeBase<string> {
 	/**
 	 * {@inheritDoc DocumentationNode."type"}
 	 */
@@ -48,8 +47,15 @@ export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeB
 	 */
 	public readonly language?: string;
 
-	public constructor(children: FencedCodeBlockNodeContent[], language?: string) {
-		super(children);
+	/**
+	 * {@inheritDoc DocumentationNode.isEmpty}
+	 */
+	public override get isEmpty(): boolean {
+		return this.value.length === 0;
+	}
+
+	public constructor(value: string, language?: string) {
+		super(value);
 		this.language = language;
 	}
 
@@ -59,6 +65,6 @@ export class FencedCodeBlockNode extends DocumentationParentNodeBase<FencedCodeB
 	 * @param language - (optional) code language to associated with the code block.
 	 */
 	public static createFromPlainText(text: string, language?: string): FencedCodeBlockNode {
-		return new FencedCodeBlockNode(createNodesFromPlainText(text), language);
+		return new FencedCodeBlockNode(text, language);
 	}
 }

--- a/tools/api-markdown-documenter/src/documentation-domain/Utilities.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/Utilities.ts
@@ -19,9 +19,7 @@ export function createNodesFromPlainText(text: string): (PlainTextNode | LineBre
 
 	const transformedLines: (PlainTextNode | LineBreakNode)[] = [];
 	for (const [index, line] of lines.entries()) {
-		if (line.length === 0) {
-			transformedLines.push(LineBreakNode.Singleton);
-		} else {
+		if (line.length > 0) {
 			transformedLines.push(new PlainTextNode(line));
 		}
 

--- a/tools/api-markdown-documenter/src/documentation-domain/index.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/index.ts
@@ -57,3 +57,4 @@ export {
 } from "./TableRowNode.js";
 export { TableNode } from "./TableNode.js";
 export type { TextFormatting } from "./TextFormatting.js";
+export { createNodesFromPlainText } from "./Utilities.js";

--- a/tools/api-markdown-documenter/src/index.ts
+++ b/tools/api-markdown-documenter/src/index.ts
@@ -38,9 +38,44 @@ export {
 	transformTsdoc,
 } from "./api-item-transforms/index.js";
 
-// We want to make sure the entirety of this domain is accessible.
-// eslint-disable-next-line no-restricted-syntax
-export * from "./documentation-domain/index.js";
+export {
+	type BlockContent,
+	type BlockContentMap,
+	CodeSpanNode,
+	DocumentNode,
+	type DocumentNodeProps,
+	type DocumentationNode,
+	type DocumentationLiteralNode,
+	DocumentationLiteralNodeBase,
+	type DocumentationParentNode,
+	DocumentationParentNodeBase,
+	FencedCodeBlockNode,
+	type FencedCodeBlockNodeContent,
+	HeadingNode,
+	HorizontalRuleNode,
+	LineBreakNode,
+	LinkNode,
+	ListItemNode,
+	ListNode,
+	ParagraphNode,
+	type PhrasingContent,
+	type PhrasingContentMap,
+	PlainTextNode,
+	SectionNode,
+	type SectionContent,
+	SpanNode,
+	type TableCellContent,
+	TableCellNode,
+	TableBodyCellNode,
+	TableHeaderCellNode,
+	TableCellKind,
+	TableRowNode,
+	TableBodyRowNode,
+	TableHeaderRowNode,
+	TableRowKind,
+	TableNode,
+	type TextFormatting,
+} from "./documentation-domain/index.js";
 
 export {
 	documentToHtml,

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderFencedCodeBlock.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderFencedCodeBlock.ts
@@ -38,7 +38,8 @@ function renderFencedCodeBlockWithMarkdownSyntax(
 	writer.ensureSkippedLine(); // Code blocks require a leading blank line
 	writer.write("```");
 	writer.writeLine(node.language);
-	writer.writeLine(node.value);
+	writer.write(node.value);
+	writer.ensureNewLine();
 	writer.ensureNewLine(); // Ensure newline after body content
 	writer.writeLine("```");
 	writer.ensureSkippedLine(); // Code blocks require a trailing blank line

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderFencedCodeBlock.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/default-renderers/RenderFencedCodeBlock.ts
@@ -5,7 +5,6 @@
 
 import type { FencedCodeBlockNode } from "../../../documentation-domain/index.js";
 import type { DocumentWriter } from "../../DocumentWriter.js";
-import { renderNodes } from "../Render.js";
 import type { RenderContext } from "../RenderContext.js";
 import { renderNodeWithHtmlSyntax } from "../Utilities.js";
 
@@ -28,22 +27,18 @@ export function renderFencedCodeBlock(
 	if (context.insideTable === true) {
 		renderNodeWithHtmlSyntax(node, writer, context);
 	} else {
-		renderFencedCodeBlockWithMarkdownSyntax(node, writer, context);
+		renderFencedCodeBlockWithMarkdownSyntax(node, writer);
 	}
 }
 
 function renderFencedCodeBlockWithMarkdownSyntax(
 	node: FencedCodeBlockNode,
 	writer: DocumentWriter,
-	context: RenderContext,
 ): void {
 	writer.ensureSkippedLine(); // Code blocks require a leading blank line
 	writer.write("```");
 	writer.writeLine(node.language);
-	renderNodes(node.children, writer, {
-		...context,
-		insideCodeBlock: true,
-	});
+	writer.writeLine(node.value);
 	writer.ensureNewLine(); // Ensure newline after body content
 	writer.writeLine("```");
 	writer.ensureSkippedLine(); // Code blocks require a trailing blank line

--- a/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderFencedCodeBlock.test.ts
+++ b/tools/api-markdown-documenter/src/renderers/markdown-renderer/test/RenderFencedCodeBlock.test.ts
@@ -5,21 +5,14 @@
 
 import { expect } from "chai";
 
-import {
-	FencedCodeBlockNode,
-	LineBreakNode,
-	PlainTextNode,
-} from "../../../documentation-domain/index.js";
+import { FencedCodeBlockNode } from "../../../documentation-domain/index.js";
 
 import { testRender } from "./Utilities.js";
 
 describe("FencedCodeBlock Markdown rendering tests", () => {
 	describe("Standard context", () => {
 		it("Simple FencedCodeBlock", () => {
-			const input = new FencedCodeBlockNode(
-				[new PlainTextNode("console.log('hello world');")],
-				"typescript",
-			);
+			const input = new FencedCodeBlockNode("console.log('hello world');", "typescript");
 			const result = testRender(input);
 
 			const expected = [
@@ -36,13 +29,7 @@ describe("FencedCodeBlock Markdown rendering tests", () => {
 
 		it("Multi-line FencedCodeBlock", () => {
 			const input = new FencedCodeBlockNode(
-				[
-					new PlainTextNode('const foo = "Hello world!"'),
-					LineBreakNode.Singleton,
-					new PlainTextNode("console.log(foo);"),
-					LineBreakNode.Singleton,
-					new PlainTextNode("return foo;"),
-				],
+				'const foo = "Hello world!";\nconsole.log(foo);\nreturn foo;',
 				"typescript",
 			);
 			const result = testRender(input);
@@ -50,7 +37,7 @@ describe("FencedCodeBlock Markdown rendering tests", () => {
 			const expected = [
 				"",
 				"```typescript",
-				'const foo = "Hello world!"',
+				'const foo = "Hello world!";',
 				"console.log(foo);",
 				"return foo;",
 				"```",
@@ -64,10 +51,7 @@ describe("FencedCodeBlock Markdown rendering tests", () => {
 
 	describe("Table context", () => {
 		it("Simple FencedCodeBlock", () => {
-			const input = new FencedCodeBlockNode(
-				[new PlainTextNode("console.log('hello world');")],
-				"typescript",
-			);
+			const input = new FencedCodeBlockNode("console.log('hello world');", "typescript");
 			const result = testRender(input, { insideTable: true });
 
 			const expected = ["<code>", "console.log('hello world');", "</code>"].join("");
@@ -77,13 +61,7 @@ describe("FencedCodeBlock Markdown rendering tests", () => {
 
 		it("Multi-line FencedCodeBlock", () => {
 			const input = new FencedCodeBlockNode(
-				[
-					new PlainTextNode('const foo = "Hello world!";'),
-					LineBreakNode.Singleton,
-					new PlainTextNode("console.log(foo);"),
-					LineBreakNode.Singleton,
-					new PlainTextNode("return foo;"),
-				],
+				'const foo = "Hello world!";\nconsole.log(foo);\nreturn foo;',
 				"typescript",
 			);
 			const result = testRender(input, { insideTable: true });

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.html
@@ -13,7 +13,7 @@
         <p>Test class property with both a getter and a setter.</p>
       </section>
       <section>
-        <h2 id="testclassgetterproperty-signature">Signature</h2><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br><br>set testClassGetterProperty(newValue: number);</code>
+        <h2 id="testclassgetterproperty-signature">Signature</h2><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br>set testClassGetterProperty(newValue: number);</code>
         <p><b>Type</b>: number</p>
       </section>
       <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.html
@@ -13,7 +13,7 @@
         <p>A test property with a getter and a setter.</p>
       </section>
       <section>
-        <h2 id="setterproperty-signature">Signature</h2><code>get setterProperty(): boolean;<br><br><br>set setterProperty(newValue: boolean);</code>
+        <h2 id="setterproperty-signature">Signature</h2><code>get setterProperty(): boolean;<br><br>set setterProperty(newValue: boolean);</code>
         <p><b>Type</b>: boolean</p>
       </section>
     </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testclass-class.html
@@ -271,7 +271,7 @@
             <p>Test class property with both a getter and a setter.</p>
           </section>
           <section>
-            <h4 id="testclassgetterproperty-signature">Signature</h4><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br><br>set testClassGetterProperty(newValue: number);</code>
+            <h4 id="testclassgetterproperty-signature">Signature</h4><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br>set testClassGetterProperty(newValue: number);</code>
             <p><b>Type</b>: number</p>
           </section>
           <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterface-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testinterface-interface.html
@@ -208,7 +208,7 @@
             <p>A test property with a getter and a setter.</p>
           </section>
           <section>
-            <h4 id="setterproperty-signature">Signature</h4><code>get setterProperty(): boolean;<br><br><br>set setterProperty(newValue: boolean);</code>
+            <h4 id="setterproperty-signature">Signature</h4><code>get setterProperty(): boolean;<br><br>set setterProperty(newValue: boolean);</code>
             <p><b>Type</b>: boolean</p>
           </section>
         </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
@@ -431,7 +431,7 @@
               <p>A test property with a getter and a setter.</p>
             </section>
             <section>
-              <h5 id="setterproperty-signature">Signature</h5><code>get setterProperty(): boolean;<br><br><br>set setterProperty(newValue: boolean);</code>
+              <h5 id="setterproperty-signature">Signature</h5><code>get setterProperty(): boolean;<br><br>set setterProperty(newValue: boolean);</code>
               <p><b>Type</b>: boolean</p>
             </section>
           </section>
@@ -1154,7 +1154,7 @@
               <p>Test class property with both a getter and a setter.</p>
             </section>
             <section>
-              <h5 id="testclassgetterproperty-signature">Signature</h5><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br><br>set testClassGetterProperty(newValue: number);</code>
+              <h5 id="testclassgetterproperty-signature">Signature</h5><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br>set testClassGetterProperty(newValue: number);</code>
               <p><b>Type</b>: number</p>
             </section>
             <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclassgetterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testclass-testclassgetterproperty-property.html
@@ -10,7 +10,7 @@
         <p>Test class property with both a getter and a setter.</p>
       </section>
       <section>
-        <h3 id="testclassgetterproperty-signature">Signature</h3><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br><br>set testClassGetterProperty(newValue: number);</code>
+        <h3 id="testclassgetterproperty-signature">Signature</h3><code>/** @virtual */<br>get testClassGetterProperty(): number;<br><br>set testClassGetterProperty(newValue: number);</code>
         <p><b>Type</b>: number</p>
       </section>
       <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-setterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testinterface-setterproperty-property.html
@@ -10,7 +10,7 @@
         <p>A test property with a getter and a setter.</p>
       </section>
       <section>
-        <h3 id="setterproperty-signature">Signature</h3><code>get setterProperty(): boolean;<br><br><br>set setterProperty(newValue: boolean);</code>
+        <h3 id="setterproperty-signature">Signature</h3><code>get setterProperty(): boolean;<br><br>set setterProperty(newValue: boolean);</code>
         <p><b>Type</b>: boolean</p>
       </section>
     </section>

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testclass-class/testclassgetterproperty-property.md
@@ -9,6 +9,7 @@ Test class property with both a getter and a setter.
 ```typescript
 /** @virtual */
 get testClassGetterProperty(): number;
+
 set testClassGetterProperty(newValue: number);
 ```
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/deep-config/test-suite-a/testinterface-interface/setterproperty-property.md
@@ -8,6 +8,7 @@ A test property with a getter and a setter.
 
 ```typescript
 get setterProperty(): boolean;
+
 set setterProperty(newValue: boolean);
 ```
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testclass-class.md
@@ -129,6 +129,7 @@ Test class property with both a getter and a setter.
 ```typescript
 /** @virtual */
 get testClassGetterProperty(): number;
+
 set testClassGetterProperty(newValue: number);
 ```
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/test-suite-a/testinterface-interface.md
@@ -115,6 +115,7 @@ A test property with a getter and a setter.
 
 ```typescript
 get setterProperty(): boolean;
+
 set setterProperty(newValue: boolean);
 ```
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/test-suite-a.md
@@ -210,6 +210,7 @@ A test property with a getter and a setter.
 
 ```typescript
 get setterProperty(): boolean;
+
 set setterProperty(newValue: boolean);
 ```
 
@@ -684,6 +685,7 @@ Test class property with both a getter and a setter.
 ```typescript
 /** @virtual */
 get testClassGetterProperty(): number;
+
 set testClassGetterProperty(newValue: number);
 ```
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-testclassgetterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testclass-testclassgetterproperty-property.md
@@ -7,6 +7,7 @@ Test class property with both a getter and a setter.
 ```typescript
 /** @virtual */
 get testClassGetterProperty(): number;
+
 set testClassGetterProperty(newValue: number);
 ```
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-setterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/test-suite-a/testinterface-setterproperty-property.md
@@ -6,6 +6,7 @@ A test property with a getter and a setter.
 
 ```typescript
 get setterProperty(): boolean;
+
 set setterProperty(newValue: boolean);
 ```
 


### PR DESCRIPTION
We are working to align this library with Markdown / `mdast`. Fenced code nodes in `mdast` are literal nodes that wrap a string representation of the code content. This PR updates `FencedCodeBlockNode` to use the same pattern and updates the code to accommodate.

This PR also fixes bugs in both Markdown and HTML rendering of fenced code blocks where the Markdown renderer was _omitting_ line breaks that should have been included, and the HTML renderer was (transitively) causing extra line breaks to be injected.