### PR TITLE
fix(docs): Don't inherit `@sealed` and `@input` notices from ancestry

### DIFF
--- a/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
+++ b/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
@@ -156,8 +156,11 @@ function createSupportNotice(apiItem, isImportable) {
  * If the item is tagged as with `tag`, displays an notice.
  *
  * @param {ApiItem} apiItem - The API item for which the notice might be created.
+ * @param {`@${string}`} tag - The tag to check for.
+ * @param {boolean} includeAncestry - Whether or not to include the `apiItem`'s ancestry when checking for the tag.
+ * @param {AdmonitionNode} notice - The notice to display if the tag is present.
  */
-function createTagNotice(apiItem, tag, notice) {
+function createTagNotice(apiItem, tag, includeAncestry, notice) {
 	if (ApiItemUtilities.ancestryHasModifierTag(apiItem, tag)) {
 		return notice;
 	}
@@ -231,7 +234,7 @@ export function layoutContent(apiItem, itemSpecificContent, config) {
 	addSection(LayoutUtilities.createSummarySection(apiItem, config));
 
 	// Add system notice (if any) that supersedes deprecation and import notices
-	if (!addSection(createTagNotice(apiItem, "@system", systemNotice))) {
+	if (!addSection(createTagNotice(apiItem, "@system", true, systemNotice))) {
 		// If no system notice:
 
 		// Add deprecation notice (if any)
@@ -242,10 +245,10 @@ export function layoutContent(apiItem, itemSpecificContent, config) {
 	}
 
 	// Add the API notice for `sealed` if present.
-	addSection(createTagNotice(apiItem, "@sealed", sealedNotice));
+	addSection(createTagNotice(apiItem, "@sealed", false, sealedNotice));
 
 	// Add the API notice for `input` if present.
-	addSection(createTagNotice(apiItem, "@input", inputNotice));
+	addSection(createTagNotice(apiItem, "@input", false, inputNotice));
 
 	// Add signature (if any)
 	addSection(LayoutUtilities.createSignatureSection(apiItem, config));

--- a/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
+++ b/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
@@ -157,15 +157,16 @@ function createSupportNotice(apiItem, isImportable) {
  *
  * @param {ApiItem} apiItem - The API item for which the notice might be created.
  * @param {`@${string}`} tag - The tag to check for.
- * @param {boolean} includeAncestry - Whether or not to include the `apiItem`'s ancestry when checking for the tag.
+ * @param {boolean} includeContainingAncestry - Whether or not to include the `apiItem`'s containing ancestry when checking for the tag.
+ * E.g. whether or not a class member should inherit the tag from its containing class. Or a class inherit from its containing package/namespace.
  * @param {AdmonitionNode} notice - The notice to display if the tag is present.
  */
-function createTagNotice(apiItem, tag, includeAncestry, notice) {
-	if (includeAncestry && ApiItemUtilities.ancestryHasModifierTag(apiItem, tag)) {
+function createTagNotice(apiItem, tag, includeContainingAncestry, notice) {
+	if (includeContainingAncestry && ApiItemUtilities.ancestryHasModifierTag(apiItem, tag)) {
 		return notice;
 	}
 
-	if (!includeAncestry && ApiItemUtilities.hasModifierTag(apiItem, tag)) {
+	if (!includeContainingAncestry && ApiItemUtilities.hasModifierTag(apiItem, tag)) {
 		return notice;
 	}
 

--- a/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
+++ b/docs/infra/api-markdown-documenter/api-documentation-layout.mjs
@@ -161,7 +161,11 @@ function createSupportNotice(apiItem, isImportable) {
  * @param {AdmonitionNode} notice - The notice to display if the tag is present.
  */
 function createTagNotice(apiItem, tag, includeAncestry, notice) {
-	if (ApiItemUtilities.ancestryHasModifierTag(apiItem, tag)) {
+	if (includeAncestry && ApiItemUtilities.ancestryHasModifierTag(apiItem, tag)) {
+		return notice;
+	}
+
+	if (!includeAncestry && ApiItemUtilities.hasModifierTag(apiItem, tag)) {
 		return notice;
 	}
 


### PR DESCRIPTION
Prevents members of `@sealed` and `@input` types from being polluted with inappropriate notices.