### PR TITLE
Stop calling attachAndGetPendingBlobs

### DIFF
--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -2289,59 +2289,6 @@ describe("Runtime", () => {
 				assert.strictEqual(typeof state, "object");
 				assert.strictEqual(state.pending?.pendingStates, pendingStates);
 			});
-			it("notifyImminentClosure. Some pending state", async () => {
-				const logger = new MockLogger();
-
-				const containerRuntime = await ContainerRuntime.loadRuntime({
-					context: getMockContext({ logger }) as IContainerContext,
-					registryEntries: [],
-					existing: false,
-					runtimeOptions: {
-						enableRuntimeIdCompressor: "on",
-					},
-					provideEntryPoint: mockProvideEntryPoint,
-				});
-				const pendingStates: IPendingMessage[] = Array.from({ length: 5 }, (_, i) => ({
-					content: i.toString(),
-					type: "message",
-					referenceSequenceNumber: 0,
-					localOpMetadata: undefined,
-					opMetadata: undefined,
-					batchInfo: { clientId: "CLIENT_ID", batchStartCsn: 1, length: 5, staged: false },
-					runtimeOp: undefined,
-				}));
-				const mockPendingStateManager = new Proxy<PendingStateManager>(
-					{} as unknown as PendingStateManager,
-					{
-						get: (_t, p: keyof PendingStateManager, _r) => {
-							switch (p) {
-								case "getLocalState": {
-									return (): IPendingLocalState => ({
-										pendingStates,
-									});
-								}
-								case "pendingMessagesCount": {
-									return 5;
-								}
-								default: {
-									assert.fail(`unexpected access to pendingStateManager.${p}`);
-								}
-							}
-						},
-					},
-				);
-
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-				(containerRuntime as any).pendingStateManager = mockPendingStateManager;
-
-				const stateP = containerRuntime.getPendingLocalState({
-					notifyImminentClosure: true,
-				}) as PromiseLike<Partial<IPendingRuntimeState>>;
-				assert("then" in stateP, "should be a promise like");
-				const state = await stateP;
-				assert.strictEqual(typeof state, "object");
-				assert.strictEqual(state.pending?.pendingStates, pendingStates);
-			});
 
 			it("sessionExpiryTimerStarted. No pending state", async () => {
 				const logger = new MockLogger();
@@ -2357,7 +2304,7 @@ describe("Runtime", () => {
 				});
 
 				const state = (await containerRuntime.getPendingLocalState({
-					notifyImminentClosure: true,
+					notifyImminentClosure: false,
 					sessionExpiryTimerStarted: 100,
 				})) as Partial<IPendingRuntimeState>;
 				assert.strictEqual(typeof state, "object");
@@ -2410,7 +2357,7 @@ describe("Runtime", () => {
 				(containerRuntime as any).pendingStateManager = mockPendingStateManager;
 
 				const state = (await containerRuntime.getPendingLocalState({
-					notifyImminentClosure: true,
+					notifyImminentClosure: false,
 					sessionExpiryTimerStarted: 100,
 				})) as Partial<IPendingRuntimeState>;
 				assert.strictEqual(state.sessionExpiryTimerStarted, 100);

--- a/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
@@ -127,7 +127,7 @@ for (const createBlobPayloadPending of [undefined, true] as const) {
 						assert.fail("Should succeed");
 					}
 					const pendingState = (await runtimeOf(dataStore1).getPendingLocalState({
-						notifyImminentClosure: true,
+						notifyImminentClosure: false,
 					})) as IPendingRuntimeState | undefined;
 					assert.strictEqual(pendingState?.pendingAttachmentBlobs, undefined);
 				});
@@ -168,7 +168,7 @@ for (const createBlobPayloadPending of [undefined, true] as const) {
 						stringToBuffer(testString, "utf-8"),
 					);
 					const pendingStateP: any = runtimeOf(dataStore1).getPendingLocalState({
-						notifyImminentClosure: true,
+						notifyImminentClosure: false,
 					});
 					map.set("key", blobHandle);
 					const pendingState = await pendingStateP;


### PR DESCRIPTION
[AB#45222](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/45222)

This starts the runtime side removal of the closeAndGetPendingState path that I started with #25091.

For now, just closing off the entrypoint on ContainerRuntime since removal from BlobManager will require deeper changes in the tests.

This also lets us drop logic around deferring connected state for blob upload - in the normal getPendingState() path the customer can't submit ops referencing the pending upload since they don't have a handle, and in the payloadPending case it's OK and normal to submit ops referencing the pending upload before it completes.