### PR TITLE
(tree) Renamed treeShaper / fieldShaper and related concepts

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
@@ -448,7 +448,7 @@ export function encodeValue(
 /**
  * Provides common contextual information during encoding, like schema and policy settings.
  * Also, provides a cache to avoid duplicating equivalent shapes during a batch of encode operations.
- * To avoid Shape duplication, any Shapes used in the encoding which cache is used with should either be:
+ * To avoid Shape duplication, any Shapes used in the encoding should either be:
  * - Singletons defined in a static scope.
  * - Cached in this object for future reuse such that all equivalent Shapes are deduplicated.
  */

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/compressedEncode.ts
@@ -221,7 +221,7 @@ export const anyNodeEncoder: NodeEncoder = {
 		outputBuffer: BufferFormat,
 	): void {
 		// TODO: Fast path uniform chunk content.
-		const shape = context.shapeFromTree(cursor.type);
+		const shape = context.nodeEncoderFromSchema(cursor.type);
 		AnyShape.encodeNode(cursor, context, outputBuffer, shape);
 	},
 
@@ -445,46 +445,53 @@ export function encodeValue(
 	}
 }
 
-export class EncoderContext implements TreeShaper, FieldShaper {
-	private readonly shapesFromSchema: Map<TreeNodeSchemaIdentifier, NodeEncoder> = new Map();
+export class EncoderContext implements NodeEncodeBuilder, FieldEncodeBuilder {
+	private readonly nodeEncodersFromSchema: Map<TreeNodeSchemaIdentifier, NodeEncoder> =
+		new Map();
 	private readonly nestedArrays: Map<NodeEncoder, NestedArrayEncoder> = new Map();
 	public constructor(
-		private readonly treeEncoder: TreeShapePolicy,
-		private readonly fieldEncoder: FieldShapePolicy,
+		private readonly nodeEncoderPolicy: NodeEncoderPolicy,
+		private readonly fieldEncoderPolicy: FieldEncoderPolicy,
 		public readonly fieldShapes: ReadonlyMap<FieldKindIdentifier, FlexFieldKind>,
 		public readonly idCompressor: IIdCompressor,
 	) {}
 
-	public shapeFromTree(schemaName: TreeNodeSchemaIdentifier): NodeEncoder {
-		return getOrCreate(this.shapesFromSchema, schemaName, () =>
-			this.treeEncoder(this, schemaName),
+	public nodeEncoderFromSchema(schemaName: TreeNodeSchemaIdentifier): NodeEncoder {
+		return getOrCreate(this.nodeEncodersFromSchema, schemaName, () =>
+			this.nodeEncoderPolicy(this, schemaName),
 		);
+	}
+
+	public fieldEncoderFromSchema(fieldSchema: TreeFieldStoredSchema): FieldEncoder {
+		return new LazyFieldEncoder(this, fieldSchema, this.fieldEncoderPolicy);
 	}
 
 	public nestedArrayEncoder(inner: NodeEncoder): NestedArrayEncoder {
 		return getOrCreate(this.nestedArrays, inner, () => new NestedArrayEncoder(inner));
 	}
-
-	public shapeFromField(field: TreeFieldStoredSchema): FieldEncoder {
-		return new LazyFieldEncoder(this, field, this.fieldEncoder);
-	}
 }
 
-export interface TreeShaper {
-	shapeFromTree(schemaName: TreeNodeSchemaIdentifier): NodeEncoder;
+export interface NodeEncodeBuilder {
+	nodeEncoderFromSchema(schemaName: TreeNodeSchemaIdentifier): NodeEncoder;
 }
 
-export interface FieldShaper {
-	shapeFromField(field: TreeFieldStoredSchema): FieldEncoder;
+export interface FieldEncodeBuilder {
+	fieldEncoderFromSchema(schema: TreeFieldStoredSchema): FieldEncoder;
 }
 
-export type FieldShapePolicy = (
-	treeShaper: TreeShaper,
-	field: TreeFieldStoredSchema,
+/**
+ * The policy for building a {@link FieldEncoder} for a field.
+ */
+export type FieldEncoderPolicy = (
+	nodeBuilder: NodeEncodeBuilder,
+	schema: TreeFieldStoredSchema,
 ) => FieldEncoder;
 
-export type TreeShapePolicy = (
-	fieldShaper: FieldShaper,
+/**
+ * The policy for building a {@link NodeEncoder} for a node.
+ */
+export type NodeEncoderPolicy = (
+	fieldBuilder: FieldEncodeBuilder,
 	schemaName: TreeNodeSchemaIdentifier,
 ) => NodeEncoder;
 
@@ -492,9 +499,9 @@ class LazyFieldEncoder implements FieldEncoder {
 	private encoderLazy: FieldEncoder | undefined;
 
 	public constructor(
-		public readonly treeShaper: TreeShaper,
-		public readonly field: TreeFieldStoredSchema,
-		private readonly fieldEncoder: FieldShapePolicy,
+		public readonly nodeBuilder: NodeEncodeBuilder,
+		public readonly fieldSchema: TreeFieldStoredSchema,
+		private readonly fieldEncoderPolicy: FieldEncoderPolicy,
 	) {}
 	public encodeField(
 		cursor: ITreeCursorSynchronous,
@@ -506,7 +513,7 @@ class LazyFieldEncoder implements FieldEncoder {
 
 	private get encoder(): FieldEncoder {
 		if (this.encoderLazy === undefined) {
-			this.encoderLazy = this.fieldEncoder(this.treeShaper, this.field);
+			this.encoderLazy = this.fieldEncoderPolicy(this.nodeBuilder, this.fieldSchema);
 		}
 		return this.encoderLazy;
 	}

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/schemaBasedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/schemaBasedEncode.ts
@@ -24,7 +24,6 @@ import {
 	type FieldEncoder,
 	type FieldEncodeBuilder,
 	type KeyedFieldEncoder,
-	type NodeEncoder,
 	type NodeEncodeBuilder,
 	anyNodeEncoder,
 	asFieldEncoder,

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/schemaBasedEncode.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/schemaBasedEncode.ts
@@ -65,7 +65,7 @@ export function buildContext(
 }
 
 /**
- * Selects encoder to use to encode fields.
+ * Selects an encoder to use to encode fields.
  */
 export function getFieldEncoder(
 	nodeBuilder: NodeEncodeBuilder,
@@ -105,7 +105,7 @@ export function getFieldEncoder(
 }
 
 /**
- * Selects encoder to use to encode nodes.
+ * Selects an encoder to use to encode nodes.
  */
 export function getNodeEncoder(
 	fieldBuilder: FieldEncodeBuilder,

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
@@ -34,13 +34,13 @@ import { testIdCompressor } from "../../../utils.js";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 
 export function checkNodeEncode(
-	shape: NodeEncoder,
+	nodeEncoder: NodeEncoder,
 	context: EncoderContext,
 	tree: JsonableTree,
 ): BufferFormat {
-	const buffer: BufferFormat = [shape.shape];
+	const buffer: BufferFormat = [nodeEncoder.shape];
 	const cursor = cursorForJsonableTreeNode(tree);
-	shape.encodeNode(cursor, context, buffer);
+	nodeEncoder.encodeNode(cursor, context, buffer);
 
 	// Check round-trip
 	checkDecode([buffer], [[tree]]);
@@ -49,14 +49,14 @@ export function checkNodeEncode(
 }
 
 export function checkFieldEncode(
-	shape: FieldEncoder,
+	fieldEncoder: FieldEncoder,
 	context: EncoderContext,
 	tree: JsonableTree[],
 	idCompressor?: IIdCompressor,
 ): BufferFormat {
-	const buffer: BufferFormat = [shape.shape];
+	const buffer: BufferFormat = [fieldEncoder.shape];
 	const cursor = cursorForJsonableTreeField(tree);
-	shape.encodeField(cursor, context, buffer);
+	fieldEncoder.encodeField(cursor, context, buffer);
 
 	// Check round-trip
 	checkDecode([buffer], [tree], idCompressor);

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
@@ -33,11 +33,11 @@ import {
 import {
 	EncoderContext,
 	type FieldEncoder,
-	type FieldShaper,
+	type FieldEncodeBuilder,
 	InlineArrayEncoder,
 	NestedArrayEncoder,
 	type NodeEncoder,
-	type TreeShaper,
+	type NodeEncodeBuilder,
 	anyFieldEncoder,
 	anyNodeEncoder,
 	asNodesEncoder,
@@ -117,9 +117,11 @@ describe("compressedEncode", () => {
 			it(name, () => {
 				const input: FieldBatch = [cursorForJsonableTreeField([jsonable])];
 				const context = new EncoderContext(
-					(fieldShaper: FieldShaper, schemaName: TreeNodeSchemaIdentifier): NodeEncoder =>
-						anyNodeShape,
-					(treeShaper: TreeShaper, field: TreeFieldStoredSchema): FieldEncoder =>
+					(
+						fieldBuilder: FieldEncodeBuilder,
+						schemaName: TreeNodeSchemaIdentifier,
+					): NodeEncoder => anyNodeShape,
+					(nodeBuilder: NodeEncodeBuilder, field: TreeFieldStoredSchema): FieldEncoder =>
 						anyFieldEncoder,
 					fieldKinds,
 					testIdCompressor,


### PR DESCRIPTION
Renamed some of the objects / types related to tree shaper and field shaper. The goal is to make these concepts less confusing and easier to understand, especially because the terms `node` and `tree`, and `shape` and `encoder` are used somewhat interchangeably. This also complements https://github.com/microsoft/FluidFramework/pull/25058 which renames other parts of the encoding logic with a similar goal.

The overall theme of this change is:
1. Update some of the concepts from using the term `shape` to `encoders` since their primary objective is encoding. The fact that these encoders are shape too is an implementation detail.
2. Update these concepts to use the term `node` instead of `tree`. While `tree` is an appropriate name when the node is considered along with its children but `node` seems more consistent with rest of the system.

Here are the renames:
- Interface `TreeShaper` -> `NodeEncodeBuilder` since it has properties that help build a node encoder from given paramteters.
  - In the interface, property `shapeFromTree` -> `nodeEncoderFromSchema` because it returns a node encoder which is a shape as well but that is an implementation detail.
- Interface `FieldShaper` -> `FieldEncodeBuilder` since it has properties that help build a field encoder from given paramteters.
  - In the interface, property `shapeFromField` -> `fieldEncoderFromSchema` because it returns a node encoder which is a shape as well but that is an implementation detail.
- Type `FieldShapePolicy` -> `FieldEncoderPolicy` since it defines a type that can be used to create a field encoder from the given params.
- Type `TreeShapePolicy` -> `NodeEncoderPolicy` since it defines a type that can be used to create a node encoder from the given params.
- Renames of variables and parameters related to the above.

[AB#45293](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/45293)