### PR TITLE
Fix webpack-fluid-loader's incremental build

### DIFF
--- a/examples/utils/webpack-fluid-loader/package.json
+++ b/examples/utils/webpack-fluid-loader/package.json
@@ -137,14 +137,13 @@
 		"webpack-cli": "^5.1.4"
 	},
 	"fluidBuild": {
+		"_tasksComment1": "webpack-fluid-loader injects a script tag pointing at its own bundle (/code/fluid-loader.bundle.js) into the page. This bundle must remain up to date for webpack-fluid-loader users.",
+		"_tasksComment2": "Using build:esnext over something like compile guarantees that this happens, since the build:esnext target depends on all transitive dependencies' build:esnext targets.",
 		"tasks": {
-			"compile": {
-				"dependsOn": [
-					"...",
-					"webpack"
-				],
-				"script": false
-			}
+			"build:esnext": [
+				"...",
+				"webpack"
+			]
 		}
 	},
 	"typeValidation": {


### PR DESCRIPTION
## Description

Our incremental build failed to pick up changes to webpack-fluid-loader when a build was run from an example using webpack-fluid-loader. Example:

1. Build repo, run inventory-app
2. Make a change to `examples\utils\webpack-fluid-loader\src\loader.ts`
3. Run `npm run build` from the inventory app
4. Run `npm run start` from the inventory app

This flow should let you see the change you made to `loader.ts`, but it did not. This is because webpack-fluid-loader injects a script tag referencing a code bundle it produces via its webpack script, but the `npm run build` in step 3 would not rerun that bundle step due to no apparent dependency in our fluid-build config.

This change adjusts webpack-fluid-loader's fluid-build config to reasonably declare this dependency.
