### PR TITLE
Remove isSessionActive check for broadcasting signals

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/api.ts
@@ -429,14 +429,11 @@ async function handleBroadcastSignal(
 	}
 
 	const serverUrl: string = config.get("worker:serverUrl");
-	const document = await storage?.getDocument(tenantId, documentId);
-	if (!document?.session?.isSessionAlive) {
+	const document = await storage.getDocument(tenantId, documentId);
+
+	if (!document?.session?.isSessionAlive || document?.scheduledDeletionTime) {
 		Lumberjack.error("Document not found", { tenantId, documentId });
 		throw new NetworkError(404, "Document not found");
-	}
-	if (!document.session.isSessionActive) {
-		Lumberjack.warning("Document session not active", { tenantId, documentId });
-		throw new NetworkError(410, "Document session not active");
 	}
 	if (document.session.ordererUrl !== serverUrl) {
 		Lumberjack.info("Redirecting broadcast-signal to correct cluster", {

--- a/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/alfred/api.spec.ts
@@ -1244,47 +1244,6 @@ describe("Routerlicious", () => {
 							.set("Content-Type", "application/json")
 							.expect(404);
 					});
-
-					it("Document session not active", async () => {
-						const body = {
-							signalContent: {
-								contents: {
-									type: "ExternalDataChanged_V1.0.0",
-									content: { taskListId: "task-list-1" },
-								},
-							},
-						};
-						const documentNoActiveSession = {
-							_id: "doc-1",
-							tenantId: appTenant1.id,
-							version: "1.0",
-							documentId: "doc-1",
-							content: "Hello, World!",
-							session: {
-								ordererUrl: defaultProvider.get("worker:serverUrl"),
-								deltaStreamUrl: defaultProvider.get("worker:deltaStreamUrl"),
-								historianUrl: defaultProvider.get("worker:blobStorageUrl"),
-								isSessionAlive: true,
-								isSessionActive: false,
-							},
-							createTime: Date.now(),
-							scribe: "",
-							deli: "",
-						};
-
-						Sinon.stub(defaultStorage, "getDocument").returns(
-							Promise.resolve(documentNoActiveSession),
-						);
-
-						await supertest
-							.post(
-								`/api/v1/${appTenant1.id}/${documentNoActiveSession._id}/broadcast-signal`,
-							)
-							.send(body)
-							.set("Authorization", tenantToken1)
-							.set("Content-Type", "application/json")
-							.expect(410);
-					});
 				});
 
 				describe("/documents", () => {


### PR DESCRIPTION
## Description

This PR aims to fix the broadcast-signal endpoint in alfred, where all requests were responding with a 410. The solution basically removes the `isSessionActive` check, as it doesn't pose a risk to the logic in general and `redis-emitter` will still be able to handle the emission without errors if the session is active.

## Reviewer Guidance

This is a simple PR, removing one check that was done initially before broadcasting a signal. The removal of this check does not affect functionality or break the API. The check was removed as tests from PP resulted in the API always failing the check.