### PR TITLE
refactor(packages/common): Update client packages to use `@legacy @beta` instead of `@legacy @alpha`

### DIFF
--- a/packages/common/client-utils/api-report/client-utils.beta.api.md
+++ b/packages/common/client-utils/api-report/client-utils.beta.api.md
@@ -6,6 +6,31 @@
 
 export { EventEmitter }
 
+// @beta @legacy
+export type EventEmitterEventType = string;
+
+// @beta @legacy
+export class TypedEventEmitter<TEvent> extends EventEmitter implements IEventProvider<TEvent & IEvent> {
+    constructor();
+    // (undocumented)
+    readonly addListener: TypedEventTransform<this, TEvent>;
+    // (undocumented)
+    readonly off: TypedEventTransform<this, TEvent>;
+    // (undocumented)
+    readonly on: TypedEventTransform<this, TEvent>;
+    // (undocumented)
+    readonly once: TypedEventTransform<this, TEvent>;
+    // (undocumented)
+    readonly prependListener: TypedEventTransform<this, TEvent>;
+    // (undocumented)
+    readonly prependOnceListener: TypedEventTransform<this, TEvent>;
+    // (undocumented)
+    readonly removeListener: TypedEventTransform<this, TEvent>;
+}
+
+// @beta @legacy (undocumented)
+export type TypedEventTransform<TThis, TEvent> = TransformedEvent<TThis, "newListener" | "removeListener", Parameters<(event: string, listener: (...args: any[]) => void) => void>> & IEventTransformer<TThis, TEvent & IEvent> & TransformedEvent<TThis, EventEmitterEventType, any[]>;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/common/client-utils/api-report/client-utils.legacy.alpha.api.md
+++ b/packages/common/client-utils/api-report/client-utils.legacy.alpha.api.md
@@ -6,10 +6,10 @@
 
 export { EventEmitter }
 
-// @alpha @legacy
+// @beta @legacy
 export type EventEmitterEventType = string;
 
-// @alpha @legacy
+// @beta @legacy
 export class TypedEventEmitter<TEvent> extends EventEmitter implements IEventProvider<TEvent & IEvent> {
     constructor();
     // (undocumented)
@@ -28,7 +28,7 @@ export class TypedEventEmitter<TEvent> extends EventEmitter implements IEventPro
     readonly removeListener: TypedEventTransform<this, TEvent>;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type TypedEventTransform<TThis, TEvent> = TransformedEvent<TThis, "newListener" | "removeListener", Parameters<(event: string, listener: (...args: any[]) => void) => void>> & IEventTransformer<TThis, TEvent & IEvent> & TransformedEvent<TThis, EventEmitterEventType, any[]>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/common/client-utils/src/typedEventEmitter.ts
+++ b/packages/common/client-utils/src/typedEventEmitter.ts
@@ -17,14 +17,12 @@ import { EventEmitter } from "./eventEmitter.cjs";
  * string | symbol vs. string | number
  *
  * The polyfill is now always used, but string is the only event type preferred.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type EventEmitterEventType = string;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type TypedEventTransform<TThis, TEvent> =
 	// Event emitter supports some special events for the emitter itself to use
@@ -46,8 +44,7 @@ export type TypedEventTransform<TThis, TEvent> =
  * Event Emitter helper class the supports emitting typed events.
  * @privateRemarks
  * This should become internal once the classes extending it become internal.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class TypedEventEmitter<TEvent>
 	extends EventEmitter

--- a/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
@@ -26,7 +26,7 @@ export namespace ConnectionState {
 // @public
 export type ConnectionState = ConnectionState.Disconnected | ConnectionState.EstablishingConnection | ConnectionState.CatchingUp | ConnectionState.Connected;
 
-// @alpha @legacy
+// @beta @legacy
 export const ContainerErrorTypes: {
     readonly clientSessionExpiredError: "clientSessionExpiredError";
     readonly genericError: "genericError";
@@ -36,10 +36,10 @@ export const ContainerErrorTypes: {
     readonly usageError: "usageError";
 };
 
-// @alpha @legacy
+// @beta @legacy
 export type ContainerErrorTypes = (typeof ContainerErrorTypes)[keyof typeof ContainerErrorTypes];
 
-// @alpha @legacy
+// @beta @legacy
 export interface ContainerWarning extends IErrorBase_2 {
     logged?: boolean;
 }
@@ -60,14 +60,14 @@ export interface IAudienceEvents extends IEvent {
     (event: "selfChanged", listener: (oldValue: ISelf | undefined, newValue: ISelf) => void): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IAudienceOwner extends IAudience {
     addMember(clientId: string, details: IClient): void;
     removeMember(clientId: string): boolean;
     setCurrentClientId(clientId: string): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IBatchMessage {
     // (undocumented)
     compression?: string;
@@ -79,12 +79,12 @@ export interface IBatchMessage {
     referenceSequenceNumber?: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComparer> {
     load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IConnectionDetails {
     checkpointSequenceNumber: number | undefined;
     // (undocumented)
@@ -94,7 +94,7 @@ export interface IConnectionDetails {
     serviceConfiguration: IClientConfiguration;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IContainer extends IEventProvider<IContainerEvents> {
     attach(request: IRequest, attachProps?: {
         deltaConnection?: "none" | "delayed";
@@ -124,7 +124,7 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
     serialize(): string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IContainerContext {
     readonly attachState: AttachState;
     // (undocumented)
@@ -176,7 +176,7 @@ export interface IContainerContext {
     updateDirtyContainerState(dirty: boolean): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IContainerEvents extends IEvent {
     (event: "readonly", listener: (readonly: boolean) => void): void;
     (event: "connected", listener: (clientId: string) => void): any;
@@ -193,7 +193,7 @@ export interface IContainerEvents extends IEvent {
     (event: "metadataUpdate", listener: (metadata: Record<string, string>) => void): any;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IContainerLoadMode {
     // (undocumented)
     deltaConnection?: "none" | "delayed" | undefined;
@@ -201,12 +201,12 @@ export interface IContainerLoadMode {
     opsBeforeReturn?: undefined | "cached" | "all";
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type IContainerPolicies = {
     maxClientLeaveWaitTime?: number;
 };
 
-// @alpha @legacy
+// @beta @legacy
 export interface IContainerStorageService {
     createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
     // @deprecated
@@ -228,7 +228,7 @@ export interface IContainerStorageService {
 // @public
 export type ICriticalContainerError = IErrorBase_2;
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>, IDeltaSender {
     readonly active: boolean;
     readonly clientDetails: IClientDetails;
@@ -247,7 +247,7 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
     readonly version: string;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface IDeltaManagerEvents extends IEvent {
     // @deprecated (undocumented)
     (event: "prepareSend", listener: (messageBuffer: any[]) => void): any;
@@ -263,7 +263,7 @@ export interface IDeltaManagerEvents extends IEvent {
     }) => void): any;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface IDeltaQueue<T> extends IEventProvider<IDeltaQueueEvents<T>>, IDisposable {
     idle: boolean;
     length: number;
@@ -278,21 +278,21 @@ export interface IDeltaQueue<T> extends IEventProvider<IDeltaQueueEvents<T>>, ID
     }>;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface IDeltaQueueEvents<T> extends IErrorEvent {
     (event: "push", listener: (task: T) => void): any;
     (event: "op", listener: (task: T) => void): any;
     (event: "idle", listener: (count: number, duration: number) => void): any;
 }
 
-// @alpha @sealed @legacy
+// @beta @sealed @legacy
 export interface IDeltaSender {
     flush(): void;
 }
 
 export { IErrorBase }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidBrowserPackage extends IFluidPackage {
     fluid: {
         browser: IFluidBrowserPackageEnvironment;
@@ -300,7 +300,7 @@ export interface IFluidBrowserPackage extends IFluidPackage {
     };
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidBrowserPackageEnvironment extends IFluidPackageEnvironment {
     umd: {
         files: string[];
@@ -308,40 +308,40 @@ export interface IFluidBrowserPackageEnvironment extends IFluidPackageEnvironmen
     };
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidCodeDetails {
     readonly config?: IFluidCodeDetailsConfig;
     readonly package: string | Readonly<IFluidPackage>;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export const IFluidCodeDetailsComparer: keyof IProvideFluidCodeDetailsComparer;
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidCodeDetailsComparer extends IProvideFluidCodeDetailsComparer {
     compare(a: IFluidCodeDetails, b: IFluidCodeDetails): Promise<number | undefined>;
     satisfies(candidate: IFluidCodeDetails, constraint: IFluidCodeDetails): Promise<boolean>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidCodeDetailsConfig {
     // (undocumented)
     readonly [key: string]: string;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IFluidModule {
     // (undocumented)
     fluidExport: FluidObject<IRuntimeFactory & IProvideFluidCodeDetailsComparer>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidModuleWithDetails {
     details: IFluidCodeDetails;
     module: IFluidModule;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidPackage {
     [key: string]: unknown;
     fluid: {
@@ -350,7 +350,7 @@ export interface IFluidPackage {
     name: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidPackageEnvironment {
     [target: string]: undefined | {
         files: string[];
@@ -358,7 +358,7 @@ export interface IFluidPackageEnvironment {
     };
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IGetPendingLocalStateProps {
     readonly notifyImminentClosure: boolean;
     readonly sessionExpiryTimerStarted?: number;
@@ -366,7 +366,7 @@ export interface IGetPendingLocalStateProps {
     readonly stopBlobAttachingSignal?: AbortSignal;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IHostLoader extends ILoader {
     createDetachedContainer(codeDetails: IFluidCodeDetails, createDetachedProps?: {
         canReconnect?: boolean;
@@ -378,12 +378,12 @@ export interface IHostLoader extends ILoader {
     }): Promise<IContainer>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ILoader extends Partial<IProvideLoader> {
     resolve(request: IRequest, pendingLocalState?: string): Promise<IContainer>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type ILoaderOptions = {
     cache?: boolean;
     client?: IClient;
@@ -392,25 +392,25 @@ export type ILoaderOptions = {
     maxClientLeaveWaitTime?: number;
 };
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IProvideFluidCodeDetailsComparer {
     // (undocumented)
     readonly IFluidCodeDetailsComparer: IFluidCodeDetailsComparer;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IProvideLoader {
     // (undocumented)
     readonly ILoader: ILoader;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IProvideRuntimeFactory {
     // (undocumented)
     readonly IRuntimeFactory: IRuntimeFactory;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IRuntime extends IDisposable {
     createSummary(blobRedirectTable?: Map<string, string>): ISummaryTree;
     getEntryPoint(): Promise<FluidObject>;
@@ -422,10 +422,10 @@ export interface IRuntime extends IDisposable {
     setConnectionState(canSendOps: boolean, clientId?: string): any;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export const IRuntimeFactory: keyof IProvideRuntimeFactory;
 
-// @alpha @legacy
+// @beta @legacy
 export interface IRuntimeFactory extends IProvideRuntimeFactory {
     instantiateRuntime(context: IContainerContext, existing: boolean): Promise<IRuntime>;
 }
@@ -436,13 +436,13 @@ export interface ISelf {
     readonly clientId: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export const isFluidBrowserPackage: (maybePkg: unknown) => maybePkg is Readonly<IFluidBrowserPackage>;
 
-// @alpha @legacy
+// @beta @legacy
 export const isFluidPackage: (pkg: unknown) => pkg is Readonly<IFluidPackage>;
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
     // (undocumented)
     blobsContents?: {
@@ -456,7 +456,7 @@ export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
 
 export { IThrottlingWarning }
 
-// @alpha @legacy
+// @beta @legacy
 export enum LoaderHeader {
     // @deprecated (undocumented)
     cache = "fluid-cache",
@@ -469,7 +469,7 @@ export enum LoaderHeader {
     version = "version"
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type ReadOnlyInfo = {
     readonly readonly: false | undefined;
 } | {

--- a/packages/common/container-definitions/src/audience.ts
+++ b/packages/common/container-definitions/src/audience.ts
@@ -7,8 +7,7 @@ import type { IEvent, IEventProvider } from "@fluidframework/core-interfaces";
 import type { IClient } from "@fluidframework/driver-definitions";
 /**
  * Manages the state and the members for {@link IAudience}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IAudienceOwner extends IAudience {
 	/**

--- a/packages/common/container-definitions/src/browserPackage.ts
+++ b/packages/common/container-definitions/src/browserPackage.ts
@@ -8,8 +8,7 @@ import { isFluidPackage } from "./fluidPackage.js";
 
 /**
  * A specific Fluid package environment for browsers
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidBrowserPackageEnvironment extends IFluidPackageEnvironment {
 	/**
@@ -33,8 +32,7 @@ export interface IFluidBrowserPackageEnvironment extends IFluidPackageEnvironmen
 
 /**
  * A Fluid package for specification for browser environments
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidBrowserPackage extends IFluidPackage {
 	/**
@@ -55,8 +53,7 @@ export interface IFluidBrowserPackage extends IFluidPackage {
 /**
  * Determines if any object is an IFluidBrowserPackage
  * @param maybePkg - The object to check for compatibility with IFluidBrowserPackage
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const isFluidBrowserPackage = (
 	maybePkg: unknown,

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -22,8 +22,7 @@ import type {
 
 /**
  * Contract representing the result of a newly established connection to the server for syncing deltas.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IConnectionDetails {
 	/**
@@ -52,8 +51,7 @@ export interface IConnectionDetails {
 /**
  * Contract supporting delivery of outbound messages to the server
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDeltaSender {
 	/**
@@ -65,8 +63,7 @@ export interface IDeltaSender {
 /**
  * Events emitted by {@link IDeltaManager}.
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDeltaManagerEvents extends IEvent {
 	/**
@@ -150,8 +147,7 @@ export interface IDeltaManagerEvents extends IEvent {
 /**
  * Manages the transmission of ops between the runtime and storage.
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDeltaManager<T, U>
 	extends IEventProvider<IDeltaManagerEvents>,
@@ -257,8 +253,7 @@ export function isIDeltaManagerFull(
 /**
  * Events emitted by {@link IDeltaQueue}.
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDeltaQueueEvents<T> extends IErrorEvent {
 	/**
@@ -302,8 +297,7 @@ export interface IDeltaQueueEvents<T> extends IErrorEvent {
 /**
  * Queue of ops to be sent to or processed from storage
  * @sealed
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDeltaQueue<T> extends IEventProvider<IDeltaQueueEvents<T>>, IDisposable {
 	/**
@@ -352,8 +346,7 @@ export interface IDeltaQueue<T> extends IEventProvider<IDeltaQueueEvents<T>>, ID
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type ReadOnlyInfo =
 	| {

--- a/packages/common/container-definitions/src/error.ts
+++ b/packages/common/container-definitions/src/error.ts
@@ -8,8 +8,7 @@ import { FluidErrorTypes } from "@fluidframework/core-interfaces/internal";
 
 /**
  * Different error types the ClientSession may report out to the Host.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const ContainerErrorTypes = {
 	...FluidErrorTypes,
@@ -22,16 +21,14 @@ export const ContainerErrorTypes = {
 
 /**
  * {@inheritDoc (ContainerErrorTypes:variable)}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type ContainerErrorTypes =
 	(typeof ContainerErrorTypes)[keyof typeof ContainerErrorTypes];
 
 /**
  * Represents warnings raised on container.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ContainerWarning extends IErrorBase {
 	/**

--- a/packages/common/container-definitions/src/fluidModule.ts
+++ b/packages/common/container-definitions/src/fluidModule.ts
@@ -9,8 +9,7 @@ import type { IProvideFluidCodeDetailsComparer } from "./fluidPackage.js";
 import type { IRuntimeFactory } from "./runtime.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidModule {
 	fluidExport: FluidObject<IRuntimeFactory & IProvideFluidCodeDetailsComparer>;

--- a/packages/common/container-definitions/src/fluidPackage.ts
+++ b/packages/common/container-definitions/src/fluidPackage.ts
@@ -5,8 +5,7 @@
 
 /**
  * Specifies an environment on Fluid property of a IFluidPackage.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidPackageEnvironment {
 	/**
@@ -37,8 +36,7 @@ export interface IFluidPackageEnvironment {
  * While compatible with the npm package format it is not necessary that that package is an
  * npm package:
  * {@link https://stackoverflow.com/questions/10065564/add-custom-metadata-or-config-to-package-json-is-it-valid}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidPackage {
 	/**
@@ -66,8 +64,7 @@ export interface IFluidPackage {
 /**
  * Check if the package.json defines a Fluid package
  * @param pkg - the package json data to check if it is a Fluid package.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const isFluidPackage = (pkg: unknown): pkg is Readonly<IFluidPackage> =>
 	typeof pkg === "object" &&
@@ -76,8 +73,7 @@ export const isFluidPackage = (pkg: unknown): pkg is Readonly<IFluidPackage> =>
 
 /**
  * Package manager configuration. Provides a key value mapping of config values
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidCodeDetailsConfig {
 	readonly [key: string]: string;
@@ -85,8 +81,7 @@ export interface IFluidCodeDetailsConfig {
 
 /**
  * Data structure used to describe the code to load on the Fluid document
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidCodeDetails {
 	/**
@@ -121,15 +116,13 @@ export const isFluidCodeDetails = (
 };
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const IFluidCodeDetailsComparer: keyof IProvideFluidCodeDetailsComparer =
 	"IFluidCodeDetailsComparer";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IProvideFluidCodeDetailsComparer {
 	readonly IFluidCodeDetailsComparer: IFluidCodeDetailsComparer;
@@ -137,8 +130,7 @@ export interface IProvideFluidCodeDetailsComparer {
 
 /**
  * Provides capability to compare Fluid code details.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidCodeDetailsComparer extends IProvideFluidCodeDetailsComparer {
 	/**

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -35,8 +35,7 @@ import type { AttachState } from "./runtime.js";
 
 /**
  * Encapsulates a module entry point with corresponding code details.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidModuleWithDetails {
 	/**
@@ -56,8 +55,7 @@ export interface IFluidModuleWithDetails {
 /**
  * Fluid code loader resolves a code module matching the document schema, i.e. code details, such as
  * a package name and package version range.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComparer> {
 	/**
@@ -105,8 +103,7 @@ export interface IFluidCodeResolver {
 
 /**
  * Events emitted by the {@link IContainer} "upwards" to the Loader and Host.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IContainerEvents extends IEvent {
 	/**
@@ -333,8 +330,7 @@ export type ConnectionState =
 
 /**
  * The Host's view of a Container and its connection to storage
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IContainer extends IEventProvider<IContainerEvents> {
 	/**
@@ -545,8 +541,7 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 
 /**
  * The Runtime's view of the Loader, used for loading Containers
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ILoader extends Partial<IProvideLoader> {
 	/**
@@ -563,8 +558,7 @@ export interface ILoader extends Partial<IProvideLoader> {
 
 /**
  * The Host's view of the Loader, used for loading Containers
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IHostLoader extends ILoader {
 	/**
@@ -594,8 +588,7 @@ export interface IHostLoader extends ILoader {
 
 /**
  * Options to configure various behaviors of the ILoader.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ILoaderOptions = {
@@ -637,8 +630,7 @@ export type ILoaderOptions = {
 
 /**
  * Policies to have various behaviors during container create and load.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type IContainerPolicies = {
@@ -650,8 +642,7 @@ export type IContainerPolicies = {
 
 /**
  * Accepted header keys for requests coming to the Loader
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum LoaderHeader {
 	/**
@@ -683,8 +674,7 @@ export enum LoaderHeader {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IContainerLoadMode {
 	opsBeforeReturn?: /*
@@ -741,8 +731,7 @@ export interface ILoaderHeader {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IProvideLoader {
 	readonly ILoader: ILoader;
@@ -753,8 +742,7 @@ export interface IProvideLoader {
  * in separate property: {@link ISnapshotTreeWithBlobContents.blobsContents}.
  *
  * @remarks This is used as the `ContainerContext`'s base snapshot when attaching.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
 	blobsContents?: { [path: string]: ArrayBufferLike };

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -62,8 +62,7 @@ export enum AttachState {
  * The IRuntime represents an instantiation of a code package within a Container.
  * Primarily held by the ContainerContext to be able to interact with the running instance of the Container.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IRuntime extends IDisposable {
 	/**
@@ -124,8 +123,7 @@ export interface IRuntime extends IDisposable {
 
 /**
  * Payload type for IContainerContext.submitBatchFn()
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IBatchMessage {
 	contents?: string;
@@ -142,8 +140,7 @@ export interface IBatchMessage {
  * allows the Runtime to not support layer compatibility with the Driver layer. Instead, it supports compatibility
  * with the Loader layer which it already does.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IContainerStorageService {
 	/**
@@ -255,8 +252,7 @@ export interface IContainerStorageService {
  * TODO: once `@alpha` tag is removed, `unknown` should be removed from submitSignalFn.
  * See {@link https://dev.azure.com/fluidframework/internal/_workitems/edit/7462}
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IContainerContext {
 	/**
@@ -357,14 +353,12 @@ export interface IContainerContext {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const IRuntimeFactory: keyof IProvideRuntimeFactory = "IRuntimeFactory";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IProvideRuntimeFactory {
 	readonly IRuntimeFactory: IRuntimeFactory;
@@ -375,8 +369,7 @@ export interface IProvideRuntimeFactory {
  *
  * Provides the entry point for the ContainerContext to load the proper IRuntime
  * to start up the running instance of the Container.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IRuntimeFactory extends IProvideRuntimeFactory {
 	/**
@@ -391,8 +384,7 @@ export interface IRuntimeFactory extends IProvideRuntimeFactory {
 
 /**
  * Defines list of properties expected for getPendingLocalState
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IGetPendingLocalStateProps {
 	/**

--- a/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.legacy.alpha.api.md
@@ -16,7 +16,7 @@ export abstract class ErasedType<out Name = unknown> {
 // @public
 export type ExtendEventProvider<TBaseEvent extends IEvent, TBase extends IEventProvider<TBaseEvent>, TEvent extends TBaseEvent> = Omit<Omit<Omit<TBase, "on">, "once">, "off"> & IEventProvider<TBaseEvent> & IEventProvider<TEvent>;
 
-// @alpha @legacy
+// @beta @legacy
 export const FluidErrorTypes: {
     readonly genericError: "genericError";
     readonly throttlingError: "throttlingError";
@@ -25,7 +25,7 @@ export const FluidErrorTypes: {
     readonly usageError: "usageError";
 };
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type FluidErrorTypes = (typeof FluidErrorTypes)[keyof typeof FluidErrorTypes];
 
 // @public
@@ -249,10 +249,10 @@ export interface IFluidHandle<out T = unknown> {
     readonly isAttached: boolean;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export const IFluidHandleContext: keyof IProvideFluidHandleContext;
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidHandleContext extends IProvideFluidHandleContext {
     readonly absolutePath: string;
     attachGraph(): void;
@@ -266,18 +266,18 @@ export interface IFluidHandleContext extends IProvideFluidHandleContext {
 export interface IFluidHandleErased<T> extends ErasedType<readonly ["IFluidHandle", T]> {
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidHandleEvents {
     payloadShared: () => void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidHandleInternal<out T = unknown> extends IFluidHandle<T>, IProvideFluidHandle {
     readonly absolutePath: string;
     attachGraph(): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IFluidHandlePayloadPending<T> extends IFluidHandle<T> {
     readonly events: Listenable<IFluidHandleEvents>;
     readonly payloadState: PayloadState;
@@ -291,29 +291,29 @@ export interface IFluidLoadable extends IProvideFluidLoadable {
     readonly handle: IFluidHandle;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ILocalFluidHandle<T> extends IFluidHandlePayloadPending<T> {
     readonly events: Listenable<IFluidHandleEvents & ILocalFluidHandleEvents>;
     readonly payloadShareError: unknown;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ILocalFluidHandleEvents extends IFluidHandleEvents {
     payloadShareFailed: (error: unknown) => void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ILoggingError extends Error {
     getTelemetryProperties(): ITelemetryBaseProperties;
 }
 
-// @alpha @deprecated @legacy (undocumented)
+// @beta @deprecated @legacy (undocumented)
 export interface IProvideFluidHandle {
     // @deprecated (undocumented)
     readonly [IFluidHandle]: IFluidHandleInternal;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IProvideFluidHandleContext {
     // (undocumented)
     readonly IFluidHandleContext: IFluidHandleContext;
@@ -377,7 +377,7 @@ export interface ITelemetryBaseProperties {
     [index: string]: TelemetryBaseEventPropertyType | Tagged<TelemetryBaseEventPropertyType>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IThrottlingWarning extends IErrorBase {
     readonly errorType: typeof FluidErrorTypes.throttlingError;
     // (undocumented)
@@ -408,7 +408,7 @@ export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
 // @public
 export type Off = () => void;
 
-// @alpha @legacy
+// @beta @legacy
 export type PayloadState = "pending" | "shared";
 
 // @public
@@ -430,7 +430,7 @@ export type TelemetryBaseEventPropertyType = string | number | boolean | undefin
 // @public
 export type TransformedEvent<TThis, E, A extends any[]> = (event: E, listener: (...args: ReplaceIEventThisPlaceHolder<A, TThis>) => void) => TThis;
 
-// @alpha @legacy
+// @beta @legacy
 export interface TypedMessage {
     content: unknown;
     type: string;

--- a/packages/common/core-interfaces/src/error.ts
+++ b/packages/common/core-interfaces/src/error.ts
@@ -7,8 +7,7 @@ import type { ITelemetryBaseProperties } from "./logger.js";
 
 /**
  * Error types the Fluid Framework may report.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const FluidErrorTypes = {
 	/**
@@ -38,8 +37,7 @@ export const FluidErrorTypes = {
 } as const;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type FluidErrorTypes = (typeof FluidErrorTypes)[keyof typeof FluidErrorTypes];
 
@@ -121,8 +119,7 @@ export interface IUsageError extends IErrorBase {
 
 /**
  * Warning emitted when requests to storage are being throttled
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IThrottlingWarning extends IErrorBase {
 	/**

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -8,14 +8,12 @@ import type { IRequest, IResponse } from "./fluidRouter.js";
 import type { Listenable } from "./internal.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const IFluidHandleContext: keyof IProvideFluidHandleContext = "IFluidHandleContext";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IProvideFluidHandleContext {
 	readonly IFluidHandleContext: IFluidHandleContext;
@@ -23,8 +21,7 @@ export interface IProvideFluidHandleContext {
 
 /**
  * Describes a routing context from which other `IFluidHandleContext`s are defined.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidHandleContext extends IProvideFluidHandleContext {
 	/**
@@ -61,8 +58,7 @@ export const IFluidHandle = "IFluidHandle";
 
 /**
  * @deprecated {@link IFluidHandleInternal} and {@link IFluidHandleInternal} should be identified should be identified using the {@link fluidHandleSymbol} symbol.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IProvideFluidHandle {
 	/**
@@ -77,8 +73,7 @@ export interface IProvideFluidHandle {
 
 /**
  * Handle to a shared {@link FluidObject}.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidHandleInternal<
 	// REVIEW: Constrain `T` to something? How do we support dds and datastores safely?
@@ -119,15 +114,13 @@ export interface IFluidHandleInternalPayloadPending<
  *
  * @remarks
  * Clients will see a transition of "pending" to "shared" when the payload has been shared to all collaborators.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type PayloadState = "pending" | "shared";
 
 /**
  * Events which fire from an IFluidHandle.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidHandleEvents {
 	/**
@@ -141,8 +134,7 @@ export interface IFluidHandleEvents {
  *
  * @privateRemarks
  * Contents to be merged to IFluidHandle, and then this separate interface should be removed.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IFluidHandlePayloadPending<T> extends IFluidHandle<T> {
 	/**
@@ -157,8 +149,7 @@ export interface IFluidHandlePayloadPending<T> extends IFluidHandle<T> {
 
 /**
  * Additional events which fire as a local handle's payload state transitions.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ILocalFluidHandleEvents extends IFluidHandleEvents {
 	/**
@@ -169,8 +160,7 @@ export interface ILocalFluidHandleEvents extends IFluidHandleEvents {
 
 /**
  * Additional observable state on a local handle regarding its payload sharing state.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ILocalFluidHandle<T> extends IFluidHandlePayloadPending<T> {
 	/**

--- a/packages/common/core-interfaces/src/logger.ts
+++ b/packages/common/core-interfaces/src/logger.ts
@@ -100,8 +100,7 @@ export interface ITelemetryErrorEvent extends ITelemetryBaseProperties {
 
 /**
  * An error object that supports exporting its properties to be logged to telemetry
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ILoggingError extends Error {
 	/**

--- a/packages/common/core-interfaces/src/messages.ts
+++ b/packages/common/core-interfaces/src/messages.ts
@@ -10,8 +10,7 @@
  * This type is meant to be used indirectly. Most commonly as a constraint
  * for generics of message structures.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface TypedMessage {
 	/**

--- a/packages/common/core-utils/api-report/core-utils.legacy.alpha.api.md
+++ b/packages/common/core-utils/api-report/core-utils.legacy.alpha.api.md
@@ -4,13 +4,13 @@
 
 ```ts
 
-// @alpha @legacy
+// @beta @legacy
 export function assert(condition: boolean, message: string | number): asserts condition;
 
-// @alpha @legacy
+// @beta @legacy
 export const compareArrays: <T>(left: readonly T[], right: readonly T[], comparator?: (leftItem: T, rightItem: T, index: number) => boolean) => boolean;
 
-// @alpha @legacy
+// @beta @legacy
 export class Deferred<T> {
     constructor();
     get isCompleted(): boolean;
@@ -19,7 +19,7 @@ export class Deferred<T> {
     resolve(value: T | PromiseLike<T>): void;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export class LazyPromise<T> implements Promise<T> {
     // (undocumented)
     get [Symbol.toStringTag](): string;
@@ -32,7 +32,7 @@ export class LazyPromise<T> implements Promise<T> {
     then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined): Promise<TResult1 | TResult2>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export class PromiseCache<TKey, TResult> {
     constructor({ expiry, removeOnError, }?: PromiseCacheOptions);
     add(key: TKey, asyncFn: () => Promise<TResult>): boolean;
@@ -44,7 +44,7 @@ export class PromiseCache<TKey, TResult> {
     remove(key: TKey): boolean;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type PromiseCacheExpiry = {
     policy: "indefinite";
 } | {
@@ -52,7 +52,7 @@ export type PromiseCacheExpiry = {
     durationMs: number;
 };
 
-// @alpha @legacy
+// @beta @legacy
 export interface PromiseCacheOptions {
     expiry?: PromiseCacheExpiry;
     removeOnError?: (error: any) => boolean;

--- a/packages/common/core-utils/src/assert.ts
+++ b/packages/common/core-utils/src/assert.ts
@@ -26,8 +26,7 @@
  * @privateRemarks
  * This should be deprecated (as a non internal API) then moved to purely internal.
  * When done the `debugAssert` reference above should be turned into a link.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export function assert(condition: boolean, message: string | number): asserts condition {
 	if (!condition) {

--- a/packages/common/core-utils/src/compare.ts
+++ b/packages/common/core-utils/src/compare.ts
@@ -6,8 +6,7 @@
 /**
  * Compare two arrays.  Returns true if their elements are equivalent and in the same order.
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  *
  * @param left - The first array to compare
  * @param right - The second array to compare

--- a/packages/common/core-utils/src/lazy.ts
+++ b/packages/common/core-utils/src/lazy.ts
@@ -41,8 +41,7 @@ export class Lazy<T> {
  * the promise is used, e.g. await, then, catch ...
  * The execute function is only called once.
  * All calls are then proxied to the promise returned by the execute method.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class LazyPromise<T> implements Promise<T> {
 	// eslint-disable-next-line @typescript-eslint/class-literal-property-style

--- a/packages/common/core-utils/src/promiseCache.ts
+++ b/packages/common/core-utils/src/promiseCache.ts
@@ -8,8 +8,7 @@
  * - indefinite: entries don't expire and must be explicitly removed
  * - absolute: entries expire after the given duration in MS, even if accessed multiple times in the mean time
  * - sliding: entries expire after the given duration in MS of inactivity (i.e. get resets the clock)
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type PromiseCacheExpiry =
 	| {
@@ -22,8 +21,7 @@ export type PromiseCacheExpiry =
 
 /**
  * Options for configuring the {@link PromiseCache}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface PromiseCacheOptions {
 	/**
@@ -91,8 +89,7 @@ class GarbageCollector<TKey> {
 /**
  * A specialized cache for async work, allowing you to safely cache the promised result of some async work
  * without fear of running it multiple times or losing track of errors.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class PromiseCache<TKey, TResult> {
 	private readonly cache = new Map<TKey, Promise<TResult>>();

--- a/packages/common/core-utils/src/promises.ts
+++ b/packages/common/core-utils/src/promises.ts
@@ -5,8 +5,7 @@
 
 /**
  * A deferred creates a promise and the ability to resolve or reject it
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export class Deferred<T> {
 	private readonly p: Promise<T>;

--- a/packages/common/driver-definitions/api-report/driver-definitions.legacy.alpha.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.legacy.alpha.api.md
@@ -7,10 +7,10 @@
 // @public
 export type ConnectionMode = "write" | "read";
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type DriverError = IThrottlingWarning | IGenericNetworkError | IAuthorizationError | ILocationRedirectionError | IDriverBasicError;
 
-// @alpha @legacy
+// @beta @legacy
 export const DriverErrorTypes: {
     readonly genericNetworkError: "genericNetworkError";
     readonly authorizationError: "authorizationError";
@@ -32,10 +32,10 @@ export const DriverErrorTypes: {
     readonly usageError: "usageError";
 };
 
-// @alpha @legacy
+// @beta @legacy
 export type DriverErrorTypes = (typeof DriverErrorTypes)[keyof typeof DriverErrorTypes];
 
-// @alpha @legacy
+// @beta @legacy
 export enum DriverHeader {
     // (undocumented)
     createNew = "createNew",
@@ -43,13 +43,13 @@ export enum DriverHeader {
     summarizingClient = "fluid-client-summarizer"
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface DriverPreCheckInfo {
     codeDetailsHint?: string;
     criticalBootDomains?: string[];
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export enum FetchSource {
     // (undocumented)
     default = "default",
@@ -57,7 +57,7 @@ export enum FetchSource {
     noCache = "noCache"
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export enum FileMode {
     // (undocumented)
     Directory = "040000",
@@ -69,28 +69,28 @@ export enum FileMode {
     Symlink = "120000"
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type FiveDaysMs = 432_000_000;
 
-// @alpha @legacy
+// @beta @legacy
 export interface IAnyDriverError extends Omit<IDriverErrorBase, "errorType"> {
     // (undocumented)
     readonly errorType: string;
     scenarioName?: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type IApprovedProposal = {
     approvalSequenceNumber: number;
 } & ISequencedProposal;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IAttachment {
     // (undocumented)
     id: string;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IAuthorizationError extends IDriverErrorBase {
     // (undocumented)
     readonly claims?: string;
@@ -100,13 +100,13 @@ export interface IAuthorizationError extends IDriverErrorBase {
     readonly tenantId?: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IBlob {
     contents: string;
     encoding: "utf-8" | "base64";
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IBranchOrigin {
     id: string;
     minimumSequenceNumber: number;
@@ -129,7 +129,7 @@ export interface IClient {
     user: IUser;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IClientConfiguration {
     blockSize: number;
     maxMessageSize: number;
@@ -147,12 +147,12 @@ export interface IClientDetails {
     type?: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type ICommittedProposal = {
     commitSequenceNumber: number;
 } & IApprovedProposal;
 
-// @alpha @legacy
+// @beta @legacy
 export interface IConnect {
     client: IClient;
     driverVersion?: string;
@@ -167,7 +167,7 @@ export interface IConnect {
     versions: string[];
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IConnected {
     checkpointSequenceNumber?: number;
     claims: ITokenClaims;
@@ -188,24 +188,24 @@ export interface IConnected {
     version: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IContainerPackageInfo {
     name: string;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ICreateBlobResponse {
     // (undocumented)
     id: string;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IDocumentAttributes {
     minimumSequenceNumber: number;
     sequenceNumber: number;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<IDocumentDeltaConnectionEvents> {
     checkpointSequenceNumber?: number;
     claims: ITokenClaims;
@@ -222,7 +222,7 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     version: string;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IDocumentDeltaConnectionEvents extends IErrorEvent {
     // (undocumented)
     (event: "nack", listener: (documentId: string, message: INack[]) => void): any;
@@ -238,12 +238,12 @@ export interface IDocumentDeltaConnectionEvents extends IErrorEvent {
     (event: "error", listener: (error: any) => void): any;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IDocumentDeltaStorageService {
     fetchMessages(from: number, to: number | undefined, abortSignal?: AbortSignal, cachedOnly?: boolean, fetchReason?: string): IStream<ISequencedDocumentMessage[]>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IDocumentMessage {
     clientSequenceNumber: number;
     compression?: string;
@@ -255,7 +255,7 @@ export interface IDocumentMessage {
     type: string;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IDocumentService extends IEventProvider<IDocumentServiceEvents> {
     connectToDeltaStorage(): Promise<IDocumentDeltaStorageService>;
     connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection>;
@@ -266,25 +266,25 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
     resolvedUrl: IResolvedUrl;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IDocumentServiceEvents extends IEvent {
     (event: "metadataUpdate", listener: (metadata: Record<string, string>) => void): any;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IDocumentServiceFactory {
     createContainer(createNewSummary: ISummaryTree | undefined, createNewResolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
     createDocumentService(resolvedUrl: IResolvedUrl, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IDocumentServicePolicies {
     readonly storageOnly?: boolean;
     readonly summarizeProtocolTree?: boolean;
     readonly supportGetSnapshotApi?: boolean;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IDocumentStorageService extends Partial<IDisposable> {
     createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
     downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
@@ -296,13 +296,13 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
     uploadSummaryWithContext(summary: ISummaryTree, context: ISummaryContext): Promise<string>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IDocumentStorageServicePolicies {
     readonly caching?: LoaderCachingPolicy;
     readonly maximumCacheDurationMs?: FiveDaysMs;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IDriverBasicError extends IDriverErrorBase {
     // (undocumented)
     readonly errorType: typeof DriverErrorTypes.genericError | typeof DriverErrorTypes.fileNotFoundOrAccessDeniedError | typeof DriverErrorTypes.offlineError | typeof DriverErrorTypes.unsupportedClientProtocolVersion | typeof DriverErrorTypes.writeError | typeof DriverErrorTypes.fetchFailure | typeof DriverErrorTypes.fetchTokenError | typeof DriverErrorTypes.incorrectServerResponse | typeof DriverErrorTypes.fileOverwrittenInStorage | typeof DriverErrorTypes.fluidInvalidSchema | typeof DriverErrorTypes.usageError | typeof DriverErrorTypes.fileIsLocked | typeof DriverErrorTypes.outOfStorageError;
@@ -310,7 +310,7 @@ export interface IDriverBasicError extends IDriverErrorBase {
     readonly statusCode?: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IDriverErrorBase {
     canRetry: boolean;
     endpointReached?: boolean;
@@ -319,7 +319,7 @@ export interface IDriverErrorBase {
     online?: string;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IGenericNetworkError extends IDriverErrorBase {
     // (undocumented)
     readonly errorType: typeof DriverErrorTypes.genericNetworkError;
@@ -327,7 +327,7 @@ export interface IGenericNetworkError extends IDriverErrorBase {
     readonly statusCode?: number;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ILocationRedirectionError extends IDriverErrorBase {
     // (undocumented)
     readonly errorType: typeof DriverErrorTypes.locationRedirection;
@@ -335,14 +335,14 @@ export interface ILocationRedirectionError extends IDriverErrorBase {
     readonly redirectUrl: IResolvedUrl;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface INack {
     content: INackContent;
     operation: IDocumentMessage | undefined;
     sequenceNumber: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface INackContent {
     code: number;
     message: string;
@@ -350,19 +350,19 @@ export interface INackContent {
     type: NackErrorType;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IProcessMessageResult {
     // (undocumented)
     immediateNoOp?: boolean;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IProposal {
     key: string;
     value: unknown;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IQuorum extends Omit<IQuorumClients, "on" | "once" | "off">, Omit<IQuorumProposals, "on" | "once" | "off"> {
     // (undocumented)
     off: IQuorum["on"];
@@ -390,7 +390,7 @@ export interface IQuorumClients {
     once: IQuorumClients["on"];
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IQuorumProposals {
     // (undocumented)
     get(key: string): unknown;
@@ -410,7 +410,7 @@ export interface IQuorumProposals {
     propose(key: string, value: unknown): Promise<void>;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IResolvedUrl {
     // (undocumented)
     endpoints: {
@@ -433,7 +433,7 @@ export interface ISequencedClient {
     sequenceNumber: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISequencedDocumentMessage {
     clientId: string | null;
     clientSequenceNumber: number;
@@ -454,12 +454,12 @@ export interface ISequencedDocumentMessage {
     type: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type ISequencedProposal = {
     sequenceNumber: number;
 } & IProposal;
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISignalClient {
     client: IClient;
     clientConnectionNumber?: number;
@@ -467,12 +467,12 @@ export interface ISignalClient {
     referenceSequenceNumber?: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISignalMessage<TMessage extends TypedMessage = TypedMessage> extends ISignalMessageBase<TMessage> {
     clientId: string | null;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISignalMessageBase<TMessage extends TypedMessage = TypedMessage> {
     clientConnectionNumber?: number;
     content: TMessage["content"];
@@ -481,7 +481,7 @@ export interface ISignalMessageBase<TMessage extends TypedMessage = TypedMessage
     type?: TMessage["type"];
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISnapshot {
     // (undocumented)
     blobContents: Map<string, ArrayBuffer>;
@@ -495,7 +495,7 @@ export interface ISnapshot {
     snapshotTree: ISnapshotTree;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISnapshotFetchOptions {
     cacheSnapshot?: boolean;
     fetchSource?: FetchSource;
@@ -504,7 +504,7 @@ export interface ISnapshotFetchOptions {
     versionId?: string;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISnapshotTree {
     // (undocumented)
     blobs: {
@@ -520,16 +520,16 @@ export interface ISnapshotTree {
     unreferenced?: true;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type IsoDate = string;
 
-// @alpha @legacy
+// @beta @legacy
 export interface IStream<T> {
     // (undocumented)
     read(): Promise<IStreamResult<T>>;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export type IStreamResult<T> = {
     done: true;
 } | {
@@ -537,7 +537,7 @@ export type IStreamResult<T> = {
     value: T;
 };
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISummaryAck {
     handle: string;
     summaryProposal: ISummaryProposal;
@@ -559,7 +559,7 @@ export interface ISummaryBlob {
     type: SummaryType.Blob;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ISummaryContent {
     details?: IUploadedSummaryDetails;
     handle: string;
@@ -568,7 +568,7 @@ export interface ISummaryContent {
     parents: string[];
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISummaryContext {
     readonly ackHandle: string | undefined;
     readonly proposalHandle: string | undefined;
@@ -584,7 +584,7 @@ export interface ISummaryHandle {
     type: SummaryType.Handle;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISummaryNack {
     code?: number;
     message?: string;
@@ -592,7 +592,7 @@ export interface ISummaryNack {
     summaryProposal: ISummaryProposal;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISummaryProposal {
     summarySequenceNumber: number;
 }
@@ -608,7 +608,7 @@ export interface ISummaryTree {
     unreferenced?: true;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IThrottlingWarning extends IDriverErrorBase {
     // (undocumented)
     readonly errorType: typeof DriverErrorTypes.throttlingError;
@@ -616,7 +616,7 @@ export interface IThrottlingWarning extends IDriverErrorBase {
     readonly retryAfterSeconds: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ITokenClaims {
     documentId: string;
     exp: number;
@@ -628,14 +628,14 @@ export interface ITokenClaims {
     ver: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ITrace {
     action: string;
     service: string;
     timestamp: number;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface ITree {
     // (undocumented)
     entries: ITreeEntry[];
@@ -644,7 +644,7 @@ export interface ITree {
     unreferenced?: true;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export type ITreeEntry = {
     path: string;
     mode: FileMode;
@@ -659,12 +659,12 @@ export type ITreeEntry = {
     value: IAttachment;
 });
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IUploadedSummaryDetails {
     includesProtocolTree?: boolean;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export interface IUrlResolver {
     getAbsoluteUrl(resolvedUrl: IResolvedUrl, relativeUrl: string, packageInfoSource?: IContainerPackageInfo): Promise<string>;
     // (undocumented)
@@ -676,20 +676,20 @@ export interface IUser {
     id: string;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IVersion {
     date?: IsoDate;
     id: string;
     treeId: string;
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export enum LoaderCachingPolicy {
     NoCaching = 0,
     Prefetch = 1
 }
 
-// @alpha @legacy (undocumented)
+// @beta @legacy (undocumented)
 export enum MessageType {
     Accept = "accept",
     ClientJoin = "join",
@@ -706,7 +706,7 @@ export enum MessageType {
     SummaryNack = "summaryNack"
 }
 
-// @alpha @legacy
+// @beta @legacy
 export enum NackErrorType {
     BadRequestError = "BadRequestError",
     InvalidScopeError = "InvalidScopeError",
@@ -714,7 +714,7 @@ export enum NackErrorType {
     ThrottlingError = "ThrottlingError"
 }
 
-// @alpha @legacy
+// @beta @legacy
 export enum ScopeType {
     DocRead = "doc:read",
     DocWrite = "doc:write",
@@ -724,7 +724,7 @@ export enum ScopeType {
 // @public
 export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISummaryAttachment;
 
-// @alpha @legacy
+// @beta @legacy
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 
 // @public
@@ -741,7 +741,7 @@ export type SummaryType = SummaryType.Attachment | SummaryType.Blob | SummaryTyp
 // @public
 export type SummaryTypeNoHandle = SummaryType.Tree | SummaryType.Blob | SummaryType.Attachment;
 
-// @alpha @legacy
+// @beta @legacy
 export enum TreeEntry {
     // (undocumented)
     Attachment = "Attachment",

--- a/packages/common/driver-definitions/src/driverError.ts
+++ b/packages/common/driver-definitions/src/driverError.ts
@@ -13,8 +13,7 @@ const { dataCorruptionError, dataProcessingError, ...FluidErrorTypesExceptDataTy
 
 /**
  * Different error types the Driver may report out to the Host.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export const DriverErrorTypes = {
 	// Inherit base error types
@@ -108,8 +107,7 @@ export const DriverErrorTypes = {
 } as const;
 /**
  * {@inheritDoc (DriverErrorTypes:variable)}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type DriverErrorTypes = (typeof DriverErrorTypes)[keyof typeof DriverErrorTypes];
 
@@ -123,8 +121,7 @@ export type DriverErrorTypes = (typeof DriverErrorTypes)[keyof typeof DriverErro
  * "Any" in the interface name is a nod to the fact that errorType has lost its type constraint.
  * It will be either {@link @fluidframework/driver-definitions#(DriverErrorTypes:variable)} or the specific driver's specialized error type enum,
  * but we can't reference a specific driver's error type enum in this code.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IAnyDriverError extends Omit<IDriverErrorBase, "errorType"> {
 	readonly errorType: string;
@@ -137,8 +134,7 @@ export interface IAnyDriverError extends Omit<IDriverErrorBase, "errorType"> {
 
 /**
  * Base interface for all errors and warnings
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDriverErrorBase {
 	/**
@@ -171,8 +167,7 @@ export interface IDriverErrorBase {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IThrottlingWarning extends IDriverErrorBase {
 	readonly errorType: typeof DriverErrorTypes.throttlingError;
@@ -180,8 +175,7 @@ export interface IThrottlingWarning extends IDriverErrorBase {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IGenericNetworkError extends IDriverErrorBase {
 	readonly errorType: typeof DriverErrorTypes.genericNetworkError;
@@ -189,8 +183,7 @@ export interface IGenericNetworkError extends IDriverErrorBase {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IAuthorizationError extends IDriverErrorBase {
 	readonly errorType: typeof DriverErrorTypes.authorizationError;
@@ -199,8 +192,7 @@ export interface IAuthorizationError extends IDriverErrorBase {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ILocationRedirectionError extends IDriverErrorBase {
 	readonly errorType: typeof DriverErrorTypes.locationRedirection;
@@ -210,8 +202,7 @@ export interface ILocationRedirectionError extends IDriverErrorBase {
 /**
  * Having this uber interface without types that have their own interfaces
  * allows compiler to differentiate interfaces based on error type
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDriverBasicError extends IDriverErrorBase {
 	readonly errorType:
@@ -232,8 +223,7 @@ export interface IDriverBasicError extends IDriverErrorBase {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type DriverError =
 	| IThrottlingWarning

--- a/packages/common/driver-definitions/src/git/resources.ts
+++ b/packages/common/driver-definitions/src/git/resources.ts
@@ -142,8 +142,7 @@ export interface IRef {
 
 /**
  * Required params to create ref
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ICreateRefParams {
 	ref: string;
@@ -152,8 +151,7 @@ export interface ICreateRefParams {
 
 /**
  * Required params to patch ref
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IPatchRefParams {
 	sha: string;

--- a/packages/common/driver-definitions/src/protocol/clients.ts
+++ b/packages/common/driver-definitions/src/protocol/clients.ts
@@ -111,8 +111,7 @@ export interface ISequencedClient {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISignalClient {
 	/**

--- a/packages/common/driver-definitions/src/protocol/config.ts
+++ b/packages/common/driver-definitions/src/protocol/config.ts
@@ -5,8 +5,7 @@
 
 /**
  * Key value store of service configuration properties provided to the client as part of connection.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IClientConfiguration {
 	/**

--- a/packages/common/driver-definitions/src/protocol/consensus.ts
+++ b/packages/common/driver-definitions/src/protocol/consensus.ts
@@ -12,8 +12,7 @@ import type { ISequencedClient } from "./clients.js";
  * Consensus on the proposal is achieved if the MSN is \>= the sequence number
  * at which the proposal is made and no client within the collaboration window rejects
  * the proposal.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IProposal {
 	/**
@@ -29,22 +28,19 @@ export interface IProposal {
 
 /**
  * Similar to {@link IProposal} except it also includes the sequence number when it was made.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type ISequencedProposal = { sequenceNumber: number } & IProposal;
 
 /**
  * Adds the sequence number at which the message was approved to an {@link ISequencedProposal}.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type IApprovedProposal = { approvalSequenceNumber: number } & ISequencedProposal;
 
 /**
  * Adds the sequence number at which the message was committed to an {@link IApprovedProposal}.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type ICommittedProposal = { commitSequenceNumber: number } & IApprovedProposal;
 
@@ -65,8 +61,7 @@ export interface IQuorumClients {
 
 /**
  * Interface for tracking proposals in the Quorum.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IQuorumProposals {
 	propose(key: string, value: unknown): Promise<void>;
@@ -93,8 +88,7 @@ export interface IQuorumProposals {
 
 /**
  * Interface combining tracking of clients as well as proposals in the Quorum.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IQuorum
 	extends Omit<IQuorumClients, "on" | "once" | "off">,
@@ -116,8 +110,7 @@ export interface IProtocolState {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IProcessMessageResult {
 	immediateNoOp?: boolean;

--- a/packages/common/driver-definitions/src/protocol/date.ts
+++ b/packages/common/driver-definitions/src/protocol/date.ts
@@ -5,7 +5,6 @@
 
 /**
  * {@link https://www.iso.org/iso-8601-date-and-time-format.html | ISO 8601 format} date: `YYYY-MM-DDTHH:MM:SSZ`.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type IsoDate = string;

--- a/packages/common/driver-definitions/src/protocol/protocol.ts
+++ b/packages/common/driver-definitions/src/protocol/protocol.ts
@@ -6,8 +6,7 @@
 import type { TypedMessage } from "@fluidframework/core-interfaces/internal";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum MessageType {
 	/**
@@ -96,8 +95,7 @@ export enum SignalType {
 
 /**
  * Messages to track latency trace.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ITrace {
 	/**
@@ -117,8 +115,7 @@ export interface ITrace {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface INack {
 	/**
@@ -139,8 +136,7 @@ export interface INack {
 
 /**
  * Document-specific message.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDocumentMessage {
 	/**
@@ -195,8 +191,7 @@ export interface IDocumentSystemMessage extends IDocumentMessage {
 
 /**
  * Branch origin information.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IBranchOrigin {
 	/**
@@ -217,8 +212,7 @@ export interface IBranchOrigin {
 
 /**
  * Sequenced message for a distributed document.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISequencedDocumentMessage {
 	/**
@@ -340,8 +334,7 @@ export interface ISequencedDocumentAugmentedMessage extends ISequencedDocumentMe
 
 /**
  * Common interface between incoming and outgoing signals.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISignalMessageBase<TMessage extends TypedMessage = TypedMessage> {
 	/**
@@ -373,8 +366,7 @@ export interface ISignalMessageBase<TMessage extends TypedMessage = TypedMessage
 
 /**
  * Interface for signals sent by the server to clients.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISignalMessage<TMessage extends TypedMessage = TypedMessage>
 	extends ISignalMessageBase<TMessage> {
@@ -394,8 +386,7 @@ export type ISentSignalMessage<TMessage extends TypedMessage = TypedMessage> =
 	ISignalMessageBase<TMessage>;
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IUploadedSummaryDetails {
 	/**
@@ -405,8 +396,7 @@ export interface IUploadedSummaryDetails {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummaryContent {
 	/**
@@ -452,8 +442,7 @@ export interface IServerError {
 
 /**
  * Data about the original proposed summary message.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummaryProposal {
 	/**
@@ -464,8 +453,7 @@ export interface ISummaryProposal {
 
 /**
  * Contents of summary ack expected from the server.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummaryAck {
 	/**
@@ -481,8 +469,7 @@ export interface ISummaryAck {
 
 /**
  * Contents of summary nack expected from the server.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummaryNack {
 	/**
@@ -512,8 +499,7 @@ export interface ISummaryNack {
 
 /**
  * Interface for nack content.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface INackContent {
 	/**
@@ -543,8 +529,7 @@ export interface INackContent {
 
 /**
  * Type of the nack.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum NackErrorType {
 	/**

--- a/packages/common/driver-definitions/src/protocol/scopes.ts
+++ b/packages/common/driver-definitions/src/protocol/scopes.ts
@@ -5,8 +5,7 @@
 
 /**
  * Defines scope access for a Container/Document.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum ScopeType {
 	/**

--- a/packages/common/driver-definitions/src/protocol/sockets.ts
+++ b/packages/common/driver-definitions/src/protocol/sockets.ts
@@ -10,8 +10,7 @@ import type { ITokenClaims } from "./tokens.js";
 
 /**
  * Message sent to connect to the given document.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IConnect {
 	/**
@@ -80,8 +79,7 @@ export interface IConnect {
 
 /**
  * Message sent to indicate a client has connected to the server.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IConnected {
 	/**

--- a/packages/common/driver-definitions/src/protocol/storage.ts
+++ b/packages/common/driver-definitions/src/protocol/storage.ts
@@ -6,8 +6,7 @@
 import type { IsoDate } from "./date.js";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDocumentAttributes {
 	/**
@@ -22,8 +21,7 @@ export interface IDocumentAttributes {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum FileMode {
 	File = "100644",
@@ -34,8 +32,7 @@ export enum FileMode {
 
 /**
  * Raw blob stored within the tree.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IBlob {
 	/**
@@ -51,16 +48,14 @@ export interface IBlob {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IAttachment {
 	id: string;
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ICreateBlobResponse {
 	id: string;
@@ -68,8 +63,7 @@ export interface ICreateBlobResponse {
 
 /**
  * A tree entry wraps a path with a type of node.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type ITreeEntry = {
 	/**
@@ -99,8 +93,7 @@ export type ITreeEntry = {
 
 /**
  * Type of entries that can be stored in a tree.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum TreeEntry {
 	Blob = "Blob",
@@ -109,8 +102,7 @@ export enum TreeEntry {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ITree {
 	entries: ITreeEntry[];
@@ -136,8 +128,7 @@ export interface ITree {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISnapshotTree {
 	id?: string;
@@ -168,8 +159,7 @@ export interface ISnapshotTreeEx extends ISnapshotTree {
 
 /**
  * Represents a version of the snapshot of a data store.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IVersion {
 	/**

--- a/packages/common/driver-definitions/src/protocol/summary.ts
+++ b/packages/common/driver-definitions/src/protocol/summary.ts
@@ -14,8 +14,7 @@ export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISumm
 
 /**
  * The root of the summary tree.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 

--- a/packages/common/driver-definitions/src/protocol/tokens.ts
+++ b/packages/common/driver-definitions/src/protocol/tokens.ts
@@ -9,8 +9,7 @@ import type { IUser } from "./users.js";
  * {@link https://jwt.io/introduction/ | JSON Web Token (JWT)} Claims
  *
  * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4}
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ITokenClaims {
 	/**

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -73,15 +73,13 @@ export interface IDeltaStorageService {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type IStreamResult<T> = { done: true } | { done: false; value: T };
 
 /**
  * Read interface for the Queue
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IStream<T> {
 	read(): Promise<IStreamResult<T>>;
@@ -89,8 +87,7 @@ export interface IStream<T> {
 
 /**
  * Interface to provide access to stored deltas for a shared object
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDocumentDeltaStorageService {
 	/**
@@ -117,16 +114,14 @@ export interface IDocumentDeltaStorageService {
 // internal assumptions of the Runtime's GC feature will be violated
 // DO NOT INCREASE THIS TYPE'S VALUE
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export type FiveDaysMs = 432_000_000; /* 5 days in milliseconds */
 
 /**
  * Policies describing attributes or characteristics of the driver's storage service,
  * to direct how other components interact with the driver
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDocumentStorageServicePolicies {
 	/**
@@ -147,8 +142,7 @@ export interface IDocumentStorageServicePolicies {
 
 /**
  * Interface to provide access to snapshots saved for a shared object
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDocumentStorageService extends Partial<IDisposable> {
 	/**
@@ -221,8 +215,7 @@ export interface IDocumentStorageService extends Partial<IDisposable> {
 
 /**
  * Events emitted by {@link IDocumentService}.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDocumentServiceEvents extends IEvent {
 	/**
@@ -233,8 +226,7 @@ export interface IDocumentServiceEvents extends IEvent {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDocumentDeltaConnectionEvents extends IErrorEvent {
 	(event: "nack", listener: (documentId: string, message: INack[]) => void);
@@ -256,8 +248,7 @@ export interface IDocumentDeltaConnectionEvents extends IErrorEvent {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDocumentDeltaConnection
 	extends IDisposable,
@@ -339,8 +330,7 @@ export interface IDocumentDeltaConnection
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum LoaderCachingPolicy {
 	/**
@@ -355,8 +345,7 @@ export enum LoaderCachingPolicy {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDocumentServicePolicies {
 	/**
@@ -378,8 +367,7 @@ export interface IDocumentServicePolicies {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDocumentService extends IEventProvider<IDocumentServiceEvents> {
 	resolvedUrl: IResolvedUrl;
@@ -420,8 +408,7 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IDocumentServiceFactory {
 	/**
@@ -463,8 +450,7 @@ export interface IDocumentServiceFactory {
 /**
  * Context for uploading a summary to storage.
  * Indicates the previously acked summary.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISummaryContext {
 	/**
@@ -481,8 +467,7 @@ export interface ISummaryContext {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum FetchSource {
 	default = "default",
@@ -492,8 +477,7 @@ export enum FetchSource {
 /**
  * A "Full" container Snapshot, including ISnapshotTree, blobs and outstanding ops (and other metadata)
  *
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISnapshot {
 	snapshotTree: ISnapshotTree;
@@ -516,8 +500,7 @@ export interface ISnapshot {
 /**
  * Snapshot fetch options which are used to communicate different things to the driver
  * when fetching the snapshot.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface ISnapshotFetchOptions {
 	/**

--- a/packages/common/driver-definitions/src/urlResolver.ts
+++ b/packages/common/driver-definitions/src/urlResolver.ts
@@ -6,8 +6,7 @@
 import type { IRequest } from "@fluidframework/core-interfaces";
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IResolvedUrl {
 	type: "fluid";
@@ -22,8 +21,7 @@ export interface IResolvedUrl {
 
 /**
  * Container package info handed off to resolver.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IContainerPackageInfo {
 	/**
@@ -33,8 +31,7 @@ export interface IContainerPackageInfo {
 }
 
 /**
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface IUrlResolver {
 	// Like DNS should be able to cache resolution requests. Then possibly just have a token provider go and do stuff?
@@ -59,8 +56,7 @@ export interface IUrlResolver {
 /**
  * Information that can be returned by a lightweight, seperately exported driver function. Used to preanalyze a URL
  * for driver compatibility and preload information.
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export interface DriverPreCheckInfo {
 	/**
@@ -77,8 +73,7 @@ export interface DriverPreCheckInfo {
 
 /**
  * Additional key in the loader request header
- * @legacy
- * @alpha
+ * @legacy @beta
  */
 export enum DriverHeader {
 	// Key to indicate whether the request for summarizer

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -146,7 +146,7 @@ export type FluidObject<T = unknown> = {
 // @public
 export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> = string extends TProp ? never : number extends TProp ? never : TProp extends keyof Required<T>[TProp] ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] ? TProp : never : never;
 
-// @alpha @legacy
+// @beta @legacy
 export interface IBranchOrigin {
     id: string;
     minimumSequenceNumber: number;
@@ -539,7 +539,7 @@ export interface IProvideFluidLoadable {
     readonly IFluidLoadable: IFluidLoadable;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ISequencedDocumentMessage {
     clientId: string | null;
     clientSequenceNumber: number;
@@ -780,7 +780,7 @@ export class IterableTreeArrayContent<T> implements Iterable<T> {
     [Symbol.iterator](): Iterator<T>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ITrace {
     action: string;
     service: string;


### PR DESCRIPTION
## Description
All of the APIs in our client packages (packages under the following directories: "packages", "examples", "experimental", "common/lib") should be updated to convert any APIs tagged as `@legacy` and `@alpha` to be `@legacy` and `@beta`.
✅ @fluidframework/core-interfaces
✅ @fluidframework/core-utils
✅ @fluidframework/driver-definitions
✅ @fluidframework/container-definitions
✅ @fluid-internal/client-utils

**Technical Changes Completed:**
JSDoc Tag Conversion: 70+ instances of @legacy @alpha → @legacy @beta
Package Configuration: All [package.json](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) scripts updated for legacy-beta
API Extractor Configs: New lint configurations for legacy-beta validation
Build System: All packages generating [legacy-beta.d.ts](vscode-file://vscode-app/c:/Users/chentong/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) files correctly
API Reports: New .legacy.beta.api.md files being generated


## Breaking Changes
~~~
Build succeeded
Total time: 637.453s (10m 37.453s)
All builds passing ✅
All exports validated ✅
API generation working ✅
~~~