### PR TITLE
Restrict typing of annotated types

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -15,7 +15,7 @@ export function adaptEnum<TScope extends string, const TEnum extends Record<stri
         }, Record<string, never>, true, Record<string, never>, undefined>; }[keyof TEnum]>;
 };
 
-// @alpha
+// @alpha @input
 export interface AllowedTypeMetadata {
     readonly custom?: unknown;
     readonly stagedSchemaUpgrade?: SchemaUpgrade;
@@ -24,7 +24,7 @@ export interface AllowedTypeMetadata {
 // @public @system
 export type AllowedTypes = readonly LazyItem<TreeNodeSchema>[];
 
-// @alpha
+// @alpha @input
 export interface AllowedTypesMetadata {
     readonly custom?: unknown;
 }
@@ -32,16 +32,16 @@ export interface AllowedTypesMetadata {
 // @alpha
 export function allowUnused<T>(t?: T): void;
 
-// @alpha
+// @alpha @sealed
 export interface AnnotatedAllowedType<T = LazyItem<TreeNodeSchema>> {
     readonly metadata: AllowedTypeMetadata;
     readonly type: T;
 }
 
-// @alpha
-export interface AnnotatedAllowedTypes {
+// @alpha @sealed
+export interface AnnotatedAllowedTypes<T = LazyItem<TreeNodeSchema>> {
     readonly metadata: AllowedTypesMetadata;
-    readonly types: readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[];
+    readonly types: readonly AnnotatedAllowedType<T>[];
 }
 
 // @public @system
@@ -298,10 +298,10 @@ export type IdentifierIndex = SimpleTreeIndex<string, TreeNode>;
 // @public
 export type ImplicitAllowedTypes = AllowedTypes | TreeNodeSchema;
 
-// @alpha
+// @alpha @input
 export type ImplicitAnnotatedAllowedTypes = TreeNodeSchema | AnnotatedAllowedType | AnnotatedAllowedTypes | readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[];
 
-// @alpha
+// @alpha @input
 export type ImplicitAnnotatedFieldSchema = FieldSchema | ImplicitAnnotatedAllowedTypes;
 
 // @public
@@ -623,10 +623,8 @@ export interface NodeSchemaOptionsAlpha<out TCustomMetadata = unknown> extends N
 // @alpha
 export const noopValidator: JsonValidator;
 
-// @alpha
-export interface NormalizedAnnotatedAllowedTypes {
-    readonly metadata: AllowedTypesMetadata;
-    readonly types: readonly AnnotatedAllowedType<TreeNodeSchema>[];
+// @alpha @sealed
+export interface NormalizedAnnotatedAllowedTypes extends AnnotatedAllowedTypes<TreeNodeSchema> {
 }
 
 // @public @system

--- a/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
+++ b/packages/dds/tree/src/simple-tree/core/allowedTypes.ts
@@ -47,7 +47,10 @@ export type AllowedTypes = readonly LazyItem<TreeNodeSchema>[];
 
 /**
  * Stores annotations for an individual allowed type.
+ * @remarks
+ * Create using APIs on {@link SchemaFactoryAlpha}, like {@link SchemaStaticsAlpha.staged}.
  * @alpha
+ * @sealed
  */
 export interface AnnotatedAllowedType<T = LazyItem<TreeNodeSchema>> {
 	/**
@@ -61,19 +64,12 @@ export interface AnnotatedAllowedType<T = LazyItem<TreeNodeSchema>> {
 }
 
 /**
- * Stores annotations for a set of evaluated annotated allowed types.
+ * {@link AnnotatedAllowedTypes} but with the lazy schema references eagerly evaluated.
+ * @sealed
  * @alpha
  */
-export interface NormalizedAnnotatedAllowedTypes {
-	/**
-	 * Annotations that apply to a set of allowed types.
-	 */
-	readonly metadata: AllowedTypesMetadata;
-	/**
-	 * All the evaluated allowed types that the annotations apply to. The types themselves are also individually annotated.
-	 */
-	readonly types: readonly AnnotatedAllowedType<TreeNodeSchema>[];
-}
+export interface NormalizedAnnotatedAllowedTypes
+	extends AnnotatedAllowedTypes<TreeNodeSchema> {}
 
 /**
  * Checks if the input is an {@link AnnotatedAllowedTypes}.
@@ -91,8 +87,9 @@ export function isAnnotatedAllowedTypes(
 /**
  * Stores annotations for a set of allowed types.
  * @alpha
+ * @sealed
  */
-export interface AnnotatedAllowedTypes {
+export interface AnnotatedAllowedTypes<T = LazyItem<TreeNodeSchema>> {
 	/**
 	 * Annotations that apply to a set of allowed types.
 	 */
@@ -100,7 +97,7 @@ export interface AnnotatedAllowedTypes {
 	/**
 	 * All the allowed types that the annotations apply to. The types themselves may also have individual annotations.
 	 */
-	readonly types: readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[];
+	readonly types: readonly AnnotatedAllowedType<T>[];
 }
 
 /**
@@ -108,6 +105,7 @@ export interface AnnotatedAllowedTypes {
  * @remarks
  * Additional optionals may be added to this as non-breaking changes, so implementations of it should be simple object literals with no unlisted members.
  * @alpha
+ * @input
  */
 export interface AllowedTypesMetadata {
 	/**
@@ -132,6 +130,7 @@ export function isAnnotatedAllowedType(
  * @remarks
  * Additional optionals may be added to this as non-breaking changes, so implementations of it should be simple object literals with no unlisted members.
  * @alpha
+ * @input
  */
 export interface AllowedTypeMetadata {
 	/**
@@ -208,6 +207,7 @@ export type ImplicitAllowedTypes = AllowedTypes | TreeNodeSchema;
  * Types of {@link TreeNode|TreeNodes} or {@link TreeLeafValue|TreeLeafValues} allowed at a location in a tree with
  * additional metadata associated with the location they're allowed at.
  * @alpha
+ * @input
  */
 export type ImplicitAnnotatedAllowedTypes =
 	| TreeNodeSchema

--- a/packages/dds/tree/src/simple-tree/fieldSchema.ts
+++ b/packages/dds/tree/src/simple-tree/fieldSchema.ts
@@ -620,8 +620,9 @@ function arePersistedMetadataEqual(
 export type ImplicitFieldSchema = FieldSchema | ImplicitAllowedTypes;
 
 /**
- * Annotated schema for a field of a tree node.
+ * {@link ImplicitFieldSchema} which supports {@link AnnotatedAllowedTypes | annotations} on the allowed types.
  * @alpha
+ * @input
  */
 export type ImplicitAnnotatedFieldSchema = FieldSchema | ImplicitAnnotatedAllowedTypes;
 

--- a/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/allowedTypes.spec.ts
@@ -216,14 +216,17 @@ const schema = new SchemaFactory("com.example");
 
 	// UnannotateAllowedTypes
 	{
-		type AnnotatedList = readonly [AnnotatedAllowedType, LazyItem<TreeNodeSchema>];
-
+		type AnnotatedList = readonly [
+			AnnotatedAllowedType,
+			{ type: typeof SchemaFactory.number; metadata: { custom: "customValue" } },
+		];
+		type Unannotated = UnannotateAllowedTypes<{
+			metadata: AllowedTypesMetadata;
+			types: AnnotatedList;
+		}>;
 		type _check = requireAssignableTo<
-			UnannotateAllowedTypes<{
-				metadata: AllowedTypesMetadata;
-				types: AnnotatedList;
-			}>,
-			readonly [LazyItem<TreeNodeSchema>, LazyItem<TreeNodeSchema>]
+			Unannotated,
+			readonly [LazyItem<TreeNodeSchema>, typeof SchemaFactory.number]
 		>;
 	}
 }
@@ -339,7 +342,7 @@ describe("allowedTypes", () => {
 
 	describe("unannotateImplicitAllowedTypes", () => {
 		const fakeSchema = schema.string;
-		const lazy = () => fakeSchema;
+		const lazy = (): typeof fakeSchema => assert.fail();
 
 		it("handles a raw TreeNodeSchema", () => {
 			assert.equal(unannotateImplicitAllowedTypes(fakeSchema), fakeSchema);
@@ -385,14 +388,6 @@ describe("allowedTypes", () => {
 				types: [],
 			};
 			assert.deepEqual(unannotateImplicitAllowedTypes(input), []);
-		});
-
-		it("handles array of mixed annotated/unannotated in AnnotatedAllowedTypes", () => {
-			const input: AnnotatedAllowedTypes = {
-				metadata: { custom: { something: true } },
-				types: [{ metadata: {}, type: lazy }, lazy],
-			};
-			assert.deepEqual(unannotateImplicitAllowedTypes(input), [lazy, lazy]);
 		});
 	});
 

--- a/packages/dds/tree/src/test/simple-tree/node-kinds/object/objectNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/node-kinds/object/objectNode.spec.ts
@@ -998,7 +998,10 @@ describeHydration(
 				const schemaRecord = {
 					bar: {
 						metadata: {},
-						types: [{ metadata: {}, type: stringSchema }, numberSchema],
+						types: [
+							{ metadata: {}, type: stringSchema },
+							{ metadata: {}, type: numberSchema },
+						],
 					},
 				};
 				const result = unannotateSchemaRecord(schemaRecord);

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -15,7 +15,7 @@ export function adaptEnum<TScope extends string, const TEnum extends Record<stri
         }, Record<string, never>, true, Record<string, never>, undefined>; }[keyof TEnum]>;
 };
 
-// @alpha
+// @alpha @input
 export interface AllowedTypeMetadata {
     readonly custom?: unknown;
     readonly stagedSchemaUpgrade?: SchemaUpgrade;
@@ -24,7 +24,7 @@ export interface AllowedTypeMetadata {
 // @public @system
 export type AllowedTypes = readonly LazyItem<TreeNodeSchema>[];
 
-// @alpha
+// @alpha @input
 export interface AllowedTypesMetadata {
     readonly custom?: unknown;
 }
@@ -32,16 +32,16 @@ export interface AllowedTypesMetadata {
 // @alpha
 export function allowUnused<T>(t?: T): void;
 
-// @alpha
+// @alpha @sealed
 export interface AnnotatedAllowedType<T = LazyItem<TreeNodeSchema>> {
     readonly metadata: AllowedTypeMetadata;
     readonly type: T;
 }
 
-// @alpha
-export interface AnnotatedAllowedTypes {
+// @alpha @sealed
+export interface AnnotatedAllowedTypes<T = LazyItem<TreeNodeSchema>> {
     readonly metadata: AllowedTypesMetadata;
-    readonly types: readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[];
+    readonly types: readonly AnnotatedAllowedType<T>[];
 }
 
 // @public @system
@@ -606,10 +606,10 @@ export interface IMember {
 // @public
 export type ImplicitAllowedTypes = AllowedTypes | TreeNodeSchema;
 
-// @alpha
+// @alpha @input
 export type ImplicitAnnotatedAllowedTypes = TreeNodeSchema | AnnotatedAllowedType | AnnotatedAllowedTypes | readonly (AnnotatedAllowedType | LazyItem<TreeNodeSchema>)[];
 
-// @alpha
+// @alpha @input
 export type ImplicitAnnotatedFieldSchema = FieldSchema | ImplicitAnnotatedAllowedTypes;
 
 // @public
@@ -979,10 +979,8 @@ export interface NodeSchemaOptionsAlpha<out TCustomMetadata = unknown> extends N
 // @alpha
 export const noopValidator: JsonValidator;
 
-// @alpha
-export interface NormalizedAnnotatedAllowedTypes {
-    readonly metadata: AllowedTypesMetadata;
-    readonly types: readonly AnnotatedAllowedType<TreeNodeSchema>[];
+// @alpha @sealed
+export interface NormalizedAnnotatedAllowedTypes extends AnnotatedAllowedTypes<TreeNodeSchema> {
 }
 
 // @public @system


### PR DESCRIPTION
## Description

Restrict annotated allowed types to only be allowed to be made be FF APIs (currently just SchemaFactoryAlpha.staged) by annotating them with `@sealed`.

Also mark implicit schema types is `@input` so adding more options to them in the future is not a breaking change.

This makes it possible to stabilize that AnotatedAllowedTypes are a thing, without having to stabilize their exact format, or any particular annotation (like staged schema)

## Breaking Changes

Existing code using these alpha APIs may need to be updated if it is violating the restrictions of the new tags.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
