### PR TITLE
Example apps in SPO mode: Use token expiry from API response instead of token parsing

### DIFF
--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -248,9 +248,7 @@ export async function refreshTokens(
 		grant_type: "refresh_token",
 		refresh_token,
 	};
-	const newTokens = await fetchTokens(server, scope, clientConfig, credentials);
-
-	return newTokens;
+	return fetchTokens(server, scope, clientConfig, credentials);
 }
 
 const createConfig = (token: string): RequestInit => ({

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -103,7 +103,6 @@
 		"@fluidframework/odsp-doclib-utils": "workspace:~",
 		"async-mutex": "^0.3.1",
 		"debug": "^4.3.4",
-		"jwt-decode": "^4.0.0",
 		"proper-lockfile": "^4.1.2"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16149,9 +16149,6 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.4.0(supports-color@8.1.1)
-      jwt-decode:
-        specifier: ^4.0.0
-        version: 4.0.0
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2


### PR DESCRIPTION
## Description

This PR fixes SPO auth for most example apps. You can run example apps with SPO via `npm run start:spo`. This addresses the bug [AB#45538](https://dev.azure.com/fluidframework/internal/_workitems/edit/45538).

Auth was broken because push tokens didn't pass auth token validation, which in turn broke our token cache, as token validation was used to get the token expiry time via token parsing. The push token couldn't be parsed as it's encrypted, see also the internal discussion [in Teams](https://teams.microsoft.com/l/message/19:53328301da384b33bcc81111124e3ab4@thread.skype/1754343252351?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=422665a0-7ad3-4d0d-9171-e8881d0397d9&parentMessageId=1754343252351&teamName=Loop&channelName=Bugs%20%F0%9F%90%9B&createdTime=1754343252351).

Repro of the bug was to just run `npm run start:spo` with any of the example apps, after having run `getKeys` to get the right credentials into your environment variables.