### PR TITLE
improvement(build-cli): Make `typeValidation` normalization clear value defaults

### DIFF
--- a/build-tools/packages/build-cli/src/commands/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/typetests.ts
@@ -125,27 +125,29 @@ If targeting prerelease versions, skipping versions, or using skipping some alte
 export function normalizeConfig(
 	config: Readonly<ITypeValidationConfig> | undefined,
 ): ITypeValidationConfig {
+	if (config?.disabled === true) {
+		// If disabled, remove other properties (which will not be used).
+		return {
+			disabled: true,
+		};
+	}
+
 	const normalized: ITypeValidationConfig = {
 		...config,
 	};
-	if (normalized.disabled === true) {
-		// If disabled, remove other properties (which will not be used).
+
+	// Omit `disabled` when false (this is the default).
+	delete normalized.disabled;
+
+	// Omit entrypoint if it is the default.
+	if (normalized.entrypoint === defaultTypeValidationConfig.entrypoint) {
 		delete normalized.entrypoint;
-		delete normalized.broken;
-	} else {
-		// Omit `disabled` when false (this is the default).
-		delete normalized.disabled;
+	}
 
-		// Omit entrypoint if it is the default.
-		if (normalized.entrypoint === defaultTypeValidationConfig.entrypoint) {
-			delete normalized.entrypoint;
-		}
-
-		// Populate empty `broken` property if it is not set.
-		// This helps make the property more discoverable and easier to edit as needed.
-		if (normalized.broken === undefined) {
-			normalized.broken = defaultTypeValidationConfig.broken;
-		}
+	// Populate empty `broken` property if it is not set.
+	// This helps make the property more discoverable and easier to edit as needed.
+	if (normalized.broken === undefined) {
+		normalized.broken = defaultTypeValidationConfig.broken;
 	}
 	return normalized;
 }

--- a/build-tools/packages/build-cli/src/commands/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/typetests.ts
@@ -112,18 +112,42 @@ If targeting prerelease versions, skipping versions, or using skipping some alte
 			}
 
 			if (this.flags.normalize) {
-				json.typeValidation = {
-					disabled:
-						json.typeValidation?.disabled === true
-							? true
-							: defaultTypeValidationConfig.disabled,
-					broken: json.typeValidation?.broken ?? defaultTypeValidationConfig.broken,
-					entrypoint:
-						json.typeValidation?.entrypoint ?? defaultTypeValidationConfig.entrypoint,
-				};
+				json.typeValidation = normalizeConfig(json.typeValidation);
 			}
 		});
 	}
+}
+
+/**
+ * Generates a simplified version of the input config.
+ * @remarks Omits some defaults, and removes other properties when the config is `disabled`.
+ */
+export function normalizeConfig(
+	config: Readonly<ITypeValidationConfig> | undefined,
+): ITypeValidationConfig {
+	const normalized: ITypeValidationConfig = {
+		...config,
+	};
+	if (normalized.disabled === true) {
+		// If disabled, remove other properties (which will not be used).
+		delete normalized.entrypoint;
+		delete normalized.broken;
+	} else {
+		// Omit `disabled` when false (this is the default).
+		delete normalized.disabled;
+
+		// Omit entrypoint if it is the default.
+		if (normalized.entrypoint === defaultTypeValidationConfig.entrypoint) {
+			delete normalized.entrypoint;
+		}
+
+		// Populate empty `broken` property if it is not set.
+		// This helps make the property more discoverable and easier to edit as needed.
+		if (normalized.broken === undefined) {
+			normalized.broken = defaultTypeValidationConfig.broken;
+		}
+	}
+	return normalized;
 }
 
 export enum VersionOptions {

--- a/build-tools/packages/build-cli/src/commands/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/typetests.ts
@@ -147,7 +147,7 @@ export function normalizeConfig(
 	// Populate empty `broken` property if it is not set.
 	// This helps make the property more discoverable and easier to edit as needed.
 	if (normalized.broken === undefined) {
-		normalized.broken = defaultTypeValidationConfig.broken;
+		normalized.broken = { ...defaultTypeValidationConfig.broken };
 	}
 	return normalized;
 }

--- a/build-tools/packages/build-cli/src/test/commands/typetests.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/typetests.test.ts
@@ -8,6 +8,7 @@ import { describe, it } from "mocha";
 
 import {
 	VersionOptions,
+	normalizeConfig,
 	previousVersion,
 	resetBrokenTests,
 	updateTypeTestDependency,
@@ -207,5 +208,36 @@ describe("typetests tests", () => {
 				assert.equal(previousVersion(input), expected);
 			});
 		}
+	});
+
+	describe("normalizeConfig", () => {
+		it("undefined config", () => {
+			const result = normalizeConfig(undefined);
+			expect(result).to.deep.equal({
+				broken: {},
+			});
+		});
+
+		it("config with defaults", () => {
+			const result = normalizeConfig(defaultTypeValidationConfig);
+			expect(result).to.deep.equal({
+				broken: {},
+			});
+		});
+
+		it("disabled config", () => {
+			const result = normalizeConfig({
+				disabled: true,
+				broken: {
+					"broken-api": {
+						backCompat: false,
+					},
+				},
+				entrypoint: defaultTypeValidationConfig.entrypoint,
+			});
+			expect(result).to.deep.equal({
+				disabled: true,
+			});
+		});
 	});
 });

--- a/build-tools/packages/build-cli/src/typeValidator/typeValidatorConfig.ts
+++ b/build-tools/packages/build-cli/src/typeValidator/typeValidatorConfig.ts
@@ -30,12 +30,12 @@ export interface ITypeValidationConfig {
 	 *
 	 * @defaultValue {@link ApiLevel.legacy}
 	 */
-	entrypoint: ApiLevel;
+	entrypoint?: ApiLevel;
 
 	/**
 	 * An object containing types that are known to be broken.
 	 */
-	broken: BrokenCompatTypes;
+	broken?: BrokenCompatTypes;
 
 	/**
 	 * If true, disables type test preparation and generation for the package.
@@ -45,10 +45,10 @@ export interface ITypeValidationConfig {
 	disabled?: boolean;
 }
 
-export const defaultTypeValidationConfig: ITypeValidationConfig = {
+export const defaultTypeValidationConfig: Required<ITypeValidationConfig> = {
 	entrypoint: "legacy",
 	broken: {},
-	disabled: undefined,
+	disabled: false,
 };
 
 /**

--- a/build-tools/packages/build-cli/src/typeValidator/typeValidatorConfig.ts
+++ b/build-tools/packages/build-cli/src/typeValidator/typeValidatorConfig.ts
@@ -33,7 +33,7 @@ export interface ITypeValidationConfig {
 	entrypoint?: ApiLevel;
 
 	/**
-	 * An object containing types that are known to be broken.
+	 * An optional record of types that are known to be broken.
 	 */
 	broken?: BrokenCompatTypes;
 


### PR DESCRIPTION
Omits some defaults, and removes other properties when the config is `disabled`.