### PR TITLE
fix(id-compressor): Fix broken function overloads

### DIFF
--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -805,8 +805,8 @@ export function deserializeIdCompressor(
 ): IIdCompressor & IIdCompressorCore;
 export function deserializeIdCompressor(
 	serialized: SerializedIdCompressor | SerializedIdCompressorWithNoSession,
-	sessionIdOrLogger?: SessionId | ITelemetryLoggerExt,
-	loggerOrUndefined?: ITelemetryLoggerExt | undefined,
+	sessionIdOrLogger: SessionId | ITelemetryLoggerExt | undefined,
+	loggerOrUndefined?: ITelemetryLoggerExt,
 ): IIdCompressor & IIdCompressorCore {
 	if (typeof sessionIdOrLogger === "string") {
 		return IdCompressor.deserialize({

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -625,19 +625,19 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 	}
 
 	public static deserialize(
-		serialized: SerializedIdCompressorWithOngoingSession,
-		logger: ITelemetryLoggerExt | undefined,
-	): IdCompressor;
-	public static deserialize(
-		serialized: SerializedIdCompressorWithNoSession,
-		logger: ITelemetryLoggerExt | undefined,
-		newSessionId: SessionId,
-	): IdCompressor;
-	public static deserialize(
-		serialized: SerializedIdCompressor,
-		logger: ITelemetryLoggerExt | undefined,
-		newSessionId?: SessionId,
+		params:
+			| {
+					serialized: SerializedIdCompressorWithOngoingSession;
+					logger?: ITelemetryLoggerExt | undefined;
+					newSessionId?: never;
+			  }
+			| {
+					serialized: SerializedIdCompressorWithNoSession;
+					newSessionId: SessionId;
+					logger?: ITelemetryLoggerExt | undefined;
+			  },
 	): IdCompressor {
+		const { serialized, newSessionId, logger } = params;
 		const buffer = stringToBuffer(serialized, "base64");
 		const index: Index = {
 			index: 0,
@@ -809,19 +809,19 @@ export function deserializeIdCompressor(
 	loggerOrUndefined?: ITelemetryLoggerExt | undefined,
 ): IIdCompressor & IIdCompressorCore {
 	if (typeof sessionIdOrLogger === "string") {
-		return IdCompressor.deserialize(
-			serialized as SerializedIdCompressorWithNoSession,
-			loggerOrUndefined,
-			sessionIdOrLogger,
-		);
+		return IdCompressor.deserialize({
+			serialized: serialized as SerializedIdCompressorWithNoSession,
+			logger: loggerOrUndefined,
+			newSessionId: sessionIdOrLogger,
+		});
 	}
 
 	assert(
 		loggerOrUndefined === undefined,
 		"logger would be in sessionIdOrLogger in this codepath",
 	);
-	return IdCompressor.deserialize(
-		serialized as SerializedIdCompressorWithOngoingSession,
-		sessionIdOrLogger,
-	);
+	return IdCompressor.deserialize({
+		serialized: serialized as SerializedIdCompressorWithOngoingSession,
+		logger: sessionIdOrLogger,
+	});
 }

--- a/packages/runtime/id-compressor/src/test/idCompressor.perf.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.perf.spec.ts
@@ -377,7 +377,7 @@ describe("IdCompressor Perf", () => {
 				serialized = perfCompressor.serialize(false);
 			},
 			benchmarkFn: () => {
-				IdCompressor.deserialize(serialized, overrideRemoteSessionId);
+				IdCompressor.deserialize(serialized, undefined /* logger */, overrideRemoteSessionId);
 			},
 		});
 	});

--- a/packages/runtime/id-compressor/src/test/idCompressor.perf.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.perf.spec.ts
@@ -377,7 +377,10 @@ describe("IdCompressor Perf", () => {
 				serialized = perfCompressor.serialize(false);
 			},
 			benchmarkFn: () => {
-				IdCompressor.deserialize(serialized, undefined /* logger */, overrideRemoteSessionId);
+				IdCompressor.deserialize({
+					serialized,
+					newSessionId: overrideRemoteSessionId,
+				});
 			},
 		});
 	});

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -943,10 +943,9 @@ describe("IdCompressor", () => {
 			compressor1.finalizeCreationRange(creationRange);
 			compressor2.finalizeCreationRange(creationRange);
 			const [_, serializedWithSession] = expectSerializes(compressor1);
-			const compressorResumed = IdCompressor.deserialize(
-				serializedWithSession,
-				undefined /* logger */,
-			);
+			const compressorResumed = IdCompressor.deserialize({
+				serialized: serializedWithSession,
+			});
 			compressorResumed.generateCompressedId();
 			const range2 = compressorResumed.takeNextCreationRange();
 			compressorResumed.finalizeCreationRange(range2);
@@ -1020,10 +1019,10 @@ describe("IdCompressor", () => {
 			const compressor = CompressorFactory.createCompressor(Client.Client1);
 			compressor.generateCompressedId();
 			const serializedWithSession = compressor.serialize(true);
-			const resumed = IdCompressor.deserialize(
-				serializedWithSession,
-				createChildLogger({ logger: mockLogger }),
-			);
+			const resumed = IdCompressor.deserialize({
+				serialized: serializedWithSession,
+				logger: createChildLogger({ logger: mockLogger }),
+			});
 			resumed.serialize(false);
 			mockLogger.assertMatchAny([
 				{ eventName: "RuntimeIdCompressor:SerializedIdCompressorSize" },
@@ -1037,11 +1036,11 @@ describe("IdCompressor", () => {
 			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
 			const serializedNoSession = compressor.serialize(false);
 			const newSessionId = createSessionId();
-			const resumed = IdCompressor.deserialize(
-				serializedNoSession,
-				createChildLogger({ logger: mockLogger }),
+			const resumed = IdCompressor.deserialize({
+				serialized: serializedNoSession,
 				newSessionId,
-			);
+				logger: createChildLogger({ logger: mockLogger }),
+			});
 			resumed.serialize(false);
 			mockLogger.assertMatchAny([
 				{ eventName: "RuntimeIdCompressor:SerializedIdCompressorSize" },
@@ -1345,11 +1344,10 @@ describe("IdCompressor", () => {
 					const serializedWithoutLocalState = compressor.serialize(false);
 					assert.throws(
 						() =>
-							IdCompressor.deserialize(
-								serializedWithoutLocalState,
-								undefined /* logger */,
-								sessionIds.get(Client.Client2),
-							),
+							IdCompressor.deserialize({
+								serialized: serializedWithoutLocalState,
+								newSessionId: sessionIds.get(Client.Client2),
+							}),
 						(e: Error) => e.message === "Cannot resume existing session.",
 					);
 				},

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -943,7 +943,10 @@ describe("IdCompressor", () => {
 			compressor1.finalizeCreationRange(creationRange);
 			compressor2.finalizeCreationRange(creationRange);
 			const [_, serializedWithSession] = expectSerializes(compressor1);
-			const compressorResumed = IdCompressor.deserialize(serializedWithSession);
+			const compressorResumed = IdCompressor.deserialize(
+				serializedWithSession,
+				undefined /* logger */,
+			);
 			compressorResumed.generateCompressedId();
 			const range2 = compressorResumed.takeNextCreationRange();
 			compressorResumed.finalizeCreationRange(range2);
@@ -1250,6 +1253,7 @@ describe("IdCompressor", () => {
 						() =>
 							IdCompressor.deserialize(
 								serializedWithoutLocalState,
+								undefined /* logger */,
 								sessionIds.get(Client.Client2),
 							),
 						(e: Error) => e.message === "Cannot resume existing session.",

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -16,6 +16,7 @@ import {
 	SessionId,
 	SessionSpaceCompressedId,
 	StableId,
+	type SerializedIdCompressorWithOngoingSession,
 } from "../index.js";
 import { createSessionId } from "../utilities.js";
 
@@ -975,6 +976,19 @@ describe("IdCompressor", () => {
 				(e: Error) => e.message === "IdCompressor version 1.0 is no longer supported.",
 			);
 		});
+
+		it("throws for unknown serialized version", () => {
+			const invalidVersion = -1;
+			// Version number is the very first float
+			const serializedWithUnknownVersion = bufferToString(
+				new Float64Array([invalidVersion]).buffer,
+				"base64",
+			) as SerializedIdCompressorWithOngoingSession;
+			assert.throws(
+				() => deserializeIdCompressor(serializedWithUnknownVersion),
+				(e: Error) => e.message === "Unknown IdCompressor serialized version.",
+			);
+		});
 	});
 
 	describe("Deserialize overloads", () => {
@@ -1046,29 +1060,6 @@ describe("IdCompressor", () => {
 				{ eventName: "RuntimeIdCompressor:SerializedIdCompressorSize" },
 			]);
 		});
-
-		//* Come back to these
-		// it("deserializeIdCompressor rejects 3rd-arg logger for withSession", () => {
-		// 	const mockLogger = new MockLogger();
-		// 	const compressor = CompressorFactory.createCompressor(Client.Client1);
-		// 	const serializedWithSession = compressor.serialize(true);
-		// 	// Passing logger in the 3rd arg when no sessionId is supplied is invalid
-		// 	assert.throws(
-		// 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		// 		() =>
-		// 			deserializeIdCompressor(serializedWithSession as any, undefined as any, mockLogger),
-		// 		(e: Error) => e.message === "logger would be in sessionIdOrLogger in this codepath",
-		// 	);
-		// });
-
-		// it("throws for unknown serialized version", () => {
-		// 	// Version number is the very first float; 999 ensures the switch default path
-		// 	const unknownVersion = bufferToString(new Float64Array([999]).buffer, "base64");
-		// 	assert.throws(
-		// 		() => deserializeIdCompressor(unknownVersion as any, createSessionId()),
-		// 		(e: Error) => e.message === "Unknown IdCompressor serialized version.",
-		// 	);
-		// });
 	});
 
 	describe("Collision detection", () => {

--- a/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
@@ -730,16 +730,15 @@ export function roundtrip(
 	const capacity: number = getClusterSize(compressor);
 	if (withSession) {
 		const serialized = compressor.serialize(withSession);
-		const roundtripped = IdCompressor.deserialize(serialized, undefined /* logger */);
+		const roundtripped = IdCompressor.deserialize({ serialized });
 		modifyClusterSize(roundtripped, capacity);
 		return [serialized, roundtripped];
 	} else {
 		const nonLocalSerialized = compressor.serialize(withSession);
-		const roundtripped = IdCompressor.deserialize(
-			nonLocalSerialized,
-			undefined /* logger */,
-			createSessionId(),
-		);
+		const roundtripped = IdCompressor.deserialize({
+			serialized: nonLocalSerialized,
+			newSessionId: createSessionId(),
+		});
 		modifyClusterSize(roundtripped, capacity);
 		return [nonLocalSerialized, roundtripped];
 	}

--- a/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
@@ -730,12 +730,16 @@ export function roundtrip(
 	const capacity: number = getClusterSize(compressor);
 	if (withSession) {
 		const serialized = compressor.serialize(withSession);
-		const roundtripped = IdCompressor.deserialize(serialized);
+		const roundtripped = IdCompressor.deserialize(serialized, undefined /* logger */);
 		modifyClusterSize(roundtripped, capacity);
 		return [serialized, roundtripped];
 	} else {
 		const nonLocalSerialized = compressor.serialize(withSession);
-		const roundtripped = IdCompressor.deserialize(nonLocalSerialized, createSessionId());
+		const roundtripped = IdCompressor.deserialize(
+			nonLocalSerialized,
+			undefined /* logger */,
+			createSessionId(),
+		);
 		modifyClusterSize(roundtripped, capacity);
 		return [nonLocalSerialized, roundtripped];
 	}


### PR DESCRIPTION
## Description

It started to seem like the logger was always `undefined` for Summarizer.  Turns out, it is, because the parameter gets dropped in the overloaded function's implementation.

There are two bugs fixed here, called out by comments on the code.  I only manually repro'd one, the other was from code inspection.

