### PR TITLE
Improve readme information on running example apps against SharePoint

### DIFF
--- a/examples/apps/blobs/README.md
+++ b/examples/apps/blobs/README.md
@@ -19,6 +19,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/blobs`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/apps/collaborative-textarea/README.md
+++ b/examples/apps/collaborative-textarea/README.md
@@ -18,6 +18,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/collaborative-textarea`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/apps/contact-collection/README.md
+++ b/examples/apps/contact-collection/README.md
@@ -30,6 +30,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/contact-collection`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/apps/data-object-grid/README.md
+++ b/examples/apps/data-object-grid/README.md
@@ -17,6 +17,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/data-object-grid`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/apps/presence-tracker/README.md
+++ b/examples/apps/presence-tracker/README.md
@@ -29,6 +29,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/presence-tracker`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/apps/staging/README.md
+++ b/examples/apps/staging/README.md
@@ -17,6 +17,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/staging`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/apps/task-selection/README.md
+++ b/examples/apps/task-selection/README.md
@@ -17,6 +17,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/task-selection`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/apps/tree-comparison/README.md
+++ b/examples/apps/tree-comparison/README.md
@@ -17,6 +17,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/tree-comparison`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/benchmarks/bubblebench/baseline/README.md
+++ b/examples/benchmarks/bubblebench/baseline/README.md
@@ -14,6 +14,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/bubblebench-baseline`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/benchmarks/bubblebench/experimental-tree/README.md
+++ b/examples/benchmarks/bubblebench/experimental-tree/README.md
@@ -17,6 +17,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/bubblebench-experimental-tree`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/benchmarks/bubblebench/ot/README.md
+++ b/examples/benchmarks/bubblebench/ot/README.md
@@ -14,6 +14,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/bubblebench-ot`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/README.md
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/README.md
@@ -16,6 +16,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/odspsnapshotfetch-perftestapp`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/benchmarks/tablebench/README.md
+++ b/examples/benchmarks/tablebench/README.md
@@ -14,6 +14,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-internal/tablebench`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/client-logger/app-insights-logger/README.md
+++ b/examples/client-logger/app-insights-logger/README.md
@@ -40,6 +40,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/app-insights-logger`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/canvas/README.md
+++ b/examples/data-objects/canvas/README.md
@@ -16,6 +16,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/canvas`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/clicker/README.md
+++ b/examples/data-objects/clicker/README.md
@@ -22,6 +22,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/clicker`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/codemirror/README.md
+++ b/examples/data-objects/codemirror/README.md
@@ -17,6 +17,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/codemirror`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/diceroller/README.md
+++ b/examples/data-objects/diceroller/README.md
@@ -18,6 +18,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/diceroller`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/inventory-app/README.md
+++ b/examples/data-objects/inventory-app/README.md
@@ -16,6 +16,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/inventory-app`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/monaco/README.md
+++ b/examples/data-objects/monaco/README.md
@@ -17,6 +17,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/monaco`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/multiview/container/README.md
+++ b/examples/data-objects/multiview/container/README.md
@@ -16,6 +16,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/multiview-container`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/prosemirror/README.md
+++ b/examples/data-objects/prosemirror/README.md
@@ -17,6 +17,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/prosemirror`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/smde/README.md
+++ b/examples/data-objects/smde/README.md
@@ -17,6 +17,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/smde`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/table-tree/README.md
+++ b/examples/data-objects/table-tree/README.md
@@ -18,6 +18,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/table-tree`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/todo/README.md
+++ b/examples/data-objects/todo/README.md
@@ -18,6 +18,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/todo`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/data-objects/webflow/README.md
+++ b/examples/data-objects/webflow/README.md
@@ -16,6 +16,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/webflow`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/external-data/README.md
+++ b/examples/external-data/README.md
@@ -115,6 +115,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/app-integration-external-data`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/service-clients/azure-client/external-controller/README.md
+++ b/examples/service-clients/azure-client/external-controller/README.md
@@ -26,6 +26,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/app-integration-external-controller`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/service-clients/azure-client/todo-list/README.md
+++ b/examples/service-clients/azure-client/todo-list/README.md
@@ -21,6 +21,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-example/azure-client-todo-list`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/utils/webpack-fluid-loader/README.md
+++ b/examples/utils/webpack-fluid-loader/README.md
@@ -99,18 +99,19 @@ npm run start:r11s --env mode=r11s \
 
 ## SharePoint
 
-To use a SharePoint server, the following environment variables must be set:
+To use a SharePoint server, run `npm run start:spo-df` if your OneDrive is on the DogFood server, and `npm run start:spo` if it is not.
+
+The following environment variables must be set:
 
 -   local\_\_testing\_\_clientId
 -   login\_\_odsp\_\_test\_\_tenants (when running against prod)
 -   login\_\_odspdf\_\_test\_\_tenants (when running against dogfood)
 
-All of these variables can be populated by running the getkeys tool.
+All of these variables can be populated by running the [getkeys](../../../tools/getkeys/README.md) tool. If you're a Microsoft developer, the recommended way to populate these variables for `start:spo` is to use the `@ff-internal/trips-setup` package.
+
 While running examples, documents will be created/loaded using the credentials found in these environment variables.
 
 Sometimes the cached tokens are out of date or incorrect, and it will not automatically refresh them. They can be manually refreshed by going navigating to http://localhost:8080/odspLogin (port may vary). To force reauth on start, the env variable `odspForceReauth` can be set. This can also be done by adding `--env forceReauth` to the end of the command. For example: `npm run start:spo-df -- --env forceReauth`.
-
-Use `spo-df` if your OneDrive is on the DogFood server, and `spo` if it is not.
 
 ---
 

--- a/examples/version-migration/live-schema-upgrade/README.md
+++ b/examples/version-migration/live-schema-upgrade/README.md
@@ -42,6 +42,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/app-integration-live-schema-upgrade`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/version-migration/same-container/README.md
+++ b/examples/version-migration/same-container/README.md
@@ -63,6 +63,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/version-migration-same-container`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/version-migration/separate-container/README.md
+++ b/examples/version-migration/separate-container/README.md
@@ -59,6 +59,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/version-migration-separate-container`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/version-migration/tree-shim/README.md
+++ b/examples/version-migration/tree-shim/README.md
@@ -21,6 +21,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/tree-shim`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/view-integration/container-views/README.md
+++ b/examples/view-integration/container-views/README.md
@@ -19,6 +19,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/app-integration-container-views`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/view-integration/external-views/README.md
+++ b/examples/view-integration/external-views/README.md
@@ -21,6 +21,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/app-integration-external-views`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/examples/view-integration/view-framework-sampler/README.md
+++ b/examples/view-integration/view-framework-sampler/README.md
@@ -17,6 +17,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluid-example/view-framework-sampler`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/packages/tools/devtools/devtools-test-app/README.md
+++ b/packages/tools/devtools/devtools-test-app/README.md
@@ -18,6 +18,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluid-private/devtools-test-app`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/tools/markdown-magic/src/transforms/exampleGettingStartedTransform.cjs
+++ b/tools/markdown-magic/src/transforms/exampleGettingStartedTransform.cjs
@@ -48,6 +48,10 @@ const generateExampleGettingStartedSection = (
 		`1. Run \`pnpm start\` from this directory and open <http://localhost:8080> in a web browser to see the app running.`,
 	);
 
+	sectionBody.push(
+		`1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run \`pnpm start:spo\` or \`pnpm start:spo-df\` and open <http://localhost:8080> like above.`,
+	);
+
 	return formattedSectionText(sectionBody.join("\n"), {
 		...headingOptions,
 		headingText: "Getting Started",

--- a/tools/markdown-magic/test/example-getting-started.md
+++ b/tools/markdown-magic/test/example-getting-started.md
@@ -13,6 +13,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluidframework/test-package`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 
@@ -32,6 +33,7 @@ You can run this example using the following steps:
     - For an even faster build, you can add the package name to the build command, like this:
       `pnpm run build:fast --nolint @fluidframework/test-package`
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 

--- a/tools/markdown-magic/test/example-readme-header.md
+++ b/tools/markdown-magic/test/example-readme-header.md
@@ -13,6 +13,7 @@ You can run this example using the following steps:
       `pnpm run build:fast --nolint @fluidframework/test-package`
 1. In a separate terminal, start a Tinylicious server by following the instructions in [Tinylicious](https://github.com/microsoft/FluidFramework/tree/main/server/routerlicious/packages/tinylicious).
 1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. If you want to run the app against SharePoint, follow the instructions in [webpack-fluid-loader](https://github.com/microsoft/FluidFramework/blob/main/examples/utils/webpack-fluid-loader/README.md#sharepoint) to get auth credentials. Then run `pnpm start:spo` or `pnpm start:spo-df` and open <http://localhost:8080> like above.
 
 <!-- prettier-ignore-end -->
 


### PR DESCRIPTION
## Description

Make it more obvious how to run example apps against SharedPoint via `pnpm start:spo` or `pnpm start:spo-df`.

## Breaking Changes

None.

## Reviewer Guidance

Pay special attention to `webpack-fluid-loader/README.md`.
