### PR TITLE
refactor(api-markdown-documenter): Remove unused properties in `DocumentationNode` hierarchy

### DIFF
--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -255,7 +255,6 @@ export interface DocumentationLiteralNode<TValue = unknown> extends Literal<TVal
 // @public
 export abstract class DocumentationLiteralNodeBase<TValue = unknown> implements DocumentationLiteralNode<TValue> {
     protected constructor(value: TValue);
-    abstract get isEmpty(): boolean;
     readonly isLiteral = true;
     readonly isParent = false;
     abstract type: string;
@@ -264,7 +263,6 @@ export abstract class DocumentationLiteralNodeBase<TValue = unknown> implements 
 
 // @public
 export interface DocumentationNode<TData extends object = Data> extends Node_2<TData> {
-    readonly isEmpty: boolean;
     readonly isLiteral: boolean;
     readonly isParent: boolean;
     readonly type: string;
@@ -296,7 +294,6 @@ export abstract class DocumentationParentNodeBase<TDocumentationNode extends Doc
     protected constructor(children: TDocumentationNode[]);
     readonly children: TDocumentationNode[];
     get hasChildren(): boolean;
-    get isEmpty(): boolean;
     readonly isLiteral = false;
     readonly isParent = true;
     abstract type: string;
@@ -451,7 +448,6 @@ export class HeadingNode implements DocumentationNode, Heading {
     id?: string | undefined);
     static createFromPlainTextHeading(heading: Heading): HeadingNode;
     readonly id?: string | undefined;
-    get isEmpty(): boolean;
     readonly isLiteral = false;
     readonly isParent = false;
     readonly title: string;
@@ -606,14 +602,12 @@ export type LoggingFunction = (message: string | Error, ...parameters: unknown[]
 // @public @sealed
 export class MarkdownBlockContentNode extends DocumentationLiteralNodeBase<BlockContent_2> {
     constructor(value: BlockContent_2);
-    get isEmpty(): boolean;
     readonly type = "markdownBlockContent";
 }
 
 // @public @sealed
 export class MarkdownPhrasingContentNode extends DocumentationLiteralNodeBase<PhrasingContent_2> {
     constructor(value: PhrasingContent_2);
-    get isEmpty(): boolean;
     readonly type = "markdownPhrasingContent";
 }
 

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.beta.api.md
@@ -246,8 +246,6 @@ export interface DocumentationHierarchyConfigurationBase {
 
 // @public
 export interface DocumentationLiteralNode<TValue = unknown> extends Literal<TValue>, DocumentationNode {
-    readonly isLiteral: true;
-    readonly isParent: false;
     readonly type: string;
     readonly value: TValue;
 }
@@ -255,16 +253,12 @@ export interface DocumentationLiteralNode<TValue = unknown> extends Literal<TVal
 // @public
 export abstract class DocumentationLiteralNodeBase<TValue = unknown> implements DocumentationLiteralNode<TValue> {
     protected constructor(value: TValue);
-    readonly isLiteral = true;
-    readonly isParent = false;
     abstract type: string;
     readonly value: TValue;
 }
 
 // @public
 export interface DocumentationNode<TData extends object = Data> extends Node_2<TData> {
-    readonly isLiteral: boolean;
-    readonly isParent: boolean;
     readonly type: string;
 }
 
@@ -283,9 +277,6 @@ export function documentationNodeToHtml(node: DocumentationNode, context: ToHtml
 // @public
 export interface DocumentationParentNode<TDocumentationNode extends DocumentationNode = DocumentationNode> extends Parent<TDocumentationNode, Data>, DocumentationNode {
     readonly children: TDocumentationNode[];
-    readonly hasChildren: boolean;
-    readonly isLiteral: false;
-    readonly isParent: true;
     readonly type: string;
 }
 
@@ -293,9 +284,6 @@ export interface DocumentationParentNode<TDocumentationNode extends Documentatio
 export abstract class DocumentationParentNodeBase<TDocumentationNode extends DocumentationNode = DocumentationNode> implements DocumentationParentNode<TDocumentationNode> {
     protected constructor(children: TDocumentationNode[]);
     readonly children: TDocumentationNode[];
-    get hasChildren(): boolean;
-    readonly isLiteral = false;
-    readonly isParent = true;
     abstract type: string;
 }
 
@@ -448,8 +436,6 @@ export class HeadingNode implements DocumentationNode, Heading {
     id?: string | undefined);
     static createFromPlainTextHeading(heading: Heading): HeadingNode;
     readonly id?: string | undefined;
-    readonly isLiteral = false;
-    readonly isParent = false;
     readonly title: string;
     readonly type = "heading";
 }

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -246,8 +246,6 @@ export interface DocumentationHierarchyConfigurationBase {
 
 // @public
 export interface DocumentationLiteralNode<TValue = unknown> extends Literal<TValue>, DocumentationNode {
-    readonly isLiteral: true;
-    readonly isParent: false;
     readonly type: string;
     readonly value: TValue;
 }
@@ -255,16 +253,12 @@ export interface DocumentationLiteralNode<TValue = unknown> extends Literal<TVal
 // @public
 export abstract class DocumentationLiteralNodeBase<TValue = unknown> implements DocumentationLiteralNode<TValue> {
     protected constructor(value: TValue);
-    readonly isLiteral = true;
-    readonly isParent = false;
     abstract type: string;
     readonly value: TValue;
 }
 
 // @public
 export interface DocumentationNode<TData extends object = Data> extends Node_2<TData> {
-    readonly isLiteral: boolean;
-    readonly isParent: boolean;
     readonly type: string;
 }
 
@@ -283,9 +277,6 @@ export function documentationNodeToHtml(node: DocumentationNode, context: ToHtml
 // @public
 export interface DocumentationParentNode<TDocumentationNode extends DocumentationNode = DocumentationNode> extends Parent<TDocumentationNode, Data>, DocumentationNode {
     readonly children: TDocumentationNode[];
-    readonly hasChildren: boolean;
-    readonly isLiteral: false;
-    readonly isParent: true;
     readonly type: string;
 }
 
@@ -293,9 +284,6 @@ export interface DocumentationParentNode<TDocumentationNode extends Documentatio
 export abstract class DocumentationParentNodeBase<TDocumentationNode extends DocumentationNode = DocumentationNode> implements DocumentationParentNode<TDocumentationNode> {
     protected constructor(children: TDocumentationNode[]);
     readonly children: TDocumentationNode[];
-    get hasChildren(): boolean;
-    readonly isLiteral = false;
-    readonly isParent = true;
     abstract type: string;
 }
 
@@ -448,8 +436,6 @@ export class HeadingNode implements DocumentationNode, Heading {
     id?: string | undefined);
     static createFromPlainTextHeading(heading: Heading): HeadingNode;
     readonly id?: string | undefined;
-    readonly isLiteral = false;
-    readonly isParent = false;
     readonly title: string;
     readonly type = "heading";
 }

--- a/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
+++ b/tools/api-markdown-documenter/api-report/api-markdown-documenter.public.api.md
@@ -255,7 +255,6 @@ export interface DocumentationLiteralNode<TValue = unknown> extends Literal<TVal
 // @public
 export abstract class DocumentationLiteralNodeBase<TValue = unknown> implements DocumentationLiteralNode<TValue> {
     protected constructor(value: TValue);
-    abstract get isEmpty(): boolean;
     readonly isLiteral = true;
     readonly isParent = false;
     abstract type: string;
@@ -264,7 +263,6 @@ export abstract class DocumentationLiteralNodeBase<TValue = unknown> implements 
 
 // @public
 export interface DocumentationNode<TData extends object = Data> extends Node_2<TData> {
-    readonly isEmpty: boolean;
     readonly isLiteral: boolean;
     readonly isParent: boolean;
     readonly type: string;
@@ -296,7 +294,6 @@ export abstract class DocumentationParentNodeBase<TDocumentationNode extends Doc
     protected constructor(children: TDocumentationNode[]);
     readonly children: TDocumentationNode[];
     get hasChildren(): boolean;
-    get isEmpty(): boolean;
     readonly isLiteral = false;
     readonly isParent = true;
     abstract type: string;
@@ -451,7 +448,6 @@ export class HeadingNode implements DocumentationNode, Heading {
     id?: string | undefined);
     static createFromPlainTextHeading(heading: Heading): HeadingNode;
     readonly id?: string | undefined;
-    get isEmpty(): boolean;
     readonly isLiteral = false;
     readonly isParent = false;
     readonly title: string;
@@ -584,14 +580,12 @@ export type LoggingFunction = (message: string | Error, ...parameters: unknown[]
 // @public @sealed
 export class MarkdownBlockContentNode extends DocumentationLiteralNodeBase<BlockContent_2> {
     constructor(value: BlockContent_2);
-    get isEmpty(): boolean;
     readonly type = "markdownBlockContent";
 }
 
 // @public @sealed
 export class MarkdownPhrasingContentNode extends DocumentationLiteralNodeBase<PhrasingContent_2> {
     constructor(value: PhrasingContent_2);
-    get isEmpty(): boolean;
     readonly type = "markdownPhrasingContent";
 }
 

--- a/tools/api-markdown-documenter/src/documentation-domain/DocumentationNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/DocumentationNode.ts
@@ -25,20 +25,6 @@ export interface DocumentationNode<TData extends object = UnistData> extends Uni
 	 * @see {@link https://github.com/syntax-tree/unist#type}.
 	 */
 	readonly type: string;
-
-	/**
-	 * Whether or not this node is a {@link https://github.com/syntax-tree/unist#literal | Literal}.
-	 *
-	 * @remarks If true, `this` is a {@link DocumentationLiteralNode}.
-	 */
-	readonly isLiteral: boolean;
-
-	/**
-	 * Whether or not this node is a {@link https://github.com/syntax-tree/unist#parent | Parent}.
-	 *
-	 * @remarks If true, `this` is a {@link DocumentationParentNode}.
-	 */
-	readonly isParent: boolean;
 }
 
 /**
@@ -58,26 +44,11 @@ export interface DocumentationParentNode<
 	readonly type: string;
 
 	/**
-	 * {@inheritDoc DocumentationNode.isLiteral}
-	 */
-	readonly isLiteral: false;
-
-	/**
-	 * {@inheritDoc DocumentationNode.isParent}
-	 */
-	readonly isParent: true;
-
-	/**
 	 * Child nodes.
 	 *
 	 * @see {@link https://github.com/syntax-tree/unist#parent}.
 	 */
 	readonly children: TDocumentationNode[];
-
-	/**
-	 * Whether or not the node has any {@link DocumentationParentNode.children}.
-	 */
-	readonly hasChildren: boolean;
 }
 
 /**
@@ -94,16 +65,6 @@ export interface DocumentationLiteralNode<TValue = unknown>
 	 * {@inheritDoc DocumentationNode."type"}
 	 */
 	readonly type: string;
-
-	/**
-	 * {@inheritDoc DocumentationNode.isLiteral}
-	 */
-	readonly isLiteral: true;
-
-	/**
-	 * {@inheritDoc DocumentationNode.isParent}
-	 */
-	readonly isParent: false;
 
 	/**
 	 * Node value.
@@ -128,29 +89,12 @@ export abstract class DocumentationParentNodeBase<
 	public abstract type: string;
 
 	/**
-	 * {@inheritDoc DocumentationNode.isLiteral}
-	 */
-	public readonly isLiteral = false;
-
-	/**
-	 * {@inheritDoc DocumentationNode.isParent}
-	 */
-	public readonly isParent = true;
-
-	/**
 	 * {@inheritDoc DocumentationParentNode.children}
 	 */
 	public readonly children: TDocumentationNode[];
 
 	protected constructor(children: TDocumentationNode[]) {
 		this.children = children;
-	}
-
-	/**
-	 * {@inheritDoc DocumentationParentNode.hasChildren}
-	 */
-	public get hasChildren(): boolean {
-		return this.children.length > 0;
 	}
 }
 
@@ -166,16 +110,6 @@ export abstract class DocumentationLiteralNodeBase<TValue = unknown>
 	 * {@inheritDoc DocumentationNode."type"}
 	 */
 	public abstract type: string;
-
-	/**
-	 * {@inheritDoc DocumentationNode.isLiteral}
-	 */
-	public readonly isLiteral = true;
-
-	/**
-	 * {@inheritDoc DocumentationNode.isParent}
-	 */
-	public readonly isParent = false;
 
 	/**
 	 * {@inheritDoc DocumentationLiteralNode.value}

--- a/tools/api-markdown-documenter/src/documentation-domain/DocumentationNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/DocumentationNode.ts
@@ -39,11 +39,6 @@ export interface DocumentationNode<TData extends object = UnistData> extends Uni
 	 * @remarks If true, `this` is a {@link DocumentationParentNode}.
 	 */
 	readonly isParent: boolean;
-
-	/**
-	 * True if and only if the node contains no content.
-	 */
-	readonly isEmpty: boolean;
 }
 
 /**
@@ -147,18 +142,6 @@ export abstract class DocumentationParentNodeBase<
 	 */
 	public readonly children: TDocumentationNode[];
 
-	/**
-	 * {@inheritDoc DocumentationNode.isEmpty}
-	 */
-	public get isEmpty(): boolean {
-		for (const child of this.children) {
-			if (!child.isEmpty) {
-				return false;
-			}
-		}
-		return true;
-	}
-
 	protected constructor(children: TDocumentationNode[]) {
 		this.children = children;
 	}
@@ -198,11 +181,6 @@ export abstract class DocumentationLiteralNodeBase<TValue = unknown>
 	 * {@inheritDoc DocumentationLiteralNode.value}
 	 */
 	public readonly value: TValue;
-
-	/**
-	 * {@inheritDoc DocumentationNode.isEmpty}
-	 */
-	public abstract get isEmpty(): boolean;
 
 	protected constructor(value: TValue) {
 		this.value = value;

--- a/tools/api-markdown-documenter/src/documentation-domain/HeadingNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/HeadingNode.ts
@@ -45,13 +45,6 @@ export class HeadingNode implements DocumentationNode, Heading {
 	 */
 	public readonly isParent = false;
 
-	/**
-	 * {@inheritDoc DocumentationNode.isEmpty}
-	 */
-	public get isEmpty(): boolean {
-		return this.title.length === 0;
-	}
-
 	public constructor(
 		/**
 		 * {@inheritDoc Heading.title}

--- a/tools/api-markdown-documenter/src/documentation-domain/HeadingNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/HeadingNode.ts
@@ -35,16 +35,6 @@ export class HeadingNode implements DocumentationNode, Heading {
 	 */
 	public readonly type = "heading";
 
-	/**
-	 * {@inheritDoc DocumentationNode.isLiteral}
-	 */
-	public readonly isLiteral = false;
-
-	/**
-	 * {@inheritDoc DocumentationNode.isParent}
-	 */
-	public readonly isParent = false;
-
 	public constructor(
 		/**
 		 * {@inheritDoc Heading.title}

--- a/tools/api-markdown-documenter/src/documentation-domain/MarkdownNode.ts
+++ b/tools/api-markdown-documenter/src/documentation-domain/MarkdownNode.ts
@@ -27,13 +27,6 @@ export class MarkdownBlockContentNode extends DocumentationLiteralNodeBase<Mdast
 	 */
 	public readonly type = "markdownBlockContent";
 
-	/**
-	 * {@inheritDoc DocumentationNode.isEmpty}
-	 */
-	public get isEmpty(): boolean {
-		return false; // Not well defined
-	}
-
 	public constructor(value: MdastBlockContent) {
 		super(value);
 	}
@@ -55,13 +48,6 @@ export class MarkdownPhrasingContentNode extends DocumentationLiteralNodeBase<Md
 	 * {@inheritDoc DocumentationNode."type"}
 	 */
 	public readonly type = "markdownPhrasingContent";
-
-	/**
-	 * {@inheritDoc DocumentationNode.isEmpty}
-	 */
-	public get isEmpty(): boolean {
-		return false; // Not well defined
-	}
 
 	public constructor(value: MdastPhrasingContent) {
 		super(value);


### PR DESCRIPTION
Removes:
- `DocumentationNode.isParent`
- `DocumentationNode.isLiteral`
- `DocumentationNode.isEmpty`