### PR TITLE
Revert removal of bindHandles in directory.ts

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -25,6 +25,7 @@ import type { IFluidSerializer } from "@fluidframework/shared-object-base/intern
 import {
 	SharedObject,
 	ValueType,
+	bindHandles,
 	parseHandles,
 } from "@fluidframework/shared-object-base/internal";
 import {
@@ -1270,6 +1271,9 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 		if (key === undefined || key === null) {
 			throw new Error("Undefined and null keys are not supported");
 		}
+
+		// Create a local value and serialize it.
+		bindHandles(value, this.serializer, this.directory.handle);
 
 		// Set the value locally.
 		const previousValue = this.setCore(key, value, true);


### PR DESCRIPTION
#24997 removed the call to bindHandles in sharedDirectory, but due to unit test failures this had to be put back. The additional tests added in the initial PR will remain checked in. [AB#45046](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/45046) tracks the investigation of the new issue. 