### PR TITLE
Fix independentInitializedView when used with ForestTypeExpensiveDebug

### DIFF
--- a/.changeset/sad-points-dance.md
+++ b/.changeset/sad-points-dance.md
@@ -5,5 +5,5 @@
 ---
 Fix independentInitializedView when used with ForestTypeExpensiveDebug
 
-Previously using [independentInitializedView](https://fluidframework.com/docs/api/tree/#independentinitializedview-function) with [ForestTypeExpensiveDebug](https://fluidframework.com/docs/api/tree/#foresttypeexpensivedebug-variable) when the root schema was not an optional field, an error was thrown about the tree being out of schema.
+Previously, when using [independentInitializedView](https://fluidframework.com/docs/api/tree/#independentinitializedview-function) with [ForestTypeExpensiveDebug](https://fluidframework.com/docs/api/tree/#foresttypeexpensivedebug-variable) and the root schema was not an optional field, an error was thrown about the tree being out of schema.
 This has been fixed.

--- a/.changeset/sad-points-dance.md
+++ b/.changeset/sad-points-dance.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Fix independentInitializedView when used with ForestTypeExpensiveDebug
+
+Previously using [independentInitializedView](https://fluidframework.com/docs/api/tree/#independentinitializedview-function) with [ForestTypeExpensiveDebug](https://fluidframework.com/docs/api/tree/#foresttypeexpensivedebug-variable) when the root schema was not an optional field, an error was thrown about the tree being out of schema.
+This has been fixed.

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -193,5 +193,3 @@ export {
 	type TreeIndexKey,
 	type TreeIndexNodes,
 } from "./indexing/index.js";
-
-export { initializeForest } from "./initializeForest.js";

--- a/packages/dds/tree/src/shared-tree/independentView.ts
+++ b/packages/dds/tree/src/shared-tree/independentView.ts
@@ -111,7 +111,7 @@ export function independentInitializedView<const TSchema extends ImplicitFieldSc
 	const fieldCursors = fieldBatchCodec.decode(content.tree as JsonCompatibleReadOnly, context);
 	assert(fieldCursors.length === 1, 0xa5b /* must have exactly 1 field in batch */);
 
-	const out: TreeViewAlpha<TSchema> = independentInitializedViewInternal<TSchema>(
+	return independentInitializedViewInternal(
 		config,
 		options,
 		schema,
@@ -120,7 +120,6 @@ export function independentInitializedView<const TSchema extends ImplicitFieldSc
 		fieldCursors[0]!,
 		idCompressor,
 	);
-	return out;
 }
 
 /**

--- a/packages/dds/tree/src/shared-tree/independentView.ts
+++ b/packages/dds/tree/src/shared-tree/independentView.ts
@@ -26,7 +26,6 @@ import {
 	type FieldBatchEncodingContext,
 	defaultSchemaPolicy,
 	TreeCompressionStrategy,
-	initializeForest,
 } from "../feature-libraries/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import type { Format } from "../feature-libraries/schema-index/formatV1.js";

--- a/packages/dds/tree/src/shared-tree/independentView.ts
+++ b/packages/dds/tree/src/shared-tree/independentView.ts
@@ -137,7 +137,7 @@ export function independentInitializedViewInternal<const TSchema extends Implici
 	const revisionTagCodec = new RevisionTagCodec(idCompressor);
 	const mintRevisionTag = (): RevisionTag => idCompressor.generateCompressedId();
 
-	// So forest is in schema when constructed, start it with empty schema and set content of schema repository later.
+	// To ensure the forest is in schema when constructed, start it with an empty schema and set the schema repository content later.
 	const schemaRepository = new TreeStoredSchemaRepository();
 
 	const forest = buildConfiguredForest(

--- a/packages/dds/tree/src/shared-tree/independentView.ts
+++ b/packages/dds/tree/src/shared-tree/independentView.ts
@@ -12,9 +12,11 @@ import {
 
 import type { ICodecOptions } from "../codec/index.js";
 import {
+	type ITreeCursorSynchronous,
 	type RevisionTag,
 	RevisionTagCodec,
 	SchemaVersion,
+	type TreeStoredSchema,
 	TreeStoredSchemaRepository,
 } from "../core/index.js";
 import {
@@ -41,6 +43,7 @@ import {
 } from "./sharedTree.js";
 import { createTreeCheckout } from "./treeCheckout.js";
 import { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
+import { initialize } from "./schematizeTree.js";
 
 /**
  * Create an uninitialized {@link TreeView} that is not tied to any {@link ITree} instance.
@@ -85,6 +88,8 @@ export function independentView<const TSchema extends ImplicitFieldSchema>(
  * Such a view can never experience collaboration or be persisted to to a Fluid Container.
  *
  * This can be useful for testing, as well as use-cases like working on local files instead of documents stored in some Fluid service.
+ * @privateRemarks
+ * TODO: Providing an API which generates a {@link ViewableTree} extended with export options from {@link ITreeAlpha} and maybe even branching APIs would likely be better that just exposing a {@link TreeViewAlpha}.
  * @alpha
  */
 export function independentInitializedView<const TSchema extends ImplicitFieldSchema>(
@@ -92,22 +97,11 @@ export function independentInitializedView<const TSchema extends ImplicitFieldSc
 	options: ForestOptions & ICodecOptions,
 	content: ViewContent,
 ): TreeViewAlpha<TSchema> {
-	const breaker = new Breakable("independentInitializedView");
 	const idCompressor: IIdCompressor = content.idCompressor;
-	const mintRevisionTag = (): RevisionTag => idCompressor.generateCompressedId();
-	const revisionTagCodec = new RevisionTagCodec(idCompressor);
-
 	const fieldBatchCodec = makeFieldBatchCodec(options, 1);
 	const schemaCodec = makeSchemaCodec(options, SchemaVersion.v1);
 
-	const schema = new TreeStoredSchemaRepository(schemaCodec.decode(content.schema as Format));
-	const forest = buildConfiguredForest(
-		breaker,
-		options.forest ?? defaultSharedTreeOptions.forest,
-		schema,
-		idCompressor,
-	);
-
+	const schema = schemaCodec.decode(content.schema as Format);
 	const context: FieldBatchEncodingContext = {
 		encodeType: TreeCompressionStrategy.Compressed,
 		idCompressor,
@@ -117,21 +111,57 @@ export function independentInitializedView<const TSchema extends ImplicitFieldSc
 
 	const fieldCursors = fieldBatchCodec.decode(content.tree as JsonCompatibleReadOnly, context);
 	assert(fieldCursors.length === 1, 0xa5b /* must have exactly 1 field in batch */);
-	// Checked above.
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	initializeForest(forest, fieldCursors[0]!, revisionTagCodec, idCompressor, false);
+
+	const out: TreeViewAlpha<TSchema> = independentInitializedViewInternal<TSchema>(
+		config,
+		options,
+		schema,
+		// Checked above.
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		fieldCursors[0]!,
+		idCompressor,
+	);
+	return out;
+}
+
+/**
+ * {@link independentInitializedView} but using internal types instead of persisted data formats.
+ */
+export function independentInitializedViewInternal<const TSchema extends ImplicitFieldSchema>(
+	config: TreeViewConfiguration<TSchema>,
+	options: ForestOptions & ICodecOptions,
+	schema: TreeStoredSchema,
+	rootFieldCursor: ITreeCursorSynchronous,
+	idCompressor: IIdCompressor,
+): SchematizingSimpleTreeView<TSchema> {
+	const breaker = new Breakable("independentInitializedView");
+	const revisionTagCodec = new RevisionTagCodec(idCompressor);
+	const mintRevisionTag = (): RevisionTag => idCompressor.generateCompressedId();
+
+	// So forest is in schema when constructed, start it with empty schema and set content of schema repository later.
+	const schemaRepository = new TreeStoredSchemaRepository();
+
+	const forest = buildConfiguredForest(
+		breaker,
+		options.forest ?? defaultSharedTreeOptions.forest,
+		schemaRepository,
+		idCompressor,
+	);
+
+	initializeForest(forest, rootFieldCursor, revisionTagCodec, idCompressor, false);
 
 	const checkout = createTreeCheckout(idCompressor, mintRevisionTag, revisionTagCodec, {
 		forest,
-		schema,
+		schema: schemaRepository,
 		breaker,
 	});
-	const out: TreeViewAlpha<TSchema> = new SchematizingSimpleTreeView<TSchema>(
+
+	initialize(checkout, { schema, initialTree: rootFieldCursor });
+	return new SchematizingSimpleTreeView<TSchema>(
 		checkout,
 		config,
 		createNodeIdentifierManager(idCompressor),
 	);
-	return out;
 }
 
 /**

--- a/packages/dds/tree/src/shared-tree/independentView.ts
+++ b/packages/dds/tree/src/shared-tree/independentView.ts
@@ -148,8 +148,6 @@ export function independentInitializedViewInternal<const TSchema extends Implici
 		idCompressor,
 	);
 
-	initializeForest(forest, rootFieldCursor, revisionTagCodec, idCompressor, false);
-
 	const checkout = createTreeCheckout(idCompressor, mintRevisionTag, revisionTagCodec, {
 		forest,
 		schema: schemaRepository,

--- a/packages/dds/tree/src/test/codec/ajvValidator.ts
+++ b/packages/dds/tree/src/test/codec/ajvValidator.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { MockHandle } from "@fluidframework/test-runtime-utils/internal";
 import type { Static, TSchema } from "@sinclair/typebox";
 // Based on ESM workaround from https://github.com/ajv-validator/ajv/issues/2047#issuecomment-1241470041 .
 // In ESM, this gets the module, in cjs, it gets the default export which is the Ajv class.
@@ -18,6 +17,7 @@ const Ajv =
 	(ajvModuleOrClass as any);
 
 import type { ISharedObjectHandle } from "@fluidframework/shared-object-base/internal";
+import { MockHandle } from "@fluidframework/test-runtime-utils/internal";
 
 import type { JsonValidator } from "../../codec/index.js";
 import { mockSerializer } from "../mockSerializer.js";
@@ -60,7 +60,7 @@ export const ajvValidator: JsonValidator = {
 					throw new Error(
 						`Invalid JSON.\n\nData: ${mockSerializer.stringify(
 							data,
-							new MockHandle(""),
+							mockHandle,
 						)}\n\nErrors: ${JSON.stringify(validate.errors)}`,
 					);
 				}

--- a/packages/dds/tree/src/test/codec/ajvValidator.ts
+++ b/packages/dds/tree/src/test/codec/ajvValidator.ts
@@ -17,8 +17,11 @@ const Ajv =
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	(ajvModuleOrClass as any);
 
+import type { ISharedObjectHandle } from "@fluidframework/shared-object-base/internal";
+
 import type { JsonValidator } from "../../codec/index.js";
 import { mockSerializer } from "../mockSerializer.js";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 // See: https://github.com/sinclairzx81/typebox#ajv
 const ajv = formats.default(new Ajv({ strict: false, allErrors: true }), [
@@ -51,6 +54,9 @@ export const ajvValidator: JsonValidator = {
 			check: (data): data is Static<Schema> => {
 				const valid = validate(data);
 				if (!valid) {
+					const mockHandle = new MockHandle("");
+					// Make stringify not assert when checking for "bind"
+					(mockHandle as IFluidHandle as ISharedObjectHandle).bind = () => {};
 					throw new Error(
 						`Invalid JSON.\n\nData: ${mockSerializer.stringify(
 							data,

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -27,7 +27,6 @@ import {
 	cursorForJsonableTreeNode,
 	cursorForMapTreeNode,
 	defaultSchemaPolicy,
-	initializeForest,
 	jsonableTreeFromCursor,
 	mapTreeFromCursor,
 } from "../../../feature-libraries/index.js";
@@ -43,6 +42,7 @@ import { generateTwitterJsonByByteSize } from "./twitter.js";
 import { toStoredSchema } from "../../../simple-tree/toStoredSchema.js";
 import { cursorToJsonObject, singleJsonCursor } from "../../json/index.js";
 import { JsonAsTree } from "../../../jsonDomainSchema.js";
+import { initializeForest } from "../../feature-libraries/index.js";
 
 // Shared tree keys that map to the type used by the Twitter type/dataset
 export const TwitterKey = {

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/uncompressedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/uncompressedEncode.spec.ts
@@ -12,10 +12,10 @@ import {
 import {
 	TreeCompressionStrategy,
 	cursorForJsonableTreeField,
+	jsonableTreeFromFieldCursor,
 } from "../../../../feature-libraries/index.js";
 import { ajvValidator } from "../../../codec/index.js";
 import { testTrees } from "../../../cursorTestSuite.js";
-import { jsonableTreesFromFieldCursor } from "../fieldCursorTestUtilities.js";
 import { testIdCompressor } from "../../../utils.js";
 
 describe("uncompressedEncode", () => {
@@ -32,7 +32,7 @@ describe("uncompressedEncode", () => {
 				const codec = makeFieldBatchCodec({ jsonValidator: ajvValidator }, 1);
 				const result = codec.encode([input], context);
 				const decoded = codec.decode(result, context);
-				const decodedJson = decoded.map(jsonableTreesFromFieldCursor);
+				const decodedJson = decoded.map(jsonableTreeFromFieldCursor);
 				assert.deepEqual([[jsonable]], decodedJson);
 			});
 		}

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -24,7 +24,6 @@ import {
 	type DefaultChangeset,
 	DefaultEditBuilder,
 	cursorForJsonableTreeField,
-	initializeForest,
 	intoDelta,
 	jsonableTreeFromCursor,
 } from "../../../feature-libraries/index.js";
@@ -40,6 +39,7 @@ import {
 } from "../../utils.js";
 import { JsonAsTree } from "../../../jsonDomainSchema.js";
 import { numberSchema, stringSchema } from "../../../simple-tree/index.js";
+import { initializeForest } from "../initializeForest.js";
 
 const defaultChangeFamily = new DefaultChangeFamily(failCodecFamily);
 const family = defaultChangeFamily;

--- a/packages/dds/tree/src/test/feature-libraries/index.ts
+++ b/packages/dds/tree/src/test/feature-libraries/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { initializeForest } from "./initializeForest.js";

--- a/packages/dds/tree/src/test/feature-libraries/initializeForest.ts
+++ b/packages/dds/tree/src/test/feature-libraries/initializeForest.ts
@@ -15,7 +15,7 @@ import {
 	deltaForRootInitialization,
 	makeDetachedFieldIndex,
 	visitDelta,
-} from "../core/index.js";
+} from "../../core/index.js";
 
 /**
  * Initializes the given forest with the given content.

--- a/packages/dds/tree/src/test/feature-libraries/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/objectForest.spec.ts
@@ -13,7 +13,7 @@ import {
 	rootFieldKey,
 	TreeStoredSchemaRepository,
 } from "../../core/index.js";
-import { cursorForMapTreeNode, initializeForest } from "../../feature-libraries/index.js";
+import { cursorForMapTreeNode } from "../../feature-libraries/index.js";
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
 import { buildForest } from "../../feature-libraries/object-forest/index.js";
@@ -22,6 +22,7 @@ import { testForest } from "../forestTestSuite.js";
 import { testIdCompressor, testRevisionTagCodec, validateUsageError } from "../utils.js";
 import { fieldJsonCursor } from "../json/index.js";
 import { toStoredSchema, SchemaFactory } from "../../simple-tree/index.js";
+import { initializeForest } from "./initializeForest.js";
 
 describe("object-forest", () => {
 	describe("forest suite", () => {

--- a/packages/dds/tree/src/test/forestTestSuite.ts
+++ b/packages/dds/tree/src/test/forestTestSuite.ts
@@ -32,7 +32,6 @@ import {
 import { typeboxValidator } from "../external-utilities/index.js";
 import {
 	cursorForJsonableTreeField,
-	initializeForest,
 	jsonableTreeFromCursor,
 } from "../feature-libraries/index.js";
 import {
@@ -63,6 +62,7 @@ import { jsonSequenceRootSchema } from "./sequenceRootUtils.js";
 import { cursorToJsonObject, fieldJsonCursor, singleJsonCursor } from "./json/index.js";
 import { JsonAsTree } from "../jsonDomainSchema.js";
 import { FluidClientVersion } from "../codec/index.js";
+import { initializeForest } from "./feature-libraries/index.js";
 
 /**
  * Configuration for the forest test suite.

--- a/packages/dds/tree/src/test/shared-tree/independentView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/independentView.spec.ts
@@ -1,0 +1,39 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+// eslint-disable-next-line import/no-internal-modules
+import { independentInitializedView } from "../../shared-tree/independentView.js";
+import {
+	extractPersistedSchema,
+	SchemaFactory,
+	TreeViewConfigurationAlpha,
+} from "../../simple-tree/index.js";
+import { ForestTypeExpensiveDebug } from "../../shared-tree/index.js";
+import { ajvValidator } from "../codec/index.js";
+import { FluidClientVersion } from "../../codec/index.js";
+import { testIdCompressor } from "../utils.js";
+
+describe("independentView", () => {
+	describe("independentInitializedView", () => {
+		// Repression test for debug forest erroring during initialization due to being out of schema.
+		it("debug forest", () => {
+			const config = new TreeViewConfigurationAlpha({ schema: SchemaFactory.number });
+			const view = independentInitializedView(
+				config,
+				{
+					forest: ForestTypeExpensiveDebug,
+					jsonValidator: ajvValidator,
+				},
+				{
+					schema: extractPersistedSchema(config, FluidClientVersion.v2_0),
+					tree: { type: "number", value: 1 },
+					idCompressor: testIdCompressor,
+				},
+			);
+			assert.equal(view.root, 1);
+		});
+	});
+});

--- a/packages/dds/tree/src/test/shared-tree/independentView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/independentView.spec.ts
@@ -23,7 +23,7 @@ import { fieldCursorFromInsertable, testIdCompressor } from "../utils.js";
 
 describe("independentView", () => {
 	describe("independentInitializedView", () => {
-		// Repression test for debug forest erroring during initialization due to being out of schema.
+		// Regression test for debug forest erroring during initialization due to being out of schema.
 		it("debug forest", () => {
 			const config = new TreeViewConfigurationAlpha({ schema: SchemaFactory.number });
 			const view = independentInitializedView(
@@ -45,7 +45,7 @@ describe("independentView", () => {
 	});
 
 	describe("independentInitializedViewInternal", () => {
-		// Repression test for debug forest erroring during initialization due to being out of schema.
+		// Regression test for debug forest erroring during initialization due to being out of schema.
 		it("debug forest", () => {
 			const config = new TreeViewConfigurationAlpha({ schema: SchemaFactory.number });
 			const view = independentInitializedViewInternal(

--- a/packages/dds/tree/src/test/shared-tree/independentView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/independentView.spec.ts
@@ -4,17 +4,22 @@
  */
 
 import { strict as assert } from "node:assert";
-// eslint-disable-next-line import/no-internal-modules
-import { independentInitializedView } from "../../shared-tree/independentView.js";
+
+import {
+	independentInitializedView,
+	independentInitializedViewInternal,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../shared-tree/independentView.js";
 import {
 	extractPersistedSchema,
 	SchemaFactory,
+	toStoredSchema,
 	TreeViewConfigurationAlpha,
 } from "../../simple-tree/index.js";
-import { ForestTypeExpensiveDebug } from "../../shared-tree/index.js";
+import { ForestTypeExpensiveDebug, TreeAlpha } from "../../shared-tree/index.js";
 import { ajvValidator } from "../codec/index.js";
 import { FluidClientVersion } from "../../codec/index.js";
-import { testIdCompressor } from "../utils.js";
+import { fieldCursorFromInsertable, testIdCompressor } from "../utils.js";
 
 describe("independentView", () => {
 	describe("independentInitializedView", () => {
@@ -29,9 +34,29 @@ describe("independentView", () => {
 				},
 				{
 					schema: extractPersistedSchema(config, FluidClientVersion.v2_0),
-					tree: { type: "number", value: 1 },
+					tree: TreeAlpha.exportCompressed(1, {
+						oldestCompatibleClient: FluidClientVersion.v2_0,
+					}),
 					idCompressor: testIdCompressor,
 				},
+			);
+			assert.equal(view.root, 1);
+		});
+	});
+
+	describe("independentInitializedViewInternal", () => {
+		// Repression test for debug forest erroring during initialization due to being out of schema.
+		it("debug forest", () => {
+			const config = new TreeViewConfigurationAlpha({ schema: SchemaFactory.number });
+			const view = independentInitializedViewInternal(
+				config,
+				{
+					forest: ForestTypeExpensiveDebug,
+					jsonValidator: ajvValidator,
+				},
+				toStoredSchema(config.schema),
+				fieldCursorFromInsertable(config.schema, 1),
+				testIdCompressor,
 			);
 			assert.equal(view.root, 1);
 		});

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeEnricher.spec.ts
@@ -27,7 +27,6 @@ import {
 	ModularEditBuilder,
 	type TreeChunk,
 	fieldKinds,
-	initializeForest,
 } from "../../feature-libraries/index.js";
 import {
 	type SharedTreeMutableChangeEnricher,
@@ -55,6 +54,7 @@ import {
 } from "../utils.js";
 import { FluidClientVersion } from "../../codec/index.js";
 import { jsonSequenceRootSchema } from "../sequenceRootUtils.js";
+import { initializeForest } from "../feature-libraries/index.js";
 
 const content: JsonCompatible = { x: 42 };
 


### PR DESCRIPTION
## Description

Fix independentInitializedView when used with ForestTypeExpensiveDebug by reusing the multi-phase initialization code SharedTree uses to keep forest in schema during initialize.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
