### PR TITLE
Add disposal method to SerializedStateManager for snapshot refresh timer cleanup

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1158,6 +1158,9 @@ export class Container
 
 				this.storageAdapter.dispose();
 
+				// Dispose serialized state manager to clean up snapshot refresh timer
+				this.serializedStateManager.dispose();
+
 				// Notify storage about critical errors. They may be due to disconnect between client & server knowledge
 				// about file, like file being overwritten in storage, but client having stale local cache.
 				// Driver need to ensure all caches are cleared on critical errors

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -474,6 +474,14 @@ export class SerializedStateManager {
 			},
 		);
 	}
+
+	/**
+	 * Dispose of the SerializedStateManager, cleaning up any active timers.
+	 * This prevents Node.js processes from hanging due to the refresh timer.
+	 */
+	public dispose(): void {
+		this.refreshTimer.clear();
+	}
 }
 
 /**


### PR DESCRIPTION
`SerializedStateManager` creates a 24-hour snapshot refresh timer (`refreshTimer`) but provides no mechanism to dispose of it. This could potentially cause Node.js processes to hang in scenarios where the timer outlives the container lifecycle.

### Root Cause
The `SerializedStateManager` class instantiates a `Timer` object with a 24-hour timeout (line 153: `60 * 60 * 24 * 1000`) for periodic snapshot refreshing. While this timer is started and restarted throughout the container lifecycle, there is no corresponding disposal method to clear it when the container is disposed.

### Solution
1. **Added `dispose()` method** to `SerializedStateManager` to clear the refresh timer
2. **Enhanced container disposal** by calling `serializedStateManager.dispose()` in `Container.disposeCore()`
3. **Added documentation** explaining the purpose and importance of the disposal

[AB#46301](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/46301)
