### PR TITLE
flub fix: Dockerfile policy check fails on Windows

### DIFF
--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/common.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/common.ts
@@ -37,12 +37,3 @@ export function readFile(file: string): string {
 export function writeFile(file: string, data: string): void {
 	fs.writeFileSync(file, data, { encoding: "utf8" });
 }
-
-/**
- * Normalizes the file path to use forward slashes for consistency across platforms.
- * @param filePath - The file path to normalize.
- * @returns The normalized file path.
- */
-export function normalizeFilePath(filePath: string): string {
-	return filePath.replace(/\\/g, "/");
-}

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/common.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/common.ts
@@ -37,3 +37,12 @@ export function readFile(file: string): string {
 export function writeFile(file: string, data: string): void {
 	fs.writeFileSync(file, data, { encoding: "utf8" });
 }
+
+/**
+ * Normalizes the file path to use forward slashes for consistency across platforms.
+ * @param filePath - The file path to normalize.
+ * @returns The normalized file path.
+ */
+export function normalizeFilePath(filePath: string): string {
+	return filePath.replace(/\\/g, "/");
+}

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/dockerfilePackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/dockerfilePackages.ts
@@ -5,7 +5,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { type Handler, readFile, writeFile } from "./common.js";
+import { type Handler, normalizeFilePath, readFile, writeFile } from "./common.js";
 
 const serverPath = "server/routerlicious/";
 
@@ -29,7 +29,7 @@ export const handler: Handler = {
 	handler: async (file: string, gitRoot: string): Promise<string | undefined> => {
 		// strip server path since all paths are relative to server directory
 		const dockerfileCopyText = getDockerfileCopyText(
-			path.relative(gitRoot, file).replace(serverPath, ""),
+			normalizeFilePath(path.relative(gitRoot, file)).replace(serverPath, ""),
 		);
 		const dockerFilePath = path.join(
 			path.relative(process.cwd(), path.join(gitRoot, serverPath)),

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/dockerfilePackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/dockerfilePackages.ts
@@ -33,7 +33,7 @@ export const handler: Handler = {
 		// This matters because the Dockerfile is checked in with POSIX-style slashes, and the Node path APIs return
 		// OS-specific file separators.
 		const dockerfileCopyText = getDockerfileCopyText(
-			TscUtils.normalizeSlashes(path.relative(gitRoot, file)).replace(serverPath, "")
+			TscUtils.normalizeSlashes(path.relative(gitRoot, file)).replace(serverPath, ""),
 		);
 		const dockerFilePath = path.join(
 			path.relative(process.cwd(), path.join(gitRoot, serverPath)),

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/dockerfilePackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/dockerfilePackages.ts
@@ -5,8 +5,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { type Handler, normalizeFilePath, readFile, writeFile } from "./common.js";
 import { TscUtils } from "@fluidframework/build-tools";
+import { type Handler, readFile, writeFile } from "./common.js";
 
 const serverPath = "server/routerlicious/";
 

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/dockerfilePackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/dockerfilePackages.ts
@@ -6,6 +6,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { type Handler, normalizeFilePath, readFile, writeFile } from "./common.js";
+import { TscUtils } from "@fluidframework/build-tools";
 
 const serverPath = "server/routerlicious/";
 
@@ -28,8 +29,11 @@ export const handler: Handler = {
 	match: /^(server\/routerlicious\/packages)\/.*\/package\.json/i,
 	handler: async (file: string, gitRoot: string): Promise<string | undefined> => {
 		// strip server path since all paths are relative to server directory
+		// Additionally, we normalize slashes here to ensure that the path is consistent across different OSes.
+		// This matters because the Dockerfile is checked in with POSIX-style slashes, and the Node path APIs return
+		// OS-specific file separators.
 		const dockerfileCopyText = getDockerfileCopyText(
-			normalizeFilePath(path.relative(gitRoot, file)).replace(serverPath, ""),
+			TscUtils.normalizeSlashes(path.relative(gitRoot, file)).replace(serverPath, "")
 		);
 		const dockerFilePath = path.join(
 			path.relative(process.cwd(), path.join(gitRoot, serverPath)),


### PR DESCRIPTION
## Description

Fixed an issue with flub that only shows up on Windows. The paths we are checking in Dockerfiles as part of the policy check use foreslashes, but we build it using paths from the filesystem. This change normalizes the path to use foreslashes.

Note that we need to make a pass over the other places that build filepaths to check against file contents. This will be a separate work item.