### PR TITLE
test(client): fix testing on Windows

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -25,7 +25,7 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"start:tinylicious:test": "PORT=7071 tinylicious > tinylicious.log 2>&1",
+		"start:tinylicious:test": "cross-env PORT=7071 tinylicious > tinylicious.log 2>&1",
 		"test": "npm run test:realsvc",
 		"test:coverage": "c8 npm test",
 		"test:realsvc": "npm run test:realsvc:tinylicious",


### PR DESCRIPTION
using `cross-env` to launch with env set