### PR TITLE
Intervals: Remove unnecessary and internal APIs in ISequenceIntervalCollection and related interval types

### DIFF
--- a/.changeset/gentle-colts-study.md
+++ b/.changeset/gentle-colts-study.md
@@ -1,0 +1,20 @@
+---
+"fluid-framework": minor
+"@fluidframework/sequence": minor
+"__section": breaking
+---
+Remove unnecessary and internal APIs in ISequenceIntervalCollection and related interval types.
+
+The following APIs are now removed:
+- `IInterval.clone`
+- `IInterval.modify`
+- `IInterval.union`
+- `ISerializableInterval`
+- `SequenceInterval.clone`
+- `SequenceInterval.modify`
+- `SequenceInterval.union`
+- `SequenceInterval.serialize`
+- `SequenceInterval.addPositionChangeListeners`
+- `SequenceInterval.removePositionChangeListeners`
+
+These APIs were never intended for public use. There is no migration path, and any usage is strongly discouraged, as it may result in severe errors or data corruption. Please remove any dependencies on these APIs as soon as possible.

--- a/.changeset/gentle-colts-study.md
+++ b/.changeset/gentle-colts-study.md
@@ -3,7 +3,7 @@
 "@fluidframework/sequence": minor
 "__section": breaking
 ---
-Remove unnecessary and internal APIs in ISequenceIntervalCollection and related interval types.
+Remove unnecessary and internal APIs in ISequenceIntervalCollection and related interval types
 
 The following APIs are now removed:
 - `IInterval.clone`

--- a/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
+++ b/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
@@ -32,17 +32,11 @@ export function discardSharedStringRevertibles(sharedString: ISharedString, reve
 
 // @alpha @legacy
 export interface IInterval {
-    // @deprecated (undocumented)
-    clone(): IInterval;
     compare(b: IInterval): number;
     compareEnd(b: IInterval): number;
     compareStart(b: IInterval): number;
-    // @deprecated
-    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedDocumentMessage, localSeq?: number, canSlideToEndpoint?: boolean): IInterval | undefined;
     // (undocumented)
     overlaps(b: IInterval): boolean;
-    // @deprecated
-    union(b: IInterval): IInterval;
 }
 
 export { InteriorSequencePlace }
@@ -177,14 +171,6 @@ export interface ISequenceOverlappingIntervalsIndex extends SequenceIntervalInde
     gatherIterationResults(results: SequenceInterval[], iteratesForward: boolean, start?: SequencePlace, end?: SequencePlace): void;
 }
 
-// @alpha @deprecated @legacy (undocumented)
-export interface ISerializableInterval extends IInterval {
-    getIntervalId(): string;
-    properties: PropertySet;
-    // @deprecated (undocumented)
-    serialize(): ISerializedInterval;
-}
-
 // @alpha @legacy
 export interface ISerializedInterval {
     end: number | "start" | "end";
@@ -303,11 +289,7 @@ export interface SequenceEvent<TOperation extends MergeTreeDeltaOperationTypes =
 }
 
 // @alpha @legacy
-export interface SequenceInterval extends ISerializableInterval {
-    // @deprecated
-    addPositionChangeListeners(beforePositionChange: () => void, afterPositionChange: () => void): void;
-    // @deprecated (undocumented)
-    clone(): SequenceInterval;
+export interface SequenceInterval extends IInterval {
     compare(b: SequenceInterval): number;
     compareEnd(b: SequenceInterval): number;
     compareStart(b: SequenceInterval): number;
@@ -317,23 +299,17 @@ export interface SequenceInterval extends ISerializableInterval {
     getIntervalId(): string;
     // (undocumented)
     readonly intervalType: IntervalType;
-    // @deprecated
-    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedDocumentMessage, localSeq?: number, canSlideToEndpoint?: boolean): SequenceInterval | undefined;
     // (undocumented)
     overlaps(b: SequenceInterval): boolean;
     // (undocumented)
     overlapsPos(bstart: number, bend: number): boolean;
     properties: PropertySet;
-    // @deprecated
-    removePositionChangeListeners(): void;
     // (undocumented)
     readonly start: LocalReferencePosition;
     // (undocumented)
     readonly startSide: Side;
     // (undocumented)
     readonly stickiness: IntervalStickiness;
-    // @deprecated
-    union(b: SequenceInterval): SequenceInterval;
 }
 
 // @alpha @legacy

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -99,7 +99,7 @@
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob dist lib {alpha,beta,internal,legacy}.d.ts \"**/*.tsbuildinfo\" \"**/*.build.log\" _api-extractor-temp nyc",
 		"eslint": "eslint --format stylish src",
-		"eslint:fix": "eslint --format stylish src --fix  --fix-type problem,suggestion,layout",
+		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
 		"format": "npm run format:biome",
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -99,7 +99,7 @@
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob dist lib {alpha,beta,internal,legacy}.d.ts \"**/*.tsbuildinfo\" \"**/*.build.log\" _api-extractor-temp nyc",
 		"eslint": "eslint --format stylish src",
-		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
+		"eslint:fix": "eslint --format stylish src --fix ",
 		"format": "npm run format:biome",
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
@@ -198,7 +198,24 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {},
+		"broken": {
+			"Interface_IInterval": {
+				"backCompat": false
+			},
+			"Interface_ISerializableInterval": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"Interface_SequenceInterval": {
+				"backCompat": false
+			},
+			"TypeAlias_IntervalRevertible": {
+				"backCompat": false
+			},
+			"TypeAlias_SharedStringRevertible": {
+				"backCompat": false
+			}
+		},
 		"entrypoint": "legacy"
 	}
 }

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -99,7 +99,7 @@
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob dist lib {alpha,beta,internal,legacy}.d.ts \"**/*.tsbuildinfo\" \"**/*.build.log\" _api-extractor-temp nyc",
 		"eslint": "eslint --format stylish src",
-		"eslint:fix": "eslint --format stylish src --fix ",
+		"eslint:fix": "eslint --format stylish src --fix  --fix-type problem,suggestion,layout",
 		"format": "npm run format:biome",
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -20,7 +20,6 @@ export {
 	IInterval,
 	IntervalOpType,
 	IntervalType,
-	ISerializableInterval,
 	ISerializedInterval,
 	SequenceInterval,
 	SerializedIntervalDelta,

--- a/packages/dds/sequence/src/intervalIndex/endpointInRangeIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/endpointInRangeIndex.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable import/no-deprecated */
-
 import { Client, PropertyAction, RedBlackTree } from "@fluidframework/merge-tree/internal";
 
 import { SequenceInterval, createTransientInterval } from "../intervals/index.js";

--- a/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable import/no-deprecated */
-
 import {
 	Client,
 	SequencePlace,

--- a/packages/dds/sequence/src/intervalIndex/startpointInRangeIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/startpointInRangeIndex.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable import/no-deprecated */
-
 import { Client, PropertyAction, RedBlackTree } from "@fluidframework/merge-tree/internal";
 
 import { SequenceInterval, createTransientInterval } from "../intervals/index.js";

--- a/packages/dds/sequence/src/intervalTree.ts
+++ b/packages/dds/sequence/src/intervalTree.ts
@@ -11,17 +11,17 @@ import {
 	RedBlackTree,
 } from "@fluidframework/merge-tree/internal";
 
-import { IInterval } from "./intervals/index.js";
+import { ISerializableInterval } from "./intervals/index.js";
 
 export interface AugmentedIntervalNode {
-	minmax: IInterval;
+	minmax: ISerializableInterval;
 }
 
-const intervalComparer = (a: IInterval, b: IInterval) => a.compare(b);
+const intervalComparer = (a: ISerializableInterval, b: ISerializableInterval) => a.compare(b);
 
-export type IntervalNode<T extends IInterval> = RBNode<T, AugmentedIntervalNode>;
+export type IntervalNode<T extends ISerializableInterval> = RBNode<T, AugmentedIntervalNode>;
 
-export class IntervalTree<T extends IInterval>
+export class IntervalTree<T extends ISerializableInterval>
 	implements IRBAugmentation<T, AugmentedIntervalNode>, IRBMatcher<T, AugmentedIntervalNode>
 {
 	public intervals = new RedBlackTree<T, AugmentedIntervalNode>(intervalComparer, this);

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -137,7 +137,7 @@ export interface ISerializableInterval extends IInterval {
 	 * @returns a new interval object with identical semantics.
 	 */
 	clone(): ISerializableInterval;
-	
+
 	/**
 	 * Unions this interval with `b`, returning a new interval.
 	 * The union operates as a convex hull, i.e. if the two intervals are disjoint, the return value includes

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -137,6 +137,7 @@ export interface ISerializableInterval extends IInterval {
 	 * @returns a new interval object with identical semantics.
 	 */
 	clone(): ISerializableInterval;
+	
 	/**
 	 * Unions this interval with `b`, returning a new interval.
 	 * The union operates as a convex hull, i.e. if the two intervals are disjoint, the return value includes

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -5,13 +5,7 @@
 
 /* eslint-disable no-bitwise */
 
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
-import {
-	PropertySet,
-	SlidingPreference,
-	SequencePlace,
-	Side,
-} from "@fluidframework/merge-tree/internal";
+import { PropertySet, SlidingPreference, Side } from "@fluidframework/merge-tree/internal";
 
 /**
  * Basic interval abstraction
@@ -19,13 +13,6 @@ import {
  * @alpha
  */
 export interface IInterval {
-	/**
-	 * @returns a new interval object with identical semantics.
-	 *
-	 * @deprecated This api is not meant or necessary for external consumption and will be removed in subsequent release
-	 * @privateRemarks Move to ISerializableInterval after deprecation period
-	 */
-	clone(): IInterval;
 	/**
 	 * Compares this interval to `b` with standard comparator semantics:
 	 * - returns -1 if this is less than `b`
@@ -47,31 +34,10 @@ export interface IInterval {
 	 */
 	compareEnd(b: IInterval): number;
 	/**
-	 * Modifies one or more of the endpoints of this interval, returning a new interval representing the result.
-	 *
-	 * @deprecated This api is not meant or necessary for external consumption and will be removed in subsequent release
-	 */
-	modify(
-		label: string,
-		start: SequencePlace | undefined,
-		end: SequencePlace | undefined,
-		op?: ISequencedDocumentMessage,
-		localSeq?: number,
-		canSlideToEndpoint?: boolean,
-	): IInterval | undefined;
-	/**
 	 * @returns whether this interval overlaps with `b`.
 	 * Intervals are considered to overlap if their intersection is non-empty.
 	 */
 	overlaps(b: IInterval): boolean;
-	/**
-	 * Unions this interval with `b`, returning a new interval.
-	 * The union operates as a convex hull, i.e. if the two intervals are disjoint, the return value includes
-	 * intermediate values between the two intervals.
-	 * @deprecated This api is not meant or necessary for external consumption and will be removed in subsequent release
-	 * @privateRemarks Move to ISerializableInterval after deprecation period
-	 */
-	union(b: IInterval): IInterval;
 }
 
 /**
@@ -156,20 +122,9 @@ export interface ISerializedInterval {
 	properties?: PropertySet;
 }
 
-/**
- * @legacy
- * @alpha
- * @deprecated This api is not meant or necessary for external consumption and will be removed in subsequent release
- * @privateRemarks Remove from external exports, and replace usages of IInterval with this interface after deprecation period
- */
 export interface ISerializableInterval extends IInterval {
 	/** Serializable bag of properties associated with the interval. */
 	properties: PropertySet;
-
-	/**
-	 * @deprecated This api is not meant or necessary for external consumption and will be removed in subsequent release
-	 */
-	serialize(): ISerializedInterval;
 
 	/**
 	 * Gets the id associated with this interval.
@@ -177,6 +132,17 @@ export interface ISerializableInterval extends IInterval {
 	 * interval.
 	 */
 	getIntervalId(): string;
+
+	/**
+	 * @returns a new interval object with identical semantics.
+	 */
+	clone(): ISerializableInterval;
+	/**
+	 * Unions this interval with `b`, returning a new interval.
+	 * The union operates as a convex hull, i.e. if the two intervals are disjoint, the return value includes
+	 * intermediate values between the two intervals.
+	 */
+	union(b: IInterval): ISerializableInterval;
 }
 
 /**

--- a/packages/dds/sequence/src/intervals/sequenceInterval.ts
+++ b/packages/dds/sequence/src/intervals/sequenceInterval.ts
@@ -36,7 +36,6 @@ import { LoggingError, UsageError } from "@fluidframework/telemetry-utils/intern
 import { v4 as uuid } from "uuid";
 
 import {
-	// eslint-disable-next-line import/no-deprecated
 	ISerializableInterval,
 	ISerializedInterval,
 	IntervalStickiness,
@@ -44,6 +43,7 @@ import {
 	computeStickinessFromSide,
 	endReferenceSlidingPreference,
 	startReferenceSlidingPreference,
+	type IInterval,
 	type SerializedIntervalDelta,
 } from "./intervalUtils.js";
 
@@ -128,8 +128,7 @@ export function getSerializedProperties(
  * @alpha
  * @legacy
  */
-// eslint-disable-next-line import/no-deprecated
-export interface SequenceInterval extends ISerializableInterval {
+export interface SequenceInterval extends IInterval {
 	readonly start: LocalReferencePosition;
 	/**
 	 * End endpoint of this interval.
@@ -144,11 +143,6 @@ export interface SequenceInterval extends ISerializableInterval {
 	/** Serializable bag of properties associated with the interval. */
 	properties: PropertySet;
 
-	/**
-	 * @returns a new interval object with identical semantics.
-	 * @deprecated This api is not meant or necessary for external consumption and will be removed in subsequent release
-	 */
-	clone(): SequenceInterval;
 	/**
 	 * Compares this interval to `b` with standard comparator semantics:
 	 * - returns -1 if this is less than `b`
@@ -169,45 +163,12 @@ export interface SequenceInterval extends ISerializableInterval {
 	 * @param b - Interval to compare against
 	 */
 	compareEnd(b: SequenceInterval): number;
-	/**
-	 * Modifies one or more of the endpoints of this interval, returning a new interval representing the result.
-	 * @deprecated This api is not meant or necessary for external consumption and will be removed in subsequent release
-	 */
-	modify(
-		label: string,
-		start: SequencePlace | undefined,
-		end: SequencePlace | undefined,
-		op?: ISequencedDocumentMessage,
-		localSeq?: number,
-		canSlideToEndpoint?: boolean,
-	): SequenceInterval | undefined;
+
 	/**
 	 * @returns whether this interval overlaps with `b`.
 	 * Intervals are considered to overlap if their intersection is non-empty.
 	 */
 	overlaps(b: SequenceInterval): boolean;
-	/**
-	 * Unions this interval with `b`, returning a new interval.
-	 * The union operates as a convex hull, i.e. if the two intervals are disjoint, the return value includes
-	 * intermediate values between the two intervals.
-	 * @deprecated This api is not meant or necessary for external consumption and will be removed in subsequent release
-	 */
-	union(b: SequenceInterval): SequenceInterval;
-
-	/**
-	 * Subscribes to position change events on this interval if there are no current listeners.
-	 * @deprecated This api is not meant or necessary for external consumption and will be removed in subsequent release
-	 */
-	addPositionChangeListeners(
-		beforePositionChange: () => void,
-		afterPositionChange: () => void,
-	): void;
-
-	/**
-	 * Removes the currently subscribed position change listeners.
-	 * @deprecated This api is not meant or necessary for external consumption and will be removed in subsequent release
-	 */
-	removePositionChangeListeners(): void;
 
 	/**
 	 * @returns whether this interval overlaps two numerical positions.
@@ -223,7 +184,6 @@ export interface SequenceInterval extends ISerializableInterval {
 }
 
 export class SequenceIntervalClass
-	// eslint-disable-next-line import/no-deprecated
 	implements SequenceInterval, ISerializableInterval, IDisposable
 {
 	readonly #props: {

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -13,7 +13,7 @@ import {
 	MergeTreeDeltaType,
 	PropertySet,
 	ReferenceType,
-	SlidingPreference, // eslint-disable-next-line import/no-deprecated
+	SlidingPreference,
 	appendToMergeTreeDeltaRevertibles,
 	discardMergeTreeDeltaRevertible,
 	getSlideToSegoff,
@@ -585,7 +585,6 @@ interface RangeInfo {
 	segment: ISegment;
 }
 
-// eslint-disable-next-line import/no-deprecated
 class SortedRangeSet extends SortedSegmentSet<RangeInfo> {}
 
 function revertLocalSequenceRemove(

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -37,7 +37,6 @@ import {
 	ReferenceType,
 	SlidingPreference,
 	createAnnotateRangeOp,
-	// eslint-disable-next-line import/no-deprecated
 	createGroupOp,
 	createInsertOp,
 	createObliterateRangeOp,
@@ -973,7 +972,6 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 				stashMessage = {
 					...message,
 					referenceSequenceNumber: stashMessage.sequenceNumber - 1,
-					// eslint-disable-next-line import/no-deprecated
 					contents: ops.length !== 1 ? createGroupOp(...ops) : ops[0],
 				};
 			}

--- a/packages/dds/sequence/src/sequenceDeltaEvent.ts
+++ b/packages/dds/sequence/src/sequenceDeltaEvent.ts
@@ -5,7 +5,6 @@
 
 import { assert, Lazy } from "@fluidframework/core-utils/internal";
 import {
-	// eslint-disable-next-line import/no-deprecated
 	Client,
 	IMergeTreeDeltaCallbackArgs,
 	IMergeTreeDeltaOpArgs,
@@ -15,7 +14,7 @@ import {
 	MergeTreeDeltaOperationTypes,
 	MergeTreeDeltaType,
 	MergeTreeMaintenanceType,
-	PropertySet, // eslint-disable-next-line import/no-deprecated
+	PropertySet,
 	SortedSegmentSet,
 } from "@fluidframework/merge-tree/internal";
 
@@ -64,7 +63,6 @@ export abstract class SequenceEventClass<
 {
 	public readonly isLocal: boolean;
 	public readonly deltaOperation: TOperation;
-	// eslint-disable-next-line import/no-deprecated
 	private readonly sortedRanges: Lazy<SortedSegmentSet<ISequenceDeltaRange<TOperation>>>;
 	private readonly pFirst: Lazy<ISequenceDeltaRange<TOperation>>;
 	private readonly pLast: Lazy<ISequenceDeltaRange<TOperation>>;
@@ -75,7 +73,6 @@ export abstract class SequenceEventClass<
 		 * Arguments reflecting the type of change that caused this event.
 		 */
 		public readonly deltaArgs: IMergeTreeDeltaCallbackArgs<TOperation>,
-		// eslint-disable-next-line import/no-deprecated
 		private readonly mergeTreeClient: Client,
 	) {
 		if (
@@ -90,9 +87,7 @@ export abstract class SequenceEventClass<
 		this.deltaOperation = deltaArgs.operation;
 		this.isLocal = opArgs?.sequencedMessage === undefined;
 
-		// eslint-disable-next-line import/no-deprecated
 		this.sortedRanges = new Lazy<SortedSegmentSet<ISequenceDeltaRange<TOperation>>>(() => {
-			// eslint-disable-next-line import/no-deprecated
 			const set = new SortedSegmentSet<ISequenceDeltaRange<TOperation>>();
 			this.deltaArgs.deltaSegments.forEach((delta) => {
 				const newRange: ISequenceDeltaRange<TOperation> = {
@@ -176,7 +171,6 @@ export class SequenceDeltaEventClass
 	constructor(
 		public readonly opArgs: IMergeTreeDeltaOpArgs,
 		deltaArgs: IMergeTreeDeltaCallbackArgs,
-		// eslint-disable-next-line import/no-deprecated
 		mergeTreeClient: Client,
 	) {
 		super(opArgs, deltaArgs, mergeTreeClient);
@@ -207,7 +201,6 @@ export class SequenceMaintenanceEventClass
 		 */
 		public readonly opArgs: IMergeTreeDeltaOpArgs | undefined,
 		deltaArgs: IMergeTreeMaintenanceCallbackArgs,
-		// eslint-disable-next-line import/no-deprecated
 		mergeTreeClient: Client,
 	) {
 		super(opArgs, deltaArgs, mergeTreeClient);

--- a/packages/dds/sequence/src/sequenceFactory.ts
+++ b/packages/dds/sequence/src/sequenceFactory.ts
@@ -13,7 +13,6 @@ import { Marker, TextSegment } from "@fluidframework/merge-tree/internal";
 import { createSharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
 import { pkgVersion } from "./packageVersion.js";
-// eslint-disable-next-line import/no-deprecated
 import { SharedStringClass, SharedStringSegment, type ISharedString } from "./sharedString.js";
 
 export class SharedStringFactory implements IChannelFactory<ISharedString> {
@@ -57,9 +56,7 @@ export class SharedStringFactory implements IChannelFactory<ISharedString> {
 		id: string,
 		services: IChannelServices,
 		attributes: IChannelAttributes,
-		// eslint-disable-next-line import/no-deprecated
 	): Promise<SharedStringClass> {
-		// eslint-disable-next-line import/no-deprecated
 		const sharedString = new SharedStringClass(runtime, id, attributes);
 		await sharedString.load(services);
 		return sharedString;
@@ -68,9 +65,7 @@ export class SharedStringFactory implements IChannelFactory<ISharedString> {
 	/**
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.create}
 	 */
-	// eslint-disable-next-line import/no-deprecated
 	public create(document: IFluidDataStoreRuntime, id: string): SharedStringClass {
-		// eslint-disable-next-line import/no-deprecated
 		const sharedString = new SharedStringClass(document, id, this.attributes);
 		sharedString.initializeLocal();
 		return sharedString;

--- a/packages/dds/sequence/src/sharedSequence.ts
+++ b/packages/dds/sequence/src/sharedSequence.ts
@@ -16,7 +16,6 @@ import {
 	PropertySet,
 } from "@fluidframework/merge-tree/internal";
 
-// eslint-disable-next-line import/no-deprecated
 import { SharedSegmentSequence } from "./sequence.js";
 
 const MaxRun = 128;
@@ -119,7 +118,6 @@ export class SubSequence<T> extends BaseSegment {
  * @deprecated SharedSequence will be removed in a upcoming release. It has been moved to the fluid-experimental/sequence-deprecated package
  * @internal
  */
-// eslint-disable-next-line import/no-deprecated
 export class SharedSequence<T> extends SharedSegmentSequence<SubSequence<T>> {
 	constructor(
 		document: IFluidDataStoreRuntime,

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -8,7 +8,6 @@ import {
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions/internal";
 import {
-	// eslint-disable-next-line import/no-deprecated
 	IMergeTreeTextHelper,
 	IRelativePosition,
 	ISegment,
@@ -20,7 +19,6 @@ import {
 	refHasTileLabel,
 } from "@fluidframework/merge-tree/internal";
 
-// eslint-disable-next-line import/no-deprecated
 import { SharedSegmentSequence, type ISharedSegmentSequence } from "./sequence.js";
 import { SharedStringFactory } from "./sequenceFactory.js";
 
@@ -143,7 +141,6 @@ export type SharedStringSegment = TextSegment | Marker;
  * @internal
  */
 export class SharedStringClass
-	// eslint-disable-next-line import/no-deprecated
 	extends SharedSegmentSequence<SharedStringSegment>
 	implements ISharedString
 {
@@ -151,7 +148,6 @@ export class SharedStringClass
 		return this;
 	}
 
-	// eslint-disable-next-line import/no-deprecated
 	private readonly mergeTreeTextHelper: IMergeTreeTextHelper;
 
 	constructor(

--- a/packages/dds/sequence/src/test/collections.intervalTree.ts
+++ b/packages/dds/sequence/src/test/collections.intervalTree.ts
@@ -5,14 +5,21 @@
 
 import { strict as assert } from "assert";
 
-import { IntervalTree } from "../intervalTree.js";
-import { IInterval } from "../intervals/index.js";
+import type { PropertySet } from "@fluidframework/merge-tree/internal";
 
-class TestInterval implements IInterval {
+import { IntervalTree } from "../intervalTree.js";
+import { ISerializableInterval } from "../intervals/index.js";
+
+class TestInterval implements ISerializableInterval {
 	constructor(
 		public start: number,
 		public end: number,
 	) {}
+
+	getIntervalId(): string {
+		return "";
+	}
+	properties: PropertySet = {};
 
 	public clone() {
 		return new TestInterval(this.start, this.end);

--- a/packages/dds/sequence/src/test/intervalTestUtils.ts
+++ b/packages/dds/sequence/src/test/intervalTestUtils.ts
@@ -11,6 +11,7 @@ import { MockContainerRuntimeForReconnection } from "@fluidframework/test-runtim
 
 import { ISequenceIntervalCollection } from "../intervalCollection.js";
 import { createOverlappingIntervalsIndex } from "../intervalIndex/index.js";
+import { SequenceIntervalClass } from "../intervals/index.js";
 import { SharedString } from "../sequenceFactory.js";
 
 export interface Client {
@@ -154,8 +155,12 @@ export const assertSequenceIntervals = (
 		intervalCollection.attachIndex(overlappingIntervalsIndex);
 		const overlapping = overlappingIntervalsIndex.findOverlappingIntervals("start", "end");
 		assert.deepEqual(
-			actual.map((i) => i.serialize()),
-			overlapping.map((i) => i.serialize()),
+			actual
+				.filter((i): i is SequenceIntervalClass => i instanceof SequenceIntervalClass)
+				.map((i) => i.serialize()),
+			overlapping
+				.filter((i): i is SequenceIntervalClass => i instanceof SequenceIntervalClass)
+				.map((i) => i.serialize()),
 			"Interval search returned inconsistent results",
 		);
 		intervalCollection.detachIndex(overlappingIntervalsIndex);

--- a/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
+++ b/packages/dds/sequence/src/test/types/validateSequencePrevious.generated.ts
@@ -265,6 +265,7 @@ declare type old_as_current_for_Interface_IInterval = requireAssignableTo<TypeOn
  * typeValidation.broken:
  * "Interface_IInterval": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IInterval = requireAssignableTo<TypeOnly<current.IInterval>, TypeOnly<old.IInterval>>
 
 /*
@@ -382,6 +383,7 @@ declare type current_as_old_for_Interface_ISequenceOverlappingIntervalsIndex = r
  * typeValidation.broken:
  * "Interface_ISerializableInterval": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ISerializableInterval = requireAssignableTo<TypeOnly<old.ISerializableInterval>, TypeOnly<current.ISerializableInterval>>
 
 /*
@@ -391,6 +393,7 @@ declare type old_as_current_for_Interface_ISerializableInterval = requireAssigna
  * typeValidation.broken:
  * "Interface_ISerializableInterval": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ISerializableInterval = requireAssignableTo<TypeOnly<current.ISerializableInterval>, TypeOnly<old.ISerializableInterval>>
 
 /*
@@ -562,6 +565,7 @@ declare type old_as_current_for_Interface_SequenceInterval = requireAssignableTo
  * typeValidation.broken:
  * "Interface_SequenceInterval": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_SequenceInterval = requireAssignableTo<TypeOnly<current.SequenceInterval>, TypeOnly<old.SequenceInterval>>
 
 /*
@@ -652,6 +656,7 @@ declare type old_as_current_for_TypeAlias_IntervalRevertible = requireAssignable
  * typeValidation.broken:
  * "TypeAlias_IntervalRevertible": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_IntervalRevertible = requireAssignableTo<TypeOnly<current.IntervalRevertible>, TypeOnly<old.IntervalRevertible>>
 
 /*
@@ -760,6 +765,7 @@ declare type old_as_current_for_TypeAlias_SharedStringRevertible = requireAssign
  * typeValidation.broken:
  * "TypeAlias_SharedStringRevertible": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_SharedStringRevertible = requireAssignableTo<TypeOnly<current.SharedStringRevertible>, TypeOnly<old.SharedStringRevertible>>
 
 /*

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -429,17 +429,11 @@ export interface IFluidLoadable extends IProvideFluidLoadable {
 
 // @alpha @legacy
 export interface IInterval {
-    // @deprecated (undocumented)
-    clone(): IInterval;
     compare(b: IInterval): number;
     compareEnd(b: IInterval): number;
     compareStart(b: IInterval): number;
-    // @deprecated
-    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedDocumentMessage, localSeq?: number, canSlideToEndpoint?: boolean): IInterval | undefined;
     // (undocumented)
     overlaps(b: IInterval): boolean;
-    // @deprecated
-    union(b: IInterval): IInterval;
 }
 
 // @public
@@ -615,14 +609,6 @@ export interface ISequenceIntervalCollectionEvents extends IEvent {
     (event: "addInterval" | "deleteInterval", listener: (interval: SequenceInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
     (event: "propertyChanged", listener: (interval: SequenceInterval, propertyDeltas: PropertySet, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
     (event: "changed", listener: (interval: SequenceInterval, propertyDeltas: PropertySet, previousInterval: SequenceInterval | undefined, local: boolean, slide: boolean) => void): void;
-}
-
-// @alpha @deprecated @legacy (undocumented)
-export interface ISerializableInterval extends IInterval {
-    getIntervalId(): string;
-    properties: PropertySet;
-    // @deprecated (undocumented)
-    serialize(): ISerializedInterval;
 }
 
 // @alpha @legacy
@@ -1038,11 +1024,7 @@ export interface SequenceEvent<TOperation extends MergeTreeDeltaOperationTypes =
 }
 
 // @alpha @legacy
-export interface SequenceInterval extends ISerializableInterval {
-    // @deprecated
-    addPositionChangeListeners(beforePositionChange: () => void, afterPositionChange: () => void): void;
-    // @deprecated (undocumented)
-    clone(): SequenceInterval;
+export interface SequenceInterval extends IInterval {
     compare(b: SequenceInterval): number;
     compareEnd(b: SequenceInterval): number;
     compareStart(b: SequenceInterval): number;
@@ -1052,23 +1034,17 @@ export interface SequenceInterval extends ISerializableInterval {
     getIntervalId(): string;
     // (undocumented)
     readonly intervalType: IntervalType;
-    // @deprecated
-    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedDocumentMessage, localSeq?: number, canSlideToEndpoint?: boolean): SequenceInterval | undefined;
     // (undocumented)
     overlaps(b: SequenceInterval): boolean;
     // (undocumented)
     overlapsPos(bstart: number, bend: number): boolean;
     properties: PropertySet;
-    // @deprecated
-    removePositionChangeListeners(): void;
     // (undocumented)
     readonly start: LocalReferencePosition;
     // (undocumented)
     readonly startSide: Side;
     // (undocumented)
     readonly stickiness: IntervalStickiness;
-    // @deprecated
-    union(b: SequenceInterval): SequenceInterval;
 }
 
 // @alpha @legacy

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -150,7 +150,6 @@ export type {
 	IInterval,
 	IntervalStickiness,
 	ISequenceDeltaRange,
-	ISerializableInterval,
 	ISerializedInterval,
 	ISharedSegmentSequenceEvents,
 	ISharedString,


### PR DESCRIPTION
Remove unnecessary and internal APIs in ISequenceIntervalCollection and related interval types.

The following APIs are now removed:
- `IInterval.clone`
- `IInterval.modify`
- `IInterval.union`
- `ISerializableInterval`
- `SequenceInterval.clone`
- `SequenceInterval.modify`
- `SequenceInterval.union`
- `SequenceInterval.serialize`
- `SequenceInterval.addPositionChangeListeners`
- `SequenceInterval.removePositionChangeListeners`

These APIs were never intended for public use. There is no migration path, and any usage is strongly discouraged, as it may result in severe errors or data corruption. Please remove any dependencies on these APIs as soon as possible.

fixes: #24794