### PR TITLE
POC: Array based op structure

### DIFF
--- a/packages/runtime/container-runtime/src/Untitled-1.ts
+++ b/packages/runtime/container-runtime/src/Untitled-1.ts
@@ -1,0 +1,119 @@
+type RuntimeOp = ["component", string, ...unknown[]];
+["attach", IAttachMess];
+["component" | "attach" | "gc", string, ...unknown[]];
+
+declare const incoming: (string | { id: string; data: unknown })[];
+
+const [runtimeType, id, ...rest] = incoming as RuntimeOp;
+
+const x = [
+	{
+		// op from DDS
+		"type": "op",
+		"contents": {
+			"payload": [
+				"component",
+				"default",
+				"ddsOp",
+				{
+					"routing": "dds1",
+					"data": {
+						"key": "dataStoreA",
+						"path": "/",
+						"type": "set",
+						"value": {
+							"type": "Plain",
+							"value": {
+								"type": "__fluid_handle__",
+								"url": "/821f974f-b73b-44d2-b0a5-6bd2965104b4",
+							},
+						},
+					},
+				},
+			],
+			"theoreticalFutureMetadataOutsideTheRoutedPayload": 123,
+		},
+	},
+	{
+		// op from DDS
+		type: "op",
+		contents: {
+			payload: [
+				{ id: "default", type: "component" },
+				{
+					id: "dds1",
+					type: "ddsOp",
+					data: {
+						key: "dataStoreA",
+						path: "/",
+						type: "set",
+						value: {
+							type: "Plain",
+							value: {
+								type: "__fluid_handle__",
+								url: "/821f974f-b73b-44d2-b0a5-6bd2965104b4",
+							},
+						},
+					},
+				},
+			],
+			theoreticalFutureMetadataOutsideTheRoutedPayload: 123,
+		},
+	},
+	{
+		type: "op",
+		contents: {
+			"routedPayloads": [
+				{ type: "EXT", id: "thing1" },
+/			],
+		}
+	}
+	{
+		// DDS attach op
+		"type": "op",
+		"contents": {
+			"path": "/__component/default/__attach/testChannel1",
+			"data": [
+				{
+					"snapshot": {
+						"entries": ["ALL THE STUFF"],
+					},
+					"type": "https://graph.microsoft.com/types/map",
+				},
+			],
+		},
+	},
+	{
+		// DataStore attach op
+		"type": "op",
+		"contents": {
+			"path": "/__attach/821f974f-b73b-44d2-b0a5-6bd2965104b4",
+			"data": [
+				{
+					"snapshot": {
+						"entries": ["ALL THE STUFF"],
+					},
+					"type": "@fluid-example/test-dataStore",
+				},
+			],
+		},
+	},
+	{
+		// Theoretical example with multiple data entries
+		"type": "op",
+		"contents": {
+			"path": "/__container/default/__op/dir1/__subdir/foo",
+			"data": [
+				{
+					"dataStoreMetadata": "hello world", // This would be set / peeled off by the DataStore
+				},
+				{
+					"type": "set", // This would be set / peeled off by the Directory
+				},
+				{
+					"value": "bar", // This would be set / peeled off by the Subdirectory
+				},
+			],
+		},
+	},
+];

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -98,7 +98,12 @@ import {
 import { DataStoreContexts } from "./dataStoreContexts.js";
 import { FluidDataStoreRegistry } from "./dataStoreRegistry.js";
 import { GCNodeType, IGCNodeUpdatedProps, urlToGCNodePath } from "./gc/index.js";
-import { ContainerMessageType, LocalContainerRuntimeMessage } from "./messageTypes.js";
+import {
+	ContainerMessageType,
+	LocalContainerRuntimeMessage,
+	type AnyNode,
+	type RuntimeOp,
+} from "./messageTypes.js";
 import { StorageServiceWithAttachBlobs } from "./storageServiceWithAttachBlobs.js";
 import {
 	IContainerRuntimeMetadata,
@@ -205,20 +210,9 @@ function wrapContextForInnerChannel(
 ): IFluidParentContext {
 	const context = wrapContext(parentContext);
 
-	context.submitMessage = (type: string, content: unknown, localOpMetadata: unknown) => {
-		const fluidDataStoreContent: FluidDataStoreMessage = {
-			content,
-			type,
-		};
-		const envelope: IEnvelope = {
-			address: id,
-			contents: fluidDataStoreContent,
-		};
-		parentContext.submitMessage(
-			ContainerMessageType.FluidDataStoreOp,
-			envelope,
-			localOpMetadata,
-		);
+	context.submitMessage = (type: string, innerOp: AnyNode[], localOpMetadata: unknown) => {
+		const op: RuntimeOp = [ContainerMessageType.FluidDataStoreOp, id, type, ...innerOp];
+		parentContext.submitMessage(op, localOpMetadata);
 	};
 
 	context.submitSignal = (type: string, contents: unknown, targetClientId?: string) => {

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -303,7 +303,7 @@ export interface ISweepMessage {
 	/**
 	 * @see GarbageCollectionMessageType.Sweep
 	 */
-	type: typeof GarbageCollectionMessageType.Sweep;
+	id: typeof GarbageCollectionMessageType.Sweep;
 	/**
 	 * The ids of nodes that are deleted.
 	 */
@@ -318,12 +318,14 @@ export interface ITombstoneLoadedMessage {
 	/**
 	 * @see GarbageCollectionMessageType.TombstoneLoaded
 	 */
-	type: typeof GarbageCollectionMessageType.TombstoneLoaded;
+	id: typeof GarbageCollectionMessageType.TombstoneLoaded;
 	/**
 	 * The id of Tombstoned node that was loaded.
 	 */
 	nodePath: string;
 }
+
+type GCMessageRouted = [] | [];
 
 /**
  * Type for a message to be used for sending / received garbage collection messages.

--- a/packages/runtime/container-runtime/src/messageTypes.ts
+++ b/packages/runtime/container-runtime/src/messageTypes.ts
@@ -81,8 +81,8 @@ interface TypedContainerRuntimeMessage<TType extends ContainerMessageType, TCont
 
 type Id = string;
 
-type AnyNode = string | Record<string, unknown>;
-type UnknownNode = "__unknown__NOT_A_RUNTIME_VALUE__";
+export type AnyNode = string | Record<string, unknown>;
+export type UnknownNode = "__unknown__NOT_A_RUNTIME_VALUE__";
 export type RuntimeOp =
 	| ["component", Id, ...AnyNode[]]
 	| ["attach", Id, AttachData]

--- a/packages/runtime/container-runtime/src/messageTypes.ts
+++ b/packages/runtime/container-runtime/src/messageTypes.ts
@@ -80,17 +80,41 @@ interface TypedContainerRuntimeMessage<TType extends ContainerMessageType, TCont
 }
 
 // Nodes in the payload are either plain strings, or objects with a routing string and optional data.
+// Before
+type Node2<D = unknown> = string | { data: D };
 type Node<R extends string = string, D = unknown> = R | { routing: R; data?: D };
 type Id = Node<string, undefined>;
 type Item<D = unknown> = Node<string, D>;
 type UnknownNode = Node<"__unknown__NOT_A_RUNTIME_VALUE__">;
 
+type Test<T = never> = never extends T ? true : false; // true, so this is a valid type
+
+// [["component"], ["id1"], ["ddsOp"], ["1234", { ... }]]
+type AnyNode2D = [string] | [string, unknown];
+type BaseNode2D<R extends string = string, D = unknown> = D extends undefined ? [R] : [R, D];
+type Router2D<R extends string, D = undefined> = BaseNode2D<R, D>;
+type Id2D = BaseNode2D<string, undefined>;
+type Item2D<D> = BaseNode2D<string, D>;
+type UnknownNode2D = BaseNode2D<"__unknown__NOT_A_RUNTIME_VALUE__">;
+export type OtherNode = BaseNode2D<"other", { foo: number }>;
+export const sampleId2D: Id2D = ["id1"];
+export type RuntimeOp2D_explicit =
+	| [["component"], [string], ...AnyNode2D[]]
+	| [["attach"], Item2D<AttachData>]
+	| [["gc", GarbageCollectionMessage]]
+	| [UnknownNode2D];
+export type RuntimeOp2D =
+	| [Router2D<"component">, Id2D, ...AnyNode2D[]]
+	| [Router2D<"attach">, Item2D<AttachData>]
+	| [Router2D<"gc", GarbageCollectionMessage>]
+	| [UnknownNode2D];
+
 // I had hoped this would support type narrowing on the rest of the tuple based on the first element,
 // but it doesn't (see processRuntimeOp)
 type RuntimeOp =
-	| ["component", Id, ...Node[]]
+	| ["component", Id, ...Node2[]]
 	| ["attach", Item<AttachData>]
-	| [Node<"gc", GarbageCollectionMessage>]
+	| ["gc", Node2<GarbageCollectionMessage>]
 	| [UnknownNode];
 
 interface AttachData {
@@ -98,19 +122,20 @@ interface AttachData {
 	snapshot: ITree;
 }
 
-// [ "component", "ABCD", "ddsOp", { routing: 1234, data: { ... } } ] => [ "component", "ABCD", "ddsOp", "1234" ]
-export function fullRoute(runtimeOp: RuntimeOp): string[] {
-	return runtimeOp.map((x: Node | string) => {
-		return typeof x === "string" ? x : x.routing;
-	});
+// [ ["component"], ["ABCD"], ["ddsOp"], ["1234", { ... }] ] => [ "component", "ABCD", "ddsOp", "1234" ]
+export function fullRoute2D(runtimeOp: AnyNode2D[]): string[] {
+	return runtimeOp.map(([r]) => r);
 }
+const op: RuntimeOp2D = [["component"], ["default"], ["ddsOp"], ["dds1", { foo: 123 }]];
+fullRoute2D(op);
 
-export function processRuntimeOp(runtimeOp: RuntimeOp): void {
+export function processRuntimeOp(runtimeOp: RuntimeOp2D_explicit): void {
 	// Array destructuring would replace unwrapping the envelope
-	switch (runtimeOp[0]) {
+	switch (runtimeOp[0][0]) {
 		case "component": {
 			// WOMP WOMP - no type narrowing here.
 			// I hoped that id would be known to be a string, and inner would be an array of Node
+			const idid = runtimeOp[1];
 			const [_, id, ...inner] = runtimeOp;
 			break;
 		}
@@ -119,11 +144,12 @@ export function processRuntimeOp(runtimeOp: RuntimeOp): void {
 
 			break;
 		}
-		case { routing: "gc" }: {
-			const [{ data }] = runtimeOp;
-			break;
-		}
+		// case { routing: "gc" }: {
+		// 	const [{ data }] = runtimeOp;
+		// 	break;
+		// }
 		default: {
+			const x = runtimeOp;
 			break;
 		}
 	}


### PR DESCRIPTION
## Description

Playing around with a flexible array-based structure for ops, rather than the nested objects we do today.  Just prototyped at the ContainerRuntime layer, and not comprehensively.

Goals:
* strong typing including type narrowing based on known path segments at a given layer (e.g. "component" v. "attach" v. "gc" at ContainerRuntime layer).
* Standard algorithm for extracting the full path from the op
* Recusive symmetry - Each layer should have the same semantics, and then get "wrapped" (but not via nested objects) at the next.

So, if we pursue a new array-based op / signal format (which I'm in favor of if there's ever a reason to make the change), this is what I found most promising.

* Internally, an op is just `(string | Record)[]`
  * `string` segments are types or IDs
  * `Record` segments are for any layer to put some data it owns on there (typically will just be the leaf that does this)
  * e.g. `["component", "ID_datastore", "op", "ID_dds", { ddsPayload: "stuff" }]`
* Filtering to just the strings gives you the path, which is a mix of types and IDs, like `["component", "ID_datastore", "op", "ID_dds]"`
  * If desired, we could use some spelling convention on types (to exclude from ID space) and filter them out to be able to get `["ID_datastore", "ID_dds"]`
* As the op flows up for submit, you prepend IDs / types / whatever routing info without touching the inner op given from below.
* As the op flows down during process, you can type narrow based on "types", to pull off IDs or data, and then pass the tail to the next layer down.