### PR TITLE
refactor(api-markdown-documenter): Add mdast wrapper node in documentation domain

### DIFF
--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -942,7 +942,7 @@ export type TransformApiItemWithoutChildren<TApiItem extends ApiItem> = (apiItem
 export function transformApiModel(options: ApiItemTransformationOptions): DocumentNode[];
 
 // @public
-export function transformTsdoc(node: DocSection, contextApiItem: ApiItem, config: ApiItemTransformationConfiguration): BlockContent[];
+export function transformTsdoc(node: DocSection, contextApiItem: ApiItem, config: ApiItemTransformationConfiguration): MarkdownBlockContentNode[];
 
 // @public
 export type UrlTarget = string;

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -177,6 +177,8 @@ export interface BlockContentMap {
     // (undocumented)
     list: ListNode;
     // (undocumented)
+    markdownBlockContent: MarkdownBlockContentNode;
+    // (undocumented)
     paragraph: ParagraphNode;
     // (undocumented)
     table: TableNode;
@@ -661,6 +663,20 @@ export interface LoggingConfiguration {
 // @public
 export type LoggingFunction = (message: string | Error, ...parameters: unknown[]) => void;
 
+// @public @sealed
+export class MarkdownBlockContentNode extends DocumentationLiteralNodeBase<BlockContent_2> {
+    constructor(value: BlockContent_2);
+    get isEmpty(): boolean;
+    readonly type = "markdownBlockContent";
+}
+
+// @public @sealed
+export class MarkdownPhrasingContentNode extends DocumentationLiteralNodeBase<PhrasingContent_2> {
+    constructor(value: PhrasingContent_2);
+    get isEmpty(): boolean;
+    readonly type = "markdownPhrasingContent";
+}
+
 declare namespace MarkdownRenderer {
     export {
         RenderApiModelAsMarkdownOptions as RenderApiModelOptions,
@@ -695,6 +711,8 @@ export interface PhrasingContentMap {
     lineBreak: LineBreakNode;
     // (undocumented)
     link: LinkNode;
+    // (undocumented)
+    markdownPhrasingContent: MarkdownPhrasingContentNode;
     // (undocumented)
     span: SpanNode;
     // (undocumented)

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -177,6 +177,8 @@ export interface BlockContentMap {
     // (undocumented)
     list: ListNode;
     // (undocumented)
+    markdownBlockContent: MarkdownBlockContentNode;
+    // (undocumented)
     paragraph: ParagraphNode;
     // (undocumented)
     table: TableNode;
@@ -639,6 +641,20 @@ export interface LoggingConfiguration {
 // @public
 export type LoggingFunction = (message: string | Error, ...parameters: unknown[]) => void;
 
+// @public @sealed
+export class MarkdownBlockContentNode extends DocumentationLiteralNodeBase<BlockContent_2> {
+    constructor(value: BlockContent_2);
+    get isEmpty(): boolean;
+    readonly type = "markdownBlockContent";
+}
+
+// @public @sealed
+export class MarkdownPhrasingContentNode extends DocumentationLiteralNodeBase<PhrasingContent_2> {
+    constructor(value: PhrasingContent_2);
+    get isEmpty(): boolean;
+    readonly type = "markdownPhrasingContent";
+}
+
 declare namespace MarkdownRenderer {
     export {
         RenderApiModelAsMarkdownOptions as RenderApiModelOptions,
@@ -673,6 +689,8 @@ export interface PhrasingContentMap {
     lineBreak: LineBreakNode;
     // (undocumented)
     link: LinkNode;
+    // (undocumented)
+    markdownPhrasingContent: MarkdownPhrasingContentNode;
     // (undocumented)
     span: SpanNode;
     // (undocumented)

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -920,7 +920,7 @@ export type TransformApiItemWithoutChildren<TApiItem extends ApiItem> = (apiItem
 export function transformApiModel(options: ApiItemTransformationOptions): DocumentNode[];
 
 // @public
-export function transformTsdoc(node: DocSection, contextApiItem: ApiItem, config: ApiItemTransformationConfiguration): BlockContent[];
+export function transformTsdoc(node: DocSection, contextApiItem: ApiItem, config: ApiItemTransformationConfiguration): MarkdownBlockContentNode[];
 
 // @public
 export type UrlTarget = string;

--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -82,6 +82,7 @@
 		"hastscript": "^9.0.0",
 		"mdast-util-from-markdown": "^2.0.2",
 		"mdast-util-gfm": "^3.1.0",
+		"mdast-util-to-hast": "^13.2.0",
 		"mdast-util-to-markdown": "^2.1.2",
 		"unist-util-remove-position": "^5.0.0"
 	},

--- a/tools/api-markdown-documenter/pnpm-lock.yaml
+++ b/tools/api-markdown-documenter/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       mdast-util-gfm:
         specifier: ^3.1.0
         version: 3.1.0
+      mdast-util-to-hast:
+        specifier: ^13.2.0
+        version: 13.2.0
       mdast-util-to-markdown:
         specifier: ^2.1.2
         version: 2.1.2
@@ -2245,8 +2248,8 @@ packages:
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
-  mdast-util-to-hast@13.1.0:
-    resolution: {integrity: sha512-/e2l/6+OdGp/FB+ctrJ9Avz71AN/GRH3oi/3KAx/kMnoUsD6q0woXlDT8lLEeViVKE7oZxE7RXzvO3T8kF2/sA==}
+  mdast-util-to-hast@13.2.0:
+    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
 
   mdast-util-to-markdown@0.6.5:
     resolution: {integrity: sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==}
@@ -2805,11 +2808,6 @@ packages:
 
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.6.3:
-    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3518,9 +3516,9 @@ snapshots:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.7.3)
       eslint-config-biome: 1.9.4
       eslint-config-prettier: 9.0.0(eslint@8.55.0)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.55.0)
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       eslint-plugin-jsdoc: 46.8.2(eslint@8.55.0)
       eslint-plugin-promise: 6.1.1(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
@@ -4846,33 +4844,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-plugin-i@2.29.1)(eslint@8.55.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.15.0
       eslint: 8.55.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.7.5(eslint@8.55.0)(typescript@5.7.3)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-plugin-i@2.29.1)(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4890,13 +4888,13 @@ snapshots:
       eslint: 8.55.0
       ignore: 5.3.2
 
-  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
+  eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-plugin-i@2.29.1(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.7.5(eslint@8.55.0)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.55.0)
       get-tsconfig: 4.8.1
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -5394,7 +5392,7 @@ snapshots:
       comma-separated-tokens: 2.0.3
       hast-util-whitespace: 3.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.1.0
+      mdast-util-to-hast: 13.2.0
       property-information: 6.4.1
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
@@ -5791,7 +5789,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.2
 
   markdown-magic-package-scripts@1.2.2(markdown-magic@2.6.1):
     dependencies:
@@ -5963,7 +5961,7 @@ snapshots:
       '@types/mdast': 4.0.4
       unist-util-is: 6.0.0
 
-  mdast-util-to-hast@13.1.0:
+  mdast-util-to-hast@13.2.0:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -6663,8 +6661,6 @@ snapshots:
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
-
-  semver@7.6.3: {}
 
   semver@7.7.2: {}
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -84,7 +84,23 @@ function getTsdocNodeTransformationOptions(
 }
 
 /**
- * Converts a {@link @microsoft/tsdoc#DocSection} to a {@link SectionNode}.
+ * Converts a {@link @microsoft/tsdoc#DocSection} to a list of {@link MarkdownBlockContentNode}s.
+ *
+ * @public
+ */
+export function transformAndWrapTsdoc(
+	node: DocSection,
+	contextApiItem: ApiItem,
+	config: ApiItemTransformationConfiguration,
+): MarkdownBlockContentNode[] {
+	const contents = transformTsdoc(node, contextApiItem, config);
+	return contents.length === 0
+		? []
+		: contents.map((mdastTree) => new MarkdownBlockContentNode(mdastTree));
+}
+
+/**
+ * Converts a {@link @microsoft/tsdoc#DocSection} to a list of {@link MarkdownBlockContentNode}s.
  *
  * @public
  */
@@ -92,12 +108,9 @@ export function transformTsdoc(
 	node: DocSection,
 	contextApiItem: ApiItem,
 	config: ApiItemTransformationConfiguration,
-): MarkdownBlockContentNode[] {
+): BlockContent[] {
 	const tsdocTransformConfig = getTsdocNodeTransformationOptions(contextApiItem, config);
-	const contents = transformTsdocSection(node, tsdocTransformConfig);
-	return contents.length === 0
-		? []
-		: contents.map((mdastTree) => new MarkdownBlockContentNode(mdastTree));
+	return transformTsdocSection(node, tsdocTransformConfig);
 }
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -19,22 +19,21 @@ import {
 	type DocHtmlStartTag,
 	type DocEscapedText,
 } from "@microsoft/tsdoc";
+import type {
+	Break,
+	BlockContent,
+	Code,
+	InlineCode,
+	List,
+	ListItem,
+	Paragraph,
+	PhrasingContent,
+	Text,
+} from "mdast";
 
 import type { Link } from "../Link.js";
 import type { LoggingConfiguration } from "../LoggingConfiguration.js";
-import {
-	type BlockContent,
-	CodeSpanNode,
-	FencedCodeBlockNode,
-	LineBreakNode,
-	LinkNode,
-	ListItemNode,
-	ListNode,
-	ParagraphNode,
-	type PhrasingContent,
-	PlainTextNode,
-	SpanNode,
-} from "../documentation-domain/index.js";
+import { MarkdownBlockContentNode } from "../documentation-domain/index.js";
 
 import { resolveSymbolicLink } from "./Utilities.js";
 import type { ApiItemTransformationConfiguration } from "./configuration/index.js";
@@ -93,9 +92,12 @@ export function transformTsdoc(
 	node: DocSection,
 	contextApiItem: ApiItem,
 	config: ApiItemTransformationConfiguration,
-): BlockContent[] {
+): MarkdownBlockContentNode[] {
 	const tsdocTransformConfig = getTsdocNodeTransformationOptions(contextApiItem, config);
-	return transformTsdocSection(node, tsdocTransformConfig);
+	const contents = transformTsdocSection(node, tsdocTransformConfig);
+	return contents.length === 0
+		? []
+		: contents.map((mdastTree) => new MarkdownBlockContentNode(mdastTree));
 }
 
 /**
@@ -167,7 +169,7 @@ function transformTsdocSectionContent(
 function transformTsdocParagraph(
 	node: DocParagraph,
 	options: TsdocNodeTransformOptions,
-): (ParagraphNode | ListNode)[] {
+): (Paragraph | List)[] {
 	// TODO: HTML contents come in as a start tag, followed by the content, followed by an end tag, rather than something with hierarchy.
 	// To ensure we map the content correctly, we should scan the child list for matching open/close tags,
 	// and map the subsequence to an "html" node.
@@ -185,16 +187,15 @@ function transformTsdocParagraph(
 	// and trim trailing whitespace from last child if it is plain text.
 	if (transformedChildren.length > 0) {
 		if (transformedChildren[0].type === "text") {
-			const plainTextNode = transformedChildren[0];
-			transformedChildren[0] = new PlainTextNode(plainTextNode.value.trimStart());
+			const text = transformedChildren[0];
+			transformedChildren[0] = { type: "text", value: text.value.trimStart() };
 		}
 		if (transformedChildren[transformedChildren.length - 1].type === "text") {
-			const plainTextNode = transformedChildren[
-				transformedChildren.length - 1
-			] as PlainTextNode;
-			transformedChildren[transformedChildren.length - 1] = new PlainTextNode(
-				plainTextNode.value.trimEnd(),
-			);
+			const text = transformedChildren[transformedChildren.length - 1];
+			transformedChildren[transformedChildren.length - 1] = {
+				type: "text",
+				value: (text as Text).value.trimEnd(),
+			};
 		}
 	}
 
@@ -204,6 +205,10 @@ function transformTsdocParagraph(
 
 	return parseContentAsBlock(transformedChildren);
 }
+
+const lineBreak: Break = {
+	type: "break",
+};
 
 // Default TSDoc implementation only supports the following DocNode kinds under a section node:
 // - DocNodeKind.BlockTag,
@@ -248,7 +253,7 @@ function transformTsdocParagraphContent(
 			return [transformTsdocPlainText(node as DocPlainText, options)];
 		}
 		case DocNodeKind.SoftBreak: {
-			return [LineBreakNode.Singleton];
+			return [lineBreak];
 		}
 		default: {
 			options.logger.error(
@@ -266,8 +271,11 @@ function transformTsdocParagraphContent(
 function transformTsdocCodeSpan(
 	node: DocCodeSpan,
 	options: TsdocNodeTransformOptions,
-): CodeSpanNode {
-	return new CodeSpanNode(node.code.trim());
+): InlineCode {
+	return {
+		type: "inlineCode",
+		value: node.code.trim(),
+	};
 }
 
 /**
@@ -301,8 +309,11 @@ function transformTsdocHtmlTag(
 function transformTsdocPlainText(
 	node: DocPlainText,
 	options: TsdocNodeTransformOptions,
-): PlainTextNode {
-	return new PlainTextNode(node.text);
+): Text {
+	return {
+		type: "text",
+		value: node.text,
+	};
 }
 
 /**
@@ -311,8 +322,11 @@ function transformTsdocPlainText(
 function transformTsdocEscapedText(
 	node: DocEscapedText,
 	options: TsdocNodeTransformOptions,
-): PlainTextNode {
-	return new PlainTextNode(node.decodedText);
+): Text {
+	return {
+		type: "text",
+		value: node.decodedText,
+	};
 }
 
 /**
@@ -321,8 +335,12 @@ function transformTsdocEscapedText(
 function transformTsdocFencedCode(
 	node: DocFencedCode,
 	options: TsdocNodeTransformOptions,
-): FencedCodeBlockNode {
-	return new FencedCodeBlockNode(node.code.trim(), node.language);
+): Code {
+	return {
+		type: "code",
+		value: node.code.trim(),
+		lang: node.language,
+	};
 }
 
 /**
@@ -331,26 +349,51 @@ function transformTsdocFencedCode(
 function transformTsdocLinkTag(
 	input: DocLinkTag,
 	options: TsdocNodeTransformOptions,
-): LinkNode | SpanNode {
+): PhrasingContent {
 	if (input.codeDestination !== undefined) {
 		const link = options.resolveApiReference(input.codeDestination);
 
 		if (link === undefined) {
 			// If the code link could not be resolved, print the unresolved text in italics.
 			const linkText = input.linkText?.trim() ?? input.codeDestination.emitAsTsdoc().trim();
-			return SpanNode.createFromPlainText(linkText, { italic: true });
+			return {
+				type: "emphasis",
+				children: [
+					{
+						type: "text",
+						value: linkText,
+					},
+				],
+			};
 		} else {
 			const linkText = input.linkText?.trim() ?? link.text;
 			const linkTarget = link.target;
-			return new LinkNode(linkText, linkTarget);
+			return {
+				type: "link",
+				url: linkTarget,
+				children: [
+					{
+						type: "text",
+						value: linkText,
+					},
+				],
+			};
 		}
 	}
 
 	if (input.urlDestination !== undefined) {
 		// If link text was not provided, use the name of the referenced element.
 		const linkText = input.linkText ?? input.urlDestination;
-
-		return new LinkNode(linkText, input.urlDestination);
+		return {
+			type: "link",
+			url: input.urlDestination,
+			children: [
+				{
+					type: "text",
+					value: linkText,
+				},
+			],
+		};
 	}
 
 	throw new Error(
@@ -377,17 +420,28 @@ function transformTsdocLinkTag(
  * for use in `{@link}` and `{@inheritDoc}` tags, so we will simply ignore them here. I.e. we
  * will return `undefined`.
  */
-function transformTsdocInlineTag(node: DocInlineTag): SpanNode | undefined {
+function transformTsdocInlineTag(node: DocInlineTag): PhrasingContent | undefined {
 	if (node.tagName === "@label") {
 		return undefined;
 	}
 
 	// For all other inline tags, there isn't really anything we can do with them except emit them
 	// as is. However, to help differentiate them in the output, we will italicize them.
-	return SpanNode.createFromPlainText(`{${node.tagName} ${node.tagContent}}`, {
-		italic: true,
-	});
+	return {
+		type: "emphasis",
+		children: [
+			{
+				type: "text",
+				value: `{${node.tagName} ${node.tagContent}}`,
+			},
+		],
+	};
 }
+
+const space: Text = {
+	type: "text",
+	value: " ",
+};
 
 /**
  * Parse the provided list of {@link PhrasingContent} into a list of {@link ParagraphNode} or {@link ListNode}, following Markdown syntax rules.
@@ -395,7 +449,7 @@ function transformTsdocInlineTag(node: DocInlineTag): SpanNode | undefined {
  * @remarks This is a workaround for TSDoc not parsing its input as Markdown.
  * We add explicit support for lists as a post-processing step.
  */
-function parseContentAsBlock(nodes: PhrasingContent[]): (ParagraphNode | ListNode)[] {
+function parseContentAsBlock(nodes: PhrasingContent[]): (Paragraph | List)[] {
 	// #region Step 1: parse source lines into lines of non-lists (paragraphs) and list items
 
 	// This regex matches lines that look like Markdown list items:
@@ -456,13 +510,13 @@ function parseContentAsBlock(nodes: PhrasingContent[]): (ParagraphNode | ListNod
 								type: "orderedListItem",
 								delimiter: orderedListItemDelimiterMatch[1] as "." | ")",
 								indentationLevel,
-								content: [new PlainTextNode(listItemContent)],
+								content: [{ type: "text", value: listItemContent }],
 							}
 						: {
 								type: "unorderedListItem",
 								delimiter: listItemDelimiter as "*" | "+" | "-",
 								indentationLevel,
-								content: [new PlainTextNode(listItemContent)],
+								content: [{ type: "text", value: listItemContent }],
 							};
 				} else {
 					// If the line doesn't start with the list item pattern, we will treat the line as the start of a paragraph.
@@ -479,7 +533,7 @@ function parseContentAsBlock(nodes: PhrasingContent[]): (ParagraphNode | ListNod
 			}
 		} else {
 			// Case: continuation of the current line
-			if (node.type === "lineBreak") {
+			if (node.type === "break") {
 				// When we encounter a line break, we will finalize the current line content.
 				parsedSourceLines.push(currentLineState);
 				currentLineState = undefined;
@@ -518,7 +572,7 @@ function parseContentAsBlock(nodes: PhrasingContent[]): (ParagraphNode | ListNod
 				) {
 					if (items.length > 0) {
 						// Add a space between content on adjacent lines in the same paragraph.
-						items.push(new PlainTextNode(" "));
+						items.push(space);
 					}
 					items.push(...parsedSourceLines[iParsed].content);
 					iParsed++;
@@ -539,7 +593,7 @@ function parseContentAsBlock(nodes: PhrasingContent[]): (ParagraphNode | ListNod
 				) {
 					if (items.length > 0) {
 						// Add a space between content on adjacent lines in the same paragraph.
-						items.push(new PlainTextNode(" "));
+						items.push(space);
 					}
 					items.push(...parsedSourceLines[iParsed].content);
 					iParsed++;
@@ -568,30 +622,42 @@ function parseContentAsBlock(nodes: PhrasingContent[]): (ParagraphNode | ListNod
 	// This means that all adjacent list items are treated as separate items in a single root list.
 	// This is sufficient for our needs at the moment, but in the future we should add support for parsing nested lists.
 
-	const result: (ParagraphNode | ListNode)[] = [];
+	const result: (Paragraph | List)[] = [];
 	let iOutput = 0;
 	while (iOutput < outputLines.length) {
 		const current = outputLines[iOutput];
 
 		switch (current.type) {
 			case "paragraphLine": {
-				result.push(new ParagraphNode(current.content));
+				result.push({ type: "paragraph", children: current.content });
 				iOutput++;
 				break;
 			}
 			case "orderedListItem":
 			case "unorderedListItem": {
-				const items: ListItemNode[] = [];
+				const items: ListItem[] = [];
 				while (
 					iOutput < outputLines.length &&
 					outputLines[iOutput].type === current.type &&
 					(outputLines[iOutput] as ParsedOrderedListItem | ParsedUnorderedListItem)
 						.delimiter === current.delimiter
 				) {
-					items.push(new ListItemNode(combineAdjacentPlainText(outputLines[iOutput].content)));
+					items.push({
+						type: "listItem",
+						children: [
+							{
+								type: "paragraph",
+								children: combineAdjacentPlainText(outputLines[iOutput].content),
+							},
+						],
+					});
 					iOutput++;
 				}
-				result.push(new ListNode(items, current.type === "orderedListItem"));
+				result.push({
+					type: "list",
+					ordered: current.type === "orderedListItem",
+					children: items,
+				});
 				break;
 			}
 			// No default
@@ -619,14 +685,14 @@ function combineAdjacentPlainText(nodes: readonly PhrasingContent[]): PhrasingCo
 			buffer += node.value;
 		} else {
 			if (buffer.length > 0) {
-				result.push(new PlainTextNode(buffer));
+				result.push({ type: "text", value: buffer });
 				buffer = "";
 			}
 			result.push(node);
 		}
 	}
 	if (buffer.length > 0) {
-		result.push(new PlainTextNode(buffer));
+		result.push({ type: "text", value: buffer });
 	}
 
 	return result;

--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -98,7 +98,7 @@ export function transformAndWrapTsdoc(
 }
 
 /**
- * Converts a {@link @microsoft/tsdoc#DocSection} to a list of {@link MarkdownBlockContentNode}s.
+ * Converts a {@link @microsoft/tsdoc#DocSection} to a list of {@link BlockContent}s.
  *
  * @public
  */

--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -657,6 +657,7 @@ function parseContentAsBlock(nodes: PhrasingContent[]): (Paragraph | List)[] {
 					type: "list",
 					ordered: current.type === "orderedListItem",
 					children: items,
+					spread: false,
 				});
 				break;
 			}

--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -219,6 +219,9 @@ function transformTsdocParagraph(
 	return parseContentAsBlock(transformedChildren);
 }
 
+/**
+ * Line break singleton
+ */
 const lineBreak: Break = {
 	type: "break",
 };
@@ -451,6 +454,9 @@ function transformTsdocInlineTag(node: DocInlineTag): PhrasingContent | undefine
 	};
 }
 
+/**
+ * Single space text singleton.
+ */
 const space: Text = {
 	type: "text",
 	value: " ",

--- a/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/TsdocNodeTransforms.ts
@@ -94,9 +94,7 @@ export function transformAndWrapTsdoc(
 	config: ApiItemTransformationConfiguration,
 ): MarkdownBlockContentNode[] {
 	const contents = transformTsdoc(node, contextApiItem, config);
-	return contents.length === 0
-		? []
-		: contents.map((mdastTree) => new MarkdownBlockContentNode(mdastTree));
+	return contents.map((mdastTree) => new MarkdownBlockContentNode(mdastTree));
 }
 
 /**

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/Helpers.ts
@@ -27,19 +27,19 @@ import {
 	type DocPlainText,
 	type DocSection,
 } from "@microsoft/tsdoc";
+import type { Nodes, Parent } from "mdast";
 
 import type { Heading } from "../../Heading.js";
 import type { Link } from "../../Link.js";
 import type { Logger } from "../../Logging.js";
 import {
 	type BlockContent,
-	type DocumentationNode,
-	type DocumentationParentNode,
 	FencedCodeBlockNode,
 	HeadingNode,
 	LinkNode,
 	ListItemNode,
 	ListNode,
+	MarkdownBlockContentNode,
 	ParagraphNode,
 	type PhrasingContent,
 	PlainTextNode,
@@ -64,7 +64,7 @@ import {
 	doesItemKindRequireOwnDocument,
 	getLinkForApiItem,
 } from "../ApiItemTransformUtilities.js";
-import { transformTsdoc } from "../TsdocNodeTransforms.js";
+import { transformAndWrapTsdoc, transformTsdoc } from "../TsdocNodeTransforms.js";
 import {
 	HierarchyKind,
 	type ApiItemTransformationConfiguration,
@@ -303,7 +303,7 @@ export function createSeeAlsoSection(
 
 	const contents: BlockContent[] = [];
 	for (const seeBlock of seeBlocks) {
-		contents.push(...transformTsdoc(seeBlock, apiItem, config));
+		contents.push(...transformAndWrapTsdoc(seeBlock, apiItem, config));
 	}
 
 	return wrapInSection(contents, {
@@ -476,7 +476,7 @@ export function createSummarySection(
 	config: ApiItemTransformationConfiguration,
 ): SectionNode | undefined {
 	if (apiItem instanceof ApiDocumentedItem && apiItem.tsdocComment !== undefined) {
-		const sectionContents = transformTsdoc(
+		const sectionContents = transformAndWrapTsdoc(
 			apiItem.tsdocComment.summarySection,
 			apiItem,
 			config,
@@ -511,7 +511,7 @@ export function createRemarksSection(
 	}
 
 	return wrapInSection(
-		transformTsdoc(apiItem.tsdocComment.remarksBlock.content, apiItem, config),
+		transformAndWrapTsdoc(apiItem.tsdocComment.remarksBlock.content, apiItem, config),
 		{ title: "Remarks", id: `${getFileSafeNameForApiItem(apiItem)}-remarks` },
 	);
 }
@@ -542,7 +542,7 @@ export function createThrowsSection(
 
 	const contents: BlockContent[] = [];
 	for (const throwsBlock of throwsBlocks) {
-		contents.push(...transformTsdoc(throwsBlock, apiItem, config));
+		contents.push(...transformAndWrapTsdoc(throwsBlock, apiItem, config));
 	}
 
 	return wrapInSection(contents, {
@@ -580,7 +580,7 @@ export function createDeprecationNoticeSection(
 				{ bold: true },
 			),
 		]),
-		...transformTsdoc(deprecatedBlock, apiItem, config),
+		...transformAndWrapTsdoc(deprecatedBlock, apiItem, config),
 	]);
 }
 
@@ -714,9 +714,7 @@ function createExampleSection(
 ): SectionNode {
 	const { logger } = config;
 
-	let exampleSection: SectionNode | undefined = new SectionNode(
-		transformTsdoc(example.content, example.apiItem, config),
-	);
+	let transformedExampleContent = transformTsdoc(example.content, example.apiItem, config);
 
 	// Per TSDoc spec, if the `@example` comment has content on the same line as the tag,
 	// that line is expected to be treated as the title.
@@ -741,15 +739,23 @@ function createExampleSection(
 		logger?.verbose(
 			`Found example comment with title "${exampleTitle}". Adjusting output to adhere to TSDoc spec...`,
 		);
-		exampleSection = stripTitleFromExampleComment(exampleSection, exampleTitle, logger);
+		transformedExampleContent = stripTitleFromExampleComment(
+			transformedExampleContent,
+			exampleTitle,
+			logger,
+		);
 	}
 
 	const headingId = `${getFileSafeNameForApiItem(example.apiItem)}-example${
 		example.exampleNumber ?? ""
 	}`;
 
+	const sectionChildren = transformedExampleContent.map(
+		(node) => new MarkdownBlockContentNode(node),
+	);
+
 	// Always emit the section, even if the body is empty after stripping out the title.
-	return wrapInSection(exampleSection?.children ?? [], {
+	return wrapInSection(sectionChildren, {
 		title: headingTitle,
 		id: headingId,
 	});
@@ -810,83 +816,60 @@ function extractTitleFromExampleSection(sectionNode: DocSection): string | undef
  *
  * @returns The updated node, if any content remains. Otherwise, `undefined`.
  */
-function stripTitleFromExampleComment<TNode extends DocumentationParentNode>(
-	node: TNode,
+function stripTitleFromExampleComment<TNode extends Nodes>(
+	nodes: readonly TNode[],
 	title: string,
 	logger: Logger | undefined,
-): TNode | undefined {
+): TNode[] {
 	// Verify title matches text of first plain text in output.
 	// This is an expected invariant. If this is not the case, then something has gone wrong.
 	// Note: if we ever allow consumers to provide custom DocNode transformations, this invariant will likely
 	// disappear, and this code will need to be updated to function differently.
 	// Reference: <https://tsdoc.org/pages/tags/example/>
-	const children = node.children;
-	if (children.length === 0) {
+	if (nodes.length === 0) {
 		logger?.error(
 			"Transformed example paragraph begins with empty parent node. This is unexpected and indicates a bug.",
 		);
-		return node;
+		return [];
 	}
 
-	const firstChild = children[0];
-	if (firstChild.isParent) {
-		const newFirstChild = stripTitleFromExampleComment(
-			firstChild as DocumentationParentNode,
-			title,
-			logger,
-		);
+	const firstChild = nodes[0];
+	if ((firstChild as Partial<Parent>).children !== undefined) {
+		const newFirst = {
+			...firstChild,
+			children: stripTitleFromExampleComment((firstChild as Parent).children, title, logger),
+		};
 
-		const remainingChildren = children.slice(1);
-		const newChildren: DocumentationNode[] =
-			newFirstChild === undefined ? remainingChildren : [newFirstChild, ...remainingChildren];
+		const remaining = nodes.slice(1);
 
-		// If there are no remaining children under this parent after stripping out the title, omit this parent node.
-		return newChildren.length === 0
-			? undefined
-			: {
-					...node,
-					children: newChildren,
-					hasChildren: newChildren.length > 0,
-				};
+		// If there are no remaining children under the first item after stripping out the title, omit that item altogether.
+		return newFirst.children.length === 0 ? remaining : [newFirst, ...remaining];
 	}
 
-	if (firstChild.isLiteral) {
-		if (firstChild.type === "text") {
-			const text = (firstChild as PlainTextNode).value;
-			if (text === title) {
-				// Remove from children, and remove any trailing line breaks
-				const newChildren = children.slice(1);
-				while (newChildren.length > 0 && newChildren[0].type === "lineBreak") {
-					newChildren.shift();
-				}
-				// If there are no remaining children under this parent after stripping out the title, omit this parent node.
-				return newChildren.length === 0
-					? undefined
-					: {
-							...node,
-							children: newChildren,
-							hasChildren: newChildren.length > 0,
-						};
-			} else {
-				logger?.error(
-					"Transformed example paragraph does not begin with expected title. This is unexpected and indicates a bug.",
-					`Expected: "${title}".`,
-					`Found: "${text}".`,
-				);
-				return node;
+	if (firstChild.type === "text") {
+		const text = firstChild.value;
+		if (text === title) {
+			// Remove the title element from the input list, and remove any intervening line breaks
+			const remaining = nodes.slice(1);
+			while (remaining.length > 0 && remaining[0].type === "break") {
+				remaining.shift();
 			}
+			// If there are no remaining children under this parent after stripping out the title, omit this parent node.
+			return remaining;
 		} else {
 			logger?.error(
-				"Transformed example paragraph does not begin with plain text. This is unexpected and indicates a bug.",
+				"Transformed example paragraph does not begin with expected title. This is unexpected and indicates a bug.",
+				`Expected: "${title}".`,
+				`Found: "${text}".`,
 			);
-			return node;
+			return [...nodes];
 		}
+	} else {
+		logger?.error(
+			"Transformed example paragraph does not begin with plain text. This is unexpected and indicates a bug.",
+		);
+		return [...nodes];
 	}
-
-	logger?.error(
-		"Transformed example paragraph begins with a non-literal, non-parent node. This is unexpected and indicates a bug.",
-	);
-	return node;
 }
 
 /**
@@ -941,7 +924,7 @@ export function createReturnsSection(
 	if (apiItem instanceof ApiDocumentedItem && apiItem.tsdocComment !== undefined) {
 		const returnsBlock = getReturnsBlock(apiItem);
 		if (returnsBlock !== undefined) {
-			children.push(...transformTsdoc(returnsBlock, apiItem, config));
+			children.push(...transformAndWrapTsdoc(returnsBlock, apiItem, config));
 		}
 	}
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
@@ -40,7 +40,7 @@ import {
 	injectSeparator,
 } from "../../utilities/index.js";
 import { getLinkForApiItem } from "../ApiItemTransformUtilities.js";
-import { transformTsdoc } from "../TsdocNodeTransforms.js";
+import { transformAndWrapTsdoc } from "../TsdocNodeTransforms.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 
 import { createExcerptSpanWithHyperlinks } from "./Helpers.js";
@@ -838,7 +838,7 @@ function transformTsdocSectionForTableCell(
 	contextApiItem: ApiItem,
 	config: ApiItemTransformationConfiguration,
 ): TableCellContent[] {
-	const transformed = transformTsdoc(tsdocSection, contextApiItem, config);
+	const transformed = transformAndWrapTsdoc(tsdocSection, contextApiItem, config);
 
 	// If the transformed contents consist of a single paragraph (common case), inline that paragraph's contents
 	// directly in the cell.

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
@@ -21,6 +21,7 @@ import {
 	CodeSpanNode,
 	HeadingNode,
 	LinkNode,
+	MarkdownPhrasingContentNode,
 	type PhrasingContent,
 	PlainTextNode,
 	SectionNode,
@@ -841,8 +842,10 @@ function transformTsdocSectionForTableCell(
 
 	// If the transformed contents consist of a single paragraph (common case), inline that paragraph's contents
 	// directly in the cell.
-	if (transformed.length === 1 && transformed[0].type === "paragraph") {
-		return transformed[0].children;
+	if (transformed.length === 1 && transformed[0].value.type === "paragraph") {
+		return transformed[0].value.children.map(
+			(child) => new MarkdownPhrasingContentNode(child),
+		);
 	}
 
 	return transformed;

--- a/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/helpers/TableHelpers.ts
@@ -21,6 +21,7 @@ import {
 	CodeSpanNode,
 	HeadingNode,
 	LinkNode,
+	MarkdownBlockContentNode,
 	MarkdownPhrasingContentNode,
 	type PhrasingContent,
 	PlainTextNode,
@@ -40,7 +41,7 @@ import {
 	injectSeparator,
 } from "../../utilities/index.js";
 import { getLinkForApiItem } from "../ApiItemTransformUtilities.js";
-import { transformAndWrapTsdoc } from "../TsdocNodeTransforms.js";
+import { transformTsdoc } from "../TsdocNodeTransforms.js";
 import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 
 import { createExcerptSpanWithHyperlinks } from "./Helpers.js";
@@ -838,15 +839,13 @@ function transformTsdocSectionForTableCell(
 	contextApiItem: ApiItem,
 	config: ApiItemTransformationConfiguration,
 ): TableCellContent[] {
-	const transformed = transformAndWrapTsdoc(tsdocSection, contextApiItem, config);
+	const transformed = transformTsdoc(tsdocSection, contextApiItem, config);
 
 	// If the transformed contents consist of a single paragraph (common case), inline that paragraph's contents
 	// directly in the cell.
-	if (transformed.length === 1 && transformed[0].value.type === "paragraph") {
-		return transformed[0].value.children.map(
-			(child) => new MarkdownPhrasingContentNode(child),
-		);
+	if (transformed.length === 1 && transformed[0].type === "paragraph") {
+		return transformed[0].children.map((child) => new MarkdownPhrasingContentNode(child));
 	}
 
-	return transformed;
+	return transformed.map((node) => new MarkdownBlockContentNode(node));
 }

--- a/tools/api-markdown-documenter/src/api-item-transforms/index.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/index.ts
@@ -50,7 +50,7 @@ export {
 	createThrowsSection,
 	createTypeParametersSection,
 } from "./helpers/index.js";
-export { transformTsdoc } from "./TsdocNodeTransforms.js";
+export { transformAndWrapTsdoc as transformTsdoc } from "./TsdocNodeTransforms.js";
 export { apiItemToDocument, apiItemToSections } from "./TransformApiItem.js";
 export { transformApiModel } from "./TransformApiModel.js";
 export { checkForDuplicateDocumentPaths } from "./Utilities.js";

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
@@ -27,6 +27,8 @@ import {
 	LinkNode,
 	ListItemNode,
 	ListNode,
+	MarkdownBlockContentNode,
+	MarkdownPhrasingContentNode,
 	ParagraphNode,
 	PlainTextNode,
 	SectionNode,
@@ -175,7 +177,12 @@ describe("ApiItem to Documentation transformation tests", () => {
 			wrapInSection(
 				[
 					// Summary section
-					wrapInSection([ParagraphNode.createFromPlainText("Test function")]),
+					wrapInSection([
+						new MarkdownBlockContentNode({
+							type: "paragraph",
+							children: [{ type: "text", value: "Test function" }],
+						}),
+					]),
 
 					// Signature section
 					wrapInSection(
@@ -190,7 +197,12 @@ describe("ApiItem to Documentation transformation tests", () => {
 										[
 											new TableBodyRowNode([
 												TableBodyCellNode.createFromPlainText("TTypeParameter"),
-												TableBodyCellNode.createFromPlainText("A test type parameter"),
+												new TableBodyCellNode([
+													new MarkdownPhrasingContentNode({
+														type: "text",
+														value: "A test type parameter",
+													}),
+												]),
 											]),
 										],
 										new TableHeaderRowNode([
@@ -217,13 +229,23 @@ describe("ApiItem to Documentation transformation tests", () => {
 										TableBodyCellNode.createFromPlainText("testParameter"),
 										TableBodyCellNode.Empty,
 										new TableBodyCellNode([new PlainTextNode("TTypeParameter")]),
-										TableBodyCellNode.createFromPlainText("A test parameter"),
+										new TableBodyCellNode([
+											new MarkdownPhrasingContentNode({
+												type: "text",
+												value: "A test parameter",
+											}),
+										]),
 									]),
 									new TableBodyRowNode([
 										TableBodyCellNode.createFromPlainText("testOptionalParameter"),
 										TableBodyCellNode.createFromPlainText("optional"),
 										new TableBodyCellNode([new PlainTextNode("TTypeParameter")]),
-										TableBodyCellNode.createFromPlainText("An optional parameter"),
+										new TableBodyCellNode([
+											new MarkdownPhrasingContentNode({
+												type: "text",
+												value: "An optional parameter",
+											}),
+										]),
 									]),
 								],
 								new TableHeaderRowNode([
@@ -243,7 +265,10 @@ describe("ApiItem to Documentation transformation tests", () => {
 					// Returns section
 					wrapInSection(
 						[
-							ParagraphNode.createFromPlainText("The provided parameter"),
+							new MarkdownBlockContentNode({
+								type: "paragraph",
+								children: [{ type: "text", value: "The provided parameter" }],
+							}),
 							new ParagraphNode([
 								SpanNode.createFromPlainText("Return type", { bold: true }),
 								new PlainTextNode(": "),
@@ -258,7 +283,12 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 					// Throws section
 					wrapInSection(
-						[ParagraphNode.createFromPlainText("An Error when something bad happens.")],
+						[
+							new MarkdownBlockContentNode({
+								type: "paragraph",
+								children: [{ type: "text", value: "An Error when something bad happens." }],
+							}),
+						],
 						{
 							title: "Throws",
 							id: `testfunction-throws`,

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/Transformation.test.ts
@@ -144,7 +144,12 @@ describe("ApiItem to Documentation transformation tests", () => {
 		const expected = [
 			wrapInSection(
 				[
-					wrapInSection([ParagraphNode.createFromPlainText("Test Constant")]),
+					wrapInSection([
+						new MarkdownBlockContentNode({
+							type: "paragraph",
+							children: [{ type: "text", value: "Test Constant" }],
+						}),
+					]),
 					wrapInSection(
 						[new FencedCodeBlockNode('TestConst = "Hello world!"', "typescript")],
 						{
@@ -321,7 +326,12 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 		const expected: DocumentationNode[] = [
 			// Summary section
-			wrapInSection([ParagraphNode.createFromPlainText("Test interface")]),
+			wrapInSection([
+				new MarkdownBlockContentNode({
+					type: "paragraph",
+					children: [{ type: "text", value: "Test interface" }],
+				}),
+			]),
 
 			// Signature section
 			wrapInSection(
@@ -331,7 +341,12 @@ describe("ApiItem to Documentation transformation tests", () => {
 
 			// Remarks section
 			wrapInSection(
-				[ParagraphNode.createFromPlainText("Here are some remarks about the interface")],
+				[
+					new MarkdownBlockContentNode({
+						type: "paragraph",
+						children: [{ type: "text", value: "Here are some remarks about the interface" }],
+					}),
+				],
 				{ title: "Remarks", id: "testinterface-remarks" },
 			),
 
@@ -348,9 +363,19 @@ describe("ApiItem to Documentation transformation tests", () => {
 									),
 								]),
 								new TableBodyCellNode([new CodeSpanNode("optional")]),
-								TableBodyCellNode.createFromPlainText("0"),
+								new TableBodyCellNode([
+									new MarkdownPhrasingContentNode({
+										type: "text",
+										value: "0",
+									}),
+								]),
 								new TableBodyCellNode([new PlainTextNode("number")]),
-								TableBodyCellNode.createFromPlainText("Test optional property"),
+								new TableBodyCellNode([
+									new MarkdownPhrasingContentNode({
+										type: "text",
+										value: "Test optional property",
+									}),
+								]),
 							]),
 						],
 						new TableHeaderRowNode([
@@ -371,7 +396,12 @@ describe("ApiItem to Documentation transformation tests", () => {
 					wrapInSection(
 						[
 							// Summary section
-							wrapInSection([ParagraphNode.createFromPlainText("Test optional property")]),
+							wrapInSection([
+								new MarkdownBlockContentNode({
+									type: "paragraph",
+									children: [{ type: "text", value: "Test optional property" }],
+								}),
+							]),
 							// Signature section
 							wrapInSection(
 								[
@@ -435,7 +465,12 @@ describe("ApiItem to Documentation transformation tests", () => {
 		// Also note that child items are listed alphabetically, so we expect `bar` before `foo`.
 		const expected: DocumentationNode[] = [
 			// Summary section
-			wrapInSection([ParagraphNode.createFromPlainText("Test namespace")]),
+			wrapInSection([
+				new MarkdownBlockContentNode({
+					type: "paragraph",
+					children: [{ type: "text", value: "Test namespace" }],
+				}),
+			]),
 
 			// Signature section
 			wrapInSection(
@@ -605,7 +640,12 @@ describe("ApiItem to Documentation transformation tests", () => {
 											]),
 											new TableBodyCellNode([new CodeSpanNode("readonly")]),
 											TableBodyCellNode.Empty, // Type
-											TableBodyCellNode.createFromPlainText("Test Constant"),
+											new TableBodyCellNode([
+												new MarkdownPhrasingContentNode({
+													type: "text",
+													value: "Test Constant",
+												}),
+											]),
 										]),
 									],
 									new TableHeaderRowNode([
@@ -625,7 +665,12 @@ describe("ApiItem to Documentation transformation tests", () => {
 								new SectionNode(
 									[
 										// Summary
-										new SectionNode([ParagraphNode.createFromPlainText("Test Constant")]),
+										new SectionNode([
+											new MarkdownBlockContentNode({
+												type: "paragraph",
+												children: [{ type: "text", value: "Test Constant" }],
+											}),
+										]),
 
 										// Signature
 										new SectionNode(
@@ -672,7 +717,12 @@ describe("ApiItem to Documentation transformation tests", () => {
 												new LinkNode("world", "/test-package/#world-variable"),
 											]),
 											TableBodyCellNode.Empty, // Type
-											TableBodyCellNode.createFromPlainText("Test Constant"),
+											new TableBodyCellNode([
+												new MarkdownPhrasingContentNode({
+													type: "text",
+													value: "Test Constant",
+												}),
+											]),
 										]),
 									],
 									new TableHeaderRowNode([
@@ -691,7 +741,12 @@ describe("ApiItem to Documentation transformation tests", () => {
 								new SectionNode(
 									[
 										// Summary
-										new SectionNode([ParagraphNode.createFromPlainText("Test Constant")]),
+										new SectionNode([
+											new MarkdownBlockContentNode({
+												type: "paragraph",
+												children: [{ type: "text", value: "Test Constant" }],
+											}),
+										]),
 
 										// Signature
 										new SectionNode(

--- a/tools/api-markdown-documenter/src/api-item-transforms/test/TsdocNodeTransforms.test.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/test/TsdocNodeTransforms.test.ts
@@ -9,14 +9,6 @@ import { expect } from "chai";
 
 import { defaultConsoleLogger } from "../../Logging.js";
 import {
-	FencedCodeBlockNode,
-	LinkNode,
-	ListItemNode,
-	ListNode,
-	ParagraphNode,
-	PlainTextNode,
-} from "../../documentation-domain/index.js";
-import {
 	transformTsdocSection,
 	type TsdocNodeTransformOptions,
 } from "../TsdocNodeTransforms.js";
@@ -25,8 +17,10 @@ const mockApiItem = {} as unknown as ApiItem;
 const transformOptions: TsdocNodeTransformOptions = {
 	logger: defaultConsoleLogger,
 	contextApiItem: mockApiItem,
-	resolveApiReference: (codeDestination) =>
-		new LinkNode(codeDestination.emitAsTsdoc(), "<URL>"),
+	resolveApiReference: (codeDestination) => ({
+		text: codeDestination.emitAsTsdoc(),
+		target: "<URL>",
+	}),
 };
 
 describe("Tsdoc node transformation tests", () => {
@@ -49,7 +43,10 @@ describe("Tsdoc node transformation tests", () => {
 			const result = transformTsdocSection(summarySection, transformOptions);
 
 			expect(result).to.deep.equal([
-				new ParagraphNode([new PlainTextNode("This is a simple comment.")]),
+				{
+					type: "paragraph",
+					children: [{ type: "text", value: "This is a simple comment." }],
+				},
 			]);
 		});
 
@@ -60,7 +57,17 @@ describe("Tsdoc node transformation tests", () => {
 
 			const result = transformTsdocSection(summarySection, transformOptions);
 
-			expect(result).to.deep.equal([new ParagraphNode([new PlainTextNode("@foo")])]);
+			expect(result).to.deep.equal([
+				{
+					type: "paragraph",
+					children: [
+						{
+							type: "text",
+							value: "@foo",
+						},
+					],
+				},
+			]);
 		});
 
 		it("@example with fenced code", () => {
@@ -76,7 +83,11 @@ describe("Tsdoc node transformation tests", () => {
 			const result = transformTsdocSection(summarySection, transformOptions);
 
 			expect(result).to.deep.equal([
-				new FencedCodeBlockNode('const foo = "bar";', "typescript"),
+				{
+					type: "code",
+					value: 'const foo = "bar";',
+					lang: "typescript",
+				},
 			]);
 		});
 
@@ -93,10 +104,24 @@ describe("Tsdoc node transformation tests", () => {
 			const result = transformTsdocSection(summarySection, transformOptions);
 
 			expect(result).to.deep.equal([
-				new ParagraphNode([
-					new PlainTextNode("This is a simple comment. It has multiple paragraphs."),
-				]),
-				new ParagraphNode([new PlainTextNode("This is the second paragraph.")]),
+				{
+					type: "paragraph",
+					children: [
+						{
+							type: "text",
+							value: "This is a simple comment. It has multiple paragraphs.",
+						},
+					],
+				},
+				{
+					type: "paragraph",
+					children: [
+						{
+							type: "text",
+							value: "This is the second paragraph.",
+						},
+					],
+				},
 			]);
 		});
 
@@ -114,14 +139,51 @@ describe("Tsdoc node transformation tests", () => {
 					const result = transformTsdocSection(summarySection, transformOptions);
 
 					expect(result).to.deep.equal([
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 1")]),
-								new ListItemNode([new LinkNode("Item 2", "<URL>")]),
-								new ListItemNode([new PlainTextNode("Item 3")]),
+						{
+							type: "list",
+							ordered: true,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 1" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [
+												{
+													type: "link",
+													url: "<URL>",
+													children: [
+														{
+															type: "text",
+															value: "Item 2",
+														},
+													],
+												},
+											],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 3" }],
+										},
+									],
+								},
 							],
-							true,
-						),
+						},
 					]);
 				});
 
@@ -143,22 +205,74 @@ describe("Tsdoc node transformation tests", () => {
 					const result = transformTsdocSection(summarySection, transformOptions);
 
 					expect(result).to.deep.equal([
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 1")]),
-								new ListItemNode([new PlainTextNode("Item 2")]),
-								new ListItemNode([new PlainTextNode("Item 3")]),
+						{
+							type: "list",
+							ordered: true,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 1" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 2" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 3" }],
+										},
+									],
+								},
 							],
-							true,
-						),
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 4")]),
-								new ListItemNode([new PlainTextNode("Item 5")]),
-								new ListItemNode([new PlainTextNode("Item 6")]),
+						},
+						{
+							type: "list",
+							ordered: true,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 4" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 5" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 6" }],
+										},
+									],
+								},
 							],
-							true,
-						),
+						},
 					]);
 				});
 
@@ -177,27 +291,81 @@ describe("Tsdoc node transformation tests", () => {
 					const result = transformTsdocSection(summarySection, transformOptions);
 
 					expect(result).to.deep.equal([
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 1")]),
-								new ListItemNode([new PlainTextNode("Item 2")]),
+						{
+							type: "list",
+							ordered: true,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 1" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 2" }],
+										},
+									],
+								},
 							],
-							true,
-						),
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 3")]),
-								new ListItemNode([new PlainTextNode("Item 4")]),
+						},
+						{
+							type: "list",
+							ordered: true,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 3" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 4" }],
+										},
+									],
+								},
 							],
-							true,
-						),
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 5")]),
-								new ListItemNode([new PlainTextNode("Item 6")]),
+						},
+						{
+							type: "list",
+							ordered: true,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 5" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 6" }],
+										},
+									],
+								},
 							],
-							true,
-						),
+						},
 					]);
 				});
 
@@ -217,16 +385,43 @@ describe("Tsdoc node transformation tests", () => {
 					const result = transformTsdocSection(summarySection, transformOptions);
 
 					expect(result).to.deep.equal([
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 1")]),
-								new ListItemNode([new PlainTextNode("Item 1.a")]),
-								new ListItemNode([new PlainTextNode("Item 1.b")]),
-								new ListItemNode([new PlainTextNode("Item 2")]),
-								new ListItemNode([new PlainTextNode("Item 2.a")]),
+						{
+							type: "list",
+							ordered: true,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 1" }] },
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 1.a" }] },
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 1.b" }] },
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 2" }] },
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 2.a" }] },
+									],
+								},
 							],
-							true,
-						),
+						},
 					]);
 				});
 			});
@@ -244,14 +439,51 @@ describe("Tsdoc node transformation tests", () => {
 					const result = transformTsdocSection(summarySection, transformOptions);
 
 					expect(result).to.deep.equal([
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 1")]),
-								new ListItemNode([new LinkNode("Item 2", "<URL>")]),
-								new ListItemNode([new PlainTextNode("Item 3")]),
+						{
+							type: "list",
+							ordered: false,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 1" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [
+												{
+													type: "link",
+													url: "<URL>",
+													children: [
+														{
+															type: "text",
+															value: "Item 2",
+														},
+													],
+												},
+											],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 3" }],
+										},
+									],
+								},
 							],
-							false,
-						),
+						},
 					]);
 				});
 
@@ -271,22 +503,74 @@ describe("Tsdoc node transformation tests", () => {
 					const result = transformTsdocSection(summarySection, transformOptions);
 
 					expect(result).to.deep.equal([
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 1")]),
-								new ListItemNode([new PlainTextNode("Item 2")]),
-								new ListItemNode([new PlainTextNode("Item 3")]),
+						{
+							type: "list",
+							ordered: false,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 1" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 2" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 3" }],
+										},
+									],
+								},
 							],
-							false,
-						),
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 4")]),
-								new ListItemNode([new PlainTextNode("Item 5")]),
-								new ListItemNode([new PlainTextNode("Item 6")]),
+						},
+						{
+							type: "list",
+							ordered: false,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 4" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 5" }],
+										},
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{
+											type: "paragraph",
+											children: [{ type: "text", value: "Item 6" }],
+										},
+									],
+								},
 							],
-							false,
-						),
+						},
 					]);
 				});
 
@@ -305,27 +589,63 @@ describe("Tsdoc node transformation tests", () => {
 					const result = transformTsdocSection(summarySection, transformOptions);
 
 					expect(result).to.deep.equal([
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 1")]),
-								new ListItemNode([new PlainTextNode("Item 2")]),
+						{
+							type: "list",
+							ordered: false,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 1" }] },
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 2" }] },
+									],
+								},
 							],
-							false,
-						),
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 3")]),
-								new ListItemNode([new PlainTextNode("Item 4")]),
+						},
+						{
+							type: "list",
+							ordered: false,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 3" }] },
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 4" }] },
+									],
+								},
 							],
-							false,
-						),
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 5")]),
-								new ListItemNode([new PlainTextNode("Item 6")]),
+						},
+						{
+							type: "list",
+							ordered: false,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 5" }] },
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 6" }] },
+									],
+								},
 							],
-							false,
-						),
+						},
 					]);
 				});
 
@@ -345,16 +665,43 @@ describe("Tsdoc node transformation tests", () => {
 					const result = transformTsdocSection(summarySection, transformOptions);
 
 					expect(result).to.deep.equal([
-						new ListNode(
-							[
-								new ListItemNode([new PlainTextNode("Item 1")]),
-								new ListItemNode([new PlainTextNode("Item 1.a")]),
-								new ListItemNode([new PlainTextNode("Item 1.b")]),
-								new ListItemNode([new PlainTextNode("Item 2")]),
-								new ListItemNode([new PlainTextNode("Item 2.a")]),
+						{
+							type: "list",
+							ordered: false,
+							spread: false,
+							children: [
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 1" }] },
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 1.a" }] },
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 1.b" }] },
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 2" }] },
+									],
+								},
+								{
+									type: "listItem",
+									children: [
+										{ type: "paragraph", children: [{ type: "text", value: "Item 2.a" }] },
+									],
+								},
 							],
-							false,
-						),
+						},
 					]);
 				});
 			});
@@ -379,24 +726,89 @@ describe("Tsdoc node transformation tests", () => {
 				const result = transformTsdocSection(summarySection, transformOptions);
 
 				expect(result).to.deep.equal([
-					new ListNode(
-						[
-							new ListItemNode([new PlainTextNode("Item 1")]),
-							new ListItemNode([new PlainTextNode("Item 2")]),
-							new ListItemNode([new PlainTextNode("Item 3")]),
+					{
+						type: "list",
+						ordered: true,
+						spread: false,
+						children: [
+							{
+								type: "listItem",
+								children: [
+									{ type: "paragraph", children: [{ type: "text", value: "Item 1" }] },
+								],
+							},
+							{
+								type: "listItem",
+								children: [
+									{ type: "paragraph", children: [{ type: "text", value: "Item 2" }] },
+								],
+							},
+							{
+								type: "listItem",
+								children: [
+									{ type: "paragraph", children: [{ type: "text", value: "Item 3" }] },
+								],
+							},
 						],
-						true,
-					),
-					new ListNode(
-						[
-							new ListItemNode([new PlainTextNode("Item 4")]),
-							new ListItemNode([new PlainTextNode("Item 5")]),
+					},
+					{
+						type: "list",
+						ordered: false,
+						spread: false,
+						children: [
+							{
+								type: "listItem",
+								children: [
+									{ type: "paragraph", children: [{ type: "text", value: "Item 4" }] },
+								],
+							},
+							{
+								type: "listItem",
+								children: [
+									{ type: "paragraph", children: [{ type: "text", value: "Item 5" }] },
+								],
+							},
 						],
-						false,
-					),
-					new ListNode([new ListItemNode([new PlainTextNode("Item 6")])], false),
-					new ListNode([new ListItemNode([new PlainTextNode("Item 7")])], true),
-					new ListNode([new ListItemNode([new PlainTextNode("Item 8")])], true),
+					},
+					{
+						type: "list",
+						ordered: false,
+						spread: false,
+						children: [
+							{
+								type: "listItem",
+								children: [
+									{ type: "paragraph", children: [{ type: "text", value: "Item 6" }] },
+								],
+							},
+						],
+					},
+					{
+						type: "list",
+						ordered: true,
+						spread: false,
+						children: [
+							{
+								type: "listItem",
+								children: [
+									{ type: "paragraph", children: [{ type: "text", value: "Item 7" }] },
+								],
+							},
+						],
+					},
+					{
+						type: "list",
+						ordered: true,
+						spread: false,
+						children: [
+							{
+								type: "listItem",
+								children: [
+									{ type: "paragraph", children: [{ type: "text", value: "Item 8" }] },
+								],
+							},
+						],
+					},
 				]);
 			});
 		});
@@ -413,21 +825,43 @@ describe("Tsdoc node transformation tests", () => {
 			const result = transformTsdocSection(summarySection, transformOptions);
 
 			expect(result).to.deep.equal([
-				new ListNode(
-					[
-						new ListItemNode([
-							new PlainTextNode(
-								"This is a list item that is long enough to require soft wrapping. It spans multiple lines, but should still be parsed as a single list item.",
-							),
-						]),
-						new ListItemNode([
-							new PlainTextNode(
-								"This is a second list item, which should end up in the same list as the previous one.",
-							),
-						]),
+				{
+					type: "list",
+					ordered: false,
+					spread: false,
+					children: [
+						{
+							type: "listItem",
+							children: [
+								{
+									type: "paragraph",
+									children: [
+										{
+											type: "text",
+											value:
+												"This is a list item that is long enough to require soft wrapping. It spans multiple lines, but should still be parsed as a single list item.",
+										},
+									],
+								},
+							],
+						},
+						{
+							type: "listItem",
+							children: [
+								{
+									type: "paragraph",
+									children: [
+										{
+											type: "text",
+											value:
+												"This is a second list item, which should end up in the same list as the previous one.",
+										},
+									],
+								},
+							],
+						},
 					],
-					false,
-				),
+				},
 			]);
 		});
 	});

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/Transformation.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/configuration/Transformation.ts
@@ -21,6 +21,8 @@ import type {
 	TableRowNode,
 	ListItemNode,
 	ListNode,
+	MarkdownBlockContentNode,
+	MarkdownPhrasingContentNode,
 } from "../../documentation-domain/index.js";
 import type { TransformationContext } from "../TransformationContext.js";
 import {
@@ -37,6 +39,7 @@ import {
 	tableRowToHtml,
 	listItemToHtml,
 	listToHtml,
+	markdownNodeToHtml,
 } from "../default-transformations/index.js";
 
 /**
@@ -88,6 +91,10 @@ export const defaultTransformations: Transformations = {
 	lineBreak: () => hastLineBreak,
 	link: (node, context) => linkToHtml(node as LinkNode, context),
 	listItem: (node, context) => listItemToHtml(node as ListItemNode, context),
+	markdownBlockContent: (node, context) =>
+		markdownNodeToHtml(node as MarkdownBlockContentNode, context),
+	markdownPhrasingContent: (node, context) =>
+		markdownNodeToHtml(node as MarkdownPhrasingContentNode, context),
 	section: (node, context) => sectionToHtml(node as SectionNode, context),
 	horizontalRule: () => hastHorizontalRule,
 	list: (node, context) => listToHtml(node as ListNode, context),

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/MarkdownNodeToHtml.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/MarkdownNodeToHtml.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { Nodes as HastNodes } from "hast";
+import { toHast } from "mdast-util-to-hast";
+
+import type {
+	MarkdownBlockContentNode,
+	MarkdownPhrasingContentNode,
+} from "../../documentation-domain/index.js";
+import type { TransformationContext } from "../TransformationContext.js";
+
+/**
+ * Transform a {@link MarkdownBlockContentNode} or {@link MarkdownPhrasingContentNode} to HTML.
+ *
+ * @param node - The node to transform.
+ * @param context - See {@link TransformationContext}.
+ */
+export function markdownNodeToHtml(
+	node: MarkdownBlockContentNode | MarkdownPhrasingContentNode,
+	context: TransformationContext,
+): HastNodes {
+	return toHast(node.value);
+}

--- a/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/index.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-html/default-transformations/index.ts
@@ -10,6 +10,7 @@ export { sectionToHtml } from "./SectionToHtml.js";
 export { linkToHtml } from "./LinkToHtml.js";
 export { listItemToHtml } from "./ListItemToHtml.js";
 export { listToHtml } from "./ListToHtml.js";
+export { markdownNodeToHtml } from "./MarkdownNodeToHtml.js";
 export { paragraphToHtml } from "./ParagraphToHtml.js";
 export { plainTextToHtml } from "./PlainTextToHtml.js";
 export { spanToHtml } from "./SpanToHtml.js";

--- a/tools/api-markdown-documenter/src/documentation-domain-to-markdown/configuration/Transformation.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-markdown/configuration/Transformation.ts
@@ -40,6 +40,8 @@ import {
 	tableRowToMarkdown,
 	listToMarkdown,
 	listItemToMarkdown,
+	markdownBlockContentNodeToMarkdown,
+	markdownPhrasingContentNodeToMarkdown,
 } from "../default-transformations/index.js";
 
 /**
@@ -104,6 +106,8 @@ export const defaultTransformations: Transformations = {
 	link: linkToMarkdown,
 	list: listToMarkdown,
 	listItem: listItemToMarkdown,
+	markdownBlockContent: markdownBlockContentNodeToMarkdown,
+	markdownPhrasingContent: markdownPhrasingContentNodeToMarkdown,
 	section: sectionToMarkdown,
 	horizontalRule: horizontalRuleToMarkdown,
 	paragraph: paragraphToMarkdown,

--- a/tools/api-markdown-documenter/src/documentation-domain-to-markdown/default-transformations/MarkdownNodeToMarkdown.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-markdown/default-transformations/MarkdownNodeToMarkdown.ts
@@ -1,0 +1,44 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type {
+	BlockContent as MdastBlockContent,
+	PhrasingContent as MdastPhrasingContent,
+} from "mdast";
+
+import type {
+	BlockContent,
+	MarkdownBlockContentNode,
+	MarkdownPhrasingContentNode,
+	PhrasingContent,
+} from "../../documentation-domain/index.js";
+import { blockContentToMarkdown, phrasingContentToMarkdown } from "../ToMarkdown.js";
+import type { TransformationContext } from "../TransformationContext.js";
+
+/**
+ * Transform a {@link MarkdownBlockContentNode} to Markdown.
+ *
+ * @param node - The node to transform.
+ * @param context - See {@link TransformationContext}.
+ */
+export function markdownBlockContentNodeToMarkdown(
+	node: MarkdownBlockContentNode,
+	context: TransformationContext,
+): MdastBlockContent[] {
+	return blockContentToMarkdown(node.value as BlockContent, context);
+}
+
+/**
+ * Transform a {@link MarkdownPhrasingContentNode} to Markdown.
+ *
+ * @param node - The node to transform.
+ * @param context - See {@link TransformationContext}.
+ */
+export function markdownPhrasingContentNodeToMarkdown(
+	node: MarkdownPhrasingContentNode,
+	context: TransformationContext,
+): MdastPhrasingContent[] {
+	return phrasingContentToMarkdown(node.value as PhrasingContent, context);
+}

--- a/tools/api-markdown-documenter/src/documentation-domain-to-markdown/default-transformations/MarkdownNodeToMarkdown.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-markdown/default-transformations/MarkdownNodeToMarkdown.ts
@@ -9,12 +9,9 @@ import type {
 } from "mdast";
 
 import type {
-	BlockContent,
 	MarkdownBlockContentNode,
 	MarkdownPhrasingContentNode,
-	PhrasingContent,
 } from "../../documentation-domain/index.js";
-import { blockContentToMarkdown, phrasingContentToMarkdown } from "../ToMarkdown.js";
 import type { TransformationContext } from "../TransformationContext.js";
 
 /**
@@ -27,7 +24,7 @@ export function markdownBlockContentNodeToMarkdown(
 	node: MarkdownBlockContentNode,
 	context: TransformationContext,
 ): MdastBlockContent[] {
-	return blockContentToMarkdown(node.value as BlockContent, context);
+	return [node.value];
 }
 
 /**
@@ -40,5 +37,5 @@ export function markdownPhrasingContentNodeToMarkdown(
 	node: MarkdownPhrasingContentNode,
 	context: TransformationContext,
 ): MdastPhrasingContent[] {
-	return phrasingContentToMarkdown(node.value as PhrasingContent, context);
+	return [node.value];
 }

--- a/tools/api-markdown-documenter/src/documentation-domain-to-markdown/default-transformations/TableCellToMarkdown.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-markdown/default-transformations/TableCellToMarkdown.ts
@@ -50,7 +50,7 @@ function transformCellContent(
 ): [MdastPhrasingContent] {
 	// Since our library supports block content under table cells, but Markdown does not,
 	// we need to wrap contents that are not simple phrasing content as HTML.
-	if (["text", "codeSpan", "link", "span"].includes(node.type)) {
+	if (["text", "codeSpan", "link", "span", "markdownPhrasingContent"].includes(node.type)) {
 		return phrasingContentToMarkdown(node as PhrasingContent, context);
 	}
 

--- a/tools/api-markdown-documenter/src/documentation-domain-to-markdown/default-transformations/index.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain-to-markdown/default-transformations/index.ts
@@ -11,6 +11,10 @@ export { lineBreakToMarkdown } from "./LineBreakToMarkdown.js";
 export { linkToMarkdown } from "./LinkToMarkdown.js";
 export { listToMarkdown } from "./ListToMarkdown.js";
 export { listItemToMarkdown } from "./ListItemToMarkdown.js";
+export {
+	markdownBlockContentNodeToMarkdown,
+	markdownPhrasingContentNodeToMarkdown,
+} from "./MarkdownNodeToMarkdown.js";
 export { paragraphToMarkdown } from "./ParagraphToMarkdown.js";
 export { plainTextToMarkdown } from "./PlainTextToMarkdown.js";
 export { sectionToMarkdown } from "./SectionToMarkdown.js";

--- a/tools/api-markdown-documenter/src/documentation-domain/BlockContent.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/BlockContent.ts
@@ -6,6 +6,7 @@
 import type { FencedCodeBlockNode } from "./FencedCodeBlockNode.js";
 import type { HorizontalRuleNode } from "./HorizontalRuleNode.js";
 import type { ListNode } from "./ListNode.js";
+import type { MarkdownBlockContentNode } from "./MarkdownNode.js";
 import type { ParagraphNode } from "./ParagraphNode.js";
 import type { TableNode } from "./TableNode.js";
 
@@ -38,6 +39,7 @@ export interface BlockContentMap {
 	list: ListNode;
 	paragraph: ParagraphNode;
 	table: TableNode;
+	markdownBlockContent: MarkdownBlockContentNode;
 }
 
 /**

--- a/tools/api-markdown-documenter/src/documentation-domain/MarkdownNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/MarkdownNode.ts
@@ -1,0 +1,69 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type {
+	BlockContent as MdastBlockContent,
+	PhrasingContent as MdastPhrasingContent,
+} from "mdast";
+
+import { DocumentationLiteralNodeBase } from "./DocumentationNode.js";
+
+/**
+ * A {@link DocumentationNode} that wraps an `mdast` "Block content" tree.
+ *
+ * @remarks
+ *
+ * This type exists as a temporary solution while this library is migrated to using `mdast` directly (replacing the entire `DocumentationNode` domain).
+ * It will eventually be removed, along with the rest of this domain.
+ *
+ * @sealed
+ * @public
+ */
+export class MarkdownBlockContentNode extends DocumentationLiteralNodeBase<MdastBlockContent> {
+	/**
+	 * {@inheritDoc DocumentationNode."type"}
+	 */
+	public readonly type = "markdownBlockContent";
+
+	/**
+	 * {@inheritDoc DocumentationNode.isEmpty}
+	 */
+	public get isEmpty(): boolean {
+		return false; // Not well defined
+	}
+
+	public constructor(value: MdastBlockContent) {
+		super(value);
+	}
+}
+
+/**
+ * A {@link DocumentationNode} that wraps an `mdast` "Phrasing content" tree.
+ *
+ * @remarks
+ *
+ * This type exists as a temporary solution while this library is migrated to using `mdast` directly (replacing the entire `DocumentationNode` domain).
+ * It will eventually be removed, along with the rest of this domain.
+ *
+ * @sealed
+ * @public
+ */
+export class MarkdownPhrasingContentNode extends DocumentationLiteralNodeBase<MdastPhrasingContent> {
+	/**
+	 * {@inheritDoc DocumentationNode."type"}
+	 */
+	public readonly type = "markdownPhrasingContent";
+
+	/**
+	 * {@inheritDoc DocumentationNode.isEmpty}
+	 */
+	public get isEmpty(): boolean {
+		return false; // Not well defined
+	}
+
+	public constructor(value: MdastPhrasingContent) {
+		super(value);
+	}
+}

--- a/tools/api-markdown-documenter/src/documentation-domain/PhrasingContent.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/PhrasingContent.ts
@@ -6,6 +6,7 @@
 import type { CodeSpanNode } from "./CodeSpanNode.js";
 import type { LineBreakNode } from "./LineBreakNode.js";
 import type { LinkNode } from "./LinkNode.js";
+import type { MarkdownPhrasingContentNode } from "./MarkdownNode.js";
 import type { PlainTextNode } from "./PlainTextNode.js";
 import type { SpanNode } from "./SpanNode.js";
 
@@ -37,6 +38,7 @@ export interface PhrasingContentMap {
 	link: LinkNode;
 	span: SpanNode;
 	text: PlainTextNode;
+	markdownPhrasingContent: MarkdownPhrasingContentNode;
 }
 
 /**

--- a/tools/api-markdown-documenter/src/documentation-domain/index.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/index.ts
@@ -37,6 +37,7 @@ export { LineBreakNode } from "./LineBreakNode.js";
 export { LinkNode } from "./LinkNode.js";
 export { ListItemNode } from "./ListItemNode.js";
 export { ListNode } from "./ListNode.js";
+export { MarkdownBlockContentNode, MarkdownPhrasingContentNode } from "./MarkdownNode.js";
 export { ParagraphNode } from "./ParagraphNode.js";
 export type { PhrasingContent, PhrasingContentMap } from "./PhrasingContent.js";
 export { PlainTextNode } from "./PlainTextNode.js";

--- a/tools/api-markdown-documenter/src/index.ts
+++ b/tools/api-markdown-documenter/src/index.ts
@@ -57,6 +57,8 @@ export {
 	LinkNode,
 	ListItemNode,
 	ListNode,
+	MarkdownBlockContentNode,
+	MarkdownPhrasingContentNode,
 	ParagraphNode,
 	type PhrasingContent,
 	type PhrasingContentMap,

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/index.html
@@ -29,13 +29,15 @@
         <ul>
           <li>Good link (no alias): <a href="/test-suite-a/testclass-class/">TestClass</a></li>
           <li>Good link (with alias): <a href="/test-suite-a/testfunction-function">function alias text</a></li>
-          <li>Bad link (no alias): <i>InvalidItem</i></li>
-          <li>Bad link (with alias): <i>even though I link to an invalid item, I would still like this text to be rendered</i></li>
+          <li>Bad link (no alias): <em>InvalidItem</em></li>
+          <li>Bad link (with alias): <em>even though I link to an invalid item, I would still like this text to be rendered</em></li>
         </ul>
       </section>
       <section>
         <h2 id="test-suite-a-example">Example</h2>
-        <p>A test example</p><code>const foo = bar;</code>
+        <p>A test example</p>
+        <pre><code class="language-typescript">const foo = bar;
+</code></pre>
       </section>
       <section>
         <h2>Interfaces</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/_constructor_-constructor.html
@@ -10,7 +10,7 @@
         <p><a href="/">Packages</a> > <a href="/test-suite-a/">test-suite-a</a> > <a href="/test-suite-a/testabstractclass-class/">TestAbstractClass</a> > <a href="/test-suite-a/testabstractclass-class/_constructor_-constructor">(constructor)(privateProperty, protectedProperty)</a></p>
       </section>
       <section>
-        <p>This is a <i>{@customTag constructor}</i>.</p>
+        <p>This is a <em>{@customTag constructor}</em>.</p>
       </section>
       <section>
         <h2 id="_constructor_-signature">Signature</h2><code>protected constructor(privateProperty: number, protectedProperty: TestEnum);</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testabstractclass-class/index.html
@@ -27,7 +27,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class/_constructor_-constructor">(constructor)(privateProperty, protectedProperty)</a></td>
-              <td>This is a <i>{@customTag constructor}</i>.</td>
+              <td>This is a <em>{@customTag constructor}</em>.</td>
             </tr>
           </tbody>
         </table>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testenum-enum/index.html
@@ -23,11 +23,15 @@
         <h2 id="testenum-examples">Examples</h2>
         <section>
           <h3 id="testenum-example1">Example 1</h3>
-          <p>Some example</p><code>const foo = TestEnum.TestEnumValue1</code>
+          <p>Some example</p>
+          <pre><code class="language-typescript">const foo = TestEnum.TestEnumValue1
+</code></pre>
         </section>
         <section>
           <h3 id="testenum-example2">Example 2</h3>
-          <p>Another example</p><code>const bar = TestEnum.TestEnumValue2</code>
+          <p>Another example</p>
+          <pre><code class="language-ts">const bar = TestEnum.TestEnumValue2
+</code></pre>
         </section>
       </section>
       <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/deep-config/test-suite-a/testnamespace-namespace/index.html
@@ -22,10 +22,20 @@
       <section>
         <h2 id="testnamespace-examples">Examples</h2>
         <section>
-          <h3 id="testnamespace-example1">Example: TypeScript Example</h3><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          <h3 id="testnamespace-example1">Example: TypeScript Example</h3>
+          <pre><code class="language-typescript">const foo: Foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
+</code></pre>
         </section>
         <section>
-          <h3 id="testnamespace-example2">Example: JavaScript Example</h3><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          <h3 id="testnamespace-example2">Example: JavaScript Example</h3>
+          <pre><code class="language-javascript">const foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
+</code></pre>
         </section>
       </section>
       <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/index.html
@@ -29,13 +29,15 @@
         <ul>
           <li>Good link (no alias): <a href="/test-suite-a/testclass-class">TestClass</a></li>
           <li>Good link (with alias): <a href="/test-suite-a/#testfunction-function">function alias text</a></li>
-          <li>Bad link (no alias): <i>InvalidItem</i></li>
-          <li>Bad link (with alias): <i>even though I link to an invalid item, I would still like this text to be rendered</i></li>
+          <li>Bad link (no alias): <em>InvalidItem</em></li>
+          <li>Bad link (with alias): <em>even though I link to an invalid item, I would still like this text to be rendered</em></li>
         </ul>
       </section>
       <section>
         <h2 id="test-suite-a-example">Example</h2>
-        <p>A test example</p><code>const foo = bar;</code>
+        <p>A test example</p>
+        <pre><code class="language-typescript">const foo = bar;
+</code></pre>
       </section>
       <section>
         <h2>Interfaces</h2>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testabstractclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testabstractclass-class.html
@@ -27,7 +27,7 @@
           <tbody>
             <tr>
               <td><a href="/test-suite-a/testabstractclass-class#_constructor_-constructor">(constructor)(privateProperty, protectedProperty)</a></td>
-              <td>This is a <i>{@customTag constructor}</i>.</td>
+              <td>This is a <em>{@customTag constructor}</em>.</td>
             </tr>
           </tbody>
         </table>
@@ -100,7 +100,7 @@
         <section>
           <h3 id="_constructor_-constructor">(constructor)</h3>
           <section>
-            <p>This is a <i>{@customTag constructor}</i>.</p>
+            <p>This is a <em>{@customTag constructor}</em>.</p>
           </section>
           <section>
             <h4 id="_constructor_-signature">Signature</h4><code>protected constructor(privateProperty: number, protectedProperty: TestEnum);</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testenum-enum.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testenum-enum.html
@@ -23,11 +23,15 @@
         <h2 id="testenum-examples">Examples</h2>
         <section>
           <h3 id="testenum-example1">Example 1</h3>
-          <p>Some example</p><code>const foo = TestEnum.TestEnumValue1</code>
+          <p>Some example</p>
+          <pre><code class="language-typescript">const foo = TestEnum.TestEnumValue1
+</code></pre>
         </section>
         <section>
           <h3 id="testenum-example2">Example 2</h3>
-          <p>Another example</p><code>const bar = TestEnum.TestEnumValue2</code>
+          <p>Another example</p>
+          <pre><code class="language-ts">const bar = TestEnum.TestEnumValue2
+</code></pre>
         </section>
       </section>
       <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/test-suite-a/testnamespace-namespace/index.html
@@ -22,10 +22,20 @@
       <section>
         <h2 id="testnamespace-examples">Examples</h2>
         <section>
-          <h3 id="testnamespace-example1">Example: TypeScript Example</h3><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          <h3 id="testnamespace-example1">Example: TypeScript Example</h3>
+          <pre><code class="language-typescript">const foo: Foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
+</code></pre>
         </section>
         <section>
-          <h3 id="testnamespace-example2">Example: JavaScript Example</h3><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          <h3 id="testnamespace-example2">Example: JavaScript Example</h3>
+          <pre><code class="language-javascript">const foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
+</code></pre>
         </section>
       </section>
       <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/test-suite-a.html
@@ -26,14 +26,16 @@
       <p>Also, here is a link test, including a bad link, because we should have some reasonable support if this happens:</p>
       <ul>
         <li>Good link (no alias): <a href="docs/test-suite-a#testclass-class">TestClass</a></li>
-        <li>Good link (with alias): <i>function alias text</i></li>
-        <li>Bad link (no alias): <i>InvalidItem</i></li>
-        <li>Bad link (with alias): <i>even though I link to an invalid item, I would still like this text to be rendered</i></li>
+        <li>Good link (with alias): <em>function alias text</em></li>
+        <li>Bad link (no alias): <em>InvalidItem</em></li>
+        <li>Bad link (with alias): <em>even though I link to an invalid item, I would still like this text to be rendered</em></li>
       </ul>
     </section>
     <section>
       <h1 id="test-suite-a-example">Example</h1>
-      <p>A test example</p><code>const foo = bar;</code>
+      <p>A test example</p>
+      <pre><code class="language-typescript">const foo = bar;
+</code></pre>
     </section>
     <section>
       <h1>Interfaces</h1>
@@ -721,7 +723,7 @@
             <tbody>
               <tr>
                 <td><a href="docs/test-suite-a#testabstractclass-_constructor_-constructor">(constructor)(privateProperty, protectedProperty)</a></td>
-                <td>This is a <i>{@customTag constructor}</i>.</td>
+                <td>This is a <em>{@customTag constructor}</em>.</td>
               </tr>
             </tbody>
           </table>
@@ -794,7 +796,7 @@
           <section>
             <h4 id="testabstractclass-_constructor_-constructor">(constructor)</h4>
             <section>
-              <p>This is a <i>{@customTag constructor}</i>.</p>
+              <p>This is a <em>{@customTag constructor}</em>.</p>
             </section>
             <section>
               <h5 id="_constructor_-signature">Signature</h5><code>protected constructor(privateProperty: number, protectedProperty: TestEnum);</code>
@@ -1312,11 +1314,15 @@
           <h3 id="testenum-examples">Examples</h3>
           <section>
             <h4 id="testenum-example1">Example 1</h4>
-            <p>Some example</p><code>const foo = TestEnum.TestEnumValue1</code>
+            <p>Some example</p>
+            <pre><code class="language-typescript">const foo = TestEnum.TestEnumValue1
+</code></pre>
           </section>
           <section>
             <h4 id="testenum-example2">Example 2</h4>
-            <p>Another example</p><code>const bar = TestEnum.TestEnumValue2</code>
+            <p>Another example</p>
+            <pre><code class="language-ts">const bar = TestEnum.TestEnumValue2
+</code></pre>
           </section>
         </section>
         <section>
@@ -1617,10 +1623,20 @@
         <section>
           <h3 id="testnamespace-examples">Examples</h3>
           <section>
-            <h4 id="testnamespace-example1">Example: TypeScript Example</h4><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+            <h4 id="testnamespace-example1">Example: TypeScript Example</h4>
+            <pre><code class="language-typescript">const foo: Foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
+</code></pre>
           </section>
           <section>
-            <h4 id="testnamespace-example2">Example: JavaScript Example</h4><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+            <h4 id="testnamespace-example2">Example: JavaScript Example</h4>
+            <pre><code class="language-javascript">const foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
+</code></pre>
           </section>
         </section>
         <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/index.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/index.html
@@ -25,14 +25,16 @@
         <p>Also, here is a link test, including a bad link, because we should have some reasonable support if this happens:</p>
         <ul>
           <li>Good link (no alias): <a href="docs/test-suite-a/testclass-class">TestClass</a></li>
-          <li>Good link (with alias): <i>function alias text</i></li>
-          <li>Bad link (no alias): <i>InvalidItem</i></li>
-          <li>Bad link (with alias): <i>even though I link to an invalid item, I would still like this text to be rendered</i></li>
+          <li>Good link (with alias): <em>function alias text</em></li>
+          <li>Bad link (no alias): <em>InvalidItem</em></li>
+          <li>Bad link (with alias): <em>even though I link to an invalid item, I would still like this text to be rendered</em></li>
         </ul>
       </section>
       <section>
         <h3 id="test-suite-a-example">Example</h3>
-        <p>A test example</p><code>const foo = bar;</code>
+        <p>A test example</p>
+        <pre><code class="language-typescript">const foo = bar;
+</code></pre>
       </section>
       <section>
         <h3>Interfaces</h3>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-_constructor_-constructor.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-_constructor_-constructor.html
@@ -7,7 +7,7 @@
     <section>
       <h2>(constructor)</h2>
       <section>
-        <p>This is a <i>{@customTag constructor}</i>.</p>
+        <p>This is a <em>{@customTag constructor}</em>.</p>
       </section>
       <section>
         <h3 id="_constructor_-signature">Signature</h3><code>protected constructor(privateProperty: number, protectedProperty: TestEnum);</code>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testabstractclass-class.html
@@ -24,7 +24,7 @@
           <tbody>
             <tr>
               <td><a href="docs/test-suite-a/testabstractclass-_constructor_-constructor">(constructor)(privateProperty, protectedProperty)</a></td>
-              <td>This is a <i>{@customTag constructor}</i>.</td>
+              <td>This is a <em>{@customTag constructor}</em>.</td>
             </tr>
           </tbody>
         </table>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testenum-enum.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testenum-enum.html
@@ -20,11 +20,15 @@
         <h3 id="testenum-examples">Examples</h3>
         <section>
           <h4 id="testenum-example1">Example 1</h4>
-          <p>Some example</p><code>const foo = TestEnum.TestEnumValue1</code>
+          <p>Some example</p>
+          <pre><code class="language-typescript">const foo = TestEnum.TestEnumValue1
+</code></pre>
         </section>
         <section>
           <h4 id="testenum-example2">Example 2</h4>
-          <p>Another example</p><code>const bar = TestEnum.TestEnumValue2</code>
+          <p>Another example</p>
+          <pre><code class="language-ts">const bar = TestEnum.TestEnumValue2
+</code></pre>
         </section>
       </section>
       <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-namespace.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/test-suite-a/testnamespace-namespace.html
@@ -19,10 +19,20 @@
       <section>
         <h3 id="testnamespace-examples">Examples</h3>
         <section>
-          <h4 id="testnamespace-example1">Example: TypeScript Example</h4><code>const foo: Foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          <h4 id="testnamespace-example1">Example: TypeScript Example</h4>
+          <pre><code class="language-typescript">const foo: Foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
+</code></pre>
         </section>
         <section>
-          <h4 id="testnamespace-example2">Example: JavaScript Example</h4><code>const foo = {<br>bar: "Hello world!";<br>baz = 42;<br>};</code>
+          <h4 id="testnamespace-example2">Example: JavaScript Example</h4>
+          <pre><code class="language-javascript">const foo = {
+	bar: "Hello world!";
+	baz = 42;
+};
+</code></pre>
         </section>
       </section>
       <section>


### PR DESCRIPTION
First step in migration to replace documentation domain with `mdast` outright.

1. Adds `DocumentationNode` implementations that wrap `mdast` trees (separate types for block and phrasing content to ensure we preserve the associated invariants there).
2. Adds `toMarkdown` and `toHtml` handlers for these new node types.
  - `toMarkdown` is trivially implemented by just returning the wrapped `mdast` tree.
  - `toHtml` is handled via [mdast-util-to-hast](https://github.com/syntax-tree/mdast-util-to-hast).
3. Update TSDoc node transformations to generate `mdast` trees rather than `DocumentationNode` trees.