### PR TITLE
improvement(matrix): Throw if removal range is out-of-bounds

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -133,32 +133,32 @@ export interface ISharedMatrix<T = any>
 	 * Inserts columns into the matrix.
 	 * @param colStart - Index of the first column to insert.
 	 * @param count - Number of columns to insert.
-	 * @remarks
-	 * Inserting 0 columns is a noop.
+	 * @remarks Inserting 0 columns is a noop.
+	 * @throws Throws an error if the start index is out of bounds.
 	 */
 	insertCols(colStart: number, count: number): void;
 	/**
 	 * Removes columns from the matrix.
 	 * @param colStart - Index of the first column to remove.
 	 * @param count - Number of columns to remove.
-	 * @remarks
-	 * Removing 0 columns is a noop.
+	 * @remarks Removing 0 columns is a noop.
+	 * @throws Throws an error if the range is out of bounds.
 	 */
 	removeCols(colStart: number, count: number): void;
 	/**
 	 * Inserts rows into the matrix.
 	 * @param rowStart - Index of the first row to insert.
 	 * @param count - Number of rows to insert.
-	 * @remarks
-	 * Inserting 0 rows is a noop.
+	 * @remarks Inserting 0 rows is a noop.
+	 * @throws Throws an error if the start index is out of bounds.
 	 */
 	insertRows(rowStart: number, count: number): void;
 	/**
 	 * Removes rows from the matrix.
 	 * @param rowStart - Index of the first row to remove.
 	 * @param count - Number of rows to remove.
-	 * @remarks
-	 * Removing 0 rows is a noop.
+	 * @remarks Removing 0 rows is a noop.
+	 * @throws Throws an error if the range is out of bounds.
 	 */
 	removeRows(rowStart: number, count: number): void;
 
@@ -584,7 +584,7 @@ export class SharedMatrix<T = any>
 		if (count === 0) {
 			return;
 		}
-		if (colStart > this.colCount) {
+		if (colStart < 0 || colStart > this.colCount) {
 			throw new UsageError("insertCols: out of bounds");
 		}
 		this.protectAgainstReentrancy(() => {
@@ -598,7 +598,7 @@ export class SharedMatrix<T = any>
 		if (count === 0) {
 			return;
 		}
-		if (colStart > this.colCount) {
+		if (colStart < 0 || colStart > this.colCount || colStart + count > this.colCount) {
 			throw new UsageError("removeCols: out of bounds");
 		}
 		this.protectAgainstReentrancy(() =>
@@ -614,7 +614,7 @@ export class SharedMatrix<T = any>
 		if (count === 0) {
 			return;
 		}
-		if (rowStart > this.rowCount) {
+		if (rowStart < 0 || rowStart > this.rowCount) {
 			throw new UsageError("insertRows: out of bounds");
 		}
 		this.protectAgainstReentrancy(() => {
@@ -628,7 +628,7 @@ export class SharedMatrix<T = any>
 		if (count === 0) {
 			return;
 		}
-		if (rowStart > this.rowCount) {
+		if (rowStart < 0 || rowStart > this.rowCount || rowStart + count > this.rowCount) {
 			throw new UsageError("removeRows: out of bounds");
 		}
 		this.protectAgainstReentrancy(() =>

--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -260,6 +260,22 @@ describe("Matrix1", () => {
 
 					matrix.insertCols(1, 1);
 					await expect([[0, undefined, 1]]);
+
+					assert.throws(() => matrix.insertCols(-1, 1), /insertCols: out of bounds/);
+					assert.throws(() => matrix.insertCols(5, 1), /insertCols: out of bounds/);
+				});
+
+				it("column removal", () => {
+					matrix.insertCols(0, 3);
+					assert.equal(matrix.colCount, 3);
+
+					assert.throws(() => matrix.removeCols(-1, 1), /removeCols: out of bounds/);
+					assert.throws(() => matrix.removeCols(5, 1), /removeCols: out of bounds/);
+					assert.throws(() => matrix.removeCols(2, 5), /removeCols: out of bounds/);
+					assert.equal(matrix.colCount, 3);
+
+					matrix.removeCols(1, 1);
+					assert.equal(matrix.colCount, 2);
 				});
 
 				// Vet that we can insert a row in a 2x1 matrix.
@@ -274,6 +290,22 @@ describe("Matrix1", () => {
 
 					matrix.insertRows(1, 1);
 					await expect([[0], [undefined], [1]]);
+
+					assert.throws(() => matrix.insertRows(-1, 1), /insertRows: out of bounds/);
+					assert.throws(() => matrix.insertRows(5, 1), /insertRows: out of bounds/);
+				});
+
+				it("row removal", () => {
+					matrix.insertRows(0, 3);
+					assert.equal(matrix.rowCount, 3);
+
+					assert.throws(() => matrix.removeRows(-1, 1), /removeRows: out of bounds/);
+					assert.throws(() => matrix.removeRows(5, 1), /removeRows: out of bounds/);
+					assert.throws(() => matrix.removeRows(2, 5), /removeRows: out of bounds/);
+					assert.equal(matrix.rowCount, 3);
+
+					matrix.removeRows(1, 1);
+					assert.equal(matrix.rowCount, 2);
 				});
 
 				// Vets that the matrix correctly handles noncontiguous handles when allocating a range


### PR DESCRIPTION
Also adds unit tests to prevent regressions.

While this could be construed as a breaking change, it seems like a safe one to make. If users are violating these constraints, that likely indicates a bug in their code.