### PR TITLE
bump(build-tools): 0.59.0

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "build-tools-release-group-root",
-	"version": "0.58.0",
+	"version": "0.59.0",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/build-cli",
-	"version": "0.58.0",
+	"version": "0.59.0",
 	"description": "Build tools for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-infrastructure/package.json
+++ b/build-tools/packages/build-infrastructure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/build-infrastructure",
-	"version": "0.58.0",
+	"version": "0.59.0",
 	"description": "Fluid build infrastructure",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/build-tools",
-	"version": "0.58.0",
+	"version": "0.59.0",
 	"description": "Fluid Build tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/bundle-size-tools",
-	"version": "0.58.0",
+	"version": "0.59.0",
 	"description": "Utility for analyzing bundle size regressions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/version-tools",
-	"version": "0.58.0",
+	"version": "0.59.0",
 	"description": "Versioning tools for Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Bump build-tools package versions from `0.58.0` to `0.59.0` in preparation for release.

Updated via:
>pnpm -r --include-workspace-root exec npm pkg set version=0.59.0