### PR TITLE
(tree) Added basic unit tests for ForestSummarizer

### DIFF
--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -42,7 +42,7 @@ import type { Format } from "./format.js";
 /**
  * The storage key for the blob in the summary containing tree data
  */
-const treeBlobKey = "ForestTree";
+export const treeBlobKey = "ForestTree";
 
 /**
  * Provides methods for summarizing and loading a forest.

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
@@ -18,7 +18,12 @@ import {
 } from "../../../feature-libraries/index.js";
 import { checkoutWithContent, testIdCompressor, testRevisionTagCodec } from "../../utils.js";
 import { jsonSequenceRootSchema } from "../../sequenceRootUtils.js";
-import type { TreeStoredContent } from "../../../shared-tree/index.js";
+import {
+	ForestTypeOptimized,
+	ForestTypeReference,
+	type ForestType,
+	type TreeStoredContent,
+} from "../../../shared-tree/index.js";
 import {
 	permissiveStoredSchemaGenerationOptions,
 	SchemaFactory,
@@ -32,10 +37,10 @@ describe("ForestSummarizer", () => {
 	function createForestSummarizer(args: {
 		// The encoding strategy to use when summarizing the forest.
 		encodeType: TreeCompressionStrategy;
+		// The type of forest to create.
+		forestType: ForestType;
 		// The content and schema to initialize the forest with. By default, it is an empty forest.
 		initialContent?: TreeStoredContent;
-		// True for creating a chunked forest.
-		chunkedForest?: true;
 	}): ForestSummarizer {
 		const {
 			initialContent = {
@@ -43,14 +48,16 @@ describe("ForestSummarizer", () => {
 				initialTree: undefined,
 			},
 			encodeType,
-			chunkedForest,
+			forestType,
 		} = args;
 		const fieldBatchCodec = makeFieldBatchCodec({ jsonValidator: typeboxValidator }, 1);
 		const options: CodecWriteOptions = {
 			jsonValidator: typeboxValidator,
 			oldestCompatibleClient: FluidClientVersion.v2_0,
 		};
-		const checkout = checkoutWithContent(initialContent, { chunkedForest });
+		const checkout = checkoutWithContent(initialContent, {
+			forestType,
+		});
 		const encoderContext: FieldBatchEncodingContext = {
 			encodeType,
 			idCompressor: testIdCompressor,
@@ -70,31 +77,33 @@ describe("ForestSummarizer", () => {
 	describe("Create and Load", () => {
 		const testCases: {
 			encodeType: TreeCompressionStrategy;
-			type: string;
-			chunkedForest?: true;
+			testType: string;
+			forestType: ForestType;
 		}[] = [
 			{
 				encodeType: TreeCompressionStrategy.Compressed,
-				type: "compressed",
+				testType: "compressed",
+				forestType: ForestTypeReference,
 			},
 			{
 				encodeType: TreeCompressionStrategy.Uncompressed,
-				type: "uncompressed",
+				testType: "uncompressed",
+				forestType: ForestTypeReference,
 			},
 			{
 				encodeType: TreeCompressionStrategy.Compressed,
-				type: "compressed chunked",
-				chunkedForest: true,
+				testType: "compressed chunked",
+				forestType: ForestTypeOptimized,
 			},
 			{
 				encodeType: TreeCompressionStrategy.Uncompressed,
-				type: "uncompressed chunked",
-				chunkedForest: true,
+				testType: "uncompressed chunked",
+				forestType: ForestTypeOptimized,
 			},
 		];
-		for (const { encodeType, type, chunkedForest } of testCases) {
-			it(`can summarize empty ${type} forest and load from it`, async () => {
-				const forestSummarizer = createForestSummarizer({ encodeType, chunkedForest });
+		for (const { encodeType, testType, forestType } of testCases) {
+			it(`can summarize empty ${testType} forest and load from it`, async () => {
+				const forestSummarizer = createForestSummarizer({ encodeType, forestType });
 				const summary = forestSummarizer.summarize({ stringify: JSON.stringify });
 				assert(
 					Object.keys(summary.summary.tree).length === 1,
@@ -109,15 +118,14 @@ describe("ForestSummarizer", () => {
 
 				// Create a new ForestSummarizer and load with the above summary.
 				const mockStorage = MockStorage.createFromSummary(summary.summary);
-				const forestSummarizer2 = createForestSummarizer({ encodeType, chunkedForest });
+				const forestSummarizer2 = createForestSummarizer({ encodeType, forestType });
 				await assert.doesNotReject(async () => {
 					await forestSummarizer2.load(mockStorage, JSON.parse);
 				});
 			});
 
-			it(`can summarize ${type} forest with simple content and load from it`, async () => {
-				const sf = new SchemaFactory("test");
-				const schema = sf.number;
+			it(`can summarize ${testType} forest with simple content and load from it`, async () => {
+				const schema = SchemaFactory.number;
 				const initialContent: TreeStoredContent = {
 					schema: toStoredSchema(schema, permissiveStoredSchemaGenerationOptions),
 					get initialTree() {
@@ -127,7 +135,7 @@ describe("ForestSummarizer", () => {
 				const forestSummarizer = createForestSummarizer({
 					initialContent,
 					encodeType,
-					chunkedForest,
+					forestType,
 				});
 				const summary = forestSummarizer.summarize({ stringify: JSON.stringify });
 				assert(
@@ -143,7 +151,7 @@ describe("ForestSummarizer", () => {
 
 				// Create a new empty ForestSummarizer and load with the above summary.
 				const mockStorage = MockStorage.createFromSummary(summary.summary);
-				const forestSummarizer2 = createForestSummarizer({ encodeType, chunkedForest });
+				const forestSummarizer2 = createForestSummarizer({ encodeType, forestType });
 				await assert.doesNotReject(async () => {
 					await forestSummarizer2.load(mockStorage, JSON.parse);
 				});

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
@@ -1,0 +1,153 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+import { SummaryType, type SummaryObject } from "@fluidframework/driver-definitions";
+import { MockStorage } from "@fluidframework/test-runtime-utils/internal";
+
+import { typeboxValidator } from "../../../external-utilities/index.js";
+import { FluidClientVersion, type CodecWriteOptions } from "../../../codec/index.js";
+import {
+	ForestSummarizer,
+	TreeCompressionStrategy,
+	defaultSchemaPolicy,
+	makeFieldBatchCodec,
+	type FieldBatchEncodingContext,
+} from "../../../feature-libraries/index.js";
+import { checkoutWithContent, testIdCompressor, testRevisionTagCodec } from "../../utils.js";
+import { jsonSequenceRootSchema } from "../../sequenceRootUtils.js";
+import type { TreeStoredContent } from "../../../shared-tree/index.js";
+import {
+	permissiveStoredSchemaGenerationOptions,
+	SchemaFactory,
+	toStoredSchema,
+} from "../../../simple-tree/index.js";
+import { singleJsonCursor } from "../../json/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { treeBlobKey } from "../../../feature-libraries/forest-summary/forestSummarizer.js";
+
+describe("ForestSummarizer", () => {
+	function createForestSummarizer(args: {
+		// The encoding strategy to use when summarizing the forest.
+		encodeType: TreeCompressionStrategy;
+		// The content and schema to initialize the forest with. By default, it is an empty forest.
+		initialContent?: TreeStoredContent;
+		// True for creating a chunked forest.
+		chunkedForest?: true;
+	}): ForestSummarizer {
+		const {
+			initialContent = {
+				schema: jsonSequenceRootSchema,
+				initialTree: undefined,
+			},
+			encodeType,
+			chunkedForest,
+		} = args;
+		const fieldBatchCodec = makeFieldBatchCodec({ jsonValidator: typeboxValidator }, 1);
+		const options: CodecWriteOptions = {
+			jsonValidator: typeboxValidator,
+			oldestCompatibleClient: FluidClientVersion.v2_0,
+		};
+		const checkout = checkoutWithContent(initialContent, { chunkedForest });
+		const encoderContext: FieldBatchEncodingContext = {
+			encodeType,
+			idCompressor: testIdCompressor,
+			originatorId: testIdCompressor.localSessionId,
+			schema: { schema: initialContent.schema, policy: defaultSchemaPolicy },
+		};
+		return new ForestSummarizer(
+			checkout.forest,
+			testRevisionTagCodec,
+			fieldBatchCodec,
+			encoderContext,
+			options,
+			testIdCompressor,
+		);
+	}
+
+	describe("Create and Load", () => {
+		const testCases: {
+			encodeType: TreeCompressionStrategy;
+			type: string;
+			chunkedForest?: true;
+		}[] = [
+			{
+				encodeType: TreeCompressionStrategy.Compressed,
+				type: "compressed",
+			},
+			{
+				encodeType: TreeCompressionStrategy.Uncompressed,
+				type: "uncompressed",
+			},
+			{
+				encodeType: TreeCompressionStrategy.Compressed,
+				type: "compressed chunked",
+				chunkedForest: true,
+			},
+			{
+				encodeType: TreeCompressionStrategy.Uncompressed,
+				type: "uncompressed chunked",
+				chunkedForest: true,
+			},
+		];
+		for (const { encodeType, type, chunkedForest } of testCases) {
+			it(`can summarize empty ${type} forest and load from it`, async () => {
+				const forestSummarizer = createForestSummarizer({ encodeType, chunkedForest });
+				const summary = forestSummarizer.summarize({ stringify: JSON.stringify });
+				assert(
+					Object.keys(summary.summary.tree).length === 1,
+					"Summary tree should only contain one entry for the forest contents",
+				);
+				const forestContentsBlob: SummaryObject | undefined =
+					summary.summary.tree[treeBlobKey];
+				assert(
+					forestContentsBlob?.type === SummaryType.Blob,
+					"Forest summary contents not found",
+				);
+
+				// Create a new ForestSummarizer and load with the above summary.
+				const mockStorage = MockStorage.createFromSummary(summary.summary);
+				const forestSummarizer2 = createForestSummarizer({ encodeType, chunkedForest });
+				await assert.doesNotReject(async () => {
+					await forestSummarizer2.load(mockStorage, JSON.parse);
+				});
+			});
+
+			it(`can summarize ${type} forest with simple content and load from it`, async () => {
+				const sf = new SchemaFactory("test");
+				const schema = sf.number;
+				const initialContent: TreeStoredContent = {
+					schema: toStoredSchema(schema, permissiveStoredSchemaGenerationOptions),
+					get initialTree() {
+						return singleJsonCursor(5);
+					},
+				};
+				const forestSummarizer = createForestSummarizer({
+					initialContent,
+					encodeType,
+					chunkedForest,
+				});
+				const summary = forestSummarizer.summarize({ stringify: JSON.stringify });
+				assert(
+					Object.keys(summary.summary.tree).length === 1,
+					"Summary tree should only contain one entry for the forest contents",
+				);
+				const forestContentsBlob: SummaryObject | undefined =
+					summary.summary.tree[treeBlobKey];
+				assert(
+					forestContentsBlob?.type === SummaryType.Blob,
+					"Forest summary contents not found",
+				);
+
+				// Create a new empty ForestSummarizer and load with the above summary.
+				const mockStorage = MockStorage.createFromSummary(summary.summary);
+				const forestSummarizer2 = createForestSummarizer({ encodeType, chunkedForest });
+				await assert.doesNotReject(async () => {
+					await forestSummarizer2.load(mockStorage, JSON.parse);
+				});
+			});
+		}
+	});
+});


### PR DESCRIPTION
Added basic unit tests for `ForestSummarizer` that validate that the `summarize` and `load` functionality works correctly. 

There are 2 test cases:
1. Summarizes an empty forest and loads another from the summary.
2. Summaries a forest with content and loads another from the same summary.

The tests run for the following combinations:
1. Uncompressed object forest.
2. Compressed object forest.
3. Uncompressed chunked forest.
4. Compressed chunked forest.