### PR TITLE
Update menu colour to fix a11y contrast issues

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -6,7 +6,7 @@
 
 /* You can override the default Infima variables here. */
 :root {
-	--ifm-color-primary: #558cf4;
+	--ifm-color-primary: #406bbb;
 	--ifm-color-primary-dark: #3300aa;
 	--ifm-color-primary-darker: #3000a1;
 	--ifm-color-primary-darkest: #280084;


### PR DESCRIPTION
[AB#33672](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/33672)

## Description

This PR updates the shade of blue used in our menu items to be a11y compliant and resolve Sev2 warnings.