### PR TITLE
build: Add rerun attempt number to artifacts published by the perf benchmarks pipeline

### DIFF
--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -193,7 +193,7 @@ stages:
         displayName: Publish Artifact - Perf tests output - execution time
         inputs:
           targetPath: '${{ variables.consolidatedTestsOutputFolder }}'
-          artifactName: 'perf-test-outputs_execution-time'
+          artifactName: 'perf-test-outputs_execution-time_attempt-$(System.JobAttempt)'
         condition: succeededOrFailed()
 
       - template: /tools/pipelines/templates/include-upload-npm-logs.yml@self
@@ -308,7 +308,7 @@ stages:
         displayName: Publish Artifact - Perf tests output - memory usage
         inputs:
           targetPath: '${{ variables.consolidatedTestsOutputFolder }}'
-          artifactName: 'perf-test-outputs_memory-usage'
+          artifactName: 'perf-test-outputs_memory-usage_attempt-$(System.JobAttempt)'
         condition: succeededOrFailed()
 
       - template: /tools/pipelines/templates/include-upload-npm-logs.yml@self
@@ -422,7 +422,7 @@ stages:
         displayName: Publish Artifact - Perf tests output - custom data usage
         inputs:
           targetPath: '${{ variables.consolidatedTestsOutputFolder }}'
-          artifactName: 'perf-test-outputs_custom-data'
+          artifactName: 'perf-test-outputs_custom-data_attempt-$(System.JobAttempt)'
         condition: succeededOrFailed()
 
       - template: /tools/pipelines/templates/include-upload-npm-logs.yml@self
@@ -576,14 +576,14 @@ stages:
 
           inputs:
             targetPath: '${{ variables.executionTimeTestOutputFolder }}'
-            artifactName: 'perf-test-outputs-e2e_execution-time-${{ endpointObject.endpointName }}'
+            artifactName: 'perf-test-outputs-e2e_execution-time-${{ endpointObject.endpointName }}_attempt-$(System.JobAttempt)'
 
         - task: PublishPipelineArtifact@1
           displayName: Publish Artifact - E2E perf tests output - memory usage {{ $stage }}
           condition: succeededOrFailed()
           inputs:
             targetPath: '${{ variables.memoryUsageTestOutputFolder }}'
-            artifactName: 'perf-test-outputs-e2e_memory-usage-${{ endpointObject.endpointName }}'
+            artifactName: 'perf-test-outputs-e2e_memory-usage-${{ endpointObject.endpointName }}_attempt-$(System.JobAttempt)'
 
         - task: Bash@3
           displayName: Remove Output Folders from local server run ${{ endpointObject.endpointName }}


### PR DESCRIPTION
## Description

Minor quality of life improvement. Today re-running a job of the performance benchmarks pipeline runs the risk of failing when trying to publish the artifact with the results if the previous attempt managed to get to that point and published one already. This PR adds the attempt number to the artifact name so each re-run publishes a separate artifact and they don't complain about it already existing.

Confirmed that it works as expected with a test run of the pipeline:

<img width="584" height="319" alt="image" src="https://github.com/user-attachments/assets/20d772bb-6818-47e7-820a-999aa13dbe64" />

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).