### PR TITLE
Store pending blobs with pending blobAttach ops in getPendingLocalState flow

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -5070,7 +5070,7 @@ export class ContainerRuntime
 					),
 				)
 			: PerformanceEvent.timedExec(this.mc.logger, perfEvent, (event) =>
-					logAndReturnPendingState(event, getSyncState()),
+					logAndReturnPendingState(event, getSyncState(this.blobManager.getPendingBlobs())),
 				);
 	}
 


### PR DESCRIPTION
[AB#45049](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/45049)

getPendingLocalState (as opposed to the previous closeAndGetPendingLocalState) doesn't attempt to store any blobManager state.  On container restore with that pending state, this will cause 0x725 if there was an outstanding blobAttach op that goes through the resubmit flow.  This was showing up in the stress tests.

This fix simply stores pending blob entries for blobs that have sent an op but not received an ack - this will allow the resubmit to proceed as normal.  It's not optimized - in this flow it is better to drop the blob and op on the floor since a customer would have no way of accessing the blob and it just becomes garbage.  However I'm planning a rewrite of this area soon and the feature is not available to customers currently, so it seems more efficient to go with the simpler option for now.