### PR TITLE
build: Remove obsolete CG disable variables in pipelines

### DIFF
--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -16,8 +16,6 @@ pr:
 - release/*
 
 variables:
-- name: skipComponentGovernanceDetection
-  value: true
 - name: pnpmStorePath
   value: $(Pipeline.Workspace)/.pnpm-store
 - group: ado-feeds

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -583,10 +583,6 @@ extends:
                 value: 'false'
               - name: COMMIT_SHA
                 value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
-              # The build job above already runs component governance tasks.
-              # We don't need them again during jobs that run tests even if we're checking out the repo.
-              - name: skipComponentGovernanceDetection
-                value: true
 
             steps:
               # Setup
@@ -747,10 +743,6 @@ extends:
                   value: 'false'
                 - name: COMMIT_SHA
                   value: $[ dependencies.build.outputs['setCommitSHA.COMMIT_SHA'] ]
-                # The build job above already runs component governance tasks.
-                # We don't need them again during jobs that run tests even if we're checking out the repo.
-                - name: skipComponentGovernanceDetection
-                  value: true
               steps:
                 # Setup
                 - checkout: self

--- a/tools/pipelines/templates/include-publish-docker-service-steps.yml
+++ b/tools/pipelines/templates/include-publish-docker-service-steps.yml
@@ -93,9 +93,6 @@ jobs:
   condition: and(succeeded(), ne('${{ parameters.tagName }}', ''))
   variables:
     version: $[ stageDependencies.build.build.outputs['SetVersion.version']]
-    # The build stage/job already ran component governance tasks.
-    # We don't need them again here even if we're checking out the repo.
-    skipComponentGovernanceDetection: true
   steps:
   - checkout: self
     clean: true

--- a/tools/pipelines/templates/include-publish-npm-package-deployment.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-deployment.yml
@@ -103,9 +103,6 @@ jobs:
   condition: and(succeeded(), ne('${{ parameters.tagName }}', ''))
   variables:
     version: $[ stageDependencies.build.build.outputs['SetVersion.version']]
-    # The build stage/job already ran component governance tasks.
-    # We don't need them again here even if we're checking out the repo.
-    skipComponentGovernanceDetection: true
   steps:
   - checkout: self
     clean: true

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -23,6 +23,9 @@ parameters:
 variables:
 - group: prague-key-vault
 - group: ado-feeds
+# Note: 'skipComponentGovernanceDetection' has no effect on pipelines that use 1ES templates.
+# Leaving it here for now in case it's doing something for other pipelines,
+# but if we can confirm it doesn't, we should remove it.
 - name: skipComponentGovernanceDetection
   value: true
 - name: testBuild

--- a/tools/pipelines/templates/include-vars.yml
+++ b/tools/pipelines/templates/include-vars.yml
@@ -26,6 +26,7 @@ variables:
 # Note: 'skipComponentGovernanceDetection' has no effect on pipelines that use 1ES templates.
 # Leaving it here for now in case it's doing something for other pipelines,
 # but if we can confirm it doesn't, we should remove it.
+# TODO: AB#45217
 - name: skipComponentGovernanceDetection
   value: true
 - name: testBuild


### PR DESCRIPTION
## Description

The `skipComponentGovernanceDetection` now does nothing for pipelines that extend the 1ES templates, so removing the setting.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).