### PR TITLE
Shared Array rollback for insert and delete remote ops

### DIFF
--- a/packages/dds/legacy-dds/src/array/sharedArray.ts
+++ b/packages/dds/legacy-dds/src/array/sharedArray.ts
@@ -429,7 +429,7 @@ export class SharedArrayClass<T extends SerializableTypeForSharedArray>
 			case OperationType.moveEntry:
 			case OperationType.toggle:
 			case OperationType.toggleMove: {
-				break;
+				throw new Error(`Rollback not implemented for ${arrayOp.type} operations`);
 			}
 			default: {
 				unreachableCase(arrayOp);

--- a/packages/dds/legacy-dds/src/array/sharedArray.ts
+++ b/packages/dds/legacy-dds/src/array/sharedArray.ts
@@ -419,7 +419,10 @@ export class SharedArrayClass<T extends SerializableTypeForSharedArray>
 						value: liveEntry.value,
 					};
 					this.emitValueChangedEvent(insertOp, true /* isLocal */);
-					this.getEntryForId(arrayOp.entryId).isLocalPendingDelete -= 1;
+					const entry = this.getEntryForId(arrayOp.entryId);
+					if (entry !== undefined && entry.isLocalPendingDelete > 0) {
+						entry.isLocalPendingDelete -= 1;
+					}
 				}
 				break;
 			}

--- a/packages/dds/legacy-dds/src/test/array/array.rollback.spec.ts
+++ b/packages/dds/legacy-dds/src/test/array/array.rollback.spec.ts
@@ -81,8 +81,8 @@ describe("SharedArray rollback", () => {
 		assert.strictEqual(valueChanges.length, 2, "Should have two value change events");
 		assert.strictEqual(
 			valueChanges[1].op.type,
-			OperationType.toggle,
-			"Second event should be for toggle",
+			OperationType.deleteEntry,
+			"Second event should be for delete",
 		);
 	});
 
@@ -107,8 +107,8 @@ describe("SharedArray rollback", () => {
 		assert.strictEqual(valueChanges.length, 2, "Should have two value change events");
 		assert.strictEqual(
 			valueChanges[1].op.type,
-			OperationType.toggle,
-			"Second event should be for toggle",
+			OperationType.insertEntry,
+			"Second event should be for insert",
 		);
 	});
 

--- a/packages/dds/legacy-dds/src/test/array/array.rollback.spec.ts
+++ b/packages/dds/legacy-dds/src/test/array/array.rollback.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
 import { strict as assert } from "node:assert";
 
 import { AttachState } from "@fluidframework/container-definitions";

--- a/packages/dds/legacy-dds/src/test/array/array.rollback.spec.ts
+++ b/packages/dds/legacy-dds/src/test/array/array.rollback.spec.ts
@@ -1,0 +1,238 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { strict as assert } from "node:assert";
+
+import { AttachState } from "@fluidframework/container-definitions";
+import {
+	MockContainerRuntimeFactory,
+	MockFluidDataStoreRuntime,
+	MockStorage,
+	type MockContainerRuntime,
+} from "@fluidframework/test-runtime-utils/internal";
+
+// eslint-disable-next-line import/no-internal-modules
+import type { ISharedArray } from "../../array/interfaces.js";
+// eslint-disable-next-line import/no-internal-modules
+import { SharedArrayFactory } from "../../array/sharedArrayFactory.js";
+import { OperationType, type ISharedArrayOperation } from "../../index.js";
+interface RollbackTestSetup {
+	sharedArray: ISharedArray<number>;
+	dataStoreRuntime: MockFluidDataStoreRuntime;
+	containerRuntimeFactory: MockContainerRuntimeFactory;
+	containerRuntime: MockContainerRuntime;
+}
+const arrayFactory = new SharedArrayFactory<number>();
+
+function setupRollbackTest(): RollbackTestSetup {
+	const containerRuntimeFactory = new MockContainerRuntimeFactory({ flushMode: 1 }); // TurnBased
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId: "1" });
+	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+	const sharedArray = arrayFactory.create(dataStoreRuntime, "shared-array-1");
+	dataStoreRuntime.setAttachState(AttachState.Attached);
+	sharedArray.connect({
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
+		objectStorage: new MockStorage(),
+	});
+	return {
+		sharedArray,
+		dataStoreRuntime,
+		containerRuntimeFactory,
+		containerRuntime,
+	};
+}
+// Helper to create another client attached to the same containerRuntimeFactory
+function createAdditionalClient(
+	containerRuntimeFactory: MockContainerRuntimeFactory,
+	id: string = "client-2",
+): {
+	sharedArray: ISharedArray<number>;
+	dataStoreRuntime: MockFluidDataStoreRuntime;
+	containerRuntime: MockContainerRuntime;
+} {
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId: id });
+	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
+	const sharedArray = arrayFactory.create(dataStoreRuntime, `shared-array-${id}`);
+	dataStoreRuntime.setAttachState(AttachState.Attached);
+	sharedArray.connect({
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
+		objectStorage: new MockStorage(),
+	});
+	return { sharedArray, dataStoreRuntime, containerRuntime };
+}
+
+describe("SharedArray rollback", () => {
+	it("should rollback insert operation", () => {
+		const { sharedArray, containerRuntime } = setupRollbackTest();
+		const valueChanges: {
+			op: ISharedArrayOperation;
+			isLocal: boolean;
+			target: ISharedArray<number>;
+		}[] = [];
+		sharedArray.on("valueChanged", (op, isLocal, target) => {
+			valueChanges.push({ op, isLocal, target });
+		});
+		sharedArray.insert(0, 0);
+		assert.strictEqual(sharedArray.get()[0], 0, "Failed getting pending value");
+		assert.strictEqual(valueChanges.length, 1, "Should have one value change event");
+		containerRuntime.rollback?.();
+		assert.strictEqual(sharedArray.get()[0], undefined, "Value should be rolled back");
+		assert.strictEqual(valueChanges.length, 2, "Should have two value change events");
+		assert.strictEqual(
+			valueChanges[1].op.type,
+			OperationType.toggle,
+			"Second event should be for toggle",
+		);
+	});
+
+	it("should rollback delete operation", () => {
+		const { sharedArray, containerRuntimeFactory, containerRuntime } = setupRollbackTest();
+		sharedArray.insert(0, 0);
+		containerRuntime.flush();
+		containerRuntimeFactory.processAllMessages();
+		const valueChanges: {
+			op: ISharedArrayOperation;
+			isLocal: boolean;
+			target: ISharedArray<number>;
+		}[] = [];
+		sharedArray.on("valueChanged", (op, isLocal, target) => {
+			valueChanges.push({ op, isLocal, target });
+		});
+		sharedArray.delete(0);
+		assert.strictEqual(sharedArray.get().length, 0, "Pending value should reflect the delete");
+		assert.strictEqual(valueChanges.length, 1, "Should have one value change event");
+		containerRuntime.rollback?.();
+		assert.strictEqual(sharedArray.get()[0], 0, "Value should be restored by rollback");
+		assert.strictEqual(valueChanges.length, 2, "Should have two value change events");
+		assert.strictEqual(
+			valueChanges[1].op.type,
+			OperationType.toggle,
+			"Second event should be for toggle",
+		);
+	});
+
+	it("should rollback insert and delete operations", () => {
+		const { sharedArray, containerRuntimeFactory, containerRuntime } = setupRollbackTest();
+		const valueChanges: {
+			op: ISharedArrayOperation;
+			isLocal: boolean;
+			target: ISharedArray<number>;
+		}[] = [];
+		sharedArray.insert(0, 0);
+		sharedArray.insert(1, 1);
+		sharedArray.insert(2, 2);
+		sharedArray.delete(0); // [1,2]
+		containerRuntime.flush();
+		containerRuntimeFactory.processAllMessages();
+		sharedArray.on("valueChanged", (op, isLocal, target) => {
+			valueChanges.push({ op, isLocal, target });
+		});
+		sharedArray.insert(1, 5); // [1,5,2]
+		sharedArray.delete(0); // [5,2]
+		assert.deepStrictEqual(
+			sharedArray.get(),
+			[5, 2],
+			"Pending value should reflect the insert and delete",
+		);
+		assert.strictEqual(valueChanges.length, 2, "Should have two value change events");
+		containerRuntime.rollback?.();
+		assert.deepStrictEqual(sharedArray.get(), [1, 2], "Values should be rolled back");
+		assert.strictEqual(valueChanges.length, 4, "Should have four value change events");
+	});
+
+	it.skip("should rollback move operation", () => {
+		const { sharedArray, containerRuntimeFactory, containerRuntime } = setupRollbackTest();
+		sharedArray.insert(0, 0);
+		sharedArray.insert(1, 1);
+		sharedArray.insert(2, 2);
+		sharedArray.insert(3, 3);
+		containerRuntime.flush();
+		containerRuntimeFactory.processAllMessages();
+		const valueChanges: {
+			op: ISharedArrayOperation;
+			isLocal: boolean;
+			target: ISharedArray<number>;
+		}[] = [];
+		sharedArray.on("valueChanged", (op, isLocal, target) => {
+			valueChanges.push({ op, isLocal, target });
+		});
+		sharedArray.move(1, 3);
+		assert.deepStrictEqual(
+			sharedArray.get(),
+			[0, 2, 1, 3],
+			"Pending value should reflect the move",
+		);
+		assert.strictEqual(valueChanges.length, 1, "Should have one value change event");
+		containerRuntime.rollback?.();
+		assert.deepStrictEqual(
+			sharedArray.get(),
+			[0, 1, 2, 3],
+			"Value should be restored by rollback",
+		);
+		assert.strictEqual(valueChanges.length, 2, "Should have two value change events");
+		assert.strictEqual(
+			valueChanges[1].op.type,
+			OperationType.toggleMove,
+			"Second event should be for toggleMove",
+		);
+	});
+
+	it.skip("should rollback toggle operation", () => {
+		const { sharedArray, containerRuntimeFactory, containerRuntime } = setupRollbackTest();
+		sharedArray.insert(0, 0);
+		sharedArray.insert(1, 1);
+		containerRuntime.flush();
+		containerRuntimeFactory.processAllMessages();
+		const valueChanges: {
+			op: ISharedArrayOperation;
+			isLocal: boolean;
+			target: ISharedArray<number>;
+		}[] = [];
+		sharedArray.on("valueChanged", (op, isLocal, target) => {
+			valueChanges.push({ op, isLocal, target });
+		});
+		sharedArray.insert(2, 2);
+		containerRuntime.flush();
+		containerRuntimeFactory.processAllMessages();
+		assert.strictEqual(sharedArray.get()[2], 2, "Failed getting pending value");
+		sharedArray.toggle(valueChanges[0].op.entryId);
+		assert.strictEqual(sharedArray.get()[2], undefined, "Value should be toggled");
+		assert.strictEqual(valueChanges.length, 2, "Should have two value change events");
+		containerRuntime.rollback?.();
+		assert.strictEqual(sharedArray.get()[2], 2, "Value should be restored by rollback");
+		assert.strictEqual(valueChanges.length, 3, "Should have three value change events");
+	});
+
+	it("should rollback local changes in presence of remote changes from another client", () => {
+		const { sharedArray, containerRuntimeFactory, containerRuntime } = setupRollbackTest();
+		// Create a second client
+		const { sharedArray: sharedArray2, containerRuntime: containerRuntime2 } =
+			createAdditionalClient(containerRuntimeFactory);
+		sharedArray.insert(0, 0);
+		sharedArray.insert(1, 1);
+		containerRuntime.flush();
+		containerRuntimeFactory.processAllMessages();
+		sharedArray.insert(2, 2);
+		sharedArray.delete(0);
+		sharedArray2.insert(2, 3); // [0,1,3]
+		sharedArray2.delete(0); // [1,3]
+		sharedArray2.insert(1, 12); // [1,12,3]
+		sharedArray2.insert(0, 10); // [10,1,12,3]
+		containerRuntime2.flush();
+		containerRuntimeFactory.processAllMessages();
+		let curArray = sharedArray.get();
+		assert.deepStrictEqual(
+			curArray,
+			[10, 1, 2, 12, 3],
+			"Array should have expected entries pre-rollback",
+		);
+		containerRuntime.rollback?.();
+		curArray = sharedArray.get();
+		assert.deepStrictEqual(
+			curArray,
+			[10, 1, 12, 3],
+			"Array should have expected entries post-rollback",
+		);
+	});
+});

--- a/packages/dds/legacy-dds/src/test/array/arrayFuzzTests.spec.ts
+++ b/packages/dds/legacy-dds/src/test/array/arrayFuzzTests.spec.ts
@@ -47,7 +47,7 @@ describe("SharedArray fuzz", () => {
 						insert: 5,
 						delete: 3,
 						move: 0,
-						insertBulkAfter: 0,
+						insertBulkAfter: 1,
 						toggle: 0,
 						toggleMove: 0,
 					}),

--- a/packages/dds/legacy-dds/src/test/array/arrayFuzzTests.spec.ts
+++ b/packages/dds/legacy-dds/src/test/array/arrayFuzzTests.spec.ts
@@ -67,7 +67,7 @@ describe("SharedArray fuzz", () => {
 			},
 			rollbackProbability: 0.2,
 			defaultTestCount: 50,
-			saveFailures: { directory: "." },
+			saveFailures: { directory: path.join(_dirname, "../../src/test/results") },
 			emitter: eventEmitterForFuzzHarness,
 		},
 	);

--- a/packages/dds/legacy-dds/src/test/array/arrayFuzzTests.spec.ts
+++ b/packages/dds/legacy-dds/src/test/array/arrayFuzzTests.spec.ts
@@ -5,11 +5,16 @@
 
 import * as path from "node:path";
 
+import { takeAsync } from "@fluid-private/stochastic-test-utils";
 import { createDDSFuzzSuite } from "@fluid-private/test-dds-utils";
 import { describe } from "mocha";
 
 import { _dirname } from "./dirname.cjs";
-import { baseSharedArrayModel, eventEmitterForFuzzHarness } from "./fuzzUtils.js";
+import {
+	baseSharedArrayModel,
+	eventEmitterForFuzzHarness,
+	makeSharedArrayOperationGenerator,
+} from "./fuzzUtils.js";
 
 describe("SharedArray fuzz", () => {
 	createDDSFuzzSuite(baseSharedArrayModel, {
@@ -30,4 +35,40 @@ describe("SharedArray fuzz", () => {
 		skip: [9, 15],
 		emitter: eventEmitterForFuzzHarness,
 	});
+
+	createDDSFuzzSuite(
+		{
+			...baseSharedArrayModel,
+			workloadName: "insert and delete rollback",
+			generatorFactory: () =>
+				takeAsync(
+					100,
+					makeSharedArrayOperationGenerator({
+						insert: 5,
+						delete: 3,
+						move: 0,
+						insertBulkAfter: 0,
+						toggle: 0,
+						toggleMove: 0,
+					}),
+				),
+		},
+		{
+			validationStrategy: { type: "fixedInterval", interval: 10 },
+			reconnectProbability: 0.15,
+			numberOfClients: 3,
+			clientJoinOptions: {
+				maxNumberOfClients: 5,
+				clientAddProbability: 0.1,
+			},
+			detachedStartOptions: {
+				numOpsBeforeAttach: 5,
+				rehydrateDisabled: true,
+			},
+			rollbackProbability: 0.2,
+			defaultTestCount: 50,
+			saveFailures: { directory: "." },
+			emitter: eventEmitterForFuzzHarness,
+		},
+	);
 });


### PR DESCRIPTION
Adding rollback method for basic Shared Array operations `insert` and `delete`. 
Enabling unit and fuzz tests to exercise rollback.
Logic behind this rollback operations is quite simple:
- rollback insert: delete the operation. Given that each operation has a unique `entryId` which is generated at insert time, rollback is as simple as deleting based on this `entryId`, which consist of setting its internal `isDeleted` property to `true`. Other internal properties are untouched since we don't generate an op at rollback time.
- rollback delete: insert the operation. Insert in this case would consist simply of setting `isDelete` property to false. Given that other clients could remove the same entryId we avoid resuscitating the entry in case it was deleted by someone else, which we use `remoteDeleteWithLocalPendingDelete` to do that.

`move`, `toggle` and `toggleMove` rollback operations should follow once other bugs related to these operations are solved.