### PR TITLE
fix(tree): boundary condition for usage of new DetachedFieldIndex format

### DIFF
--- a/.changeset/silver-suns-shop.md
+++ b/.changeset/silver-suns-shop.md
@@ -9,9 +9,9 @@ Before this release, attaching a SharedTree instance to an already attached cont
 (This is the case when nodes are removed before attaching and there is a local branch that forks from a commit that made such a removal or from an earlier commit. This is also the case when retaining `Revertible` objects for those commits).
 
 After this release, the behavior depends on the `CodecWriteOptions.oldestCompatibleClient` value:
-* For values <= `FluidClientVersion.v2_52`, the behavior is the same.
-* For values > `FluidClientVersion.v2_52`, the attach will succeed, but use a newer storage format.
+* For values < `FluidClientVersion.v2_52`, the behavior is the same.
+* For values >= `FluidClientVersion.v2_52`, the attach will succeed, but use a newer storage format.
 
-Applications should take care to saturate their clients with FF version `2.52` (or greater) before using a `CodecWriteOptions.oldestCompatibleClient` that is greater than `FluidClientVersion.v2_52`.
-Failure to do so may lead clients with `CodecWriteOptions.oldestCompatibleClient` greater than `FluidClientVersion.v2_52` to attach SharedTree instances using a storage format that is not supported by FF versions before `2.52`.
+Applications should take care to saturate their clients with FF version `2.52` (or greater) before using a `CodecWriteOptions.oldestCompatibleClient` that is equal to or greater than `FluidClientVersion.v2_52`.
+Failure to do so may lead clients with `CodecWriteOptions.oldestCompatibleClient` equal to or greater than `FluidClientVersion.v2_52` to attach SharedTree instances using a storage format that is not supported by FF versions before `2.52`.
 This means that application versions using FF versions before `2.52` will be unable to open documents where such an operation has happened.

--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodecs.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodecs.ts
@@ -28,7 +28,7 @@ export function makeDetachedFieldIndexCodec(
 ): IJsonCodec<DetachedFieldSummaryData> {
 	const family = makeDetachedFieldIndexCodecFamily(revisionTagCodec, options, idCompressor);
 	const writeVersion =
-		options.oldestCompatibleClient <= FluidClientVersion.v2_52 ? version1 : version2;
+		options.oldestCompatibleClient < FluidClientVersion.v2_52 ? version1 : version2;
 	return makeVersionDispatchingCodec(family, { ...options, writeVersion });
 }
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -2367,7 +2367,7 @@ describe("SharedTree", () => {
 		const sharedObject = configuredSharedTree({
 			jsonValidator: typeboxValidator,
 			forest: ForestTypeExpensiveDebug,
-			oldestCompatibleClient: FluidClientVersion.EnableUnstableFeatures,
+			oldestCompatibleClient: FluidClientVersion.v2_52,
 		}) as SharedObjectKind<ISharedTree> & ISharedObjectKind<ISharedTree>;
 		const tree = sharedObject.getFactory().create(runtime, "tree");
 		const runtimeFactory = new MockContainerRuntimeFactory();


### PR DESCRIPTION
## Description

Amends the logic that decides when to use the new `DetachedFieldIndex` format. Before this change `CodecWriteOptions.oldestCompatibleClient` had to be set to a value greater than `FluidClientVersion.v2_52`. After this change, it has to be set to a value equal to or greater than `FluidClientVersion.v2_52`.

## Breaking Changes

The new format will now be used in situations where it wasn't before. This should not be a problem since no public release has been made since the new format was introduced.
