### PR TITLE
Remove attachAndGetPendingBlobs

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1898,7 +1898,7 @@ export class ContainerRuntime
 			routeContext: this.handleContext,
 			blobManagerLoadInfo,
 			storage: this.storage,
-			sendBlobAttachOp: (localId: string, blobId?: string) => {
+			sendBlobAttachOp: (localId: string, blobId: string) => {
 				if (!this.disposed) {
 					this.submit(
 						{ type: ContainerMessageType.BlobAttach, contents: undefined },

--- a/packages/runtime/container-runtime/src/metadata.ts
+++ b/packages/runtime/container-runtime/src/metadata.ts
@@ -46,9 +46,17 @@ export interface IBatchMetadata {
  * Blob handling makes assumptions about what might be on the metadata. This interface codifies those assumptions, but does not validate them.
  */
 export interface IBlobMetadata {
-	blobId?: string;
-	localId?: string;
+	blobId: string;
+	localId: string;
 }
+
+export const isBlobMetadata = (metadata: unknown): metadata is IBlobMetadata => {
+	return (
+		!!metadata &&
+		typeof (metadata as IBlobMetadata).blobId === "string" &&
+		typeof (metadata as IBlobMetadata).localId === "string"
+	);
+};
 
 /**
  * ContainerRuntime needs to know if this is a replayed savedOp as those need to be skipped in stashed ops scenarios.

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -270,7 +270,7 @@ export class MockRuntime
 	}
 
 	public async processStashed(processStashedWithRetry?: boolean): Promise<void> {
-		const uploadP = this.blobManager.stashedBlobsUploadP;
+		// const uploadP = this.blobManager.stashedBlobsUploadP;
 		this.processing = true;
 		if (processStashedWithRetry) {
 			await this.processBlobs(false, false, 0);
@@ -281,7 +281,7 @@ export class MockRuntime
 		} else {
 			await this.processBlobs(true);
 		}
-		await uploadP;
+		// await uploadP;
 		this.processing = false;
 	}
 

--- a/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.stashed.spec.ts
@@ -89,7 +89,8 @@ describe("BlobManager.stashed", () => {
 		assert.strictEqual(blobManager.hasPendingStashedUploads(), false);
 	});
 
-	it("Stashed blob", async () => {
+	// ADO#44999: Update for placeholder pending blob creation and getPendingLocalState
+	it.skip("Stashed blob", async () => {
 		const createResponse = new Deferred<ICreateBlobResponse>();
 		const blobManager = createBlobManager({
 			sendBlobAttachOp(_localId, _storageId) {},
@@ -117,7 +118,8 @@ describe("BlobManager.stashed", () => {
 		assert.strictEqual(blobManager2.hasPendingStashedUploads(), true);
 	});
 
-	it("Process blob and complete stashed upload after", async () => {
+	// ADO#44999: Update for placeholder pending blob creation and getPendingLocalState
+	it.skip("Process blob and complete stashed upload after", async () => {
 		const createResponse = new Deferred<ICreateBlobResponse>();
 		const blobManager = createBlobManager({
 			sendBlobAttachOp(_localId, _storageId) {},

--- a/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/getPendingBlobs.spec.ts
@@ -16,7 +16,8 @@ import type { IPendingBlobs } from "../blobManager/index.js";
 
 import { MockRuntime, validateSummary } from "./blobManager.spec.js";
 
-describe("getPendingLocalState", () => {
+// ADO#44999: Update for placeholder pending blob creation and getPendingLocalState
+describe.skip("getPendingLocalState with blobs", () => {
 	let runtime: MockRuntime;
 	let mc: MonitoringContext;
 


### PR DESCRIPTION
[AB#45409](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/45409) and continuation of #25108

This removes the implementation of attachAndGetPendingBlobs.  It also removes a few members that were specific to tracking the state of that flow (stopAttaching, pendingStashedBlobs, stashedBlobsUploadP, hasPendingStashedUploads) - some of these will have equivalents with payload pending handles, but the flow will be different enough that we don't need to keep the old ones.

This change also guts several tests for this old functionality, particularly those that require those members to inspect/verify the BlobManager's internal state.  I stop short of removing the tests entirely because they are good scenarios to cover with payload pending handles, and I instead just clarify the scenario they were testing in their description and skip them.  I'll reimplement these as the payload pending support comes online.

Aside from removing the unsupported flow, this permits us to make a few other improvements.  IBlobMetadata members become non-nullable (the blobId could have been undefined in the old flow).  sendBlobAttachOp gets non-nullable params for the same reason.  We can type-assert the metadata earlier and more strongly.  All of these combine to simplify the implementations of reSubmit and processBlobAttachMessage.