### PR TITLE
improvement(tree): Update `removeColumn` to remove cells as well

### DIFF
--- a/.changeset/clean-eternities-terminate.md
+++ b/.changeset/clean-eternities-terminate.md
@@ -1,0 +1,11 @@
+---
+"@fluidframework/tree": minor
+"__section": tree
+---
+TableSchema's "removeColumn" API now removes corresponding cells (alpha)
+
+Previously, the [removeColumn]() API on Table nodes derived from [TableSchema]() (alpha) only removed the `Column` node from the list of columns tracked by the table.
+To also remove the corresponding cells from the table (which are stored on the `Row` nodes), the user was required to write a custom transaction that removed the column and cells.
+
+The motivation for this design was due to performance concerns with transactions.
+Those concerns are still relevant, but the data leak risk of dropping columns without removing corresponding cells seems a greater risk, and we have plans to address the performance issues with transactions.

--- a/.changeset/clean-eternities-terminate.md
+++ b/.changeset/clean-eternities-terminate.md
@@ -4,7 +4,7 @@
 ---
 TableSchema's "removeColumn" API now removes corresponding cells (alpha)
 
-Previously, the [removeColumn]() API on Table nodes derived from [TableSchema]() (alpha) only removed the `Column` node from the list of columns tracked by the table.
+Previously, the [removeColumn](https://fluidframework.com/docs/api/fluid-framework/tableschema-namespace/table-interface#removecolumn-methodsignature) API on Table nodes derived from [TableSchema](https://fluidframework.com/docs/api/fluid-framework/tableschema-namespace/) (alpha) only removed the `Column` node from the list of columns tracked by the table.
 To also remove the corresponding cells from the table (which are stored on the `Row` nodes), the user was required to write a custom transaction that removed the column and cells.
 
 The motivation for this design was due to performance concerns with transactions.

--- a/examples/data-objects/table-tree/src/react/tableView.tsx
+++ b/examples/data-objects/table-tree/src/react/tableView.tsx
@@ -54,7 +54,7 @@ export const TableView: React.FC<{ tableModel: TableDataObject }> = ({ tableMode
 
 	const handleRemoveRow = (index: number): void => {
 		if (index >= 0 && index < rows.length) {
-			table.rows.removeAt(index);
+			table.removeRow(table.rows[index]);
 		}
 	};
 

--- a/examples/data-objects/table-tree/src/react/tableView.tsx
+++ b/examples/data-objects/table-tree/src/react/tableView.tsx
@@ -39,32 +39,34 @@ export const TableView: React.FC<{ tableModel: TableDataObject }> = ({ tableMode
 	const [draggedRowIndex, setDraggedRowIndex] = useState<number | undefined>(undefined);
 	const [draggedColumnIndex, setDraggedColumnIndex] = useState<number | undefined>(undefined);
 
-	useTree(tableModel.treeView.root);
+	const table = tableModel.treeView.root;
 
-	const columns = [...tableModel.treeView.root.columns];
-	const rows = [...tableModel.treeView.root.rows];
+	useTree(table);
+
+	const columns = [...table.columns];
+	const rows = [...table.rows];
 
 	const handleAppendNewRow = (): void => {
-		tableModel.treeView.root.insertRow({
+		table.insertRow({
 			row: { cells: {} },
 		});
 	};
 
 	const handleRemoveRow = (index: number): void => {
 		if (index >= 0 && index < rows.length) {
-			tableModel.treeView.root.rows.removeAt(index);
+			table.rows.removeAt(index);
 		}
 	};
 
 	const handleAppendNewColumn = (newColumn: Column): void => {
-		tableModel.treeView.root.insertColumn({
+		table.insertColumn({
 			column: newColumn,
 		});
 	};
 
 	const handleRemoveColumn = (index: number): void => {
 		if (index >= 0 && index < columns.length) {
-			tableModel.treeView.root.columns.removeAt(index);
+			table.removeColumn(table.columns[index]);
 		}
 	};
 
@@ -79,7 +81,7 @@ export const TableView: React.FC<{ tableModel: TableDataObject }> = ({ tableMode
 	const handleRowDrop = (targetIndex: number): void => {
 		if (draggedRowIndex !== undefined && draggedRowIndex !== targetIndex) {
 			const destinationGap = draggedRowIndex < targetIndex ? targetIndex + 1 : targetIndex;
-			tableModel.treeView.root.rows.moveToIndex(destinationGap, draggedRowIndex);
+			table.rows.moveToIndex(destinationGap, draggedRowIndex);
 		}
 		setDraggedRowIndex(undefined);
 	};
@@ -95,7 +97,7 @@ export const TableView: React.FC<{ tableModel: TableDataObject }> = ({ tableMode
 	const handleColumnDrop = (targetIndex: number): void => {
 		if (draggedColumnIndex !== undefined && draggedColumnIndex !== targetIndex) {
 			const destinationGap = draggedColumnIndex < targetIndex ? targetIndex + 1 : targetIndex;
-			tableModel.treeView.root.columns.moveToIndex(destinationGap, draggedColumnIndex);
+			table.columns.moveToIndex(destinationGap, draggedColumnIndex);
 		}
 		setDraggedColumnIndex(undefined);
 	};

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1519,7 +1519,13 @@ export namespace TableSchema {
 
 		/**
 		 * Removes the specified column from the table.
-		 * @remarks Also removes any corresponding cells from the table's rows.
+		 * @remarks
+		 * Also removes any corresponding cells from the table's rows.
+		 *
+		 * Note: this operation can be slow for tables with many rows.
+		 * We are actively working on improving the performance of this operation, but for now it may have a negative
+		 * impact on performance.
+		 *
 		 * @param column - The {@link TableSchema.Column | column} or {@link TableSchema.Column.id | column ID} to remove.
 		 * @throws Throws an error if the column is not in the table.
 		 * In this case, no columns are removed.
@@ -1530,7 +1536,13 @@ export namespace TableSchema {
 
 		/**
 		 * Removes 0 or more columns from the table.
-		 * @remarks Also removes any corresponding cells from the table's rows.
+		 * @remarks
+		 * Also removes any corresponding cells from the table's rows.
+		 *
+		 * Note: this operation can be slow for tables with many rows.
+		 * We are actively working on improving the performance of this operation, but for now it may have a negative
+		 * impact on performance.
+		 *
 		 * @param columns - The columns to remove.
 		 * @throws Throws an error if any of the columns are not in the table.
 		 * In this case, no columns are removed.
@@ -1540,7 +1552,14 @@ export namespace TableSchema {
 		): TreeNodeFromImplicitAllowedTypes<TColumn>[];
 		/**
 		 * Removes 0 or more columns from the table.
-		 * @remarks Also removes any corresponding cells from the table's rows.
+		 *
+		 * @remarks
+		 * Also removes any corresponding cells from the table's rows.
+		 *
+		 * Note: this operation can be slow for tables with many rows.
+		 * We are actively working on improving the performance of this operation, but for now it may have a negative
+		 * impact on performance.
+		 *
 		 * @param columns - The columns to remove, specified by their {@link TableSchema.Column.id}.
 		 * @throws Throws an error if any of the columns are not in the table.
 		 * In this case, no columns are removed.
@@ -1549,6 +1568,14 @@ export namespace TableSchema {
 
 		/**
 		 * Removes all columns from the table.
+		 *
+		 * @remarks
+		 * Also removes any corresponding cells from the table's rows.
+		 *
+		 * Note: this operation can be slow for tables with many rows.
+		 * We are actively working on improving the performance of this operation, but for now it may have a negative
+		 * impact on performance.
+		 *
 		 * @returns The removed columns.
 		 */
 		removeAllColumns(): TreeNodeFromImplicitAllowedTypes<TColumn>[];

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { oob } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { Tree, TreeAlpha } from "./shared-tree/index.js";
@@ -780,8 +780,20 @@ export namespace System_TableSchema {
 						`Specified column with ID "${columnId}" does not exist in the table.`,
 					);
 				}
-				this.columns.removeAt(index);
-				return column as ColumnValueType;
+				assert(column !== undefined, "column should not be undefined");
+
+				Tree.runTransaction(this, () => {
+					// Remove the corresponding cell from all rows.
+					for (const row of this.rows) {
+						// TypeScript is unable to narrow the row type correctly here, hence the cast.
+						// See: https://github.com/microsoft/TypeScript/issues/52144
+						(row as RowValueType).removeCell(column);
+					}
+
+					this.columns.removeAt(index);
+				});
+
+				return column;
 			}
 
 			public removeAllColumns(): ColumnValueType[] {
@@ -1078,29 +1090,6 @@ export namespace System_TableSchema {
  * // But it won't fire when a row's properties change, or when the row's cells change, etc.
  * Tree.on(table.rows, "nodeChanged", () => {
  * 	// Respond to the change.
- * });
- * ```
- *
- * @example Removing column and cells in a transaction
- *
- * When removing a column, if you wish to ensure that all of its corresponding cells are also removed (and not
- * orphaned), you can remove the column and all of the relevant cells in a transaction.
- * Note that there are performance implications to this.
- *
- * ```typescript
- * // Remove column1 and all of its cells.
- * // The "transaction" method will ensure that all changes are applied atomically.
- * Tree.runTransaction(table, () => {
- * 	// Remove column1.
- * 	table.removeColumn(column1);
- *
- * 	// Remove the cell at column1 for each row.
- * 	for (const row of table.rows) {
- * 		table.removeCell({
- * 			column: column1,
- * 			row,
- * 		});
- * 	}
  * });
  * ```
  *
@@ -1530,14 +1519,10 @@ export namespace TableSchema {
 
 		/**
 		 * Removes the specified column from the table.
-		 *
-		 * @remarks
-		 * Note: this does not remove any cells from the table's rows.
-		 * To remove the corresponding cells, use {@link TableSchema.Table.removeCell}.
-		 *
+		 * @remarks Also removes any corresponding cells from the table's rows.
 		 * @param column - The {@link TableSchema.Column | column} or {@link TableSchema.Column.id | column ID} to remove.
 		 * @throws Throws an error if the column is not in the table.
-		 * @privateRemarks TODO (future): Actually remove corresponding cells from table rows.
+		 * In this case, no columns are removed.
 		 */
 		removeColumn(
 			column: string | TreeNodeFromImplicitAllowedTypes<TColumn>,
@@ -1545,11 +1530,7 @@ export namespace TableSchema {
 
 		/**
 		 * Removes 0 or more columns from the table.
-		 *
-		 * @remarks
-		 * Note: this does not remove any cells from the table's rows.
-		 * To remove the corresponding cells, use {@link TableSchema.Table.removeCell}.
-		 *
+		 * @remarks Also removes any corresponding cells from the table's rows.
 		 * @param columns - The columns to remove.
 		 * @throws Throws an error if any of the columns are not in the table.
 		 * In this case, no columns are removed.
@@ -1559,11 +1540,7 @@ export namespace TableSchema {
 		): TreeNodeFromImplicitAllowedTypes<TColumn>[];
 		/**
 		 * Removes 0 or more columns from the table.
-		 *
-		 * @remarks
-		 * Note: this does not remove any cells from the table's rows.
-		 * To remove the corresponding cells, use {@link TableSchema.Table.removeCell}.
-		 *
+		 * @remarks Also removes any corresponding cells from the table's rows.
 		 * @param columns - The columns to remove, specified by their {@link TableSchema.Column.id}.
 		 * @throws Throws an error if any of the columns are not in the table.
 		 * In this case, no columns are removed.
@@ -1580,6 +1557,7 @@ export namespace TableSchema {
 		 * Removes the specified row from the table.
 		 * @param row - The {@link TableSchema.Row | row} or {@link TableSchema.Row.id | row ID} to remove.
 		 * @throws Throws an error if the row is not in the table.
+		 * In this case, no rows are removed.
 		 */
 		removeRow(
 			row: string | TreeNodeFromImplicitAllowedTypes<TRow>,

--- a/packages/dds/tree/src/test/memory/tableTree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tableTree.spec.ts
@@ -15,7 +15,6 @@ import {
 	Row,
 	UndoRedoManager,
 	createTableTree,
-	removeColumnAndCells,
 	type Table,
 	type TableTreeOptions,
 } from "../tablePerformanceTestUtilities.js";
@@ -448,7 +447,7 @@ describe("SharedTree table APIs memory usage", () => {
 						operation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = table.columns[Math.floor(table.columns.length / 2)];
-								removeColumnAndCells(table, column);
+								table.removeColumn(column);
 							}
 						},
 					}),
@@ -463,7 +462,7 @@ describe("SharedTree table APIs memory usage", () => {
 						setupOperation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = table.columns[Math.floor(table.columns.length / 2)];
-								removeColumnAndCells(table, column);
+								table.removeColumn(column);
 							}
 						},
 						stackOperation: (undoRedoManager) => {
@@ -485,7 +484,7 @@ describe("SharedTree table APIs memory usage", () => {
 				// 		setupOperation: (table, undoRedoManager) => {
 				// 			for (let i = 0; i < count; i++) {
 				// 				const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 				removeColumnAndCells(table, column);
+				// 				table.removeColumn(column);
 				// 			}
 				// 			for (let i = 0; i < count; i++) {
 				// 				undoRedoManager.undo();
@@ -575,7 +574,7 @@ describe("SharedTree table APIs memory usage", () => {
 						operation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = table.columns[Math.floor(table.columns.length / 2)];
-								removeColumnAndCells(table, column);
+								table.removeColumn(column);
 								const row = table.rows[Math.floor(table.rows.length / 2)];
 								table.removeRow(row);
 							}
@@ -592,7 +591,7 @@ describe("SharedTree table APIs memory usage", () => {
 						setupOperation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = table.columns[Math.floor(table.columns.length / 2)];
-								removeColumnAndCells(table, column);
+								table.removeColumn(column);
 								const row = table.rows[Math.floor(table.rows.length / 2)];
 								table.removeRow(row);
 							}
@@ -619,7 +618,7 @@ describe("SharedTree table APIs memory usage", () => {
 				// 		setupOperation: (table, undoRedoManager) => {
 				// 			for (let i = 0; i < count; i++) {
 				// 				const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 				removeColumnAndCells(table, column);
+				// 				table.removeColumn(column);
 				// 				const row = table.rows[Math.floor(table.rows.length / 2)];
 				// 				table.removeRow(row);
 				// 			}
@@ -657,7 +656,7 @@ describe("SharedTree table APIs memory usage", () => {
 								table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
 								const row = new Row({ id: `row-${i}`, cells: {} });
 								table.insertRow({ index: Math.floor(table.rows.length / 2), row });
-								removeColumnAndCells(table, column);
+								table.removeColumn(column);
 								table.removeRow(row);
 							}
 						},
@@ -677,7 +676,7 @@ describe("SharedTree table APIs memory usage", () => {
 				// 				table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
 				// 				const row = new Row({ id: `row-${i}`, cells: {} });
 				// 				table.insertRow({ index: Math.floor(table.rows.length / 2), row });
-				// 				removeColumnAndCells(table, column);
+				// 				table.removeColumn(column);
 				// 				table.removeRow(row);
 				// 			}
 				// 		},
@@ -709,7 +708,7 @@ describe("SharedTree table APIs memory usage", () => {
 				// 				table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
 				// 				const row = new Row({ id: `row-${i}`, cells: {} });
 				// 				table.insertRow({ index: Math.floor(table.rows.length / 2), row });
-				// 				removeColumnAndCells(table, column);
+				// 				table.removeColumn(column);
 				// 				table.removeRow(row);
 				// 			}
 				// 			for (let i = 0; i < count; i++) {

--- a/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
@@ -17,7 +17,6 @@ import {
 	Row,
 	UndoRedoManager,
 	createTableTree,
-	removeColumnAndCells,
 	type Table,
 	type TableTreeDefinition,
 	type TableTreeOptions,
@@ -342,7 +341,7 @@ describe("SharedTree table APIs execution time", () => {
 				// 		for (let i = 0; i < count; i++) {
 				// 			const column = table.columns[Math.floor(table.columns.length / 2)];
 				// 			const row = table.rows[Math.floor(table.rows.length / 2)];
-				// 			removeColumnAndCells(table, column);
+				// 			table.removeColumn(column);
 				// 			table.removeRow(row);
 				// 		}
 				// 		for (let i = 0; i < count; i++) {
@@ -381,7 +380,7 @@ describe("SharedTree table APIs execution time", () => {
 							const row = new Row({ cells: {} });
 							table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
 							table.insertRow({ index: Math.floor(table.rows.length / 2), row });
-							removeColumnAndCells(table, column);
+							table.removeColumn(column);
 							table.removeRow(row);
 						}
 					},
@@ -400,7 +399,7 @@ describe("SharedTree table APIs execution time", () => {
 				// 			const row = new Row({ cells: {} });
 				// 			table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
 				// 			table.insertRow({ index: Math.floor(table.rows.length / 2), row });
-				// 			removeColumnAndCells(table, column);
+				// 			table.removeColumn(column);
 				// 			table.removeRow(row);
 				// 		}
 				// 		assert(undoRedoManager.canUndo);
@@ -435,7 +434,7 @@ describe("SharedTree table APIs execution time", () => {
 				// 			const row = new Row({ cells: {} });
 				// 			table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
 				// 			table.insertRow({ index: Math.floor(table.rows.length / 2), row });
-				// 			removeColumnAndCells(table, column);
+				// 			table.removeColumn(column);
 				// 			table.removeRow(row);
 				// 		}
 				// 		for (let i = 0; i < count; i++) {
@@ -475,7 +474,7 @@ describe("SharedTree table APIs execution time", () => {
 					operation: (table) => {
 						for (let i = 0; i < count; i++) {
 							const column = table.columns[Math.floor(table.columns.length / 2)];
-							removeColumnAndCells(table, column);
+							table.removeColumn(column);
 						}
 					},
 					maxBenchmarkDurationSeconds,
@@ -491,7 +490,7 @@ describe("SharedTree table APIs execution time", () => {
 				// 	beforeOperation: (table, undoRedoManager) => {
 				// 		for (let i = 0; i < count; i++) {
 				// 			const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 			removeColumnAndCells(table, column);
+				// 			table.removeColumn(column);
 				// 		}
 				// 		assert(undoRedoManager.canUndo);
 				// 	},
@@ -515,7 +514,7 @@ describe("SharedTree table APIs execution time", () => {
 				// 	beforeOperation: (table, undoRedoManager) => {
 				// 		for (let i = 0; i < count; i++) {
 				// 			const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 			removeColumnAndCells(table, column);
+				// 			table.removeColumn(column);
 				// 		}
 				// 		for (let i = 0; i < count; i++) {
 				// 			undoRedoManager.undo();
@@ -610,7 +609,7 @@ describe("SharedTree table APIs execution time", () => {
 					operation: (table) => {
 						for (let i = 0; i < count; i++) {
 							const column = table.columns[Math.floor(table.columns.length / 2)];
-							removeColumnAndCells(table, column);
+							table.removeColumn(column);
 							const row = table.rows[Math.floor(table.rows.length / 2)];
 							table.removeRow(row);
 						}
@@ -628,7 +627,7 @@ describe("SharedTree table APIs execution time", () => {
 				// 	beforeOperation: (table, undoRedoManager) => {
 				// 		for (let i = 0; i < count; i++) {
 				// 			const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 			removeColumnAndCells(table, column);
+				// 			table.removeColumn(column);
 				// 			const row = table.rows[Math.floor(table.rows.length / 2)];
 				// 			table.removeRow(row);
 				// 		}
@@ -657,7 +656,7 @@ describe("SharedTree table APIs execution time", () => {
 				// 	beforeOperation: (table, undoRedoManager) => {
 				// 		for (let i = 0; i < count; i++) {
 				// 			const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 			removeColumnAndCells(table, column);
+				// 			table.removeColumn(column);
 				// 			const row = table.rows[Math.floor(table.rows.length / 2)];
 				// 			table.removeRow(row);
 				// 		}

--- a/packages/dds/tree/src/test/tablePerformanceTestUtilities.ts
+++ b/packages/dds/tree/src/test/tablePerformanceTestUtilities.ts
@@ -16,7 +16,6 @@ import { DefaultTestSharedTreeKind } from "./utils.js";
 import { AttachState } from "@fluidframework/container-definitions";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 import { CommitKind, type Revertible } from "../core/index.js";
-import { Tree } from "../shared-tree/index.js";
 import assert from "node:assert";
 
 /**
@@ -145,20 +144,6 @@ export function createTableTree({
 		table,
 		treeView,
 	};
-}
-
-/**
- * Currently table schema does not support removing cells when a column is removed.
- * This function provides a way to remove a column and its associated cells from the table. Might remove in the future
- * if the table schema is updated to handle this automatically.
- */
-export function removeColumnAndCells(table: InstanceType<typeof Table>, column: Column): void {
-	Tree.runTransaction(table, () => {
-		table.removeColumn(column);
-		for (const row of table.rows) {
-			table.removeCell({ column, row });
-		}
-	});
 }
 
 /**

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -1055,7 +1055,9 @@ describe("TableFactory unit tests", () => {
 				rows: [
 					{
 						id: "row-0",
-						cells: {},
+						cells: {
+							"column-0": { value: "Hello world!" },
+						},
 						props: {},
 					},
 				],
@@ -1090,7 +1092,9 @@ describe("TableFactory unit tests", () => {
 				rows: [
 					{
 						id: "row-0",
-						cells: {},
+						cells: {
+							"column-0": { value: "Hello world!" },
+						},
 						props: {},
 					},
 				],
@@ -1113,7 +1117,7 @@ describe("TableFactory unit tests", () => {
 			});
 		});
 
-		it("Removing column that does not exist on table errors", () => {
+		it("Removing a column that does not exist in the table errors", () => {
 			const { treeView, Column } = createTableTree();
 			treeView.initialize({
 				columns: [],
@@ -1615,96 +1619,6 @@ describe("TableFactory unit tests", () => {
 			// But it won't fire when a row's properties change, or when the row's cells change, etc.
 			Tree.on(table.rows, "nodeChanged", () => {
 				// Respond to the change.
-			});
-		});
-
-		it("TableSchema: Remove column and corresponding cells in a transaction", () => {
-			// #region Don't include this in the example docs.
-
-			const Cell = schemaFactory.string;
-
-			class Column extends TableSchema.column({
-				schemaFactory,
-				cell: Cell,
-				props: schemaFactory.object("TableColumnProps", {
-					label: schemaFactory.string,
-				}),
-			}) {}
-
-			class Row extends TableSchema.row({
-				schemaFactory,
-				cell: Cell,
-			}) {}
-
-			class Table extends TableSchema.table({
-				schemaFactory,
-				cell: Cell,
-				column: Column,
-				row: Row,
-			}) {}
-
-			const treeView = independentView(
-				new TreeViewConfiguration({
-					schema: Table,
-					enableSchemaValidation: true,
-				}),
-				{ idCompressor: createIdCompressor() },
-			);
-			treeView.initialize(
-				new Table({
-					columns: [
-						{ id: "column-0", props: { label: "Column 0" } },
-						{ id: "column-1", props: { label: "Column 1" } },
-						{ id: "column-2", props: { label: "Column 2" } },
-					],
-					rows: [
-						{
-							id: "row-0",
-							cells: {
-								"column-0": "0-0",
-								"column-1": "0-1",
-								"column-2": "0-2",
-							},
-						},
-						{
-							id: "row-1",
-							cells: {
-								"column-0": "1-0",
-								"column-1": "1-1",
-								"column-2": "1-2",
-							},
-						},
-						{
-							id: "row-2",
-							cells: {
-								"column-0": "2-0",
-								"column-1": "2-1",
-								"column-2": "2-2",
-							},
-						},
-					],
-				}),
-			);
-
-			const table = treeView.root;
-
-			const column1 = table.getColumn("column-1") ?? fail("Column not found");
-
-			// #endregion
-
-			// Remove column1 and all of its cells.
-			// The "transaction" method will ensure that all changes are applied atomically.
-			Tree.runTransaction(table, () => {
-				// Remove column1
-				table.removeColumn(column1);
-
-				// Remove the cell at column1 for each row.
-				for (const row of table.rows) {
-					table.removeCell({
-						column: column1,
-						row,
-					});
-				}
 			});
 		});
 	});


### PR DESCRIPTION
Previously, the [removeColumn](https://fluidframework.com/docs/api/fluid-framework/tableschema-namespace/table-interface#removecolumn-methodsignature) API on Table nodes derived from [TableSchema](https://fluidframework.com/docs/api/fluid-framework/tableschema-namespace/) (alpha) only removed the `Column` node from the list of columns tracked by the table.
To also remove the corresponding cells from the table (which are stored on the `Row` nodes), the user was required to write a custom transaction that removed the column and cells.

The motivation for this design was due to performance concerns with transactions.
Those concerns are still relevant, but the data leak risk of dropping columns without removing corresponding cells seems a greater risk, and we have plans to address the performance issues with transactions.