### PR TITLE
test(matrix): Refactor matrix perf tests to make memory and execution time tests use the same configurations and structure

### DIFF
--- a/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
@@ -13,7 +13,7 @@ import {
 import type { IMatrixConsumer } from "@tiny-calc/nano";
 
 import type { ISharedMatrix } from "../../index.js";
-import { createLocalMatrix, type TestMatrixOptions } from "../performanceTestUtilities.js";
+import { createTestMatrix, type TestMatrixOptions } from "../performanceTestUtilities.js";
 import { UndoRedoStackManager } from "../undoRedoStackManager.js";
 
 /**
@@ -45,7 +45,7 @@ function createMatrix(options: TestMatrixOptions): {
 	 */
 	cleanUp: () => void;
 } {
-	const matrix = createLocalMatrix(options);
+	const matrix = createTestMatrix(options);
 
 	// Configure event listeners
 	const eventListeners: IMatrixConsumer<string> = {

--- a/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
@@ -329,7 +329,9 @@ describe("SharedMatrix memory usage", () => {
 								matrix.removeRows(Math.floor(matrix.rowCount / 2), 1);
 							}
 						},
-					}); // Test the memory usage of the SharedMatrix for undoing the insertion of a row and a column and then removing them right away for a given number of times.
+					});
+
+					// Test the memory usage of the SharedMatrix for undoing the insertion of a row and a column and then removing them right away for a given number of times.
 					runBenchmark({
 						title: `Undo insert and remove a row and a column ${count} times`,
 						matrixSize,
@@ -398,7 +400,9 @@ describe("SharedMatrix memory usage", () => {
 								matrix.removeCols(Math.floor(matrix.colCount / 2), 1);
 							}
 						},
-					}); // Test the memory usage of the SharedMatrix for undoing the removal of a column in the middle for a given number of times.
+					});
+
+					// Test the memory usage of the SharedMatrix for undoing the removal of a column in the middle for a given number of times.
 					runBenchmark({
 						title: `Undo remove the middle column ${count} times`,
 						matrixSize,

--- a/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "@fluid-tools/benchmark";
 
 import type { ISharedMatrix } from "../../index.js";
-import { createTestMatrix, type TestMatrixOptions } from "../performanceTestUtilities.js";
+import { createTestMatrix, type MatrixBenchmarkOptions } from "../performanceTestUtilities.js";
 import type { UndoRedoStackManager } from "../undoRedoStackManager.js";
 
 /**
@@ -25,37 +25,6 @@ import type { UndoRedoStackManager } from "../undoRedoStackManager.js";
 // - unify with time measurement tests (in terms of API)
 
 /**
- * {@link createBenchmark} options.
- */
-interface BenchmarkOptions extends TestMatrixOptions {
-	/**
-	 * The title of the benchmark test.
-	 */
-	readonly title: string;
-
-	/**
-	 * Optional action to perform on the matrix before the operation being measured.
-	 */
-	readonly beforeOperation?: (
-		matrix: ISharedMatrix,
-		undoRedoStack: UndoRedoStackManager,
-	) => void;
-
-	/**
-	 * The operation to be measured.
-	 */
-	readonly operation: (matrix: ISharedMatrix, undoRedo: UndoRedoStackManager) => void;
-
-	/**
-	 * Optional action to perform on the matrix after the operation being measured.
-	 */
-	readonly afterOperation?: (
-		matrix: ISharedMatrix,
-		undoRedoStack: UndoRedoStackManager,
-	) => void;
-}
-
-/**
  * Creates a benchmark for operations on a SharedMatrix.
  */
 function createBenchmark({
@@ -65,7 +34,7 @@ function createBenchmark({
 	beforeOperation,
 	operation,
 	afterOperation,
-}: BenchmarkOptions): IMemoryTestObject {
+}: MatrixBenchmarkOptions): IMemoryTestObject {
 	return new (class implements IMemoryTestObject {
 		readonly title = title;
 

--- a/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
@@ -10,11 +10,10 @@ import {
 	benchmarkMemory,
 	isInPerformanceTestingMode,
 } from "@fluid-tools/benchmark";
-import type { IMatrixConsumer } from "@tiny-calc/nano";
 
 import type { ISharedMatrix } from "../../index.js";
 import { createTestMatrix, type TestMatrixOptions } from "../performanceTestUtilities.js";
-import { UndoRedoStackManager } from "../undoRedoStackManager.js";
+import type { UndoRedoStackManager } from "../undoRedoStackManager.js";
 
 /**
  * Note: These benchmarks are designed to closely match the benchmarks in SharedTree.
@@ -24,51 +23,6 @@ import { UndoRedoStackManager } from "../undoRedoStackManager.js";
 
 // TODOs (AB#46340):
 // - unify with time measurement tests (in terms of API)
-
-/**
- * Initializes a SharedMatrix for testing.
- * @remarks Includes initialization of the undo/redo stack, as well as mock event subscriptions.
- */
-function createMatrix(options: TestMatrixOptions): {
-	/**
-	 * The initialized matrix.
-	 */
-	matrix: ISharedMatrix;
-
-	/**
-	 * The undo/redo stack manager for the matrix.
-	 */
-	undoRedoStack: UndoRedoStackManager;
-
-	/**
-	 * Cleanup function to run after the test to close the matrix and release resources.
-	 */
-	cleanUp: () => void;
-} {
-	const matrix = createTestMatrix(options);
-
-	// Configure event listeners
-	const eventListeners: IMatrixConsumer<string> = {
-		rowsChanged: () => {},
-		colsChanged: () => {},
-		cellsChanged: () => {},
-	};
-	matrix.openMatrix(eventListeners);
-
-	// Configure undo/redo
-	const undoRedoStack = new UndoRedoStackManager();
-	matrix.openUndo(undoRedoStack);
-
-	const cleanUp = (): void => {
-		matrix.closeMatrix(eventListeners);
-	};
-
-	return {
-		matrix,
-		undoRedoStack,
-		cleanUp,
-	};
-}
 
 /**
  * {@link createBenchmark} options.
@@ -126,7 +80,7 @@ function createBenchmark({
 		}
 
 		beforeIteration(): void {
-			const { matrix, undoRedoStack, cleanUp } = createMatrix({
+			const { matrix, undoRedoStack, cleanUp } = createTestMatrix({
 				matrixSize,
 				initialCellValue,
 			});

--- a/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
@@ -13,8 +13,8 @@ import {
 import type { IMatrixConsumer } from "@tiny-calc/nano";
 
 import type { ISharedMatrix } from "../../index.js";
+import { createLocalMatrix, type TestMatrixOptions } from "../performanceTestUtilities.js";
 import { UndoRedoStackManager } from "../undoRedoStackManager.js";
-import { createLocalMatrix, type TestMatrixOptions } from "../utils.js";
 
 /**
  * Note: These benchmarks are designed to closely match the benchmarks in SharedTree.

--- a/packages/dds/matrix/src/test/performanceTestUtilities.ts
+++ b/packages/dds/matrix/src/test/performanceTestUtilities.ts
@@ -83,3 +83,34 @@ export function createTestMatrix(options: TestMatrixOptions): {
 		cleanUp,
 	};
 }
+
+/**
+ * Benchmark test options.
+ */
+export interface MatrixBenchmarkOptions extends TestMatrixOptions {
+	/**
+	 * The title of the benchmark test.
+	 */
+	readonly title: string;
+
+	/**
+	 * Optional action to perform on the matrix before the operation being measured.
+	 */
+	readonly beforeOperation?: (
+		matrix: ISharedMatrix,
+		undoRedoStack: UndoRedoStackManager,
+	) => void;
+
+	/**
+	 * The operation to be measured.
+	 */
+	readonly operation: (matrix: ISharedMatrix, undoRedo: UndoRedoStackManager) => void;
+
+	/**
+	 * Optional action to perform on the matrix after the operation being measured.
+	 */
+	readonly afterOperation?: (
+		matrix: ISharedMatrix,
+		undoRedoStack: UndoRedoStackManager,
+	) => void;
+}

--- a/packages/dds/matrix/src/test/performanceTestUtilities.ts
+++ b/packages/dds/matrix/src/test/performanceTestUtilities.ts
@@ -11,7 +11,7 @@ import type { ISharedMatrix } from "../index.js";
 import { matrixFactory } from "./utils.js";
 
 /**
- * {@link createLocalMatrix} options.
+ * {@link createTestMatrix} options.
  */
 export interface TestMatrixOptions {
 	/**
@@ -29,7 +29,7 @@ export interface TestMatrixOptions {
  * Creates a local matrix with the specified size and for dense test matrix given initial value.
  * Otherwise, leaving the initial value as undefined will create a sparse matrix.
  */
-export function createLocalMatrix({
+export function createTestMatrix({
 	matrixSize,
 	initialCellValue,
 }: TestMatrixOptions): ISharedMatrix & IChannel {

--- a/packages/dds/matrix/src/test/performanceTestUtilities.ts
+++ b/packages/dds/matrix/src/test/performanceTestUtilities.ts
@@ -1,0 +1,48 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { IChannel } from "@fluidframework/datastore-definitions/internal";
+import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
+
+import type { ISharedMatrix } from "../index.js";
+
+import { matrixFactory } from "./utils.js";
+
+/**
+ * {@link createLocalMatrix} options.
+ */
+export interface TestMatrixOptions {
+	/**
+	 * The number of rows and columns that will be in the matrix.
+	 */
+	readonly matrixSize: number;
+	/**
+	 * The initial value of each cell in the dense matrix.
+	 * @remarks If not specified, no cell values will be inserted into the table, leaving it sparse.
+	 */
+	readonly initialCellValue?: string | undefined;
+}
+
+/**
+ * Creates a local matrix with the specified size and for dense test matrix given initial value.
+ * Otherwise, leaving the initial value as undefined will create a sparse matrix.
+ */
+export function createLocalMatrix({
+	matrixSize,
+	initialCellValue,
+}: TestMatrixOptions): ISharedMatrix & IChannel {
+	const matrix = matrixFactory.create(new MockFluidDataStoreRuntime(), "test-matrix");
+	matrix.insertRows(0, matrixSize);
+	matrix.insertCols(0, matrixSize);
+
+	if (initialCellValue !== undefined) {
+		for (let row = 0; row < matrixSize; row++) {
+			for (let col = 0; col < matrixSize; col++) {
+				matrix.setCell(row, col, initialCellValue);
+			}
+		}
+	}
+	return matrix;
+}

--- a/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
@@ -15,7 +15,7 @@ import {
 import type { IMatrixConsumer } from "@tiny-calc/nano";
 
 import type { ISharedMatrix } from "../../index.js";
-import { createLocalMatrix, type TestMatrixOptions } from "../performanceTestUtilities.js";
+import { createTestMatrix, type TestMatrixOptions } from "../performanceTestUtilities.js";
 import { UndoRedoStackManager } from "../undoRedoStackManager.js";
 
 /**
@@ -82,7 +82,7 @@ function runBenchmark({
 				assert.equal(state.iterationsPerBatch, 1, "Expected exactly one iteration per batch");
 
 				// Create matrix
-				const localMatrix = createLocalMatrix({
+				const localMatrix = createTestMatrix({
 					matrixSize,
 					initialCellValue,
 				});

--- a/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
@@ -26,9 +26,6 @@ import { createTestMatrix, type MatrixBenchmarkOptions } from "../performanceTes
  * {@link runBenchmark} configuration.
  */
 interface BenchmarkConfig extends BenchmarkTimingOptions, MatrixBenchmarkOptions {
-	/**
-	 * {@inheritDoc @fluid-tools/benchmark#BenchmarkTimingOptions.maxBenchmarkDurationSeconds}
-	 */
 	readonly maxBenchmarkDurationSeconds: number;
 }
 

--- a/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
@@ -13,9 +13,7 @@ import {
 	type BenchmarkTimingOptions,
 } from "@fluid-tools/benchmark";
 
-import type { ISharedMatrix } from "../../index.js";
-import { createTestMatrix, type TestMatrixOptions } from "../performanceTestUtilities.js";
-import type { UndoRedoStackManager } from "../undoRedoStackManager.js";
+import { createTestMatrix, type MatrixBenchmarkOptions } from "../performanceTestUtilities.js";
 
 /**
  * Note: These benchmarks are designed to closely match the benchmarks in SharedTree.
@@ -26,33 +24,7 @@ import type { UndoRedoStackManager } from "../undoRedoStackManager.js";
 /**
  * {@link runBenchmark} configuration.
  */
-interface BenchmarkConfig extends BenchmarkTimingOptions, TestMatrixOptions {
-	/**
-	 * The title of the benchmark test.
-	 */
-	readonly title: string;
-
-	/**
-	 * Optional action to perform on the matrix before the operation being measured.
-	 */
-	readonly beforeOperation?: (
-		matrix: ISharedMatrix,
-		undoRedoStack: UndoRedoStackManager,
-	) => void;
-
-	/**
-	 * The operation to be measured.
-	 */
-	readonly operation: (matrix: ISharedMatrix, undoRedoStack: UndoRedoStackManager) => void;
-
-	/**
-	 * Optional action to perform on the matrix after the operation being measured.
-	 */
-	readonly afterOperation?: (
-		matrix: ISharedMatrix,
-		undoRedoStack: UndoRedoStackManager,
-	) => void;
-
+interface BenchmarkConfig extends BenchmarkTimingOptions, MatrixBenchmarkOptions {
 	/**
 	 * {@inheritDoc @fluid-tools/benchmark#BenchmarkTimingOptions.maxBenchmarkDurationSeconds}
 	 */

--- a/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
@@ -12,6 +12,7 @@ import {
 	type BenchmarkTimer,
 	type BenchmarkTimingOptions,
 } from "@fluid-tools/benchmark";
+import type { Test } from "mocha";
 
 import { createTestMatrix, type MatrixBenchmarkOptions } from "../performanceTestUtilities.js";
 
@@ -43,8 +44,8 @@ function runBenchmark({
 	afterOperation,
 	minBatchDurationSeconds = 0,
 	maxBenchmarkDurationSeconds,
-}: BenchmarkConfig): void {
-	benchmark({
+}: BenchmarkConfig): Test {
+	return benchmark({
 		type: BenchmarkType.Measurement,
 		title,
 		benchmarkFnCustom: async <T>(state: BenchmarkTimer<T>) => {

--- a/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
@@ -15,8 +15,8 @@ import {
 import type { IMatrixConsumer } from "@tiny-calc/nano";
 
 import type { ISharedMatrix } from "../../index.js";
+import { createLocalMatrix, type TestMatrixOptions } from "../performanceTestUtilities.js";
 import { UndoRedoStackManager } from "../undoRedoStackManager.js";
-import { createLocalMatrix, type TestMatrixOptions } from "../utils.js";
 
 /**
  * Note: These benchmarks are designed to closely match the benchmarks in SharedTree.

--- a/packages/dds/matrix/src/test/utils.ts
+++ b/packages/dds/matrix/src/test/utils.ts
@@ -5,8 +5,6 @@
 
 import { strict as assert } from "node:assert";
 
-import type { IChannel } from "@fluidframework/datastore-definitions/internal";
-import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 import type {
 	IMatrixConsumer,
 	IMatrixProducer,
@@ -14,7 +12,7 @@ import type {
 	IMatrixWriter,
 } from "@tiny-calc/nano";
 
-import { type ISharedMatrix, SharedMatrix } from "../index.js";
+import { SharedMatrix } from "../index.js";
 
 /**
  * Convenience export of SharedMatrix's factory for usage in tests.
@@ -222,42 +220,5 @@ export function insertFragmented(
 
 	expectSize(matrix, rowCount, colCount);
 
-	return matrix;
-}
-
-/**
- * {@link createLocalMatrix} options.
- */
-export interface TestMatrixOptions {
-	/**
-	 * The number of rows and columns that will be in the matrix.
-	 */
-	readonly matrixSize: number;
-	/**
-	 * The initial value of each cell in the dense matrix.
-	 * @remarks If not specified, no cell values will be inserted into the table, leaving it sparse.
-	 */
-	readonly initialCellValue?: string | undefined;
-}
-
-/**
- * Creates a local matrix with the specified size and for dense test matrix given initial value.
- * Otherwise, leaving the initial value as undefined will create a sparse matrix.
- */
-export function createLocalMatrix({
-	matrixSize,
-	initialCellValue,
-}: TestMatrixOptions): ISharedMatrix & IChannel {
-	const matrix = matrixFactory.create(new MockFluidDataStoreRuntime(), "test-matrix");
-	matrix.insertRows(0, matrixSize);
-	matrix.insertCols(0, matrixSize);
-
-	if (initialCellValue !== undefined) {
-		for (let row = 0; row < matrixSize; row++) {
-			for (let col = 0; col < matrixSize; col++) {
-				matrix.setCell(row, col, initialCellValue);
-			}
-		}
-	}
 	return matrix;
 }


### PR DESCRIPTION
We have 2 sets of tests that are intended to be the same but are run independently to measure execution time vs memory consumption. The sets of tests were structured very differently from one another but are intended to test the same scenarios.

This PR updates the tests to be more structurally similar and share more infrastructure.

In a future PR, I plan to update the overall test pattern to declare the set of test scenarios once and run execution time and memory consumption tests against the same inputs. This will make future maintenance significantly easier.

Additionally, similar changes will be made to the corresponding SharedTree table tests.

[AB#46340](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/46340)