### PR TITLE
refactor(tree): Remove single-node removal APIs from `TableSchema`

### DIFF
--- a/.changeset/damp-toads-stall.md
+++ b/.changeset/damp-toads-stall.md
@@ -3,7 +3,7 @@
 "fluid-framework": minor
 "__section": tree
 ---
-Single-node insertion/removal APIs have been remove from TableSchema (alpha)
+Single-node insertion/removal APIs have been removed from TableSchema (alpha)
 
 There is a significant performance benefit to inserting / removing rows / columns in batches.
 To help encourage more performant usage patterns, single-node insertion and removal APIs.

--- a/.changeset/damp-toads-stall.md
+++ b/.changeset/damp-toads-stall.md
@@ -6,7 +6,7 @@
 Single-node insertion/removal APIs have been removed from TableSchema (alpha)
 
 There is a significant performance benefit to inserting / removing rows / columns in batches.
-To help encourage more performant usage patterns, single-node insertion and removal APIs.
+To help encourage more performant usage patterns, single-node insertion and removal APIs have been removed.
 The APIs that operate on batches should be used instead.
 
 Specifically:

--- a/.changeset/damp-toads-stall.md
+++ b/.changeset/damp-toads-stall.md
@@ -1,0 +1,21 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Single-node insertion/removal APIs have been remove from TableSchema (alpha)
+
+There is a significant performance benefit to inserting / removing rows / columns in batches.
+To help encourage more performant usage patterns, single-node insertion and removal APIs.
+The APIs that operate on batches should be used instead.
+
+Specifically:
+
+- `insertColumn`
+	- Use `insertColumns` instead
+- `insertRow`
+	- Use `insertRows` instead
+- `removeColumn`
+	- Use `removeColumns` instead
+- `removeRow`
+	- Use `removeRows` instead

--- a/examples/data-objects/table-tree/src/react/tableView.tsx
+++ b/examples/data-objects/table-tree/src/react/tableView.tsx
@@ -54,6 +54,7 @@ export const TableView: React.FC<{ tableModel: TableDataObject }> = ({ tableMode
 
 	const handleRemoveRow = (index: number): void => {
 		if (index >= 0 && index < rows.length) {
+			// TODO: use index-based removal API once that has been added.
 			table.removeRows([table.rows[index]]);
 		}
 	};
@@ -66,6 +67,7 @@ export const TableView: React.FC<{ tableModel: TableDataObject }> = ({ tableMode
 
 	const handleRemoveColumn = (index: number): void => {
 		if (index >= 0 && index < columns.length) {
+			// TODO: use index-based removal API once that has been added.
 			table.removeColumns([table.columns[index]]);
 		}
 	};

--- a/examples/data-objects/table-tree/src/react/tableView.tsx
+++ b/examples/data-objects/table-tree/src/react/tableView.tsx
@@ -8,7 +8,7 @@ import { Add24Regular } from "@fluentui/react-icons";
 import React, { useState, DragEvent } from "react";
 
 import { TableDataObject } from "../dataObject.js";
-import { Column } from "../schema.js";
+import { Column, Row } from "../schema.js";
 
 import { TableHeaderView } from "./tableHeaderView.js";
 import { TableRowView } from "./tableRowView.js";
@@ -47,26 +47,26 @@ export const TableView: React.FC<{ tableModel: TableDataObject }> = ({ tableMode
 	const rows = [...table.rows];
 
 	const handleAppendNewRow = (): void => {
-		table.insertRow({
-			row: { cells: {} },
+		table.insertRows({
+			rows: [new Row({ cells: {} })],
 		});
 	};
 
 	const handleRemoveRow = (index: number): void => {
 		if (index >= 0 && index < rows.length) {
-			table.removeRow(table.rows[index]);
+			table.removeRows([table.rows[index]]);
 		}
 	};
 
 	const handleAppendNewColumn = (newColumn: Column): void => {
-		table.insertColumn({
-			column: newColumn,
+		table.insertColumns({
+			columns: [newColumn],
 		});
 	};
 
 	const handleRemoveColumn = (index: number): void => {
 		if (index >= 0 && index < columns.length) {
-			table.removeColumn(table.columns[index]);
+			table.removeColumns([table.columns[index]]);
 		}
 	};
 

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1150,17 +1150,9 @@ export namespace TableSchema {
     export function column<const TScope extends string | undefined, const TCell extends ImplicitAllowedTypes, const TProps extends ImplicitAnnotatedFieldSchema>(params: System_TableSchema.CreateColumnOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
         readonly props: TProps;
     }): System_TableSchema.ColumnSchemaBase<TScope, TCell, TProps>;
-    export interface InsertColumnParameters<TColumn extends ImplicitAllowedTypes> {
-        readonly column: InsertableTreeNodeFromImplicitAllowedTypes<TColumn>;
-        readonly index?: number | undefined;
-    }
     export interface InsertColumnsParameters<TColumn extends ImplicitAllowedTypes> {
         readonly columns: InsertableTreeNodeFromImplicitAllowedTypes<TColumn>[];
         readonly index?: number | undefined;
-    }
-    export interface InsertRowParameters<TRow extends ImplicitAllowedTypes> {
-        readonly index?: number | undefined;
-        readonly row: InsertableTreeNodeFromImplicitAllowedTypes<TRow>;
     }
     export interface InsertRowsParameters<TRow extends ImplicitAllowedTypes> {
         readonly index?: number | undefined;
@@ -1196,9 +1188,7 @@ export namespace TableSchema {
         getCell(key: CellKey<TColumn, TRow>): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
         getColumn(id: string): TreeNodeFromImplicitAllowedTypes<TColumn> | undefined;
         getRow(id: string): TreeNodeFromImplicitAllowedTypes<TRow> | undefined;
-        insertColumn(params: InsertColumnParameters<TColumn>): TreeNodeFromImplicitAllowedTypes<TColumn>;
         insertColumns(params: InsertColumnsParameters<TColumn>): TreeNodeFromImplicitAllowedTypes<TColumn>[];
-        insertRow(params: InsertRowParameters<TRow>): TreeNodeFromImplicitAllowedTypes<TRow>;
         insertRows(params: InsertRowsParameters<TRow>): TreeNodeFromImplicitAllowedTypes<TRow>[];
         removeAllColumns(): TreeNodeFromImplicitAllowedTypes<TColumn>[];
         removeAllRows(): TreeNodeFromImplicitAllowedTypes<TRow>[];

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1203,10 +1203,8 @@ export namespace TableSchema {
         removeAllColumns(): TreeNodeFromImplicitAllowedTypes<TColumn>[];
         removeAllRows(): TreeNodeFromImplicitAllowedTypes<TRow>[];
         removeCell(key: CellKey<TColumn, TRow>): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
-        removeColumn(column: string | TreeNodeFromImplicitAllowedTypes<TColumn>): TreeNodeFromImplicitAllowedTypes<TColumn>;
         removeColumns(columns: readonly TreeNodeFromImplicitAllowedTypes<TColumn>[]): TreeNodeFromImplicitAllowedTypes<TColumn>[];
         removeColumns(columns: readonly string[]): TreeNodeFromImplicitAllowedTypes<TColumn>[];
-        removeRow(row: string | TreeNodeFromImplicitAllowedTypes<TRow>): TreeNodeFromImplicitAllowedTypes<TRow>;
         removeRows(rows: readonly TreeNodeFromImplicitAllowedTypes<TRow>[]): TreeNodeFromImplicitAllowedTypes<TRow>[];
         removeRows(rows: readonly string[]): TreeNodeFromImplicitAllowedTypes<TRow>[];
         readonly rows: TreeArrayNode<TRow>;

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -632,17 +632,6 @@ export namespace System_TableSchema {
 				return row.getCell(column);
 			}
 
-			public insertColumn({
-				column,
-				index,
-			}: TableSchema.InsertColumnParameters<TColumnSchema>): ColumnValueType {
-				const inserted = this.insertColumns({
-					columns: [column],
-					index,
-				});
-				return inserted[0] ?? oob();
-			}
-
 			public insertColumns({
 				columns,
 				index,
@@ -664,17 +653,6 @@ export namespace System_TableSchema {
 
 				// Inserting the input nodes into the tree hydrates them, making them usable as nodes.
 				return columns as unknown as ColumnValueType[];
-			}
-
-			public insertRow({
-				row,
-				index,
-			}: TableSchema.InsertRowParameters<TRowSchema>): RowValueType {
-				const inserted = this.insertRows({
-					rows: [row],
-					index,
-				});
-				return inserted[0] ?? oob();
 			}
 
 			public insertRows({
@@ -1334,23 +1312,6 @@ export namespace TableSchema {
 	}
 
 	/**
-	 * {@link TableSchema.Table.insertColumn} parameters.
-	 * @alpha
-	 */
-	export interface InsertColumnParameters<TColumn extends ImplicitAllowedTypes> {
-		/**
-		 * The index at which to insert the new column.
-		 * @remarks If not provided, the column will be appended to the end of the table.
-		 */
-		readonly index?: number | undefined;
-
-		/**
-		 * The column to insert.
-		 */
-		readonly column: InsertableTreeNodeFromImplicitAllowedTypes<TColumn>;
-	}
-
-	/**
 	 * {@link TableSchema.Table.insertColumns} parameters.
 	 * @alpha
 	 */
@@ -1365,23 +1326,6 @@ export namespace TableSchema {
 		 * The columns to insert.
 		 */
 		readonly columns: InsertableTreeNodeFromImplicitAllowedTypes<TColumn>[];
-	}
-
-	/**
-	 * {@link TableSchema.Table.insertRow} parameters.
-	 * @alpha
-	 */
-	export interface InsertRowParameters<TRow extends ImplicitAllowedTypes> {
-		/**
-		 * The index at which to insert the new row.
-		 * @remarks If not provided, the row will be appended to the end of the table.
-		 */
-		readonly index?: number | undefined;
-
-		/**
-		 * The row to insert.
-		 */
-		readonly row: InsertableTreeNodeFromImplicitAllowedTypes<TRow>;
 	}
 
 	/**
@@ -1462,17 +1406,6 @@ export namespace TableSchema {
 		getCell(key: CellKey<TColumn, TRow>): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
 
 		/**
-		 * Inserts a column into the table.
-		 *
-		 * @throws Throws an error if the specified index is out of range.
-		 *
-		 * No column is inserted in this case.
-		 */
-		insertColumn(
-			params: InsertColumnParameters<TColumn>,
-		): TreeNodeFromImplicitAllowedTypes<TColumn>;
-
-		/**
 		 * Inserts 0 or more columns into the table.
 		 *
 		 * @throws Throws an error if the specified index is out of range.
@@ -1482,20 +1415,6 @@ export namespace TableSchema {
 		insertColumns(
 			params: InsertColumnsParameters<TColumn>,
 		): TreeNodeFromImplicitAllowedTypes<TColumn>[];
-
-		/**
-		 * Inserts a row into the table.
-		 *
-		 * @throws
-		 * Throws an error in the following cases:
-		 *
-		 * - The row contains cells, but the table does not contain matching columns for one or more of those cells.
-		 *
-		 * - The specified index is out of range.
-		 *
-		 * No row is inserted in these cases.
-		 */
-		insertRow(params: InsertRowParameters<TRow>): TreeNodeFromImplicitAllowedTypes<TRow>;
 
 		/**
 		 * Inserts 0 or more rows into the table.

--- a/packages/dds/tree/src/tableSchema.ts
+++ b/packages/dds/tree/src/tableSchema.ts
@@ -1518,23 +1518,6 @@ export namespace TableSchema {
 		setCell(params: SetCellParameters<TCell, TColumn, TRow>): void;
 
 		/**
-		 * Removes the specified column from the table.
-		 * @remarks
-		 * Also removes any corresponding cells from the table's rows.
-		 *
-		 * Note: this operation can be slow for tables with many rows.
-		 * We are actively working on improving the performance of this operation, but for now it may have a negative
-		 * impact on performance.
-		 *
-		 * @param column - The {@link TableSchema.Column | column} or {@link TableSchema.Column.id | column ID} to remove.
-		 * @throws Throws an error if the column is not in the table.
-		 * In this case, no columns are removed.
-		 */
-		removeColumn(
-			column: string | TreeNodeFromImplicitAllowedTypes<TColumn>,
-		): TreeNodeFromImplicitAllowedTypes<TColumn>;
-
-		/**
 		 * Removes 0 or more columns from the table.
 		 * @remarks
 		 * Also removes any corresponding cells from the table's rows.
@@ -1579,16 +1562,6 @@ export namespace TableSchema {
 		 * @returns The removed columns.
 		 */
 		removeAllColumns(): TreeNodeFromImplicitAllowedTypes<TColumn>[];
-
-		/**
-		 * Removes the specified row from the table.
-		 * @param row - The {@link TableSchema.Row | row} or {@link TableSchema.Row.id | row ID} to remove.
-		 * @throws Throws an error if the row is not in the table.
-		 * In this case, no rows are removed.
-		 */
-		removeRow(
-			row: string | TreeNodeFromImplicitAllowedTypes<TRow>,
-		): TreeNodeFromImplicitAllowedTypes<TRow>;
 
 		/**
 		 * Removes 0 or more rows from the table.

--- a/packages/dds/tree/src/test/memory/tableTree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tableTree.spec.ts
@@ -239,7 +239,10 @@ describe("SharedTree table APIs memory usage", () => {
 						operation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = new Column({});
-								table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
+								table.insertColumns({
+									index: Math.floor(table.columns.length / 2),
+									columns: [column],
+								});
 							}
 						},
 					}),
@@ -254,7 +257,10 @@ describe("SharedTree table APIs memory usage", () => {
 						setupOperation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = new Column({});
-								table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
+								table.insertColumns({
+									index: Math.floor(table.columns.length / 2),
+									columns: [column],
+								});
 							}
 						},
 						stackOperation: (undoRedoManager) => {
@@ -275,7 +281,10 @@ describe("SharedTree table APIs memory usage", () => {
 						setupOperation: (table, undoRedoManager) => {
 							for (let i = 0; i < count; i++) {
 								const column = new Column({});
-								table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
+								table.insertColumns({
+									index: Math.floor(table.columns.length / 2),
+									columns: [column],
+								});
 							}
 							for (let i = 0; i < count; i++) {
 								undoRedoManager.undo();
@@ -302,7 +311,7 @@ describe("SharedTree table APIs memory usage", () => {
 						operation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const row = new Row({ cells: {} });
-								table.insertRow({ index: Math.floor(table.rows.length / 2), row });
+								table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
 							}
 						},
 					}),
@@ -317,7 +326,7 @@ describe("SharedTree table APIs memory usage", () => {
 						setupOperation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const row = new Row({ cells: {} });
-								table.insertRow({ index: Math.floor(table.rows.length / 2), row });
+								table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
 							}
 						},
 						stackOperation: (undoRedoManager) => {
@@ -338,7 +347,7 @@ describe("SharedTree table APIs memory usage", () => {
 						setupOperation: (table, undoRedoManager) => {
 							for (let i = 0; i < count; i++) {
 								const row = new Row({ cells: {} });
-								table.insertRow({ index: Math.floor(table.rows.length / 2), row });
+								table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
 							}
 							for (let i = 0; i < count; i++) {
 								undoRedoManager.undo();
@@ -365,9 +374,12 @@ describe("SharedTree table APIs memory usage", () => {
 						operation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = new Column({});
-								table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
+								table.insertColumns({
+									index: Math.floor(table.columns.length / 2),
+									columns: [column],
+								});
 								const row = new Row({ id: `row-${i}`, cells: {} });
-								table.insertRow({ index: Math.floor(table.rows.length / 2), row });
+								table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
 							}
 						},
 					}),
@@ -382,9 +394,12 @@ describe("SharedTree table APIs memory usage", () => {
 						setupOperation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = new Column({});
-								table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
+								table.insertColumns({
+									index: Math.floor(table.columns.length / 2),
+									columns: [column],
+								});
 								const row = new Row({ id: `row-${i}`, cells: {} });
-								table.insertRow({ index: Math.floor(table.rows.length / 2), row });
+								table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
 							}
 						},
 						stackOperation: (undoRedoManager) => {
@@ -409,9 +424,9 @@ describe("SharedTree table APIs memory usage", () => {
 				// 		setupOperation: (table, undoRedoManager) => {
 				// 			for (let i = 0; i < count; i++) {
 				// 				const column = new Column({});
-				// 				table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
+				// 				table.insertColumns({ index: Math.floor(table.columns.length / 2), columns: [column] });
 				// 				const row = new Row({ id: `row-${i}`, cells: {} });
-				// 				table.insertRow({ index: Math.floor(table.rows.length / 2), row });
+				// 				table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
 				// 			}
 				// 			for (let i = 0; i < count; i++) {
 				// 				// Undo row insertion
@@ -447,7 +462,7 @@ describe("SharedTree table APIs memory usage", () => {
 						operation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = table.columns[Math.floor(table.columns.length / 2)];
-								table.removeColumn(column);
+								table.removeColumns([column]);
 							}
 						},
 					}),
@@ -462,7 +477,7 @@ describe("SharedTree table APIs memory usage", () => {
 						setupOperation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = table.columns[Math.floor(table.columns.length / 2)];
-								table.removeColumn(column);
+								table.removeColumns([column]);
 							}
 						},
 						stackOperation: (undoRedoManager) => {
@@ -484,7 +499,7 @@ describe("SharedTree table APIs memory usage", () => {
 				// 		setupOperation: (table, undoRedoManager) => {
 				// 			for (let i = 0; i < count; i++) {
 				// 				const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 				table.removeColumn(column);
+				// 				table.removeColumns([column]);
 				// 			}
 				// 			for (let i = 0; i < count; i++) {
 				// 				undoRedoManager.undo();
@@ -511,7 +526,7 @@ describe("SharedTree table APIs memory usage", () => {
 						operation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const row = table.rows[Math.floor(table.rows.length / 2)];
-								table.removeRow(row);
+								table.removeRows([row]);
 							}
 						},
 					}),
@@ -526,7 +541,7 @@ describe("SharedTree table APIs memory usage", () => {
 						setupOperation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const row = table.rows[Math.floor(table.rows.length / 2)];
-								table.removeRow(row);
+								table.removeRows([row]);
 							}
 						},
 						stackOperation: (undoRedoManager) => {
@@ -547,7 +562,7 @@ describe("SharedTree table APIs memory usage", () => {
 						setupOperation: (table, undoRedoManager) => {
 							for (let i = 0; i < count; i++) {
 								const row = table.rows[Math.floor(table.rows.length / 2)];
-								table.removeRow(row);
+								table.removeRows([row]);
 							}
 							for (let i = 0; i < count; i++) {
 								undoRedoManager.undo();
@@ -574,9 +589,9 @@ describe("SharedTree table APIs memory usage", () => {
 						operation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = table.columns[Math.floor(table.columns.length / 2)];
-								table.removeColumn(column);
+								table.removeColumns([column]);
 								const row = table.rows[Math.floor(table.rows.length / 2)];
-								table.removeRow(row);
+								table.removeRows([row]);
 							}
 						},
 					}),
@@ -591,9 +606,9 @@ describe("SharedTree table APIs memory usage", () => {
 						setupOperation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = table.columns[Math.floor(table.columns.length / 2)];
-								table.removeColumn(column);
+								table.removeColumns([column]);
 								const row = table.rows[Math.floor(table.rows.length / 2)];
-								table.removeRow(row);
+								table.removeRows([row]);
 							}
 						},
 						stackOperation: (undoRedoManager) => {
@@ -618,9 +633,9 @@ describe("SharedTree table APIs memory usage", () => {
 				// 		setupOperation: (table, undoRedoManager) => {
 				// 			for (let i = 0; i < count; i++) {
 				// 				const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 				table.removeColumn(column);
+				// 				table.removeColumns([column]);
 				// 				const row = table.rows[Math.floor(table.rows.length / 2)];
-				// 				table.removeRow(row);
+				// 				table.removeRows([row]);
 				// 			}
 				// 			for (let i = 0; i < count; i++) {
 				// 				// Undo row removal
@@ -653,11 +668,15 @@ describe("SharedTree table APIs memory usage", () => {
 						operation: (table) => {
 							for (let i = 0; i < count; i++) {
 								const column = new Column({});
-								table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
+								table.insertColumns({
+									index: Math.floor(table.columns.length / 2),
+									columns: [column],
+								});
 								const row = new Row({ id: `row-${i}`, cells: {} });
-								table.insertRow({ index: Math.floor(table.rows.length / 2), row });
-								table.removeColumn(column);
-								table.removeRow(row);
+								table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
+
+								table.removeColumns([column]);
+								table.removeRows([row]);
 							}
 						},
 					}),
@@ -673,11 +692,11 @@ describe("SharedTree table APIs memory usage", () => {
 				// 		setupOperation: (table) => {
 				// 			for (let i = 0; i < count; i++) {
 				// 				const column = new Column({});
-				// 				table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
+				// 				table.insertColumns({ index: Math.floor(table.columns.length / 2), columns: [column] });
 				// 				const row = new Row({ id: `row-${i}`, cells: {} });
-				// 				table.insertRow({ index: Math.floor(table.rows.length / 2), row });
-				// 				table.removeColumn(column);
-				// 				table.removeRow(row);
+				// 				table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
+				// 				table.removeColumns([column]);
+				// 				table.removeRows([row]);
 				// 			}
 				// 		},
 				// 		stackOperation: (undoRedoManager) => {
@@ -705,11 +724,11 @@ describe("SharedTree table APIs memory usage", () => {
 				// 		setupOperation: (table, undoRedoManager) => {
 				// 			for (let i = 0; i < count; i++) {
 				// 				const column = new Column({});
-				// 				table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
+				// 				table.insertColumns({ index: Math.floor(table.columns.length / 2), columns: [column] });
 				// 				const row = new Row({ id: `row-${i}`, cells: {} });
-				// 				table.insertRow({ index: Math.floor(table.rows.length / 2), row });
-				// 				table.removeColumn(column);
-				// 				table.removeRow(row);
+				// 				table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
+				// 				table.removeColumns([column]);
+				// 				table.removeRows([row]);
 				// 			}
 				// 			for (let i = 0; i < count; i++) {
 				// 				// Undo row removal

--- a/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/tableTree.bench.ts
@@ -163,7 +163,10 @@ describe("SharedTree table APIs execution time", () => {
 					operation: (table) => {
 						for (let i = 0; i < count; i++) {
 							const column = new Column({});
-							table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
+							table.insertColumns({
+								index: Math.floor(table.columns.length / 2),
+								columns: [column],
+							});
 						}
 					},
 					maxBenchmarkDurationSeconds,
@@ -177,7 +180,10 @@ describe("SharedTree table APIs execution time", () => {
 					beforeOperation: (table, undoRedoManager) => {
 						for (let i = 0; i < count; i++) {
 							const column = new Column({});
-							table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
+							table.insertColumns({
+								index: Math.floor(table.columns.length / 2),
+								columns: [column],
+							});
 						}
 						assert(undoRedoManager.canUndo);
 					},
@@ -200,7 +206,10 @@ describe("SharedTree table APIs execution time", () => {
 					beforeOperation: (table, undoRedoManager) => {
 						for (let i = 0; i < count; i++) {
 							const column = new Column({});
-							table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
+							table.insertColumns({
+								index: Math.floor(table.columns.length / 2),
+								columns: [column],
+							});
 						}
 						for (let i = 0; i < count; i++) {
 							undoRedoManager.undo();
@@ -229,7 +238,7 @@ describe("SharedTree table APIs execution time", () => {
 					operation: (table) => {
 						for (let i = 0; i < count; i++) {
 							const row = new Row({ cells: {} });
-							table.insertRow({ index: Math.floor(table.rows.length / 2), row });
+							table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
 						}
 					},
 					maxBenchmarkDurationSeconds,
@@ -243,7 +252,7 @@ describe("SharedTree table APIs execution time", () => {
 					beforeOperation: (table, undoRedoManager) => {
 						for (let i = 0; i < count; i++) {
 							const row = new Row({ cells: {} });
-							table.insertRow({ index: Math.floor(table.rows.length / 2), row });
+							table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
 						}
 						assert(undoRedoManager.canUndo);
 					},
@@ -266,7 +275,7 @@ describe("SharedTree table APIs execution time", () => {
 					beforeOperation: (table, undoRedoManager) => {
 						for (let i = 0; i < count; i++) {
 							const row = new Row({ cells: {} });
-							table.insertRow({ index: Math.floor(table.rows.length / 2), row });
+							table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
 						}
 						for (let i = 0; i < count; i++) {
 							undoRedoManager.undo();
@@ -296,8 +305,11 @@ describe("SharedTree table APIs execution time", () => {
 						for (let i = 0; i < count; i++) {
 							const column = new Column({});
 							const row = new Row({ cells: {} });
-							table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
-							table.insertRow({ index: Math.floor(table.rows.length / 2), row });
+							table.insertColumns({
+								index: Math.floor(table.columns.length / 2),
+								columns: [column],
+							});
+							table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
 						}
 					},
 					maxBenchmarkDurationSeconds,
@@ -312,8 +324,11 @@ describe("SharedTree table APIs execution time", () => {
 						for (let i = 0; i < count; i++) {
 							const column = new Column({});
 							const row = new Row({ cells: {} });
-							table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
-							table.insertRow({ index: Math.floor(table.rows.length / 2), row });
+							table.insertColumns({
+								index: Math.floor(table.columns.length / 2),
+								columns: [column],
+							});
+							table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
 						}
 						assert(undoRedoManager.canUndo);
 					},
@@ -341,8 +356,8 @@ describe("SharedTree table APIs execution time", () => {
 				// 		for (let i = 0; i < count; i++) {
 				// 			const column = table.columns[Math.floor(table.columns.length / 2)];
 				// 			const row = table.rows[Math.floor(table.rows.length / 2)];
-				// 			table.removeColumn(column);
-				// 			table.removeRow(row);
+				// 			table.removeColumns([column]);
+				// 			table.removeRows([row]);
 				// 		}
 				// 		for (let i = 0; i < count; i++) {
 				// 			// Undo remove row
@@ -378,10 +393,13 @@ describe("SharedTree table APIs execution time", () => {
 						for (let i = 0; i < count; i++) {
 							const column = new Column({});
 							const row = new Row({ cells: {} });
-							table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
-							table.insertRow({ index: Math.floor(table.rows.length / 2), row });
-							table.removeColumn(column);
-							table.removeRow(row);
+							table.insertColumns({
+								index: Math.floor(table.columns.length / 2),
+								columns: [column],
+							});
+							table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
+							table.removeColumns([column]);
+							table.removeRows([row]);
 						}
 					},
 					maxBenchmarkDurationSeconds,
@@ -397,10 +415,10 @@ describe("SharedTree table APIs execution time", () => {
 				// 		for (let i = 0; i < count; i++) {
 				// 			const column = new Column({});
 				// 			const row = new Row({ cells: {} });
-				// 			table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
-				// 			table.insertRow({ index: Math.floor(table.rows.length / 2), row });
-				// 			table.removeColumn(column);
-				// 			table.removeRow(row);
+				// 			table.insertColumns({ index: Math.floor(table.columns.length / 2), columns: [column] });
+				// 			table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
+				// 			table.removeColumns([column]);
+				// 			table.removeRows([row]);
 				// 		}
 				// 		assert(undoRedoManager.canUndo);
 				// 	},
@@ -432,10 +450,10 @@ describe("SharedTree table APIs execution time", () => {
 				// 		for (let i = 0; i < count; i++) {
 				// 			const column = new Column({});
 				// 			const row = new Row({ cells: {} });
-				// 			table.insertColumn({ index: Math.floor(table.columns.length / 2), column });
-				// 			table.insertRow({ index: Math.floor(table.rows.length / 2), row });
-				// 			table.removeColumn(column);
-				// 			table.removeRow(row);
+				// 			table.insertColumns({ index: Math.floor(table.columns.length / 2), columns: [column] });
+				// 			table.insertRows({ index: Math.floor(table.rows.length / 2), rows: [row] });
+				// 			table.removeColumns([column]);
+				// 			table.removeRows([row]);
 				// 		}
 				// 		for (let i = 0; i < count; i++) {
 				// 			undoRedoManager.undo();
@@ -474,7 +492,7 @@ describe("SharedTree table APIs execution time", () => {
 					operation: (table) => {
 						for (let i = 0; i < count; i++) {
 							const column = table.columns[Math.floor(table.columns.length / 2)];
-							table.removeColumn(column);
+							table.removeColumns([column]);
 						}
 					},
 					maxBenchmarkDurationSeconds,
@@ -490,7 +508,7 @@ describe("SharedTree table APIs execution time", () => {
 				// 	beforeOperation: (table, undoRedoManager) => {
 				// 		for (let i = 0; i < count; i++) {
 				// 			const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 			table.removeColumn(column);
+				// 			table.removeColumns([column]);
 				// 		}
 				// 		assert(undoRedoManager.canUndo);
 				// 	},
@@ -514,7 +532,7 @@ describe("SharedTree table APIs execution time", () => {
 				// 	beforeOperation: (table, undoRedoManager) => {
 				// 		for (let i = 0; i < count; i++) {
 				// 			const column = table.columns[Math.floor(table.columns.length / 2)];
-				// 			table.removeColumn(column);
+				// 			table.removeColumns([column]);
 				// 		}
 				// 		for (let i = 0; i < count; i++) {
 				// 			undoRedoManager.undo();
@@ -543,7 +561,7 @@ describe("SharedTree table APIs execution time", () => {
 					operation: (table) => {
 						for (let i = 0; i < count; i++) {
 							const row = table.rows[Math.floor(table.rows.length / 2)];
-							table.removeRow(row);
+							table.removeRows([row]);
 						}
 					},
 					maxBenchmarkDurationSeconds,
@@ -557,7 +575,7 @@ describe("SharedTree table APIs execution time", () => {
 					beforeOperation: (table, undoRedoManager) => {
 						for (let i = 0; i < count; i++) {
 							const row = table.rows[Math.floor(table.rows.length / 2)];
-							table.removeRow(row);
+							table.removeRows([row]);
 						}
 						assert(undoRedoManager.canUndo);
 					},
@@ -580,7 +598,7 @@ describe("SharedTree table APIs execution time", () => {
 					beforeOperation: (table, undoRedoManager) => {
 						for (let i = 0; i < count; i++) {
 							const row = table.rows[Math.floor(table.rows.length / 2)];
-							table.removeRow(row);
+							table.removeRows([row]);
 						}
 						for (let i = 0; i < count; i++) {
 							undoRedoManager.undo();
@@ -603,15 +621,15 @@ describe("SharedTree table APIs execution time", () => {
 			describe(`Column and Row Removal`, () => {
 				// Test the execute time of the SharedTree for removing a row and a column in the middle for a given number of times.
 				runBenchmark({
-					title: `Remove a column and a row in the middle ${count} times`,
+					title: `Remove a single column and a row in the middle ${count} times`,
 					tableSize,
 					initialCellValue,
 					operation: (table) => {
 						for (let i = 0; i < count; i++) {
 							const column = table.columns[Math.floor(table.columns.length / 2)];
-							table.removeColumn(column);
+							table.removeColumns([column]);
 							const row = table.rows[Math.floor(table.rows.length / 2)];
-							table.removeRow(row);
+							table.removeRows([row]);
 						}
 					},
 					maxBenchmarkDurationSeconds,

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -135,7 +135,7 @@ describe("TableFactory unit tests", () => {
 				validateUsageError(/Column with ID "column-0" is not contained in a table./),
 			);
 
-			table.insertColumn({ column: column0 });
+			table.insertColumns({ columns: [column0] });
 
 			// No rows or cells have been inserted yet.
 			assert.equal(column0.getCells().length, 0);
@@ -204,7 +204,7 @@ describe("TableFactory unit tests", () => {
 			const table = treeView.root;
 
 			const row = new Row({ id: "row-0", cells: {} });
-			table.insertRow({ row });
+			table.insertRows({ rows: [row] });
 
 			// No columns or cells have been inserted yet.
 			assert.equal(row.getCells().length, 0);
@@ -396,110 +396,6 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("insertColumn", () => {
-		it("Insert new column into empty list", () => {
-			const { treeView, Table } = createTableTree();
-			treeView.initialize(Table.empty());
-
-			treeView.root.insertColumn({
-				index: 0,
-				column: { id: "column-0", props: {} },
-			});
-
-			assertEqualTrees(treeView.root, {
-				columns: [
-					{
-						id: "column-0",
-						props: {},
-					},
-				],
-				rows: [],
-			});
-		});
-
-		it("Insert new column into non-empty list", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
-				rows: [],
-				columns: [
-					{ id: "column-a", props: {} },
-					{ id: "column-b", props: {} },
-				],
-			});
-
-			treeView.root.insertColumn({
-				index: 1,
-				column: { id: "column-c", props: {} },
-			});
-
-			assertEqualTrees(treeView.root, {
-				columns: [
-					{
-						id: "column-a",
-						props: {},
-					},
-					{
-						id: "column-c",
-						props: {},
-					},
-					{
-						id: "column-b",
-						props: {},
-					},
-				],
-				rows: [],
-			});
-		});
-
-		it("Append new column", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
-				rows: [],
-				columns: [
-					{ id: "column-a", props: {} },
-					{ id: "column-b", props: {} },
-				],
-			});
-
-			// By not specifying an index, the column should be appended to the end of the list.
-			treeView.root.insertColumn({
-				column: { id: "column-c", props: {} },
-			});
-
-			assertEqualTrees(treeView.root, {
-				columns: [
-					{
-						id: "column-a",
-						props: {},
-					},
-					{
-						id: "column-b",
-						props: {},
-					},
-					{
-						id: "column-c",
-						props: {},
-					},
-				],
-				rows: [],
-			});
-		});
-
-		it("Inserting column at out-of-bounds index fails", () => {
-			const { treeView, Table } = createTableTree();
-			treeView.initialize(Table.empty());
-
-			assert.throws(
-				() =>
-					treeView.root.insertColumn({
-						index: 1,
-						column: { props: {} },
-					}),
-				validateUsageError(/The index specified for insertion is out of bounds./),
-			);
-		});
-	});
-
 	describe("insertColumns", () => {
 		it("Insert empty columns list", () => {
 			const { treeView, Table } = createTableTree();
@@ -641,147 +537,6 @@ describe("TableFactory unit tests", () => {
 				],
 				rows: [],
 			});
-		});
-	});
-
-	describe("insertRow", () => {
-		it("Insert new row into empty list", () => {
-			const { treeView, Table } = createTableTree();
-			treeView.initialize(Table.empty());
-
-			treeView.root.insertRow({
-				index: 0,
-				row: { id: "row-0", cells: {}, props: {} },
-			});
-
-			assertEqualTrees(treeView.root, {
-				columns: [],
-				rows: [
-					{
-						id: "row-0",
-						cells: {},
-						props: {},
-					},
-				],
-			});
-		});
-
-		it("Insert new row into non-empty list", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
-				columns: [],
-				rows: [
-					{ id: "row-a", cells: {}, props: {} },
-					{ id: "row-b", cells: {}, props: {} },
-				],
-			});
-
-			treeView.root.insertRow({
-				index: 1,
-				row: { id: "row-c", cells: {}, props: {} },
-			});
-
-			assertEqualTrees(treeView.root, {
-				columns: [],
-				rows: [
-					{
-						id: "row-a",
-						cells: {},
-						props: {},
-					},
-					{
-						id: "row-c",
-						cells: {},
-						props: {},
-					},
-					{
-						id: "row-b",
-						cells: {},
-						props: {},
-					},
-				],
-			});
-		});
-
-		it("Append new row", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
-				columns: [],
-				rows: [
-					{ id: "row-a", cells: {}, props: {} },
-					{ id: "row-b", cells: {}, props: {} },
-				],
-			});
-
-			// By not specifying an index, the column should be appended to the end of the list.
-			treeView.root.insertRow({
-				row: { id: "row-c", cells: {}, props: {} },
-			});
-
-			assertEqualTrees(treeView.root, {
-				columns: [],
-				rows: [
-					{
-						id: "row-a",
-						cells: {},
-						props: {},
-					},
-					{
-						id: "row-b",
-						cells: {},
-						props: {},
-					},
-					{
-						id: "row-c",
-						cells: {},
-						props: {},
-					},
-				],
-			});
-		});
-
-		it("Inserting row at out-of-bounds index fails", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
-				columns: [],
-				rows: [],
-			});
-
-			assert.throws(
-				() =>
-					treeView.root.insertRow({
-						index: 1,
-						row: { cells: {}, props: {} },
-					}),
-				validateUsageError(/The index specified for insertion is out of bounds./),
-			);
-		});
-
-		it("Inserting a row with cells that have no matching column fails", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
-				rows: [],
-				columns: [{ id: "column-a", props: {} }],
-			});
-
-			assert.throws(
-				() =>
-					treeView.root.insertRow({
-						row: {
-							id: "row-a",
-							cells: {
-								"column-a": { value: "Hello" },
-								"column-b": { value: "world!" },
-							},
-						},
-					}),
-				validateUsageError(
-					/Attempted to insert row a cell under column ID "column-b", but the table does not contain a column with that ID./,
-				),
-			);
-
-			// Ensure the row was not inserted
-			assert(treeView.root.rows.length === 0);
 		});
 	});
 
@@ -1042,9 +797,95 @@ describe("TableFactory unit tests", () => {
 		});
 	});
 
-	describe("removeColumn", () => {
-		it("Remove column by ID", () => {
-			const { treeView } = createTableTree();
+	describe("removeColumns", () => {
+		it("Remove empty list", () => {
+			const { treeView, Column, Row } = createTableTree();
+			treeView.initialize({
+				columns: [
+					new Column({
+						id: "column-0",
+						props: {},
+					}),
+				],
+				rows: [
+					new Row({
+						id: "row-0",
+						cells: {
+							"column-0": { value: "Hello world!" },
+						},
+						props: {},
+					}),
+				],
+			});
+
+			treeView.root.removeColumns([]);
+			assertEqualTrees(treeView.root, {
+				columns: [{ id: "column-0", props: {} }],
+				rows: [
+					{
+						id: "row-0",
+						cells: {
+							"column-0": { value: "Hello world!" },
+						},
+						props: {},
+					},
+				],
+			});
+		});
+
+		it("Remove single column", () => {
+			const { treeView, Column, Row } = createTableTree();
+			const column0 = new Column({ id: "column-0", props: {} });
+			const column1 = new Column({ id: "column-1", props: {} });
+			treeView.initialize({
+				columns: [column0, column1],
+				rows: [
+					new Row({
+						id: "row-0",
+						cells: {
+							"column-0": { value: "Hello world!" },
+						},
+						props: {},
+					}),
+				],
+			});
+
+			// Remove column0 (by node)
+			treeView.root.removeColumns([column0]);
+			assertEqualTrees(treeView.root, {
+				columns: [{ id: "column-1", props: {} }],
+				rows: [
+					{
+						id: "row-0",
+						cells: {
+							"column-0": { value: "Hello world!" },
+						},
+						props: {},
+					},
+				],
+			});
+
+			// Remove column1 (by ID)
+			treeView.root.removeColumns(["column-1"]);
+			assertEqualTrees(treeView.root, {
+				columns: [],
+				rows: [
+					{
+						id: "row-0",
+						cells: {},
+						props: {},
+					},
+				],
+			});
+		});
+
+		// TODO: update case to have some cells populated to verify cell deletion behavior
+		it("Remove multiple columns", () => {
+			const { treeView, Column } = createTableTree();
+			const column0 = new Column({ id: "column-0", props: {} });
+			const column1 = new Column({ id: "column-1", props: {} });
+			const column2 = new Column({ id: "column-2", props: {} });
+			const column3 = new Column({ id: "column-3", props: {} });
 			treeView.initialize({
 				columns: [
 					{
@@ -1063,61 +904,27 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 
-			const removed = treeView.root.removeColumn("column-0");
-			assertEqualTrees(removed, {
-				id: "column-0",
-				props: { label: "Column 0" },
-			});
-			assertEqualTrees(treeView.root, {
-				columns: [],
-				rows: [
-					{
-						id: "row-0",
-						cells: {},
-						props: {},
-					},
-				],
-			});
-		});
+			const table = treeView.root;
 
-		it("Remove column by node", () => {
-			const { treeView } = createTableTree();
-			treeView.initialize({
+			// Remove columns 1 and 3 (by node)
+			table.removeColumns([column1, column3]);
+			assertEqualTrees(table, {
 				columns: [
-					{
-						id: "column-0",
-						props: { label: "Column 0" },
-					},
+					{ id: "column-0", props: {} },
+					{ id: "column-2", props: {} },
 				],
-				rows: [
-					{
-						id: "row-0",
-						cells: {
-							"column-0": { value: "Hello world!" },
-						},
-						props: {},
-					},
-				],
+				rows: [],
 			});
 
-			const removed = treeView.root.removeColumn(treeView.root.columns[0]);
-			assertEqualTrees(removed, {
-				id: "column-0",
-				props: { label: "Column 0" },
-			});
-			assertEqualTrees(treeView.root, {
+			// Remove columns 2 and 0 (by ID)
+			treeView.root.removeColumns([column2.id, column0.id]);
+			assertEqualTrees(table, {
 				columns: [],
-				rows: [
-					{
-						id: "row-0",
-						cells: {},
-						props: {},
-					},
-				],
+				rows: [],
 			});
 		});
 
-		it("Removing a column that does not exist in the table errors", () => {
+		it("Removing a single column that doesn't exist on table errors", () => {
 			const { treeView, Column } = createTableTree();
 			treeView.initialize({
 				columns: [],
@@ -1125,26 +932,42 @@ describe("TableFactory unit tests", () => {
 			});
 
 			assert.throws(
-				() => treeView.root.removeColumn(new Column({ id: "unhydrated-column", props: {} })),
-				validateUsageError(
-					/Specified column with ID "unhydrated-column" does not exist in the table./,
-				),
+				() => treeView.root.removeColumns([new Column({ id: "column-0", props: {} })]),
+				validateUsageError(/Specified column with ID "column-0" does not exist in the table./),
 			);
+		});
+
+		it("Removing multiple columns errors if at least one column doesn't exist", () => {
+			const { treeView, Column } = createTableTree();
+			const column0 = new Column({ id: "column-0", props: {} });
+			treeView.initialize({
+				columns: [column0],
+				rows: [],
+			});
+
+			assert.throws(
+				() =>
+					treeView.root.removeColumns([column0, new Column({ id: "column-1", props: {} })]),
+				validateUsageError(/Specified column with ID "column-1" does not exist in the table./),
+			);
+
+			// Additionally, `column-0` should not have been removed.
+			assert(treeView.root.columns.length === 1);
 		});
 	});
 
 	describe("removeRows", () => {
 		it("Remove empty list", () => {
-			const { treeView } = createTableTree();
+			const { treeView, Row } = createTableTree();
 			treeView.initialize({
 				columns: [],
-				rows: [],
+				rows: [new Row({ id: "row-0", cells: {}, props: {} })],
 			});
 
-			treeView.root.removeAllRows();
+			treeView.root.removeRows([]);
 			assertEqualTrees(treeView.root, {
 				columns: [],
-				rows: [],
+				rows: [{ id: "row-0", cells: {}, props: {} }],
 			});
 		});
 
@@ -1157,15 +980,15 @@ describe("TableFactory unit tests", () => {
 				rows: [row0, row1],
 			});
 
-			// Remove row0
+			// Remove row0 (by node)
 			treeView.root.removeRows([row0]);
 			assertEqualTrees(treeView.root, {
 				columns: [],
 				rows: [{ id: "row-1", cells: {}, props: {} }],
 			});
 
-			// Remove row1
-			treeView.root.removeRows([row1]);
+			// Remove row1 (by ID)
+			treeView.root.removeRows(["row-1"]);
 			assertEqualTrees(treeView.root, {
 				columns: [],
 				rows: [],
@@ -1183,7 +1006,7 @@ describe("TableFactory unit tests", () => {
 				rows: [row0, row1, row2, row3],
 			});
 
-			// Remove rows 1 and 3
+			// Remove rows 1 and 3 (by node)
 			treeView.root.removeRows([row1, row3]);
 			assertEqualTrees(treeView.root, {
 				columns: [],
@@ -1201,8 +1024,8 @@ describe("TableFactory unit tests", () => {
 				],
 			});
 
-			// Remove rows 0 and 3
-			treeView.root.removeRows([row0, row2]);
+			// Remove rows 2 and 0 (by ID)
+			treeView.root.removeRows([row2.id, row0.id]);
 			assertEqualTrees(treeView.root, {
 				columns: [],
 				rows: [],
@@ -1380,14 +1203,14 @@ describe("TableFactory unit tests", () => {
 			});
 
 			// Add a row
-			treeView.root.insertRow({
-				row: new Row({ id: "row-0", cells: {}, props: {} }),
+			treeView.root.insertRows({
+				rows: [new Row({ id: "row-0", cells: {}, props: {} })],
 			});
 			assert.equal(eventCount, 1);
 
 			// Add a column
-			treeView.root.insertColumn({
-				column: { id: "column-0", props: {} },
+			treeView.root.insertColumns({
+				columns: [{ id: "column-0", props: {} }],
 			});
 			assert.equal(eventCount, 2);
 
@@ -1442,7 +1265,7 @@ describe("TableFactory unit tests", () => {
 			assert.equal(eventCount, 1); // Event should not have fired for column node changes
 
 			// Insert a row
-			table.insertRow({ row: { id: "row-0", cells: {}, props: {} } });
+			table.insertRows({ rows: [{ id: "row-0", cells: {}, props: {} }] });
 			assert.equal(eventCount, 1); // Event should not have fired for row insertion
 
 			// Re-order columns
@@ -1450,7 +1273,7 @@ describe("TableFactory unit tests", () => {
 			assert.equal(eventCount, 2);
 
 			// Remove column
-			table.removeColumn("column-0");
+			table.removeColumns(["column-0"]);
 			assert.equal(eventCount, 3);
 		});
 	});

--- a/packages/dds/tree/src/test/tableSchema.spec.ts
+++ b/packages/dds/tree/src/test/tableSchema.spec.ts
@@ -857,9 +857,7 @@ describe("TableFactory unit tests", () => {
 				rows: [
 					{
 						id: "row-0",
-						cells: {
-							"column-0": { value: "Hello world!" },
-						},
+						cells: {},
 						props: {},
 					},
 				],
@@ -879,28 +877,22 @@ describe("TableFactory unit tests", () => {
 			});
 		});
 
-		// TODO: update case to have some cells populated to verify cell deletion behavior
 		it("Remove multiple columns", () => {
-			const { treeView, Column } = createTableTree();
+			const { treeView, Column, Row } = createTableTree();
 			const column0 = new Column({ id: "column-0", props: {} });
 			const column1 = new Column({ id: "column-1", props: {} });
 			const column2 = new Column({ id: "column-2", props: {} });
 			const column3 = new Column({ id: "column-3", props: {} });
 			treeView.initialize({
-				columns: [
-					{
-						id: "column-0",
-						props: { label: "Column 0" },
-					},
-				],
+				columns: [column0, column1, column2, column3],
 				rows: [
-					{
+					new Row({
 						id: "row-0",
 						cells: {
 							"column-0": { value: "Hello world!" },
 						},
 						props: {},
-					},
+					}),
 				],
 			});
 
@@ -913,14 +905,28 @@ describe("TableFactory unit tests", () => {
 					{ id: "column-0", props: {} },
 					{ id: "column-2", props: {} },
 				],
-				rows: [],
+				rows: [
+					{
+						id: "row-0",
+						cells: {
+							"column-0": { value: "Hello world!" },
+						},
+						props: {},
+					},
+				],
 			});
 
 			// Remove columns 2 and 0 (by ID)
 			treeView.root.removeColumns([column2.id, column0.id]);
 			assertEqualTrees(table, {
 				columns: [],
-				rows: [],
+				rows: [
+					{
+						id: "row-0",
+						cells: {},
+						props: {},
+					},
+				],
 			});
 		});
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1522,17 +1522,9 @@ export namespace TableSchema {
     export function column<const TScope extends string | undefined, const TCell extends ImplicitAllowedTypes, const TProps extends ImplicitAnnotatedFieldSchema>(params: System_TableSchema.CreateColumnOptionsBase<SchemaFactoryAlpha<TScope>, TCell> & {
         readonly props: TProps;
     }): System_TableSchema.ColumnSchemaBase<TScope, TCell, TProps>;
-    export interface InsertColumnParameters<TColumn extends ImplicitAllowedTypes> {
-        readonly column: InsertableTreeNodeFromImplicitAllowedTypes<TColumn>;
-        readonly index?: number | undefined;
-    }
     export interface InsertColumnsParameters<TColumn extends ImplicitAllowedTypes> {
         readonly columns: InsertableTreeNodeFromImplicitAllowedTypes<TColumn>[];
         readonly index?: number | undefined;
-    }
-    export interface InsertRowParameters<TRow extends ImplicitAllowedTypes> {
-        readonly index?: number | undefined;
-        readonly row: InsertableTreeNodeFromImplicitAllowedTypes<TRow>;
     }
     export interface InsertRowsParameters<TRow extends ImplicitAllowedTypes> {
         readonly index?: number | undefined;
@@ -1568,9 +1560,7 @@ export namespace TableSchema {
         getCell(key: CellKey<TColumn, TRow>): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
         getColumn(id: string): TreeNodeFromImplicitAllowedTypes<TColumn> | undefined;
         getRow(id: string): TreeNodeFromImplicitAllowedTypes<TRow> | undefined;
-        insertColumn(params: InsertColumnParameters<TColumn>): TreeNodeFromImplicitAllowedTypes<TColumn>;
         insertColumns(params: InsertColumnsParameters<TColumn>): TreeNodeFromImplicitAllowedTypes<TColumn>[];
-        insertRow(params: InsertRowParameters<TRow>): TreeNodeFromImplicitAllowedTypes<TRow>;
         insertRows(params: InsertRowsParameters<TRow>): TreeNodeFromImplicitAllowedTypes<TRow>[];
         removeAllColumns(): TreeNodeFromImplicitAllowedTypes<TColumn>[];
         removeAllRows(): TreeNodeFromImplicitAllowedTypes<TRow>[];

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1575,10 +1575,8 @@ export namespace TableSchema {
         removeAllColumns(): TreeNodeFromImplicitAllowedTypes<TColumn>[];
         removeAllRows(): TreeNodeFromImplicitAllowedTypes<TRow>[];
         removeCell(key: CellKey<TColumn, TRow>): TreeNodeFromImplicitAllowedTypes<TCell> | undefined;
-        removeColumn(column: string | TreeNodeFromImplicitAllowedTypes<TColumn>): TreeNodeFromImplicitAllowedTypes<TColumn>;
         removeColumns(columns: readonly TreeNodeFromImplicitAllowedTypes<TColumn>[]): TreeNodeFromImplicitAllowedTypes<TColumn>[];
         removeColumns(columns: readonly string[]): TreeNodeFromImplicitAllowedTypes<TColumn>[];
-        removeRow(row: string | TreeNodeFromImplicitAllowedTypes<TRow>): TreeNodeFromImplicitAllowedTypes<TRow>;
         removeRows(rows: readonly TreeNodeFromImplicitAllowedTypes<TRow>[]): TreeNodeFromImplicitAllowedTypes<TRow>[];
         removeRows(rows: readonly string[]): TreeNodeFromImplicitAllowedTypes<TRow>[];
         readonly rows: TreeArrayNode<TRow>;


### PR DESCRIPTION
There is a significant performance benefit to inserting / removing rows / columns in batches.
To help encourage more performant usage patterns, single-node insertion and removal APIs.
The APIs that operate on batches should be used instead.

Specifically:

- `insertColumn`
	- Use `insertColumns` instead
- `insertRow`
	- Use `insertRows` instead
- `removeColumn`
	- Use `removeColumns` instead
- `removeRow`
	- Use `removeRows` instead