### PR TITLE
Remove closeAndGetPendingLocalState

### DIFF
--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -695,7 +695,8 @@ export async function withContainerOffline<TReturn>(
 	await provider.ensureSynchronized();
 	await provider.opProcessingController.pauseProcessing(container);
 	const actionReturn = action();
-	const pendingLocalState = await container.closeAndGetPendingLocalState?.();
+	const pendingLocalState = await container.getPendingLocalState?.();
+	container.close();
 	assert(pendingLocalState !== undefined, 0x726 /* pendingLocalState should be defined */);
 	return { actionReturn, pendingLocalState };
 }

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1742,7 +1742,8 @@ describe("SharedTree", () => {
 			await provider.opProcessingController.pauseProcessing(pausedContainer);
 			pausedTree.root.insertAt(1, "b");
 			pausedTree.root.insertAt(2, "c");
-			const pendingOps = await pausedContainer.closeAndGetPendingLocalState?.();
+			const pendingOps = await pausedContainer.getPendingLocalState?.();
+			pausedContainer.close();
 			provider.opProcessingController.resumeProcessing();
 
 			const otherLoadedView = provider.trees[1].viewWith(
@@ -2054,7 +2055,8 @@ describe("SharedTree", () => {
 				}),
 			);
 			pausedView.initialize([]);
-			const pendingOps = await pausedContainer.closeAndGetPendingLocalState?.();
+			const pendingOps = await pausedContainer.getPendingLocalState?.();
+			pausedContainer.close();
 			provider.opProcessingController.resumeProcessing();
 
 			const loadedContainer = await provider.loadTestContainer(

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -26,7 +26,6 @@ import type {
 	IFluidCodeDetails,
 	IFluidCodeDetailsComparer,
 	IFluidModuleWithDetails,
-	IGetPendingLocalStateProps,
 	IProvideFluidCodeDetailsComparer,
 	IProvideRuntimeFactory,
 	IRuntime,
@@ -1191,30 +1190,12 @@ export class Container
 		}
 	}
 
-	public async closeAndGetPendingLocalState(
-		stopBlobAttachingSignal?: AbortSignal,
-	): Promise<string> {
-		// runtime matches pending ops to successful ones by clientId and client seq num, so we need to close the
-		// container at the same time we get pending state, otherwise this container could reconnect and resubmit with
-		// a new clientId and a future container using stale pending state without the new clientId would resubmit them
-		const pendingState = await this.getPendingLocalStateCore({
-			notifyImminentClosure: true,
-			stopBlobAttachingSignal,
-		});
-		this.close();
-		return pendingState;
-	}
-
 	/**
 	 * Serialize current container state required to rehydrate to the same position without dataloss.
 	 * Note: The container must already be attached. For detached containers use {@link serialize}
 	 * @returns stringified {@link IPendingContainerState} for the container
 	 */
 	public async getPendingLocalState(): Promise<string> {
-		return this.getPendingLocalStateCore({ notifyImminentClosure: false });
-	}
-
-	private async getPendingLocalStateCore(props: IGetPendingLocalStateProps): Promise<string> {
 		if (this.closed || this._disposed) {
 			throw new UsageError(
 				"Pending state cannot be retried if the container is closed or disposed",
@@ -1229,7 +1210,6 @@ export class Container
 			0x0d2 /* "resolved url should be valid Fluid url" */,
 		);
 		const pendingState = await this.serializedStateManager.getPendingLocalState(
-			props,
 			this.clientId,
 			this.runtime,
 			this.resolvedUrl,
@@ -1244,7 +1224,7 @@ export class Container
 	/**
 	 * Serialize current container state required to rehydrate to the same position without dataloss.
 	 * Note: The container must be detached and not closed. For attached containers use
-	 * {@link getPendingLocalState} or {@link closeAndGetPendingLocalState}
+	 * {@link getPendingLocalState}
 	 * @returns stringified {@link IPendingDetachedContainerState} for the container
 	 */
 	public serialize(): string {
@@ -2586,10 +2566,4 @@ export interface IContainerExperimental extends IContainer {
 	 * @returns serialized blob that can be passed to Loader.resolve()
 	 */
 	getPendingLocalState?(): Promise<string>;
-
-	/**
-	 * Closes the container and returns serialized local state intended to be
-	 * given to a newly loaded container.
-	 */
-	closeAndGetPendingLocalState?(stopBlobAttachingSignal?: AbortSignal): Promise<string>;
 }

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -4,10 +4,7 @@
  */
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
-import {
-	IGetPendingLocalStateProps,
-	IRuntime,
-} from "@fluidframework/container-definitions/internal";
+import { IRuntime } from "@fluidframework/container-definitions/internal";
 import type {
 	IEventProvider,
 	IEvent,
@@ -422,7 +419,6 @@ export class SerializedStateManager {
 	 * to be stored and used to rehydrate the container at a later time.
 	 */
 	public async getPendingLocalState(
-		props: IGetPendingLocalStateProps,
 		clientId: string | undefined,
 		runtime: Pick<IRuntime, "getPendingLocalState">,
 		resolvedUrl: IResolvedUrl,
@@ -432,9 +428,9 @@ export class SerializedStateManager {
 			{
 				eventName: "getPendingLocalState",
 				details: {
-					notifyImminentClosure: props.notifyImminentClosure,
-					sessionExpiryTimerStarted: props.sessionExpiryTimerStarted,
-					snapshotSequenceNumber: props.snapshotSequenceNumber,
+					notifyImminentClosure: false,
+					sessionExpiryTimerStarted: undefined,
+					snapshotSequenceNumber: undefined,
 					processedOpsSize: this.processedOps.length,
 				},
 				clientId,
@@ -445,7 +441,7 @@ export class SerializedStateManager {
 				}
 				assert(this.snapshot !== undefined, 0x8e5 /* no base data */);
 				const pendingRuntimeState = await runtime.getPendingLocalState({
-					...props,
+					notifyImminentClosure: false,
 					snapshotSequenceNumber: this.snapshot.snapshotSequenceNumber,
 					sessionExpiryTimerStarted: this.snapshot.snapshotFetchedTime,
 				});

--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -198,9 +198,6 @@ describe("serializedStateManager", () => {
 			await assert.rejects(
 				async () =>
 					serializedStateManager.getPendingLocalState(
-						{
-							notifyImminentClosure: false,
-						},
 						"clientId",
 						new MockRuntime(),
 						resolvedUrl,
@@ -231,7 +228,6 @@ describe("serializedStateManager", () => {
 				},
 			});
 			await serializedStateManager.getPendingLocalState(
-				{ notifyImminentClosure: false },
 				"clientId",
 				new MockRuntime(),
 				resolvedUrl,
@@ -257,7 +253,6 @@ describe("serializedStateManager", () => {
 			assert(baseSnapshot);
 			assert.strictEqual(version, undefined);
 			const state = await serializedStateManager.getPendingLocalState(
-				{ notifyImminentClosure: false },
 				"clientId",
 				new MockRuntime(),
 				resolvedUrl,
@@ -282,7 +277,6 @@ describe("serializedStateManager", () => {
 			assert.strictEqual(version?.id, "fromStorage");
 			assert.strictEqual(version.treeId, "fromStorage");
 			const state = await serializedStateManager.getPendingLocalState(
-				{ notifyImminentClosure: false },
 				"clientId",
 				new MockRuntime(),
 				resolvedUrl,
@@ -333,7 +327,6 @@ describe("serializedStateManager", () => {
 			// getting pending state without waiting for fetching new snapshot.
 			assert.strictEqual(getLatestSnapshotInfoP.isCompleted, false);
 			const state = await serializedStateManager.getPendingLocalState(
-				{ notifyImminentClosure: false },
 				"clientId",
 				new MockRuntime(),
 				resolvedUrl,
@@ -384,7 +377,6 @@ describe("serializedStateManager", () => {
 			}
 
 			const state = await serializedStateManager.getPendingLocalState(
-				{ notifyImminentClosure: false },
 				"clientId",
 				new MockRuntime(),
 				resolvedUrl,
@@ -442,7 +434,6 @@ describe("serializedStateManager", () => {
 			await serializedStateManager.refreshSnapshotP;
 
 			const state = await serializedStateManager.getPendingLocalState(
-				{ notifyImminentClosure: false },
 				"clientId",
 				new MockRuntime(),
 				resolvedUrl,
@@ -498,7 +489,6 @@ describe("serializedStateManager", () => {
 					},
 				]);
 				const state = await serializedStateManager.getPendingLocalState(
-					{ notifyImminentClosure: false },
 					"clientId",
 					new MockRuntime(),
 					resolvedUrl,
@@ -559,7 +549,6 @@ describe("serializedStateManager", () => {
 					},
 				]);
 				const state = await serializedStateManager.getPendingLocalState(
-					{ notifyImminentClosure: false },
 					"clientId",
 					new MockRuntime(),
 					resolvedUrl,
@@ -608,7 +597,6 @@ describe("serializedStateManager", () => {
 					eventEmitter.emit("saved");
 				}
 				const state = await serializedStateManager.getPendingLocalState(
-					{ notifyImminentClosure: false },
 					"clientId",
 					new MockRuntime(),
 					resolvedUrl,
@@ -655,7 +643,6 @@ describe("serializedStateManager", () => {
 				await serializedStateManager.fetchSnapshot(undefined);
 				await serializedStateManager.refreshSnapshotP;
 				const state = await serializedStateManager.getPendingLocalState(
-					{ notifyImminentClosure: false },
 					"clientId",
 					new MockRuntime(),
 					resolvedUrl,
@@ -710,7 +697,6 @@ describe("serializedStateManager", () => {
 				}
 
 				const state = await serializedStateManager.getPendingLocalState(
-					{ notifyImminentClosure: false },
 					"clientId",
 					new MockRuntime(),
 					resolvedUrl,
@@ -777,7 +763,6 @@ describe("serializedStateManager", () => {
 				}
 
 				const state = await serializedStateManager.getPendingLocalState(
-					{ notifyImminentClosure: false },
 					"clientId",
 					new MockRuntime(),
 					resolvedUrl,
@@ -815,7 +800,6 @@ describe("serializedStateManager", () => {
 					},
 				};
 				const state = await serializedStateManager.getPendingLocalState(
-					{ notifyImminentClosure: false },
 					"clientId",
 					mockRuntime,
 					resolvedUrl,
@@ -858,7 +842,6 @@ describe("serializedStateManager", () => {
 					},
 				};
 				const state = await serializedStateManager.getPendingLocalState(
-					{ notifyImminentClosure: false },
 					"clientId",
 					mockRuntime,
 					resolvedUrl,
@@ -913,7 +896,6 @@ describe("serializedStateManager", () => {
 					},
 				};
 				const state = await serializedStateManager.getPendingLocalState(
-					{ notifyImminentClosure: false },
 					"clientId",
 					mockRuntime,
 					resolvedUrl,
@@ -957,7 +939,6 @@ describe("serializedStateManager", () => {
 		): Promise<void> => {
 			// pending state validation
 			const state = await serializedStateManager.getPendingLocalState(
-				{ notifyImminentClosure: false },
 				"clientId",
 				new MockRuntime(),
 				resolvedUrl,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -5054,7 +5054,7 @@ export class ContainerRuntime
 		};
 
 		// Flush pending batch.
-		// getPendingLocalState() is only exposed through Container.closeAndGetPendingLocalState(), so it's safe
+		// getPendingLocalState() is only exposed through Container.getPendingLocalState(), so it's safe
 		// to close current batch.
 		this.flush();
 

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -324,7 +324,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 		assert.strictEqual(runCount, 1);
 	});
 
-	it("closeAndGetPendingLocalState() called on container", async () => {
+	it("getPendingLocalState() called on container", async () => {
 		const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
 			getRawConfig: (name: string): ConfigTypes => settings[name],
 		});
@@ -348,7 +348,8 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 
 		const container: IContainerExperimental =
 			await localTestObjectProvider.makeTestContainer(testContainerConfig);
-		const pendingString = await container.closeAndGetPendingLocalState?.();
+		const pendingString = await container.getPendingLocalState?.();
+		container.close();
 		assert.ok(pendingString);
 		const pendingLocalState: { url?: string } = JSON.parse(pendingString);
 		assert.strictEqual(container.closed, true);

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
@@ -143,10 +143,11 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 
 		// Get Pending state and close
 		assert(
-			container.closeAndGetPendingLocalState !== undefined,
-			"Test can't run without closeAndGetPendingLocalState",
+			container.getPendingLocalState !== undefined,
+			"Test can't run without getPendingLocalState",
 		);
-		const pendingState = await container.closeAndGetPendingLocalState();
+		const pendingState = await container.getPendingLocalState();
+		container.close();
 
 		// Load from the pending state
 		const container3 = await provider.loadContainer(
@@ -234,8 +235,9 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 		dataObjectA2._root.set("A2", "A2");
 
 		// Get Pending state and close
-		assert(container2.closeAndGetPendingLocalState !== undefined, "Missing method!");
-		const pendingState = await container2.closeAndGetPendingLocalState();
+		assert(container2.getPendingLocalState !== undefined, "Missing method!");
+		const pendingState = await container2.getPendingLocalState();
+		container2.close();
 
 		// Load from the pending state
 		const container3 = await provider.loadContainer(
@@ -356,8 +358,9 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 		dataObjectB2._root.set("B2", "B2");
 
 		// Get Pending state and close
-		assert(container2.closeAndGetPendingLocalState !== undefined, "Missing method!");
-		const pendingState = await container2.closeAndGetPendingLocalState();
+		assert(container2.getPendingLocalState !== undefined, "Missing method!");
+		const pendingState = await container2.getPendingLocalState();
+		container2.close();
 
 		// Load from the pending state
 		const container3 = await provider.loadContainer(

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/initialSequenceNumberAndStashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/initialSequenceNumberAndStashedOps.spec.ts
@@ -59,7 +59,8 @@ describeCompat(
 			mainObject._root.set("4", "4");
 
 			// Generate pending state
-			const pendingState = await container.closeAndGetPendingLocalState?.();
+			const pendingState = await container.getPendingLocalState?.();
+			container.close();
 
 			// Load from the pending state
 			const container2 = (await provider.loadTestContainer(

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/noGroupIdOfflineFlow.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/noGroupIdOfflineFlow.spec.ts
@@ -85,7 +85,8 @@ describeCompat("Offline Attach Ops", "NoCompat", (getTestObjectProvider, apis) =
 		const childObject = await dataObjectFactory.createInstance(mainObject.containerRuntime);
 		mainObject._root.set("testObject2", childObject.handle);
 
-		const serializedState = await container.closeAndGetPendingLocalState?.();
+		const serializedState = await container.getPendingLocalState?.();
+		container.close();
 		assert(serializedState !== undefined, "serializedState should not be undefined");
 
 		// This should not hang

--- a/packages/test/test-end-to-end-tests/src/test/intervalCollectionEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/intervalCollectionEndToEndTests.spec.ts
@@ -142,8 +142,8 @@ describeCompat(
 			const collection = sharedString.getIntervalCollection(collectionId);
 			collection.change(id, { start: 3, end: 8 });
 
-			const pendingState: string | undefined =
-				await container.closeAndGetPendingLocalState?.();
+			const pendingState: string | undefined = await container.getPendingLocalState?.();
+			container.close();
 			provider.opProcessingController.resumeProcessing();
 			assert.ok(pendingState);
 

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/reconnect.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/reconnect.spec.ts
@@ -295,7 +295,8 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider, apis) => {
 		updateQuantity(legacyTree1, 3);
 		updateQuantity(legacyTree1, 4);
 		updateQuantity(legacyTree1, 5);
-		const pendingState = await container1.closeAndGetPendingLocalState?.();
+		const pendingState = await container1.getPendingLocalState?.();
+		container1.close();
 		assert(pendingState !== undefined, "Pending state should be defined");
 
 		const loader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory2]]);
@@ -333,7 +334,8 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider, apis) => {
 		node1.quantity = 3;
 		node1.quantity = 4;
 		node1.quantity = 5;
-		const pendingState = await container1.closeAndGetPendingLocalState?.();
+		const pendingState = await container1.getPendingLocalState?.();
+		container1.close();
 		assert(pendingState !== undefined, "Pending state should be defined");
 
 		const loader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory2]]);
@@ -395,7 +397,8 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider, apis) => {
 		node2.quantity = 3;
 		node2.quantity = 4;
 		node2.quantity = 5;
-		const pendingState = await container2.closeAndGetPendingLocalState?.();
+		const pendingState = await container2.getPendingLocalState?.();
+		container2.close();
 		assert(pendingState !== undefined, "Pending state should be defined");
 
 		const loader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory2]]);
@@ -436,7 +439,8 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider, apis) => {
 		updateQuantity(legacyTree1, 3);
 		updateQuantity(legacyTree1, 4);
 		updateQuantity(legacyTree1, 5);
-		const pendingState = await container1.closeAndGetPendingLocalState?.();
+		const pendingState = await container1.getPendingLocalState?.();
+		container1.close();
 		assert(pendingState !== undefined, "Pending state should be defined");
 		shim2.submitMigrateOp();
 		await promise2;
@@ -499,7 +503,8 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider, apis) => {
 		await toIDeltaManagerFull(container1.deltaManager).outbound.pause();
 
 		shim1.submitMigrateOp();
-		const pendingState = await container1.closeAndGetPendingLocalState?.();
+		const pendingState = await container1.getPendingLocalState?.();
+		container1.close();
 		assert(pendingState !== undefined, "Pending state should be defined");
 		updateQuantity(legacyTree2, 1);
 		updateQuantity(legacyTree2, 2);

--- a/packages/test/test-end-to-end-tests/src/test/offline/blobHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/blobHandles.spec.ts
@@ -5,8 +5,10 @@
 
 import { strict as assert } from "assert";
 
+import { stringToBuffer } from "@fluid-internal/client-utils";
 import { describeCompat } from "@fluid-private/test-version-utils";
-import { type IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
+import type { IContainerExperimental } from "@fluidframework/container-loader/internal";
+import type { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { Deferred } from "@fluidframework/core-utils/internal";
 import {
@@ -103,57 +105,59 @@ describeCompat("Offline and Blobs", "NoCompat", (getTestObjectProvider, apis) =>
 		);
 	});
 
-	// TODO: Update for placeholder pending blob creation and getPendingLocalState
-	// it("Slow blob create request before container closes", async () => {
-	// 	const container = (await provider.createContainer(runtimeFactory, {
-	// 		configProvider,
-	// 	})) as IContainerExperimental;
-	// 	const mainObject = (await container.getEntryPoint()) as TestDataObject;
+	// ADO#44999: Update for placeholder pending blob creation and getPendingLocalState
+	it.skip("Slow blob create request before container closes", async () => {
+		const container = (await provider.createContainer(runtimeFactory, {
+			configProvider,
+		})) as IContainerExperimental;
+		const mainObject = (await container.getEntryPoint()) as TestDataObject;
 
-	// 	await provider.ensureSynchronized();
+		await provider.ensureSynchronized();
 
-	// 	const storeBlobHandleAsync = async () => {
-	// 		const blobHandle = await mainObject._runtime.uploadBlob(stringToBuffer("test", "utf-8"));
-	// 		mainObject._root.set("blobHandle", blobHandle);
-	// 	};
+		const storeBlobHandleAsync = async () => {
+			const blobHandle = await mainObject._runtime.uploadBlob(stringToBuffer("test", "utf-8"));
+			mainObject._root.set("blobHandle", blobHandle);
+		};
 
-	// 	// Start blob creation
-	// 	const storeBlobHandlePromise = storeBlobHandleAsync();
-	// 	// Start closing the container and get the pending local state before blob creation through the network completes
-	// 	const serializedStatePromise = container.closeAndGetPendingLocalState?.();
-	// 	// wait for blob creation to finish first so that the handle op is created
-	// 	await storeBlobHandlePromise;
-	// 	// Let the rest of the close and get pending local state finish.
-	// 	const serializedState = await serializedStatePromise;
-	// 	assert(serializedState !== undefined, "Serialized state should exist");
+		// Start blob creation
+		const storeBlobHandlePromise = storeBlobHandleAsync();
+		// Start closing the container and get the pending local state before blob creation through the network completes
+		// TODO: This portion was using closeAndGetPendingLocalState - using getPendingLocalState instead to allow compilation
+		// const serializedStatePromise = container.closeAndGetPendingLocalState?.();
+		const serializedStatePromise = container.getPendingLocalState?.();
+		// wait for blob creation to finish first so that the handle op is created
+		await storeBlobHandlePromise;
+		// Let the rest of the close and get pending local state finish.
+		const serializedState = await serializedStatePromise;
+		assert(serializedState !== undefined, "Serialized state should exist");
 
-	// 	// One potential solution could be to fix the serialized state.
+		// One potential solution could be to fix the serialized state.
 
-	// 	// Load the remote container
-	// 	const container3 = await provider.loadContainer(runtimeFactory);
-	// 	const mainObject3 = (await container3.getEntryPoint()) as TestDataObject;
+		// Load the remote container
+		const container3 = await provider.loadContainer(runtimeFactory);
+		const mainObject3 = (await container3.getEntryPoint()) as TestDataObject;
 
-	// 	const container2 = await provider.loadContainer(
-	// 		runtimeFactory,
-	// 		undefined,
-	// 		undefined,
-	// 		serializedState,
-	// 	);
-	// 	// Finish the blob creation after the container is loaded so that the blob attach op is sent after the handle op
-	// 	throwOnBlobCreate = true;
-	// 	deferred.resolve();
-	// 	await container2.getEntryPoint();
+		const container2 = await provider.loadContainer(
+			runtimeFactory,
+			undefined,
+			undefined,
+			serializedState,
+		);
+		// Finish the blob creation after the container is loaded so that the blob attach op is sent after the handle op
+		throwOnBlobCreate = true;
+		deferred.resolve();
+		await container2.getEntryPoint();
 
-	// 	// send the ops
-	// 	await provider.ensureSynchronized();
+		// send the ops
+		await provider.ensureSynchronized();
 
-	// 	// So the handleGetPromise executes as soon as the handle op is processed, before the blob attach op is processed
-	// 	// original test which has been solved
-	// 	// await assert.rejects(
-	// 	// 	mainObject3.handleGetPromise.promise,
-	// 	// 	(error: Error) => error.message === "Error: 0x11f",
-	// 	// 	"Blob should not be fetched",
-	// 	// );
-	// 	await mainObject3.handleGetPromise.promise;
-	// });
+		// So the handleGetPromise executes as soon as the handle op is processed, before the blob attach op is processed
+		// original test which has been solved
+		// await assert.rejects(
+		// 	mainObject3.handleGetPromise.promise,
+		// 	(error: Error) => error.message === "Error: 0x11f",
+		// 	"Blob should not be fetched",
+		// );
+		await mainObject3.handleGetPromise.promise;
+	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/offline/blobHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/blobHandles.spec.ts
@@ -5,9 +5,7 @@
 
 import { strict as assert } from "assert";
 
-import { stringToBuffer } from "@fluid-internal/client-utils";
 import { describeCompat } from "@fluid-private/test-version-utils";
-import type { IContainerExperimental } from "@fluidframework/container-loader/internal";
 import { type IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { Deferred } from "@fluidframework/core-utils/internal";
@@ -105,56 +103,57 @@ describeCompat("Offline and Blobs", "NoCompat", (getTestObjectProvider, apis) =>
 		);
 	});
 
-	it("Slow blob create request before container closes", async () => {
-		const container = (await provider.createContainer(runtimeFactory, {
-			configProvider,
-		})) as IContainerExperimental;
-		const mainObject = (await container.getEntryPoint()) as TestDataObject;
+	// TODO: Update for placeholder pending blob creation and getPendingLocalState
+	// it("Slow blob create request before container closes", async () => {
+	// 	const container = (await provider.createContainer(runtimeFactory, {
+	// 		configProvider,
+	// 	})) as IContainerExperimental;
+	// 	const mainObject = (await container.getEntryPoint()) as TestDataObject;
 
-		await provider.ensureSynchronized();
+	// 	await provider.ensureSynchronized();
 
-		const storeBlobHandleAsync = async () => {
-			const blobHandle = await mainObject._runtime.uploadBlob(stringToBuffer("test", "utf-8"));
-			mainObject._root.set("blobHandle", blobHandle);
-		};
+	// 	const storeBlobHandleAsync = async () => {
+	// 		const blobHandle = await mainObject._runtime.uploadBlob(stringToBuffer("test", "utf-8"));
+	// 		mainObject._root.set("blobHandle", blobHandle);
+	// 	};
 
-		// Start blob creation
-		const storeBlobHandlePromise = storeBlobHandleAsync();
-		// Start closing the container and get the pending local state before blob creation through the network completes
-		const serializedStatePromise = container.closeAndGetPendingLocalState?.();
-		// wait for blob creation to finish first so that the handle op is created
-		await storeBlobHandlePromise;
-		// Let the rest of the close and get pending local state finish.
-		const serializedState = await serializedStatePromise;
-		assert(serializedState !== undefined, "Serialized state should exist");
+	// 	// Start blob creation
+	// 	const storeBlobHandlePromise = storeBlobHandleAsync();
+	// 	// Start closing the container and get the pending local state before blob creation through the network completes
+	// 	const serializedStatePromise = container.closeAndGetPendingLocalState?.();
+	// 	// wait for blob creation to finish first so that the handle op is created
+	// 	await storeBlobHandlePromise;
+	// 	// Let the rest of the close and get pending local state finish.
+	// 	const serializedState = await serializedStatePromise;
+	// 	assert(serializedState !== undefined, "Serialized state should exist");
 
-		// One potential solution could be to fix the serialized state.
+	// 	// One potential solution could be to fix the serialized state.
 
-		// Load the remote container
-		const container3 = await provider.loadContainer(runtimeFactory);
-		const mainObject3 = (await container3.getEntryPoint()) as TestDataObject;
+	// 	// Load the remote container
+	// 	const container3 = await provider.loadContainer(runtimeFactory);
+	// 	const mainObject3 = (await container3.getEntryPoint()) as TestDataObject;
 
-		const container2 = await provider.loadContainer(
-			runtimeFactory,
-			undefined,
-			undefined,
-			serializedState,
-		);
-		// Finish the blob creation after the container is loaded so that the blob attach op is sent after the handle op
-		throwOnBlobCreate = true;
-		deferred.resolve();
-		await container2.getEntryPoint();
+	// 	const container2 = await provider.loadContainer(
+	// 		runtimeFactory,
+	// 		undefined,
+	// 		undefined,
+	// 		serializedState,
+	// 	);
+	// 	// Finish the blob creation after the container is loaded so that the blob attach op is sent after the handle op
+	// 	throwOnBlobCreate = true;
+	// 	deferred.resolve();
+	// 	await container2.getEntryPoint();
 
-		// send the ops
-		await provider.ensureSynchronized();
+	// 	// send the ops
+	// 	await provider.ensureSynchronized();
 
-		// So the handleGetPromise executes as soon as the handle op is processed, before the blob attach op is processed
-		// original test which has been solved
-		// await assert.rejects(
-		// 	mainObject3.handleGetPromise.promise,
-		// 	(error: Error) => error.message === "Error: 0x11f",
-		// 	"Blob should not be fetched",
-		// );
-		await mainObject3.handleGetPromise.promise;
-	});
+	// 	// So the handleGetPromise executes as soon as the handle op is processed, before the blob attach op is processed
+	// 	// original test which has been solved
+	// 	// await assert.rejects(
+	// 	// 	mainObject3.handleGetPromise.promise,
+	// 	// 	(error: Error) => error.message === "Error: 0x11f",
+	// 	// 	"Blob should not be fetched",
+	// 	// );
+	// 	await mainObject3.handleGetPromise.promise;
+	// });
 });

--- a/packages/test/test-end-to-end-tests/src/test/offline/offlineTestsUtils.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/offlineTestsUtils.ts
@@ -66,7 +66,8 @@ export const generatePendingState = async (
 		await testObjectProvider.ensureSynchronized(); // Note: This will have a different clientId than in pendingState
 		container.close();
 	} else {
-		pendingState = await container.closeAndGetPendingLocalState?.();
+		pendingState = await container.getPendingLocalState?.();
+		container.close();
 	}
 
 	testObjectProvider.opProcessingController.resumeProcessing();

--- a/packages/test/test-end-to-end-tests/src/test/offline/refreshSerializerLifeCycle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/refreshSerializerLifeCycle.spec.ts
@@ -209,7 +209,8 @@ describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider,
 				await provider.ensureSynchronized(container);
 			}
 
-			const pendingOps = await container1.closeAndGetPendingLocalState?.();
+			const pendingOps = await container1.getPendingLocalState?.();
+			container1.close();
 			assert.ok(pendingOps);
 
 			if (testConfig.summaryWhileOffline) {
@@ -270,7 +271,8 @@ describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider,
 				groupIdDataObject2.root.set(`${j}`, j++);
 			}
 
-			const pendingOps2 = await container2.closeAndGetPendingLocalState?.();
+			const pendingOps2 = await container2.getPendingLocalState?.();
+			container2.close();
 			// first container which loads from a snapshot with groupId
 			const container3: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
 			const dataStore3 = (await container3.getEntryPoint()) as ITestFluidObject;
@@ -288,7 +290,8 @@ describeCompat("Refresh snapshot lifecycle", "NoCompat", (getTestObjectProvider,
 			map3.set(`${i}`, i++);
 			groupIdDataObject3.root.set(`${j}`, j++);
 
-			const pendingOps3 = await container3.closeAndGetPendingLocalState?.();
+			const pendingOps3 = await container3.getPendingLocalState?.();
+			container3.close();
 			// container created just for validation.
 			const container4: IContainerExperimental = await loader.resolve({ url }, pendingOps3);
 			const dataStore4 = (await container4.getEntryPoint()) as ITestFluidObject;

--- a/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/stashedOps.spec.ts
@@ -1442,136 +1442,144 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		assert.strictEqual(bufferToString(handleGet2, "utf8"), "blob contents");
 	});
 
-	// TODO: The following scenarios are possible with payload pending, but will function differently.
+	// ADO#44999: The following scenarios are possible with payload pending, but will function differently.
 	// The in-flight blob upload will need to be completable after loading with the pending state, but
 	// we will expect the customer to have already stored the blob handle prior to calling getPendingState.
 
-	// it("close while uploading blob", async function () {
-	// 	const dataStore = (await container1.getEntryPoint()) as ITestFluidObject;
-	// 	const map = await dataStore.getSharedObject<ISharedMap>(mapId);
-	// 	await provider.ensureSynchronized();
+	it.skip("close while uploading blob", async function () {
+		const dataStore = (await container1.getEntryPoint()) as ITestFluidObject;
+		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
+		await provider.ensureSynchronized();
 
-	// 	const blobP = dataStore.runtime.uploadBlob(stringToBuffer("blob contents", "utf8"));
-	// 	const pendingOpsP = container1.closeAndGetPendingLocalState?.();
-	// 	const handle = await blobP;
-	// 	map.set("blob handle", handle);
-	// 	const pendingOps = await pendingOpsP;
+		const blobP = dataStore.runtime.uploadBlob(stringToBuffer("blob contents", "utf8"));
+		// TODO: This portion was using closeAndGetPendingLocalState - using getPendingLocalState instead to allow compilation
+		// const pendingOpsP = container1.closeAndGetPendingLocalState?.();
+		const pendingOpsP = container1.getPendingLocalState?.();
+		const handle = await blobP;
+		map.set("blob handle", handle);
+		const pendingOps = await pendingOpsP;
 
-	// 	const container2 = await loader.resolve({ url }, pendingOps);
-	// 	const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
-	// 	const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
+		const container2 = await loader.resolve({ url }, pendingOps);
+		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
 
-	// 	await provider.ensureSynchronized();
-	// 	assert.strictEqual(
-	// 		bufferToString(await map1.get("blob handle").get(), "utf8"),
-	// 		"blob contents",
-	// 	);
-	// 	assert.strictEqual(
-	// 		bufferToString(await map2.get("blob handle").get(), "utf8"),
-	// 		"blob contents",
-	// 	);
-	// });
+		await provider.ensureSynchronized();
+		assert.strictEqual(
+			bufferToString(await map1.get("blob handle").get(), "utf8"),
+			"blob contents",
+		);
+		assert.strictEqual(
+			bufferToString(await map2.get("blob handle").get(), "utf8"),
+			"blob contents",
+		);
+	});
 
-	// it("close while uploading multiple blob", async function () {
-	// 	const dataStore = (await container1.getEntryPoint()) as ITestFluidObject;
-	// 	const map = await dataStore.getSharedObject<ISharedMap>(mapId);
-	// 	await provider.ensureSynchronized();
+	it.skip("close while uploading multiple blob", async function () {
+		const dataStore = (await container1.getEntryPoint()) as ITestFluidObject;
+		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
+		await provider.ensureSynchronized();
 
-	// 	const blobP1 = dataStore.runtime.uploadBlob(stringToBuffer("blob contents 1", "utf8"));
-	// 	const blobP2 = dataStore.runtime.uploadBlob(stringToBuffer("blob contents 2", "utf8"));
-	// 	const blobP3 = dataStore.runtime.uploadBlob(stringToBuffer("blob contents 3", "utf8"));
-	// 	const pendingOpsP = container1.closeAndGetPendingLocalState?.();
-	// 	map.set("blob handle 1", await blobP1);
-	// 	map.set("blob handle 2", await blobP2);
-	// 	map.set("blob handle 3", await blobP3);
-	// 	const pendingOps = await pendingOpsP;
+		const blobP1 = dataStore.runtime.uploadBlob(stringToBuffer("blob contents 1", "utf8"));
+		const blobP2 = dataStore.runtime.uploadBlob(stringToBuffer("blob contents 2", "utf8"));
+		const blobP3 = dataStore.runtime.uploadBlob(stringToBuffer("blob contents 3", "utf8"));
+		// TODO: This portion was using closeAndGetPendingLocalState - using getPendingLocalState instead to allow compilation
+		// const pendingOpsP = container1.closeAndGetPendingLocalState?.();
+		const pendingOpsP = container1.getPendingLocalState?.();
+		map.set("blob handle 1", await blobP1);
+		map.set("blob handle 2", await blobP2);
+		map.set("blob handle 3", await blobP3);
+		const pendingOps = await pendingOpsP;
 
-	// 	const container2 = await loader.resolve({ url }, pendingOps);
-	// 	const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
-	// 	const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
-	// 	await provider.ensureSynchronized();
-	// 	for (let i = 1; i <= 3; i++) {
-	// 		assert.strictEqual(
-	// 			bufferToString(await map1.get(`blob handle ${i}`).get(), "utf8"),
-	// 			`blob contents ${i}`,
-	// 		);
-	// 		assert.strictEqual(
-	// 			bufferToString(await map2.get(`blob handle ${i}`).get(), "utf8"),
-	// 			`blob contents ${i}`,
-	// 		);
-	// 	}
-	// });
+		const container2 = await loader.resolve({ url }, pendingOps);
+		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
+		await provider.ensureSynchronized();
+		for (let i = 1; i <= 3; i++) {
+			assert.strictEqual(
+				bufferToString(await map1.get(`blob handle ${i}`).get(), "utf8"),
+				`blob contents ${i}`,
+			);
+			assert.strictEqual(
+				bufferToString(await map2.get(`blob handle ${i}`).get(), "utf8"),
+				`blob contents ${i}`,
+			);
+		}
+	});
 
-	// it("load offline from stashed ops with pending blob", async function () {
-	// 	const container = await loadContainerOffline(testContainerConfig, provider, { url });
-	// 	const dataStore = (await container.container.getEntryPoint()) as ITestFluidObject;
-	// 	const map = await dataStore.getSharedObject<ISharedMap>(mapId);
+	it.skip("load offline from stashed ops with pending blob", async function () {
+		const container = await loadContainerOffline(testContainerConfig, provider, { url });
+		const dataStore = (await container.container.getEntryPoint()) as ITestFluidObject;
+		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
 
-	// 	// Call uploadBlob() while offline to get local ID handle, and generate an op referencing it
-	// 	const handleP = dataStore.runtime.uploadBlob(stringToBuffer("blob contents 1", "utf8"));
-	// 	const stashedChangesP = container.container.closeAndGetPendingLocalState?.();
-	// 	const handle = await handleP;
-	// 	map.set("blob handle 1", handle);
+		// Call uploadBlob() while offline to get local ID handle, and generate an op referencing it
+		const handleP = dataStore.runtime.uploadBlob(stringToBuffer("blob contents 1", "utf8"));
+		// TODO: This portion was using closeAndGetPendingLocalState - using getPendingLocalState instead to allow compilation
+		// const stashedChangesP = container.container.closeAndGetPendingLocalState?.();
+		const stashedChangesP = container.container.getPendingLocalState?.();
+		const handle = await handleP;
+		map.set("blob handle 1", handle);
 
-	// 	const stashedChanges = await stashedChangesP;
+		const stashedChanges = await stashedChangesP;
 
-	// 	const container3 = await loadContainerOffline(
-	// 		testContainerConfig,
-	// 		provider,
-	// 		{ url },
-	// 		stashedChanges,
-	// 	);
-	// 	const dataStore3 = (await container3.container.getEntryPoint()) as ITestFluidObject;
-	// 	const map3 = await dataStore3.getSharedObject<ISharedMap>(mapId);
+		const container3 = await loadContainerOffline(
+			testContainerConfig,
+			provider,
+			{ url },
+			stashedChanges,
+		);
+		const dataStore3 = (await container3.container.getEntryPoint()) as ITestFluidObject;
+		const map3 = await dataStore3.getSharedObject<ISharedMap>(mapId);
 
-	// 	// blob is accessible offline
-	// 	assert.strictEqual(
-	// 		bufferToString(await map3.get("blob handle 1").get(), "utf8"),
-	// 		"blob contents 1",
-	// 	);
-	// 	container3.connect();
-	// 	await waitForContainerConnection(container3.container);
-	// 	await provider.ensureSynchronized();
+		// blob is accessible offline
+		assert.strictEqual(
+			bufferToString(await map3.get("blob handle 1").get(), "utf8"),
+			"blob contents 1",
+		);
+		container3.connect();
+		await waitForContainerConnection(container3.container);
+		await provider.ensureSynchronized();
 
-	// 	assert.strictEqual(
-	// 		bufferToString(await map3.get("blob handle 1").get(), "utf8"),
-	// 		"blob contents 1",
-	// 	);
-	// 	assert.strictEqual(
-	// 		bufferToString(await map1.get("blob handle 1").get(), "utf8"),
-	// 		"blob contents 1",
-	// 	);
-	// });
+		assert.strictEqual(
+			bufferToString(await map3.get("blob handle 1").get(), "utf8"),
+			"blob contents 1",
+		);
+		assert.strictEqual(
+			bufferToString(await map1.get("blob handle 1").get(), "utf8"),
+			"blob contents 1",
+		);
+	});
 
-	// it("stashed changes with blobs", async function () {
-	// 	const container = await loadContainerOffline(testContainerConfig, provider, { url });
-	// 	const dataStore = (await container.container.getEntryPoint()) as ITestFluidObject;
-	// 	const map = await dataStore.getSharedObject<ISharedMap>(mapId);
+	it.skip("stashed changes with blobs", async function () {
+		const container = await loadContainerOffline(testContainerConfig, provider, { url });
+		const dataStore = (await container.container.getEntryPoint()) as ITestFluidObject;
+		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
 
-	// 	// Call uploadBlob() while offline to get local ID handle, and generate an op referencing it
-	// 	const handleP = dataStore.runtime.uploadBlob(stringToBuffer("blob contents 1", "utf8"));
-	// 	const stashedChangesP = container.container.closeAndGetPendingLocalState?.();
-	// 	const handle = await handleP;
-	// 	map.set("blob handle 1", handle);
+		// Call uploadBlob() while offline to get local ID handle, and generate an op referencing it
+		const handleP = dataStore.runtime.uploadBlob(stringToBuffer("blob contents 1", "utf8"));
+		// TODO: This portion was using closeAndGetPendingLocalState - using getPendingLocalState instead to allow compilation
+		// const stashedChangesP = container.container.closeAndGetPendingLocalState?.();
+		const stashedChangesP = container.container.getPendingLocalState?.();
+		const handle = await handleP;
+		map.set("blob handle 1", handle);
 
-	// 	const stashedChanges = await stashedChangesP;
+		const stashedChanges = await stashedChangesP;
 
-	// 	const container3 = await loader.resolve({ url }, stashedChanges);
-	// 	const dataStore3 = (await container3.getEntryPoint()) as ITestFluidObject;
-	// 	const map3 = await dataStore3.getSharedObject<ISharedMap>(mapId);
+		const container3 = await loader.resolve({ url }, stashedChanges);
+		const dataStore3 = (await container3.getEntryPoint()) as ITestFluidObject;
+		const map3 = await dataStore3.getSharedObject<ISharedMap>(mapId);
 
-	// 	await provider.ensureSynchronized();
+		await provider.ensureSynchronized();
 
-	// 	// Blob is uploaded and accessible by all clients
-	// 	assert.strictEqual(
-	// 		bufferToString(await map1.get("blob handle 1").get(), "utf8"),
-	// 		"blob contents 1",
-	// 	);
-	// 	assert.strictEqual(
-	// 		bufferToString(await map3.get("blob handle 1").get(), "utf8"),
-	// 		"blob contents 1",
-	// 	);
-	// });
+		// Blob is uploaded and accessible by all clients
+		assert.strictEqual(
+			bufferToString(await map1.get("blob handle 1").get(), "utf8"),
+			"blob contents 1",
+		);
+		assert.strictEqual(
+			bufferToString(await map3.get("blob handle 1").get(), "utf8"),
+			"blob contents 1",
+		);
+	});
 
 	it("offline attach", async function () {
 		const newMapId = "newMap";

--- a/packages/test/test-end-to-end-tests/src/test/offline/waitForSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/waitForSummary.spec.ts
@@ -260,7 +260,8 @@ describeCompat(
 				const map2 = await getMap(dataStore2);
 				// generate ops with RSN === summary SN
 				map2.set("2", "2");
-				const stashBlob = await container2.closeAndGetPendingLocalState?.();
+				const stashBlob = await container2.getPendingLocalState?.();
+				container2.close();
 				assert(stashBlob);
 				const pendingState = JSON.parse(stashBlob);
 
@@ -294,7 +295,17 @@ describeCompat(
 					new Promise<string | undefined>((resolve, reject) =>
 						container.on("op", (op) => {
 							if (op.type === "summarize") {
-								resolve(container.closeAndGetPendingLocalState?.());
+								const pendingStateP = container.getPendingLocalState?.();
+								if (pendingStateP) {
+									pendingStateP
+										.then((pendingState) => {
+											container.close();
+											resolve(pendingState);
+										})
+										.catch(reject);
+								} else {
+									resolve(undefined);
+								}
 							}
 						}),
 					),

--- a/packages/test/test-end-to-end-tests/src/test/offline/waitForSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/waitForSummary.spec.ts
@@ -295,9 +295,9 @@ describeCompat(
 					new Promise<string | undefined>((resolve, reject) =>
 						container.on("op", (op) => {
 							if (op.type === "summarize") {
-								const pendingStateP = container.getPendingLocalState?.();
-								if (pendingStateP) {
-									pendingStateP
+								if (container.getPendingLocalState !== undefined) {
+									container
+										.getPendingLocalState()
 										.then((pendingState) => {
 											container.close();
 											resolve(pendingState);

--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
@@ -121,7 +121,8 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
 		map.set(testKey, testValue);
 		await waitForSummary(container);
-		const pendingOps = await container.closeAndGetPendingLocalState?.();
+		const pendingOps = await container.getPendingLocalState?.();
+		container.close();
 		assert.ok(pendingOps);
 		// make sure we got stashed ops with seqnum === 0,
 		assert(/sequenceNumber[^\w,}]*0/.test(pendingOps));
@@ -130,7 +131,8 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 		await timeoutAwait(getLatestSnapshotInfoP.promise, {
 			errorMsg: "Timeout on waiting for getLatestSnapshotInfo",
 		});
-		const pendingOps2 = await container1.closeAndGetPendingLocalState?.();
+		const pendingOps2 = await container1.getPendingLocalState?.();
+		container1.close();
 		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
 		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
 		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
@@ -192,7 +194,8 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 		await timeoutAwait(getLatestSnapshotInfoP.promise, {
 			errorMsg: "Timeout on waiting for getLatestSnapshotInfo",
 		});
-		const pendingOps = await container.closeAndGetPendingLocalState?.();
+		const pendingOps = await container.getPendingLocalState?.();
+		container.close();
 		assert.ok(pendingOps);
 
 		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps);
@@ -253,7 +256,8 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
 		map.set(testKey, testValue);
 		// not waiting for summary to reuse the stashed snapshot for new loaded containers
-		const pendingOps = await container.closeAndGetPendingLocalState?.();
+		const pendingOps = await container.getPendingLocalState?.();
+		container.close();
 		assert.ok(pendingOps);
 		// make sure we got stashed ops with seqnum === 0,
 		assert(/sequenceNumber[^\w,}]*0/.test(pendingOps));
@@ -262,7 +266,8 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 		await timeoutAwait(getLatestSnapshotInfoP.promise, {
 			errorMsg: "Timeout on waiting for getLatestSnapshotInfo",
 		});
-		const pendingOps2 = await container1.closeAndGetPendingLocalState?.();
+		const pendingOps2 = await container1.getPendingLocalState?.();
+		container1.close();
 		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
 		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
 		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -531,10 +531,12 @@ async function scheduleOffline(
 				if (
 					runConfig.loaderConfig?.enableOfflineLoad === true &&
 					random.real() < stashPercent &&
-					container.closeAndGetPendingLocalState
+					container.getPendingLocalState
 				) {
 					printStatus(runConfig, "closing offline container!");
-					return container.closeAndGetPendingLocalState();
+					const pendingState = await container.getPendingLocalState();
+					container.close();
+					return pendingState;
 				}
 				printStatus(runConfig, "going online!");
 				ds.goOnline();


### PR DESCRIPTION
The purpose of closeAndGetPendingLocalState (as opposed to getPendingLocalState) is to trigger a special behavior of the BlobManager to fake blob upload completion, such that the customer then will store their handles to be included in the pending state.  However, this flow is not needed with payload pending handles, which is the only flow we intend to support in combination with pending state going forward.

Removing this entry point to the special behavior frees us up to make simplifications in the runtime and BlobManager (to be done in a following PR).  This should be a safe removal as it's an internal-only API with no current customers.

Internal uses of the API are primarily just converted to call getPendingLocalState followed by close(), except where the test is specifically for blob functionality.  These will need to be updated after we add blob support to getPendingLocalState via payload pending handles.

[AB#45000](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/45000)