### PR TITLE
fix(Test logs): Avoid squashing 'details' logging property

### DIFF
--- a/packages/test/mocha-test-setup/src/mochaHooks.ts
+++ b/packages/test/mocha-test-setup/src/mochaHooks.ts
@@ -17,7 +17,7 @@ import { pkgName } from "./packageVersion.js";
 Error.stackTraceLimit = Number.POSITIVE_INFINITY;
 
 const testVariant = process.env.FLUID_TEST_VARIANT;
-const propsDict =
+const envLoggerProps =
 	process.env.FLUID_LOGGER_PROPS != null
 		? JSON.parse(process.env.FLUID_LOGGER_PROPS)
 		: undefined;
@@ -46,8 +46,8 @@ class FluidTestRunLogger implements ITelemetryBufferedLogger {
 			...event,
 			// Setting hostname to pkgName is the behavior we had for a long time, so keeping it just in case.
 			// But prefer a value set through FLUID_LOGGER_PROPS if it exists.
-			hostName: propsDict?.hostName ?? pkgName,
-			details: JSON.stringify(propsDict),
+			hostName: envLoggerProps?.hostName ?? pkgName,
+			testEnvProps: JSON.stringify(envLoggerProps),
 		});
 	}
 	async flush() {


### PR DESCRIPTION
## Description

In our test logs, every log has the `details` property set to the same thing, something like `{ "displayName": "RealStressService"}` (depending on the specific test).  This is because the mocha hooks overwrite the `details` property.

The fix I'm proposing is to put that `displayName` property (and any other props added via ENV) in the logs under `testEnvProps`, leaving `details` for whatever the actual code said.
