### PR TITLE
Fixed double logger error

### DIFF
--- a/packages/test/mocha-test-setup/mocharc-common.cjs
+++ b/packages/test/mocha-test-setup/mocharc-common.cjs
@@ -42,7 +42,7 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 	});
 
 	if (process.env.FLUID_TEST_LOGGER_PKG_SPECIFIER) {
-		const modulePath = require.resolve(process.env.FLUID_TEST_LOGGER_PKG_SPECIFIER);
+		const modulePath = path.join(moduleDir, process.env.FLUID_TEST_LOGGER_PKG_SPECIFIER);
 		// Inject implementation of createTestLogger, put it first before mocha-test-setup
 		if (existsSync(modulePath)) {
 			requiredModulePaths.unshift(modulePath);


### PR DESCRIPTION
## Description

When merging this PR: [Here](https://github.com/microsoft/FluidFramework/pull/24880/files#diff-ed55acf5d71c17b285dadd6ba41c1438b6206ab9475ea32ac2b3e2b34d58c386) an error was merged that caused the pipeline to create two session loggers, this change will fix that error.

## Reviewer Guidance

Let me know if there's something I should change or be aware of.

Fixes: [AB#44795](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/44795)