### PR TITLE
Only apply locks to odsp and frs stages in perf benchmarks and stress tests

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -111,7 +111,7 @@ parameters:
 
 stages:
 - stage: ${{ parameters.stageId}}
-  ${{ if or(eq(parameters.stageId, 'e2e_routerlicious'), eq(parameters.stageId, 'e2e_frs')) }}:
+  ${{ if in(parameters.stageId, 'e2e_routerlicious', 'e2e_frs', 'stress_tests_odsp', 'stress_tests_odspdf', 'stress_tests_frs', 'stress_tests_frs_canary') }}:
     lockBehavior: sequential
   condition: ${{ parameters.condition }}
   displayName: ${{ parameters.stageDisplayName }}

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -87,7 +87,6 @@ variables:
   - name: DisableCodeQL
     value: true
 
-lockBehavior: sequential
 stages:
   # Performance unit tests - runtime
   - stage: perf_unit_tests_runtime
@@ -439,10 +438,14 @@ stages:
     - stage: perf_e2e_tests_${{ endpointObject.endpointName }}
       displayName: Perf e2e tests - ${{ endpointObject.endpointName }}
       dependsOn: []
+      # If the stage needs locking, configure the lock behavior. Note that null gets coalesced into an empty string.
+      ${{ if ne(endpointObject.lockVariableGroupName, '') }}:
+        lockBehavior: sequential
       variables:
         # Use contention-lock variable groups when appropriate. Note that null gets coalesced into an empty string.
         - ${{ if ne(endpointObject.lockVariableGroupName, '') }}:
           - group: ${{ endpointObject.lockVariableGroupName }}
+
 
         # The following two paths are defined by the npm scripts invocations in @fluid-private/test-end-to-end-tests
         - name: executionTimeTestOutputFolder

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -446,7 +446,6 @@ stages:
         - ${{ if ne(endpointObject.lockVariableGroupName, '') }}:
           - group: ${{ endpointObject.lockVariableGroupName }}
 
-
         # The following two paths are defined by the npm scripts invocations in @fluid-private/test-end-to-end-tests
         - name: executionTimeTestOutputFolder
           value: ${{ variables.testWorkspace }}/node_modules/@fluid-private/test-end-to-end-tests/.timeTestsOutput

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -35,7 +35,6 @@ variables:
 - name: DisableCodeQL
   value: true
 
-lockBehavior: sequential
 stages:
   # stress tests odsp
   - template: /tools/pipelines/templates/include-test-real-service.yml@self


### PR DESCRIPTION
## Description

Today all stages of the perf benchmarks pipeline and the stress tests pipeline have to wait for the corresponding stage in other runs to finish before starting itself. This is not necessary in all stages, only in the ones that we know could stress external services. This PR makes it so only the stages against ODSP and FRS have that behavior.

Same idea as https://github.com/microsoft/FluidFramework/pull/24942 which did the same thing for end-to-end tests.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
