### PR TITLE
Fix placeholder text color contrast

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -17,7 +17,7 @@
 	--docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 
 	// Search bar
-	--ifm-navbar-search-input-placeholder-color: dimgray;
+	--docsearch-muted-color: #666c77 !important;
 	--ifm-navbar-search-input-color: black;
 
 	// Workaround for <https://github.com/easyops-cn/docusaurus-search-local/issues/336>
@@ -39,7 +39,7 @@
 	--docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 
 	// Search bar
-	--ifm-navbar-search-input-placeholder-color: lightgray;
+	--docsearch-muted-color: #748497 !important;
 	--ifm-navbar-search-input-color: white;
 
 	// Workaround for <https://github.com/easyops-cn/docusaurus-search-local/issues/336>


### PR DESCRIPTION
[AB#33672](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/33672)

## Description

This PR fixes an accessibility issue by updating the color of the placeholder text in the search bar so that it meets contrast ratio thresholds. The darker text colour was a suggestion from the Microsoft Accessibility Insights for Web extension after detecting the initial color contrast violation

Before

<img width="176" height="50" alt="Screenshot 2025-07-31 at 3 32 02 PM" src="https://github.com/user-attachments/assets/10f6c1f4-04d2-4b1a-baab-8945eab8507d" />

After

<img width="200" height="48" alt="Screenshot 2025-07-31 at 3 31 17 PM" src="https://github.com/user-attachments/assets/4b3f20ea-ea53-4c52-b504-997d8b49b03a" />
