### PR TITLE
test(tree): Add end-to-end test for revert constraint

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -213,6 +213,7 @@ function makeModularChangeCodec(
 		context: FieldChangeEncodingContext,
 	): EncodedNodeChangeset {
 		const encodedChange: EncodedNodeChangeset = {};
+		// Note: revert constraints are ignored for now because they would only be needed if we supported reverting changes made by peers.
 		const { fieldChanges, nodeExistsConstraint } = change;
 
 		if (fieldChanges !== undefined) {

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -3039,6 +3039,8 @@ describe("Editing", () => {
 			});
 
 			it("inverse constraint violated by a change between the original and the revert", () => {
+				// Unlike most other tests, this test uses TestTreeProviderLite codecs are exercised.
+				// This ensures that the feature works across peers as opposed to solely across branches.
 				const provider = new TestTreeProviderLite(2);
 				const config = new TreeViewConfiguration({ schema: JsonAsTree.JsonObject });
 				const viewA = asTreeViewAlpha(provider.trees[0].viewWith(config));

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -27,18 +27,11 @@ import {
 	expectNoRemovedRoots,
 	makeTreeFromJson,
 	moveWithin,
-	TestTreeProviderLite,
 	validateUsageError,
 	type TreeStoredContentStrict,
 } from "../utils.js";
 import { insert, makeTreeFromJsonSequence, remove } from "../sequenceRootUtils.js";
-import {
-	asTreeViewAlpha,
-	numberSchema,
-	SchemaFactory,
-	toInitialSchema,
-	TreeViewConfiguration,
-} from "../../simple-tree/index.js";
+import { numberSchema, SchemaFactory, toInitialSchema } from "../../simple-tree/index.js";
 import { JsonAsTree } from "../../jsonDomainSchema.js";
 import { fieldJsonCursor } from "../json/index.js";
 
@@ -3113,17 +3106,6 @@ describe("Editing", () => {
 				expectJsonTree(tree, [{ foo: "C", bar: "new" }]);
 
 				stack.unsubscribe();
-			});
-
-			it("cannot be attached into a hydrated array", () => {
-				const sf = new SchemaFactory(undefined);
-				class Child extends sf.object("Child", {}) {}
-				class Parent extends sf.array("Parent", Child) {}
-				const provider = new TestTreeProviderLite(1);
-				const view = provider.trees[0].viewWith(new TreeViewConfiguration({ schema: Parent }));
-				view.initialize(new Parent([new Child({})]));
-				const hydratedChild = view.root[0];
-				assert.throws(() => view.root.insertAtEnd(hydratedChild));
 			});
 		});
 


### PR DESCRIPTION
## Description

This PR updates an existing test. The existing test demonstrated that revert constraints work in a scenario involving edits on a local branch. The updated test demonstrates that revert constraints work in a scenario that involves peers communicating across encoding and decoding boundaries.

The motivation for this test was a fear that, because `ModularChangeFamily` codecs ignore revert constraints, the constraint would only be respected on the peer that emitted the edit with the revert constraint. This is not the case because revert constraints are turned into "normal" constraints when reverting, and it's the normal constraint that needs to be sent across peers. Note this relies on the assumption that the revert commit generated from the commit with the revert constraint is only ever generated by the peer who authored the commit with the revert constraint. IOW, that a peer can't undo/redo another peer's changes.

## Breaking Changes

None