### PR TITLE
build: Use correct approach to disable codeQL in (non-1ES-template) test pipelines

### DIFF
--- a/tools/pipelines/test-dds-stress.yml
+++ b/tools/pipelines/test-dds-stress.yml
@@ -24,7 +24,8 @@ variables:
 - name: testWorkspace
   value: $(Pipeline.Workspace)/test
 # This is a test pipeline, not a build one, so we don't need to run CodeQL tasks
-- name: DisableCodeQL
+# Note that using this variable only works for non-1ES-template pipelines.
+- name: Codeql.SkipTaskAutoInjection
   value: true
 
 parameters:

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -84,7 +84,8 @@ variables:
     value: 'PerformanceBenchmark'
     readonly: true
   # This is a test pipeline, not a build one, so we don't need to run CodeQL tasks
-  - name: DisableCodeQL
+  # Note that using this variable only works for non-1ES-template pipelines.
+  - name: Codeql.SkipTaskAutoInjection
     value: true
 
 stages:

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -32,7 +32,8 @@ variables:
   value: 'RealStressService'
   readonly: true
 # This is a test pipeline, not a build one, so we don't need to run CodeQL tasks
-- name: DisableCodeQL
+# Note that using this variable only works for non-1ES-template pipelines.
+- name: Codeql.SkipTaskAutoInjection
   value: true
 
 stages:

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -42,7 +42,8 @@ variables:
   value: 'EndToEndTests'
   readonly: true
 # This is a test pipeline, not a build one, so we don't need to run CodeQL tasks
-- name: DisableCodeQL
+# Note that using this variable only works for non-1ES-template pipelines.
+- name: Codeql.SkipTaskAutoInjection
   value: true
 
 stages:

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -35,7 +35,8 @@ variables:
   value: 'ServiceClientsEndToEndTests'
   readonly: true
 # This is a test pipeline, not a build one, so we don't need to run CodeQL tasks
-- name: DisableCodeQL
+# Note that using this variable only works for non-1ES-template pipelines.
+- name: Codeql.SkipTaskAutoInjection
   value: true
 
 stages:

--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -143,7 +143,8 @@ variables:
 - name: pnpmStorePath
   value: $(Pipeline.Workspace)/.pnpm-store
 # This is a test pipeline, not a build one, so we don't need to run CodeQL tasks
-- name: DisableCodeQL
+# Note that using this variable only works for non-1ES-template pipelines.
+- name: Codeql.SkipTaskAutoInjection
   value: true
 
 stages:


### PR DESCRIPTION
## Description

Our test pipelines don't need to run CodeQL tasks since our build pipelines already do it. We were trying to disable those tasks in them already but the way to do it might have changed at some point, so our approach is having no effect. This PR updates the test pipelines to disable the CodeQL tasks in the correct way. This should save a bit of time on all jobs of the test pipelines, in addition to preventing any spurious failures due to stage timeout when the "Finalize CodeQL" task tries to create the source code database (which usually takes 30+ minutes).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Validated with a test run of the perf benchmarks pipeline:

<img width="605" height="623" alt="image" src="https://github.com/user-attachments/assets/772d69f8-4ba4-4ffd-9cf5-ddef2bcb5167" />
