### PR TITLE
Import strict as assert

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/assertTags.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/assertTags.ts
@@ -9,7 +9,7 @@ import type { Package } from "@fluidframework/build-tools";
 import { PackageCommand } from "../../BasePackageCommand.js";
 import type { PackageKind, PackageWithKind } from "../../filter.js";
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 import { Flags } from "@oclif/core";
 import { cosmiconfig } from "cosmiconfig";
 import {

--- a/build-tools/packages/build-cli/src/library/azureDevops/getBaselineBuildMetrics.ts
+++ b/build-tools/packages/build-cli/src/library/azureDevops/getBaselineBuildMetrics.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 import { getZipObjectFromArtifact } from "@fluidframework/bundle-size-tools";
 import type { WebApi } from "azure-devops-node-api";
 import { BuildResult } from "azure-devops-node-api/interfaces/BuildInterfaces.js";

--- a/build-tools/packages/build-cli/src/library/layerGraph.ts
+++ b/build-tools/packages/build-cli/src/library/layerGraph.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Package } from "@fluidframework/build-tools";

--- a/build-tools/packages/build-tools/src/common/biomeConfig.ts
+++ b/build-tools/packages/build-tools/src/common/biomeConfig.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert/strict";
+import { strict as assert } from "node:assert/strict";
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import ignore from "ignore";

--- a/build-tools/packages/build-tools/src/test/biomeConfig.test.ts
+++ b/build-tools/packages/build-tools/src/test/biomeConfig.test.ts
@@ -7,7 +7,7 @@
 // There are no cases in this file where the values being checked should be undefined, so `!.` is more correct with
 // respect to intent than `?.`.
 
-import assert from "node:assert/strict";
+import { strict as assert } from "node:assert/strict";
 import path from "node:path";
 import {
 	BiomeConfigReader,

--- a/build-tools/packages/bundle-size-tools/src/ADO/AdoArtifactFileProvider.ts
+++ b/build-tools/packages/bundle-size-tools/src/ADO/AdoArtifactFileProvider.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import type { WebApi } from "azure-devops-node-api";
 import type JSZip from "jszip";
 import type { StatsCompilation } from "webpack";

--- a/build-tools/packages/bundle-size-tools/src/ADO/getCommentForBundleDiff.ts
+++ b/build-tools/packages/bundle-size-tools/src/ADO/getCommentForBundleDiff.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import type { BundleComparison, BundleMetric } from "../BundleBuddyTypes";
 import { totalSizeMetricName } from "./Constants";

--- a/examples/data-objects/webflow/src/view/layout.ts
+++ b/examples/data-objects/webflow/src/view/layout.ts
@@ -4,7 +4,7 @@
  */
 
 // eslint-disable-next-line import/no-nodejs-modules
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { EventEmitter } from "@fluid-example/example-utils";
 import { MergeTreeMaintenanceType, segmentIsRemoved } from "@fluidframework/merge-tree/legacy";

--- a/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/sharedMatrix.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import {
 	type IMemoryTestObject,

--- a/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
+++ b/packages/dds/matrix/src/test/time/sharedMatrix.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import {
 	benchmark,

--- a/packages/dds/merge-tree/src/test/client.replay.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.replay.spec.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 import * as fs from "node:fs";
 
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";

--- a/packages/dds/merge-tree/src/test/ordinal.spec.ts
+++ b/packages/dds/merge-tree/src/test/ordinal.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { computeHierarchicalOrdinal } from "../ordinal.js";
 

--- a/packages/dds/merge-tree/src/test/revertibleFarm.spec.ts
+++ b/packages/dds/merge-tree/src/test/revertibleFarm.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { makeRandom } from "@fluid-private/stochastic-test-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";

--- a/packages/dds/shared-object-base/src/test/handle.test.ts
+++ b/packages/dds/shared-object-base/src/test/handle.test.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { isISharedObjectHandle, SharedObjectHandle } from "../handle.js";
 

--- a/packages/dds/tree/src/test/memory/tableTree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tableTree.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 import {
 	benchmarkMemory,
 	isInPerformanceTestingMode,

--- a/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 import {
 	benchmark,
 	BenchmarkType,

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -30,7 +30,7 @@ import {
 	MockFluidDataStoreRuntime,
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 import {
 	asTreeViewAlpha,
 	SchemaFactory,

--- a/packages/dds/tree/src/test/tablePerformanceTestUtilities.ts
+++ b/packages/dds/tree/src/test/tablePerformanceTestUtilities.ts
@@ -16,7 +16,7 @@ import { DefaultTestSharedTreeKind } from "./utils.js";
 import { AttachState } from "@fluidframework/container-definitions";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 import { CommitKind, type Revertible } from "../core/index.js";
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 /**
  * Define a return type for table tree creation.

--- a/packages/dds/tree/src/test/util/testTreeProvider.spec.ts
+++ b/packages/dds/tree/src/test/util/testTreeProvider.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { SharedTreeCore } from "../../shared-tree-core/index.js";
 import { SummarizeType, TestTreeProvider, spyOnMethod } from "../utils.js";

--- a/packages/drivers/odsp-driver/src/test/mockFetch.ts
+++ b/packages/drivers/odsp-driver/src/test/mockFetch.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { stub } from "sinon";
 

--- a/packages/drivers/odsp-driver/src/test/tokenFetch.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/tokenFetch.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import {
 	isTokenFromCache,

--- a/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/errorUtils.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { FluidErrorTypes } from "@fluidframework/core-interfaces/internal";
 import { IThrottlingWarning } from "@fluidframework/driver-definitions/internal";

--- a/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { RateLimiter } from "@fluidframework/driver-utils/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";

--- a/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
 import { ISession } from "@fluidframework/server-services-client";

--- a/packages/drivers/routerlicious-driver/src/test/wholeSummaryDocumentStorageService.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/wholeSummaryDocumentStorageService.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";

--- a/packages/framework/presence/src/test/broadcastControlsTests.ts
+++ b/packages/framework/presence/src/test/broadcastControlsTests.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import type { BroadcastControls, BroadcastControlSettings } from "../broadcastControls.js";
 import type { Presence } from "../presence.js";

--- a/packages/framework/presence/src/test/timerManager.spec.ts
+++ b/packages/framework/presence/src/test/timerManager.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { describe, it, after, afterEach, before, beforeEach } from "mocha";
 import { useFakeTimers, type SinonFakeTimers, spy } from "sinon";

--- a/packages/framework/tree-agent/src/test/systemPrompt.spec.ts
+++ b/packages/framework/tree-agent/src/test/systemPrompt.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { createIdCompressor } from "@fluidframework/id-compressor/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";

--- a/packages/loader/container-loader/src/test/container.spec.ts
+++ b/packages/loader/container-loader/src/test/container.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { AttachState, IAudience } from "@fluidframework/container-definitions/";

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import type { IProvideLayerCompatDetails } from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";

--- a/packages/runtime/container-runtime/src/test/hardwareStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/hardwareStats.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { IContainerContext } from "@fluidframework/container-definitions/internal";
 import { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { booleanCases, generatePairwiseOptions } from "@fluid-private/test-pairwise-generator";
 import {

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import os from "os";
 
 import { ITestDriver, OdspEndpoint } from "@fluid-internal/test-driver-definitions";

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { ITestDriver, RouterliciousEndpoint } from "@fluid-internal/test-driver-definitions";
 import { IRequest } from "@fluidframework/core-interfaces";

--- a/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { describeCompat } from "@fluid-private/test-version-utils";

--- a/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";

--- a/packages/test/test-end-to-end-tests/src/test/createNewSummaryCachingTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createNewSummaryCachingTests.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { AttachState } from "@fluidframework/container-definitions";

--- a/packages/test/test-end-to-end-tests/src/test/fluidObjectHandle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/fluidObjectHandle.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import {
 	ITestDataObject,

--- a/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { generatePairwiseOptions } from "@fluid-private/test-pairwise-generator";
 import { describeCompat } from "@fluid-private/test-version-utils";

--- a/packages/test/test-end-to-end-tests/src/test/newFluidObjectVisibility.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/newFluidObjectVisibility.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import {
 	ITestDataObject,

--- a/packages/test/test-end-to-end-tests/src/test/offline/containerDirtyFlag.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/containerDirtyFlag.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer, IHostLoader } from "@fluidframework/container-definitions/internal";

--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainerExperimental } from "@fluidframework/container-loader/internal";

--- a/packages/test/test-end-to-end-tests/src/test/t9sregressiontest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/t9sregressiontest.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import type { ISharedMap } from "@fluidframework/map/internal";

--- a/packages/test/test-service-load/src/test/mini.spec.ts
+++ b/packages/test/test-service-load/src/test/mini.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import child_process from "child_process";
 
 const childArgs: string[] = ["./dist/main.js", "--driver", "tinylicious", "--profile", "mini"];

--- a/packages/test/test-utils/src/localCodeLoader.ts
+++ b/packages/test/test-utils/src/localCodeLoader.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import {
 	ICodeDetailsLoader,

--- a/packages/utils/odsp-doclib-utils/src/test/facetCode.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/facetCode.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { parseFacetCodes, tryParseErrorResponse } from "../odspErrorUtils.js";
 

--- a/packages/utils/odsp-doclib-utils/src/test/odspDocLibUtils.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/odspDocLibUtils.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { getAadTenant } from "../odspDocLibUtils.js";
 

--- a/packages/utils/odsp-doclib-utils/src/test/parseAuthErrorClaims.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/parseAuthErrorClaims.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { parseAuthErrorClaims } from "../parseAuthErrorClaims.js";
 

--- a/packages/utils/odsp-doclib-utils/src/test/parseAuthErrorTenant.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/parseAuthErrorTenant.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import { parseAuthErrorTenant } from "../parseAuthErrorTenant.js";
 

--- a/packages/utils/telemetry-utils/src/test/sampledTelemetryHelper.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/sampledTelemetryHelper.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import type {
 	ITelemetryBaseEvent,

--- a/packages/utils/telemetry-utils/src/test/telemetryEventBatcher.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/telemetryEventBatcher.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import type { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
 import sinon from "sinon";

--- a/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/telemetryLogger.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import type { ITelemetryBaseEvent, Tagged } from "@fluidframework/core-interfaces";
 

--- a/packages/utils/telemetry-utils/src/test/thresholdCounter.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/thresholdCounter.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "node:assert";
+import { strict as assert } from "node:assert";
 
 import type { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
 

--- a/server/gitrest/packages/gitrest-base/src/test/redis.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/redis.spec.ts
@@ -6,7 +6,7 @@
 import { TestRedisClientConnectionManagerWithInvalidation } from "./testRedisClientConnectionManagerWithInvalidation";
 import { Redis, HashMapRedis } from "../utils/redisFs/redis";
 import { RedisOptions } from "ioredis-mock";
-import assert from "assert";
+import { strict as assert } from "assert";
 
 type GitRedisFileSystem = "redisfs" | "hashmap-redisfs";
 

--- a/server/gitrest/packages/gitrest-base/src/test/routes.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/routes.spec.ts
@@ -14,7 +14,7 @@ import {
 	ICreateRefParamsExternal,
 	IGetRefParamsExternal,
 } from "@fluidframework/server-services-client";
-import assert from "assert";
+import { strict as assert } from "assert";
 import * as async from "async";
 import lorem from "lorem-ipsum";
 import sillyname from "sillyname";

--- a/server/gitrest/packages/gitrest-base/src/test/storageAccess.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/storageAccess.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import type { IFileSystemPromises } from "../utils";
 

--- a/server/gitrest/packages/gitrest-base/src/test/summaries.spec.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/summaries.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { v4 as uuid } from "uuid";
 import { SinonSpiedInstance, restore, spy } from "sinon";
 import { Provider } from "nconf";

--- a/server/historian/packages/historian-base/src/test/redis.spec.ts
+++ b/server/historian/packages/historian-base/src/test/redis.spec.ts
@@ -6,7 +6,7 @@
 import { TestRedisClientConnectionManagerWithInvalidation } from "./testRedisClientConnectionManagerWithInvalidation";
 import { RedisCache, RedisTenantCache } from "../services";
 import { RedisOptions } from "ioredis-mock";
-import assert from "assert";
+import { strict as assert } from "assert";
 
 type GitRedisFileSystem = "redisCache" | "redisTenantCache";
 

--- a/server/historian/packages/historian-base/src/test/routes.spec.ts
+++ b/server/historian/packages/historian-base/src/test/routes.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import express from "express";
 import * as sinon from "sinon";
 import request from "supertest";

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { EventEmitter } from "events";
 
 import type {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { EventEmitter } from "events";
 
 import type {

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/checkpointManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import { Deferred } from "@fluidframework/common-utils";
 import type { IConsumer, IQueuedMessage } from "@fluidframework/server-services-core";

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { inspect } from "util";
 
 import type { ProtocolOpHandler } from "@fluidframework/protocol-base";

--- a/server/routerlicious/packages/memory-orderer/src/localNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { EventEmitter } from "events";
 
 import type { IDocumentMessage } from "@fluidframework/protocol-definitions";

--- a/server/routerlicious/packages/memory-orderer/src/localOrderManager.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import type { IOrderer } from "@fluidframework/server-services-core";
 

--- a/server/routerlicious/packages/memory-orderer/src/nodeManager.ts
+++ b/server/routerlicious/packages/memory-orderer/src/nodeManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { EventEmitter } from "events";
 
 import type { MongoManager } from "@fluidframework/server-services-core";

--- a/server/routerlicious/packages/memory-orderer/src/pubsub.ts
+++ b/server/routerlicious/packages/memory-orderer/src/pubsub.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 
 import type { IWebSocket } from "@fluidframework/server-services-core";
 

--- a/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { EventEmitter } from "events";
 
 import { Deferred } from "@fluidframework/common-utils";

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
@@ -26,7 +26,7 @@ import {
 	TestTenantManager,
 	TestThrottler,
 } from "@fluidframework/server-test-utils";
-import assert from "assert";
+import { strict as assert } from "assert";
 import express from "express";
 import nconf from "nconf";
 import Sinon from "sinon";

--- a/server/routerlicious/packages/routerlicious-base/src/test/riddler/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/riddler/api.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import * as crypto from "crypto";
 import express from "express";
 import request from "supertest";

--- a/server/routerlicious/packages/routerlicious-base/src/test/riddler/tenantManager.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/riddler/tenantManager.spec.ts
@@ -20,7 +20,7 @@ import {
 	TenantKeyGenerator,
 	generateToken,
 } from "@fluidframework/server-services-utils";
-import assert from "assert";
+import { strict as assert } from "assert";
 import { NetworkError } from "@fluidframework/server-services-client";
 import { ScopeType } from "@fluidframework/protocol-definitions";
 

--- a/server/routerlicious/packages/services-client/src/test/historian.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/historian.spec.ts
@@ -5,7 +5,7 @@
 
 import { fromUtf8ToBase64 } from "@fluidframework/common-utils";
 import * as git from "@fluidframework/gitresources";
-import assert from "assert";
+import { strict as assert } from "assert";
 import Axios, { AxiosRequestConfig } from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { Historian, ICredentials, getAuthorizationTokenFromCredentials } from "../historian";

--- a/server/routerlicious/packages/services-client/src/test/storageUtils.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/storageUtils.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { fromUtf8ToBase64, stringToBuffer } from "@fluidframework/common-utils";
 import {
 	buildTreePath,

--- a/server/routerlicious/packages/services-shared/src/test/configDumper.spec.ts
+++ b/server/routerlicious/packages/services-shared/src/test/configDumper.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { ConfigDumper } from "../configDumper";
 
 describe("ConfigDumper", () => {

--- a/server/routerlicious/packages/services-shared/src/test/http.spec.ts
+++ b/server/routerlicious/packages/services-shared/src/test/http.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { NetworkError } from "@fluidframework/server-services-client";
 import { Deferred } from "@fluidframework/common-utils";
 import type { Response, Request } from "express";

--- a/server/routerlicious/packages/services-shared/src/test/restLess.spec.ts
+++ b/server/routerlicious/packages/services-shared/src/test/restLess.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { AxiosRequestConfig } from "axios";
 import { json, urlencoded } from "body-parser";
 import express from "express";

--- a/server/routerlicious/packages/services-telemetry/src/test/baseSanitizationLumberFormatter.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/baseSanitizationLumberFormatter.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { Lumber } from "../lumber";
 import { LumberEventName } from "../lumberEventNames";
 import * as resources from "../resources";

--- a/server/routerlicious/packages/services-telemetry/src/test/lumber.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/lumber.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import Sinon from "sinon";
 import { Lumber } from "../lumber";
 import { LumberEventName } from "../lumberEventNames";

--- a/server/routerlicious/packages/services-telemetry/src/test/lumberjack.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/lumberjack.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import Sinon from "sinon";
 import { TestEngine1, TestEngine2, TestLumberjack } from "../lumberjackCommonTestUtils";
 import { LumberEventName } from "../lumberEventNames";

--- a/server/routerlicious/packages/services-telemetry/src/test/sanitizationLumberFormatter.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/sanitizationLumberFormatter.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { Lumber } from "../lumber";
 import { LumberEventName } from "../lumberEventNames";
 import * as resources from "../resources";

--- a/server/routerlicious/packages/services-telemetry/src/test/schema.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/schema.spec.ts
@@ -5,7 +5,7 @@
 
 import { BaseTelemetryProperties, QueuedMessageProperties } from "../resources";
 import { LambdaSchemaValidator, BasePropertiesValidator } from "../schema";
-import assert from "assert";
+import { strict as assert } from "assert";
 
 describe("LumberjackSchemaValidator", () => {
 	it("Makes sure BasePropertiesValidator can use BaseLumberjackSchemaValidator's base functionality and validation passes.", async () => {

--- a/server/routerlicious/packages/services-utils/src/test/asyncContext.spec.ts
+++ b/server/routerlicious/packages/services-utils/src/test/asyncContext.spec.ts
@@ -5,7 +5,7 @@
 
 import { ITelemetryContextProperties } from "@fluidframework/server-services-telemetry";
 import { v4 as uuid } from "uuid";
-import assert from "assert";
+import { strict as assert } from "assert";
 import {
 	AsyncLocalStorageAbortControllerContext,
 	AsyncLocalStorageContextProvider,

--- a/server/routerlicious/packages/services-utils/src/test/denyList.spec.ts
+++ b/server/routerlicious/packages/services-utils/src/test/denyList.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { DenyList } from "../denyList";
 
 describe("denyList", () => {

--- a/server/routerlicious/packages/services-utils/src/test/responseSizeMiddleware.spec.ts
+++ b/server/routerlicious/packages/services-utils/src/test/responseSizeMiddleware.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import express from "express";
 import request from "supertest";
 import { ResponseSizeMiddleware } from "../responseSizeMiddleware";

--- a/server/routerlicious/packages/services-utils/src/test/throttlerConfigs.spec.ts
+++ b/server/routerlicious/packages/services-utils/src/test/throttlerConfigs.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import {
 	ISimpleThrottleConfig,
 	IThrottleConfig,

--- a/server/routerlicious/packages/services-utils/src/test/throttlerMiddleware.spec.ts
+++ b/server/routerlicious/packages/services-utils/src/test/throttlerMiddleware.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import express from "express";
 import request from "supertest";
 import { IThrottler } from "@fluidframework/server-services-core";

--- a/server/routerlicious/packages/services-utils/src/test/webSocketTracker.spec.ts
+++ b/server/routerlicious/packages/services-utils/src/test/webSocketTracker.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { WebSocketTracker } from "../webSocketTracker";
 import { IWebSocket } from "@fluidframework/server-services-core";
 

--- a/server/routerlicious/packages/services/src/test/redisSessionManager.spec.ts
+++ b/server/routerlicious/packages/services/src/test/redisSessionManager.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { TestEngine1, Lumberjack } from "@fluidframework/server-services-telemetry";
 import { TestRedisClientConnectionManager } from "@fluidframework/server-test-utils";
 import { RedisCollaborationSessionManager } from "../redisSessionManager";

--- a/server/routerlicious/packages/services/src/test/redisThrottleAndUsageStorageManager.spec.ts
+++ b/server/routerlicious/packages/services/src/test/redisThrottleAndUsageStorageManager.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { IThrottlingMetrics, IUsageData } from "@fluidframework/server-services-core";
 import { TestEngine1, Lumberjack } from "@fluidframework/server-services-telemetry";
 import { RedisThrottleAndUsageStorageManager } from "../redisThrottleAndUsageStorageManager";

--- a/server/routerlicious/packages/services/src/test/throttler.spec.ts
+++ b/server/routerlicious/packages/services/src/test/throttler.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { TestThrottlerHelper } from "@fluidframework/server-test-utils";
 import { Throttler } from "../throttler";
 import { IThrottler, ThrottlingError } from "@fluidframework/server-services-core";

--- a/server/routerlicious/packages/services/src/test/throttlerHelper.spec.ts
+++ b/server/routerlicious/packages/services/src/test/throttlerHelper.spec.ts
@@ -6,7 +6,7 @@
 import { IThrottlerResponse } from "@fluidframework/server-services-core";
 import { TestThrottleAndUsageStorageManager } from "@fluidframework/server-test-utils";
 import { TestEngine1, Lumberjack } from "@fluidframework/server-services-telemetry";
-import assert from "assert";
+import { strict as assert } from "assert";
 import Sinon from "sinon";
 import { ThrottlerHelper } from "../throttlerHelper";
 

--- a/server/routerlicious/packages/test-utils/src/test/testsForCollection.spec.ts
+++ b/server/routerlicious/packages/test-utils/src/test/testsForCollection.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { TestCollection } from "../testCollection";
 
 describe("Test for TestUtils", () => {

--- a/server/routerlicious/packages/test-utils/src/test/testsForThrottleAndUsageStorageManager.spec.ts
+++ b/server/routerlicious/packages/test-utils/src/test/testsForThrottleAndUsageStorageManager.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import assert from "assert";
+import { strict as assert } from "assert";
 import { IThrottlingMetrics, IUsageData } from "@fluidframework/server-services-core";
 import { TestThrottleAndUsageStorageManager } from "../testThrottleAndUsageStorageManager";
 

--- a/server/routerlicious/packages/test-utils/src/test/testsForThrottler.spec.ts
+++ b/server/routerlicious/packages/test-utils/src/test/testsForThrottler.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { ThrottlingError } from "@fluidframework/server-services-core";
-import assert from "assert";
+import { strict as assert } from "assert";
 import { TestThrottler } from "../testThrottler";
 
 describe("Test for Test Utils", () => {

--- a/server/routerlicious/packages/test-utils/src/test/testsForThrottlerHelper.spec.ts
+++ b/server/routerlicious/packages/test-utils/src/test/testsForThrottlerHelper.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { IThrottlerResponse } from "@fluidframework/server-services-core";
-import assert from "assert";
+import { strict as assert } from "assert";
 import Sinon from "sinon";
 import { TestThrottlerHelper } from "../testThrottlerHelper";
 


### PR DESCRIPTION
## Description

We generally prefer strict asserts by importing "strict as assert" (~800 files use this pattern). Find and replace cases where non-strict asserts were being used.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
