### PR TITLE
test(client-presence): multi-process test refactor

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/childClient.ts
@@ -14,13 +14,14 @@ import {
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
 import type { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
+// eslint-disable-next-line import/no-internal-modules
+import { ExperimentalPresenceManager } from "@fluidframework/presence/alpha";
 import {
 	getPresence,
 	type Attendee,
-	ExperimentalPresenceManager,
 	type Presence,
 	// eslint-disable-next-line import/no-internal-modules
-} from "@fluidframework/presence/alpha";
+} from "@fluidframework/presence/beta";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
@@ -136,6 +137,11 @@ class MessageHandler {
 
 	public async onMessage(msg: MessageFromParent): Promise<void> {
 		switch (msg.command) {
+			case "ping": {
+				send({ event: "ack" });
+				break;
+			}
+
 			// Respond to connect command by connecting to Fluid container with the provided user information.
 			case "connect": {
 				// Check if valid user information has been provided by parent/orchestrator
@@ -172,7 +178,7 @@ class MessageHandler {
 					send(m);
 				});
 				send({
-					event: "ready",
+					event: "connected",
 					containerId,
 					attendeeId: presence.attendees.getMyself().attendeeId,
 				});

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/messageTypes.ts
@@ -7,43 +7,95 @@ import type { AzureUser } from "@fluidframework/azure-client/internal";
 // eslint-disable-next-line import/no-internal-modules
 import type { AttendeeId } from "@fluidframework/presence/beta";
 
-export type MessageToChild = ConnectCommand | DisconnectSelfCommand;
-interface ConnectCommand {
+/**
+ * Message types sent from the orchestrator to the child processes
+ */
+export type MessageToChild = ConnectCommand | DisconnectSelfCommand | PingCommand;
+
+/**
+ * Can be sent to check child responsiveness.
+ * An {@link AcknowledgeEvent} should be expected in response.
+ */
+interface PingCommand {
+	command: "ping";
+}
+
+/**
+ * Instructs a child process to connect to a Fluid container.
+ * A {@link ConnectedEvent} should be expected in response.
+ */
+export interface ConnectCommand {
 	command: "connect";
 	user: AzureUser;
+	/**
+	 * The ID of the Fluid container to connect to.
+	 * If not provided, a new Fluid container will be created.
+	 */
 	containerId?: string;
 }
 
+/**
+ * Instructs a child process to disconnect from a Fluid container.
+ * A {@link DisconnectedSelfEvent} should be expected in response.
+ */
 interface DisconnectSelfCommand {
 	command: "disconnectSelf";
 }
 
+/**
+ * Message types sent from the child processes to the orchestrator
+ */
 export type MessageFromChild =
+	| AcknowledgeEvent
+	| AttendeeConnectedEvent
 	| AttendeeDisconnectedEvent
-	| attendeeConnectedEvent
-	| ReadyEvent
+	| ConnectedEvent
 	| DisconnectedSelfEvent
 	| ErrorEvent;
+
+/**
+ * Sent from the child processes to the orchestrator in response to a {@link PingCommand}.
+ */
+interface AcknowledgeEvent {
+	event: "ack";
+}
+
+/**
+ * Sent arbitrarily to indicate a new attendee has connected.
+ */
+interface AttendeeConnectedEvent {
+	event: "attendeeConnected";
+	attendeeId: AttendeeId;
+}
+
+/**
+ * Sent arbitrarily to indicate an attendee has disconnected.
+ */
 interface AttendeeDisconnectedEvent {
 	event: "attendeeDisconnected";
 	attendeeId: AttendeeId;
 }
 
-interface attendeeConnectedEvent {
-	event: "attendeeConnected";
-	attendeeId: AttendeeId;
-}
-
-interface ReadyEvent {
-	event: "ready";
+/**
+ * Sent from the child processes to the orchestrator in response to a {@link ConnectCommand}.
+ */
+interface ConnectedEvent {
+	event: "connected";
 	containerId: string;
 	attendeeId: AttendeeId;
 }
 
+/**
+ * Sent from the child processes to the orchestrator in response to a {@link DisconnectSelfCommand}.
+ */
 interface DisconnectedSelfEvent {
 	event: "disconnectedSelf";
 	attendeeId: AttendeeId;
 }
+
+/**
+ * Sent at any time to indicate an error.
+ */
 interface ErrorEvent {
 	event: "error";
 	error: string;

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/multiprocess/presenceTest.spec.ts
@@ -6,15 +6,20 @@
 import { strict as assert } from "node:assert";
 import { fork, type ChildProcess } from "node:child_process";
 
-import { timeoutPromise } from "@fluidframework/test-utils/internal";
+// eslint-disable-next-line import/no-internal-modules
+import type { AttendeeId } from "@fluidframework/presence/beta";
+import { timeoutAwait, timeoutPromise } from "@fluidframework/test-utils/internal";
 
-import type { MessageFromChild, MessageToChild } from "./messageTypes.js";
+import type { ConnectCommand, MessageFromChild } from "./messageTypes.js";
 
 /**
  * This test suite is a prototype for a multi-process end to end test for Fluid using the new Presence API on AzureClient.
  * In the future we hope to expand and generalize this pattern to broadly test more Fluid features.
- * Currently our E2E tests are limited to running multiple clients on a single process which does not effectively
- * simulate real-world production scenarios where clients are usually running on different machines.
+ * Other E2E tests are limited to running multiple clients on a single process which does not effectively
+ * simulate real-world production scenarios where clients are usually running on different machines. Since
+ * the Fluid Framework client is designed to carry most of the work burden, multi-process testing from a
+ * single machine is also not representative but does at least work past some limitations of a single
+ * Node.js process handling multiple clients.
  *
  * The pattern demonstrated in this test suite is as follows:
  *
@@ -31,146 +36,300 @@ import type { MessageFromChild, MessageToChild } from "./messageTypes.js";
  * - Listen for command messages from the orchestrator.
  * - Perform the requested action.
  * - Send response messages including any relevant data back to the orchestrator to verify expected behavior.
+ */
+
+/**
+ * Fork child processes to simulate multiple Fluid clients.
  *
+ * @remarks
+ * Individual child processes may be scheduled concurrently on a multi-core CPU
+ * and separate processes will never share a port when connected to a service.
+ *
+ * @param numProcesses - The number of child processes to fork.
+ * @param cleanUpAccumulator - An array to accumulate cleanup functions for
+ * each child process. This is build per instance to accommodate any errors
+ * that might occur before completing all forking.
+ *
+ * @returns A promise that resolves with an object containing the child
+ * processes and a promise that rejects on any child process errors.
+ */
+async function forkChildProcesses(
+	numProcesses: number,
+	cleanUpAccumulator: (() => void)[],
+): Promise<{
+	children: ChildProcess[];
+	/**
+	 * Will never resolve successfully, it is only used to reject on child process error.
+	 */
+	childErrorPromise: Promise<void>;
+}> {
+	const children: ChildProcess[] = [];
+	const childReadyPromises: Promise<void>[] = [];
+	// Collect all child process error promises into this array
+	const childErrorPromises: Promise<void>[] = [];
+	// Fork child processes
+	for (let i = 0; i < numProcesses; i++) {
+		const child = fork("./lib/test/multiprocess/childClient.js", [
+			`child${i}` /* identifier passed to child process */,
+		]);
+		// Register a cleanup function to kill the child process
+		cleanUpAccumulator.push(() => {
+			child.kill();
+			child.removeAllListeners();
+		});
+		const readyPromise = new Promise<void>((resolve, reject) => {
+			child.once("message", (msg: MessageFromChild) => {
+				if (msg.event === "ack") {
+					resolve();
+				} else {
+					reject(
+						new Error(`Unexpected (non-"ack") message from child${i}: ${JSON.stringify(msg)}`),
+					);
+				}
+			});
+		});
+		childReadyPromises.push(readyPromise);
+		const errorPromise = new Promise<void>((_, reject) => {
+			child.on("error", (error) => {
+				reject(new Error(`Child${i} process errored: ${error.message}`));
+			});
+		});
+		childErrorPromises.push(errorPromise);
+
+		child.send({ command: "ping" });
+
+		children.push(child);
+	}
+	// This race will be used to reject any of the following tests on any child process errors
+	const childErrorPromise = Promise.race(childErrorPromises);
+
+	// All children are always expected to connect successfully and acknowledge the ping.
+	await Promise.race([Promise.all(childReadyPromises), childErrorPromise]);
+
+	return {
+		children,
+		childErrorPromise,
+	};
+}
+
+function composeConnectMessage(id: string | number): ConnectCommand {
+	return {
+		command: "connect",
+		user: {
+			id: `test-user-id-${id}`,
+			name: `test-user-name-${id}`,
+		},
+	};
+}
+
+async function connectChildProcesses(
+	childProcesses: ChildProcess[],
+	readyTimeoutMs: number,
+): Promise<{
+	containerCreatorAttendeeId: AttendeeId;
+	attendeeIdPromises: Promise<AttendeeId>[];
+}> {
+	if (childProcesses.length === 0) {
+		throw new Error("No child processes provided for connection.");
+	}
+	const firstChild = childProcesses[0];
+	const containerReadyPromise = new Promise<{
+		containerCreatorAttendeeId: AttendeeId;
+		containerId: string;
+	}>((resolve, reject) => {
+		firstChild.once("message", (msg: MessageFromChild) => {
+			if (msg.event === "connected" && msg.containerId) {
+				resolve({
+					containerCreatorAttendeeId: msg.attendeeId,
+					containerId: msg.containerId,
+				});
+			} else {
+				reject(new Error(`Non-connected message from child0: ${JSON.stringify(msg)}`));
+			}
+		});
+	});
+	{
+		firstChild.send(composeConnectMessage(0));
+	}
+	const { containerCreatorAttendeeId, containerId } = await timeoutAwait(
+		containerReadyPromise,
+		{
+			durationMs: readyTimeoutMs,
+			errorMsg: "did not receive 'connected' from child process",
+		},
+	);
+
+	const attendeeIdPromises: Promise<AttendeeId>[] = [];
+	for (const [index, child] of childProcesses.entries()) {
+		if (index === 0) {
+			// The first child process is the container creator, it has already sent the 'connected' message.
+			attendeeIdPromises.push(Promise.resolve(containerCreatorAttendeeId));
+			continue;
+		}
+		const message = composeConnectMessage(index);
+
+		// For subsequent children, send containerId but do not wait for a response.
+		message.containerId = containerId;
+
+		attendeeIdPromises.push(
+			new Promise<AttendeeId>((resolve, reject) => {
+				child.once("message", (msg: MessageFromChild) => {
+					if (msg.event === "connected") {
+						resolve(msg.attendeeId);
+					} else if (msg.event === "error") {
+						reject(new Error(`Child process error: ${msg.error}`));
+					}
+				});
+			}),
+		);
+
+		child.send(message);
+	}
+
+	if (containerCreatorAttendeeId === undefined) {
+		throw new Error("No container creator session ID received from child processes.");
+	}
+
+	return { containerCreatorAttendeeId, attendeeIdPromises };
+}
+
+/**
+ * Connects the child processes and waits for the specified number of attendees to connect.
+ * @remarks
+ * This function can be used directly as a test. Comments in the functionality describe the
+ * breakdown of test blocks.
+ *
+ * @param children - Array of child processes to connect.
+ * @param attendeeCountRequired - The number of attendees that must connect.
+ * @param childConnectTimeoutMs - Timeout duration for child process connections.
+ * @param attendeesJoinedTimeoutMs - Timeout duration for required attendees to join.
+ * @param earlyExitPromise - Promise that resolves/rejects when the test should early exit.
+ */
+async function connectAndWaitForAttendees(
+	children: ChildProcess[],
+	attendeeCountRequired: number,
+	childConnectTimeoutMs: number,
+	attendeesJoinedTimeoutMs: number,
+	earlyExitPromise: Promise<void> = Promise.resolve(),
+): Promise<{ containerCreatorAttendeeId: AttendeeId }> {
+	// Setup
+	const attendeeConnectedPromise = new Promise<void>((resolve) => {
+		let attendeesJoinedEvents = 0;
+		children[0].on("message", (msg: MessageFromChild) => {
+			if (msg.event === "attendeeConnected") {
+				attendeesJoinedEvents++;
+				if (attendeesJoinedEvents >= attendeeCountRequired) {
+					resolve();
+				}
+			}
+		});
+	});
+
+	// Act - connect all child processes
+	const connectResult = await connectChildProcesses(children, childConnectTimeoutMs);
+
+	Promise.all(connectResult.attendeeIdPromises)
+		.then(() => console.log("All attendees connected."))
+		.catch((error) => {
+			console.error("Error connecting children:", error);
+		});
+
+	// Verify - wait for all 'attendeeConnected' events
+	await timeoutAwait(Promise.race([attendeeConnectedPromise, earlyExitPromise]), {
+		durationMs: attendeesJoinedTimeoutMs,
+		errorMsg: "did not receive all 'attendeeConnected' events",
+	});
+
+	return connectResult;
+}
+
+/**
  * This particular test suite tests the following E2E functionality for Presence:
  * - Announce 'attendeeConnected' when remote client joins session.
  * - Announce 'attendeeDisconnected' when remote client disconnects.
  */
 describe(`Presence with AzureClient`, () => {
-	const numClients = 5; // Set the total number of Fluid clients to create
-	assert(numClients > 1, "Must have at least two clients");
-	let children: ChildProcess[] = [];
-	// This promise is used to capture all errors that occur in the child processes.
-	// It will never resolve successfully, it is only used to reject on child process error.
-	let childErrorPromise: Promise<void>;
-	// Timeout duration used when waiting for response messages from child processes.
-	const durationMs = 10_000;
-
 	const afterCleanUp: (() => void)[] = [];
 
-	async function connectChildProcesses(
-		childProcesses: ChildProcess[],
-	): Promise<string | undefined> {
-		let containerIdPromise: Promise<string> | undefined;
-		let containerCreatorSessionId: string | undefined;
-		for (const [index, child] of childProcesses.entries()) {
-			const user = { id: `test-user-id-${index}`, name: `test-user-name-${index}` };
-			const message: MessageToChild = { command: "connect", user };
-
-			if (containerIdPromise === undefined) {
-				// Create a promise that resolves with the containerId from the created container.
-				containerIdPromise = timeoutPromise<string>(
-					(resolve, reject) => {
-						child.once("message", (msg: MessageFromChild) => {
-							if (msg.event === "ready" && msg.containerId) {
-								containerCreatorSessionId = msg.attendeeId;
-								resolve(msg.containerId);
-							} else {
-								reject(new Error(`Non-ready message from child0: ${JSON.stringify(msg)}`));
-							}
-						});
-					},
-					{
-						durationMs,
-						errorMsg: "did not receive 'ready' from child process",
-					},
-				);
-			} else {
-				// For subsequent children, wait for containerId from the promise only when needed.
-				message.containerId = await containerIdPromise;
-			}
-
-			child.send(message);
-		}
-		return containerCreatorSessionId;
-	}
-
-	beforeEach("setup", async () => {
-		// Collect all child process error promises into this array
-		const childErrorPromises: Promise<void>[] = [];
-		// Fork child processes
-		for (let i = 0; i < numClients; i++) {
-			const child = fork("./lib/test/multiprocess/childClient.js", [
-				`child${i}` /* identifier passed to child process */,
-			]);
-			const errorPromise = new Promise<void>((_, reject) => {
-				child.on("error", (error) => {
-					reject(new Error(`Child${i} process errored: ${error.message}`));
-				});
-			});
-			childErrorPromises.push(errorPromise);
-			children.push(child);
-			// Register cleanup for the child process listeners.
-			afterCleanUp.push(() => child.removeAllListeners());
-		}
-		// This race will be used to reject any of the following tests on any child process errors
-		childErrorPromise = Promise.race(childErrorPromises);
-	});
-
-	// After each test, kill each child process and call any cleanup functions that were registered
+	// After each test, call any cleanup functions that were registered (kill each child process)
 	afterEach(async () => {
-		for (const child of children) {
-			child.kill();
-		}
-		children = [];
 		for (const cleanUp of afterCleanUp) {
 			cleanUp();
 		}
 		afterCleanUp.length = 0;
 	});
 
-	it("announces 'attendeeConnected' when remote client joins session and 'attendeeDisconnected' when remote client disconnects", async () => {
-		// Setup
-		const attendeeConnectedPromise = timeoutPromise(
-			(resolve) => {
-				let attendeesJoinedEvents = 0;
-				children[0].on("message", (msg: MessageFromChild) => {
-					if (msg.event === "attendeeConnected") {
-						attendeesJoinedEvents++;
-						if (attendeesJoinedEvents === numClients - 1) {
-							resolve();
-						}
-					}
-				});
-			},
-			{
-				durationMs,
-				errorMsg: "did not receive all 'attendeeConnected' events",
-			},
-		);
+	// Note that on slower systems 50+ clients may take too long to join.
+	const numClientsForAttendeeTests = [5, 20, 50, 100];
+	// TODO: AB#45620: "Presence: perf: update Join pattern for scale" may help, then remove .slice.
+	for (const numClients of numClientsForAttendeeTests.slice(0, 2)) {
+		assert(numClients > 1, "Must have at least two clients");
 
-		// Act - connect all child processes
-		const creatorSessionId = await connectChildProcesses(children);
+		// Timeout duration used when waiting for response messages from child processes.
+		const childConnectTimeoutMs = 1000 * numClients;
+		const allConnectedTimeoutMs = 2000;
 
-		// Verify - wait for all 'attendeeConnected' events
-		await Promise.race([attendeeConnectedPromise, childErrorPromise]);
-
-		// Setup
-		const waitForDisconnected = children
-			.filter((_, index) => index !== 0)
-			.map(async (child, index) =>
-				timeoutPromise(
-					(resolve) => {
-						child.on("message", (msg: MessageFromChild) => {
-							if (
-								msg.event === "attendeeDisconnected" &&
-								msg.attendeeId === creatorSessionId
-							) {
-								resolve();
-							}
-						});
-					},
-					{
-						durationMs,
-						errorMsg: `Attendee[${index}] Disconnected Timeout`,
-					},
-				),
+		it(`announces 'attendeeConnected' when remote client joins session [${numClients} clients]`, async () => {
+			// Setup
+			const { children, childErrorPromise } = await forkChildProcesses(
+				numClients,
+				afterCleanUp,
 			);
 
-		// Act - disconnect first child process
-		children[0].send({ command: "disconnectSelf" });
+			// Further Setup with Act and Verify
+			await connectAndWaitForAttendees(
+				children,
+				numClients - 1,
+				childConnectTimeoutMs,
+				allConnectedTimeoutMs,
+				childErrorPromise,
+			);
+		});
 
-		// Verify - wait for all 'attendeeDisconnected' events
-		await Promise.race([Promise.all(waitForDisconnected), childErrorPromise]);
-	});
+		it(`announces 'attendeeDisconnected' when remote client disconnects [${numClients} clients]`, async () => {
+			// Setup
+			const { children, childErrorPromise } = await forkChildProcesses(
+				numClients,
+				afterCleanUp,
+			);
+
+			const connectResult = await connectAndWaitForAttendees(
+				children,
+				numClients - 1,
+				childConnectTimeoutMs,
+				allConnectedTimeoutMs,
+				childErrorPromise,
+			);
+
+			const childDisconnectTimeoutMs = 10_000;
+
+			const waitForDisconnected = children.map(async (child, index) =>
+				index === 0
+					? Promise.resolve()
+					: timeoutPromise(
+							(resolve) => {
+								child.on("message", (msg: MessageFromChild) => {
+									if (
+										msg.event === "attendeeDisconnected" &&
+										msg.attendeeId === connectResult.containerCreatorAttendeeId
+									) {
+										console.log(`Child[${index}] saw creator disconnect`);
+										resolve();
+									}
+								});
+							},
+							{
+								durationMs: childDisconnectTimeoutMs,
+								errorMsg: `Attendee[${index}] Disconnected Timeout`,
+							},
+						),
+			);
+
+			// Act - disconnect first child process
+			children[0].send({ command: "disconnectSelf" });
+
+			// Verify - wait for all 'attendeeDisconnected' events
+			await Promise.race([Promise.all(waitForDisconnected), childErrorPromise]);
+		});
+	}
 });


### PR DESCRIPTION
- refactor pieces for reusability
- adjust timeouts to begin after a triggering event (in case trigger is itself slow)
- separate connect and disconnect tests
- add test for 20 clients in addition to 5 clients
  - 50 and 100 client tests are omitted while waiting for performance improvements
- create ping-ack protocol to check initial readiness (and responsiveness as needed)
- document inter-process messages and relationships