### PR TITLE
Simplify shared tree initialize

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -414,17 +414,15 @@ export interface ValueFieldEditBuilder<TContent> {
 	/**
 	 * Issues a change which replaces the current newContent of the field with `newContent`.
 	 * @param newContent - the new content for the field.
-	 * The cursor can be in either Field or Node mode and must represent exactly one node.
 	 */
 	set(newContent: TContent): void;
 }
 
 export interface OptionalFieldEditBuilder<TContent> {
 	/**
-	 * Issues a change which replaces the current newContent of the field with `newContent`
+	 * Issues a change which replaces the current newContent of the field with `newContent`.
 	 * @param newContent - the new content for the field.
-	 * If provided, the cursor can be in either Field or Node mode and must represent exactly one node.
-	 * @param wasEmpty - whether the field is empty when creating this change
+	 * @param wasEmpty - whether the field is empty when creating this change.
 	 */
 	set(newContent: TContent | undefined, wasEmpty: boolean): void;
 }

--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -35,7 +35,7 @@ export {
 	type TreeBranchFork,
 } from "./treeCheckout.js";
 
-export { type TreeStoredContent } from "./schematizeTree.js";
+export type { TreeStoredContentStrict } from "./schematizeTree.js";
 
 export { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
 

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -16,7 +16,7 @@ import { anchorSlot } from "../core/index.js";
 import {
 	type NodeIdentifierManager,
 	defaultSchemaPolicy,
-	cursorForMapTreeNode,
+	cursorForMapTreeField,
 	TreeStatus,
 	Context,
 } from "../feature-libraries/index.js";
@@ -186,7 +186,7 @@ export class SchematizingSimpleTreeView<
 
 			initialize(this.checkout, {
 				schema,
-				initialTree: mapTree === undefined ? undefined : cursorForMapTreeNode(mapTree),
+				initialTree: cursorForMapTreeField(mapTree === undefined ? [] : [mapTree]),
 			});
 		});
 	}

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
@@ -22,14 +22,14 @@ import {
 	ForestTypeOptimized,
 	ForestTypeReference,
 	type ForestType,
-	type TreeStoredContent,
+	type TreeStoredContentStrict,
 } from "../../../shared-tree/index.js";
 import {
 	permissiveStoredSchemaGenerationOptions,
 	SchemaFactory,
 	toStoredSchema,
 } from "../../../simple-tree/index.js";
-import { singleJsonCursor } from "../../json/index.js";
+import { fieldJsonCursor } from "../../json/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { treeBlobKey } from "../../../feature-libraries/forest-summary/forestSummarizer.js";
 
@@ -40,7 +40,7 @@ describe("ForestSummarizer", () => {
 		// The type of forest to create.
 		forestType: ForestType;
 		// The content and schema to initialize the forest with. By default, it is an empty forest.
-		initialContent?: TreeStoredContent;
+		initialContent?: TreeStoredContentStrict;
 	}): ForestSummarizer {
 		const {
 			initialContent = {
@@ -126,10 +126,10 @@ describe("ForestSummarizer", () => {
 
 			it(`can summarize ${testType} forest with simple content and load from it`, async () => {
 				const schema = SchemaFactory.number;
-				const initialContent: TreeStoredContent = {
+				const initialContent: TreeStoredContentStrict = {
 					schema: toStoredSchema(schema, permissiveStoredSchemaGenerationOptions),
 					get initialTree() {
-						return singleJsonCursor(5);
+						return fieldJsonCursor([5]);
 					},
 				};
 				const forestSummarizer = createForestSummarizer({

--- a/packages/dds/tree/src/test/scalableTestTrees.ts
+++ b/packages/dds/tree/src/test/scalableTestTrees.ts
@@ -27,7 +27,7 @@ import {
 	type UnsafeUnknownSchema,
 	type ValidateRecursiveSchema,
 } from "../simple-tree/index.js";
-import type { TreeStoredContent } from "../shared-tree/index.js";
+import type { TreeStoredContentStrict } from "../shared-tree/index.js";
 
 import type {
 	TreeSimpleContent,
@@ -90,7 +90,7 @@ export function makeDeepContentSimple(
 export function makeDeepStoredContent(
 	depth: number,
 	leafValue: number = 1,
-): TreeStoredContent {
+): TreeStoredContentStrict {
 	const content = makeDeepContentSimple(depth, leafValue);
 	return {
 		initialTree: fieldCursorFromInsertable<UnsafeUnknownSchema>(
@@ -125,7 +125,7 @@ export function makeWideContentWithEndValueSimple(
 export function makeWideStoredContentWithEndValue(
 	numberOfNodes: number,
 	endLeafValue?: number,
-): TreeStoredContent {
+): TreeStoredContentStrict {
 	const content = makeWideContentWithEndValueSimple(numberOfNodes, endLeafValue);
 	return {
 		initialTree: fieldCursorFromInsertable<UnsafeUnknownSchema>(

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -16,7 +16,7 @@ import {
 	type NormalizedUpPath,
 	type TreeNodeSchemaIdentifier,
 } from "../../core/index.js";
-import type { ITreeCheckout, TreeStoredContent } from "../../shared-tree/index.js";
+import type { ITreeCheckout, TreeStoredContentStrict } from "../../shared-tree/index.js";
 import { type JsonCompatible, brand, makeArray } from "../../util/index.js";
 import {
 	checkoutWithContent,
@@ -32,6 +32,7 @@ import {
 import { insert, makeTreeFromJsonSequence, remove } from "../sequenceRootUtils.js";
 import { numberSchema, SchemaFactory, toInitialSchema } from "../../simple-tree/index.js";
 import { JsonAsTree } from "../../jsonDomainSchema.js";
+import { fieldJsonCursor } from "../json/index.js";
 
 const rootField: NormalizedFieldUpPath = {
 	parent: undefined,
@@ -52,9 +53,11 @@ const rootNode2: NormalizedUpPath = {
 	detachedNodeId: undefined,
 };
 
-const emptyJsonContent: TreeStoredContent = {
+const emptyJsonContent: TreeStoredContentStrict = {
 	schema: toInitialSchema(SchemaFactory.optional(JsonAsTree.Tree)),
-	initialTree: undefined,
+	get initialTree() {
+		return fieldJsonCursor([]);
+	},
 };
 
 describe("Editing", () => {

--- a/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
@@ -14,7 +14,7 @@ import {
 	TreeStoredSchemaRepository,
 	type AnchorSetRootEvents,
 } from "../../core/index.js";
-import { singleJsonCursor } from "../json/index.js";
+import { fieldJsonCursor } from "../json/index.js";
 import {
 	FieldKinds,
 	allowsRepoSuperset,
@@ -25,9 +25,9 @@ import type {
 	ITreeCheckoutFork,
 	CheckoutEvents,
 	ISharedTreeEditor,
+	TreeStoredContentStrict,
 } from "../../shared-tree/index.js";
 import {
-	type TreeStoredContent,
 	UpdateType,
 	canInitialize,
 	ensureSchema,
@@ -81,7 +81,7 @@ function makeSchemaRepository(repository: TreeStoredSchemaRepository): {
 
 describe("schematizeTree", () => {
 	describe("initializeContent", () => {
-		function testInitialize(name: string, content: TreeStoredContent): void {
+		function testInitialize(name: string, content: TreeStoredContentStrict): void {
 			describe(`Initialize ${name}`, () => {
 				it("correct output", () => {
 					const storedSchema = new TreeStoredSchemaRepository();
@@ -141,15 +141,15 @@ describe("schematizeTree", () => {
 
 		testInitialize("optional-empty", {
 			schema: toInitialSchema(schema),
-			initialTree: undefined,
+			initialTree: fieldJsonCursor([]),
 		});
 		testInitialize("optional-full", {
 			schema: toInitialSchema(schema),
-			initialTree: singleJsonCursor(5),
+			initialTree: fieldJsonCursor([5]),
 		});
 		testInitialize("value", {
 			schema: toInitialSchema(schemaValueRoot),
-			initialTree: singleJsonCursor(6),
+			initialTree: fieldJsonCursor([6]),
 		});
 
 		// TODO: Test schema validation of initial tree (once we have a utility for it)
@@ -249,9 +249,9 @@ describe("schematizeTree", () => {
 		});
 
 		it("compatible: upgrade optional root", () => {
-			const emptyContent: TreeStoredContent = {
+			const emptyContent: TreeStoredContentStrict = {
 				schema: toInitialSchema(emptySchema),
-				initialTree: undefined,
+				initialTree: fieldJsonCursor([]),
 			};
 
 			// Schema upgraded, but content not initialized
@@ -272,9 +272,9 @@ describe("schematizeTree", () => {
 		});
 
 		it("incompatible: empty to required root", () => {
-			const emptyContent: TreeStoredContent = {
+			const emptyContent: TreeStoredContentStrict = {
 				schema: toInitialSchema(emptySchema),
-				initialTree: undefined,
+				initialTree: fieldJsonCursor([]),
 			};
 			const emptyCheckout = checkoutWithContent(emptyContent);
 
@@ -289,16 +289,16 @@ describe("schematizeTree", () => {
 		});
 
 		it("update non-empty", () => {
-			const initialContent: TreeStoredContent = {
+			const initialContent: TreeStoredContentStrict = {
 				schema: toInitialSchema(schema),
 				get initialTree() {
-					return singleJsonCursor(5);
+					return fieldJsonCursor([5]);
 				},
 			};
 			const initialCheckout = checkoutWithContent(initialContent);
-			const content: TreeStoredContent = {
+			const content: TreeStoredContentStrict = {
 				schema: toInitialSchema(schemaGeneralized),
-				initialTree: singleJsonCursor("Should not be used"),
+				initialTree: fieldJsonCursor(["Should not be used"]),
 			};
 			const updatedCheckout = checkoutWithContent({
 				schema: toInitialSchema(schemaGeneralized),

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -39,7 +39,7 @@ import {
 	ForestTypeExpensiveDebug,
 	ForestTypeReference,
 	type TreeCheckout,
-	type TreeStoredContent,
+	type TreeStoredContentStrict,
 } from "../../shared-tree/index.js";
 import type { Mutable } from "../../util/index.js";
 import { brand } from "../../util/index.js";
@@ -63,7 +63,7 @@ function checkoutWithInitialTree(
 		viewConfig.schema,
 		unhydratedInitialTree,
 	);
-	const treeContent: TreeStoredContent = {
+	const treeContent: TreeStoredContentStrict = {
 		schema: toInitialSchema(viewConfig.schema),
 		initialTree,
 	};

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -10,7 +10,7 @@ import {
 	RevertibleStatus,
 	rootFieldKey,
 } from "../../core/index.js";
-import { singleJsonCursor } from "../json/index.js";
+import { fieldJsonCursor } from "../json/index.js";
 import type { ITreeCheckout } from "../../shared-tree/index.js";
 import { type JsonCompatible, brand } from "../../util/index.js";
 import {
@@ -709,7 +709,7 @@ export function createCheckout(json: JsonCompatible[], attachTree: boolean): ITr
 	runtimeFactory.createContainerRuntime(runtime);
 	initialize(tree.kernel.checkout, {
 		schema: jsonSequenceRootSchema,
-		initialTree: json.map(singleJsonCursor),
+		initialTree: fieldJsonCursor(json),
 	});
 
 	if (attachTree) {

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -70,7 +70,7 @@ import {
 	SchematizingSimpleTreeView,
 	TreeAlpha,
 	type TreeCheckout,
-	type TreeStoredContent,
+	type TreeStoredContentStrict,
 } from "../../../shared-tree/index.js";
 import { FieldKinds } from "../../../feature-libraries/index.js";
 import {
@@ -3143,7 +3143,7 @@ function checkoutWithInitialTree(
 		viewConfig.schema,
 		unhydratedInitialTree,
 	);
-	const treeContent: TreeStoredContent = {
+	const treeContent: TreeStoredContentStrict = {
 		schema: toInitialSchema(viewConfig.schema),
 		initialTree,
 	};

--- a/packages/dds/tree/src/test/testTrees.ts
+++ b/packages/dds/tree/src/test/testTrees.ts
@@ -3,14 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert, fail } from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { MockHandle } from "@fluidframework/test-runtime-utils/internal";
 
 import {
-	type ITreeCursorSynchronous,
 	type JsonableTree,
-	Multiplicity,
 	ObjectNodeStoredSchema,
 	type TreeNodeSchemaIdentifier,
 	type TreeStoredSchema,
@@ -19,18 +17,14 @@ import {
 } from "../core/index.js";
 import {
 	FieldKinds,
-	type FlexFieldKind,
 	type FullSchemaPolicy,
 	cursorForJsonableTreeField,
-	cursorForJsonableTreeNode,
 	defaultSchemaPolicy,
-	fieldKinds,
 	jsonableTreeFromFieldCursor,
 } from "../feature-libraries/index.js";
 import {
 	ForestTypeExpensiveDebug,
 	type SchematizingSimpleTreeView,
-	type TreeStoredContent,
 } from "../shared-tree/index.js";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import {
@@ -134,30 +128,6 @@ function test(name: string, schemaData: TreeStoredSchema, data: JsonableTree[]):
 		schemaData,
 		treeFactory: () => data,
 		policy: defaultSchemaPolicy,
-	};
-}
-
-function cursorsToFieldContent(
-	cursors: readonly ITreeCursorSynchronous[],
-	schema: FlexFieldKind,
-): readonly ITreeCursorSynchronous[] | ITreeCursorSynchronous | undefined {
-	if (schema.multiplicity === Multiplicity.Sequence) {
-		return cursors;
-	}
-	if (cursors.length === 1) {
-		return cursors[0];
-	}
-	assert(cursors.length === 0);
-	return undefined;
-}
-
-export function treeContentFromTestTree(testData: TestTree): TreeStoredContent {
-	return {
-		schema: testData.schemaData,
-		initialTree: cursorsToFieldContent(
-			testData.treeFactory().map(cursorForJsonableTreeNode),
-			fieldKinds.get(testData.schemaData.rootFieldSchema.kind) ?? fail("missing kind"),
-		),
 	};
 }
 

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -133,7 +133,6 @@ import {
 	type ISharedTreeEditor,
 	type ITreeCheckoutFork,
 	independentView,
-	type TreeStoredContent,
 	SchematizingSimpleTreeView,
 	type ForestOptions,
 	type SharedTreeOptionsInternal,
@@ -689,23 +688,12 @@ export function validateFuzzTreeConsistency(
 	);
 }
 
-function contentToJsonableTree(content: TreeStoredContent): JsonableTree[] {
-	return jsonableTreeFromFieldCursor(normalizeNewFieldContent(content.initialTree));
-}
-
 export function validateTreeContent(tree: ITreeCheckout, content: TreeSimpleContent): void {
 	const contentReference = jsonableTreeFromFieldCursor(
 		fieldCursorFromInsertable<UnsafeUnknownSchema>(content.schema, content.initialTree),
 	);
 	assert.deepEqual(toJsonableTree(tree), contentReference);
 	expectSchemaEqual(tree.storedSchema, toInitialSchema(content.schema));
-}
-export function validateTreeStoredContent(
-	tree: ITreeCheckout,
-	content: TreeStoredContent,
-): void {
-	assert.deepEqual(toJsonableTree(tree), contentToJsonableTree(content));
-	expectSchemaEqual(tree.storedSchema, content.schema);
 }
 
 export function expectSchemaEqual(
@@ -1548,4 +1536,23 @@ export class TestSchemaRepository extends TreeStoredSchemaRepository {
 		}
 		return false;
 	}
+}
+
+/**
+ * Content that can populate a `SharedTree`.
+ * @remarks
+ * Consider using TreeStoredContentStrict instead which has more specific typing.
+ */
+interface TreeStoredContent {
+	readonly schema: TreeStoredSchema;
+
+	/**
+	 * Default tree content to initialize the tree with iff the tree is uninitialized
+	 * (meaning it does not even have any schema set at all).
+	 *
+	 * Can be a single field cursor, array of nodes cursors, or undefined, or a single node cursor (in which case the root is assumed to have a single child).
+	 *
+	 * This cannot encode the dummy "above root" node and thus can not specify additional detached fields.
+	 */
+	readonly initialTree: readonly ITreeCursorSynchronous[] | ITreeCursorSynchronous | undefined;
 }


### PR DESCRIPTION
## Description

The initialize logic in SharedTree is simplified to remove some unneeded initalTree format options.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).