### PR TITLE
Fix(tree): rebase over dependent change of conflicted transaction

### DIFF
--- a/.changeset/public-donkeys-juggle.md
+++ b/.changeset/public-donkeys-juggle.md
@@ -9,7 +9,7 @@ Before this release, making concurrent edits to an array or a sequence could lea
 * Some edit `e1` was a transaction with a constraint that turned out to be violated by edits concurrent to (and sequenced before) `e1`
 * Some edit `e2` was dependent on `e1` (from before the violation of its constraint)
 * Some edit `e3` was concurrent to and sequenced after both `e1` and `e2`
-* `e3` was either rebased over or the revert of some other edit `e0` that predated `e1`, `e2`, and `e3`.
-* `e0` and `e2` made edits to the same gap (i.e., in the same space between nodes) in the sequence/array.
+* `e3` was either concurrent to or the revert of some other edit `e0` that predated `e1`, `e2`, and `e3`.
+* `e0` and `e2` made edits to the same gap (that is, in the same space between nodes) in the sequence/array.
 
-After this release, these scenarios will work as expected (i.e., no assert).
+After this release, these scenarios will work as expected (that is, no assert).

--- a/.changeset/public-donkeys-juggle.md
+++ b/.changeset/public-donkeys-juggle.md
@@ -1,0 +1,15 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": fix
+---
+Allow edits in arrays and sequences to be concurrent to dependent edits of transactions with violated constraints
+
+Before this release, making concurrent edits to an array or a sequence could lead to a firing of assert `0x8a2` if the following conditions were met:
+* Some edit `e1` was a transaction with a constraint that turned out to be violated by edits concurrent to (and sequenced before) `e1`
+* Some edit `e2` was dependent on `e1` (from before the violation of its constraint)
+* Some edit `e3` was concurrent to and sequenced after both `e1` and `e2`
+* `e3` was either rebased over or the revert of some other edit `e0` that predated `e1`, `e2`, and `e3`.
+* `e0` and `e2` made edits to the same gap (i.e., in the same space between nodes) in the sequence/array.
+
+After this release, these scenarios will work as expected (i.e., no assert).

--- a/.changeset/public-donkeys-juggle.md
+++ b/.changeset/public-donkeys-juggle.md
@@ -3,9 +3,9 @@
 "fluid-framework": minor
 "__section": fix
 ---
-Allow edits in arrays and sequences to be concurrent to dependent edits of transactions with violated constraints
+Allow edits in arrays to be concurrent to dependent edits of transactions with violated constraints
 
-Before this release, making concurrent edits to an array or a sequence could lead to assertion error `0x8a2` being thrown if the following conditions were met:
+Before this release, making concurrent edits to an array could lead to assertion error `0x8a2` being thrown if the following conditions were met:
 * Some edit `e1` was a transaction with a constraint that turned out to be violated by edits concurrent to (and sequenced before) `e1`
 * Some edit `e2` was dependent on `e1` (from before the violation of its constraint)
 * Some edit `e3` was concurrent to and sequenced after both `e1` and `e2`

--- a/.changeset/public-donkeys-juggle.md
+++ b/.changeset/public-donkeys-juggle.md
@@ -5,11 +5,11 @@
 ---
 Allow edits in arrays and sequences to be concurrent to dependent edits of transactions with violated constraints
 
-Before this release, making concurrent edits to an array or a sequence could lead to a firing of assert `0x8a2` if the following conditions were met:
+Before this release, making concurrent edits to an array or a sequence could lead to assertion error `0x8a2` being thrown if the following conditions were met:
 * Some edit `e1` was a transaction with a constraint that turned out to be violated by edits concurrent to (and sequenced before) `e1`
 * Some edit `e2` was dependent on `e1` (from before the violation of its constraint)
 * Some edit `e3` was concurrent to and sequenced after both `e1` and `e2`
 * `e3` was either concurrent to or the revert of some other edit `e0` that predated `e1`, `e2`, and `e3`.
 * `e0` and `e2` made edits to the same gap (that is, in the same space between nodes) in the sequence/array.
 
-After this release, these scenarios will work as expected (that is, no assert).
+After this release, these scenarios will work as expected (that is, no assertion error thrown).

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -41,6 +41,7 @@ export const noChangeHandler: FieldChangeHandler<0> = {
 		compose: (change1: 0, change2: 0) => 0,
 		invert: (changes: 0) => 0,
 		rebase: (change: 0, over: 0) => 0,
+		mute: (changes: 0) => 0,
 	}),
 	codecsFactory: () => noChangeCodecFamily,
 	editor: { buildChildChanges: () => fail(0xb0d /* Child changes not supported */) },

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -172,7 +172,7 @@ export interface FieldChangeRebaser<TChangeset> {
 
 	/**
 	 * Returns a copy of the given changeset with the same declarations (e.g., new cells) but no actual changes.
-	 * This is a kludge. TODO: remove once AD#46104 is completed.
+	 * This is a kludge. TODO: remove once AB#46104 is completed.
 	 */
 	mute(change: TChangeset): TChangeset;
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -169,6 +169,12 @@ export interface FieldChangeRebaser<TChangeset> {
 		oldRevisions: Set<RevisionTag | undefined>,
 		newRevisions: RevisionTag | undefined,
 	): TChangeset;
+
+	/**
+	 * Returns a copy of the given changeset with the same declarations (e.g., new cells) but no actual changes.
+	 * This is a kludge. TODO: remove once AD#46104 is completed.
+	 */
+	mute(change: TChangeset): TChangeset;
 }
 
 /**
@@ -179,11 +185,13 @@ export function referenceFreeFieldChangeRebaser<TChangeset>(data: {
 	compose: (change1: TChangeset, change2: TChangeset) => TChangeset;
 	invert: (change: TChangeset) => TChangeset;
 	rebase: (change: TChangeset, over: TChangeset) => TChangeset;
+	mute: (change: TChangeset) => TChangeset;
 }): FieldChangeRebaser<TChangeset> {
 	return isolatedFieldChangeRebaser({
 		compose: (change1, change2, _composeChild, _genId) => data.compose(change1, change2),
 		invert: (change, _invertChild, _genId) => data.invert(change),
 		rebase: (change, over, _rebaseChild, _genId) => data.rebase(change, over),
+		mute: (change) => data.mute(change),
 	});
 }
 
@@ -191,6 +199,7 @@ export function isolatedFieldChangeRebaser<TChangeset>(data: {
 	compose: FieldChangeRebaser<TChangeset>["compose"];
 	invert: FieldChangeRebaser<TChangeset>["invert"];
 	rebase: FieldChangeRebaser<TChangeset>["rebase"];
+	mute: FieldChangeRebaser<TChangeset>["mute"];
 }): FieldChangeRebaser<TChangeset> {
 	return {
 		...data,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -39,6 +39,7 @@ export const genericChangeHandler: FieldChangeHandler<GenericChangeset> = {
 		rebase: rebaseGenericChange,
 		prune: pruneGenericChange,
 		replaceRevisions,
+		mute: (change: GenericChangeset): GenericChangeset => change,
 	},
 	codecsFactory: makeGenericChangeCodec,
 	editor: {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -853,6 +853,8 @@ export class ModularChangeFamily
 		potentiallyConflictedOver: TaggedChange<ModularChangeset>,
 		revisionMetadata: RevisionMetadataSource,
 	): ModularChangeset {
+		// Our current cell ordering scheme depends on acquiring tombstones when rebasing over a change with conflicts.
+		// TODO: remove once AD#46104 is completed
 		const over = mapTaggedChange(
 			potentiallyConflictedOver,
 			this.getEffectiveChange(potentiallyConflictedOver.change),

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -1723,6 +1723,7 @@ export class ModularChangeFamily
 	private muteChange(change: ModularChangeset): ModularChangeset {
 		const muted: Mutable<ModularChangeset> = {
 			...change,
+			crossFieldKeys: newCrossFieldKeyTable(),
 			fieldChanges: this.muteFieldChanges(change.fieldChanges),
 			nodeChanges: brand(change.nodeChanges.mapValues((v) => this.muteNodeChange(v))),
 		};

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -219,8 +219,8 @@ export class ModularChangeFamily
 		revInfos: RevisionInfo[],
 		idState: IdAllocationState,
 	): ModularChangesetContent {
-		// Our current cell ordering scheme depends on acquiring tombstones when rebasing over a change with conflicts.
-		// This means that compose must preserve cell information introduced by conflicted changes (so that we can rebase over the composition).
+		// Our current cell ordering scheme in sequences depends on being able to rebase over a change with conflicts.
+		// This means that compose must preserve declarations (e.g., new cells) made by conflicted changes (so that we can rebase over the composition).
 		// TODO: remove once AD#46104 is completed
 		const change1 = this.getEffectiveChange(potentiallyConflictedChange1);
 		const change2 = this.getEffectiveChange(potentiallyConflictedChange2);
@@ -853,7 +853,9 @@ export class ModularChangeFamily
 		potentiallyConflictedOver: TaggedChange<ModularChangeset>,
 		revisionMetadata: RevisionMetadataSource,
 	): ModularChangeset {
-		// Our current cell ordering scheme depends on acquiring tombstones when rebasing over a change with conflicts.
+		// Our current cell ordering scheme in sequences depends on being able to rebase over a change with conflicts.
+		// This means that we must rebase over a muted version of the conflicted changeset.
+		// That is, a version that includes its declarations (e.g., new cells) but not its changes.
 		// TODO: remove once AD#46104 is completed
 		const over = mapTaggedChange(
 			potentiallyConflictedOver,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -221,7 +221,7 @@ export class ModularChangeFamily
 	): ModularChangesetContent {
 		// Our current cell ordering scheme in sequences depends on being able to rebase over a change with conflicts.
 		// This means that compose must preserve declarations (e.g., new cells) made by conflicted changes (so that we can rebase over the composition).
-		// TODO: remove once AD#46104 is completed
+		// TODO: remove once AB#46104 is completed
 		const change1 = this.getEffectiveChange(potentiallyConflictedChange1);
 		const change2 = this.getEffectiveChange(potentiallyConflictedChange2);
 
@@ -856,7 +856,7 @@ export class ModularChangeFamily
 		// Our current cell ordering scheme in sequences depends on being able to rebase over a change with conflicts.
 		// This means that we must rebase over a muted version of the conflicted changeset.
 		// That is, a version that includes its declarations (e.g., new cells) but not its changes.
-		// TODO: remove once AD#46104 is completed
+		// TODO: remove once AB#46104 is completed
 		const over = mapTaggedChange(
 			potentiallyConflictedOver,
 			this.getEffectiveChange(potentiallyConflictedOver.change),

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -39,6 +39,7 @@ import {
 	newChangeAtomIdRangeMap,
 	type DeltaDetachedNodeChanges,
 	type DeltaDetachedNodeRename,
+	mapTaggedChange,
 } from "../../core/index.js";
 import {
 	type IdAllocationState,
@@ -213,24 +214,16 @@ export class ModularChangeFamily
 	}
 
 	private composeAllFields(
-		change1: ModularChangeset,
-		change2: ModularChangeset,
+		potentiallyConflictedChange1: ModularChangeset,
+		potentiallyConflictedChange2: ModularChangeset,
 		revInfos: RevisionInfo[],
 		idState: IdAllocationState,
 	): ModularChangesetContent {
-		if (hasConflicts(change1) && hasConflicts(change2)) {
-			return {
-				fieldChanges: new Map(),
-				nodeChanges: newTupleBTree(),
-				nodeToParent: newTupleBTree(),
-				nodeAliases: newTupleBTree(),
-				crossFieldKeys: newCrossFieldKeyTable(),
-			};
-		} else if (hasConflicts(change1)) {
-			return change2;
-		} else if (hasConflicts(change2)) {
-			return change1;
-		}
+		// Our current cell ordering scheme depends on acquiring tombstones when rebasing over a change with conflicts.
+		// This means that compose must preserve cell information introduced by conflicted changes (so that we can rebase over the composition).
+		// TODO: remove once AD#46104 is completed
+		const change1 = this.getEffectiveChange(potentiallyConflictedChange1);
+		const change2 = this.getEffectiveChange(potentiallyConflictedChange2);
 
 		const genId: IdAllocator = idAllocatorFromState(idState);
 		const revisionMetadata: RevisionMetadataSource = revisionMetadataSourceFromInfo(revInfos);
@@ -857,12 +850,13 @@ export class ModularChangeFamily
 
 	public rebase(
 		taggedChange: TaggedChange<ModularChangeset>,
-		over: TaggedChange<ModularChangeset>,
+		potentiallyConflictedOver: TaggedChange<ModularChangeset>,
 		revisionMetadata: RevisionMetadataSource,
 	): ModularChangeset {
-		if (hasConflicts(over.change)) {
-			return taggedChange.change;
-		}
+		const over = mapTaggedChange(
+			potentiallyConflictedOver,
+			this.getEffectiveChange(potentiallyConflictedOver.change),
+		);
 
 		const change = taggedChange.change;
 		const maxId = Math.max(change.maxId ?? -1, over.change.maxId ?? -1);
@@ -1710,6 +1704,49 @@ export class ModularChangeFamily
 		}
 
 		return numChildren;
+	}
+
+	private getEffectiveChange(change: ModularChangeset): ModularChangeset {
+		if (hasConflicts(change)) {
+			return this.muteChange(change);
+		}
+		return change;
+	}
+
+	/**
+	 * Returns a copy of the given changeset with the same declarations (e.g., new cells) but no actual changes.
+	 */
+	private muteChange(change: ModularChangeset): ModularChangeset {
+		const muted: Mutable<ModularChangeset> = {
+			...change,
+			fieldChanges: this.muteFieldChanges(change.fieldChanges),
+			nodeChanges: brand(change.nodeChanges.mapValues((v) => this.muteNodeChange(v))),
+		};
+		return muted;
+	}
+
+	private muteNodeChange(change: NodeChangeset): NodeChangeset {
+		if (change.fieldChanges === undefined) {
+			return change;
+		}
+		return {
+			...change,
+			fieldChanges: this.muteFieldChanges(change.fieldChanges),
+		};
+	}
+
+	private muteFieldChanges(change: FieldChangeMap): FieldChangeMap {
+		return new Map(
+			Array.from(change.entries(), ([key, value]) => [key, this.muteFieldChange(value)]),
+		);
+	}
+
+	private muteFieldChange(change: FieldChange): FieldChange {
+		const handler = getChangeHandler(this.fieldKinds, change.fieldKind);
+		return {
+			fieldKind: change.fieldKind,
+			change: brand(handler.rebaser.mute(change.change)),
+		};
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -465,6 +465,10 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 
 		return updated;
 	},
+
+	mute: (change: OptionalChangeset): OptionalChangeset => {
+		return { childChanges: change.childChanges, moves: [] };
+	},
 };
 
 function replaceReplaceRevisions(

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldChangeRebaser.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldChangeRebaser.ts
@@ -11,6 +11,7 @@ import { prune } from "./prune.js";
 import { rebase } from "./rebase.js";
 import { replaceRevisions } from "./replaceRevisions.js";
 import type { Changeset } from "./types.js";
+import { omitMarkEffect } from "./utils.js";
 
 export type SequenceChangeRebaser = FieldChangeRebaser<Changeset>;
 
@@ -20,4 +21,7 @@ export const sequenceFieldChangeRebaser = {
 	rebase,
 	prune,
 	replaceRevisions,
+	mute: (change: Changeset): Changeset => {
+		return change.map((mark) => omitMarkEffect(mark));
+	},
 };

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
@@ -29,6 +29,7 @@ import { makeValueCodec } from "../../codec/index.js";
 export function lastWriteWinsRebaser<TChange>(data: {
 	noop: TChange;
 	invert: (changes: TChange) => TChange;
+	mute: (changes: TChange) => TChange;
 }): FieldChangeRebaser<TChange> {
 	const compose = (_change1: TChange, change2: TChange) => change2;
 	const rebase = (change: TChange, _over: TChange) => change;
@@ -69,6 +70,9 @@ export function replaceRebaser<T>(): FieldChangeRebaser<ReplaceOp<T>> {
 		},
 		invert: (changes: ReplaceOp<T>) => {
 			return changes === 0 ? 0 : { old: changes.new, new: changes.old };
+		},
+		mute: (_change: ReplaceOp<T>) => {
+			return 0;
 		},
 	});
 }

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -108,6 +108,7 @@ const singleNodeRebaser: FieldChangeRebaser<SingleNodeChangeset> = {
 			? undefined
 			: composeChild(change1, change2),
 	invert: (change) => change,
+	mute: (change: SingleNodeChangeset) => change,
 	rebase: (change, base, rebaseChild) => rebaseChild(change, base),
 	prune: (change, pruneChild) => (change === undefined ? undefined : pruneChild(change)),
 	replaceRevisions: (change, oldRevisions, newRevision) =>

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -3178,7 +3178,9 @@ describe("Editing", () => {
 			rootTree.merge(addB);
 			expectJsonTree(rootTree, ["B"]);
 
-			rootTree.merge(partiallyRebasedRestoreC); // Fails when trying to order the cells of "A" and "C"
+			// This merge requires that we order the cells of "A" and "C".
+			// This is challenging because they were introduced commits that are not taking part in the rebase.
+			rootTree.merge(partiallyRebasedRestoreC);
 			expectJsonTree(rootTree, ["B", "C"]);
 		});
 	});

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -3134,6 +3134,53 @@ describe("Editing", () => {
 			const expected = ["B", "C"];
 			expectJsonTree([tree1, tree2, tree3], expected);
 		});
+
+		it("Rebase over a commit that depends on a commit that has become conflicted", () => {
+			const rootTree = makeTreeFromJsonSequence(["C", "D"]);
+
+			const removeAnRestoreC = rootTree.branch();
+			const { undoStack, unsubscribe } = createTestUndoRedoStacks(removeAnRestoreC.events);
+			remove(removeAnRestoreC, 0, 1);
+			const removeC = removeAnRestoreC.branch();
+			expectJsonTree(removeC, ["D"]);
+
+			(undoStack.pop() ?? assert.fail("Missing undo")).revert();
+			unsubscribe();
+			const restoreC = removeAnRestoreC.branch();
+			expectJsonTree(restoreC, ["C", "D"]);
+
+			const addA = removeC.branch();
+			addA.transaction.start();
+			addA.editor.addNodeExistsConstraint(rootNode);
+			addA.editor.sequenceField(rootField).insert(0, chunkFromJsonTrees(["A"]));
+			addA.transaction.commit();
+			expectJsonTree(addA, ["A", "D"]);
+
+			const addB = addA.branch();
+			addB.editor.sequenceField(rootField).insert(1, chunkFromJsonTrees(["B"]));
+			expectJsonTree(addB, ["A", "B", "D"]);
+
+			// Removing "D" will violate the constraint in the transaction that adds A.
+			const removeD = removeC.branch();
+			remove(removeD, 0, 1);
+			expectJsonTree(removeD, []);
+
+			expectJsonTree(rootTree, ["C", "D"]);
+			rootTree.merge(removeC);
+			rootTree.merge(removeD);
+			rootTree.merge(addA); // No-op
+			expectJsonTree(rootTree, []);
+
+			const partiallyRebasedRestoreC = rootTree.branch();
+			partiallyRebasedRestoreC.merge(restoreC);
+			expectJsonTree(partiallyRebasedRestoreC, ["C"]);
+
+			rootTree.merge(addB);
+			expectJsonTree(rootTree, ["B"]);
+
+			rootTree.merge(partiallyRebasedRestoreC); // Fails when trying to order the cells of "A" and "C"
+			expectJsonTree(rootTree, ["B", "C"]);
+		});
 	});
 
 	it.skip("edit removed content", () => {


### PR DESCRIPTION
## Description

This PR fixes a document-corrupting bug. Before this PR, making concurrent edits to an array or a sequence could lead to a firing of assert `0x8a2` if the following conditions were met:
* Some edit `e1` was a transaction with a constraint that turned out to be violated by edits concurrent to (and sequenced before) `e1`
* Some edit `e2` was dependent on `e1` (from before the violation of its constraint)
* Some edit `e3` was concurrent to and sequenced after both `e1` and `e2`
* `e3` was either rebased over or the revert of some other edit `e0` that predated `e1`, `e2`, and `e3`.
* `e0` and `e2` made edits to the same gap (i.e., in the same space between nodes) in the sequence/array.
(See the test added by this PR for an example)

This was due to the fact that our current cell ordering scheme depends on acquiring tombstones when rebasing over a change with conflicts, but our implementation of rebase and compose did not allow this.

In the future, we would rather not require rebasing over conflicted changes has an effect on the rebased changes. See https://dev.azure.com/fluidframework/internal/_workitems/edit/46104.

## Breaking Changes

None