### PR TITLE
Support instanceof TreeNode

### DIFF
--- a/.changeset/some-regions-battle.md
+++ b/.changeset/some-regions-battle.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Export TreeNode not only as a type
+
+`TreeNode` can now be uses as a runtime object.
+This enables checking if an object is a `TreeNode` with `instanceof`.
+`TreeNode` has customized `instanceof` support so it can detect `TreeNode` instances, even if they hide their prototype like [POJO mode nodes](https://fluidframework.com/docs/api/fluid-framework/schemafactory-class#schemafactory-remarks) do.

--- a/.changeset/some-regions-battle.md
+++ b/.changeset/some-regions-battle.md
@@ -5,6 +5,6 @@
 ---
 Export TreeNode not only as a type
 
-`TreeNode` can now be uses as a runtime object.
+`TreeNode` can now be used as a runtime object.
 This enables checking if an object is a `TreeNode` with `instanceof`.
 `TreeNode` has customized `instanceof` support so it can detect `TreeNode` instances, even if they hide their prototype like [POJO mode nodes](https://fluidframework.com/docs/api/fluid-framework/schemafactory-class#schemafactory-remarks) do.

--- a/packages/dds/tree/src/simple-tree/core/treeNode.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNode.ts
@@ -10,6 +10,7 @@ import { tryGetTreeNodeSchema } from "./treeNodeKernel.js";
 import { NodeKind, type TreeNodeSchemaClass } from "./treeNodeSchema.js";
 // eslint-disable-next-line import/no-deprecated
 import { type WithType, typeNameSymbol, type typeSchemaSymbol } from "./withType.js";
+import { markEager } from "./flexList.js";
 
 /**
  * A non-{@link NodeKind.Leaf|leaf} SharedTree node. Includes objects, arrays, and maps.
@@ -37,13 +38,10 @@ import { type WithType, typeNameSymbol, type typeSchemaSymbol } from "./withType
  * @privateRemarks
  * This is a class not an interface to enable stricter type checking (see {@link TreeNode.#brand})
  * and some runtime enforcement of schema class policy (see the the validation in the constructor).
- * This class is however only `type` exported not value exported, preventing the class object from being used,
- * similar to how interfaces work.
  *
  * Not all node implementations include this in their prototype chain (some hide it with a proxy),
  * and thus cause the default/built in `instanceof` to return false despite our type checking and all other APIs treating them as TreeNodes.
  * This class provides a custom `Symbol.hasInstance` to fix `instanceof` for this class and all classes extending it.
- * For now the type-only export prevents use of `instanceof` on this class (but allows it in subclasses like schema classes).
  * @sealed @public
  */
 export abstract class TreeNode implements WithType {
@@ -138,6 +136,8 @@ export abstract class TreeNode implements WithType {
 		}
 	}
 }
+// Class objects are functions (callable), so we need a strong way to distinguish between `schema` and `() => schema` when used as a `LazyItem`.
+markEager(TreeNode);
 
 /**
  * `token` to pass to {@link TreeNode}'s constructor used to detect invalid subclasses.

--- a/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
@@ -8,7 +8,6 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { type FlexTreeNode, isFlexTreeNode } from "../../feature-libraries/index.js";
 
-import { markEager } from "./flexList.js";
 import { inPrototypeChain, privateToken, TreeNode } from "./treeNode.js";
 import { UnhydratedFlexTreeNode } from "./unhydratedFlexTree.js";
 import {
@@ -209,8 +208,6 @@ export abstract class TreeNodeValid<TInput> extends TreeNode {
 		return result;
 	}
 }
-// Class objects are functions (callable), so we need a strong way to distinguish between `schema` and `() => schema` when used as a `LazyItem`.
-markEager(TreeNodeValid);
 
 /**
  * Data cached about the most derived type in a schema's class hierarchy.

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -14,9 +14,7 @@ export {
 	type TreeNodeSchemaClass,
 	type TreeNodeSchemaNonClass,
 	type TreeNodeSchemaCore,
-	// TreeNode is only type exported, which prevents use of the class object for unsupported use-cases like direct sub-classing and instanceof.
-	// See docs on TreeNode for more details.
-	type TreeNode,
+	TreeNode,
 	type Unhydrated,
 	type InternalTreeNode,
 	isTreeNode,


### PR DESCRIPTION
## Description

Support `instanceof TreeNode`.

In the past there was some reluctance to support this. Users however have tried to use it and noted it not being supported. Opinions seem to be on the side of supporting it now.

This API can't trivially be stabilized incrementally using release tags since type and non-type exports are required to have matching tags (and docs). It could be aliased to a different name, and that exported as TreeNodeAlpha. Generally, though this seems like a low risk change as this has been working an supported internally in the package for a long time, so going straight to public seems reasonable.

Note that API reports do not capture if something it type only exported, so it is a defect in API reporting that this does not show up as a change to all API surfaces for both tree and fluid-framework.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

