### PR TITLE
Refactor SharedTree initialize logic

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/index.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/index.ts
@@ -22,3 +22,4 @@ export {
 	type FieldBatchEncodingContext,
 	fluidVersionToFieldBatchCodecWriteVersion,
 } from "./codec/index.js";
+export { emptyChunk } from "./emptyChunk.js";

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { oob } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import type { ICodecFamily } from "../../codec/index.js";
@@ -206,6 +206,10 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 	public valueField(field: FieldUpPath): ValueFieldEditBuilder<TreeChunk> {
 		return {
 			set: (newContent: TreeChunk): void => {
+				assert(
+					newContent.topLevelLength === 1,
+					"Value fields should have a single top level node",
+				);
 				const revision = this.mintRevisionTag();
 				const fill: ChangeAtomId = { localId: this.modularBuilder.generateId(), revision };
 				const detach: ChangeAtomId = { localId: this.modularBuilder.generateId(), revision };
@@ -232,6 +236,11 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 	public optionalField(field: FieldUpPath): OptionalFieldEditBuilder<TreeChunk> {
 		return {
 			set: (newContent: TreeChunk | undefined, wasEmpty: boolean): void => {
+				// The choice to ban empty chunks here instead of treating them as a clear is a subjective choice made to err of the side of more explicitness and stricter validation.
+				assert(
+					newContent === undefined || newContent.topLevelLength === 1,
+					"optional fields should have a single top level node, or undefined",
+				);
 				const edits: EditDescription[] = [];
 				let optionalChange: OptionalChangeset;
 				const revision = this.mintRevisionTag();

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -92,6 +92,7 @@ export { mapRootChanges } from "./deltaUtils.js";
 export {
 	type TreeChunk,
 	chunkTree,
+	chunkField,
 	chunkFieldSingle,
 	buildChunkedForest,
 	defaultChunkPolicy,
@@ -101,6 +102,7 @@ export {
 	makeFieldBatchCodec,
 	fluidVersionToFieldBatchCodecWriteVersion,
 	type FieldBatchEncodingContext,
+	emptyChunk,
 } from "./chunked-forest/index.js";
 
 export {

--- a/packages/dds/tree/src/shared-tree/independentView.ts
+++ b/packages/dds/tree/src/shared-tree/independentView.ts
@@ -152,7 +152,7 @@ export function independentInitializedViewInternal<const TSchema extends Implici
 		breaker,
 	});
 
-	initialize(checkout, { schema, initialTree: rootFieldCursor });
+	initialize(checkout, schema, () => checkout.forest.chunkField(rootFieldCursor));
 	return new SchematizingSimpleTreeView<TSchema>(
 		checkout,
 		config,

--- a/packages/dds/tree/src/shared-tree/independentView.ts
+++ b/packages/dds/tree/src/shared-tree/independentView.ts
@@ -42,7 +42,7 @@ import {
 } from "./sharedTree.js";
 import { createTreeCheckout } from "./treeCheckout.js";
 import { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
-import { initialize } from "./schematizeTree.js";
+import { initialize, initializerFromChunk } from "./schematizeTree.js";
 
 /**
  * Create an uninitialized {@link TreeView} that is not tied to any {@link ITree} instance.
@@ -152,7 +152,11 @@ export function independentInitializedViewInternal<const TSchema extends Implici
 		breaker,
 	});
 
-	initialize(checkout, schema, () => checkout.forest.chunkField(rootFieldCursor));
+	initialize(
+		checkout,
+		schema,
+		initializerFromChunk(checkout, () => checkout.forest.chunkField(rootFieldCursor)),
+	);
 	return new SchematizingSimpleTreeView<TSchema>(
 		checkout,
 		config,

--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -35,8 +35,6 @@ export {
 	type TreeBranchFork,
 } from "./treeCheckout.js";
 
-export type { TreeStoredContentStrict } from "./schematizeTree.js";
-
 export { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
 
 export type {

--- a/packages/dds/tree/src/shared-tree/schematizeTree.ts
+++ b/packages/dds/tree/src/shared-tree/schematizeTree.ts
@@ -5,84 +5,16 @@
 
 import { assert, fail } from "@fluidframework/core-utils/internal";
 
-import {
-	type ITreeCursorSynchronous,
-	type TreeStoredSchema,
-	rootFieldKey,
-	schemaDataIsEmpty,
-} from "../core/index.js";
+import { type TreeStoredSchema, rootFieldKey, schemaDataIsEmpty } from "../core/index.js";
 import {
 	FieldKinds,
 	allowsRepoSuperset,
 	defaultSchemaPolicy,
+	type IDefaultEditBuilder,
+	type TreeChunk,
 } from "../feature-libraries/index.js";
 
 import type { ITreeCheckout } from "./treeCheckout.js";
-
-/**
- * Modify `storedSchema` and invoke `setInitialTree` when it's time to set the tree content.
- *
- * Requires `storedSchema` to be in its default/empty state.
- *
- * This is done in such a way that if the content (implicitly assumed to start empty)
- * is never out of schema.
- * This means that if the root field of the new schema requires content (like a value field),
- * a temporary intermediate schema is used so the initial empty state is not out of schema.
- *
- * Since this makes multiple changes, callers may want to wrap it in a transaction.
- */
-export function initializeContent(
-	schemaRepository: {
-		storedSchema: ITreeCheckout["storedSchema"];
-		updateSchema: ITreeCheckout["updateSchema"];
-	},
-	newSchema: TreeStoredSchema,
-	setInitialTree: () => void,
-): void {
-	assert(
-		schemaDataIsEmpty(schemaRepository.storedSchema),
-		0x743 /* cannot initialize after a schema is set */,
-	);
-
-	const rootSchema = newSchema.rootFieldSchema;
-	const rootKind = rootSchema.kind;
-
-	// To keep the data in schema during the update, first define a schema that tolerates the current (empty) tree as well as the final (initial) tree.
-	let incrementalSchemaUpdate: TreeStoredSchema;
-	if (
-		rootKind === FieldKinds.sequence.identifier ||
-		rootKind === FieldKinds.optional.identifier
-	) {
-		// These kinds are known to tolerate empty, so use the schema as is:
-		incrementalSchemaUpdate = newSchema;
-	} else {
-		assert(rootKind === FieldKinds.required.identifier, 0x5c8 /* Unexpected kind */);
-		// Replace value kind with optional kind in root field schema:
-		incrementalSchemaUpdate = {
-			nodeSchema: newSchema.nodeSchema,
-			rootFieldSchema: {
-				kind: FieldKinds.optional.identifier,
-				types: rootSchema.types,
-				persistedMetadata: rootSchema.persistedMetadata,
-			},
-		};
-	}
-
-	assert(
-		allowsRepoSuperset(defaultSchemaPolicy, newSchema, incrementalSchemaUpdate),
-		0x5c9 /* Incremental Schema during update should allow a superset of the final schema */,
-	);
-	// Update to intermediate schema
-	schemaRepository.updateSchema(incrementalSchemaUpdate);
-	// Insert initial tree
-	setInitialTree();
-
-	// If intermediate schema is not final desired schema, update to the final schema:
-	if (incrementalSchemaUpdate !== newSchema) {
-		// This makes the root more strict, so set allowNonSupersetSchema to true.
-		schemaRepository.updateSchema(newSchema, true);
-	}
-}
 
 export function canInitialize(checkout: ITreeCheckout): boolean {
 	// Check for empty.
@@ -92,58 +24,153 @@ export function canInitialize(checkout: ITreeCheckout): boolean {
 /**
  * Initialize a checkout with a schema and tree content.
  * This function should only be called when the tree is uninitialized (no schema or content).
- * @remarks
  *
- * If the proposed schema (from `treeContent`) is not compatible with the empty tree, this function handles using an intermediate schema
+ * @param checkout - The tree checkout to initialize.
+ * @param newSchema - The new schema to apply.
+ * @param contentFactory - A function that returns the initial tree content as a chunk.
+ * Invoked after a schema containing all nodes from newSchema is applied.
+ * Note that the final root field schema may not have been applied yet: if the root is required, it will be optional at this time
+ * (so the root being empty before the insertion is not out of schema).
+ * @remarks
+ * If `newSchema` is not compatible with the empty tree, this function handles it using an intermediate schema
  * which supports the empty tree as well as the final tree content.
+ * @privateRemarks
+ * This takes in a checkout using a subset of the checkout interface to enable easier unit testing.
  */
 export function initialize(
-	checkout: ITreeCheckout,
-	treeContent: TreeStoredContentStrict,
+	checkout: Pick<ITreeCheckout, "storedSchema" | "updateSchema"> & {
+		readonly editor: IDefaultEditBuilder;
+	},
+	newSchema: TreeStoredSchema,
+	contentFactory: () => TreeChunk,
 ): void {
-	checkout.transaction.start();
-	try {
-		initializeContent(checkout, treeContent.schema, () => {
-			const field = { field: rootFieldKey, parent: undefined };
-			const contentChunk = checkout.forest.chunkField(treeContent.initialTree);
+	assert(
+		schemaDataIsEmpty(checkout.storedSchema),
+		0x743 /* cannot initialize after a schema is set */,
+	);
 
-			switch (checkout.storedSchema.rootFieldSchema.kind) {
-				case FieldKinds.optional.identifier: {
-					const fieldEditor = checkout.editor.optionalField(field);
-					assert(
-						contentChunk.topLevelLength <= 1,
-						0x7f4 /* optional field content should normalize at most one item */,
-					);
-					fieldEditor.set(contentChunk.topLevelLength === 0 ? undefined : contentChunk, true);
-					break;
-				}
-				case FieldKinds.sequence.identifier: {
-					const fieldEditor = checkout.editor.sequenceField(field);
-					// TODO: should do an idempotent edit here.
-					fieldEditor.insert(0, contentChunk);
-					break;
-				}
-				default: {
-					fail(0xac7 /* unexpected root field kind during initialize */);
-				}
-			}
-		});
-	} finally {
-		checkout.transaction.commit();
+	// To keep the data in schema during the update, first define a schema that tolerates the current (empty) tree as well as the final (initial) tree.
+	let incrementalSchemaUpdate: TreeStoredSchema;
+	{
+		const rootSchema = newSchema.rootFieldSchema;
+		const rootKind = rootSchema.kind;
+		if (
+			rootKind === FieldKinds.sequence.identifier ||
+			rootKind === FieldKinds.optional.identifier
+		) {
+			// These kinds are known to tolerate empty, so use the schema as is:
+			incrementalSchemaUpdate = newSchema;
+		} else {
+			assert(rootKind === FieldKinds.required.identifier, 0x5c8 /* Unexpected kind */);
+			// Replace value kind with optional kind in root field schema:
+			incrementalSchemaUpdate = {
+				nodeSchema: newSchema.nodeSchema,
+				rootFieldSchema: {
+					kind: FieldKinds.optional.identifier,
+					types: rootSchema.types,
+					persistedMetadata: rootSchema.persistedMetadata,
+				},
+			};
+		}
+	}
+
+	assert(
+		allowsRepoSuperset(defaultSchemaPolicy, newSchema, incrementalSchemaUpdate),
+		0x5c9 /* Incremental Schema during update should allow a superset of the final schema */,
+	);
+
+	// Update to intermediate schema
+	checkout.updateSchema(incrementalSchemaUpdate);
+
+	// Insert initial tree
+	const contentChunk = contentFactory();
+	const field = { field: rootFieldKey, parent: undefined };
+	switch (checkout.storedSchema.rootFieldSchema.kind) {
+		case FieldKinds.optional.identifier: {
+			const fieldEditor = checkout.editor.optionalField(field);
+			assert(
+				contentChunk.topLevelLength <= 1,
+				0x7f4 /* optional field content should normalize at most one item */,
+			);
+			fieldEditor.set(contentChunk.topLevelLength === 0 ? undefined : contentChunk, true);
+			break;
+		}
+		case FieldKinds.sequence.identifier: {
+			const fieldEditor = checkout.editor.sequenceField(field);
+			// TODO: should do an idempotent edit here.
+			fieldEditor.insert(0, contentChunk);
+			break;
+		}
+		default: {
+			fail(0xac7 /* unexpected root field kind during initialize */);
+		}
+	}
+
+	// If intermediate schema is not final desired schema, update to the final schema:
+	if (incrementalSchemaUpdate !== newSchema) {
+		// This makes the root more strict, so set allowNonSupersetSchema to true.
+		checkout.updateSchema(newSchema, true);
 	}
 }
 
-/**
- * Content that can populate a `SharedTree`.
- */
-export interface TreeStoredContentStrict {
-	/**
-	 * The stored schema.
-	 */
-	readonly schema: TreeStoredSchema;
+export function initializerFromChunk(
+	checkout: Pick<ITreeCheckout, "storedSchema"> & {
+		readonly editor: IDefaultEditBuilder;
+	},
+	contentFactory: () => TreeChunk,
+): () => void {
+	const contentChunk = contentFactory();
+	const field = { field: rootFieldKey, parent: undefined };
+	switch (checkout.storedSchema.rootFieldSchema.kind) {
+		case FieldKinds.optional.identifier: {
+			const fieldEditor = checkout.editor.optionalField(field);
+			assert(
+				contentChunk.topLevelLength <= 1,
+				0x7f4 /* optional field content should normalize at most one item */,
+			);
+			fieldEditor.set(contentChunk.topLevelLength === 0 ? undefined : contentChunk, true);
+			break;
+		}
+		// This case is not reachable from the public API, but the internal flex-tree abstraction layer can have sequence roots.
+		case FieldKinds.sequence.identifier: {
+			const fieldEditor = checkout.editor.sequenceField(field);
+			// TODO: should do an idempotent edit here.
+			fieldEditor.insert(0, contentChunk);
+			break;
+		}
+		default: {
+			fail(0xac7 /* unexpected root field kind during initialize */);
+		}
+	}
+}
 
-	/**
-	 * Field cursor with the initial tree content for the {@link rootField}.
-	 */
-	readonly initialTree: ITreeCursorSynchronous;
+function initializerFromChunk(
+	checkout: Pick<ITreeCheckout, "storedSchema"> & {
+		readonly editor: IDefaultEditBuilder;
+	},
+	contentFactory: () => TreeChunk,
+): void {
+	const contentChunk = contentFactory();
+	const field = { field: rootFieldKey, parent: undefined };
+	switch (checkout.storedSchema.rootFieldSchema.kind) {
+		case FieldKinds.optional.identifier: {
+			const fieldEditor = checkout.editor.optionalField(field);
+			assert(
+				contentChunk.topLevelLength <= 1,
+				0x7f4 /* optional field content should normalize at most one item */,
+			);
+			fieldEditor.set(contentChunk.topLevelLength === 0 ? undefined : contentChunk, true);
+			break;
+		}
+		// This case is not reachable from the public API, but the internal flex-tree abstraction layer can have sequence roots.
+		case FieldKinds.sequence.identifier: {
+			const fieldEditor = checkout.editor.sequenceField(field);
+			// TODO: should do an idempotent edit here.
+			fieldEditor.insert(0, contentChunk);
+			break;
+		}
+		default: {
+			fail(0xac7 /* unexpected root field kind during initialize */);
+		}
+	}
 }

--- a/packages/dds/tree/src/shared-tree/schematizeTree.ts
+++ b/packages/dds/tree/src/shared-tree/schematizeTree.ts
@@ -94,7 +94,7 @@ export function initialize(
  * Note that the final root field schema may not have been applied yet: if the root is required, it will be optional at this time
  * (so the root being empty before the insertion is not out of schema).
  * @remarks
- * This does not support sequence roots as they are now allowed in the public API surface.
+ * This does not support sequence roots as they are not allowed in the public API surface.
  * A test utility for them can be found as `initializeSequenceRoot` for testing internal logic which uses a sequence root.
  */
 export function initializerFromChunk(

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -64,7 +64,7 @@ import {
 	type WithBreakable,
 } from "../util/index.js";
 
-import { canInitialize, initialize } from "./schematizeTree.js";
+import { canInitialize, initialize, initializerFromChunk } from "./schematizeTree.js";
 import type { ITreeCheckout, TreeCheckout } from "./treeCheckout.js";
 
 /**
@@ -186,12 +186,17 @@ export class SchematizingSimpleTreeView<
 			);
 
 			this.checkout.transaction.start();
-			initialize(this.checkout, schema, () => {
-				// This must be done after initial schema is set!
-				return this.checkout.forest.chunkField(
-					cursorForMapTreeField(mapTree === undefined ? [] : [mapTree]),
-				);
-			});
+
+			initialize(
+				this.checkout,
+				schema,
+				initializerFromChunk(this.checkout, () => {
+					// This must be done after initial schema is set!
+					return this.checkout.forest.chunkField(
+						cursorForMapTreeField(mapTree === undefined ? [] : [mapTree]),
+					);
+				}),
+			);
 			this.checkout.transaction.commit();
 		});
 	}

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -185,10 +185,14 @@ export class SchematizingSimpleTreeView<
 				schema.rootFieldSchema,
 			);
 
-			initialize(this.checkout, {
-				schema,
-				initialTree: cursorForMapTreeField(mapTree === undefined ? [] : [mapTree]),
+			this.checkout.transaction.start();
+			initialize(this.checkout, schema, () => {
+				// This must be done after initial schema is set!
+				return this.checkout.forest.chunkField(
+					cursorForMapTreeField(mapTree === undefined ? [] : [mapTree]),
+				);
 			});
+			this.checkout.transaction.commit();
 		});
 	}
 

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
@@ -16,13 +16,17 @@ import {
 	makeFieldBatchCodec,
 	type FieldBatchEncodingContext,
 } from "../../../feature-libraries/index.js";
-import { checkoutWithContent, testIdCompressor, testRevisionTagCodec } from "../../utils.js";
+import {
+	checkoutWithContent,
+	testIdCompressor,
+	testRevisionTagCodec,
+	type TreeStoredContentStrict,
+} from "../../utils.js";
 import { jsonSequenceRootSchema } from "../../sequenceRootUtils.js";
 import {
 	ForestTypeOptimized,
 	ForestTypeReference,
 	type ForestType,
-	type TreeStoredContentStrict,
 } from "../../../shared-tree/index.js";
 import {
 	permissiveStoredSchemaGenerationOptions,

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -14,7 +14,6 @@ import {
 	type ModularChangeset,
 	FieldKindWithEditor,
 	type RelevantRemovedRootsFromChild,
-	chunkTree,
 	defaultChunkPolicy,
 	type TreeChunk,
 	cursorForJsonableTreeField,
@@ -41,7 +40,6 @@ import {
 	type FieldKey,
 	type UpPath,
 	revisionMetadataSourceFromInfo,
-	type ITreeCursorSynchronous,
 	type DeltaFieldChanges,
 	type DeltaRoot,
 	type DeltaDetachedNodeId,
@@ -70,11 +68,12 @@ import {
 	testChangeReceiver,
 	testIdCompressor,
 	testRevisionTagCodec,
+	treeChunkFromCursor,
 } from "../../utils.js";
 
 import { type ValueChangeset, valueField } from "./basicRebasers.js";
 import { ajvValidator } from "../../codec/index.js";
-import { fieldJsonCursor, singleJsonCursor } from "../../json/index.js";
+import { fieldJsonCursor } from "../../json/index.js";
 import {
 	newCrossFieldKeyTable,
 	type ChangeAtomIdBTree,
@@ -445,10 +444,7 @@ const rootChangeWithoutNodeFieldChanges: ModularChangeset = family.compose([
 
 const objectNode = chunkFromJsonTrees([{}]);
 const node1Chunk = chunkFromJsonTrees([1]);
-const nodesChunk = chunkFieldSingle(fieldJsonCursor([{}, {}]), {
-	policy: defaultChunkPolicy,
-	idCompressor: testIdCompressor,
-});
+const nodesChunk = treeChunkFromCursor(fieldJsonCursor([{}, {}]));
 
 describe("ModularChangeFamily", () => {
 	describe("compose", () => {
@@ -485,7 +481,7 @@ describe("ModularChangeFamily", () => {
 				builds: newTupleBTree([
 					[
 						[undefined as RevisionTag | undefined, brand(0)],
-						treeChunkFromCursor(singleJsonCursor(2)),
+						treeChunkFromCursor(fieldJsonCursor([2])),
 					],
 				]),
 			};
@@ -1258,9 +1254,9 @@ describe("ModularChangeFamily", () => {
 		const bMajor = mintRevisionTag();
 		const b1 = { major: bMajor, minor: 1 };
 
-		const node2 = singleJsonCursor(2);
+		const node2 = fieldJsonCursor([2]);
 		const node2Chunk = treeChunkFromCursor(node2);
-		const node3 = singleJsonCursor(3);
+		const node3 = fieldJsonCursor([3]);
 		const node3Chunk = treeChunkFromCursor(node3);
 
 		const nodesArray: [DeltaDetachedNodeId, TreeChunk][] = [
@@ -1495,10 +1491,6 @@ describe("ModularChangeFamily", () => {
 		assertEqual(changes, [expectedChange.change]);
 	});
 });
-
-function treeChunkFromCursor(cursor: ITreeCursorSynchronous): TreeChunk {
-	return chunkTree(cursor, { policy: defaultChunkPolicy, idCompressor: testIdCompressor });
-}
 
 function deepCloneChunkedTree(chunk: TreeChunk): TreeChunk {
 	const jsonable = jsonableTreeFromFieldCursor(chunk.cursor());

--- a/packages/dds/tree/src/test/scalableTestTrees.ts
+++ b/packages/dds/tree/src/test/scalableTestTrees.ts
@@ -27,13 +27,12 @@ import {
 	type UnsafeUnknownSchema,
 	type ValidateRecursiveSchema,
 } from "../simple-tree/index.js";
-import type { TreeStoredContentStrict } from "../shared-tree/index.js";
 
 import type {
 	TreeSimpleContent,
 	// eslint-disable-next-line import/no-internal-modules
 } from "./feature-libraries/flex-tree/utils.js";
-import { fieldCursorFromInsertable } from "./utils.js";
+import { fieldCursorFromInsertable, type TreeStoredContentStrict } from "./utils.js";
 
 /**
  * Test trees which can be parametrically scaled to any size.

--- a/packages/dds/tree/src/test/shared-tree-core/utils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/utils.ts
@@ -139,6 +139,21 @@ export function createTreeSharedObject<TIndexes extends readonly Summarizable[]>
 	);
 }
 
+export function makeTestDefaultChangeFamily(options?: {
+	idCompressor?: IIdCompressor;
+	chunkCompressionStrategy?: TreeCompressionStrategy;
+}) {
+	return new DefaultChangeFamily(
+		makeModularChangeCodecFamily(
+			fieldKindConfigurations,
+			new RevisionTagCodec(options?.idCompressor ?? testIdCompressor),
+			makeFieldBatchCodec(codecOptions, formatVersions.fieldBatch),
+			codecOptions,
+			options?.chunkCompressionStrategy ?? TreeCompressionStrategy.Compressed,
+		),
+	);
+}
+
 function createTreeInner(
 	sharedObject: IChannelView & IFluidLoadable,
 	serializer: IFluidSerializer,
@@ -152,15 +167,7 @@ function createTreeInner(
 	enricher?: ChangeEnricherReadonlyCheckout<DefaultChangeset>,
 	editor?: () => DefaultEditBuilder,
 ): [SharedTreeCore<DefaultEditBuilder, DefaultChangeset>, DefaultChangeFamily] {
-	const codec = makeModularChangeCodecFamily(
-		fieldKindConfigurations,
-		new RevisionTagCodec(idCompressor),
-		makeFieldBatchCodec(codecOptions, formatVersions.fieldBatch),
-		codecOptions,
-		chunkCompressionStrategy,
-	);
-	const changeFamily = new DefaultChangeFamily(codec);
-
+	const changeFamily = makeTestDefaultChangeFamily({ idCompressor, chunkCompressionStrategy });
 	return [
 		new SharedTreeCore(
 			new Breakable("createTreeInner"),

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -16,7 +16,7 @@ import {
 	type NormalizedUpPath,
 	type TreeNodeSchemaIdentifier,
 } from "../../core/index.js";
-import type { ITreeCheckout, TreeStoredContentStrict } from "../../shared-tree/index.js";
+import type { ITreeCheckout } from "../../shared-tree/index.js";
 import { type JsonCompatible, brand, makeArray } from "../../util/index.js";
 import {
 	checkoutWithContent,
@@ -28,6 +28,7 @@ import {
 	makeTreeFromJson,
 	moveWithin,
 	validateUsageError,
+	type TreeStoredContentStrict,
 } from "../utils.js";
 import { insert, makeTreeFromJsonSequence, remove } from "../sequenceRootUtils.js";
 import { numberSchema, SchemaFactory, toInitialSchema } from "../../simple-tree/index.js";

--- a/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
@@ -13,23 +13,24 @@ import {
 	type TreeStoredSchema,
 	TreeStoredSchemaRepository,
 	type AnchorSetRootEvents,
+	type TaggedChange,
 } from "../../core/index.js";
 import { fieldJsonCursor } from "../json/index.js";
 import {
 	FieldKinds,
 	allowsRepoSuperset,
 	defaultSchemaPolicy,
+	type ModularChangeset,
 } from "../../feature-libraries/index.js";
 import type {
 	ITreeCheckout,
 	ITreeCheckoutFork,
 	CheckoutEvents,
 	ISharedTreeEditor,
-	TreeStoredContentStrict,
 } from "../../shared-tree/index.js";
 import {
 	canInitialize,
-	initializeContent,
+	initialize,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../shared-tree/schematizeTree.js";
 import type { Listenable } from "@fluidframework/core-interfaces";
@@ -42,6 +43,13 @@ import {
 import { toInitialSchema } from "../../simple-tree/index.js";
 import type { Transactor } from "../../shared-tree-core/index.js";
 import { Breakable } from "../../util/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { makeTestDefaultChangeFamily } from "../shared-tree-core/utils.js";
+import {
+	mintRevisionTag,
+	type TreeStoredContentStrict,
+	treeChunkFromCursor,
+} from "../utils.js";
 
 const builder = new SchemaFactory("test");
 const root = builder.number;
@@ -58,29 +66,34 @@ function expectSchema(actual: TreeStoredSchema, expected: TreeStoredSchema): voi
 	assert(allowsRepoSuperset(defaultSchemaPolicy, expected, actual));
 }
 
-function makeSchemaRepository(repository: TreeStoredSchemaRepository): {
-	storedSchema: ITreeCheckout["storedSchema"];
-	updateSchema: ITreeCheckout["updateSchema"];
-} {
+function makeSchemaRepository(
+	repository: TreeStoredSchemaRepository,
+	onChange: (change: TaggedChange<ModularChangeset>) => void = () => {},
+) {
+	const editor = makeTestDefaultChangeFamily().buildEditor(mintRevisionTag, onChange);
+
 	return {
 		storedSchema: repository,
 		updateSchema: (newSchema: TreeStoredSchema) => {
 			// This test repository applies the schema immediately.
 			repository.apply(newSchema);
 		},
+		editor,
 	};
 }
 
 describe("schematizeTree", () => {
-	describe("initializeContent", () => {
+	describe("initialize", () => {
 		function testInitialize(name: string, content: TreeStoredContentStrict): void {
 			describe(`Initialize ${name}`, () => {
 				it("correct output", () => {
 					const storedSchema = new TreeStoredSchemaRepository();
 					let count = 0;
-					initializeContent(makeSchemaRepository(storedSchema), content.schema, () => {
-						count++;
-					});
+					initialize(
+						makeSchemaRepository(storedSchema, () => count++),
+						content.schema,
+						() => treeChunkFromCursor(content.initialTree),
+					);
 					assert.equal(count, 1);
 					expectSchema(storedSchema, content.schema);
 				});
@@ -99,11 +112,15 @@ describe("schematizeTree", () => {
 					});
 
 					let currentData: typeof content.initialTree;
-					initializeContent(makeSchemaRepository(storedSchema), content.schema, () => {
-						// TODO: check currentData is compatible with current schema.
-						// TODO: check data in cursors is compatible with current schema.
-						currentData = content.initialTree;
-					});
+					initialize(
+						makeSchemaRepository(storedSchema, () => {
+							// TODO: check currentData is compatible with current schema.
+							// TODO: check data in cursors is compatible with current schema.
+							currentData = content.initialTree;
+						}),
+						content.schema,
+						() => treeChunkFromCursor(content.initialTree),
+					);
 
 					// Ensure final schema change was actually tested.
 					// This would fail if event is triggered before schema update so last update is missed (and first update checks noop).
@@ -117,8 +134,10 @@ describe("schematizeTree", () => {
 					storedSchema.events.on("afterSchemaChange", () => {
 						log.push("schema");
 					});
-					initializeContent(makeSchemaRepository(storedSchema), content.schema, () =>
-						log.push("content"),
+					initialize(
+						makeSchemaRepository(storedSchema, () => log.push("content")),
+						content.schema,
+						() => treeChunkFromCursor(content.initialTree),
 					);
 
 					assert.deepEqual(
@@ -132,11 +151,11 @@ describe("schematizeTree", () => {
 		}
 
 		testInitialize("optional-empty", {
-			schema: toInitialSchema(schema),
+			schema: toInitialSchema(builder.optional(schema)),
 			initialTree: fieldJsonCursor([]),
 		});
 		testInitialize("optional-full", {
-			schema: toInitialSchema(schema),
+			schema: toInitialSchema(builder.optional(schema)),
 			initialTree: fieldJsonCursor([5]),
 		});
 		testInitialize("value", {

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -34,13 +34,13 @@ import {
 	TestTreeProviderLite,
 	validateUsageError,
 	validateViewConsistency,
+	type TreeStoredContentStrict,
 } from "../utils.js";
 import { insert, makeTreeFromJsonSequence } from "../sequenceRootUtils.js";
 import {
 	ForestTypeExpensiveDebug,
 	ForestTypeReference,
 	type TreeCheckout,
-	type TreeStoredContentStrict,
 } from "../../shared-tree/index.js";
 import type { Mutable } from "../../util/index.js";
 import { brand } from "../../util/index.js";

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -36,7 +36,7 @@ import {
 	TreeViewConfiguration,
 } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
-import { initialize } from "../../shared-tree/schematizeTree.js";
+import { initialize, initializerFromChunk } from "../../shared-tree/schematizeTree.js";
 
 const rootPath: NormalizedUpPath = {
 	detachedNodeId: undefined,
@@ -707,8 +707,12 @@ export function createCheckout(json: JsonCompatible[], attachTree: boolean): ITr
 	const tree = sharedTreeFactory.create(runtime, "tree");
 	const runtimeFactory = new MockContainerRuntimeFactory();
 	runtimeFactory.createContainerRuntime(runtime);
-	initialize(tree.kernel.checkout, jsonSequenceRootSchema, () =>
-		tree.kernel.checkout.forest.chunkField(fieldJsonCursor(json)),
+	initialize(
+		tree.kernel.checkout,
+		jsonSequenceRootSchema,
+		initializerFromChunk(tree.kernel.checkout, () =>
+			tree.kernel.checkout.forest.chunkField(fieldJsonCursor(json)),
+		),
 	);
 
 	if (attachTree) {

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -707,10 +707,9 @@ export function createCheckout(json: JsonCompatible[], attachTree: boolean): ITr
 	const tree = sharedTreeFactory.create(runtime, "tree");
 	const runtimeFactory = new MockContainerRuntimeFactory();
 	runtimeFactory.createContainerRuntime(runtime);
-	initialize(tree.kernel.checkout, {
-		schema: jsonSequenceRootSchema,
-		initialTree: fieldJsonCursor(json),
-	});
+	initialize(tree.kernel.checkout, jsonSequenceRootSchema, () =>
+		tree.kernel.checkout.forest.chunkField(fieldJsonCursor(json)),
+	);
 
 	if (attachTree) {
 		tree.connect({

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -9,6 +9,7 @@ import {
 	type Revertible,
 	RevertibleStatus,
 	rootFieldKey,
+	type TreeChunk,
 } from "../../core/index.js";
 import { fieldJsonCursor } from "../json/index.js";
 import type { ITreeCheckout } from "../../shared-tree/index.js";
@@ -36,7 +37,8 @@ import {
 	TreeViewConfiguration,
 } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
-import { initialize, initializerFromChunk } from "../../shared-tree/schematizeTree.js";
+import { initialize } from "../../shared-tree/schematizeTree.js";
+import { FieldKinds } from "../../feature-libraries/index.js";
 
 const rootPath: NormalizedUpPath = {
 	detachedNodeId: undefined,
@@ -707,10 +709,9 @@ export function createCheckout(json: JsonCompatible[], attachTree: boolean): ITr
 	const tree = sharedTreeFactory.create(runtime, "tree");
 	const runtimeFactory = new MockContainerRuntimeFactory();
 	runtimeFactory.createContainerRuntime(runtime);
-	initialize(
-		tree.kernel.checkout,
-		jsonSequenceRootSchema,
-		initializerFromChunk(tree.kernel.checkout, () =>
+	initialize(tree.kernel.checkout, jsonSequenceRootSchema, () =>
+		initializeSequenceRoot(
+			tree.kernel.checkout,
 			tree.kernel.checkout.forest.chunkField(fieldJsonCursor(json)),
 		),
 	);
@@ -727,3 +728,14 @@ export function createCheckout(json: JsonCompatible[], attachTree: boolean): ITr
 }
 
 let temp: unknown;
+
+/**
+ * Helper for use with `initialize` when the root is a sequence.
+ */
+function initializeSequenceRoot(checkout: ITreeCheckout, content: TreeChunk): void {
+	const field = { field: rootFieldKey, parent: undefined };
+	assert(checkout.storedSchema.rootFieldSchema.kind === FieldKinds.sequence.identifier);
+	const fieldEditor = checkout.editor.sequenceField(field);
+	// TODO: should do an idempotent edit here.
+	fieldEditor.insert(0, content);
+}

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -45,6 +45,7 @@ import {
 	testIdCompressor,
 	TestTreeProviderLite,
 	validateUsageError,
+	type TreeStoredContentStrict,
 } from "../../utils.js";
 import { describeHydration, getViewForForkedBranch, hydrate } from "../utils.js";
 import { brand, type areSafelyAssignable, type requireTrue } from "../../../util/index.js";
@@ -70,7 +71,6 @@ import {
 	SchematizingSimpleTreeView,
 	TreeAlpha,
 	type TreeCheckout,
-	type TreeStoredContentStrict,
 } from "../../../shared-tree/index.js";
 import { FieldKinds } from "../../../feature-libraries/index.js";
 import {

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1556,3 +1556,25 @@ interface TreeStoredContent {
 	 */
 	readonly initialTree: readonly ITreeCursorSynchronous[] | ITreeCursorSynchronous | undefined;
 }
+
+/**
+ * Content that can populate a `SharedTree`.
+ */
+export interface TreeStoredContentStrict {
+	/**
+	 * The stored schema.
+	 */
+	readonly schema: TreeStoredSchema;
+
+	/**
+	 * Field cursor with the initial tree content for the {@link rootField}.
+	 */
+	readonly initialTree: ITreeCursorSynchronous;
+}
+
+export function treeChunkFromCursor(fieldCursor: ITreeCursorSynchronous): TreeChunk {
+	return chunkFieldSingle(fieldCursor, {
+		policy: defaultChunkPolicy,
+		idCompressor: testIdCompressor,
+	});
+}


### PR DESCRIPTION
## Description

Add some missing validation, move some sequence root handling logic to a test utility, reduce coupling between utilities in schematizeTree.ts, and make more of the relevant code use TreeChunk to match the underling storage.

Additionally clarify in the docs when the callback is run as this is both important now to allow use of forest.chunkTree (which needs the schema to have been set) but also for the future when moving to an create then attach model.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
