### PR TITLE
Fix unify and test UnannotateAllowedType

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1559,21 +1559,18 @@ const typeNameSymbol: unique symbol;
 export const typeSchemaSymbol: unique symbol;
 
 // @alpha @system
-export type UnannotateAllowedType<T extends AnnotatedAllowedType | LazyItem<TreeNodeSchema>> = T extends AnnotatedAllowedType<infer X> ? [X] : T;
-
-// @alpha @system
-export type UnannotateAllowedTypeOrLazyItem<T extends AnnotatedAllowedType | LazyItem<TreeNodeSchema>> = T extends AnnotatedAllowedType<infer X> ? X : T;
+export type UnannotateAllowedType<T extends AnnotatedAllowedType | LazyItem<TreeNodeSchema>> = T extends AnnotatedAllowedType<infer X> ? X : T;
 
 // @alpha @system
 export type UnannotateAllowedTypes<T extends AnnotatedAllowedTypes> = UnannotateAllowedTypesList<T["types"]>;
 
 // @alpha @system
 export type UnannotateAllowedTypesList<T extends readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[]> = {
-    [I in keyof T]: UnannotateAllowedTypeOrLazyItem<T[I]>;
+    [I in keyof T]: UnannotateAllowedType<T[I]>;
 };
 
 // @alpha @system
-export type UnannotateImplicitAllowedTypes<T extends ImplicitAnnotatedAllowedTypes> = T extends AnnotatedAllowedTypes ? UnannotateAllowedTypes<T> : T extends AnnotatedAllowedType ? UnannotateAllowedType<T> : T extends readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[] ? UnannotateAllowedTypesList<T> : T extends TreeNodeSchema ? T : never;
+export type UnannotateImplicitAllowedTypes<T extends ImplicitAnnotatedAllowedTypes> = T extends AnnotatedAllowedTypes ? UnannotateAllowedTypes<T> : T extends AnnotatedAllowedType ? UnannotateAllowedTypesList<[T]> : T extends readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[] ? UnannotateAllowedTypesList<T> : T extends TreeNodeSchema ? T : never;
 
 // @alpha @system
 export type UnannotateImplicitFieldSchema<T extends ImplicitAnnotatedFieldSchema> = T extends ImplicitAnnotatedAllowedTypes ? UnannotateImplicitAllowedTypes<T> : T;

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -169,7 +169,6 @@ export {
 	type UnannotateAllowedTypes,
 	type UnannotateAllowedType,
 	type UnannotateAllowedTypesList,
-	type UnannotateAllowedTypeOrLazyItem,
 	type UnannotateImplicitFieldSchema,
 	type UnannotateSchemaRecord,
 	type SchemaStaticsAlpha,

--- a/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
+++ b/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
@@ -250,7 +250,7 @@ export type UnannotateAllowedTypes<T extends AnnotatedAllowedTypes> =
 /**
  * Removes annotations from an allowed type.
  * @remarks
- * In the input could be lazy
+ * If the input could be lazy
  * (is a LazyItem or AnnotatedAllowedType<LazyItem> instead of just a TreeNodeSchema | AnnotatedAllowedType<TreeNodeSchema>)
  * then the output of this will be a LazyItem and thus is not valid as an ImplicitAllowedTypes without wrapping it in an array.
  * This can however be used on items within an AllowedTypes array.

--- a/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
+++ b/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
@@ -223,7 +223,7 @@ export type UnannotateImplicitAllowedTypes<T extends ImplicitAnnotatedAllowedTyp
 	T extends AnnotatedAllowedTypes
 		? UnannotateAllowedTypes<T>
 		: T extends AnnotatedAllowedType
-			? UnannotateAllowedType<T>
+			? UnannotateAllowedTypesList<[T]>
 			: T extends readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[]
 				? UnannotateAllowedTypesList<T>
 				: T extends TreeNodeSchema
@@ -237,16 +237,8 @@ export type UnannotateImplicitAllowedTypes<T extends ImplicitAnnotatedAllowedTyp
 export type UnannotateAllowedTypesList<
 	T extends readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[],
 > = {
-	[I in keyof T]: UnannotateAllowedTypeOrLazyItem<T[I]>;
+	[I in keyof T]: UnannotateAllowedType<T[I]>;
 };
-
-/**
- * Removes annotations from an allowed type that may contain annotations.
- * @system @alpha
- */
-export type UnannotateAllowedTypeOrLazyItem<
-	T extends AnnotatedAllowedType | LazyItem<TreeNodeSchema>,
-> = T extends AnnotatedAllowedType<infer X> ? X : T;
 
 /**
  * Removes all annotations from a set of allowed types.
@@ -257,10 +249,15 @@ export type UnannotateAllowedTypes<T extends AnnotatedAllowedTypes> =
 
 /**
  * Removes annotations from an allowed type.
+ * @remarks
+ * In the input could be lazy
+ * (is a LazyItem or AnnotatedAllowedType<LazyItem> instead of just a TreeNodeSchema | AnnotatedAllowedType<TreeNodeSchema>)
+ * then the output of this will be a LazyItem and thus is not valid as an ImplicitAllowedTypes without wrapping it in an array.
+ * This can however be used on items within an AllowedTypes array.
  * @system @alpha
  */
 export type UnannotateAllowedType<T extends AnnotatedAllowedType | LazyItem<TreeNodeSchema>> =
-	T extends AnnotatedAllowedType<infer X> ? [X] : T;
+	T extends AnnotatedAllowedType<infer X> ? X : T;
 
 /**
  * Normalizes a {@link ImplicitAllowedTypes} to a set of {@link TreeNodeSchema}s, by eagerly evaluating any

--- a/packages/dds/tree/src/simple-tree/core/index.ts
+++ b/packages/dds/tree/src/simple-tree/core/index.ts
@@ -75,7 +75,6 @@ export type {
 	UnannotateAllowedTypes,
 	UnannotateAllowedType,
 	UnannotateAllowedTypesList,
-	UnannotateAllowedTypeOrLazyItem,
 	AllowedTypeMetadata,
 	AnnotatedAllowedTypes,
 } from "./allowedTypes.js";

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -47,7 +47,6 @@ export {
 	type UnannotateAllowedTypes,
 	type UnannotateAllowedType,
 	type UnannotateAllowedTypesList,
-	type UnannotateAllowedTypeOrLazyItem,
 	type AllowedTypeMetadata,
 	type AnnotatedAllowedTypes,
 	type SchemaUpgrade,

--- a/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
@@ -33,6 +33,7 @@ import {
 	normalizeAllowedTypes,
 	normalizeAnnotatedAllowedTypes,
 	normalizeToAnnotatedAllowedType,
+	unannotateAllowedType,
 	unannotateImplicitAllowedTypes,
 	type AllowedTypes,
 	type AllowedTypesMetadata,
@@ -43,7 +44,7 @@ import {
 	type InsertableTreeNodeFromAllowedTypes,
 	type InsertableTreeNodeFromImplicitAllowedTypes,
 	type TreeNodeFromImplicitAllowedTypes,
-	type UnannotateAllowedTypeOrLazyItem,
+	type UnannotateAllowedType,
 	type UnannotateAllowedTypes,
 	type UnannotateAllowedTypesList,
 	type UnannotateImplicitAllowedTypes,
@@ -173,16 +174,32 @@ const schema = new SchemaFactory("com.example");
 		}
 	}
 
-	// UnannotateAllowedTypeOrLazyItem
+	// UnannotateAllowedType
 	{
-		type A = LazyItem<TreeNodeSchema>;
-		type B = AnnotatedAllowedType;
+		// Generic cases
+		{
+			type A = LazyItem<TreeNodeSchema>;
+			type B = AnnotatedAllowedType;
 
-		type _check1 = requireAssignableTo<A, UnannotateAllowedTypeOrLazyItem<A>>;
+			type _check1 = requireAssignableTo<A, UnannotateAllowedType<A>>;
+			type _check2 = requireAssignableTo<UnannotateAllowedType<A>, A>;
+			type _check3 = requireAssignableTo<UnannotateAllowedType<B>, A>;
+			type _check4 = requireAssignableTo<
+				UnannotateAllowedType<AnnotatedAllowedType<TreeNodeSchema>>,
+				TreeNodeSchema
+			>;
+		}
+		// Concrete cases
+		{
+			type A = typeof SchemaFactory.number;
 
-		type _check2 = requireAssignableTo<UnannotateAllowedTypeOrLazyItem<A>, A>;
+			type _check1 = requireTrue<areSafelyAssignable<UnannotateAllowedType<A>, A>>;
+			type _check2 = requireTrue<
+				areSafelyAssignable<UnannotateAllowedType<{ type: A; metadata: { custom: "x" } }>, A>
+			>;
 
-		type _check3 = requireAssignableTo<UnannotateAllowedTypeOrLazyItem<B>, A>;
+			type _check4 = requireAssignableTo<UnannotateAllowedType<A>, A>;
+		}
 	}
 
 	// UnannotateAllowedTypesList
@@ -235,6 +252,21 @@ describe("allowedTypes", () => {
 			}
 			assert(!isAnnotatedAllowedType(Test2));
 		});
+	});
+
+	it("unannotateAllowedType", () => {
+		assert.equal(unannotateAllowedType(SchemaFactory.number), SchemaFactory.number);
+		const lazy = (): typeof SchemaFactory.string => assert.fail();
+		{
+			const result = unannotateAllowedType(lazy);
+			assert.equal(result, lazy);
+			type _check1 = requireTrue<areSafelyAssignable<typeof lazy, typeof result>>;
+		}
+		{
+			const result = unannotateAllowedType({ type: lazy, metadata: {} });
+			assert.equal(result, lazy);
+			type _check1 = requireTrue<areSafelyAssignable<typeof lazy, typeof result>>;
+		}
 	});
 
 	describe("normalizeAllowedTypes", () => {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1945,21 +1945,18 @@ const typeNameSymbol: unique symbol;
 export const typeSchemaSymbol: unique symbol;
 
 // @alpha @system
-export type UnannotateAllowedType<T extends AnnotatedAllowedType | LazyItem<TreeNodeSchema>> = T extends AnnotatedAllowedType<infer X> ? [X] : T;
-
-// @alpha @system
-export type UnannotateAllowedTypeOrLazyItem<T extends AnnotatedAllowedType | LazyItem<TreeNodeSchema>> = T extends AnnotatedAllowedType<infer X> ? X : T;
+export type UnannotateAllowedType<T extends AnnotatedAllowedType | LazyItem<TreeNodeSchema>> = T extends AnnotatedAllowedType<infer X> ? X : T;
 
 // @alpha @system
 export type UnannotateAllowedTypes<T extends AnnotatedAllowedTypes> = UnannotateAllowedTypesList<T["types"]>;
 
 // @alpha @system
 export type UnannotateAllowedTypesList<T extends readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[]> = {
-    [I in keyof T]: UnannotateAllowedTypeOrLazyItem<T[I]>;
+    [I in keyof T]: UnannotateAllowedType<T[I]>;
 };
 
 // @alpha @system
-export type UnannotateImplicitAllowedTypes<T extends ImplicitAnnotatedAllowedTypes> = T extends AnnotatedAllowedTypes ? UnannotateAllowedTypes<T> : T extends AnnotatedAllowedType ? UnannotateAllowedType<T> : T extends readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[] ? UnannotateAllowedTypesList<T> : T extends TreeNodeSchema ? T : never;
+export type UnannotateImplicitAllowedTypes<T extends ImplicitAnnotatedAllowedTypes> = T extends AnnotatedAllowedTypes ? UnannotateAllowedTypes<T> : T extends AnnotatedAllowedType ? UnannotateAllowedTypesList<[T]> : T extends readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[] ? UnannotateAllowedTypesList<T> : T extends TreeNodeSchema ? T : never;
 
 // @alpha @system
 export type UnannotateImplicitFieldSchema<T extends ImplicitAnnotatedFieldSchema> = T extends ImplicitAnnotatedAllowedTypes ? UnannotateImplicitAllowedTypes<T> : T;


### PR DESCRIPTION
## Description

UnannotateAllowedType no longer wraps its output in an array. This fixes a typing error in unannotateAllowedType, and allows removal of UnannotateAllowedTypeOrLazyItem.

Fix unify and test UnannotateAllowedType

## Breaking Changes

UnannotateAllowedTypeOrLazyItem and UnannotateAllowedType are both alpha system API: thats two distinct reasons changing them should be allowed and non-breaking.

The APIs which use these types should be unchanged as they have been updated accordingly.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

