### PR TITLE
Simplify schema upgrade logic

### DIFF
--- a/packages/dds/tree/src/shared-tree/schematizeTree.ts
+++ b/packages/dds/tree/src/shared-tree/schematizeTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
+import { assert, fail } from "@fluidframework/core-utils/internal";
 
 import {
 	type ITreeCursorSynchronous,
@@ -16,7 +16,6 @@ import {
 	allowsRepoSuperset,
 	defaultSchemaPolicy,
 } from "../feature-libraries/index.js";
-import { toUpgradeSchema, type SchemaCompatibilityTester } from "../simple-tree/index.js";
 
 import type { ITreeCheckout } from "./treeCheckout.js";
 
@@ -85,46 +84,6 @@ export function initializeContent(
 	}
 }
 
-export enum UpdateType {
-	/**
-	 * Already compatible, no update needed.
-	 */
-	None,
-	/**
-	 * Schema can be upgraded leaving tree as is.
-	 */
-	SchemaCompatible,
-	/**
-	 * No update currently supported.
-	 */
-	Incompatible,
-}
-
-/**
- * Returns how compatible updating checkout's schema is with the viewSchema.
- */
-export function evaluateUpdate(
-	viewSchema: SchemaCompatibilityTester,
-	checkout: ITreeCheckout,
-): UpdateType {
-	const compatibility = viewSchema.checkCompatibility(checkout.storedSchema);
-
-	if (compatibility.canUpgrade && compatibility.canView) {
-		// Compatible as is
-		return UpdateType.None;
-	}
-
-	if (!compatibility.canUpgrade) {
-		// Existing stored schema permits trees which are incompatible with the view schema, so schema can not be updated
-		return UpdateType.Incompatible;
-	}
-
-	assert(!compatibility.canView, 0x8bd /* unexpected case */);
-	assert(compatibility.canUpgrade, 0x8be /* unexpected case */);
-
-	return UpdateType.SchemaCompatible;
-}
-
 export function canInitialize(checkout: ITreeCheckout): boolean {
 	// Check for empty.
 	return checkout.forest.isEmpty && schemaDataIsEmpty(checkout.storedSchema);
@@ -171,40 +130,6 @@ export function initialize(
 		});
 	} finally {
 		checkout.transaction.commit();
-	}
-}
-
-/**
- * Ensure a {@link ITreeCheckout} can be used with a given {@link SchemaCompatibilityTester}.
- *
- * @remarks
- * It is up to the caller to ensure that compatibility is reevaluated if the checkout's stored schema is edited in the future.
- *
- * @param viewSchema - View schema that `checkout` should be made compatible with.
- * @param allowedSchemaModifications - Flags enum describing the ways this is allowed to modify `checkout`.
- * @param checkout - To be modified as needed to be compatible with `viewSchema`.
- * @param treeContent - Content to be used to initialize `checkout`'s the tree if needed and allowed.
- * @returns true iff checkout now is compatible with `viewSchema`.
- */
-export function ensureSchema(
-	viewSchema: SchemaCompatibilityTester,
-	checkout: ITreeCheckout,
-): boolean {
-	const updatedNeeded = evaluateUpdate(viewSchema, checkout);
-	switch (updatedNeeded) {
-		case UpdateType.None: {
-			return true;
-		}
-		case UpdateType.Incompatible: {
-			return false;
-		}
-		case UpdateType.SchemaCompatible: {
-			checkout.updateSchema(toUpgradeSchema(viewSchema.viewSchema.root));
-			return true;
-		}
-		default: {
-			unreachableCase(updatedNeeded);
-		}
 	}
 }
 

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -55,6 +55,7 @@ import {
 	FieldSchemaAlpha,
 	TreeViewConfigurationAlpha,
 	toInitialSchema,
+	toUpgradeSchema,
 } from "../simple-tree/index.js";
 import {
 	type Breakable,
@@ -63,7 +64,7 @@ import {
 	type WithBreakable,
 } from "../util/index.js";
 
-import { canInitialize, ensureSchema, initialize } from "./schematizeTree.js";
+import { canInitialize, initialize } from "./schematizeTree.js";
 import type { ITreeCheckout, TreeCheckout } from "./treeCheckout.js";
 
 /**
@@ -206,10 +207,8 @@ export class SchematizingSimpleTreeView<
 			);
 		}
 
-		this.runSchemaEdit(() => {
-			const result = ensureSchema(this.viewSchema, this.checkout);
-			assert(result, 0x8bf /* Schema upgrade should always work if canUpgrade is set. */);
-		});
+		const newSchema = toUpgradeSchema(this.viewSchema.viewSchema.root);
+		this.runSchemaEdit(() => this.checkout.updateSchema(newSchema));
 	}
 
 	/**

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -505,7 +505,7 @@ describe("SchematizingSimpleTreeView", () => {
 			assert(!view.compatibility.canUpgrade);
 
 			// Case which doesn't update due to root being required
-			assert.throws(() => view.upgradeSchema());
+			assert.throws(() => view.upgradeSchema(), validateUsageError(/cannot be upgraded/));
 
 			const reference = checkoutWithContent({
 				schema: emptySchema,

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -33,6 +33,7 @@ import {
 	getView,
 	TestTreeProviderLite,
 	validateUsageError,
+	validateViewConsistency,
 } from "../utils.js";
 import { insert, makeTreeFromJsonSequence } from "../sequenceRootUtils.js";
 import {
@@ -45,6 +46,8 @@ import type { Mutable } from "../../util/index.js";
 import { brand } from "../../util/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { UnhydratedFlexTreeNode } from "../../simple-tree/core/unhydratedFlexTree.js";
+import { testDocumentIndependentView } from "../testTrees.js";
+import { fieldJsonCursor } from "../json/index.js";
 
 const schema = new SchemaFactoryAlpha("com.example");
 const config = new TreeViewConfiguration({ schema: schema.number });
@@ -446,6 +449,92 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(viewGeneralized.root[1].name, "Alice");
 		assert.equal(viewGeneralized.root[1].age, 42);
 		assert.equal(viewGeneralized.root[1].address, "123 Main St");
+	});
+
+	describe("upgradeSchema", () => {
+		const builder = new SchemaFactory("test");
+		const root = builder.number;
+
+		const schemaGeneralized = builder.optional([root, builder.string]);
+		const schemaValueRoot = [root, builder.string];
+
+		// Schema for tree that must always be empty.
+		const emptyViewSchema = builder.optional([]);
+
+		it("compatible empty schema", () => {
+			const view = testDocumentIndependentView({
+				ambiguous: false,
+				schema: emptyViewSchema,
+				schemaData: emptySchema,
+				treeFactory: () => [],
+			});
+
+			view.events.on("rootChanged", () => assert.fail());
+			view.events.on("schemaChanged", () => assert.fail());
+
+			assert(view.compatibility.isEquivalent);
+			assert(view.compatibility.canUpgrade);
+			view.upgradeSchema();
+		});
+
+		it("compatible: upgrade optional root", () => {
+			const view = testDocumentIndependentView({
+				ambiguous: false,
+				schema: schemaGeneralized,
+				schemaData: emptySchema,
+				treeFactory: () => [],
+			});
+
+			view.upgradeSchema();
+			const reference = checkoutWithContent({
+				schema: toInitialSchema(schemaGeneralized),
+				initialTree: fieldJsonCursor([]),
+			});
+			validateViewConsistency(reference, view.checkout);
+		});
+
+		it("incompatible: empty to required root", () => {
+			const view = testDocumentIndependentView({
+				ambiguous: false,
+				schema: schemaValueRoot,
+				schemaData: emptySchema,
+				treeFactory: () => [],
+			});
+
+			assert(!view.compatibility.isEquivalent);
+			assert(!view.compatibility.canUpgrade);
+
+			// Case which doesn't update due to root being required
+			assert.throws(() => view.upgradeSchema());
+
+			const reference = checkoutWithContent({
+				schema: emptySchema,
+				initialTree: fieldJsonCursor([]),
+			});
+			validateViewConsistency(reference, view.checkout);
+		});
+
+		it("update non-empty", () => {
+			const view = testDocumentIndependentView({
+				ambiguous: false,
+				schema: schemaGeneralized,
+				schemaData: toInitialSchema(builder.number),
+				treeFactory: () => [
+					{ type: brand(SchemaFactory.number.identifier), value: 5, fields: {} },
+				],
+			});
+
+			const updatedCheckout = checkoutWithContent({
+				schema: toInitialSchema(schemaGeneralized),
+				initialTree: fieldJsonCursor([5]),
+			});
+
+			assert(!view.compatibility.isEquivalent);
+			assert(view.compatibility.canUpgrade);
+
+			view.upgradeSchema();
+			validateViewConsistency(view.checkout, updatedCheckout);
+		});
 	});
 
 	it("Open upgradable document, then upgrade schema", () => {


### PR DESCRIPTION
## Description

Remove unneeded complexity from schema upgrade logic by directly using new abstractions that were written after the initial upgrade logic was implemented.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
