### PR TITLE
feat(eslint-config-fluid): Add import rules

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @fluidframework/eslint-config-fluid Changelog
 
-## [5.9.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.9_0)
+## [6.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v6.0_0)
 
 Adds the following [@typescript-eslint/no-restricted-imports](https://typescript-eslint.io/rules/no-restricted-imports/) rules:
 

--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -5,9 +5,9 @@
 Adds the following [@typescript-eslint/no-restricted-imports](https://typescript-eslint.io/rules/no-restricted-imports/) rules:
 
 1. Prefer using [strict](https://nodejs.org/api/assert.html#strict-assertion-mode) assertions from Node's `assert` library.
-	- E.g. prefer `import { strict as assert } from "assert";` over `import assert from "assert";`.
+    - E.g. prefer `import { strict as assert } from "assert";` over `import assert from "assert";`.
 2. Don't import from parent index file.
-	- E.g. prefer `import { Foo } from "./Foo.js";` over `import { Foo } from "./index.js";`
+    - E.g. prefer `import { Foo } from "./Foo.js";` over `import { Foo } from "./index.js";`
 
 ## [5.8.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.8_0)
 

--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @fluidframework/eslint-config-fluid Changelog
 
+## [5.9.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.9_0)
+
+Adds the following [@typescript-eslint/no-restricted-imports](https://typescript-eslint.io/rules/no-restricted-imports/) rules:
+
+1. Prefer using [strict](https://nodejs.org/api/assert.html#strict-assertion-mode) assertions from Node's `assert` library.
+	- E.g. prefer `import { strict as assert } from "assert";` over `import assert from "assert";`.
+2. Don't import from parent index file.
+	- E.g. prefer `import { Foo } from "./Foo.js";` over `import { Foo } from "./index.js";`
+
 ## [5.8.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.8_0)
 
 Promotes the following rules from the `strict` ruleset to the `recommended` ruleset:

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -167,11 +167,13 @@ module.exports = {
 						message:
 							'Use `strict` instead. E.g. `import { strict as assert } from "node:assert";`',
 					},
+				],
+				patterns: [
 					// Don't import from the parent index file.
 					{
-						name: "./index.js",
+						group: ["./index.js", "**/../index.js"],
 						message:
-							"Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead.",
+							"Importing from a parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead.",
 					},
 				],
 			},

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -52,13 +52,10 @@ const restrictedImportPatternsForProductionCode = [
 ];
 
 /**
- * "Minimal" eslint configuration.
+ * DO NOT USE.
  *
- * This configuration is primarily intended for use in packages during prototyping / initial setup.
- * Ideally, all of packages in the fluid-framework repository should derive from either the "Recommended" or
- * "Strict" configuration.
- *
- * Production packages **should not** use this configuration.
+ * This configuration is extended by our `recommended` and `strict` configurations,
+ * but this configuration should not be used directly.
  *
  * @deprecated This config is too permissive and should not be used. It will be removed in a future release.
  * Use the "Recommended" or "Strict" configuration instead.

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -149,6 +149,34 @@ module.exports = {
 		"@typescript-eslint/no-non-null-assertion": "error",
 		"@typescript-eslint/no-unnecessary-type-assertion": "error",
 
+		"@typescript-eslint/no-restricted-imports": [
+			"error",
+			{
+				paths: [
+					// Prefer strict assertions
+					// See: <https://nodejs.org/api/assert.html#strict-assertion-mode>
+					{
+						name: "assert",
+						importNames: ["default", "assert"],
+						message:
+							'Use `strict` instead. E.g. `import { strict as assert } from "assert";`',
+					},
+					{
+						name: "node:assert",
+						importNames: ["default", "assert"],
+						message:
+							'Use `strict` instead. E.g. `import { strict as assert } from "node:assert";`',
+					},
+					// Don't import from the parent index file.
+					{
+						name: "./index.js",
+						message:
+							"Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead.",
+					},
+				],
+			},
+		],
+
 		"eqeqeq": ["error", "smart"],
 		"import/no-deprecated": "error",
 		"max-len": [

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -24,6 +24,33 @@ const permittedImports = [
 	"*/index.js",
 ];
 
+// Restricted import patterns for all code.
+const restrictedImportPaths = [
+	// Prefer strict assertions
+	// See: <https://nodejs.org/api/assert.html#strict-assertion-mode>
+	{
+		name: "assert",
+		importNames: ["default"],
+		message: 'Use `strict` instead. E.g. `import { strict as assert } from "assert";`',
+	},
+	{
+		name: "node:assert",
+		importNames: ["default"],
+		message: 'Use `strict` instead. E.g. `import { strict as assert } from "node:assert";`',
+	},
+];
+
+// Restricted import patterns for production code.
+// Not applied to test code.
+const restrictedImportPatternsForProductionCode = [
+	// Don't import from the parent index file.
+	{
+		group: ["./index.js", "**/../index.js"],
+		message:
+			"Importing from a parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead.",
+	},
+];
+
 /**
  * "Minimal" eslint configuration.
  *
@@ -152,30 +179,8 @@ module.exports = {
 		"@typescript-eslint/no-restricted-imports": [
 			"error",
 			{
-				paths: [
-					// Prefer strict assertions
-					// See: <https://nodejs.org/api/assert.html#strict-assertion-mode>
-					{
-						name: "assert",
-						importNames: ["default"],
-						message:
-							'Use `strict` instead. E.g. `import { strict as assert } from "assert";`',
-					},
-					{
-						name: "node:assert",
-						importNames: ["default"],
-						message:
-							'Use `strict` instead. E.g. `import { strict as assert } from "node:assert";`',
-					},
-				],
-				patterns: [
-					// Don't import from the parent index file.
-					{
-						group: ["./index.js", "**/../index.js"],
-						message:
-							"Importing from a parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead.",
-					},
-				],
+				paths: restrictedImportPaths,
+				patterns: restrictedImportPatternsForProductionCode,
 			},
 		],
 
@@ -472,6 +477,13 @@ module.exports = {
 				// Disabled for test files
 				"@typescript-eslint/consistent-type-exports": "off",
 				"@typescript-eslint/consistent-type-imports": "off",
+
+				"@typescript-eslint/no-restricted-imports": [
+					"error",
+					{
+						paths: restrictedImportPaths,
+					},
+				],
 
 				// For test files only, additionally allow import of '/test*' and '/internal/test*' exports.
 				"import/no-internal-modules": [

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -157,13 +157,13 @@ module.exports = {
 					// See: <https://nodejs.org/api/assert.html#strict-assertion-mode>
 					{
 						name: "assert",
-						importNames: ["default", "assert"],
+						importNames: ["default"],
 						message:
 							'Use `strict` instead. E.g. `import { strict as assert } from "assert";`',
 					},
 					{
 						name: "node:assert",
-						importNames: ["default", "assert"],
+						importNames: ["default"],
 						message:
 							'Use `strict` instead. E.g. `import { strict as assert } from "node:assert";`',
 					},

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -31,7 +31,7 @@ const restrictedImportPaths = [
 	{
 		name: "assert",
 		importNames: ["default"],
-		message: 'Use `strict` instead. E.g. `import { strict as assert } from "assert";`',
+		message: 'Use `strict` instead. E.g. `import { strict as assert } from "node:assert";`',
 	},
 	{
 		name: "node:assert",

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "5.9.0",
+	"version": "6.0.0",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "5.8.0",
+	"version": "5.9.0",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -262,16 +262,14 @@
                     {
                         "name": "assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
                     },
                     {
                         "name": "node:assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -255,6 +255,33 @@
         "@typescript-eslint/no-require-imports": [
             "error"
         ],
+        "@typescript-eslint/no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                    },
+                    {
+                        "name": "node:assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
+                    },
+                    {
+                        "name": "./index.js",
+                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                    }
+                ]
+            }
+        ],
         "@typescript-eslint/no-shadow": [
             "error",
             {

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -272,10 +272,15 @@
                             "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
-                    },
+                    }
+                ],
+                "patterns": [
                     {
-                        "name": "./index.js",
-                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                        "group": [
+                            "./index.js",
+                            "**/../index.js"
+                        ],
+                        "message": "Importing from a parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
                     }
                 ]
             }

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -264,7 +264,7 @@
                         "importNames": [
                             "default"
                         ],
-                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },
                     {
                         "name": "node:assert",

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -253,10 +253,15 @@
                             "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
-                    },
+                    }
+                ],
+                "patterns": [
                     {
-                        "name": "./index.js",
-                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                        "group": [
+                            "./index.js",
+                            "**/../index.js"
+                        ],
+                        "message": "Importing from a parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
                     }
                 ]
             }

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -243,16 +243,14 @@
                     {
                         "name": "assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
                     },
                     {
                         "name": "node:assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -245,7 +245,7 @@
                         "importNames": [
                             "default"
                         ],
-                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },
                     {
                         "name": "node:assert",

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -236,6 +236,33 @@
         "@typescript-eslint/no-require-imports": [
             "error"
         ],
+        "@typescript-eslint/no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                    },
+                    {
+                        "name": "node:assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
+                    },
+                    {
+                        "name": "./index.js",
+                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                    }
+                ]
+            }
+        ],
         "@typescript-eslint/no-shadow": [
             "error",
             {

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -257,6 +257,33 @@
         "@typescript-eslint/no-require-imports": [
             "error"
         ],
+        "@typescript-eslint/no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                    },
+                    {
+                        "name": "node:assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
+                    },
+                    {
+                        "name": "./index.js",
+                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                    }
+                ]
+            }
+        ],
         "@typescript-eslint/no-shadow": [
             "error",
             {

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -264,16 +264,14 @@
                     {
                         "name": "assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
                     },
                     {
                         "name": "node:assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -274,10 +274,15 @@
                             "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
-                    },
+                    }
+                ],
+                "patterns": [
                     {
-                        "name": "./index.js",
-                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                        "group": [
+                            "./index.js",
+                            "**/../index.js"
+                        ],
+                        "message": "Importing from a parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
                     }
                 ]
             }

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -266,7 +266,7 @@
                         "importNames": [
                             "default"
                         ],
-                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },
                     {
                         "name": "node:assert",

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -262,16 +262,14 @@
                     {
                         "name": "assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
                     },
                     {
                         "name": "node:assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -255,6 +255,33 @@
         "@typescript-eslint/no-require-imports": [
             "error"
         ],
+        "@typescript-eslint/no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                    },
+                    {
+                        "name": "node:assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
+                    },
+                    {
+                        "name": "./index.js",
+                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                    }
+                ]
+            }
+        ],
         "@typescript-eslint/no-shadow": [
             "error",
             {

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -272,10 +272,15 @@
                             "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
-                    },
+                    }
+                ],
+                "patterns": [
                     {
-                        "name": "./index.js",
-                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                        "group": [
+                            "./index.js",
+                            "**/../index.js"
+                        ],
+                        "message": "Importing from a parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
                     }
                 ]
             }

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -264,7 +264,7 @@
                         "importNames": [
                             "default"
                         ],
-                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },
                     {
                         "name": "node:assert",

--- a/common/build/eslint-config-fluid/printed-configs/strict-biome.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict-biome.json
@@ -287,16 +287,14 @@
                     {
                         "name": "assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
                     },
                     {
                         "name": "node:assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },

--- a/common/build/eslint-config-fluid/printed-configs/strict-biome.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict-biome.json
@@ -280,6 +280,33 @@
         "@typescript-eslint/no-require-imports": [
             "error"
         ],
+        "@typescript-eslint/no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                    },
+                    {
+                        "name": "node:assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
+                    },
+                    {
+                        "name": "./index.js",
+                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                    }
+                ]
+            }
+        ],
         "@typescript-eslint/no-shadow": [
             "error",
             {

--- a/common/build/eslint-config-fluid/printed-configs/strict-biome.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict-biome.json
@@ -289,7 +289,7 @@
                         "importNames": [
                             "default"
                         ],
-                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },
                     {
                         "name": "node:assert",

--- a/common/build/eslint-config-fluid/printed-configs/strict-biome.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict-biome.json
@@ -297,10 +297,15 @@
                             "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
-                    },
+                    }
+                ],
+                "patterns": [
                     {
-                        "name": "./index.js",
-                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                        "group": [
+                            "./index.js",
+                            "**/../index.js"
+                        ],
+                        "message": "Importing from a parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
                     }
                 ]
             }

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -265,6 +265,33 @@
         "@typescript-eslint/no-require-imports": [
             "error"
         ],
+        "@typescript-eslint/no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                    },
+                    {
+                        "name": "node:assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
+                    },
+                    {
+                        "name": "./index.js",
+                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                    }
+                ]
+            }
+        ],
         "@typescript-eslint/no-shadow": [
             "error",
             {

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -282,10 +282,15 @@
                             "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
-                    },
+                    }
+                ],
+                "patterns": [
                     {
-                        "name": "./index.js",
-                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                        "group": [
+                            "./index.js",
+                            "**/../index.js"
+                        ],
+                        "message": "Importing from a parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
                     }
                 ]
             }

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -272,16 +272,14 @@
                     {
                         "name": "assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
                     },
                     {
                         "name": "node:assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -274,7 +274,7 @@
                         "importNames": [
                             "default"
                         ],
-                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },
                     {
                         "name": "node:assert",

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -262,16 +262,14 @@
                     {
                         "name": "assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
                     },
                     {
                         "name": "node:assert",
                         "importNames": [
-                            "default",
-                            "assert"
+                            "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -255,6 +255,33 @@
         "@typescript-eslint/no-require-imports": [
             "error"
         ],
+        "@typescript-eslint/no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                    },
+                    {
+                        "name": "node:assert",
+                        "importNames": [
+                            "default",
+                            "assert"
+                        ],
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
+                    },
+                    {
+                        "name": "./index.js",
+                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                    }
+                ]
+            }
+        ],
         "@typescript-eslint/no-shadow": [
             "error",
             {

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -272,10 +272,15 @@
                             "default"
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
-                    },
+                    }
+                ],
+                "patterns": [
                     {
-                        "name": "./index.js",
-                        "message": "Importing from the parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
+                        "group": [
+                            "./index.js",
+                            "**/../index.js"
+                        ],
+                        "message": "Importing from a parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
                     }
                 ]
             }

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -264,7 +264,7 @@
                         "importNames": [
                             "default"
                         ],
-                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"assert\";`"
+                        "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     },
                     {
                         "name": "node:assert",

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -273,15 +273,6 @@
                         ],
                         "message": "Use `strict` instead. E.g. `import { strict as assert } from \"node:assert\";`"
                     }
-                ],
-                "patterns": [
-                    {
-                        "group": [
-                            "./index.js",
-                            "**/../index.js"
-                        ],
-                        "message": "Importing from a parent index file tends to cause cyclic dependencies. Import from a more specific sibling file instead."
-                    }
                 ]
             }
         ],


### PR DESCRIPTION
Adds the following [@typescript-eslint/no-restricted-imports](https://typescript-eslint.io/rules/no-restricted-imports/) rules:

1. Prefer using [strict](https://nodejs.org/api/assert.html#strict-assertion-mode) assertions from Node's `assert` library.
	- E.g. prefer `import { strict as assert } from "assert";` over `import assert from "assert";`.
2. Don't import from parent index file.
	- E.g. prefer `import { Foo } from "./Foo.js";` over `import { Foo } from "./index.js";`