### PR TITLE
build(api-markdown-documenter): Validate formatting in build pipeline

### DIFF
--- a/tools/pipelines/build-api-markdown-documenter.yml
+++ b/tools/pipelines/build-api-markdown-documenter.yml
@@ -95,3 +95,5 @@ extends:
     taskLint: true
     taskTest:
     - test
+    checks:
+    - check:format


### PR DESCRIPTION
## Description

Makes it so the build pipeline for api-markdown-documenter runs a check on code formatting within that package. This will prevent merges of code with formatting issues, which are then caught by the build-client CI pipeline (because it formats the whole repo and does checks for extraneous modified files) and cause it to fail.

Validated that the build pipeline for this PR [failed](https://dev.azure.com/fluidframework/public/_build/results?buildId=349424&view=logs&j=eefa678c-f484-5837-78d3-627f1635913b&t=a53dad46-1a42-5abb-a3cd-1368a15b6673) while the formatting issue was still present in the `main` branch.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).