### PR TITLE
fix(api-markdown-documenter): Fix example parsing

### DIFF
--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -714,7 +714,7 @@ function createExampleSection(
 ): SectionNode {
 	const { logger } = config;
 
-	let exampleSection: SectionNode = new SectionNode(
+	let exampleSection: SectionNode | undefined = new SectionNode(
 		transformTsdoc(example.content, example.apiItem, config),
 	);
 
@@ -748,7 +748,7 @@ function createExampleSection(
 		example.exampleNumber ?? ""
 	}`;
 
-	return wrapInSection(exampleSection.children, {
+	return wrapInSection(exampleSection?.children ?? [], {
 		title: headingTitle,
 		id: headingId,
 	});
@@ -806,12 +806,14 @@ function extractTitleFromExampleSection(sectionNode: DocSection): string | undef
  *
  * In the case where the output is not in a form we expect, we will log an error and return the node we were given,
  * rather than making a copy.
+ *
+ * @returns The updated node, if any content remains. Otherwise, `undefined`.
  */
 function stripTitleFromExampleComment<TNode extends DocumentationParentNode>(
 	node: TNode,
 	title: string,
 	logger: Logger | undefined,
-): TNode {
+): TNode | undefined {
 	// Verify title matches text of first plain text in output.
 	// This is an expected invariant. If this is not the case, then something has gone wrong.
 	// Note: if we ever allow consumers to provide custom DocNode transformations, this invariant will likely
@@ -833,13 +835,18 @@ function stripTitleFromExampleComment<TNode extends DocumentationParentNode>(
 			logger,
 		);
 
-		const newChildren: DocumentationNode[] = [newFirstChild, ...children.slice(1)];
+		const remainingChildren = children.slice(1);
+		const newChildren: DocumentationNode[] =
+			newFirstChild === undefined ? remainingChildren : [newFirstChild, ...remainingChildren];
 
-		return {
-			...node,
-			children: newChildren,
-			hasChildren: newChildren.length > 0,
-		};
+		// If there are no remaining children under this parent after stripping out the title, omit this parent node.
+		return newChildren.length === 0
+			? undefined
+			: {
+					...node,
+					children: newChildren,
+					hasChildren: newChildren.length > 0,
+				};
 	}
 
 	if (firstChild.isLiteral) {
@@ -851,11 +858,14 @@ function stripTitleFromExampleComment<TNode extends DocumentationParentNode>(
 				while (newChildren.length > 0 && newChildren[0].type === "lineBreak") {
 					newChildren.shift();
 				}
-				return {
-					...node,
-					children: newChildren,
-					hasChildren: newChildren.length > 0,
-				};
+				// If there are no remaining children under this parent after stripping out the title, omit this parent node.
+				return newChildren.length === 0
+					? undefined
+					: {
+							...node,
+							children: newChildren,
+							hasChildren: newChildren.length > 0,
+						};
 			} else {
 				logger?.error(
 					"Transformed example paragraph does not begin with expected title. This is unexpected and indicates a bug.",

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -748,6 +748,7 @@ function createExampleSection(
 		example.exampleNumber ?? ""
 	}`;
 
+	// Always emit the section, even if the body is empty after stripping out the title.
 	return wrapInSection(exampleSection?.children ?? [], {
 		title: headingTitle,
 		id: headingId,

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.html
@@ -22,12 +22,10 @@
       <section>
         <h2 id="testnamespace-examples">Examples</h2>
         <section>
-          <h3 id="testnamespace-example1">Example: TypeScript Example</h3>
-          <p></p><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          <h3 id="testnamespace-example1">Example: TypeScript Example</h3><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
         </section>
         <section>
-          <h3 id="testnamespace-example2">Example: JavaScript Example</h3>
-          <p></p><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          <h3 id="testnamespace-example2">Example: JavaScript Example</h3><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
         </section>
       </section>
       <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.html
@@ -22,12 +22,10 @@
       <section>
         <h2 id="testnamespace-examples">Examples</h2>
         <section>
-          <h3 id="testnamespace-example1">Example: TypeScript Example</h3>
-          <p></p><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          <h3 id="testnamespace-example1">Example: TypeScript Example</h3><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
         </section>
         <section>
-          <h3 id="testnamespace-example2">Example: JavaScript Example</h3>
-          <p></p><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          <h3 id="testnamespace-example2">Example: JavaScript Example</h3><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
         </section>
       </section>
       <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
@@ -1617,12 +1617,10 @@
         <section>
           <h3 id="testnamespace-examples">Examples</h3>
           <section>
-            <h4 id="testnamespace-example1">Example: TypeScript Example</h4>
-            <p></p><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+            <h4 id="testnamespace-example1">Example: TypeScript Example</h4><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
           </section>
           <section>
-            <h4 id="testnamespace-example2">Example: JavaScript Example</h4>
-            <p></p><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+            <h4 id="testnamespace-example2">Example: JavaScript Example</h4><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
           </section>
         </section>
         <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-namespace.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-namespace.html
@@ -19,12 +19,10 @@
       <section>
         <h3 id="testnamespace-examples">Examples</h3>
         <section>
-          <h4 id="testnamespace-example1">Example: TypeScript Example</h4>
-          <p></p><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          <h4 id="testnamespace-example1">Example: TypeScript Example</h4><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
         </section>
         <section>
-          <h4 id="testnamespace-example2">Example: JavaScript Example</h4>
-          <p></p><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          <h4 id="testnamespace-example2">Example: JavaScript Example</h4><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
         </section>
       </section>
       <section>


### PR DESCRIPTION
Fixes `stripTitleFromExampleComment` to ensure empty parent nodes are omitted after stripping out the title. See updated test assets for impact.