### PR TITLE
Cleanup related to schema annotations

### DIFF
--- a/packages/dds/tree/.vscode/settings.json
+++ b/packages/dds/tree/.vscode/settings.json
@@ -23,7 +23,6 @@
 		"contravariantly",
 		"covariantly",
 		"deprioritized",
-		"enablable",
 		"endregion",
 		"fluidframework",
 		"insertable",

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1547,7 +1547,7 @@ const typeNameSymbol: unique symbol;
 export const typeSchemaSymbol: unique symbol;
 
 // @alpha @system
-export type UnannotateAllowedType<T extends AnnotatedAllowedType> = T extends AnnotatedAllowedType<infer X> ? [X] : T;
+export type UnannotateAllowedType<T extends AnnotatedAllowedType | LazyItem<TreeNodeSchema>> = T extends AnnotatedAllowedType<infer X> ? [X] : T;
 
 // @alpha @system
 export type UnannotateAllowedTypeOrLazyItem<T extends AnnotatedAllowedType | LazyItem<TreeNodeSchema>> = T extends AnnotatedAllowedType<infer X> ? X : T;

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -53,6 +53,7 @@ import {
 	type FieldSchema,
 	toStoredSchema,
 	tryDisposeTreeNode,
+	FieldSchemaAlpha,
 	TreeViewConfigurationAlpha,
 } from "../simple-tree/index.js";
 import {
@@ -317,12 +318,16 @@ export class SchematizingSimpleTreeView<
 				this.nodeKeyManager,
 			);
 			assert(!slots.has(SimpleContextSlot), 0xa47 /* extra simple tree context */);
+			assert(
+				this.rootFieldSchema instanceof FieldSchemaAlpha,
+				"all field schema should be FieldSchemaAlpha",
+			);
 			slots.set(
 				SimpleContextSlot,
 				new HydratedContext(
 					this.flexTreeContext,
 					HydratedContext.schemaMapFromRootSchema(
-						normalizeFieldSchema(this.rootFieldSchema).annotatedAllowedTypesNormalized,
+						this.rootFieldSchema.annotatedAllowedTypesNormalized,
 					),
 				),
 			);

--- a/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
@@ -150,7 +150,7 @@ export class SchemaCompatibilityTester {
 						// View schema has added a node type that the stored schema doesn't know about.
 						// Note that all cases which trigger this should also trigger an AllowedTypeDiscrepancy (where the type is used).
 						// This means this case should be redundant and could be removed in the future if there is a reason to do so
-						// (like simplifying enablable type support).
+						// (like simplifying staged type support).
 						// See the TODO in getAllowedContentDiscrepancies.
 						canView = false;
 					} else if (discrepancy.view === undefined) {
@@ -189,6 +189,9 @@ export class SchemaCompatibilityTester {
 			}
 		}
 
+		// If "canUpgrade" is true, then an upgrade, if done it would set the stored schema to `toStoredSchema(this.viewSchema.root)`.
+		// For that to be valid, that operation must not decrease the set of documents which are allowed by the stored schema:
+		// If it did, then the upgrade could cause the document to become out of schema, and thus invalid/corrupted.
 		if (canUpgrade) {
 			assert(
 				allowsRepoSuperset(policy, stored, toStoredSchema(this.viewSchema.root)),

--- a/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
+++ b/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
@@ -379,9 +379,7 @@ export function checkForUninitializedSchema(
 ): void {
 	if (schema === undefined) {
 		throw new UsageError(
-			`Encountered an undefined schema.
-			This could indicate that some referenced schema has not yet been instantiated.
-			Consider using a lazy schema reference (like "() => schema") or delaying the evaluation of the lazy reference if one is already being used.`,
+			`Encountered an undefined schema. This could indicate that some referenced schema has not yet been instantiated. Consider using a lazy schema reference (like "() => schema") or delaying the evaluation of the lazy reference if one is already being used.`
 		);
 	}
 }

--- a/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
+++ b/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
@@ -379,7 +379,7 @@ export function checkForUninitializedSchema(
 ): void {
 	if (schema === undefined) {
 		throw new UsageError(
-			`Encountered an undefined schema. This could indicate that some referenced schema has not yet been instantiated. Consider using a lazy schema reference (like "() => schema") or delaying the evaluation of the lazy reference if one is already being used.`
+			`Encountered an undefined schema. This could indicate that some referenced schema has not yet been instantiated. Consider using a lazy schema reference (like "() => schema") or delaying the evaluation of the lazy reference if one is already being used.`,
 		);
 	}
 }

--- a/packages/dds/tree/src/simple-tree/core/index.ts
+++ b/packages/dds/tree/src/simple-tree/core/index.ts
@@ -53,6 +53,7 @@ export {
 	isAnnotatedAllowedType,
 	normalizeAllowedTypes,
 	normalizeAnnotatedAllowedTypes,
+	normalizeToAnnotatedAllowedType,
 	unannotateImplicitAllowedTypes,
 	markSchemaMostDerived,
 	evaluateLazySchema,

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -182,7 +182,7 @@ export {
 	type UnannotateImplicitFieldSchema,
 	FieldKind,
 	FieldSchema,
-	type FieldSchemaAlpha,
+	FieldSchemaAlpha,
 	type InsertableTreeFieldFromImplicitField,
 	type DefaultProvider,
 	type FieldProps,

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -848,15 +848,15 @@ type Insertable<T extends ImplicitAllowedTypes> = readonly (
 	| IterableTreeArrayContent<InsertableTreeNodeFromImplicitAllowedTypes<T>>
 )[];
 
-abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
+abstract class CustomArrayNodeBase<const T extends ImplicitAnnotatedAllowedTypes>
 	extends TreeNodeWithArrayFeatures<
-		Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>,
-		TreeNodeFromImplicitAllowedTypes<T>
+		Iterable<InsertableTreeNodeFromImplicitAllowedTypes<UnannotateImplicitAllowedTypes<T>>>,
+		TreeNodeFromImplicitAllowedTypes<UnannotateImplicitAllowedTypes<T>>
 	>
-	implements TreeArrayNode<T>
+	implements TreeArrayNode<UnannotateImplicitAllowedTypes<T>>
 {
 	// Indexing must be provided by subclass.
-	[k: number]: TreeNodeFromImplicitAllowedTypes<T>;
+	[k: number]: TreeNodeFromImplicitAllowedTypes<UnannotateImplicitAllowedTypes<T>>;
 
 	public static readonly kind = NodeKind.Array;
 
@@ -869,12 +869,16 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 	>;
 
 	public constructor(
-		input?: Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>> | InternalTreeNode,
+		input?:
+			| Iterable<InsertableTreeNodeFromImplicitAllowedTypes<UnannotateImplicitAllowedTypes<T>>>
+			| InternalTreeNode,
 	) {
 		super(input ?? []);
 	}
 
-	#mapTreesFromFieldData(value: Insertable<T>): FlexibleFieldContent {
+	#mapTreesFromFieldData(
+		value: Insertable<UnannotateImplicitAllowedTypes<T>>,
+	): FlexibleFieldContent {
 		const sequenceField = getSequenceField(this);
 		const content = value as readonly (
 			| InsertableContent
@@ -906,7 +910,9 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		return fail(0xadb /* Proxy should intercept length */);
 	}
 
-	public [Symbol.iterator](): IterableIterator<TreeNodeFromImplicitAllowedTypes<T>> {
+	public [Symbol.iterator](): IterableIterator<
+		TreeNodeFromImplicitAllowedTypes<UnannotateImplicitAllowedTypes<T>>
+	> {
 		return this.values();
 	}
 
@@ -918,9 +924,9 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 	}
 
 	public at(
-		this: TreeArrayNode<T>,
+		this: TreeArrayNode<UnannotateImplicitAllowedTypes<T>>,
 		index: number,
-	): TreeNodeFromImplicitAllowedTypes<T> | undefined {
+	): TreeNodeFromImplicitAllowedTypes<UnannotateImplicitAllowedTypes<T>> | undefined {
 		const field = getSequenceField(this);
 		const val = field.boxedAt(index);
 
@@ -928,18 +934,23 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 			return val;
 		}
 
-		return getOrCreateNodeFromInnerNode(val) as TreeNodeFromImplicitAllowedTypes<T>;
+		return getOrCreateNodeFromInnerNode(val) as TreeNodeFromImplicitAllowedTypes<
+			UnannotateImplicitAllowedTypes<T>
+		>;
 	}
-	public insertAt(index: number, ...value: Insertable<T>): void {
+	public insertAt(
+		index: number,
+		...value: Insertable<UnannotateImplicitAllowedTypes<T>>
+	): void {
 		const field = getSequenceField(this);
 		validateIndex(index, field, "insertAt", true);
 		const content = this.#mapTreesFromFieldData(value);
 		field.editor.insert(index, content);
 	}
-	public insertAtStart(...value: Insertable<T>): void {
+	public insertAtStart(...value: Insertable<UnannotateImplicitAllowedTypes<T>>): void {
 		this.insertAt(0, ...value);
 	}
-	public insertAtEnd(...value: Insertable<T>): void {
+	public insertAtEnd(...value: Insertable<UnannotateImplicitAllowedTypes<T>>): void {
 		this.insertAt(this.length, ...value);
 	}
 	public removeAt(index: number): void {
@@ -1079,12 +1090,14 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		}
 	}
 
-	public values(): IterableIterator<TreeNodeFromImplicitAllowedTypes<T>> {
+	public values(): IterableIterator<
+		TreeNodeFromImplicitAllowedTypes<UnannotateImplicitAllowedTypes<T>>
+	> {
 		return this.generateValues(getKernel(this).generationNumber);
 	}
 	private *generateValues(
 		initialLastUpdatedStamp: number,
-	): Generator<TreeNodeFromImplicitAllowedTypes<T>> {
+	): Generator<TreeNodeFromImplicitAllowedTypes<UnannotateImplicitAllowedTypes<T>>> {
 		const kernel = getKernel(this);
 		if (initialLastUpdatedStamp !== kernel.generationNumber) {
 			throw new UsageError(`Concurrent editing and iteration is not allowed.`);
@@ -1138,7 +1151,7 @@ export function arraySchema<
 
 	// This class returns a proxy from its constructor to handle numeric indexing.
 	// Alternatively it could extend a normal class which gets tons of numeric properties added.
-	class Schema extends CustomArrayNodeBase<UnannotateImplicitAllowedTypes<T>> {
+	class Schema extends CustomArrayNodeBase<T> {
 		public static override prepareInstance<T2>(
 			this: typeof TreeNodeValid<T2>,
 			instance: TreeNodeValid<T2>,
@@ -1229,8 +1242,8 @@ export function arraySchema<
 			return Schema.constructorCached?.constructor as unknown as Output;
 		}
 
-		protected get simpleSchema(): UnannotateImplicitAllowedTypes<T> {
-			return unannotatedTypes;
+		protected get simpleSchema(): T {
+			return info;
 		}
 		protected get allowedTypes(): ReadonlySet<TreeNodeSchema> {
 			return lazyChildTypes.value;

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -223,8 +223,9 @@ function createFlexKeyMapping(
 ): SimpleKeyMap {
 	const keyMap: Map<string | symbol, { storedKey: FieldKey; schema: FieldSchema }> = new Map();
 	for (const [propertyKey, fieldSchema] of Object.entries(fields)) {
-		const storedKey = getStoredKey(propertyKey, fieldSchema);
-		keyMap.set(propertyKey, { storedKey, schema: normalizeFieldSchema(fieldSchema) });
+		const schema = normalizeFieldSchema(fieldSchema);
+		const storedKey = getStoredKey(propertyKey, schema);
+		keyMap.set(propertyKey, { storedKey, schema });
 	}
 
 	return keyMap;

--- a/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
+++ b/packages/dds/tree/src/simple-tree/prepareForInsertion.ts
@@ -21,7 +21,7 @@ import {
 	type FlexibleNodeContent,
 	throwOutOfSchema,
 } from "../feature-libraries/index.js";
-import { normalizeFieldSchema, type ImplicitFieldSchema } from "./fieldSchema.js";
+import { normalizeFieldSchema, type ImplicitAnnotatedFieldSchema } from "./fieldSchema.js";
 import {
 	type InsertableContent,
 	unhydratedFlexTreeFromInsertable,
@@ -30,7 +30,7 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { brand } from "../util/index.js";
 import {
 	getKernel,
-	type ImplicitAllowedTypes,
+	type ImplicitAnnotatedAllowedTypes,
 	type TreeNode,
 	type UnhydratedFlexTreeNode,
 } from "./core/index.js";
@@ -56,7 +56,7 @@ const validateSchema = true;
  */
 export function prepareForInsertion<TIn extends InsertableContent | undefined>(
 	data: TIn,
-	schema: ImplicitFieldSchema,
+	schema: ImplicitAnnotatedFieldSchema,
 	destinationContext: FlexTreeContext,
 ): TIn extends undefined ? undefined : FlexibleNodeContent {
 	return prepareForInsertionContextless(
@@ -82,7 +82,7 @@ export function prepareForInsertion<TIn extends InsertableContent | undefined>(
  */
 export function prepareArrayContentForInsertion(
 	data: readonly InsertableContent[],
-	schema: ImplicitAllowedTypes,
+	schema: ImplicitAnnotatedAllowedTypes,
 	destinationContext: FlexTreeContext,
 ): FlexibleFieldContent {
 	const mapTrees: UnhydratedFlexTreeNode[] = data.map((item) =>
@@ -116,7 +116,7 @@ export function prepareArrayContentForInsertion(
  */
 export function prepareForInsertionContextless<TIn extends InsertableContent | undefined>(
 	data: TIn,
-	schema: ImplicitFieldSchema,
+	schema: ImplicitAnnotatedFieldSchema,
 	schemaAndPolicy: SchemaAndPolicy,
 	hydratedData: FlexTreeHydratedContextMinimal | undefined,
 ): TIn extends undefined ? undefined : FlexibleNodeContent {

--- a/packages/dds/tree/src/simple-tree/unhydratedFlexTreeFromInsertable.ts
+++ b/packages/dds/tree/src/simple-tree/unhydratedFlexTreeFromInsertable.ts
@@ -9,7 +9,11 @@ import { assert } from "@fluidframework/core-utils/internal";
 
 import { hasSingle } from "../util/index.js";
 
-import { type ImplicitFieldSchema, normalizeFieldSchema, FieldKind } from "./fieldSchema.js";
+import {
+	normalizeFieldSchema,
+	FieldKind,
+	type ImplicitAnnotatedFieldSchema,
+} from "./fieldSchema.js";
 import {
 	CompatibilityLevel,
 	getKernel,
@@ -50,7 +54,7 @@ import { getUnhydratedContext } from "./createContext.js";
  */
 export function unhydratedFlexTreeFromInsertable<TIn extends InsertableContent | undefined>(
 	data: TIn,
-	allowedTypes: ImplicitFieldSchema,
+	allowedTypes: ImplicitAnnotatedFieldSchema,
 ): TIn extends undefined ? undefined : UnhydratedFlexTreeNode {
 	const normalizedFieldSchema = normalizeFieldSchema(allowedTypes);
 

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -5,72 +5,17 @@
 
 import { strict as assert } from "node:assert";
 
+import { EmptyKey, storedEmptyFieldSchema } from "../../../core/index.js";
+import { defaultSchemaPolicy } from "../../../feature-libraries/index.js";
 import {
-	EmptyKey,
-	type TreeFieldStoredSchema,
-	type TreeNodeSchemaIdentifier,
-	type TreeStoredSchema,
-	TreeStoredSchemaRepository,
-	storedEmptyFieldSchema,
-} from "../../../core/index.js";
-import {
-	type FullSchemaPolicy,
-	defaultSchemaPolicy,
-} from "../../../feature-libraries/index.js";
-import {
-	allowsFieldSuperset,
-	allowsTreeSuperset,
-	// eslint-disable-next-line import/no-internal-modules
-} from "../../../feature-libraries/modular-schema/index.js";
-import {
-	getStoredSchema,
 	toStoredSchema,
 	SchemaCompatibilityTester,
-	type TreeNodeSchema,
-	type SimpleNodeSchema,
 	SchemaFactoryAlpha,
 	getAllowedContentDiscrepancies,
 	TreeViewConfigurationAlpha,
+	schemaStatics,
 } from "../../../simple-tree/index.js";
-import { brand } from "../../../util/index.js";
-import { schemaStatics } from "../../../simple-tree/index.js";
-
-class TestSchemaRepository extends TreeStoredSchemaRepository {
-	public constructor(
-		public readonly policy: FullSchemaPolicy,
-		data?: TreeStoredSchema,
-	) {
-		super(data);
-	}
-
-	/**
-	 * Updates the specified schema iff all possible in schema data would remain in schema after the change.
-	 * @returns true iff update was performed.
-	 */
-	public tryUpdateRootFieldSchema(schema: TreeFieldStoredSchema): boolean {
-		if (allowsFieldSuperset(this.policy, this, this.rootFieldSchema, schema)) {
-			this.rootFieldSchemaData = schema;
-			this._events.emit("afterSchemaChange", this);
-			return true;
-		}
-		return false;
-	}
-	/**
-	 * Updates the specified schema iff all possible in schema data would remain in schema after the change.
-	 * @returns true iff update was performed.
-	 */
-	public tryUpdateTreeSchema(schema: SimpleNodeSchema & TreeNodeSchema): boolean {
-		const storedSchema = getStoredSchema(schema);
-		const name: TreeNodeSchemaIdentifier = brand(schema.identifier);
-		const original = this.nodeSchema.get(name);
-		if (allowsTreeSuperset(this.policy, this, original, storedSchema)) {
-			this.nodeSchemaData.set(name, storedSchema);
-			this._events.emit("afterSchemaChange", this);
-			return true;
-		}
-		return false;
-	}
-}
+import { TestSchemaRepository } from "../../utils.js";
 
 function assertEnumEqual<TEnum extends { [key: number]: string }>(
 	enumObject: TEnum,

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1929,7 +1929,7 @@ const typeNameSymbol: unique symbol;
 export const typeSchemaSymbol: unique symbol;
 
 // @alpha @system
-export type UnannotateAllowedType<T extends AnnotatedAllowedType> = T extends AnnotatedAllowedType<infer X> ? [X] : T;
+export type UnannotateAllowedType<T extends AnnotatedAllowedType | LazyItem<TreeNodeSchema>> = T extends AnnotatedAllowedType<infer X> ? [X] : T;
 
 // @alpha @system
 export type UnannotateAllowedTypeOrLazyItem<T extends AnnotatedAllowedType | LazyItem<TreeNodeSchema>> = T extends AnnotatedAllowedType<infer X> ? X : T;


### PR DESCRIPTION
## Description

Changes split out from https://github.com/microsoft/FluidFramework/pull/25116 with additional tests, and some additional cleanup. Generally these changes make annotations on allowed types more usable. These annotations will be used to implement staged allowed types.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
